### PR TITLE
[FLINK-16177][FLINK-16357][checkpointing] Complete / improve checkpointing for OperatorCoordinators

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1127,16 +1127,44 @@ public class CheckpointCoordinator {
 			boolean errorIfNoCheckpoint,
 			boolean allowNonRestoredState) throws Exception {
 
-		return restoreLatestCheckpointedState(new HashSet<>(tasks.values()), errorIfNoCheckpoint, allowNonRestoredState);
+		return restoreLatestCheckpointedStateInternal(new HashSet<>(tasks.values()), true, errorIfNoCheckpoint, allowNonRestoredState);
 	}
 
 	/**
-	 * Restores the latest checkpointed state.
+	 * Restores the latest checkpointed state to a set of subtasks. This method represents a "local"
+	 * or "regional" failover and does restore states to coordinators. Note that a regional failover
+	 * might still include all tasks.
 	 *
 	 * @param tasks Set of job vertices to restore. State for these vertices is
 	 * restored via {@link Execution#setInitialState(JobManagerTaskRestore)}.
-	 * @param errorIfNoCheckpoint Fail if no completed checkpoint is available to
-	 * restore from.
+
+	 * @return <code>true</code> if state was restored, <code>false</code> otherwise.
+	 * @throws IllegalStateException If the CheckpointCoordinator is shut down.
+	 * @throws IllegalStateException If no completed checkpoint is available and
+	 *                               the <code>failIfNoCheckpoint</code> flag has been set.
+	 * @throws IllegalStateException If the checkpoint contains state that cannot be
+	 *                               mapped to any job vertex in <code>tasks</code> and the
+	 *                               <code>allowNonRestoredState</code> flag has not been set.
+	 * @throws IllegalStateException If the max parallelism changed for an operator
+	 *                               that restores state from this checkpoint.
+	 * @throws IllegalStateException If the parallelism changed for an operator
+	 *                               that restores <i>non-partitioned</i> state from this
+	 *                               checkpoint.
+	 */
+	public boolean restoreLatestCheckpointedStateToSubtasks(final Set<ExecutionJobVertex> tasks) throws Exception {
+		// when restoring subtasks only we accept potentially unmatched state because what we
+		// end up restoring from might be a previous savepoint if there is no newer checkpoint
+		return restoreLatestCheckpointedStateInternal(tasks, false, false, true);
+	}
+
+	/**
+	 * Restores the latest checkpointed state to all tasks and all coordinators.
+	 * This method represents a "global restore"-style operation where all stateful tasks
+	 * and coordinators from the given set of Job Vertices are restored.
+	 * are restored to their latest checkpointed state.
+	 *
+	 * @param tasks Set of job vertices to restore. State for these vertices is
+	 * restored via {@link Execution#setInitialState(JobManagerTaskRestore)}.
 	 * @param allowNonRestoredState Allow checkpoint state that cannot be mapped
 	 * to any job vertex in tasks.
 	 * @return <code>true</code> if state was restored, <code>false</code> otherwise.
@@ -1152,10 +1180,18 @@ public class CheckpointCoordinator {
 	 *                               that restores <i>non-partitioned</i> state from this
 	 *                               checkpoint.
 	 */
