### PR TITLE
[FLINK-16611] [datadog-metrics] Make number of metrics per request configurable

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -770,6 +770,7 @@ Parameters:
 - `proxyHost` - (optional) The proxy host to use when sending to Datadog.
 - `proxyPort` - (optional) The proxy port to use when sending to Datadog, defaults to 8080.
 - `dataCenter` - (optional) The data center (`EU`/`US`) to connect to, defaults to `US`.
+- `maxMetricsPerRequest` - (optional) The maximum number of metrics to include in each request, defaults to 2000.
 
 Example configuration:
 
@@ -781,6 +782,7 @@ metrics.reporter.dghttp.tags: myflinkapp,prod
 metrics.reporter.dghttp.proxyHost: my.web.proxy.com
 metrics.reporter.dghttp.proxyPort: 8080
 metrics.reporter.dhhttp.dataCenter: US
+metrics.reporter.dhhttp.maxMetricsPerRequest: 2000
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -781,11 +781,8 @@ metrics.reporter.dghttp.apikey: xxx
 metrics.reporter.dghttp.tags: myflinkapp,prod
 metrics.reporter.dghttp.proxyHost: my.web.proxy.com
 metrics.reporter.dghttp.proxyPort: 8080
-<<<<<<< HEAD
 metrics.reporter.dhhttp.dataCenter: US
-=======
 metrics.reporter.dhhttp.maxMetricsPerRequest: 2000
->>>>>>> [FLINK-16611] [datadog-metrics] Make number of metrics per request configurable
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -770,6 +770,7 @@ Parameters:
 - `proxyHost` - (optional) The proxy host to use when sending to Datadog.
 - `proxyPort` - (optional) The proxy port to use when sending to Datadog, defaults to 8080.
 - `dataCenter` - (optional) The data center (`EU`/`US`) to connect to, defaults to `US`.
+- `maxMetricsPerRequest` - (optional) The maximum number of metrics to include in each request, defaults to 2000.
 
 Example configuration:
 
@@ -780,7 +781,11 @@ metrics.reporter.dghttp.apikey: xxx
 metrics.reporter.dghttp.tags: myflinkapp,prod
 metrics.reporter.dghttp.proxyHost: my.web.proxy.com
 metrics.reporter.dghttp.proxyPort: 8080
+<<<<<<< HEAD
 metrics.reporter.dhhttp.dataCenter: US
+=======
+metrics.reporter.dhhttp.maxMetricsPerRequest: 2000
+>>>>>>> [FLINK-16611] [datadog-metrics] Make number of metrics per request configurable
 
 {% endhighlight %}
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
@@ -52,6 +52,7 @@ public class DCounter extends DMetric {
 		return difference;
 	}
 
+	@Override
 	public void ackReport() {
 		lastReportCount = currentReportCount;
 	}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
@@ -78,4 +78,7 @@ public abstract class DMetric {
 
 	@JsonIgnore
 	public abstract Number getMetricValue();
+
+	public void ackReport() {
+	}
 }

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
@@ -35,6 +35,10 @@ public class DSeries {
 		series = new ArrayList<>();
 	}
 
+	public DSeries(List<DMetric> series) {
+		this.series = series;
+	}
+
 	public void addGauge(DGauge gauge) {
 		series.add(gauge);
 	}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -145,8 +145,9 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 		while (fromIndex < totalMetrics) {
 			int toIndex = Math.min(fromIndex + maxMetricsPerRequestValue, totalMetrics);
 			try {
-				client.send(new DSeries(request.getSeries().subList(fromIndex, toIndex)));
-				request.getSeries().subList(fromIndex, toIndex).forEach(DMetric::ackReport);
+				DSeries chunk = new DSeries(request.getSeries().subList(fromIndex, toIndex));
+				client.send(chunk);
+				chunk.forEach(DMetric::ackReport);
 				LOGGER.debug("Reported series with size {}.", (toIndex - fromIndex));
 			} catch (SocketTimeoutException e) {
 				LOGGER.warn("Failed reporting metrics to Datadog because of socket timeout: {}", e.getMessage());

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -148,7 +148,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				DSeries chunk = new DSeries(request.getSeries().subList(fromIndex, toIndex));
 				client.send(chunk);
 				chunk.forEach(DMetric::ackReport);
-				LOGGER.debug("Reported series with size {}.", (toIndex - fromIndex));
+				LOGGER.debug("Reported series with size {}.", chunk.size());
 			} catch (SocketTimeoutException e) {
 				LOGGER.warn("Failed reporting metrics to Datadog because of socket timeout: {}", e.getMessage());
 			} catch (Exception e) {

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -146,6 +146,8 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 			int toIndex = Math.min(fromIndex + maxMetricsPerRequestValue, totalMetrics);
 			try {
 				client.send(new DSeries(request.getSeries().subList(fromIndex, toIndex)));
+				request.getSeries().subList(fromIndex, toIndex).forEach(DMetric::ackReport);
+				LOGGER.debug("Reported series with size {}.", (toIndex - fromIndex));
 			} catch (SocketTimeoutException e) {
 				LOGGER.warn("Failed reporting metrics to Datadog because of socket timeout: {}", e.getMessage());
 			} catch (Exception e) {
@@ -153,8 +155,6 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 			}
 			fromIndex = toIndex;
 		}
-		LOGGER.debug("Reported series with size {}.", totalMetrics);
-		counters.values().forEach(DCounter::ackReport);
 	}
 
 	private void addGaugesAndUnregisterOnException(DSeries request) {

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -147,8 +147,8 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 			try {
 				DSeries chunk = new DSeries(request.getSeries().subList(fromIndex, toIndex));
 				client.send(chunk);
-				chunk.forEach(DMetric::ackReport);
-				LOGGER.debug("Reported series with size {}.", chunk.size());
+				chunk.getSeries().forEach(DMetric::ackReport);
+				LOGGER.debug("Reported series with size {}.", chunk.getSeries().size());
 			} catch (SocketTimeoutException e) {
 				LOGGER.warn("Failed reporting metrics to Datadog because of socket timeout: {}", e.getMessage());
 			} catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

Datadog limits how large a single request may be. If too large, Datadog returns a 413 and the metrics are not received. This pull request allows a user to set the maximum number of metrics to include in a single request to Datadog so they can control its size.

## Brief change log

*(for example:)*
  - Set `maxMetricsPerRequest` from config or default if not found
  - Kept track of the number of metrics in each request iteration. Send the request when the max size has been met or no more metrics are left to add.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
