### PR TITLE
[FLINK-17701][build] Exclude transitive jdk:tools dependency from all Hadoop dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,10 @@ under the License.
 				<version>${hadoop.version}</version>
 				<exclusions>
 					<exclusion>
+						<groupId>jdk.tools</groupId>
+						<artifactId>jdk.tools</artifactId>
+					</exclusion>
+					<exclusion>
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
 					</exclusion>
@@ -328,6 +332,10 @@ under the License.
 				<artifactId>hadoop-hdfs</artifactId>
 				<version>${hadoop.version}</version>
 				<exclusions>
+					<exclusion>
+						<groupId>jdk.tools</groupId>
+						<artifactId>jdk.tools</artifactId>
+					</exclusion>
 					<exclusion>
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
@@ -345,6 +353,10 @@ under the License.
 				<version>${hadoop.version}</version>
 				<exclusions>
 					<exclusion>
+						<groupId>jdk.tools</groupId>
+						<artifactId>jdk.tools</artifactId>
+					</exclusion>
+					<exclusion>
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
 					</exclusion>
@@ -361,6 +373,10 @@ under the License.
 				<version>${hadoop.version}</version>
 				<exclusions>
 					<exclusion>
+						<groupId>jdk.tools</groupId>
+						<artifactId>jdk.tools</artifactId>
+					</exclusion>
+					<exclusion>
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
 					</exclusion>
@@ -376,6 +392,10 @@ under the License.
 				<artifactId>hadoop-yarn-client</artifactId>
 				<version>${hadoop.version}</version>
 				<exclusions>
+					<exclusion>
+						<groupId>jdk.tools</groupId>
+						<artifactId>jdk.tools</artifactId>
+					</exclusion>
 					<exclusion>
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

Fixes issues with dependencies when using Java 9+.

The `jdk:tools` dependency is referenced by Hadoop, but not available in Java 9+ any more. Importing the code into an IDE that runs Java 11 fails as a result.

This transitive dependency is not needed when running the code, because the classes are always present anyways. It can be safely excluded form the transitive dependencies.

## Brief change log

Adds an exclusion for `jdk:tools` to the Hadoop entries in the dependency management section.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes!**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**