-	public boolean restoreLatestCheckpointedState(
+	public boolean restoreLatestCheckpointedStateToAll(
 			final Set<ExecutionJobVertex> tasks,
-			final boolean errorIfNoCheckpoint,
 			final boolean allowNonRestoredState) throws Exception {
+
+		return restoreLatestCheckpointedStateInternal(tasks, true, false, allowNonRestoredState);
+	}
+
+	private boolean restoreLatestCheckpointedStateInternal(
+		final Set<ExecutionJobVertex> tasks,
+		final boolean restoreCoordinators,
+		final boolean errorIfNoCheckpoint,
+		final boolean allowNonRestoredState) throws Exception {
 
 		synchronized (lock) {
 			if (shutdown) {
@@ -1202,7 +1238,9 @@ public class CheckpointCoordinator {
 
 			stateAssignmentOperation.assignStates();
 
-			// call master hooks for restore
+			// call master hooks for restore. we currently call them also on "regional restore" because
+			// there is no other failure notification mechanism in the master hooks
+			// ultimately these should get removed anyways in favor of the operator coordinators
 
 			MasterHooks.restoreMasterHooks(
 					masterHooks,
@@ -1211,7 +1249,9 @@ public class CheckpointCoordinator {
 					allowNonRestoredState,
 					LOG);
 
-			restoreStateToCoordinators(operatorStates);
+			if (restoreCoordinators) {
+				restoreStateToCoordinators(operatorStates);
+			}
 
 			// update metrics
 
@@ -1267,7 +1307,7 @@ public class CheckpointCoordinator {
 
 		LOG.info("Reset the checkpoint ID of job {} to {}.", job, nextCheckpointId);
 
-		return restoreLatestCheckpointedState(new HashSet<>(tasks.values()), true, allowNonRestored);
+		return restoreLatestCheckpointedStateInternal(new HashSet<>(tasks.values()), true, true, allowNonRestored);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.util.clock.Clock;
 import org.apache.flink.runtime.util.clock.SystemClock;
 import org.apache.flink.util.ExceptionUtils;
@@ -1210,6 +1211,8 @@ public class CheckpointCoordinator {
 					allowNonRestoredState,
 					LOG);
 
+			restoreStateToCoordinators(operatorStates);
+
 			// update metrics
 
 			if (statsTracker != null) {
@@ -1414,6 +1417,20 @@ public class CheckpointCoordinator {
 		return timer.scheduleAtFixedRate(
 			new ScheduledTrigger(),
 			initDelay, baseInterval, TimeUnit.MILLISECONDS);
+	}
+
+	private void restoreStateToCoordinators(final Map<OperatorID, OperatorState> operatorStates) throws Exception {
+		for (OperatorCoordinatorCheckpointContext coordContext : coordinatorsToCheckpoint) {
+			final OperatorState state = operatorStates.get(coordContext.operatorId());
+			if (state == null) {
+				continue;
+			}
+
+			final ByteStreamStateHandle coordinatorState = state.getCoordinatorState();
+			if (coordinatorState != null) {
+				coordContext.coordinator().resetToCheckpoint(coordinatorState.getData());
+			}
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -171,16 +171,13 @@ public class Checkpoints {
 			} else if (allowNonRestoredState) {
 				LOG.info("Skipping savepoint state for operator {}.", operatorState.getOperatorID());
 			} else {
+				if (operatorState.getCoordinatorState() != null) {
+					throwNonRestoredStateException(checkpointPointer, operatorState.getOperatorID());
+				}
+
 				for (OperatorSubtaskState operatorSubtaskState : operatorState.getStates()) {
 					if (operatorSubtaskState.hasState()) {
-						String msg = String.format("Failed to rollback to checkpoint/savepoint %s. " +
-										"Cannot map checkpoint/savepoint state for operator %s to the new program, " +
-										"because the operator is not available in the new program. If " +
-										"you want to allow to skip this, you can set the --allowNonRestoredState " +
-										"option on the CLI.",
-								checkpointPointer, operatorState.getOperatorID());
-
-						throw new IllegalStateException(msg);
+						throwNonRestoredStateException(checkpointPointer, operatorState.getOperatorID());
 					}
 				}
 
@@ -200,6 +197,17 @@ public class Checkpoints {
 				checkpointMetadata.getMasterStates(),
 				props,
 				location);
+	}
+
+	private static void throwNonRestoredStateException(String checkpointPointer, OperatorID operatorId) {
+		String msg = String.format("Failed to rollback to checkpoint/savepoint %s. " +
+				"Cannot map checkpoint/savepoint state for operator %s to the new program, " +
+				"because the operator is not available in the new program. If " +
+				"you want to allow to skip this, you can set the --allowNonRestoredState " +
+				"option on the CLI.",
+			checkpointPointer, operatorId);
+
+		throw new IllegalStateException(msg);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import java.util.ArrayList;
@@ -130,13 +129,9 @@ final class OperatorCoordinatorCheckpoints {
 	static final class CoordinatorSnapshot {
 
 		final OperatorCoordinatorCheckpointContext coordinator;
-		final StreamStateHandle state;
+		final ByteStreamStateHandle state;
 
-		CoordinatorSnapshot(OperatorCoordinatorCheckpointContext coordinator, StreamStateHandle state) {
-			// if this is not true any more, we need more elaborate dispose/cleanup handling
-			// see comment above the class.
-			assert state instanceof ByteStreamStateHandle;
-
+		CoordinatorSnapshot(OperatorCoordinatorCheckpointContext coordinator, ByteStreamStateHandle state) {
 			this.coordinator = coordinator;
 			this.state = state;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
-import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -50,7 +50,7 @@ public class OperatorState implements CompositeStateHandle {
 
 	/** The state of the operator coordinator. Null, if no such state exists. */
 	@Nullable
-	private StreamStateHandle coordinatorState;
+	private ByteStreamStateHandle coordinatorState;
 
 	/** The parallelism of the operator when it was checkpointed. */
 	private final int parallelism;
@@ -96,13 +96,13 @@ public class OperatorState implements CompositeStateHandle {
 		}
 	}
 
-	public void setCoordinatorState(@Nullable StreamStateHandle coordinatorState) {
+	public void setCoordinatorState(@Nullable ByteStreamStateHandle coordinatorState) {
 		checkState(this.coordinatorState == null, "coordinator state already set");
 		this.coordinatorState = coordinatorState;
 	}
 
 	@Nullable
-	public StreamStateHandle getCoordinatorState() {
+	public ByteStreamStateHandle getCoordinatorState() {
 		return coordinatorState;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StateUtil;
-import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -432,7 +432,7 @@ public class PendingCheckpoint {
 
 	public TaskAcknowledgeResult acknowledgeCoordinatorState(
 			OperatorCoordinatorCheckpointContext coordinatorInfo,
-			@Nullable StreamStateHandle stateHandle) {
+			@Nullable ByteStreamStateHandle stateHandle) {
 
 		synchronized (lock) {
 			if (discarded) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -89,7 +89,7 @@ public class StateAssignmentOperation {
 			// find the states of all operators belonging to this task
 			List<OperatorIDPair> operatorIDPairs = executionJobVertex.getOperatorIDs();
 			List<OperatorState> operatorStates = new ArrayList<>(operatorIDPairs.size());
-			boolean statelessTask = true;
+			boolean statelessSubTasks = true;
 			for (OperatorIDPair operatorIDPair : operatorIDPairs) {
 				OperatorID operatorID = operatorIDPair.getUserDefinedOperatorID().orElse(operatorIDPair.getGeneratedOperatorID());
 
@@ -99,12 +99,12 @@ public class StateAssignmentOperation {
 						operatorID,
 						executionJobVertex.getParallelism(),
 						executionJobVertex.getMaxParallelism());
-				} else {
-					statelessTask = false;
+				} else if (operatorState.getNumberCollectedStates() > 0) {
+					statelessSubTasks = false;
 				}
 				operatorStates.add(operatorState);
 			}
-			if (!statelessTask) { // skip tasks where no operator has any state
+			if (!statelessSubTasks) { // skip tasks where no operator has any state
 				assignAttemptState(executionJobVertex, operatorStates);
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -468,6 +468,7 @@ public abstract class MetadataV2V3SerializerBase {
 		dos.flush();
 	}
 
+	@Nullable
 	public static StreamStateHandle deserializeStreamStateHandle(DataInputStream dis) throws IOException {
 		final int type = dis.read();
 		if (NULL_HANDLE == type) {
@@ -484,6 +485,15 @@ public abstract class MetadataV2V3SerializerBase {
 			return new ByteStreamStateHandle(handleName, data);
 		} else {
 			throw new IOException("Unknown implementation of StreamStateHandle, code: " + type);
+		}
+	}
+
+	public static ByteStreamStateHandle deserializeAndCheckByteStreamStateHandle(DataInputStream dis) throws IOException {
+		final StreamStateHandle handle = deserializeStreamStateHandle(dis);
+		if (handle == null || handle instanceof ByteStreamStateHandle) {
+			return (ByteStreamStateHandle) handle;
+		} else {
+			throw new IOException("Expected a ByteStreamStateHandle but found a " + handle.getClass().getName());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
@@ -117,7 +117,7 @@ public class MetadataV3Serializer extends MetadataV2V3SerializerBase implements 
 		final OperatorState operatorState = new OperatorState(jobVertexId, parallelism, maxParallelism);
 
 		// Coordinator state
-		operatorState.setCoordinatorState(deserializeStreamStateHandle(dis));
+		operatorState.setCoordinatorState(deserializeAndCheckByteStreamStateHandle(dis));
 
 		// Sub task states
 		final int numSubTaskStates = dis.readInt();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -650,8 +650,6 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 				}
 			}
 
-			jobVertex.getOperatorCoordinators().forEach((c -> c.subtaskFailed(getParallelSubtaskIndex())));
-
 			CoLocationGroup grp = jobVertex.getCoLocationGroup();
 			if (grp != null) {
 				locationConstraint = grp.getLocationConstraint(subTaskIndex);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
@@ -41,18 +41,22 @@ public class FailureHandlingResult {
 	/** Reason why the failure is not recoverable. */
 	private final Throwable error;
 
+	/** True if the original failure was a global failure. **/
+	private final boolean globalFailure;
+
 	/**
 	 * Creates a result of a set of tasks to restart to recover from the failure.
 	 *
 	 * @param verticesToRestart containing task vertices to restart to recover from the failure
 	 * @param restartDelayMS indicate a delay before conducting the restart
 	 */
-	private FailureHandlingResult(Set<ExecutionVertexID> verticesToRestart, long restartDelayMS) {
+	private FailureHandlingResult(Set<ExecutionVertexID> verticesToRestart, long restartDelayMS, boolean globalFailure) {
 		checkState(restartDelayMS >= 0);
 
 		this.verticesToRestart = Collections.unmodifiableSet(checkNotNull(verticesToRestart));
 		this.restartDelayMS = restartDelayMS;
 		this.error = null;
+		this.globalFailure = globalFailure;
 	}
 
 	/**
@@ -60,10 +64,11 @@ public class FailureHandlingResult {
 	 *
 	 * @param error reason why the failure is not recoverable
 	 */
-	private FailureHandlingResult(Throwable error) {
+	private FailureHandlingResult(Throwable error, boolean globalFailure) {
 		this.verticesToRestart = null;
 		this.restartDelayMS = -1;
 		this.error = checkNotNull(error);
+		this.globalFailure = globalFailure;
 	}
 
 	/**
@@ -115,6 +120,14 @@ public class FailureHandlingResult {
 	}
 
 	/**
+	 * Checks if this failure was a global failure, i.e., coming from a "safety net" failover that involved
+	 * all tasks and should reset also components like the coordinators.
+	 */
+	public boolean isGlobalFailure() {
+		return globalFailure;
+	}
+
+	/**
 	 * Creates a result of a set of tasks to restart to recover from the failure.
 	 *
 	 * @param verticesToRestart containing task vertices to restart to recover from the failure
@@ -122,7 +135,20 @@ public class FailureHandlingResult {
 	 * @return result of a set of tasks to restart to recover from the failure
 	 */
 	public static FailureHandlingResult restartable(Set<ExecutionVertexID> verticesToRestart, long restartDelayMS) {
-		return new FailureHandlingResult(verticesToRestart, restartDelayMS);
+		return new FailureHandlingResult(verticesToRestart, restartDelayMS, false);
+	}
+
+	/**
+	 * Creates a result of a set of tasks to restart to recover from the failure.
+	 * The result is flagged to be from a global failure triggered by the scheduler, rather than from
+	 * the failure of an individual task.
+	 *
+	 * @param verticesToRestart containing task vertices to restart to recover from the failure
+	 * @param restartDelayMS indicate a delay before conducting the restart
+	 * @return result of a set of tasks to restart to recover from the failure
+	 */
+	public static FailureHandlingResult restartableGlobalFailure(Set<ExecutionVertexID> verticesToRestart, long restartDelayMS) {
+		return new FailureHandlingResult(verticesToRestart, restartDelayMS, true);
 	}
 
 	/**
@@ -132,6 +158,18 @@ public class FailureHandlingResult {
 	 * @return result indicating the failure is not recoverable
 	 */
 	public static FailureHandlingResult unrecoverable(Throwable error) {
-		return new FailureHandlingResult(error);
+		return new FailureHandlingResult(error, false);
+	}
+
+	/**
+	 * Creates a result that the failure is not recoverable and no restarting should be conducted.
+	 * The result is flagged to be from a global failure triggered by the scheduler, rather than from
+	 * the failure of an individual task.
+	 *
+	 * @param error reason why the failure is not recoverable
+	 * @return result indicating the failure is not recoverable
+	 */
+	public static FailureHandlingResult unrecoverableGlobalFailure(Throwable error) {
+		return new FailureHandlingResult(error, true);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 
@@ -61,7 +63,7 @@ public interface OperatorCoordinator extends AutoCloseable {
 	/**
 	 * Called when one of the subtasks of the task running the coordinated operator failed.
 	 */
-	void subtaskFailed(int subtask);
+	void subtaskFailed(int subtask, @Nullable Throwable reason);
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -196,7 +196,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		final ExecutionJobVertex jobVertex = getExecutionJobVertex(executionVertexId.getJobVertexId());
 		final int subtaskIndex = executionVertexId.getSubtaskIndex();
 
-		jobVertex.getOperatorCoordinators().forEach(c -> c.subtaskFailed(subtaskIndex));
+		jobVertex.getOperatorCoordinators().forEach(c -> c.subtaskFailed(subtaskIndex, error));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
@@ -963,5 +964,14 @@ public abstract class SchedulerBase implements SchedulerNG {
 		return getExecutionGraph().getAllVertices().values().stream()
 			.flatMap((vertex) -> vertex.getOperatorCoordinators().stream())
 			.collect(Collectors.toList());
+	}
+
+	// ------------------------------------------------------------------------
+	//  access utils for testing
+	// ------------------------------------------------------------------------
+
+	@VisibleForTesting
+	JobID getJobId() {
+		return jobGraph.getJobID();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -331,18 +331,25 @@ public abstract class SchedulerBase implements SchedulerNG {
 
 	}
 
-	protected void restoreState(final Set<ExecutionVertexID> vertices) throws Exception {
+	protected void restoreState(final Set<ExecutionVertexID> vertices, final boolean isGlobalRecovery) throws Exception {
+		final CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
+		if (checkpointCoordinator == null) {
+			return;
+		}
+
 		// if there is checkpointed state, reload it into the executions
-		if (executionGraph.getCheckpointCoordinator() != null) {
-			// abort pending checkpoints to
-			// i) enable new checkpoint triggering without waiting for last checkpoint expired.
-			// ii) ensure the EXACTLY_ONCE semantics if needed.
-			executionGraph.getCheckpointCoordinator().abortPendingCheckpoints(
+
+		// abort pending checkpoints to
+		// i) enable new checkpoint triggering without waiting for last checkpoint expired.
+		// ii) ensure the EXACTLY_ONCE semantics if needed.
+		checkpointCoordinator.abortPendingCheckpoints(
 				new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
 
-			executionGraph.getCheckpointCoordinator().restoreLatestCheckpointedStateToAll(
-				getInvolvedExecutionJobVertices(vertices),
-				true);
+		final Set<ExecutionJobVertex> jobVerticesToRestore = getInvolvedExecutionJobVertices(vertices);
+		if (isGlobalRecovery) {
+			checkpointCoordinator.restoreLatestCheckpointedStateToAll(jobVerticesToRestore, true);
+		} else {
+			checkpointCoordinator.restoreLatestCheckpointedStateToSubtasks(jobVerticesToRestore);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -415,6 +415,10 @@ public abstract class SchedulerBase implements SchedulerNG {
 		return executionGraph.getAllVertices().get(executionVertexId.getJobVertexId()).getTaskVertices()[executionVertexId.getSubtaskIndex()];
 	}
 
+	public ExecutionJobVertex getExecutionJobVertex(final JobVertexID jobVertexId) {
+		return executionGraph.getAllVertices().get(jobVertexId);
+	}
+
 	protected JobGraph getJobGraph() {
 		return jobGraph;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -235,9 +235,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 
 		if (checkpointCoordinator != null) {
 			// check whether we find a valid checkpoint
-			if (!checkpointCoordinator.restoreLatestCheckpointedState(
+			if (!checkpointCoordinator.restoreLatestCheckpointedStateToAll(
 				new HashSet<>(newExecutionGraph.getAllVertices().values()),
-				false,
 				false)) {
 
 				// check whether we can restore from a savepoint
@@ -341,9 +340,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 			executionGraph.getCheckpointCoordinator().abortPendingCheckpoints(
 				new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
 
-			executionGraph.getCheckpointCoordinator().restoreLatestCheckpointedState(
+			executionGraph.getCheckpointCoordinator().restoreLatestCheckpointedStateToAll(
 				getInvolvedExecutionJobVertices(vertices),
-				false,
 				true);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -35,6 +35,8 @@ import org.apache.flink.runtime.source.event.SourceEventWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -145,7 +147,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 	}
 
 	@Override
-	public void subtaskFailed(int subtaskId) {
+	public void subtaskFailed(int subtaskId, @Nullable Throwable reason) {
 		ensureStarted();
 		coordinatorExecutor.execute(() -> {
 			try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -141,9 +141,8 @@ public class CheckpointCoordinatorMasterHooksTest {
 		cc.addMasterHook(hook2);
 
 		// initialize the hooks
-		cc.restoreLatestCheckpointedState(
+		cc.restoreLatestCheckpointedStateToAll(
 			Collections.emptySet(),
-			false,
 			false);
 		verify(hook1, times(1)).reset();
 		verify(hook2, times(1)).reset();
@@ -280,9 +279,8 @@ public class CheckpointCoordinatorMasterHooksTest {
 		cc.addMasterHook(statefulHook2);
 
 		cc.getCheckpointStore().addCheckpoint(checkpoint);
-		cc.restoreLatestCheckpointedState(
+		cc.restoreLatestCheckpointedStateToAll(
 				Collections.emptySet(),
-				true,
 				false);
 
 		verify(statefulHook1, times(1)).restoreCheckpoint(eq(checkpointId), eq(state1));
@@ -335,18 +333,16 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 		// since we have unmatched state, this should fail
 		try {
-			cc.restoreLatestCheckpointedState(
+			cc.restoreLatestCheckpointedStateToAll(
 					Collections.emptySet(),
-					true,
 					false);
 			fail("exception expected");
 		}
 		catch (IllegalStateException ignored) {}
 
 		// permitting unmatched state should succeed
-		cc.restoreLatestCheckpointedState(
+		cc.restoreLatestCheckpointedStateToAll(
 				Collections.emptySet(),
-				true,
 				true);
 
 		verify(statefulHook, times(1)).restoreCheckpoint(eq(checkpointId), eq(state1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -204,7 +204,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		tasks.add(jobVertex1);
 		tasks.add(jobVertex2);
 
-		coord.restoreLatestCheckpointedState(tasks, true, false);
+		assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
 
 		// validate that all shared states are registered again after the recovery.
 		for (CompletedCheckpoint completedCheckpoint : completedCheckpoints) {
@@ -333,7 +333,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			assertNotNull(savepointFuture.get());
 
 			//restore and jump the latest savepoint
-			coord.restoreLatestCheckpointedState(tasks, true, false);
+			assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
 
 			//compare and see if it used the checkpoint's subtaskStates
 			BaseMatcher<JobManagerTaskRestore> matcher = new BaseMatcher<JobManagerTaskRestore>() {
@@ -493,7 +493,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 		tasks.add(newJobVertex1);
 		tasks.add(newJobVertex2);
-		coord.restoreLatestCheckpointedState(tasks, true, false);
+		assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
 
 		// verify the restored state
 		verifyStateRestore(jobVertexID1, newJobVertex1, keyGroupPartitions1);
@@ -639,7 +639,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		tasks.add(newJobVertex1);
 		tasks.add(newJobVertex2);
 
-		coord.restoreLatestCheckpointedState(tasks, true, false);
+		assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
 
 		fail("The restoration should have failed because the max parallelism changed.");
 	}
@@ -813,7 +813,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
-		coord.restoreLatestCheckpointedState(tasks, false, true);
+		coord.restoreLatestCheckpointedStateToAll(tasks, true);
 
 		for (int i = 0; i < newJobVertex1.getParallelism(); i++) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -1930,7 +1930,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		CheckpointStatsTracker tracker = mock(CheckpointStatsTracker.class);
 		coord.setCheckpointStatsTracker(tracker);
 
-		assertTrue(coord.restoreLatestCheckpointedState(Collections.emptySet(), false, true));
+		assertTrue(coord.restoreLatestCheckpointedStateToAll(Collections.emptySet(), true));
 
 		verify(tracker, times(1))
 			.reportRestoredCheckpoint(any(RestoredCheckpointStats.class));
@@ -2046,7 +2046,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// restore the store
 		Set<ExecutionJobVertex> tasks = new HashSet<>();
 		tasks.add(jobVertex1);
-		coord.restoreLatestCheckpointedState(tasks, true, false);
+		assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
 
 		// validate that all shared states are registered again after the recovery.
 		cp = 0;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLo
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +43,6 @@ import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNew
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
 import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -54,37 +54,90 @@ import static org.mockito.Mockito.when;
  */
 public class CheckpointMetadataLoadingTest {
 
+	private final ClassLoader cl = getClass().getClassLoader();
+
 	/**
-	 * Tests loading and validation of savepoints with correct setup,
-	 * parallelism mismatch, and a missing task.
+	 * Tests correct savepoint loading.
 	 */
 	@Test
-	public void testLoadAndValidateSavepoint() throws Exception {
-		final Random rnd = new Random();
+	public void testAllStateRestored() throws Exception {
+		final JobID jobId = new JobID();
+		final OperatorID operatorId = new OperatorID();
+		final long checkpointId = Integer.MAX_VALUE + 123123L;
+		final int parallelism = 128128;
 
-		int parallelism = 128128;
-		long checkpointId = Integer.MAX_VALUE + 123123L;
-		JobVertexID jobVertexID = new JobVertexID();
-		OperatorID operatorID = OperatorID.fromJobVertexID(jobVertexID);
+		final CompletedCheckpointStorageLocation testSavepoint = createSavepointWithOperatorSubtaskState(checkpointId, operatorId, parallelism);
+		final Map<JobVertexID, ExecutionJobVertex> tasks = createTasks(operatorId, parallelism, parallelism);
 
-		OperatorSubtaskState subtaskState = new OperatorSubtaskState(
-				new OperatorStreamStateHandle(Collections.emptyMap(), new ByteStreamStateHandle("testHandler", new byte[0])),
-				null,
-				null,
-				null,
-				singleton(createNewInputChannelStateHandle(10, rnd)),
-				singleton(createNewResultSubpartitionStateHandle(10, rnd)));
+		final CompletedCheckpoint loaded = Checkpoints.loadAndValidateCheckpoint(jobId, tasks, testSavepoint, cl, false);
 
-		OperatorState state = new OperatorState(operatorID, parallelism, parallelism);
-		state.putState(0, subtaskState);
+		assertEquals(jobId, loaded.getJobId());
+		assertEquals(checkpointId, loaded.getCheckpointID());
+	}
 
-		Map<OperatorID, OperatorState> taskStates = new HashMap<>();
-		taskStates.put(operatorID, state);
+	/**
+	 * Tests that savepoint loading fails when there is a max-parallelism mismatch.
+	 */
+	@Test
+	public void testMaxParallelismMismatch() throws Exception {
+		final OperatorID operatorId = new OperatorID();
+		final int parallelism = 128128;
 
-		JobID jobId = new JobID();
+		final CompletedCheckpointStorageLocation testSavepoint = createSavepointWithOperatorSubtaskState(242L, operatorId, parallelism);
+		final Map<JobVertexID, ExecutionJobVertex> tasks = createTasks(operatorId, parallelism, parallelism + 1);
 
-		// Store savepoint
-		final CheckpointMetadata savepoint = new CheckpointMetadata(checkpointId, taskStates.values(), Collections.emptyList());
+		try {
+			Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+			fail("Did not throw expected Exception");
+		} catch (IllegalStateException expected) {
+			assertTrue(expected.getMessage().contains("Max parallelism mismatch"));
+		}
+	}
+
+	/**
+	 * Tests that savepoint loading fails when there is non-restored state, but it is not allowed.
+	 */
+	@Test
+	public void testNonRestoredStateWhenDisallowed() throws Exception {
+		final OperatorID operatorId = new OperatorID();
+		final int parallelism = 9;
+
+		final CompletedCheckpointStorageLocation testSavepoint = createSavepointWithOperatorSubtaskState(242L, operatorId, parallelism);
+		final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
+
+		try {
+			Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+			fail("Did not throw expected Exception");
+		} catch (IllegalStateException expected) {
+			assertTrue(expected.getMessage().contains("allowNonRestoredState"));
+		}
+	}
+
+	/**
+	 * Tests that savepoint loading succeeds when there is non-restored state and it is not allowed.
+	 */
+	@Test
+	public void testNonRestoredStateWhenAllowed() throws Exception {
+		final OperatorID operatorId = new OperatorID();
+		final int parallelism = 9;
+
+		final CompletedCheckpointStorageLocation testSavepoint = createSavepointWithOperatorSubtaskState(242L, operatorId, parallelism);
+		final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
+
+		final CompletedCheckpoint loaded = Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, true);
+
+		assertTrue(loaded.getOperatorStates().isEmpty());
+	}
+
+	// ------------------------------------------------------------------------
+	//  setup utils
+	// ------------------------------------------------------------------------
+
+	private static CompletedCheckpointStorageLocation createSavepointWithOperatorState(
+			final long checkpointId,
+			final OperatorState state) throws IOException {
+
+		final CheckpointMetadata savepoint = new CheckpointMetadata(checkpointId, Collections.singletonList(state), Collections.emptyList());
 		final StreamStateHandle serializedMetadata;
 
 		try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
@@ -92,47 +145,45 @@ public class CheckpointMetadataLoadingTest {
 			serializedMetadata = new ByteStreamStateHandle("checkpoint", os.toByteArray());
 		}
 
-		final CompletedCheckpointStorageLocation storageLocation = new TestCompletedCheckpointStorageLocation(
-				serializedMetadata, "dummy/pointer");
+		return new TestCompletedCheckpointStorageLocation(serializedMetadata, "dummy/pointer");
+	}
+
+	private static CompletedCheckpointStorageLocation createSavepointWithOperatorSubtaskState(
+			final long checkpointId,
+			final OperatorID operatorId,
+			final int parallelism) throws IOException {
+
+		final Random rnd = new Random();
+
+		final OperatorSubtaskState subtaskState = new OperatorSubtaskState(
+			new OperatorStreamStateHandle(Collections.emptyMap(), new ByteStreamStateHandle("testHandler", new byte[0])),
+			null,
+			null,
+			null,
+			singleton(createNewInputChannelStateHandle(10, rnd)),
+			singleton(createNewResultSubpartitionStateHandle(10, rnd)));
+
+		final OperatorState state = new OperatorState(operatorId, parallelism, parallelism);
+		state.putState(0, subtaskState);
+
+		return createSavepointWithOperatorState(checkpointId, state);
+	}
+
+	private static Map<JobVertexID, ExecutionJobVertex> createTasks(OperatorID operatorId, int parallelism, int maxParallelism) {
+		final JobVertexID vertexId = new JobVertexID(operatorId.getLowerPart(), operatorId.getUpperPart());
 
 		ExecutionJobVertex vertex = mock(ExecutionJobVertex.class);
 		when(vertex.getParallelism()).thenReturn(parallelism);
-		when(vertex.getMaxParallelism()).thenReturn(parallelism);
-		when(vertex.getOperatorIDs()).thenReturn(Collections.singletonList(OperatorIDPair.generatedIDOnly(operatorID)));
+		when(vertex.getMaxParallelism()).thenReturn(maxParallelism);
+		when(vertex.getOperatorIDs()).thenReturn(Collections.singletonList(OperatorIDPair.generatedIDOnly(operatorId)));
+
+		if (parallelism != maxParallelism) {
+			when(vertex.isMaxParallelismConfigured()).thenReturn(true);
+		}
 
 		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
-		tasks.put(jobVertexID, vertex);
+		tasks.put(vertexId, vertex);
 
-		ClassLoader ucl = Thread.currentThread().getContextClassLoader();
-
-		// 1) Load and validate: everything correct
-		CompletedCheckpoint loaded = Checkpoints.loadAndValidateCheckpoint(jobId, tasks, storageLocation, ucl, false);
-
-		assertEquals(jobId, loaded.getJobId());
-		assertEquals(checkpointId, loaded.getCheckpointID());
-
-		// 2) Load and validate: max parallelism mismatch
-		when(vertex.getMaxParallelism()).thenReturn(222);
-		when(vertex.isMaxParallelismConfigured()).thenReturn(true);
-
-		try {
-			Checkpoints.loadAndValidateCheckpoint(jobId, tasks, storageLocation, ucl, false);
-			fail("Did not throw expected Exception");
-		} catch (IllegalStateException expected) {
-			assertTrue(expected.getMessage().contains("Max parallelism mismatch"));
-		}
-
-		// 3) Load and validate: missing vertex
-		assertNotNull(tasks.remove(jobVertexID));
-
-		try {
-			Checkpoints.loadAndValidateCheckpoint(jobId, tasks, storageLocation, ucl, false);
-			fail("Did not throw expected Exception");
-		} catch (IllegalStateException expected) {
-			assertTrue(expected.getMessage().contains("allowNonRestoredState"));
-		}
-
-		// 4) Load and validate: ignore missing vertex
-		Checkpoints.loadAndValidateCheckpoint(jobId, tasks, storageLocation, ucl, true);
+		return tasks;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -30,12 +30,9 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,9 +54,6 @@ import static org.mockito.Mockito.when;
  */
 public class CheckpointMetadataLoadingTest {
 
-	@Rule
-	public final TemporaryFolder tmpFolder = new TemporaryFolder();
-
 	/**
 	 * Tests loading and validation of savepoints with correct setup,
 	 * parallelism mismatch, and a missing task.
@@ -67,7 +61,6 @@ public class CheckpointMetadataLoadingTest {
 	@Test
 	public void testLoadAndValidateSavepoint() throws Exception {
 		final Random rnd = new Random();
-		File tmp = tmpFolder.newFolder();
 
 		int parallelism = 128128;
 		long checkpointId = Integer.MAX_VALUE + 123123L;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -50,6 +50,8 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -138,7 +140,7 @@ public class CheckpointStateRestoreTest {
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 
 			// let the coordinator inject the state
-			coord.restoreLatestCheckpointedState(tasks, true, false);
+			assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
 
 			// verify that each stateful vertex got the state
 
@@ -177,13 +179,8 @@ public class CheckpointStateRestoreTest {
 				new CheckpointCoordinatorBuilder()
 					.build();
 
-			try {
-				coord.restoreLatestCheckpointedState(Collections.emptySet(), true, false);
-				fail("this should throw an exception");
-			}
-			catch (IllegalStateException e) {
-				// expected
-			}
+			final boolean restored = coord.restoreLatestCheckpointedStateToAll(Collections.emptySet(), false);
+			assertFalse(restored);
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -245,8 +242,8 @@ public class CheckpointStateRestoreTest {
 
 		coord.getCheckpointStore().addCheckpoint(checkpoint);
 
-		coord.restoreLatestCheckpointedState(tasks, true, false);
-		coord.restoreLatestCheckpointedState(tasks, true, true);
+		assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
+		assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, true));
 
 		// --- (3) JobVertex missing for task state that is part of the checkpoint ---
 		JobVertexID newJobVertexID = new JobVertexID();
@@ -273,11 +270,12 @@ public class CheckpointStateRestoreTest {
 		coord.getCheckpointStore().addCheckpoint(checkpoint);
 
 		// (i) Allow non restored state (should succeed)
-		coord.restoreLatestCheckpointedState(tasks, true, true);
+		final boolean restored = coord.restoreLatestCheckpointedStateToAll(tasks, true);
+		assertTrue(restored);
 
 		// (ii) Don't allow non restored state (should fail)
 		try {
-			coord.restoreLatestCheckpointedState(tasks, true, false);
+			coord.restoreLatestCheckpointedStateToAll(tasks, false);
 			fail("Did not throw the expected Exception.");
 		} catch (IllegalStateException ignored) {
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -35,9 +35,9 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinator;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.SharedStateRegistry;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestingStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -519,7 +519,7 @@ public class PendingCheckpointTest {
 		return checkpoint;
 	}
 
-	private PendingCheckpoint createPendingCheckpointWithAcknowledgedCoordinators(StreamStateHandle... handles) throws IOException {
+	private PendingCheckpoint createPendingCheckpointWithAcknowledgedCoordinators(ByteStreamStateHandle... handles) throws IOException {
 		OperatorCoordinatorCheckpointContext[] coords = new OperatorCoordinatorCheckpointContext[handles.length];
 		for (int i = 0; i < handles.length; i++) {
 			coords[i] = createOperatorCoordinator();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -75,7 +75,7 @@ public class CheckpointTestUtils {
 
 			final boolean hasCoordinatorState = random.nextBoolean();
 			if (hasCoordinatorState) {
-				final StreamStateHandle stateHandle = createDummyStreamStateHandle(random);
+				final ByteStreamStateHandle stateHandle = createDummyStreamStateHandle(random);
 				taskState.setCoordinatorState(stateHandle);
 			}
 
@@ -209,7 +209,7 @@ public class CheckpointTestUtils {
 			createDummyStreamStateHandle(rnd));
 	}
 
-	public static StreamStateHandle createDummyStreamStateHandle(Random rnd) {
+	public static ByteStreamStateHandle createDummyStreamStateHandle(Random rnd) {
 		return new ByteStreamStateHandle(
 			String.valueOf(createRandomUUID(rnd)),
 			String.valueOf(createRandomUUID(rnd)).getBytes(ConfigConstants.DEFAULT_CHARSET));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -32,7 +32,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -43,8 +42,6 @@ import java.util.stream.Collectors;
  */
 public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
 
-	private final Executor executorDelegate;
-
 	private final ArrayDeque<Runnable> queuedRunnables = new ArrayDeque<>();
 
 	private final ConcurrentLinkedQueue<ScheduledTask<?>> nonPeriodicScheduledTasks =
@@ -52,10 +49,6 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
 
 	private final ConcurrentLinkedQueue<ScheduledTask<?>> periodicScheduledTasks =
 		new ConcurrentLinkedQueue<>();
-
-	public ManuallyTriggeredScheduledExecutor() {
-		this.executorDelegate = Runnable::run;
-	}
 
 	@Override
 	public void execute(@Nonnull Runnable command) {
@@ -82,7 +75,7 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
 			next = queuedRunnables.removeFirst();
 		}
 
-		CompletableFuture.runAsync(next, executorDelegate).join();
+		next.run();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
+import javax.annotation.Nullable;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -42,7 +44,7 @@ public final class MockOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
-	public void subtaskFailed(int subtask) {
+	public void subtaskFailed(int subtask, @Nullable Throwable reason) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -69,6 +69,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -267,6 +268,17 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 
 		assertArrayEquals("coordinator should have a restored checkpoint",
 				coordinatorState, coordinator.getLastRestoredCheckpointState());
+	}
+
+	@Test
+	public void testLocalFailureDoesNotResetToCheckpoint() throws Exception {
+		final DefaultScheduler scheduler = createSchedulerAndDeployTasks();
+		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
+
+		takeCompleteCheckpoint(scheduler, coordinator, new byte[] {37, 11, 83, 4});
+		failAndRestartTask(scheduler, 0);
+
+		assertNull("coordinator should not have a restored checkpoint", coordinator.getLastRestoredCheckpointState());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -39,7 +39,6 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.TestingCheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -127,12 +126,23 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 	}
 
 	@Test
-	public void taskFailureNotifiesCoordinator() throws Exception {
+	public void deployingTaskFailureNotifiesCoordinator() throws Exception {
 		final DefaultScheduler scheduler = createAndStartScheduler();
 		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
 
 		failTask(scheduler, 1);
-		executor.triggerScheduledTasks();
+
+		assertEquals(1, coordinator.getFailedTasks().size());
+		assertThat(coordinator.getFailedTasks(), contains(1));
+		assertThat(coordinator.getFailedTasks(), not(contains(0)));
+	}
+
+	@Test
+	public void runningTaskFailureNotifiesCoordinator() throws Exception {
+		final DefaultScheduler scheduler = createSchedulerAndDeployTasks();
+		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
+
+		failTask(scheduler, 1);
 
 		assertEquals(1, coordinator.getFailedTasks().size());
 		assertThat(coordinator.getFailedTasks(), contains(1));
@@ -144,10 +154,8 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 		final DefaultScheduler scheduler = createSchedulerAndDeployTasks();
 		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
 
-		failTask(scheduler, 0);
-		executor.triggerScheduledTasks();
-		failTask(scheduler, 0);
-		executor.triggerScheduledTasks();
+		failAndRestartTask(scheduler, 0);
+		failAndRestartTask(scheduler, 0);
 
 		assertEquals(2, coordinator.getFailedTasks().size());
 		assertThat(coordinator.getFailedTasks(), contains(0, 0));
@@ -184,6 +192,11 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 	private DefaultScheduler createAndStartScheduler() throws Exception {
 		final DefaultScheduler scheduler = setupTestJobAndScheduler(new TestingOperatorCoordinator.Provider(testOperatorId));
 		scheduler.startScheduling();
+		executor.triggerAll();
+
+		// guard test assumptions: this brings tasks into DEPLOYING state
+		assertEquals(ExecutionState.DEPLOYING, SchedulerTestingUtils.getExecutionState(scheduler, testVertexId, 0));
+
 		return scheduler;
 	}
 
@@ -197,6 +210,10 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 		executor.triggerAll();
 		executor.triggerScheduledTasks();
 		SchedulerTestingUtils.setAllExecutionsToRunning(scheduler);
+
+		// guard test assumptions: this brings tasks into RUNNING state
+		assertEquals(ExecutionState.RUNNING, SchedulerTestingUtils.getExecutionState(scheduler, testVertexId, 0));
+
 		return scheduler;
 	}
 
@@ -206,6 +223,10 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 		executor.triggerAll();
 		executor.triggerScheduledTasks();
 		SchedulerTestingUtils.setAllExecutionsToRunning(scheduler);
+
+		// guard test assumptions: this brings tasks into RUNNING state
+		assertEquals(ExecutionState.RUNNING, SchedulerTestingUtils.getExecutionState(scheduler, testVertexId, 0));
+
 		return scheduler;
 	}
 
@@ -274,12 +295,27 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 	// ------------------------------------------------------------------------
 
 	private void failTask(DefaultScheduler scheduler, int subtask) {
-		final ExecutionJobVertex ejv = getJobVertex(scheduler, testVertexId);
-		assert ejv != null;
-		final ExecutionAttemptID attemptID = ejv.getTaskVertices()[subtask].getCurrentExecutionAttempt().getAttemptId();
+		SchedulerTestingUtils.failExecution(scheduler, testVertexId, subtask);
+		executor.triggerAll();
 
-		scheduler.updateTaskExecutionState(new TaskExecutionState(
-				ejv.getJobId(), attemptID, ExecutionState.FAILED, new Exception("test task failure")));
+		// guard the test assumptions: This must not lead to a restart, but must keep the task in FAILED state
+		assertEquals(ExecutionState.FAILED, SchedulerTestingUtils.getExecutionState(scheduler, testVertexId, subtask));
+	}
+
+	private void failAndRedeployTask(DefaultScheduler scheduler, int subtask) {
+		failTask(scheduler, subtask);
+		executor.triggerScheduledTasks();
+
+		// guard the test assumptions: This must lead to a restarting and redeploying
+		assertEquals(ExecutionState.DEPLOYING, SchedulerTestingUtils.getExecutionState(scheduler, testVertexId, subtask));
+	}
+
+	private void failAndRestartTask(DefaultScheduler scheduler, int subtask) {
+		failAndRedeployTask(scheduler, subtask);
+		SchedulerTestingUtils.setExecutionToRunning(scheduler, testVertexId, subtask);
+
+		// guard the test assumptions: This must bring the task back to RUNNING
+		assertEquals(ExecutionState.RUNNING, SchedulerTestingUtils.getExecutionState(scheduler, testVertexId, subtask));
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Matcher;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -65,6 +66,7 @@ import java.util.function.Consumer;
 import static org.apache.flink.core.testutils.FlinkMatchers.futureFailedWith;
 import static org.apache.flink.core.testutils.FlinkMatchers.futureWillCompleteExceptionally;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
@@ -171,6 +173,17 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 	}
 
 	@Test
+	public void cancellationAsPartOfFailoverNotifiesCoordinator() throws Exception {
+		final DefaultScheduler scheduler = createSchedulerWithAllRestartOnFailureAndDeployTasks();
+		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
+
+		failTask(scheduler, 1);
+
+		assertEquals(2, coordinator.getFailedTasks().size());
+		assertThat(coordinator.getFailedTasks(), containsInAnyOrder(0, 1));
+	}
+
+	@Test
 	public void taskRepeatedFailureNotifyCoordinator() throws Exception {
 		final DefaultScheduler scheduler = createSchedulerAndDeployTasks();
 		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
@@ -200,6 +213,36 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 		final CompletableFuture<?> result = context.sendEvent(new TestOperatorEvent(), 0);
 
 		assertThat(result, futureFailedWith(TestException.class));
+	}
+
+	// THESE TESTS BELOW SHOULD LEGITIMATELY WORK, BUT THE SCHEDULER ITSELF SEEMS TO NOT HANDLE
+	// THIS SITUATION AT THE MOMENT
+	// WE KEEP THESE TESTS HERE TO ENABLE THEM ONCE THE SCHEDULER'S CONTRACT SUPPORTS THEM
+
+	@Ignore
+	@Test
+	public void deployingTaskCancellationNotifiesCoordinator() throws Exception {
+		final DefaultScheduler scheduler = createAndStartScheduler();
+		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
+
+		cancelTask(scheduler, 1);
+
+		assertEquals(1, coordinator.getFailedTasks().size());
+		assertThat(coordinator.getFailedTasks(), contains(1));
+		assertThat(coordinator.getFailedTasks(), not(contains(0)));
+	}
+
+	@Ignore
+	@Test
+	public void runningTaskCancellationNotifiesCoordinator() throws Exception {
+		final DefaultScheduler scheduler = createSchedulerAndDeployTasks();
+		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
+
+		cancelTask(scheduler, 0);
+
+		assertEquals(1, coordinator.getFailedTasks().size());
+		assertThat(coordinator.getFailedTasks(), contains(0));
+		assertThat(coordinator.getFailedTasks(), not(contains(1)));
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.util.SerializableFunction;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -57,7 +59,7 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 	public void handleEventFromOperator(int subtask, OperatorEvent event) {}
 
 	@Override
-	public void subtaskFailed(int subtask) {
+	public void subtaskFailed(int subtask, @Nullable Throwable reason) {
 		failedTasks.add(subtask);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.SlotProviderStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.NoRestartBackoffTimeStrategy;
@@ -61,9 +62,11 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.VoidBackPressureStatsTracker;
 import org.apache.flink.runtime.scheduler.strategy.EagerSchedulingStrategy;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -72,6 +75,9 @@ import org.apache.flink.util.SerializedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -181,6 +187,10 @@ public class SchedulerTestingUtils {
 	}
 
 	public static void enableCheckpointing(final JobGraph jobGraph) {
+		enableCheckpointing(jobGraph, null);
+	}
+
+	public static void enableCheckpointing(final JobGraph jobGraph, @Nullable StateBackend stateBackend) {
 		final List<JobVertexID> triggerVertices = new ArrayList<>();
 		final List<JobVertexID> allVertices = new ArrayList<>();
 
@@ -202,15 +212,47 @@ public class SchedulerTestingUtils {
 			false,
 			0);
 
+		SerializedValue<StateBackend> serializedStateBackend = null;
+		if (stateBackend != null) {
+			try {
+				serializedStateBackend = new SerializedValue<>(stateBackend);
+			} catch (IOException e) {
+				throw new RuntimeException("could not serialize state backend", e);
+			}
+		}
+
 		jobGraph.setSnapshotSettings(new JobCheckpointingSettings(
 				triggerVertices, allVertices, allVertices,
-				config, null));
+				config, serializedStateBackend));
 	}
 
 	public static Collection<ExecutionAttemptID> getAllCurrentExecutionAttempts(DefaultScheduler scheduler) {
 		return StreamSupport.stream(scheduler.requestJob().getAllExecutionVertices().spliterator(), false)
 			.map((vertex) -> vertex.getCurrentExecutionAttempt().getAttemptId())
 			.collect(Collectors.toList());
+	}
+
+	public static ExecutionState getExecutionState(DefaultScheduler scheduler, JobVertexID jvid, int subtask) {
+		final ExecutionJobVertex ejv = getJobVertex(scheduler, jvid);
+		return ejv.getTaskVertices()[subtask].getCurrentExecutionAttempt().getState();
+	}
+
+	public static void failExecution(DefaultScheduler scheduler, JobVertexID jvid, int subtask) {
+		final ExecutionJobVertex ejv = getJobVertex(scheduler, jvid);
+		assert ejv != null;
+		final ExecutionAttemptID attemptID = ejv.getTaskVertices()[subtask].getCurrentExecutionAttempt().getAttemptId();
+
+		scheduler.updateTaskExecutionState(new TaskExecutionState(
+			ejv.getJobId(), attemptID, ExecutionState.FAILED, new Exception("test task failure")));
+	}
+
+	public static void setExecutionToRunning(DefaultScheduler scheduler, JobVertexID jvid, int subtask) {
+		final ExecutionJobVertex ejv = getJobVertex(scheduler, jvid);
+		assert ejv != null;
+		final ExecutionAttemptID attemptID = ejv.getTaskVertices()[subtask].getCurrentExecutionAttempt().getAttemptId();
+
+		scheduler.updateTaskExecutionState(new TaskExecutionState(
+			ejv.getJobId(), attemptID, ExecutionState.RUNNING));
 	}
 
 	public static void setAllExecutionsToRunning(final DefaultScheduler scheduler) {
@@ -248,6 +290,11 @@ public class SchedulerTestingUtils {
 	@SuppressWarnings("deprecation")
 	public static CheckpointCoordinator getCheckpointCoordinator(SchedulerBase scheduler) {
 		return scheduler.getExecutionGraph().getCheckpointCoordinator();
+	}
+
+	private static ExecutionJobVertex getJobVertex(DefaultScheduler scheduler, JobVertexID jobVertexId) {
+		final ExecutionVertexID id = new ExecutionVertexID(jobVertexId, 0);
+		return scheduler.getExecutionVertex(id).getJobVertex();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -53,7 +53,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 				failureMessage, "The coordinator has not started yet.");
 		verifyException(() -> sourceCoordinator.handleEventFromOperator(0, null),
 				failureMessage, "The coordinator has not started yet.");
-		verifyException(() -> sourceCoordinator.subtaskFailed(0),
+		verifyException(() -> sourceCoordinator.subtaskFailed(0, null),
 				failureMessage, "The coordinator has not started yet.");
 		verifyException(() -> sourceCoordinator.checkpointCoordinator(100L),
 				failureMessage, "The coordinator has not started yet.");
@@ -160,7 +160,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 		});
 
 		// Fail reader 0.
-		sourceCoordinator.subtaskFailed(0);
+		sourceCoordinator.subtaskFailed(0, null);
 
 		// check the state again.
 		check(() -> {
@@ -190,7 +190,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 		sourceCoordinator.checkpointComplete(100L);
 
 		// Fail reader 0.
-		sourceCoordinator.subtaskFailed(0);
+		sourceCoordinator.subtaskFailed(0, null);
 
 		check(() -> {
 			// Reader 0 hase been unregistered.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageCoordinatorView.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageCoordinatorView.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
+import org.apache.flink.runtime.state.memory.NonPersistentMetadataCheckpointStorageLocation;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+
+/**
+ * A testing implementation of the {@link CheckpointStorageCoordinatorView}.
+ */
+@SuppressWarnings("serial")
+public class TestingCheckpointStorageCoordinatorView implements CheckpointStorage, java.io.Serializable {
+
+	private final HashMap<String, TestingCompletedCheckpointStorageLocation> registeredSavepoints = new HashMap<>();
+
+	// ------------------------------------------------------------------------
+	//  test setup methods
+	// ------------------------------------------------------------------------
+
+	public void registerSavepoint(String pointer, byte[] metadata) {
+		registeredSavepoints.put(pointer, new TestingCompletedCheckpointStorageLocation(pointer, metadata));
+	}
+
+	// ------------------------------------------------------------------------
+	//  CheckpointStorageCoordinatorView methods
+	// ------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsHighlyAvailableStorage() {
+		return false;
+	}
+
+	@Override
+	public boolean hasDefaultSavepointLocation() {
+		return false;
+	}
+
+	@Override
+	public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) throws IOException {
+		final CompletedCheckpointStorageLocation location = registeredSavepoints.get(externalPointer);
+		if (location != null) {
+			return location;
+		} else {
+			throw new IOException("Could not find savepoint for pointer: " + externalPointer);
+		}
+	}
+
+	@Override
+	public void initializeBaseLocations() throws IOException {}
+
+	@Override
+	public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) throws IOException {
+		return new NonPersistentMetadataCheckpointStorageLocation(Integer.MAX_VALUE);
+	}
+
+	@Override
+	public CheckpointStorageLocation initializeLocationForSavepoint(long checkpointId, @Nullable String externalLocationPointer) throws IOException {
+		return new NonPersistentMetadataCheckpointStorageLocation(Integer.MAX_VALUE);
+	}
+
+	@Override
+	public CheckpointStreamFactory resolveCheckpointStorageLocation(
+			long checkpointId,
+			CheckpointStorageLocationReference reference) {
+		return new MemCheckpointStreamFactory(Integer.MAX_VALUE);
+	}
+
+	@Override
+	public CheckpointStreamFactory.CheckpointStateOutputStream createTaskOwnedStateStream() {
+		return new MemCheckpointStreamFactory.MemoryCheckpointOutputStream(Integer.MAX_VALUE);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utils
+	// ------------------------------------------------------------------------
+
+	public StateBackend asStateBackend() {
+		return new FactoringStateBackend(this);
+	}
+
+	// ------------------------------------------------------------------------
+	//  internal support classes
+	// ------------------------------------------------------------------------
+
+	private static final class TestingCompletedCheckpointStorageLocation
+			implements CompletedCheckpointStorageLocation, java.io.Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		private final String pointer;
+		private final byte[] metadata;
+
+		TestingCompletedCheckpointStorageLocation(String pointer, byte[] metadata) {
+			this.pointer = pointer;
+			this.metadata = metadata;
+		}
+
+		@Override
+		public String getExternalPointer() {
+			return pointer;
+		}
+
+		@Override
+		public StreamStateHandle getMetadataHandle() {
+			return new ByteStreamStateHandle(pointer, metadata);
+		}
+
+		@Override
+		public void disposeStorageLocation() throws IOException {}
+	}
+
+	// ------------------------------------------------------------------------
+	//   Everything below here is necessary only to make it possible to
+	//   pass the CheckpointStorageCoordinatorView to the CheckpointCoordinator
+	//   via the JobGraph, because that part expects a StateBackend
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A StateBackend whose only purpose is to create a given CheckpointStorage.
+	 */
+	private static final class FactoringStateBackend implements StateBackend {
+
+		private final TestingCheckpointStorageCoordinatorView testingCoordinatorView;
+
+		private FactoringStateBackend(TestingCheckpointStorageCoordinatorView testingCoordinatorView) {
+			this.testingCoordinatorView = testingCoordinatorView;
+		}
+
+
+		@Override
+		public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) throws IOException {
+			return testingCoordinatorView.resolveCheckpoint(externalPointer);
+		}
+
+		@Override
+		public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+			return testingCoordinatorView;
+		}
+
+		@Override
+		public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(Environment env, JobID jobID, String operatorIdentifier, TypeSerializer<K> keySerializer, int numberOfKeyGroups, KeyGroupRange keyGroupRange, TaskKvStateRegistry kvStateRegistry, TtlTimeProvider ttlTimeProvider, MetricGroup metricGroup, @Nonnull Collection<KeyedStateHandle> stateHandles, CloseableRegistry cancelStreamRegistry) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public OperatorStateBackend createOperatorStateBackend(Environment env, String operatorIdentifier, @Nonnull Collection<OperatorStateHandle> stateHandles, CloseableRegistry cancelStreamRegistry) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingStreamStateHandle.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingStreamStateHandle.java
@@ -18,50 +18,28 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
-import javax.annotation.Nullable;
+import java.util.UUID;
 
 /**
  * A simple test mock for a {@link StreamStateHandle}.
  */
-public class TestingStreamStateHandle implements StreamStateHandle {
+public class TestingStreamStateHandle extends ByteStreamStateHandle {
 	private static final long serialVersionUID = 1L;
-
-	@Nullable
-	private final FSDataInputStream inputStream;
-
-	private final long size;
 
 	private boolean disposed;
 
 	public TestingStreamStateHandle() {
-		this(null, 0L);
-	}
-
-	public TestingStreamStateHandle(@Nullable FSDataInputStream inputStream, long size) {
-		this.inputStream = inputStream;
-		this.size = size;
+		super(UUID.randomUUID().toString(), new byte[0]);
 	}
 
 	// ------------------------------------------------------------------------
 
 	@Override
-	public FSDataInputStream openInputStream() {
-		if (inputStream == null) {
-			throw new UnsupportedOperationException("no input stream provided");
-		}
-		return inputStream;
-	}
-
-	@Override
 	public void discardState() {
+		super.discardState();
 		disposed = true;
-	}
-
-	@Override
-	public long getStateSize() {
-		return size;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This Pull Request contains a series of changes that ultimately serve two goals:

  1. Complete checkpointing/restoring state for OperatorCoordinators (previously restores were not implemented)
  2. Only restore operator coordinators on after "global failures" or "global restore".

The distinction between Global failures/restores and task failures/restores mean the following:
  - When a task fails, then that task and others (in the same failover region) are restarted with the latest checkpoint state. In that case, the Operator Coordinators only get notifications, the coordinator is not reset to the previous checkpoint. That is because some subtasks may potentially continue to run.
  - When a global failure happens (for example as part of a master failover, a change in JobManager leader status, or through the safety net in the scheduler) then all tasks are reset to the previous state, and likewise the coordinators are reset to the previous checkpoint. In those situations, there would be the danger inconistencies if the coordinator did not reset to the checkpoint.
  - A restore from a savepoint is likewise a global restore (it is a special case of a change in leader status)

## Brief change log

Changes 42f3576, ad78321, 16c1524, 2a3fabc, 5e8dfd8, e6063a8 are simple refactoring and fixes of minor bugs. These commits should be self contained not too complex.

11bc22f improves the failure handling by sending failure notifications to the `OperatorCoordinator` as soon as a task failed, and not only when it gets recovered. That makes failure handling in the coordinator faster.

6452bd9 simply forwards the exception that caused the failure originally to the `OperatorCoordinator.subtaskFailed()` method.

40f9067 Completes the remainders of the checkpointing integration. It fixes various previous issues and makes sure that `restore()` is always called on the `OperatorCoordinator` whenever a checkpoint is restored.

a7e2a16 Introduces the two different methods in the `CheckpointCoordinator`:
  - `restoreLatestCheckpointedStateToAll(...)` for restores after global failures. This is the same as the previous behavior. This method also restores `OperatorCoordinators`.
  - `restoreLatestCheckpointedStateToSubtasks` for restores of (a subset of) subtasks only. The method is initially unused.
The commit also removes the `failIfNoCheckpoint`flag which was only used during savepoint restores. Because savepoint restores have their dedicated method in the `CheckpointCoordinator` this flag was never used in the production code and was not re-included in the two new methods.

2c5bd3b Changes the scheduler to call the two different methods introduces in the previous commits in the respective situations (task failure versus global failure).


## Verifying this change

The changes here are covered by various additional unit tests, specifically in the class `OperatorCoordinatorSchedulerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** (not a user-facing feature)
  - If yes, how is the feature documented? **not applicable**
