### PR TITLE
[FLINK-13811][python] Support converting flink Table to pandas DataFrame

### DIFF
--- a/docs/dev/table/python/conversion_of_pandas.md
+++ b/docs/dev/table/python/conversion_of_pandas.md
@@ -57,3 +57,24 @@ table = t_env.from_pandas(pdf,
                           DataTypes.ROW([DataTypes.FIELD("f0", DataTypes.DOUBLE()),
                                          DataTypes.FIELD("f1", DataTypes.DOUBLE())])
 {% endhighlight %}
+
+## Convert PyFlink Table to Pandas DataFrame
+
+It also supports to convert a PyFlink Table to a Pandas DataFrame. Internally, it will materialize the results of the 
+table and serialize them into multiple arrow batches of Arrow columnar format at client side. The maximum arrow batch size
+is determined by the config option [python.fn-execution.arrow.batch.size]({{ site.baseurl }}/dev/table/python/python_config.html#python-fn-execution-arrow-batch-size).
+The serialized data will then be converted to Pandas DataFrame.
+
+The following example shows how to convert a PyFlink Table to a Pandas DataFrame:
+
+{% highlight python %}
+import pandas as pd
+import numpy as np
+
+# Create a PyFlink Table
+pdf = pd.DataFrame(np.random.rand(1000, 2))
+table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
+
+# Convert the PyFlink Table to a Pandas DataFrame
+pdf = table.to_pandas()
+{% endhighlight %}

--- a/docs/dev/table/python/conversion_of_pandas.md
+++ b/docs/dev/table/python/conversion_of_pandas.md
@@ -29,7 +29,7 @@ It supports to convert between PyFlink Table and Pandas DataFrame.
 
 ## Convert Pandas DataFrame to PyFlink Table
 
-It supports to create a PyFlink Table from a Pandas DataFrame. Internally, it will serialize the Pandas DataFrame
+It supports creating a PyFlink Table from a Pandas DataFrame. Internally, it will serialize the Pandas DataFrame
 using Arrow columnar format at client side and the serialized data will be processed and deserialized in Arrow source
 during execution. The Arrow source could also be used in streaming jobs and it will properly handle the checkpoint
 and provides the exactly once guarantees.
@@ -60,8 +60,8 @@ table = t_env.from_pandas(pdf,
 
 ## Convert PyFlink Table to Pandas DataFrame
 
-It also supports to convert a PyFlink Table to a Pandas DataFrame. Internally, it will materialize the results of the 
-table and serialize them into multiple arrow batches of Arrow columnar format at client side. The maximum arrow batch size
+It also supports converting a PyFlink Table to a Pandas DataFrame. Internally, it will materialize the results of the 
+table and serialize them into multiple Arrow batches of Arrow columnar format at client side. The maximum Arrow batch size
 is determined by the config option [python.fn-execution.arrow.batch.size]({{ site.baseurl }}/dev/table/python/python_config.html#python-fn-execution-arrow-batch-size).
 The serialized data will then be converted to Pandas DataFrame.
 

--- a/docs/dev/table/python/conversion_of_pandas.zh.md
+++ b/docs/dev/table/python/conversion_of_pandas.zh.md
@@ -57,3 +57,24 @@ table = t_env.from_pandas(pdf,
                           DataTypes.ROW([DataTypes.FIELD("f0", DataTypes.DOUBLE()),
                                          DataTypes.FIELD("f1", DataTypes.DOUBLE())])
 {% endhighlight %}
+
+## Convert PyFlink Table to Pandas DataFrame
+
+It also supports to convert a PyFlink Table to a Pandas DataFrame. Internally, it will materialize the results of the 
+table and serialize them into multiple arrow batches of Arrow columnar format at client side. The maximum arrow batch size
+is determined by the config option [python.fn-execution.arrow.batch.size]({{ site.baseurl }}/zh/dev/table/python/python_config.html#python-fn-execution-arrow-batch-size).
+The serialized data will then be converted to Pandas DataFrame.
+
+The following example shows how to convert a PyFlink Table to a Pandas DataFrame:
+
+{% highlight python %}
+import pandas as pd
+import numpy as np
+
+# Create a PyFlink Table
+pdf = pd.DataFrame(np.random.rand(1000, 2))
+table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
+
+# Convert the PyFlink Table to a Pandas DataFrame
+pdf = table.to_pandas()
+{% endhighlight %}

--- a/docs/dev/table/python/conversion_of_pandas.zh.md
+++ b/docs/dev/table/python/conversion_of_pandas.zh.md
@@ -29,7 +29,7 @@ It supports to convert between PyFlink Table and Pandas DataFrame.
 
 ## Convert Pandas DataFrame to PyFlink Table
 
-It supports to create a PyFlink Table from a Pandas DataFrame. Internally, it will serialize the Pandas DataFrame
+It supports creating a PyFlink Table from a Pandas DataFrame. Internally, it will serialize the Pandas DataFrame
 using Arrow columnar format at client side and the serialized data will be processed and deserialized in Arrow source
 during execution. The Arrow source could also be used in streaming jobs and it will properly handle the checkpoint
 and provides the exactly once guarantees.
@@ -60,8 +60,8 @@ table = t_env.from_pandas(pdf,
 
 ## Convert PyFlink Table to Pandas DataFrame
 
-It also supports to convert a PyFlink Table to a Pandas DataFrame. Internally, it will materialize the results of the 
-table and serialize them into multiple arrow batches of Arrow columnar format at client side. The maximum arrow batch size
+It also supports converting a PyFlink Table to a Pandas DataFrame. Internally, it will materialize the results of the 
+table and serialize them into multiple Arrow batches of Arrow columnar format at client side. The maximum Arrow batch size
 is determined by the config option [python.fn-execution.arrow.batch.size]({{ site.baseurl }}/zh/dev/table/python/python_config.html#python-fn-execution-arrow-batch-size).
 The serialized data will then be converted to Pandas DataFrame.
 

--- a/flink-python/pyflink/table/serializers.py
+++ b/flink-python/pyflink/table/serializers.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import io
+
 from pyflink.serializers import Serializer
 from pyflink.table.utils import arrow_to_pandas, pandas_to_arrow
 
@@ -51,3 +53,26 @@ class ArrowSerializer(Serializer):
         reader = pa.ipc.open_stream(stream)
         for batch in reader:
             yield arrow_to_pandas(self._timezone, self._field_types, [batch])
+
+    def load_from_iterator(self, itor):
+        class IteratorIO(io.RawIOBase):
+            def __init__(self, itor):
+                self.itor = itor
+                self.leftover = None
+
+            def readable(self):
+                return True
+
+            def readinto(self, b):
+                output_buffer_len = len(b)
+                input = self.leftover or (self.itor.next() if self.itor.hasNext() else None)
+                if input is None:
+                    return 0
+                output, self.leftover = input[:output_buffer_len], input[output_buffer_len:]
+                b[:len(output)] = output
+                return len(output)
+        import pyarrow as pa
+        reader = pa.ipc.open_stream(
+            io.BufferedReader(IteratorIO(itor), buffer_size=io.DEFAULT_BUFFER_SIZE))
+        for batch in reader:
+            yield batch

--- a/flink-python/pyflink/table/serializers.py
+++ b/flink-python/pyflink/table/serializers.py
@@ -57,6 +57,7 @@ class ArrowSerializer(Serializer):
     def load_from_iterator(self, itor):
         class IteratorIO(io.RawIOBase):
             def __init__(self, itor):
+                super(IteratorIO, self).__init__()
                 self.itor = itor
                 self.leftover = None
 

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -18,6 +18,8 @@
 import datetime
 import decimal
 
+from pandas.util.testing import assert_frame_equal
+
 from pyflink.table.types import DataTypes, Row
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
@@ -129,6 +131,17 @@ class PandasConversionITTests(PandasConversionTestBase):
                             "1000000000000000000.010000000000000000,2014-09-13,01:00:01,"
                             "1970-01-01 00:00:00.123,[hello, 中文],1,hello,"
                             "1970-01-01 00:00:00.123,[1, 2]"])
+
+    def test_to_pandas(self):
+        table = self.t_env.from_pandas(self.pdf, self.data_type)
+        result_pdf = table.to_pandas()
+        self.assertTrue(2, len(result_pdf))
+        assert_frame_equal(self.pdf, result_pdf)
+
+    def test_empty_to_pandas(self):
+        table = self.t_env.from_pandas(self.pdf, self.data_type)
+        pdf = table.filter("f1 < 0").to_pandas()
+        self.assertTrue(pdf.empty)
 
 
 class StreamPandasConversionTests(PandasConversionITTests,

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -135,7 +135,7 @@ class PandasConversionITTests(PandasConversionTestBase):
     def test_to_pandas(self):
         table = self.t_env.from_pandas(self.pdf, self.data_type)
         result_pdf = table.to_pandas()
-        self.assertTrue(2, len(result_pdf))
+        self.assertEqual(2, len(result_pdf))
         assert_frame_equal(self.pdf, result_pdf)
 
     def test_empty_to_pandas(self):

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -20,9 +20,20 @@ package org.apache.flink.table.runtime.arrow;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.internal.TableEnvImpl;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.delegation.Planner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.sinks.SelectTableSinkSchemaConverter;
 import org.apache.flink.table.runtime.arrow.readers.ArrayFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
@@ -113,6 +124,7 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 import org.apache.flink.types.Row;
 
 import org.apache.arrow.flatbuf.MessageHeader;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -135,6 +147,7 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.MessageMetadataResult;
@@ -146,7 +159,10 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -157,6 +173,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -165,6 +182,8 @@ import java.util.stream.Collectors;
  */
 @Internal
 public final class ArrowUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ArrowUtils.class);
 
 	private static RootAllocator rootAllocator;
 
@@ -585,6 +604,89 @@ public final class ArrowUtils {
 				throw new EOFException(String.format("Not enough bytes in channel (expected %d).",
 					expected));
 			}
+		}
+	}
+
+	/**
+	 * Convert Flink table to Pandas DataFrame.
+	 */
+	public static Iterator<byte[]> collectAsPandasDataFrame(Table table, int maxArrowBatchSize) throws Exception {
+		BufferAllocator allocator = getRootAllocator().newChildAllocator("collectAsPandasDataFrame", 0, Long.MAX_VALUE);
+		RowType rowType = (RowType) table.getSchema().toRowDataType().getLogicalType();
+		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ArrowStreamWriter arrowStreamWriter = new ArrowStreamWriter(root, null, baos);
+		arrowStreamWriter.start();
+
+		ArrowWriter arrowWriter;
+		Iterator<Row> results = table.execute().collect();
+		Iterator convertedResults;
+		if (isBlinkPlanner(table)) {
+			arrowWriter = createRowDataArrowWriter(root, rowType);
+			convertedResults = new Iterator<RowData>() {
+				@Override
+				public boolean hasNext() {
+					return results.hasNext();
+				}
+
+				@Override
+				public RowData next() {
+					// The SelectTableSink of blink planner will convert the table schema and we
+					// need to keep the table schema used here be consistent with the converted table schema
+					TableSchema convertedTableSchema = SelectTableSinkSchemaConverter.changeDefaultConversionClass(table.getSchema());
+					DataFormatConverters.DataFormatConverter converter = DataFormatConverters.getConverterForDataType(convertedTableSchema.toRowDataType());
+					return (RowData) converter.toInternal(results.next());
+				}
+			};
+		} else {
+			arrowWriter = createRowArrowWriter(root, rowType);
+			convertedResults = results;
+		}
+
+		return new Iterator<byte[]>() {
+			@Override
+			public boolean hasNext() {
+				return convertedResults.hasNext();
+			}
+
+			@Override
+			public byte[] next() {
+				try {
+					int i = 0;
+					while (convertedResults.hasNext() && i < maxArrowBatchSize) {
+						i++;
+						arrowWriter.write(convertedResults.next());
+					}
+					arrowWriter.finish();
+					arrowStreamWriter.writeBatch();
+					return baos.toByteArray();
+				} catch (Throwable t) {
+					String msg = "Failed to serialize the data of the table";
+					LOG.error(msg, t);
+					throw new RuntimeException(msg, t);
+				} finally {
+					arrowWriter.reset();
+					baos.reset();
+
+					if (!hasNext()) {
+						root.close();
+						allocator.close();
+					}
+				}
+			}
+		};
+	}
+
+	private static boolean isBlinkPlanner(Table table) {
+		TableEnvironment tableEnv = ((TableImpl) table).getTableEnvironment();
+		if (tableEnv instanceof BatchTableEnvironment || tableEnv instanceof TableEnvImpl) {
+			return false;
+		} else if (tableEnv instanceof TableEnvironmentImpl) {
+			Planner planner = ((TableEnvironmentImpl) tableEnv).getPlanner();
+			return planner instanceof PlannerBase;
+		} else {
+			throw new RuntimeException(String.format(
+				"Could not determine the planner type for table environment class %s", tableEnv.getClass()));
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkSchemaConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkSchemaConverter.java
@@ -28,12 +28,12 @@ import org.apache.flink.table.types.logical.TimestampType;
 /**
  * An utility class that provides abilities to change {@link TableSchema}.
  */
-class SelectTableSinkSchemaConverter {
+public class SelectTableSinkSchemaConverter {
 
 	/**
 	 * Change to default conversion class and build a new {@link TableSchema}.
 	 */
-	static TableSchema changeDefaultConversionClass(TableSchema tableSchema) {
+	public static TableSchema changeDefaultConversionClass(TableSchema tableSchema) {
 		DataType[] oldTypes = tableSchema.getFieldDataTypes();
 		String[] fieldNames = tableSchema.getFieldNames();
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add support to convert flink Table to pandas DataFrame*

## Brief change log

  - *Add utility ArrowUtils.collectAsPandasDataFrame to materialize the results of the table and serialize them into arrow format*
  - *Add Table.to_pandas in PyFlink to convert flink Table to pandas DataFrame*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_pandas_conversion.test_to_pandas and test_pandas_conversion.test_empty_to_pandas*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
