### PR TITLE
[FLINK-17161][docs][docker] Document the official docker hub image and examples of how to use it

### DIFF
--- a/docs/ops/deployment/docker.md
+++ b/docs/ops/deployment/docker.md
@@ -23,120 +23,497 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-[Docker](https://www.docker.com) is a popular container runtime. 
-There are Docker images for Apache Flink available on Docker Hub which can be used to deploy a session cluster.
-The Flink repository also contains tooling to create container images to deploy a job cluster.
+[Docker](https://www.docker.com) is a popular container runtime.
+There are Docker images for Apache Flink available [on Docker Hub](https://hub.docker.com/_/flink).
+You can use the docker images to deploy a *Session* or *Job cluster* in a containerized environment, e.g.,
+[standalone Kubernetes](kubernetes.html) or [native Kubernetes](native_kubernetes.html).
 
 * This will be replaced by the TOC
 {:toc}
 
-## Flink session cluster
-
-A Flink session cluster can be used to run multiple jobs. 
-Each job needs to be submitted to the cluster after it has been deployed. 
-
-### Docker images
+## Docker Hub Flink images
 
 The [Flink Docker repository](https://hub.docker.com/_/flink/) is hosted on
 Docker Hub and serves images of Flink version 1.2.1 and later.
 
-Images for each supported combination of Hadoop and Scala are available, and tag aliases are provided for convenience.
+### Image tags
 
-Beginning with Flink 1.5, image tags that omit a Hadoop version (e.g.
-`-hadoop28`) correspond to Hadoop-free releases of Flink that do not include a
-bundled Hadoop distribution.
+Images for each supported combination of Flink and Scala versions are available, and
+[tag aliases](https://hub.docker.com/_/flink?tab=tags) are provided for convenience.
 
-For example, the following aliases can be used: *(`1.5.y` indicates the latest
-release of Flink 1.5)*
+For example, you can use the following aliases:
 
 * `flink:latest` → `flink:<latest-flink>-scala_<latest-scala>`
-* `flink:1.5` → `flink:1.5.y-scala_2.11`
-* `flink:1.5-hadoop27` → `flink:1.5.y-hadoop27-scala_2.11`
+* `flink:1.11` → `flink:1.11.<latest-flink-1.11>-scala_2.11`
 
-**Note:** The Docker images are provided as a community project by individuals
-on a best-effort basis. They are not official releases by the Apache Flink PMC.
+<span class="label label-info">Note</span> Prio to Flink 1.5 version, Hadoop dependencies were always bundled with Flink.
+You can see that certain tags include the version of Hadoop, e.g. (e.g. `-hadoop28`).
+Beginning with Flink 1.5, image tags that omit the Hadoop version correspond to Hadoop-free releases of Flink
+that do not include a bundled Hadoop distribution.
 
-## Flink job cluster
+## How to run Flink image
 
-A Flink job cluster is a dedicated cluster which runs a single job. 
-The job is part of the image and, thus, there is no extra job submission needed. 
+The Flink image contains a regular Flink distribution with its default configuration and a standard entry point script.
+You can run its entry point in the following modes:
+* [Flink Master]({{ site.baseurl }}/concepts/glossary.html#flink-master) for [a Session cluster](#start-a-session-cluster)
+* *Flink Master* for [a Job cluster](#start-a-job-cluster)
+* [TaskManager]({{ site.baseurl }}/concepts/glossary.html#flink-taskmanager) for any cluster
 
-### Docker images
+This allows you to deploy a standalone cluster (Session or Job) in any containerised environment, for example:
+* manually in a local Docker setup,
+* [in a Kubernetes cluster](kubernetes.html),
+* [with Docker Compose](#flink-with-docker-compose),
+* [with Docker swarm](#flink-with-docker-swarm).
 
-The Flink job cluster image needs to contain the user code jars of the job for which the cluster is started.
-Therefore, one needs to build a dedicated container image for every job.
-The `flink-container` module contains a `build.sh` script which can be used to create such an image.
-Please see the [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/README.md) for more details. 
+<span class="label label-info">Note</span> [The native Kubernetes](native_kubernetes.html) also runs the same image by default
+and deploys *TaskManagers* on demand so that you do not have to do it manually.
 
-## Using plugins
+The next chapters describe how to start a single Flink Docker container for various purposes.
+
+### Start a Session Cluster
+
+A *Flink Session cluster* can be used to run multiple jobs. Each job needs to be submitted to the cluster after it has been deployed.
+To deploy a *Flink Session cluster* with Docker, you need to start a *Flink Master* container:
+
+```sh
+docker run flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} jobmanager
+```
+
+and one or more *TaskManager* containers:
+
+```sh
+docker run flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} taskmanager
+```
+
+### Start a Job Cluster
+
+A *Flink Job cluster* is a dedicated cluster which runs a single job.
+In this case, you deploy the cluster with the job as one step, thus, there is no extra job submission needed.
+
+The *job artifacts* are included into the class path of Flink's JVM process within the container and consist of:
+* your job jar, which you would normally submit to a *Session cluster* and
+* all other necessary dependencies or resources, not included into Flink.
+
+To deploy a cluster for a single job with Docker, you need to
+* make *job artifacts* available locally *in all containers* under `/opt/flink/usrlib`,
+* start a *Flink Master* container in the *Job Cluster* mode
+* start the required number of *TaskManager* containers.
+
+To make the **job artifacts available** locally in the container, you can
+
+* **either mount a volume** (or multiple volumes) with the artifacts to `/opt/flink/usrlib` when you start
+the *Flink Master* and *TaskManagers*:
+
+    ```sh
+    docker run \
+        --mount type=bind,src=/host/path/to/job/artifacts1,target=/opt/flink/usrlib/artifacts1 \
+        --mount type=bind,src=/host/path/to/job/artifacts2,target=/opt/flink/usrlib/artifacts2 \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} standalone-job \
+        --job-classname com.job.ClassName \
+        --job-id <job id> \
+        [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] \
+        [job arguments]
+
+    docker run \
+        --mount type=bind,src=/host/path/to/job/artifacts1,target=/opt/flink/usrlib/artifacts1 \
+        --mount type=bind,src=/host/path/to/job/artifacts2,target=/opt/flink/usrlib/artifacts2 \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} taskmanager
+    ```
+
+* **or extend the Flink image** by writing a custom `Dockerfile`, build it and use it for starting the *Flink Master* and *TaskManagers*:
+
+    ```dockerfile
+    FROM flink
+    ADD /host/path/to/job/artifacts/1 /opt/flink/usrlib/artifacts/1
+    ADD /host/path/to/job/artifacts/2 /opt/flink/usrlib/artifacts/2
+    ```
+
+    ```sh
+    docker build -t flink_with_job_artifacts .
+    docker run \
+        flink_with_job_artifacts standalone-job \
+        --job-classname com.job.ClassName \
+        --job-id <job id> \
+        [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] \
+        [job arguments]
+
+    docker run flink_with_job_artifacts taskmanager
+    ```
+
+The `standalone-job` argument starts a *Flink Master* container in the *Job Cluster* mode.
+
+#### Flink Master additional command line arguments
+
+You can provide the following additional command line arguments to the cluster entrypoint:
+
+* `--job-classname <job class name>`: Class name of the job to run.
+
+  By default, Flink scans its class path for a JAR with a Main-Class or program-class manifest entry and chooses it as the job class.
+  Use this command line argument to manually set the job class.
+  This argument is required in case that no or more than one JAR with such a manifest entry is available on the class path.
+
+* `--job-id <job id>` (optional): Manually set a Flink job ID for the job (default: 00000000000000000000000000000000)
+
+* `--fromSavepoint /path/to/savepoint` (optional): Restore from a savepoint
+
+  In order to resume from a savepoint, you also need to pass the savepoint path.
+  Note that `/path/to/savepoint` needs to be accessible in all Docker containers of the cluster
+  (e.g., storing it on a DFS or from the mounted volume or adding it to the image).
+
+* `--allowNonRestoredState` (optional): Skip broken savepoint state
+
+  Additionally you can specify this argument to allow that savepoint state is skipped which cannot be restored.
+
+If the main function of the user job main class accepts arguments, you can also pass them at the end of the `docker run` command.
+
+## Customize Flink image
+
+When you run the Flink containers, there may be a need to customize them.
+The next chapters describe some how-tos of what you can usually customize.
+
+### Configure options
+
+When you run Flink image, you can also change its configuration options by setting the environment variable `FLINK_PROPERTIES`:
+
+```sh
+FLINK_PROPERTIES="jobmanager.rpc.address: host
+taskmanager.numberOfTaskSlots: 3
+blob.server.port: 6124
+"
+docker run --env FLINK_PROPERTIES=${FLINK_PROPERTIES} flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
+```
+
+The [`jobmanager.rpc.address`](../config.html#jobmanager-rpc-address) option must be configured, others are optional to set.
+
+The environment variable `FLINK_PROPERTIES` should contain a list of Flink cluster configuration options separated by new line,
+the same way as in the `flink-conf.yaml`.
+
+### Provide custom configuration
+
+The configuration files (`flink-conf.yaml`, logging, hosts etc) are located in the `/opt/flink/conf` directory in the Flink image.
+To provide a custom location for the Flink configuration files, you can
+
+* **either mount a volume** with the custom configuration files to this path `/opt/flink/conf` when you run the Flink image:
+
+    ```sh
+    docker run \
+        --mount type=bind,src=/host/path/to/custom/conf,target=/opt/flink/conf \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
+    ```
+
+* or add them to your **custom Flink image**, build and run it:
+
+    ```dockerfile
+    FROM flink
+    ADD /host/path/to/flink-conf.yaml /opt/flink/conf/flink-conf.yaml
+    ADD /host/path/to/log4j.properties /opt/flink/conf/log4j.properties
+    ```
+
+<span class="label label-warning">Warning!</span> The mounted volume must contain all necessary configuration files.
+The `flink-conf.yaml` file must have write permission so that the Docker entry point script can modify it in certain cases.
+
+### Using plugins
+
 As described in the [plugins]({{ site.baseurl }}/ops/plugins.html) documentation page: in order to use plugins they must be
 copied to the correct location in the Flink installation for them to work.
 
-When running Flink from one of the provided Docker images by default no plugins have been activated.
-The simplest way to enable plugins is to modify the provided official Flink docker images by adding
-an additional layer. This does however assume you have a docker registry available where you can push images to and
-that is accessible by your cluster.
+If you want to enable plugins provided with Flink, you can pass the environment variable `ENABLE_BUILT_IN_PLUGINS`
+when you run the Flink image.
+The `ENABLE_BUILT_IN_PLUGINS` should contain a list of plugin jar file names separated by `;`.
 
-As an example assume you want to enable the [S3]({{ site.baseurl }}/ops/filesystems/s3.html) plugins in your installation.
+    ```sh
+    docker run \
+        --env ENABLE_BUILT_IN_PLUGINS=flink-plugin1.jar;flink-plugin2.jar \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
+    ```
 
-Create a Dockerfile with a content something like this: {% highlight dockerfile %}
-# On which specific version of Flink is this based?
-# Check https://hub.docker.com/_/flink?tab=tags for current options
-FROM flink:{{ site.version }}-scala_2.12
+There are also more [advanced ways](#advanced-customization) for customizing the Flink image.
 
-# Install Flink S3 FS Presto plugin
-RUN mkdir /opt/flink/plugins/s3-fs-presto && cp /opt/flink/opt/flink-s3-fs-presto* /opt/flink/plugins/s3-fs-presto
+### Advanced customization
 
-# Install Flink S3 FS Hadoop plugin
-RUN mkdir /opt/flink/plugins/s3-fs-hadoop && cp /opt/flink/opt/flink-s3-fs-hadoop* /opt/flink/plugins/s3-fs-hadoop
-{% endhighlight %}
+There are several ways in which you can further customize the Flink image:
 
-Then build and push that image to your registry
-{% highlight bash %}
-docker build -t docker.example.nl/flink:{{ site.version }}-scala_2.12-s3 .
-docker push     docker.example.nl/flink:{{ site.version }}-scala_2.12-s3
-{% endhighlight %}
+* install custom software (e.g. python)
+* enable (symlink) optional libraries or plugins from `/opt/flink/opt` into `/opt/flink/lib` or `/opt/flink/plugins`
+* add other libraries to `/opt/flink/lib` (e.g. [hadoop](hadoop.html#adding-hadoop-to-lib))
+* add other plugins to `/opt/flink/plugins`
 
-Now you can reference this image in your cluster deployment and the installed plugins are available for use.
+you can achieve this in several ways:
+
+* **override the container entry point** with a custom script where you can run any bootstrap actions.
+At the end you can call the standard `/docker-entrypoint.sh` script of the Flink image with the same arguments
+as described in [how to run the Flink image](#how-to-run-flink-image).
+
+  The following example creates a custom entry point script which enables more libraries and plugins.
+  The custom script, custom library and plugin are provided from a mounted volume.
+  Then it runs the standard entry point script of the Flink image:
+
+    ```sh
+    # create custom_lib.jar
+    # create custom_plugin.jar
+
+    echo "
+    ln -fs /opt/flink/opt/flink-queryable-state-runtime-*.jar /opt/flink/lib/.  # enable an optional library
+    ln -fs /mnt/custom_lib.jar /opt/flink/lib/.  # enable a custom library
+
+    mkdir -p /opt/flink/plugins/flink-s3-fs-hadoop
+    ln -fs /opt/flink/opt/flink-s3-fs-hadoop-*.jar /opt/flink/plugins/flink-s3-fs-hadoop/.  # enable an optional plugin
+
+    mkdir -p /opt/flink/plugins/custom_plugin
+    ln -fs /mnt/custom_plugin.jar /opt/flink/plugins/custom_plugin/.  # enable a custom plugin
+
+    /docker-entrypoint.sh <jobmanager|standalone-job|taskmanager>
+    " > custom_entry_point_script.sh
+
+    chmod 755 custom_entry_point_script.sh
+
+    docker run \
+        --mount type=bind,src=$(pwd),target=/mnt
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} /mnt/custom_entry_point_script.sh
+    ```
+
+* **extend the Flink image** by writing a custom `Dockerfile` and build a custom image:
+
+    ```dockerfile
+    FROM flink
+
+    RUN set -ex; apt-get update; apt-get -y install python
+
+    ADD /host/path/to/flink-conf.yaml /container/local/path/to/custom/conf/flink-conf.yaml
+    ADD /host/path/to/log4j.properties /container/local/path/to/custom/conf/log4j.properties
+
+    RUN ln -fs /opt/flink/opt/flink-queryable-state-runtime-*.jar /opt/flink/lib/.
+
+    RUN mkdir -p /opt/flink/plugins/flink-s3-fs-hadoop
+    RUN ln -fs /opt/flink/opt/flink-s3-fs-hadoop-*.jar /opt/flink/plugins/flink-s3-fs-hadoop/.
+
+    ENV VAR_NAME value
+    ```
+
+    ```sh
+    docker build -t custom_flink_image .
+    # optional push to your docker image registry if you have it,
+    # e.g. to distribute the custom image to your cluster
+    docker push custom_flink_image
+    ```
+
+{% top %}
 
 ## Flink with Docker Compose
 
-[Docker Compose](https://docs.docker.com/compose/) is a convenient way to run a
-group of Docker containers locally.
-
-Example config files for a [session cluster](https://github.com/docker-flink/examples/blob/master/docker-compose.yml) and a [job cluster](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/docker-compose.yml)
-are available on GitHub.
+[Docker Compose](https://docs.docker.com/compose/) is a way to run a group of Docker containers locally.
+The next chapters show examples of configuration files to run Flink.
 
 ### Usage
 
+* Create the `yaml` files with the container configuration, check examples for:
+    * [Session cluster](#session-cluster-with-docker-compose)
+    * [Job cluster](#job-cluster-with-docker-compose)
+
+    See also [the Flink Docker image tags](#image-tags) and [how to customize the Flink Docker image](#advanced-customization)
+    for usage in the configuration files.
+
 * Launch a cluster in the foreground
 
-        docker-compose up
+    ```sh
+    docker-compose up
+    ```
 
 * Launch a cluster in the background
 
-        docker-compose up -d
+    ```sh
+    docker-compose up -d
+    ```
 
-* Scale the cluster up or down to *N* TaskManagers
+* Scale the cluster up or down to *N TaskManagers*
 
-        docker-compose scale taskmanager=<N>
+    ```sh
+    docker-compose scale taskmanager=<N>
+    ```
+
+* Access the *Flink Master* container
+
+    ```sh
+    docker exec -it $(docker ps --filter name=jobmanager --format={{.ID}}) /bin/sh
+    ```
 
 * Kill the cluster
 
-        docker-compose kill
+    ```sh
+    docker-compose kill
+    ```
 
-When the cluster is running, you can visit the web UI at [http://localhost:8081](http://localhost:8081). 
-You can also use the web UI to submit a job to a session cluster.
+* Access Web UI
 
-To submit a job to a session cluster via the command line, you must copy the JAR to the JobManager
-container and submit the job from there.
+    When the cluster is running, you can visit the web UI at [http://localhost:8081](http://localhost:8081).
+    You can also use the web UI to submit a job to a *Session cluster*.
 
-For example:
+* To submit a job to a *Session cluster* via the command line, you can either
 
-{% raw %}
-    $ JOBMANAGER_CONTAINER=$(docker ps --filter name=jobmanager --format={{.ID}})
-    $ docker cp path/to/jar "$JOBMANAGER_CONTAINER":/job.jar
-    $ docker exec -t -i "$JOBMANAGER_CONTAINER" flink run /job.jar
-{% endraw %}
+  * use [Flink CLI](..//cli.html) on the host if it is installed:
+
+    ```sh
+    flink run -d -c ${JOB_CLASS_NAME} /job.jar
+    ```
+
+  * or copy the JAR to the *Flink Master* container and submit the job using the [CLI](..//cli.html) from there, for example:
+
+    ```sh
+    JOB_CLASS_NAME="com.job.ClassName"
+    MASTER_CONTAINER=$(docker ps --filter name=jobmanager --format={{.ID}})
+    docker cp path/to/jar "${MASTER_CONTAINER}":/job.jar
+    docker exec -t -i "${MASTER_CONTAINER}" flink run -d -c ${JOB_CLASS_NAME} /job.jar
+    ```
+
+### Session Cluster with Docker Compose
+
+```yaml
+version: "2.2"
+services:
+  jobmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    ports:
+      - "8081:8081"
+    command: jobmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+
+  taskmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    depends_on:
+      - jobmanager
+    command: taskmanager
+    scale: 1
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 2
+```
+
+### Job Cluster with Docker Compose
+
+The artifacts must be available in the Flink containers, check details [here](#start-a-job-cluster).
+See also [how to specify the Flink Master arguments](#flink-master-additional-command-line-arguments)
+in the `command` for the `jobmanager` service.
+
+```yaml
+version: "2.2"
+services:
+  jobmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    ports:
+      - "8081:8081"
+    command: standalone-job --job-classname com.job.ClassName [--job-id <job id>] [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] [job arguments]
+    volumes:
+      - /host/path/to/job/artifacts:/opt/flink/usrlib
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        parallelism.default: 2
+
+  taskmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    depends_on:
+      - jobmanager
+    command: taskmanager
+    scale: 1
+    volumes:
+      - /host/path/to/job/artifacts:/opt/flink/usrlib
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 2
+        parallelism.default: 2
+```
+
+{% top %}
+
+## Flink with Docker Swarm
+
+The [Docker swarm](https://docs.docker.com/engine/swarm) is a container orchestration tool, that
+allows you to manage multiple containers deployed across multiple host machines.
+
+The following chapters contain examples of how to configure and start *Flink Master* and *TaskManager* containers.
+You can adjust them accordingly to start a cluster.
+See also [the Flink Docker image tags](#image-tags) and [how to customize the Flink Docker image](#advanced-customization) for usage in the provided scripts.
+
+The port `8081` is exposed for the Flink Web UI access.
+If you run the swarm locally, you can visit the web UI at [http://localhost:8081](http://localhost:8081) after starting the cluster.
+
+### Session Cluster with Docker Swarm
+
+```sh
+FLINK_PROPERTIES="jobmanager.rpc.address: flink-session-jobmanager
+taskmanager.numberOfTaskSlots: 2
+"
+
+# Create overlay network
+docker network create -d overlay flink-session
+
+# Create the Flink Master service
+docker service create \
+  --name flink-session-jobmanager \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  -p 8081:8081 \
+  --network flink-session \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    jobmanager
+
+# Create the TaskManager service (scale this out as needed)
+docker service create \
+  --name flink-session-taskmanager \
+  --replicas 2 \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  --network flink-session \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    taskmanager
+```
+
+### Job Cluster with Docker Swarm
+
+```sh
+FLINK_PROPERTIES="jobmanager.rpc.address: flink-master
+taskmanager.numberOfTaskSlots: 2
+"
+
+# Create overlay network
+docker network create -d overlay flink-job
+
+# Create the Flink Master service
+docker service create \
+  --name flink-master \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  --mount type=bind,source=/host/path/to/job/artifacts,target=/opt/flink/usrlib \
+  -p 8081:8081 \
+  --network flink-job \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    standalone-job \
+    --job-classname com.job.ClassName \
+    [--job-id <job id>] \
+    [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] \
+    [job arguments]
+
+# Create the TaskManager service (scale this out as needed)
+docker service create \
+  --name flink-job-taskmanager \
+  --replicas 2 \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  --mount type=bind,source=/host/path/to/job/artifacts,target=/opt/flink/usrlib \
+  --network flink-job \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    taskmanager
+```
+
+The *job artifacts* must be available in the *Flink Master* container, as outlined [here](#start-a-job-cluster).
+See also [how to specify the Flink Master arguments](#flink-master-additional-command-line-arguments) to pass them
+to the `flink-master` container.
+
+The example assumes that you run the swarm locally and expects the *job artifacts* to be in `/host/path/to/job/artifacts`.
+It also mounts the host path with the artifacts as a volume to the container's path `/opt/flink/usrlib`.
 
 {% top %}

--- a/docs/ops/deployment/docker.zh.md
+++ b/docs/ops/deployment/docker.zh.md
@@ -23,120 +23,497 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-[Docker](https://www.docker.com) is a popular container runtime. 
-There are Docker images for Apache Flink available on Docker Hub which can be used to deploy a session cluster.
-The Flink repository also contains tooling to create container images to deploy a job cluster.
+[Docker](https://www.docker.com) is a popular container runtime.
+There are Docker images for Apache Flink available [on Docker Hub](https://hub.docker.com/_/flink).
+You can use the docker images to deploy a *Session* or *Job cluster* in a containerized environment, e.g.,
+[standalone Kubernetes](kubernetes.html) or [native Kubernetes](native_kubernetes.html).
 
 * This will be replaced by the TOC
 {:toc}
 
-## Flink session cluster
-
-A Flink session cluster can be used to run multiple jobs. 
-Each job needs to be submitted to the cluster after it has been deployed. 
-
-### Docker images
+## Docker Hub Flink images
 
 The [Flink Docker repository](https://hub.docker.com/_/flink/) is hosted on
 Docker Hub and serves images of Flink version 1.2.1 and later.
 
-Images for each supported combination of Hadoop and Scala are available, and tag aliases are provided for convenience.
+### Image tags
 
-Beginning with Flink 1.5, image tags that omit a Hadoop version (e.g.
-`-hadoop28`) correspond to Hadoop-free releases of Flink that do not include a
-bundled Hadoop distribution.
+Images for each supported combination of Flink and Scala versions are available, and
+[tag aliases](https://hub.docker.com/_/flink?tab=tags) are provided for convenience.
 
-For example, the following aliases can be used: *(`1.5.y` indicates the latest
-release of Flink 1.5)*
+For example, you can use the following aliases:
 
 * `flink:latest` → `flink:<latest-flink>-scala_<latest-scala>`
-* `flink:1.5` → `flink:1.5.y-scala_2.11`
-* `flink:1.5-hadoop27` → `flink:1.5.y-hadoop27-scala_2.11`
+* `flink:1.11` → `flink:1.11.<latest-flink-1.11>-scala_2.11`
 
-**Note:** The Docker images are provided as a community project by individuals
-on a best-effort basis. They are not official releases by the Apache Flink PMC.
+<span class="label label-info">Note</span> Prio to Flink 1.5 version, Hadoop dependencies were always bundled with Flink.
+You can see that certain tags include the version of Hadoop, e.g. (e.g. `-hadoop28`).
+Beginning with Flink 1.5, image tags that omit the Hadoop version correspond to Hadoop-free releases of Flink
+that do not include a bundled Hadoop distribution.
 
-## Flink job cluster
+## How to run Flink image
 
-A Flink job cluster is a dedicated cluster which runs a single job. 
-The job is part of the image and, thus, there is no extra job submission needed. 
+The Flink image contains a regular Flink distribution with its default configuration and a standard entry point script.
+You can run its entry point in the following modes:
+* [Flink Master]({{ site.baseurl }}/concepts/glossary.html#flink-master) for [a Session cluster](#start-a-session-cluster)
+* *Flink Master* for [a Job cluster](#start-a-job-cluster)
+* [TaskManager]({{ site.baseurl }}/concepts/glossary.html#flink-taskmanager) for any cluster
 
-### Docker images
+This allows you to deploy a standalone cluster (Session or Job) in any containerised environment, for example:
+* manually in a local Docker setup,
+* [in a Kubernetes cluster](kubernetes.html),
+* [with Docker Compose](#flink-with-docker-compose),
+* [with Docker swarm](#flink-with-docker-swarm).
 
-The Flink job cluster image needs to contain the user code jars of the job for which the cluster is started.
-Therefore, one needs to build a dedicated container image for every job.
-The `flink-container` module contains a `build.sh` script which can be used to create such an image.
-Please see the [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/README.md) for more details. 
+<span class="label label-info">Note</span> [The native Kubernetes](native_kubernetes.html) also runs the same image by default
+and deploys *TaskManagers* on demand so that you do not have to do it manually.
 
-## Using plugins
+The next chapters describe how to start a single Flink Docker container for various purposes.
+
+### Start a Session Cluster
+
+A *Flink Session cluster* can be used to run multiple jobs. Each job needs to be submitted to the cluster after it has been deployed.
+To deploy a *Flink Session cluster* with Docker, you need to start a *Flink Master* container:
+
+```sh
+docker run flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} jobmanager
+```
+
+and one or more *TaskManager* containers:
+
+```sh
+docker run flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} taskmanager
+```
+
+### Start a Job Cluster
+
+A *Flink Job cluster* is a dedicated cluster which runs a single job.
+In this case, you deploy the cluster with the job as one step, thus, there is no extra job submission needed.
+
+The *job artifacts* are included into the class path of Flink's JVM process within the container and consist of:
+* your job jar, which you would normally submit to a *Session cluster* and
+* all other necessary dependencies or resources, not included into Flink.
+
+To deploy a cluster for a single job with Docker, you need to
+* make *job artifacts* available locally *in all containers* under `/opt/flink/usrlib`,
+* start a *Flink Master* container in the *Job Cluster* mode
+* start the required number of *TaskManager* containers.
+
+To make the **job artifacts available** locally in the container, you can
+
+* **either mount a volume** (or multiple volumes) with the artifacts to `/opt/flink/usrlib` when you start
+the *Flink Master* and *TaskManagers*:
+
+    ```sh
+    docker run \
+        --mount type=bind,src=/host/path/to/job/artifacts1,target=/opt/flink/usrlib/artifacts1 \
+        --mount type=bind,src=/host/path/to/job/artifacts2,target=/opt/flink/usrlib/artifacts2 \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} standalone-job \
+        --job-classname com.job.ClassName \
+        --job-id <job id> \
+        [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] \
+        [job arguments]
+
+    docker run \
+        --mount type=bind,src=/host/path/to/job/artifacts1,target=/opt/flink/usrlib/artifacts1 \
+        --mount type=bind,src=/host/path/to/job/artifacts2,target=/opt/flink/usrlib/artifacts2 \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} taskmanager
+    ```
+
+* **or extend the Flink image** by writing a custom `Dockerfile`, build it and use it for starting the *Flink Master* and *TaskManagers*:
+
+    ```dockerfile
+    FROM flink
+    ADD /host/path/to/job/artifacts/1 /opt/flink/usrlib/artifacts/1
+    ADD /host/path/to/job/artifacts/2 /opt/flink/usrlib/artifacts/2
+    ```
+
+    ```sh
+    docker build -t flink_with_job_artifacts .
+    docker run \
+        flink_with_job_artifacts standalone-job \
+        --job-classname com.job.ClassName \
+        --job-id <job id> \
+        [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] \
+        [job arguments]
+
+    docker run flink_with_job_artifacts taskmanager
+    ```
+
+The `standalone-job` argument starts a *Flink Master* container in the *Job Cluster* mode.
+
+#### Flink Master additional command line arguments
+
+You can provide the following additional command line arguments to the cluster entrypoint:
+
+* `--job-classname <job class name>`: Class name of the job to run.
+
+  By default, Flink scans its class path for a JAR with a Main-Class or program-class manifest entry and chooses it as the job class.
+  Use this command line argument to manually set the job class.
+  This argument is required in case that no or more than one JAR with such a manifest entry is available on the class path.
+
+* `--job-id <job id>` (optional): Manually set a Flink job ID for the job (default: 00000000000000000000000000000000)
+
+* `--fromSavepoint /path/to/savepoint` (optional): Restore from a savepoint
+
+  In order to resume from a savepoint, you also need to pass the savepoint path.
+  Note that `/path/to/savepoint` needs to be accessible in all Docker containers of the cluster
+  (e.g., storing it on a DFS or from the mounted volume or adding it to the image).
+
+* `--allowNonRestoredState` (optional): Skip broken savepoint state
+
+  Additionally you can specify this argument to allow that savepoint state is skipped which cannot be restored.
+
+If the main function of the user job main class accepts arguments, you can also pass them at the end of the `docker run` command.
+
+## Customize Flink image
+
+When you run the Flink containers, there may be a need to customize them.
+The next chapters describe some how-tos of what you can usually customize.
+
+### Configure options
+
+When you run Flink image, you can also change its configuration options by setting the environment variable `FLINK_PROPERTIES`:
+
+```sh
+FLINK_PROPERTIES="jobmanager.rpc.address: host
+taskmanager.numberOfTaskSlots: 3
+blob.server.port: 6124
+"
+docker run --env FLINK_PROPERTIES=${FLINK_PROPERTIES} flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
+```
+
+The [`jobmanager.rpc.address`](../config.html#jobmanager-rpc-address) option must be configured, others are optional to set.
+
+The environment variable `FLINK_PROPERTIES` should contain a list of Flink cluster configuration options separated by new line,
+the same way as in the `flink-conf.yaml`.
+
+### Provide custom configuration
+
+The configuration files (`flink-conf.yaml`, logging, hosts etc) are located in the `/opt/flink/conf` directory in the Flink image.
+To provide a custom location for the Flink configuration files, you can
+
+* **either mount a volume** with the custom configuration files to this path `/opt/flink/conf` when you run the Flink image:
+
+    ```sh
+    docker run \
+        --mount type=bind,src=/host/path/to/custom/conf,target=/opt/flink/conf \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
+    ```
+
+* or add them to your **custom Flink image**, build and run it:
+
+    ```dockerfile
+    FROM flink
+    ADD /host/path/to/flink-conf.yaml /opt/flink/conf/flink-conf.yaml
+    ADD /host/path/to/log4j.properties /opt/flink/conf/log4j.properties
+    ```
+
+<span class="label label-warning">Warning!</span> The mounted volume must contain all necessary configuration files.
+The `flink-conf.yaml` file must have write permission so that the Docker entry point script can modify it in certain cases.
+
+### Using plugins
+
 As described in the [plugins]({{ site.baseurl }}/zh/ops/plugins.html) documentation page: in order to use plugins they must be
 copied to the correct location in the Flink installation for them to work.
 
-When running Flink from one of the provided Docker images by default no plugins have been activated.
-The simplest way to enable plugins is to modify the provided official Flink docker images by adding
-an additional layer. This does however assume you have a docker registry available where you can push images to and
-that is accessible by your cluster.
+If you want to enable plugins provided with Flink, you can pass the environment variable `ENABLE_BUILT_IN_PLUGINS`
+when you run the Flink image.
+The `ENABLE_BUILT_IN_PLUGINS` should contain a list of plugin jar file names separated by `;`.
 
-As an example assume you want to enable the [S3]({{ site.baseurl }}/zh/ops/filesystems/s3.html) plugins in your installation.
+    ```sh
+    docker run \
+        --env ENABLE_BUILT_IN_PLUGINS=flink-plugin1.jar;flink-plugin2.jar \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
+    ```
 
-Create a Dockerfile with a content something like this: {% highlight dockerfile %}
-# On which specific version of Flink is this based?
-# Check https://hub.docker.com/_/flink?tab=tags for current options
-FROM flink:{{ site.version }}-scala_2.12
+There are also more [advanced ways](#advanced-customization) for customizing the Flink image.
 
-# Install Flink S3 FS Presto plugin
-RUN mkdir /opt/flink/plugins/s3-fs-presto && cp /opt/flink/opt/flink-s3-fs-presto* /opt/flink/plugins/s3-fs-presto
+### Advanced customization
 
-# Install Flink S3 FS Hadoop plugin
-RUN mkdir /opt/flink/plugins/s3-fs-hadoop && cp /opt/flink/opt/flink-s3-fs-hadoop* /opt/flink/plugins/s3-fs-hadoop
-{% endhighlight %}
+There are several ways in which you can further customize the Flink image:
 
-Then build and push that image to your registry
-{% highlight bash %}
-docker build -t docker.example.nl/flink:{{ site.version }}-scala_2.12-s3 .
-docker push     docker.example.nl/flink:{{ site.version }}-scala_2.12-s3
-{% endhighlight %}
+* install custom software (e.g. python)
+* enable (symlink) optional libraries or plugins from `/opt/flink/opt` into `/opt/flink/lib` or `/opt/flink/plugins`
+* add other libraries to `/opt/flink/lib` (e.g. [hadoop](hadoop.html#adding-hadoop-to-lib))
+* add other plugins to `/opt/flink/plugins`
 
-Now you can reference this image in your cluster deployment and then these plugins are available for use.
+you can achieve this in several ways:
+
+* **override the container entry point** with a custom script where you can run any bootstrap actions.
+At the end you can call the standard `/docker-entrypoint.sh` script of the Flink image with the same arguments
+as described in [how to run the Flink image](#how-to-run-flink-image).
+
+  The following example creates a custom entry point script which enables more libraries and plugins.
+  The custom script, custom library and plugin are provided from a mounted volume.
+  Then it runs the standard entry point script of the Flink image:
+
+    ```sh
+    # create custom_lib.jar
+    # create custom_plugin.jar
+
+    echo "
+    ln -fs /opt/flink/opt/flink-queryable-state-runtime-*.jar /opt/flink/lib/.  # enable an optional library
+    ln -fs /mnt/custom_lib.jar /opt/flink/lib/.  # enable a custom library
+
+    mkdir -p /opt/flink/plugins/flink-s3-fs-hadoop
+    ln -fs /opt/flink/opt/flink-s3-fs-hadoop-*.jar /opt/flink/plugins/flink-s3-fs-hadoop/.  # enable an optional plugin
+
+    mkdir -p /opt/flink/plugins/custom_plugin
+    ln -fs /mnt/custom_plugin.jar /opt/flink/plugins/custom_plugin/.  # enable a custom plugin
+
+    /docker-entrypoint.sh <jobmanager|standalone-job|taskmanager>
+    " > custom_entry_point_script.sh
+
+    chmod 755 custom_entry_point_script.sh
+
+    docker run \
+        --mount type=bind,src=$(pwd),target=/mnt
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} /mnt/custom_entry_point_script.sh
+    ```
+
+* **extend the Flink image** by writing a custom `Dockerfile` and build a custom image:
+
+    ```dockerfile
+    FROM flink
+
+    RUN set -ex; apt-get update; apt-get -y install python
+
+    ADD /host/path/to/flink-conf.yaml /container/local/path/to/custom/conf/flink-conf.yaml
+    ADD /host/path/to/log4j.properties /container/local/path/to/custom/conf/log4j.properties
+
+    RUN ln -fs /opt/flink/opt/flink-queryable-state-runtime-*.jar /opt/flink/lib/.
+
+    RUN mkdir -p /opt/flink/plugins/flink-s3-fs-hadoop
+    RUN ln -fs /opt/flink/opt/flink-s3-fs-hadoop-*.jar /opt/flink/plugins/flink-s3-fs-hadoop/.
+
+    ENV VAR_NAME value
+    ```
+
+    ```sh
+    docker build -t custom_flink_image .
+    # optional push to your docker image registry if you have it,
+    # e.g. to distribute the custom image to your cluster
+    docker push custom_flink_image
+    ```
+
+{% top %}
 
 ## Flink with Docker Compose
 
-[Docker Compose](https://docs.docker.com/compose/) is a convenient way to run a
-group of Docker containers locally.
-
-Example config files for a [session cluster](https://github.com/docker-flink/examples/blob/master/docker-compose.yml) and a [job cluster](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/docker-compose.yml)
-are available on GitHub.
+[Docker Compose](https://docs.docker.com/compose/) is a way to run a group of Docker containers locally.
+The next chapters show examples of configuration files to run Flink.
 
 ### Usage
 
+* Create the `yaml` files with the container configuration, check examples for:
+    * [Session cluster](#session-cluster-with-docker-compose)
+    * [Job cluster](#job-cluster-with-docker-compose)
+
+    See also [the Flink Docker image tags](#image-tags) and [how to customize the Flink Docker image](#advanced-customization)
+    for usage in the configuration files.
+
 * Launch a cluster in the foreground
 
-        docker-compose up
+    ```sh
+    docker-compose up
+    ```
 
 * Launch a cluster in the background
 
-        docker-compose up -d
+    ```sh
+    docker-compose up -d
+    ```
 
-* Scale the cluster up or down to *N* TaskManagers
+* Scale the cluster up or down to *N TaskManagers*
 
-        docker-compose scale taskmanager=<N>
+    ```sh
+    docker-compose scale taskmanager=<N>
+    ```
+
+* Access the *Flink Master* container
+
+    ```sh
+    docker exec -it $(docker ps --filter name=jobmanager --format={{.ID}}) /bin/sh
+    ```
 
 * Kill the cluster
 
-        docker-compose kill
+    ```sh
+    docker-compose kill
+    ```
 
-When the cluster is running, you can visit the web UI at [http://localhost:8081](http://localhost:8081). 
-You can also use the web UI to submit a job to a session cluster.
+* Access Web UI
 
-To submit a job to a session cluster via the command line, you must copy the JAR to the JobManager
-container and submit the job from there.
+    When the cluster is running, you can visit the web UI at [http://localhost:8081](http://localhost:8081).
+    You can also use the web UI to submit a job to a *Session cluster*.
 
-For example:
+* To submit a job to a *Session cluster* via the command line, you can either
 
-{% raw %}
-    $ JOBMANAGER_CONTAINER=$(docker ps --filter name=jobmanager --format={{.ID}})
-    $ docker cp path/to/jar "$JOBMANAGER_CONTAINER":/job.jar
-    $ docker exec -t -i "$JOBMANAGER_CONTAINER" flink run /job.jar
-{% endraw %}
+  * use [Flink CLI](..//cli.html) on the host if it is installed:
+
+    ```sh
+    flink run -d -c ${JOB_CLASS_NAME} /job.jar
+    ```
+
+  * or copy the JAR to the *Flink Master* container and submit the job using the [CLI](..//cli.html) from there, for example:
+
+    ```sh
+    JOB_CLASS_NAME="com.job.ClassName"
+    MASTER_CONTAINER=$(docker ps --filter name=jobmanager --format={{.ID}})
+    docker cp path/to/jar "${MASTER_CONTAINER}":/job.jar
+    docker exec -t -i "${MASTER_CONTAINER}" flink run -d -c ${JOB_CLASS_NAME} /job.jar
+    ```
+
+### Session Cluster with Docker Compose
+
+```yaml
+version: "2.2"
+services:
+  jobmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    ports:
+      - "8081:8081"
+    command: jobmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+
+  taskmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    depends_on:
+      - jobmanager
+    command: taskmanager
+    scale: 1
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 2
+```
+
+### Job Cluster with Docker Compose
+
+The artifacts must be available in the Flink containers, check details [here](#start-a-job-cluster).
+See also [how to specify the Flink Master arguments](#flink-master-additional-command-line-arguments)
+in the `command` for the `jobmanager` service.
+
+```yaml
+version: "2.2"
+services:
+  jobmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    ports:
+      - "8081:8081"
+    command: standalone-job --job-classname com.job.ClassName [--job-id <job id>] [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] [job arguments]
+    volumes:
+      - /host/path/to/job/artifacts:/opt/flink/usrlib
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        parallelism.default: 2
+
+  taskmanager:
+    image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+    depends_on:
+      - jobmanager
+    command: taskmanager
+    scale: 1
+    volumes:
+      - /host/path/to/job/artifacts:/opt/flink/usrlib
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 2
+        parallelism.default: 2
+```
+
+{% top %}
+
+## Flink with Docker Swarm
+
+The [Docker swarm](https://docs.docker.com/engine/swarm) is a container orchestration tool, that
+allows you to manage multiple containers deployed across multiple host machines.
+
+The following chapters contain examples of how to configure and start *Flink Master* and *TaskManager* containers.
+You can adjust them accordingly to start a cluster.
+See also [the Flink Docker image tags](#image-tags) and [how to customize the Flink Docker image](#advanced-customization) for usage in the provided scripts.
+
+The port `8081` is exposed for the Flink Web UI access.
+If you run the swarm locally, you can visit the web UI at [http://localhost:8081](http://localhost:8081) after starting the cluster.
+
+### Session Cluster with Docker Swarm
+
+```sh
+FLINK_PROPERTIES="jobmanager.rpc.address: flink-session-jobmanager
+taskmanager.numberOfTaskSlots: 2
+"
+
+# Create overlay network
+docker network create -d overlay flink-session
+
+# Create the Flink Master service
+docker service create \
+  --name flink-session-jobmanager \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  -p 8081:8081 \
+  --network flink-session \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    jobmanager
+
+# Create the TaskManager service (scale this out as needed)
+docker service create \
+  --name flink-session-taskmanager \
+  --replicas 2 \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  --network flink-session \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    taskmanager
+```
+
+### Job Cluster with Docker Swarm
+
+```sh
+FLINK_PROPERTIES="jobmanager.rpc.address: flink-master
+taskmanager.numberOfTaskSlots: 2
+"
+
+# Create overlay network
+docker network create -d overlay flink-job
+
+# Create the Flink Master service
+docker service create \
+  --name flink-master \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  --mount type=bind,source=/host/path/to/job/artifacts,target=/opt/flink/usrlib \
+  -p 8081:8081 \
+  --network flink-job \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    standalone-job \
+    --job-classname com.job.ClassName \
+    [--job-id <job id>] \
+    [--fromSavepoint /path/to/savepoint [--allowNonRestoredState]] \
+    [job arguments]
+
+# Create the TaskManager service (scale this out as needed)
+docker service create \
+  --name flink-job-taskmanager \
+  --replicas 2 \
+  --env FLINK_PROPERTIES="${FLINK_PROPERTIES}" \
+  --mount type=bind,source=/host/path/to/job/artifacts,target=/opt/flink/usrlib \
+  --network flink-job \
+  flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} \
+    taskmanager
+```
+
+The *job artifacts* must be available in the *Flink Master* container, as outlined [here](#start-a-job-cluster).
+See also [how to specify the Flink Master arguments](#flink-master-additional-command-line-arguments) to pass them
+to the `flink-master` container.
+
+The example assumes that you run the swarm locally and expects the *job artifacts* to be in `/host/path/to/job/artifacts`.
+It also mounts the host path with the artifacts as a volume to the container's path `/opt/flink/usrlib`.
 
 {% top %}

--- a/docs/ops/deployment/kubernetes.zh.md
+++ b/docs/ops/deployment/kubernetes.zh.md
@@ -23,12 +23,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This page describes how to deploy a Flink job and session cluster on [Kubernetes](https://kubernetes.io).
+This page describes how to deploy a *Flink Job* and *Session cluster* on [Kubernetes](https://kubernetes.io).
 
 * This will be replaced by the TOC
 {:toc}
 
-{% info %} This page describes deploying a [standalone](#cluster_setup.html) Flink session on top of Kubernetes. For information on native Kubernetes deployments read [here]({{ site.baseurl }}/zh/ops/deployment/native_kubernetes.html).
+{% info %} This page describes deploying a [standalone](#cluster_setup.html) Flink cluster on top of Kubernetes.
+You can find more information on native Kubernetes deployments [here]({{ site.baseurl }}/zh/ops/deployment/native_kubernetes.html).
 
 ## Setup Kubernetes
 
@@ -40,34 +41,31 @@ If you want to run Kubernetes locally, we recommend using [MiniKube](https://kub
   Otherwise Flink components are not able to self reference themselves through a Kubernetes service.
 </div>
 
-## Flink session cluster on Kubernetes
+## Flink Docker image
 
-A Flink session cluster is executed as a long-running Kubernetes Deployment.
-Note that you can run multiple Flink jobs on a session cluster.
-Each job needs to be submitted to the cluster after the cluster has been deployed.
+Before deploying the Flink Kubernetes components, please read [the Flink Docker image documentation](docker.html),
+[its tags](docker.html#image-tags), [how to customize the Flink Docker image](docker.html#customize-flink-image) and
+[enable plugins](docker.html#using-plugins) to use the image in the Kubernetes definition files.
 
-A basic Flink session cluster deployment in Kubernetes has three components:
+## Deploy Flink cluster on Kubernetes
 
-* a Deployment/Job which runs the JobManager
-* a Deployment for a pool of TaskManagers
-* a Service exposing the JobManager's REST and UI ports
+Using [the common resource definitions](#common-cluster-resource-definitions), launch the common cluster components
+with the `kubectl` command:
 
-### Deploy Flink session cluster on Kubernetes
-
-Using the resource definitions for a [session cluster](#session-cluster-resource-definitions), launch the cluster with the `kubectl` command:
-
+```sh
     kubectl create -f flink-configuration-configmap.yaml
     kubectl create -f jobmanager-service.yaml
-    kubectl create -f jobmanager-deployment.yaml
-    kubectl create -f taskmanager-deployment.yaml
+```
 
 Note that you could define your own customized options of `flink-conf.yaml` within `flink-configuration-configmap.yaml`.
+
+Then launch the specific components depending on whether you want to deploy a [Session](#deploy-session-cluster) or [Job](#deploy-job-cluster) cluster.
 
 You can then access the Flink UI via different ways:
 *  `kubectl proxy`:
 
     1. Run `kubectl proxy` in a terminal.
-    2. Navigate to [http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy](http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy) in your browser.
+    2. Navigate to [http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:webui/proxy](http://localhost:8001/api/v1/namespaces/default/services/flink-jobmanager:webui/proxy) in your browser.
 
 *  `kubectl port-forward`:
     1. Run `kubectl port-forward ${flink-jobmanager-pod} 8081:8081` to forward your jobmanager's web ui port to local 8081.
@@ -76,57 +74,91 @@ You can then access the Flink UI via different ways:
     {% highlight bash %}./bin/flink run -m localhost:8081 ./examples/streaming/WordCount.jar{% endhighlight %}
 
 *  Create a `NodePort` service on the rest service of jobmanager:
-    1. Run `kubectl create -f jobmanager-rest-service.yaml` to create the `NodePort` service on jobmanager. The example of `jobmanager-rest-service.yaml` can be found in [appendix](#session-cluster-resource-definitions).
+    1. Run `kubectl create -f jobmanager-rest-service.yaml` to create the `NodePort` service on jobmanager. The example of `jobmanager-rest-service.yaml` can be found in [appendix](#common-cluster-resource-definitions).
     2. Run `kubectl get svc flink-jobmanager-rest` to know the `node-port` of this service and navigate to [http://&lt;public-node-ip&gt;:&lt;node-port&gt;](http://<public-node-ip>:<node-port>) in your browser.
-    3. Similarly to `port-forward` solution, you could also use the following command below to submit jobs to the cluster:
+    3. If you use minikube, you can get its public ip by running `minikube ip`.
+    4. Similarly to the `port-forward` solution, you could also use the following command below to submit jobs to the cluster:
 
         {% highlight bash %}./bin/flink run -m <public-node-ip>:<node-port> ./examples/streaming/WordCount.jar{% endhighlight %}
 
-In order to terminate the Flink session cluster, use `kubectl`:
+In order to terminate the Flink cluster, delete the specific [Session](#deploy-session-cluster) or [Job](#deploy-job-cluster) cluster components
+and use `kubectl` to terminate the common components:
 
-    kubectl delete -f jobmanager-deployment.yaml
-    kubectl delete -f taskmanager-deployment.yaml
+```sh
     kubectl delete -f jobmanager-service.yaml
     kubectl delete -f flink-configuration-configmap.yaml
+    # if created then also the rest service
+    kubectl delete -f jobmanager-rest-service.yaml
+```
 
-## Flink job cluster on Kubernetes
+### Deploy Session Cluster
 
-A Flink job cluster is a dedicated cluster which runs a single job.
-The job is part of the image and, thus, there is no extra job submission needed.
+A *Flink Session cluster* is executed as a long-running Kubernetes Deployment.
+Note that you can run multiple Flink jobs on a *Session cluster*.
+Each job needs to be submitted to the cluster after the cluster has been deployed.
 
-### Creating the job-specific image
+A *Flink Session cluster* deployment in Kubernetes has at least three components:
 
-The Flink job cluster image needs to contain the user code jars of the job for which the cluster is started.
-Therefore, one needs to build a dedicated container image for every job.
-Please follow these [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/README.md) to build the Docker image.
+* a *Deployment* which runs a [Flink Master]({{ site.baseurl }}/concepts/glossary.html#flink-master)
+* a *Deployment* for a pool of [TaskManagers]({{ site.baseurl }}/concepts/glossary.html#flink-taskmanager)
+* a *Service* exposing the *Flink Master's* REST and UI ports
 
-### Using plugins
+After creating [the common cluster components](#deploy-flink-cluster-on-kubernetes), use [the Session specific resource definitions](#session-cluster-resource-definitions)
+to launch the *Session cluster* with the `kubectl` command:
 
-As described in the [plugins]({{ site.baseurl }}/zh/ops/plugins.html) documentation page: in order to use plugins they must be
-copied to the correct location in the flink installation for them to work.
+```sh
+    kubectl create -f jobmanager-session-deployment.yaml
+    kubectl create -f taskmanager-session-deployment.yaml
+```
 
-The simplest way to enable plugins for use on Kubernetes is to modify the provided Flink docker image by adding
-an additional layer. This does however assume you have a docker registry available where you can push images to and
-that is accessible by your Kubernetes cluster.
+To terminate the *Session cluster*, these components can be deleted along with [the common ones](#deploy-flink-cluster-on-kubernetes) with the `kubectl` command:
 
-How this can be done is described on the [Docker Setup]({{ site.baseurl }}/zh/ops/deployment/docker.html#using-plugins) page.
+```sh
+    kubectl delete -f taskmanager-session-deployment.yaml
+    kubectl delete -f jobmanager-session-deployment.yaml
+```
 
-With such an image created you can now start your Kubernetes based Flink cluster which can use the enabled plugins.
+### Deploy Job Cluster
 
-### Deploy Flink job cluster on Kubernetes
+A *Flink Job cluster* is a dedicated cluster which runs a single job.
+You can find more details [here](#start-a-job-cluster).
 
-In order to deploy the a job cluster on Kubernetes please follow these [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/kubernetes/README.md#deploy-flink-job-cluster).
+A basic *Flink Job cluster* deployment in Kubernetes has three components:
 
-## Advanced Cluster Deployment
+* a *Job* which runs a *Flink Master*
+* a *Deployment* for a pool of *TaskManagers*
+* a *Service* exposing the *Flink Master's* REST and UI ports
 
-An early version of a [Flink Helm chart](https://github.com/docker-flink/examples) is available on GitHub.
+Check [the Job cluster specific resource definitions](#job-cluster-resource-definitions) and adjust them accordingly.
+
+The `args` attribute in the `jobmanager-job.yaml` has to specify the main class of the user job.
+See also [how to specify the Flink Master arguments](docker.html#flink-master-additional-command-line-arguments) to understand
+how to pass other `args` to the Flink image in the `jobmanager-job.yaml`.
+
+The *job artifacts* should be available from the `job-artifacts-volume` in [the resource definition examples](#job-cluster-resource-definitions).
+The definition examples mount the volume as a local directory of the host assuming that you create the components in a minikube cluster.
+If you do not use a minikube cluster, you can use any other type of volume, available in your Kubernetes cluster, to supply the *job artifacts*.
+Alternatively, you can build [a custom image](docker.html#start-a-job-cluster) which already contains the artifacts instead.
+
+After creating [the common cluster components](#deploy-flink-cluster-on-kubernetes), use [the Job cluster specific resource definitions](#job-cluster-resource-definitions)
+to launch the cluster with the `kubectl` command:
+
+```sh
+    kubectl create -f jobmanager-job.yaml
+    kubectl create -f taskmanager-job-deployment.yaml
+```
+
+To terminate the single job cluster, these components can be deleted along with [the common ones](#deploy-flink-cluster-on-kubernetes)
+with the `kubectl` command:
+
+```sh
+    kubectl delete -f taskmanager-job-deployment.yaml
+    kubectl delete -f jobmanager-job.yaml
+```
 
 ## Appendix
 
-### Session cluster resource definitions
-
-The Deployment definitions use the pre-built image `flink:latest` which can be found [on Docker Hub](https://hub.docker.com/r/_/flink/).
-The image is built from this [Github repository](https://github.com/docker-flink/docker-flink).
+### Common cluster resource definitions
 
 `flink-configuration-configmap.yaml`
 {% highlight yaml %}
@@ -139,12 +171,14 @@ metadata:
 data:
   flink-conf.yaml: |+
     jobmanager.rpc.address: flink-jobmanager
-    taskmanager.numberOfTaskSlots: 1
+    taskmanager.numberOfTaskSlots: 2
     blob.server.port: 6124
     jobmanager.rpc.port: 6123
     taskmanager.rpc.port: 6122
-    jobmanager.memory.process.size: 1472m
-    taskmanager.memory.process.size: 1024m
+    queryable-state.server.ports: 6125
+    jobmanager.memory.process.size: 1600m
+    taskmanager.memory.process.size: 1728m
+    parallelism.default: 2
   log4j.properties: |+
     rootLogger.level = INFO
     rootLogger.appenderRef.file.ref = MainAppender
@@ -166,7 +200,49 @@ data:
     logger.netty.level = ERROR
 {% endhighlight %}
 
-`jobmanager-deployment.yaml`
+`jobmanager-service.yaml`
+{% highlight yaml %}
+apiVersion: v1
+kind: Service
+metadata:
+  name: flink-jobmanager
+spec:
+  type: ClusterIP
+  ports:
+  - name: rpc
+    port: 6123
+  - name: blob-server
+    port: 6124
+  - name: query-state
+    port: 6125
+  - name: webui
+    port: 8081
+  selector:
+    app: flink
+    component: jobmanager
+{% endhighlight %}
+
+`jobmanager-rest-service.yaml`. Optional service, that exposes the jobmanager `rest` port as public Kubernetes node's port.
+{% highlight yaml %}
+apiVersion: v1
+kind: Service
+metadata:
+  name: flink-jobmanager-rest
+spec:
+  type: NodePort
+  ports:
+  - name: rest
+    port: 8081
+    targetPort: 8081
+    nodePort: 8081
+  selector:
+    app: flink
+    component: jobmanager
+{% endhighlight %}
+
+### Session cluster resource definitions
+
+`jobmanager-session-deployment.yaml`
 {% highlight yaml %}
 apiVersion: apps/v1
 kind: Deployment
@@ -186,22 +262,17 @@ spec:
     spec:
       containers:
       - name: jobmanager
-        image: flink:latest
-        workingDir: /opt/flink
-        command: ["/bin/bash", "-c", "$FLINK_HOME/bin/jobmanager.sh start;\
-          while :;
-          do
-            if [[ -f $(find log -name '*jobmanager*.log' -print -quit) ]];
-              then tail -f -n +1 log/*jobmanager*.log;
-            fi;
-          done"]
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        args: ["jobmanager"]
         ports:
         - containerPort: 6123
           name: rpc
         - containerPort: 6124
-          name: blob
+          name: blob-server
+        - containerPort: 6125
+          name: query-state
         - containerPort: 8081
-          name: ui
+          name: webui
         livenessProbe:
           tcpSocket:
             port: 6123
@@ -223,7 +294,7 @@ spec:
             path: log4j.properties
 {% endhighlight %}
 
-`taskmanager-deployment.yaml`
+`taskmanager-session-deployment.yaml`
 {% highlight yaml %}
 apiVersion: apps/v1
 kind: Deployment
@@ -243,15 +314,8 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:latest
-        workingDir: /opt/flink
-        command: ["/bin/bash", "-c", "$FLINK_HOME/bin/taskmanager.sh start; \
-          while :;
-          do
-            if [[ -f $(find log -name '*taskmanager*.log' -print -quit) ]];
-              then tail -f -n +1 log/*taskmanager*.log;
-            fi;
-          done"]
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        args: ["taskmanager"]
         ports:
         - containerPort: 6122
           name: rpc
@@ -274,44 +338,119 @@ spec:
             path: flink-conf.yaml
           - key: log4j.properties
             path: log4j.properties
-
 {% endhighlight %}
 
-`jobmanager-service.yaml`
+### Job cluster resource definitions
+
+`jobmanager-job.yaml`
 {% highlight yaml %}
-apiVersion: v1
-kind: Service
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: flink-jobmanager
 spec:
-  type: ClusterIP
-  ports:
-  - name: rpc
-    port: 6123
-  - name: blob
-    port: 6124
-  - name: ui
-    port: 8081
+  replicas: 1
   selector:
-    app: flink
-    component: jobmanager
+    matchLabels:
+      app: flink
+      component: jobmanager
+  template:
+    metadata:
+      labels:
+        app: flink
+        component: jobmanager
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: jobmanager
+          image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+          env:
+          args: ["standalone-job", "--job-classname", "com.job.ClassName", ["--job-id", "<job id>",] ["--fromSavepoint", "/path/to/savepoint", ["--allowNonRestoredState",]] [job arguments]]
+          ports:
+            - containerPort: 6123
+              name: rpc
+            - containerPort: 6124
+              name: blob-server
+            - containerPort: 6125
+              name: query-state
+            - containerPort: 8081
+              name: webui
+          livenessProbe:
+            tcpSocket:
+              port: 6123
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          volumeMounts:
+            - name: flink-config-volume
+              mountPath: /opt/flink/conf
+            - name: job-artifacts-volume
+              mountPath: /opt/flink/usrlib
+          securityContext:
+            runAsUser: 9999  # refers to user _flink_ from official flink image, change if necessary
+      volumes:
+        - name: flink-config-volume
+          configMap:
+            name: flink-config
+            items:
+              - key: flink-conf.yaml
+                path: flink-conf.yaml
+              - key: log4j.properties
+                path: log4j.properties
+        - name: job-artifacts-volume
+          hostPath:
+            path: /host/path/to/job/artifacts
 {% endhighlight %}
 
-`jobmanager-rest-service.yaml`. Optional service, that exposes the jobmanager `rest` port as public Kubernetes node's port.
+`taskmanager-job-deployment.yaml`
 {% highlight yaml %}
-apiVersion: v1
-kind: Service
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: flink-jobmanager-rest
+  name: flink-taskmanager
 spec:
-  type: NodePort
-  ports:
-  - name: rest
-    port: 8081
-    targetPort: 8081
+  replicas: 2
   selector:
-    app: flink
-    component: jobmanager
+    matchLabels:
+      app: flink
+      component: taskmanager
+  template:
+    metadata:
+      labels:
+        app: flink
+        component: taskmanager
+    spec:
+      containers:
+      - name: taskmanager
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        env:
+        args: ["taskmanager"]
+        ports:
+        - containerPort: 6122
+          name: rpc
+        livenessProbe:
+          tcpSocket:
+            port: 6122
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        volumeMounts:
+        - name: flink-config-volume
+          mountPath: /opt/flink/conf/
+        - name: job-artifacts-volume
+          mountPath: /opt/flink/usrlib
+        securityContext:
+          runAsUser: 9999  # refers to user _flink_ from official flink image, change if necessary
+      volumes:
+      - name: flink-config-volume
+        configMap:
+          name: flink-config
+          items:
+          - key: flink-conf.yaml
+            path: flink-conf.yaml
+          - key: log4j.properties
+            path: log4j.properties
+      - name: job-artifacts-volume
+        hostPath:
+          path: /host/path/to/job/artifacts
 {% endhighlight %}
 
 {% top %}

--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -74,7 +74,23 @@ faster and during development you have more time to inspect the logfiles of your
 The system will use the configuration in `conf/flink-conf.yaml`.
 Please follow our [configuration guide]({{ site.baseurl }}/ops/config.html) if you want to change something.
 
-If you do not specify a particular name for your session by `kubernetes.cluster-id`, the Flink client will generate a UUID name. 
+If you do not specify a particular name for your session by `kubernetes.cluster-id`, the Flink client will generate a UUID name.
+
+### Custom Flink Docker image
+
+If you want to use a custom Docker image to deploy Flink containers, check [the Flink Docker image documentation](docker.html),
+[its tags](#image-tags), [how to customize the Flink Docker image](docker.html#customize-flink-image) and [enable plugins](docker.html#using-plugins).
+If you created a custom Docker image you can provide it by setting the [`kubernetes.container.image`](../config.html#kubernetes-container-image) configuration option:
+
+{% highlight bash %}
+./bin/kubernetes-session.sh \
+  -Dkubernetes.cluster-id=<ClusterId> \
+  -Dtaskmanager.memory.process.size=4096m \
+  -Dkubernetes.taskmanager.cpu=2 \
+  -Dtaskmanager.numberOfTaskSlots=4 \
+  -Dresourcemanager.taskmanager-timeout=3600000 \
+  -Dkubernetes.container.image=<custom_image_name>
+{% endhighlight %}
 
 ### Submitting jobs to an existing Session
 
@@ -95,14 +111,14 @@ You can then use `localhost:8081` to submit a Flink job to the session or view t
 
 {% highlight bash %}
 $ kubectl port-forward service/<ServiceName> 8081
-{% endhighlight %} 
+{% endhighlight %}
 
 - `NodePort`: Exposes the service on each Node’s IP at a static port (the `NodePort`). `<NodeIP>:<NodePort>` could be used to contact the Job Manager Service. `NodeIP` could be easily replaced with Kubernetes ApiServer address.
 You could find it in your kube config file.
 
 - `LoadBalancer`: Default value, exposes the service externally using a cloud provider’s load balancer.
 Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.
-You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`. 
+You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`.
 
 - `ExternalName`: Map a service to a DNS name, not supported in current version.
 
@@ -127,8 +143,8 @@ $ echo 'stop' | ./bin/kubernetes-session.sh -Dkubernetes.cluster-id=<ClusterId> 
 #### Manual Resource Cleanup
 
 Flink uses [Kubernetes OwnerReference's](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) to cleanup all cluster components.
-All the Flink created resources, including `ConfigMap`, `Service`, `Pod`, have been set the OwnerReference to `deployment/<ClusterId>`. 
-When the deployment is deleted, all other resources will be deleted automatically. 
+All the Flink created resources, including `ConfigMap`, `Service`, `Pod`, have been set the OwnerReference to `deployment/<ClusterId>`.
+When the deployment is deleted, all other resources will be deleted automatically.
 
 {% highlight bash %}
 $ kubectl delete deployment/<ClusterID>
@@ -136,7 +152,7 @@ $ kubectl delete deployment/<ClusterID>
 
 ## Log Files
 
-By default, the JobManager and TaskManager only store logs under `/opt/flink/log` in each pod. 
+By default, the JobManager and TaskManager only store logs under `/opt/flink/log` in each pod.
 If you want to use `kubectl logs <PodName>` to view the logs, you must perform the following:
 
 1. Add a new appender to the log4j.properties in the Flink client.
@@ -152,33 +168,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 {% endhighlight %}
 
-If the pod is running, you can use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process. 
-
-## Using plugins
-
-As described in the [plugins]({{ site.baseurl }}/ops/plugins.html) documentation page: in order to use plugins they must be
-copied to the correct location in the flink installation for them to work.
-
-The simplest way to enable plugins for use on Kubernetes is to modify the provided official Flink docker images by adding
-an additional layer. This does however assume you have a docker registry available where you can push images to and
-that is accessible by your Kubernetes cluster.
-
-How this can be done is described on the [Docker Setup]({{ site.baseurl }}/ops/deployment/docker.html#using-plugins) page.
-
-With such an image created you can now start your Kubernetes based Flink session cluster with the additional parameter
-`kubernetes.container.image` which must specify the image that was created: `docker.example.nl/flink:{{ site.version }}-2.12-s3`
-
-Extending the above example command to start the session cluster makes it this:
-
-{% highlight bash %}
-./bin/kubernetes-session.sh \
-  -Dkubernetes.cluster-id=<ClusterId> \
-  -Dtaskmanager.memory.process.size=4096m \
-  -Dkubernetes.taskmanager.cpu=2 \
-  -Dtaskmanager.numberOfTaskSlots=4 \
-  -Dresourcemanager.taskmanager-timeout=3600000 \
-  -Dkubernetes.container.image=docker.example.nl/flink:{{ site.version }}-2.12-s3
-{% endhighlight %}
+If the pod is running, you can use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process.
 
 ## Kubernetes concepts
 

--- a/docs/ops/deployment/native_kubernetes.zh.md
+++ b/docs/ops/deployment/native_kubernetes.zh.md
@@ -74,7 +74,23 @@ faster and during development you have more time to inspect the logfiles of your
 The system will use the configuration in `conf/flink-conf.yaml`.
 Please follow our [configuration guide]({{ site.baseurl }}/zh/ops/config.html) if you want to change something.
 
-If you do not specify a particular name for your session by `kubernetes.cluster-id`, the Flink client will generate a UUID name. 
+If you do not specify a particular name for your session by `kubernetes.cluster-id`, the Flink client will generate a UUID name.
+
+### Custom Flink Docker image
+
+If you want to use a custom Docker image to deploy Flink containers, check [the Flink Docker image documentation](docker.html),
+[its tags](#image-tags), [how to customize the Flink Docker image](docker.html#customize-flink-image) and [enable plugins](docker.html#using-plugins).
+If you created a custom Docker image you can provide it by setting the [`kubernetes.container.image`](../config.html#kubernetes-container-image) configuration option:
+
+{% highlight bash %}
+./bin/kubernetes-session.sh \
+  -Dkubernetes.cluster-id=<ClusterId> \
+  -Dtaskmanager.memory.process.size=4096m \
+  -Dkubernetes.taskmanager.cpu=2 \
+  -Dtaskmanager.numberOfTaskSlots=4 \
+  -Dresourcemanager.taskmanager-timeout=3600000 \
+  -Dkubernetes.container.image=<custom_image_name>
+{% endhighlight %}
 
 ### Submitting jobs to an existing Session
 
@@ -95,14 +111,14 @@ You can then use `localhost:8081` to submit a Flink job to the session or view t
 
 {% highlight bash %}
 $ kubectl port-forward service/<ServiceName> 8081
-{% endhighlight %} 
+{% endhighlight %}
 
 - `NodePort`: Exposes the service on each Node’s IP at a static port (the `NodePort`). `<NodeIP>:<NodePort>` could be used to contact the Job Manager Service. `NodeIP` could be easily replaced with Kubernetes ApiServer address.
 You could find it in your kube config file.
 
 - `LoadBalancer`: Default value, exposes the service externally using a cloud provider’s load balancer.
 Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.
-You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`. 
+You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`.
 
 - `ExternalName`: Map a service to a DNS name, not supported in current version.
 
@@ -127,8 +143,8 @@ $ echo 'stop' | ./bin/kubernetes-session.sh -Dkubernetes.cluster-id=<ClusterId> 
 #### Manual Resource Cleanup
 
 Flink uses [Kubernetes OwnerReference's](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) to cleanup all cluster components.
-All the Flink created resources, including `ConfigMap`, `Service`, `Pod`, have been set the OwnerReference to `deployment/<ClusterId>`. 
-When the deployment is deleted, all other resources will be deleted automatically. 
+All the Flink created resources, including `ConfigMap`, `Service`, `Pod`, have been set the OwnerReference to `deployment/<ClusterId>`.
+When the deployment is deleted, all other resources will be deleted automatically.
 
 {% highlight bash %}
 $ kubectl delete deployment/<ClusterID>
@@ -136,7 +152,7 @@ $ kubectl delete deployment/<ClusterID>
 
 ## Log Files
 
-By default, the JobManager and TaskManager only store logs under `/opt/flink/log` in each pod. 
+By default, the JobManager and TaskManager only store logs under `/opt/flink/log` in each pod.
 If you want to use `kubectl logs <PodName>` to view the logs, you must perform the following:
 
 1. Add a new appender to the log4j.properties in the Flink client.
@@ -152,33 +168,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 {% endhighlight %}
 
-If the pod is running, you can use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process. 
-
-## Using plugins
-
-As described in the [plugins]({{ site.baseurl }}/zh/ops/plugins.html) documentation page: in order to use plugins they must be
-copied to the correct location in the flink installation for them to work.
-
-The simplest way to enable plugins for use on Kubernetes is to modify the provided official Flink docker images by adding
-an additional layer. This does however assume you have a docker registry available where you can push images to and
-that is accessible by your Kubernetes cluster.
-
-How this can be done is described on the [Docker Setup]({{ site.baseurl }}/zh/ops/deployment/docker.html#using-plugins) page.
-
-With such an image created you can now start your Kubernetes based Flink session cluster with the additional parameter
-`kubernetes.container.image` which must specify the image that was created: `docker.example.nl/flink:{{ site.version }}-2.12-s3`
-
-Extending the above example command to start the session cluster makes it this:
-
-{% highlight bash %}
-./bin/kubernetes-session.sh \
-  -Dkubernetes.cluster-id=<ClusterId> \
-  -Dtaskmanager.memory.process.size=4096m \
-  -Dkubernetes.taskmanager.cpu=2 \
-  -Dtaskmanager.numberOfTaskSlots=4 \
-  -Dresourcemanager.taskmanager-timeout=3600000 \
-  -Dkubernetes.container.image=docker.example.nl/flink:{{ site.version }}-2.12-s3
-{% endhighlight %}
+If the pod is running, you can use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process.
 
 ## Kubernetes concepts
 


### PR DESCRIPTION
## What is the purpose of the change

This PR refactors the documentation about the docker usage with Flink.
It mostly relies on [the official docker image](https://github.com/apache/flink-docker)
The new docker documentation focuses on how to use the official docker image and 
extend it to run in different modes to deploy a session or job cluster in various container environments  (plain docker, docker compose, docker swarm and kubernetes).

## Verifying this change

```sh
cd docs/docker
./run.sh
./build_docs.sh -i
```
