### PR TITLE
[FLINK-17679][python] Fix the bug of encoding bytes in cython coder

### DIFF
--- a/flink-python/pyflink/fn_execution/fast_coder_impl.pxd
+++ b/flink-python/pyflink/fn_execution/fast_coder_impl.pxd
@@ -116,7 +116,7 @@ cdef class FlattenRowCoderImpl(StreamCoderImpl):
     cdef void _encode_bigint(self, libc.stdint.int64_t v)
     cdef void _encode_float(self, float v)
     cdef void _encode_double(self, double v)
-    cdef void _encode_bytes(self, char*b)
+    cdef void _encode_bytes(self, char*b, size_t length)
 
     # decode data from input_stream
     cdef void _decode_next_row(self)

--- a/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
@@ -110,7 +110,7 @@ class CodersTest(unittest.TestCase):
         self.check_cython_coder(python_field_coders, cython_field_coders, [data])
 
     def test_cython_binary_coder(self):
-        data = [b'pyflink']
+        data = [b'pyflink', b'x\x00\x00\x00']
         python_field_coders = [coder_impl.BinaryCoderImpl() for _ in range(len(data))]
         cython_field_coders = [fast_coder_impl.BinaryCoderImpl() for _ in range(len(data))]
         self.check_cython_coder(python_field_coders, cython_field_coders, [data])


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of encoding bytes in cython coder*

## Brief change log

  - *replace strlen() of C Function with len() of Python Function to compute the length of bytes array in cython coder*

## Verifying this change

This change added tests and can be verified as follows:

  - *add a test data b'x\x00\x00\x00' in the method test_cython_binary_coder of test_fast_coders.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
