### PR TITLE
[various] Cleanups and improvements to the SourceOperators

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerialization.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerialization.java
@@ -146,7 +146,7 @@ public class SimpleVersionedSerialization {
 	public static <T> T readVersionAndDeSerialize(SimpleVersionedSerializer<T> serializer, byte[] bytes) throws IOException {
 		checkNotNull(serializer, "serializer");
 		checkNotNull(bytes, "bytes");
-		checkArgument(bytes.length >= 4, "byte array below minimum length (4 bytes)");
+		checkArgument(bytes.length >= 8, "byte array below minimum length (8 bytes)");
 
 		final byte[] dataOnly = Arrays.copyOfRange(bytes, 8, bytes.length);
 		final int version =

--- a/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
@@ -20,8 +20,11 @@ package org.apache.flink.util;
 
 import org.apache.flink.annotation.Internal;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,5 +84,19 @@ public final class CollectionUtil {
 			.stream()
 			.map(projector)
 			.collect(toList());
+	}
+
+	/**
+	 * Collects the elements in the Iterable in a List. If the iterable argument is null,
+	 * this method returns an empty list.
+	 */
+	public static <E> List<E> iterableToList(@Nullable Iterable<E> iterable) {
+		if (iterable == null) {
+			return Collections.emptyList();
+		}
+
+		final ArrayList<E> list = new ArrayList<>();
+		iterable.iterator().forEachRemaining(list::add);
+		return list;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorEventDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorEventDispatcher.java
@@ -21,10 +21,20 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 
 /**
- * The dispatcher through which Operators receive operator events and through which they can send operator
- * events back to the coordinator.
+ * The dispatcher through which Operators receive {@link OperatorEvent}s and through which they can
+ * send OperatorEvents back to the {@code OperatorCoordinator}.
  */
 public interface OperatorEventDispatcher {
 
-	OperatorEventGateway registerEventHandler(OperatorID operator, OperatorEventHandler handler);
+	/**
+	 * Register a listener that is notified every time an OperatorEvent is sent from the
+	 * OperatorCoordinator (of the operator with the given OperatorID) to this subtask.
+	 */
+	void registerEventHandler(OperatorID operator, OperatorEventHandler handler);
+
+	/**
+	 * Gets the gateway through which events can be passed to the OperatorCoordinator for
+	 * the operator identified by the given OperatorID.
+	 */
+	OperatorEventGateway getOperatorEventGateway(OperatorID operatorId);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -156,7 +156,7 @@ public abstract class AbstractStreamOperator<OUT>
 		this.config = config;
 		try {
 			OperatorMetricGroup operatorMetricGroup = environment.getMetricGroup().getOrAddOperator(config.getOperatorID(), config.getOperatorName());
-			this.output = new CountingOutput(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+			this.output = new CountingOutput<>(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
 			if (config.isChainStart()) {
 				operatorMetricGroup.getIOMetricGroup().reuseInputMetricsForTask();
 			}
@@ -394,7 +394,6 @@ public abstract class AbstractStreamOperator<OUT>
 		return runtimeContext;
 	}
 
-	@SuppressWarnings("unchecked")
 	@VisibleForTesting
 	public <K> KeyedStateBackend<K> getKeyedStateBackend() {
 		return stateHandler.getKeyedStateBackend();
@@ -462,12 +461,10 @@ public abstract class AbstractStreamOperator<OUT>
 		}
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void setCurrentKey(Object key) {
 		stateHandler.setCurrentKey(key);
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	public Object getCurrentKey() {
 		return stateHandler.getCurrentKey();
 	}
@@ -551,6 +548,7 @@ public abstract class AbstractStreamOperator<OUT>
 		if (timeServiceManager == null) {
 			throw new RuntimeException("The timer service has not been initialized.");
 		}
+		@SuppressWarnings("unchecked")
 		InternalTimeServiceManager<K> keyedTimeServiceHandler = (InternalTimeServiceManager<K>) timeServiceManager;
 		return keyedTimeServiceHandler.getInternalTimerService(
 			name,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CoordinatedOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CoordinatedOperatorFactory.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
-import org.apache.flink.runtime.operators.coordination.OperatorEventDispatcher;
 
 /**
  * A factory class for the {@link StreamOperator}s implementing
@@ -43,15 +42,4 @@ public interface CoordinatedOperatorFactory<OUT> extends StreamOperatorFactory<O
 	 * @return the provider of the {@link OperatorCoordinator} for this operator.
 	 */
 	OperatorCoordinator.Provider getCoordinatorProvider(String operatorName, OperatorID operatorID);
-
-	/**
-	 * Sets the {@link OperatorEventDispatcher} for registering the
-	 * {@link org.apache.flink.runtime.operators.coordination.OperatorEventHandler OperaterEventHandler} and setup the
-	 * {@link org.apache.flink.runtime.operators.coordination.OperatorEventGateway OperatorEventGateway} for the
-	 * SourceOperator to send events to the operator coordinator. This method will be invoked before
-	 * {@link #createStreamOperator(StreamOperatorParameters)} is invoked.
-	 *
-	 * @param operatorEventDispatcher the {@link OperatorEventDispatcher} to register the
-	 */
-	void setOperatorEventDispatcher(OperatorEventDispatcher operatorEventDispatcher);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -51,14 +51,18 @@ import java.util.concurrent.CompletableFuture;
  * the interface of {@link PushingAsyncDataInput} for naturally compatible with one input processing in runtime
  * stack.
  *
- * <p>Note: We are expecting this to be changed to the concrete class once SourceReader interface is introduced.
+ * <p><b>Important Note on Serialization:</b> The SourceOperator inherits the {@link java.io.Serializable}
+ * interface from the StreamOperator, but is in fact NOT serializable. The operator must only be instantiates
+ * in the StreamTask from its factory.
  *
  * @param <OUT> The output type of the operator.
  */
 @Internal
+@SuppressWarnings("serial")
 public class SourceOperator<OUT, SplitT extends SourceSplit>
 		extends AbstractStreamOperator<OUT>
 		implements OperatorEventHandler, PushingAsyncDataInput<OUT> {
+
 	// Package private for unit test.
 	static final ListStateDescriptor<byte[]> SPLITS_STATE_DESC =
 			new ListStateDescriptor<>("SourceReaderState", BytePrimitiveArraySerializer.INSTANCE);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
@@ -30,10 +30,15 @@ import org.apache.flink.runtime.source.coordinator.SourceCoordinatorProvider;
  */
 public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OUT>
 		implements CoordinatedOperatorFactory<OUT> {
+
+	private static final long serialVersionUID = 1L;
+
 	/** The {@link Source} to create the {@link SourceOperator}. */
 	private final Source<OUT, ?, ?> source;
+
 	/** The number of worker thread for the source coordinator. */
 	private final int numCoordinatorWorkerThread;
+
 	/** The {@link OperatorEventDispatcher} to register the SourceOperator. */
 	private OperatorEventDispatcher operatorEventDispatcher;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
@@ -24,7 +24,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceAware;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
-import org.apache.flink.util.Preconditions;
 
 import java.util.Optional;
 
@@ -61,20 +60,14 @@ public class StreamOperatorFactoryUtil {
 			((ProcessingTimeServiceAware) operatorFactory).setProcessingTimeService(processingTimeService);
 		}
 
-		if (operatorFactory instanceof CoordinatedOperatorFactory) {
-			Preconditions.checkNotNull(
-					operatorEventDispatcher,
-					"The OperatorEventDispatcher should not be null.");
-			((CoordinatedOperatorFactory<OUT>) operatorFactory).setOperatorEventDispatcher(operatorEventDispatcher);
-		}
-
 		// TODO: what to do with ProcessingTimeServiceAware?
 		OP op = operatorFactory.createStreamOperator(
 			new StreamOperatorParameters<>(
 				containingTask,
 				configuration,
 				output,
-				processingTimeService));
+				processingTimeService,
+				operatorEventDispatcher));
 		return new Tuple2<>(op, Optional.ofNullable(processingTimeService));
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorParameters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorParameters.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.runtime.operators.coordination.OperatorEventDispatcher;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
@@ -37,16 +38,19 @@ public class StreamOperatorParameters<OUT> {
 	private final StreamConfig config;
 	private final Output<StreamRecord<OUT>> output;
 	private final ProcessingTimeService processingTimeService;
+	private final OperatorEventDispatcher operatorEventDispatcher;
 
 	public StreamOperatorParameters(
 			StreamTask<?, ?> containingTask,
 			StreamConfig config,
 			Output<StreamRecord<OUT>> output,
-			ProcessingTimeService processingTimeService) {
+			ProcessingTimeService processingTimeService,
+			OperatorEventDispatcher operatorEventDispatcher) {
 		this.containingTask = containingTask;
 		this.config = config;
 		this.output = output;
 		this.processingTimeService = processingTimeService;
+		this.operatorEventDispatcher = operatorEventDispatcher;
 	}
 
 	public StreamTask<?, ?> getContainingTask() {
@@ -63,5 +67,9 @@ public class StreamOperatorParameters<OUT> {
 
 	public ProcessingTimeService getProcessingTimeService() {
 		return processingTimeService;
+	}
+
+	public OperatorEventDispatcher getOperatorEventDispatcher() {
+		return operatorEventDispatcher;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/SimpleVersionedListState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/SimpleVersionedListState.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.util;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link ListState} that uses a {@link SimpleVersionedSerializer} instead of a {@link TypeSerializer}.
+ *
+ * <p>The state wraps a {@link ListState} of type {@code byte[]}, meaning it internally keeps only bytes
+ * and lazily deserializes them into objects. This has two major implications, compared to a {@code ListState}
+ * states that uses a {@code TypeSerializer}:
+ *
+ * <ul>
+ *     <li>This state does not participate in <i>>state migration</i>. The bytes are never converted and
+ *         different state versions are lazily resolved by the versioned serializer.
+ *     <li>This state is generally slower than states that directly use the {@code TypeSerializer}, because
+ *         of extra copies into byte arrays and extra version encodings.
+ * </ul>
+ *
+ * @param <T> The type of the objects stored in the state.
+ */
+public class SimpleVersionedListState<T> implements ListState<T> {
+
+	private final ListState<byte[]> rawState;
+
+	private final SimpleVersionedSerializer<T> serializer;
+
+	/**
+	 * Creates a new SimpleVersionedListState that reads and writes bytes from the given raw ListState
+	 * with the given serializer.
+	 */
+	public SimpleVersionedListState(ListState<byte[]> rawState, SimpleVersionedSerializer<T> serializer) {
+		this.rawState = checkNotNull(rawState);
+		this.serializer = checkNotNull(serializer);
+	}
+
+	@Override
+	public void update(@Nullable List<T> values) throws Exception {
+		rawState.update(serializeAll(values));
+	}
+
+	@Override
+	public void addAll(@Nullable List<T> values) throws Exception {
+		rawState.addAll(serializeAll(values));
+	}
+
+	@Override
+	public Iterable<T> get() throws Exception {
+		final Iterable<byte[]> rawIterable = rawState.get();
+		final SimpleVersionedSerializer<T> serializer = this.serializer;
+
+		return () -> new DeserializingIterator<>(rawIterable.iterator(), serializer);
+	}
+
+	@Override
+	public void add(T value) throws Exception {
+		rawState.add(serialize(value));
+	}
+
+	@Override
+	public void clear() {
+		rawState.clear();
+	}
+
+	// ------------------------------------------------------------------------
+	//  utils
+	// ------------------------------------------------------------------------
+
+	private byte[] serialize(T value) throws IOException {
+		return SimpleVersionedSerialization.writeVersionAndSerialize(serializer, value);
+	}
+
+	@Nullable
+	private List<byte[]> serializeAll(@Nullable List<T> values) throws IOException {
+		if (values == null) {
+			return null;
+		}
+
+		final ArrayList<byte[]> rawValues = new ArrayList<>(values.size());
+		for (T value : values) {
+			rawValues.add(serialize(value));
+		}
+		return rawValues;
+	}
+
+	private static final class DeserializingIterator<T> implements Iterator<T> {
+
+		private final Iterator<byte[]> rawIterator;
+		private final SimpleVersionedSerializer<T> serializer;
+
+		private DeserializingIterator(Iterator<byte[]> rawIterator, SimpleVersionedSerializer<T> serializer) {
+			this.rawIterator = rawIterator;
+			this.serializer = serializer;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return rawIterator.hasNext();
+		}
+
+		@Override
+		public T next() {
+			final byte[] bytes = rawIterator.next();
+			try {
+				return SimpleVersionedSerialization.readVersionAndDeSerialize(serializer, bytes);
+			}
+			catch (IOException e) {
+				throw new FlinkRuntimeException("Failed to deserialize value", e);
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorEventDispatcherImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorEventDispatcherImpl.java
@@ -74,16 +74,16 @@ final class OperatorEventDispatcherImpl implements OperatorEventDispatcher {
 	}
 
 	@Override
-	public OperatorEventGateway registerEventHandler(OperatorID operator, OperatorEventHandler handler) {
-		final OperatorEventGateway gateway = new OperatorEventGatewayImpl(toCoordinator, operator);
+	public void registerEventHandler(OperatorID operator, OperatorEventHandler handler) {
 		final OperatorEventHandler prior = handlers.putIfAbsent(operator, handler);
-
-		if (prior == null) {
-			return gateway;
-		}
-		else {
+		if (prior != null) {
 			throw new IllegalStateException("already a handler registered for this operatorId");
 		}
+	}
+
+	@Override
+	public OperatorEventGateway getOperatorEventGateway(OperatorID operatorId) {
+		return new OperatorEventGatewayImpl(toCoordinator, operatorId);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -19,11 +19,8 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.api.common.state.OperatorStateStore;
-import org.apache.flink.api.connector.source.Boundedness;
-import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceEvent;
-import org.apache.flink.api.connector.source.SourceSplit;
-import org.apache.flink.api.connector.source.mocks.MockSource;
+import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
@@ -31,6 +28,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
@@ -61,20 +59,18 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("serial")
 public class SourceOperatorTest {
 
-	private static final int NUM_SPLITS = 5;
 	private static final int SUBTASK_INDEX = 1;
 	private static final MockSourceSplit MOCK_SPLIT = new MockSourceSplit(1234, 10);
 
-	private MockSource source;
+	private MockSourceReader mockSourceReader;
 	private MockOperatorEventGateway mockGateway;
 	private SourceOperator<Integer, MockSourceSplit> operator;
 
 	@Before
 	public void setup() {
-		this.source = new MockSource(Boundedness.BOUNDED, NUM_SPLITS);
-		this.operator = new TestingSourceOperator<>(source, SUBTASK_INDEX);
+		this.mockSourceReader = new MockSourceReader();
 		this.mockGateway = new MockOperatorEventGateway();
-		this.operator.setOperatorEventGateway(mockGateway);
+		this.operator = new TestingSourceOperator<>(mockSourceReader, mockGateway, SUBTASK_INDEX);
 	}
 
 	@Test
@@ -91,9 +87,7 @@ public class SourceOperatorTest {
 		operator.initializeState(getStateContext());
 		// Open the operator.
 		operator.open();
-		// A source reader should have been created.
-		assertEquals(1, source.getCreatedReaders().size());
-		MockSourceReader mockSourceReader = source.getCreatedReaders().get(0);
+
 		// The source reader should have been assigned a split.
 		assertEquals(Collections.singletonList(MOCK_SPLIT), mockSourceReader.getAssignedSplits());
 		// The source reader should have started.
@@ -112,8 +106,7 @@ public class SourceOperatorTest {
 		operator.open();
 		MockSourceSplit newSplit = new MockSourceSplit((2));
 		operator.handleOperatorEvent(new AddSplitEvent<>(Collections.singletonList(newSplit)));
-		// The source reader should bave been assigned two splits.
-		MockSourceReader mockSourceReader = source.getCreatedReaders().get(0);
+		// The source reader should have been assigned two splits.
 		assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), mockSourceReader.getAssignedSplits());
 	}
 
@@ -123,8 +116,7 @@ public class SourceOperatorTest {
 		operator.open();
 		SourceEvent event = new SourceEvent() {};
 		operator.handleOperatorEvent(new SourceEventWrapper(event));
-		// The source reader should bave been assigned two splits.
-		MockSourceReader mockSourceReader = source.getCreatedReaders().get(0);
+		// The source reader should have been assigned two splits.
 		assertEquals(Collections.singletonList(event), mockSourceReader.getReceivedSourceEvents());
 	}
 
@@ -179,13 +171,20 @@ public class SourceOperatorTest {
 	/**
 	 * A testing class that overrides the getRuntimeContext() Method.
 	 */
-	private static class TestingSourceOperator<OUT, SplitT extends SourceSplit>
-			extends SourceOperator<OUT, SplitT> {
+	private static class TestingSourceOperator<OUT> extends SourceOperator<OUT, MockSourceSplit> {
 
 		private final int subtaskIndex;
 
-		TestingSourceOperator(Source<OUT, SplitT, ?> source, int subtaskIndex) {
-			super(source);
+		TestingSourceOperator(
+				SourceReader<OUT, MockSourceSplit> reader,
+				OperatorEventGateway eventGateway,
+				int subtaskIndex) {
+
+			super(
+					(context) -> reader,
+					eventGateway,
+					new MockSourceSplitSerializer());
+
 			this.subtaskIndex = subtaskIndex;
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -58,10 +58,13 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit test for {@link SourceOperator}.
  */
+@SuppressWarnings("serial")
 public class SourceOperatorTest {
+
 	private static final int NUM_SPLITS = 5;
 	private static final int SUBTASK_INDEX = 1;
 	private static final MockSourceSplit MOCK_SPLIT = new MockSourceSplit(1234, 10);
+
 	private MockSource source;
 	private MockOperatorEventGateway mockGateway;
 	private SourceOperator<Integer, MockSourceSplit> operator;
@@ -176,8 +179,9 @@ public class SourceOperatorTest {
 	/**
 	 * A testing class that overrides the getRuntimeContext() Method.
 	 */
-	private static class TestingSourceOperator<OUT, SplitT extends SourceSplit> extends
-																				SourceOperator<OUT, SplitT> {
+	private static class TestingSourceOperator<OUT, SplitT extends SourceSplit>
+			extends SourceOperator<OUT, SplitT> {
+
 		private final int subtaskIndex;
 
 		TestingSourceOperator(Source<OUT, SplitT, ?> source, int subtaskIndex) {


### PR DESCRIPTION
## What is the purpose of the change

This PR contains various small fixes and improvements for the `SourceOperator` implementation.
Nothing is any change in user-facing behavior, these are only improvements for better future maintenance.

## Brief change log

### (1) Simplify State Access in SourceOperator

The SourceOperator has some boiler plate code taking the bytes out of the `ListState<byte[]>` and applying the `SimpleVersionedSerializer` to turn them into the splits.

This change encapsulates that code in a utility class `SimpleVersionedListState<SplitT>` which wraps a `ListState<byte[]>` and applies the serialization and de-serialization.

### (2) Initialization of the SourceOperator

Before this change, the `SourceOperator` takes a `Source` in the constructor.
All actual components that the `SourceOperator` relies on when working are lazily initialized, in `open()` or via setters. This change moves towards more eager initialization, as is the purpose of the new `SourceOperatorFactory`-based appraoch.

Relying on something as broad as Source also means that a lot of redundant context has to be provided to the `SourceOperator` during initialization. The Source is, for example, also responsible for the `SourceEnumerator`, which is independent of the `SourceOperator`. However, it needed to be considered during testing, because the tests need to mock a full `Source` in order to instantiate a SourceOperator.

This change passes the collaborators of the `SourceOperator` directly eagerly into the constructor. It is not fully possible with the `SourceReader`, but for that we can still reduce the scope by passing a targeted factory function.

## Verifying this change

This PR does not change any behavior, only internal design. The functionality is already covered by existing unit tests. The PR adjusts the relevant teste where needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
