### PR TITLE
[FLINK-17968][hbase] Fix Hadoop Configuration is not properly serialized in HBaseRowInputFormat

### DIFF
--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/addons/hbase/TableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/addons/hbase/TableInputFormat.java
@@ -31,4 +31,8 @@ import org.apache.flink.connector.hbase.source.HBaseInputFormat;
 public abstract class TableInputFormat<T extends Tuple> extends HBaseInputFormat<T> {
 	private static final long serialVersionUID = 1L;
 
+	public TableInputFormat(org.apache.hadoop.conf.Configuration hConf) {
+		super(hConf);
+	}
+
 }

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/AbstractTableInputFormat.java
@@ -24,8 +24,10 @@ import org.apache.flink.api.common.io.LocatableInputSplitAssigner;
 import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
 import org.apache.flink.core.io.InputSplitAssigner;
 
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -59,6 +61,13 @@ abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, TableInput
 
 	protected byte[] currentRow;
 	protected long scannedRows;
+
+	// Configuration is not serializable
+	protected byte[] serializedConfig;
+
+	public AbstractTableInputFormat(org.apache.hadoop.conf.Configuration hConf) {
+		setSerializedConfig(hConf);
+	}
 
 	/**
 	 * Returns an instance of Scan that retrieves the required subset of records from the HBase table.
@@ -98,6 +107,14 @@ abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, TableInput
 	 * @see Configuration
 	 */
 	public abstract void configure(Configuration parameters);
