### PR TITLE
[FLINK-17578][flink-streaming] Union of 2 SideOutputs behaviour incorrect

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.OutputTag;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -137,12 +138,7 @@ public class StreamEdge implements Serializable {
 
 	@Override
 	public int hashCode() {
-		int result = 17;
-		result = 31 * result + edgeId.hashCode();
-		if (outputTag != null) {
-			result = 31 * result + outputTag.hashCode();
-		}
-		return result;
+		return Objects.hash(edgeId, outputTag);
 	}
 
 	@Override
@@ -155,9 +151,8 @@ public class StreamEdge implements Serializable {
 		}
 
 		StreamEdge that = (StreamEdge) o;
-		return edgeId != null && edgeId.equals(that.edgeId) &&
-			((outputTag == null && that.outputTag == null) ||
-				(outputTag != null && that.outputTag != null && outputTag.equals(that.outputTag)));
+		return Objects.equals(edgeId, that.edgeId) &&
+			Objects.equals(outputTag, that.outputTag);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -137,7 +137,12 @@ public class StreamEdge implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return edgeId.hashCode();
+		int result = 17;
+		result = 31 * result + edgeId.hashCode();
+		if (outputTag != null) {
+			result = 31 * result + outputTag.hashCode();
+		}
+		return result;
 	}
 
 	@Override
@@ -150,8 +155,9 @@ public class StreamEdge implements Serializable {
 		}
 
 		StreamEdge that = (StreamEdge) o;
-
-		return edgeId.equals(that.edgeId);
+		return edgeId != null && edgeId.equals(that.edgeId) &&
+			((outputTag == null && that.outputTag == null) ||
+				(outputTag != null && that.outputTag != null && outputTag.equals(that.outputTag)));
 	}
 
 	@Override


### PR DESCRIPTION

## What is the purpose of the change
 This pull request fixes the behavior: when we take the union of two side outputs of the same operator. Flink was repeating the data from one twice and it was not printing the other one.


## Brief change log

* Added outputTag in hashcode and equals of StreamEdge. 

## Verifying this change
This change added tests and can be verified as follows:

*SideOutputITCase*
 - Added tests to check the various cases that can occur while taking union of the output of two side outputs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
