### PR TITLE
[FLINK-17691][Connectors/Kafka] fix the bug FlinkKafkaProducer011 transactional.id too long when use Semantic.EXACTLY_ONCE mode

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kafka.internal;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.utils.EncodingUtils;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -55,7 +56,7 @@ public class TransactionalIdsGenerator {
 		checkArgument(safeScaleDownFactor > 0);
 		checkArgument(subtaskIndex >= 0);
 
-		this.prefix = checkNotNull(prefix);
+		this.prefix = EncodingUtils.hex(EncodingUtils.md5(checkNotNull(prefix)));
 		this.subtaskIndex = subtaskIndex;
 		this.totalNumberOfSubtasks = totalNumberOfSubtasks;
 		this.poolSize = poolSize;

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.connectors.kafka.internal;
 
+import org.apache.flink.table.utils.EncodingUtils;
+
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -40,8 +42,9 @@ public class TransactionalIdsGeneratorTest {
 	public void testGenerateIdsToUse() {
 		TransactionalIdsGenerator generator = new TransactionalIdsGenerator("test", 2, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
 
+		String md5Prefix = md5Hex("test");
 		assertEquals(
-			new HashSet<>(Arrays.asList("test-42", "test-43", "test-44")),
+			new HashSet<>(Arrays.asList(md5Prefix + "-42", md5Prefix + "-43", md5Prefix + "-44")),
 			generator.generateIdsToUse(36));
 	}
 
@@ -52,8 +55,9 @@ public class TransactionalIdsGeneratorTest {
 	public void testTaskNameMayContainPercentSign() {
 		TransactionalIdsGenerator generator = new TransactionalIdsGenerator("%pattern%", 2, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
 
+		String md5Prefix = md5Hex("%pattern%");
 		assertEquals(
-			new HashSet<>(Arrays.asList("%pattern%-42", "%pattern%-43", "%pattern%-44")),
+			new HashSet<>(Arrays.asList(md5Prefix + "-42", md5Prefix + "-43", md5Prefix + "-44")),
 			generator.generateIdsToUse(36));
 	}
 
@@ -87,5 +91,9 @@ public class TransactionalIdsGeneratorTest {
 		HashSet<T> actual = new HashSet<>(first);
 		actual.retainAll(second);
 		assertEquals(Collections.emptySet(), actual);
+	}
+
+	private String md5Hex(String prefix) {
+		return EncodingUtils.hex(EncodingUtils.md5(prefix));
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kafka.internal;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.utils.EncodingUtils;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -55,7 +56,7 @@ public class TransactionalIdsGenerator {
 		checkArgument(safeScaleDownFactor > 0);
 		checkArgument(subtaskIndex >= 0);
 
-		this.prefix = checkNotNull(prefix);
+		this.prefix = EncodingUtils.hex(EncodingUtils.md5(checkNotNull(prefix)));
 		this.subtaskIndex = subtaskIndex;
 		this.totalNumberOfSubtasks = totalNumberOfSubtasks;
 		this.poolSize = poolSize;


### PR DESCRIPTION
[FLINK-17691](https://issues.apache.org/jira/browse/FLINK-17691)

# What is the purpose of the change

This pull request is to fix the bug that the kafka producer011 failed to send msg when the auto setting transactional.id too long

When in `Semantic.EXACTLY_ONCE`  mode, the producer011 will ignore the transactional.id which user defined, But auto generator by [TransactionalIdsGenerator](https://github.com/apache/flink/blob/ff861c2d8d522638821708fbefaea0bfdc77d358/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java#L47)

# Brief change log

* Do md5 on the transactional.id prefix

# Verifying this change

* create a sink kafka job in `Semantic.EXACTLY_ONCE` mode
* make the operatorName's length large than 32767 (or a large sql operator, which sql string's length is larger than 32767)
 [FlinkKafkaProducer011 init TransactionalIdsGenerator](https://github.com/apache/flink/blob/ff861c2d8d522638821708fbefaea0bfdc77d358/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java#L839) prefix
  ```java
   getRuntimeContext().getTaskName() + "-" + ((StreamingRuntimeContext) getRuntimeContext()).getOperatorUniqueID()
  ```

# Does this pull request potentially affect one of the following parts:

* Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
* The serializers: (no)
* The runtime per-record code paths (performance sensitive): (no)
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
* The S3 file system connector: (no)

# Documentation
* Does this pull request introduce a new feature? (no)
* If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)