+
+	protected void setSerializedConfig(org.apache.hadoop.conf.Configuration hConf) {
+		serializedConfig = HBaseConfigurationUtil.serializeConfiguration(hConf);
+	}
+
+	protected org.apache.hadoop.conf.Configuration getSerializedConfig() {
+		return HBaseConfigurationUtil.deserializeConfiguration(serializedConfig, HBaseConfiguration.create());
+	}
 
 	@Override
 	public void open(TableInputSplit split) throws IOException {

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/AbstractTableInputFormat.java
@@ -66,7 +66,7 @@ abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, TableInput
 	protected byte[] serializedConfig;
 
 	public AbstractTableInputFormat(org.apache.hadoop.conf.Configuration hConf) {
-		setSerializedConfig(hConf);
+		serializedConfig = HBaseConfigurationUtil.serializeConfiguration(hConf);
 	}
 
 	/**
@@ -108,11 +108,7 @@ abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, TableInput
 	 */
 	public abstract void configure(Configuration parameters);
 
-	protected void setSerializedConfig(org.apache.hadoop.conf.Configuration hConf) {
-		serializedConfig = HBaseConfigurationUtil.serializeConfiguration(hConf);
-	}
-
-	protected org.apache.hadoop.conf.Configuration getSerializedConfig() {
+	protected org.apache.hadoop.conf.Configuration getHadoopConfiguration() {
 		return HBaseConfigurationUtil.deserializeConfiguration(serializedConfig, HBaseConfiguration.create());
 	}
 

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseInputFormat.java
@@ -35,6 +35,11 @@ public abstract class HBaseInputFormat<T extends Tuple> extends AbstractTableInp
 
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Constructs a {@link InputFormat} with hbase configuration to read data from hbase.
+	 * @param hConf The configuration that connect to hbase.
+	 *              At least hbase.zookeeper.quorum and zookeeper.znode.parent need to be set.
+	 */
 	public HBaseInputFormat(org.apache.hadoop.conf.Configuration hConf) {
 		super(hConf);
 	}
@@ -82,7 +87,7 @@ public abstract class HBaseInputFormat<T extends Tuple> extends AbstractTableInp
 	 */
 	private HTable createTable() {
 		LOG.info("Initializing HBaseConfiguration");
-		org.apache.hadoop.conf.Configuration hConf = getSerializedConfig();
+		org.apache.hadoop.conf.Configuration hConf = getHadoopConfiguration();
 
 		try {
 			return new HTable(hConf, getTableName());

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseInputFormat.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.configuration.Configuration;
 
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
@@ -35,6 +34,10 @@ import org.apache.hadoop.hbase.client.Scan;
 public abstract class HBaseInputFormat<T extends Tuple> extends AbstractTableInputFormat<T> {
 
 	private static final long serialVersionUID = 1L;
+
+	public HBaseInputFormat(org.apache.hadoop.conf.Configuration hConf) {
+		super(hConf);
+	}
 
 	/**
 	 * Returns an instance of Scan that retrieves the required subset of records from the HBase table.
@@ -79,8 +82,7 @@ public abstract class HBaseInputFormat<T extends Tuple> extends AbstractTableInp
 	 */
 	private HTable createTable() {
 		LOG.info("Initializing HBaseConfiguration");
-		//use files found in the classpath
-		org.apache.hadoop.conf.Configuration hConf = HBaseConfiguration.create();
+		org.apache.hadoop.conf.Configuration hConf = getSerializedConfig();
 
 		try {
 			return new HTable(hConf, getTableName());

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataInputFormat.java
@@ -87,7 +87,7 @@ public class HBaseRowDataInputFormat extends AbstractTableInputFormat<RowData> {
 
 	private void connectToTable() {
 		try {
-			Connection conn = ConnectionFactory.createConnection(getSerializedConfig());
+			Connection conn = ConnectionFactory.createConnection(getHadoopConfiguration());
 			super.table = (HTable) conn.getTable(TableName.valueOf(tableName));
 		} catch (TableNotFoundException tnfe) {
 			LOG.error("The table " + tableName + " not found ", tnfe);

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataInputFormat.java
@@ -24,7 +24,6 @@ import org.apache.flink.connector.hbase.util.HBaseSerde;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.table.data.RowData;
 
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Connection;
@@ -50,15 +49,13 @@ public class HBaseRowDataInputFormat extends AbstractTableInputFormat<RowData> {
 
 	private transient HBaseSerde serde;
 
-	private transient org.apache.hadoop.conf.Configuration conf;
-
 	public HBaseRowDataInputFormat(
 			org.apache.hadoop.conf.Configuration conf,
 			String tableName,
 			HBaseTableSchema schema,
 			String nullStringLiteral) {
+		super(conf);
 		this.tableName = tableName;
-		this.conf = conf;
 		this.schema = schema;
 		this.nullStringLiteral = nullStringLiteral;
 	}
@@ -89,13 +86,8 @@ public class HBaseRowDataInputFormat extends AbstractTableInputFormat<RowData> {
 	}
 
 	private void connectToTable() {
-
-		if (this.conf == null) {
-			this.conf = HBaseConfiguration.create();
-		}
-
 		try {
-			Connection conn = ConnectionFactory.createConnection(conf);
+			Connection conn = ConnectionFactory.createConnection(getSerializedConfig());
 			super.table = (HTable) conn.getTable(TableName.valueOf(tableName));
 		} catch (TableNotFoundException tnfe) {
 			LOG.error("The table " + tableName + " not found ", tnfe);

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowInputFormat.java
@@ -89,7 +89,7 @@ public class HBaseRowInputFormat extends AbstractTableInputFormat<Row> implement
 
 	private void connectToTable() {
 		try {
-			Connection conn = ConnectionFactory.createConnection(getSerializedConfig());
+			Connection conn = ConnectionFactory.createConnection(getHadoopConfiguration());
 			super.table = (HTable) conn.getTable(TableName.valueOf(tableName));
 		} catch (TableNotFoundException tnfe) {
 			LOG.error("The table " + tableName + " not found ", tnfe);

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowInputFormat.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowInputFormat.java
@@ -28,7 +28,6 @@ import org.apache.flink.connector.hbase.util.HBaseReadWriteHelper;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.types.Row;
 
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Connection;
@@ -54,12 +53,11 @@ public class HBaseRowInputFormat extends AbstractTableInputFormat<Row> implement
 	private final String tableName;
 	private final HBaseTableSchema schema;
 
-	private transient org.apache.hadoop.conf.Configuration conf;
 	private transient HBaseReadWriteHelper readHelper;
 
 	public HBaseRowInputFormat(org.apache.hadoop.conf.Configuration conf, String tableName, HBaseTableSchema schema) {
+		super(conf);
 		this.tableName = tableName;
-		this.conf = conf;
 		this.schema = schema;
 	}
 
@@ -90,13 +88,8 @@ public class HBaseRowInputFormat extends AbstractTableInputFormat<Row> implement
 	}
 
 	private void connectToTable() {
-
-		if (this.conf == null) {
-			this.conf = HBaseConfiguration.create();
-		}
-
 		try {
-			Connection conn = ConnectionFactory.createConnection(conf);
+			Connection conn = ConnectionFactory.createConnection(getSerializedConfig());
 			super.table = (HTable) conn.getTable(TableName.valueOf(tableName));
 		} catch (TableNotFoundException tnfe) {
 			LOG.error("The table " + tableName + " not found ", tnfe);

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/example/HBaseReadExample.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/example/HBaseReadExample.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.hbase.source.HBaseInputFormat;
 
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -47,7 +48,7 @@ public class HBaseReadExample {
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		@SuppressWarnings("serial")
-		DataSet<Tuple2<String, String>> hbaseDs = env.createInput(new HBaseInputFormat<Tuple2<String, String>>() {
+		DataSet<Tuple2<String, String>> hbaseDs = env.createInput(new HBaseInputFormat<Tuple2<String, String>>(HBaseConfiguration.create()) {
 
 				@Override
 				public String getTableName() {

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/util/HBaseTestBase.java
@@ -74,7 +74,6 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 
 	@BeforeClass
 	public static void activateHBaseCluster() throws IOException {
-		registerHBaseMiniClusterInClasspath();
 		prepareTables();
 	}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Because the `Configuration` in HBaseRowInputFormat cannot be serialized, the task cannot obtain the zk address set in the table parameter, which prevents the task from connecting to Hbase.   
Because the default value of `hbase.zookeeper.quorum` is localhost, the unit test is ok


## Brief change log

Fix failure to read hbase table

## Verifying this change

no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
