### PR TITLE
[FLINK-17718][avro] Integrate avro to file system connector

### DIFF
--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -93,6 +93,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Avro RowData schema test dependency -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- TODO This could be dropped if we move the Table Avro IT Case -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -140,6 +140,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<profiles>

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileSystemFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileSystemFormatFactory.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.FileSystemFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.utils.PartitionPathUtils;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileConstants;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.DatumWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
+
+/**
+ * Avro format factory for file system.
+ */
+public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
+
+	public static final String AVRO_OUTPUT_CODEC = "format." + DataFileConstants.CODEC;
+
+	@Override
+	public boolean supportsSchemaDerivation() {
+		return true;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> options = new ArrayList<>();
+		options.add(AVRO_OUTPUT_CODEC);
+		return options;
+	}
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(FORMAT, "avro");
+		return context;
+	}
+
+	@Override
+	public InputFormat<RowData, ?> createReader(ReaderContext context) {
+		DescriptorProperties properties = new DescriptorProperties();
+		properties.putProperties(context.getFormatProperties());
+
+		String[] fieldNames = context.getSchema().getFieldNames();
+		List<String> projectFields = Arrays.stream(context.getProjectFields())
+			.mapToObj(idx -> fieldNames[idx])
+			.collect(Collectors.toList());
+		List<String> csvFields = Arrays.stream(fieldNames)
+			.filter(field -> !context.getPartitionKeys().contains(field))
+			.collect(Collectors.toList());
+
+		int[] selectFieldToProjectField = context.getFormatProjectFields().stream()
+			.mapToInt(projectFields::indexOf)
+			.toArray();
+		int[] selectFieldToFormatField = context.getFormatProjectFields().stream()
+			.mapToInt(csvFields::indexOf)
+			.toArray();
+
+		//noinspection unchecked
+		return new RowDataAvroInputFormat(
+				context.getPaths(),
+				context.getFormatRowType(),
+				context.getSchema().getFieldDataTypes(),
+				context.getSchema().getFieldNames(),
+				context.getProjectFields(),
+				context.getPartitionKeys(),
+				context.getDefaultPartName(),
+				context.getPushedDownLimit(),
+				selectFieldToProjectField,
+				selectFieldToFormatField);
+	}
+
+	@Override
+	public Optional<Encoder<RowData>> createEncoder(WriterContext context) {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<BulkWriter.Factory<RowData>> createBulkWriterFactory(WriterContext context) {
+		return Optional.of(new RowDataAvroWriterFactory(
+				context.getFormatRowType(),
+				context.getFormatProperties().get(AVRO_OUTPUT_CODEC)));
+	}
+
+	/**
+	 * InputFormat that reads avro record into {@link RowData}.
+	 *
+	 * <p>This extends {@link AvroInputFormat}, but {@link RowData} is not a avro record,
+	 * so now we remove generic information.
+	 * TODO {@link AvroInputFormat} support type conversion.
+	 */
+	private static class RowDataAvroInputFormat extends AvroInputFormat {
+
+		private static final long serialVersionUID = 1L;
+
+		private final DataType[] fieldTypes;
+		private final String[] fieldNames;
+		private final int[] selectFields;
+		private final List<String> partitionKeys;
+		private final String defaultPartValue;
+		private final long limit;
+		private final int[] selectFieldToProjectField;
+		private final int[] selectFieldToFormatField;
+		private final RowType formatRowType;
+
+		private transient long emitted;
+		// reuse object for per record
+		private transient GenericRowData rowData;
+		private transient IndexedRecord record;
+		private transient AvroRowDataDeserializationSchema.DeserializationRuntimeConverter converter;
+
+		public RowDataAvroInputFormat(
+				Path[] filePaths,
+				RowType formatRowType,
+				DataType[] fieldTypes,
+				String[] fieldNames,
+				int[] selectFields,
+				List<String> partitionKeys,
+				String defaultPartValue,
+				long limit,
+				int[] selectFieldToProjectField,
+				int[] selectFieldToFormatField) {
+			super(filePaths[0], GenericRecord.class);
+			super.setFilePaths(filePaths);
+			this.formatRowType = formatRowType;
+			this.fieldTypes = fieldTypes;
+			this.fieldNames = fieldNames;
+			this.partitionKeys = partitionKeys;
+			this.defaultPartValue = defaultPartValue;
+			this.selectFields = selectFields;
+			this.limit = limit;
+			this.emitted = 0;
+			this.selectFieldToProjectField = selectFieldToProjectField;
+			this.selectFieldToFormatField = selectFieldToFormatField;
+		}
+
+		@Override
+		public void open(FileInputSplit split) throws IOException {
+			super.open(split);
+			Schema schema = AvroSchemaConverter.convertToSchema(formatRowType);
+			record = new GenericData.Record(schema);
+			rowData = PartitionPathUtils.fillPartitionValueForRecord(
+					fieldNames,
+					fieldTypes,
+					selectFields,
+					partitionKeys,
+					currentSplit.getPath(),
+					defaultPartValue);
+			this.converter = AvroRowDataDeserializationSchema.createRowConverter(formatRowType);
+		}
+
+		@Override
+		public boolean reachedEnd() throws IOException {
+			return emitted >= limit || super.reachedEnd();
+		}
+
+		@Override
+		public Object nextRecord(Object reuse) throws IOException {
+			@SuppressWarnings("unchecked")
+			IndexedRecord r = (IndexedRecord) super.nextRecord(record);
+			if (r == null) {
+				return null;
+			}
+			GenericRowData row = (GenericRowData) converter.convert(r);
+
+			for (int i = 0; i < selectFieldToFormatField.length; i++) {
+				rowData.setField(selectFieldToProjectField[i],
+						row.getField(selectFieldToFormatField[i]));
+			}
+			emitted++;
+			return rowData;
+		}
+	}
+
+	/**
+	 * A {@link BulkWriter.Factory} to convert {@link RowData} to {@link GenericRecord} and
+	 * wrap {@link AvroWriterFactory}.
+	 */
+	private static class RowDataAvroWriterFactory implements BulkWriter.Factory<RowData> {
+
+		private static final long serialVersionUID = 1L;
+
+		private final AvroWriterFactory<GenericRecord> factory;
+		private final RowType rowType;
+
+		private RowDataAvroWriterFactory(RowType rowType, String codec) {
+			this.rowType = rowType;
+			this.factory = new AvroWriterFactory<>((AvroBuilder<GenericRecord>) out -> {
+				Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+				DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
+				DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter);
+
+				if (codec != null) {
+					dataFileWriter.setCodec(CodecFactory.fromString(codec));
+				}
+				dataFileWriter.create(schema, out);
+				return dataFileWriter;
+			});
+		}
+
+		@Override
+		public BulkWriter<RowData> create(FSDataOutputStream out) throws IOException {
+			BulkWriter<GenericRecord> writer = factory.create(out);
+			AvroRowDataSerializationSchema.SerializationRuntimeConverter converter =
+					AvroRowDataSerializationSchema.createRowConverter(rowType);
+			return new BulkWriter<RowData>() {
+
+				@Override
+				public void addElement(RowData element) throws IOException {
+					GenericRecord record = (GenericRecord) converter.convert(element);
+					writer.addElement(record);
+				}
+
+				@Override
+				public void flush() throws IOException {
+					writer.flush();
+				}
+
+				@Override
+				public void finish() throws IOException {
+					writer.finish();
+				}
+			};
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.LocalDate;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.formats.avro.typeutils.AvroSchemaConverter.extractValueTypeToAvroMap;
+
+/**
+ * Deserialization schema from Avro bytes to {@link RowData}.
+ *
+ * <p>Deserializes the <code>byte[]</code> messages into (nested) Flink RowData. It converts Avro types
+ * into types that are compatible with Flink's Table & SQL API.
+ *
+ * <p>Projects with Avro records containing logical date/time types need to add a JodaTime
+ * dependency.
+ *
+ * <p>Note: Changes in this class need to be kept in sync with the corresponding runtime
+ * class {@link AvroRowDataSerializationSchema} and schema converter {@link AvroSchemaConverter}.
+ */
+@PublicEvolving
+public class AvroRowDataDeserializationSchema implements DeserializationSchema<RowData> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Used for converting Date type.
+	 */
+	private static final int MILLIS_PER_DAY = 86400_000;
+
+	/**
+	 * Logical type describing the result type.
+	 */
+	private final RowType rowType;
+
+	/**
+	 * Type information describing the result type.
+	 */
+	private final TypeInformation<RowData> typeInfo;
+
+	/**
+	 * Runtime instance that performs the actual work.
+	 */
+	private final DeserializationRuntimeConverter runtimeConverter;
+
+	/**
+	 * Record to deserialize byte array.
+	 */
+	private transient IndexedRecord record;
+
+	/**
+	 * Reader that deserializes byte array into a record.
+	 */
+	private transient DatumReader<IndexedRecord> datumReader;
+
+	/**
+	 * Input stream to read message from.
+	 */
+	private transient MutableByteArrayInputStream inputStream;
+
+	/**
+	 * Avro decoder that decodes binary data.
+	 */
+	private transient Decoder decoder;
+
+	/**
+	 * Creates a Avro deserialization schema for the given logical type.
+	 *
+	 * @param rowType  The logical type used to deserialize the data.
+	 * @param typeInfo The TypeInformation to be used by {@link AvroRowDataDeserializationSchema#getProducedType()}.
+	 */
+	public AvroRowDataDeserializationSchema(
+			RowType rowType,
+			TypeInformation<RowData> typeInfo) {
+		this.rowType = rowType;
+		this.typeInfo = typeInfo;
+		this.runtimeConverter = createRowConverter(rowType);
+	}
+
+	@Override
+	public void open(InitializationContext context) throws Exception {
+		final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+		this.record = new GenericData.Record(schema);
+		this.datumReader = new SpecificDatumReader<>(schema);
+		this.inputStream = new MutableByteArrayInputStream();
+		this.decoder = DecoderFactory.get().binaryDecoder(this.inputStream, null);
+	}
+
+	@Override
+	public RowData deserialize(byte[] message) throws IOException {
+		try {
+			inputStream.setBuffer(message);
+			record = datumReader.read(record, decoder);
+			return (RowData) runtimeConverter.convert(record);
+		} catch (Exception e) {
+			throw new IOException("Failed to deserialize Avro record.", e);
+		}
+	}
+
+	@Override
+	public boolean isEndOfStream(RowData nextElement) {
+		return false;
+	}
+
+	@Override
+	public TypeInformation<RowData> getProducedType() {
+		return typeInfo;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final AvroRowDataDeserializationSchema that = (AvroRowDataDeserializationSchema) o;
+		return Objects.equals(rowType, that.rowType) &&
+			Objects.equals(typeInfo, that.typeInfo);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(rowType, typeInfo);
+	}
+
+	// -------------------------------------------------------------------------------------
+	// Runtime Converters
+	// -------------------------------------------------------------------------------------
+
+	/**
+	 * Runtime converter that converts Avro data structures into objects of Flink Table & SQL
+	 * internal data structures.
+	 */
+	@FunctionalInterface
+	private interface DeserializationRuntimeConverter extends Serializable {
+		Object convert(Object object);
+	}
+
+	private DeserializationRuntimeConverter createRowConverter(RowType rowType) {
+		final DeserializationRuntimeConverter[] fieldConverters = rowType.getFields().stream()
+			.map(RowType.RowField::getType)
+			.map(this::createNullableConverter)
+			.toArray(DeserializationRuntimeConverter[]::new);
+		final int arity = rowType.getFieldCount();
+
+		return avroObject -> {
+			IndexedRecord record = (IndexedRecord) avroObject;
+			GenericRowData row = new GenericRowData(arity);
+			for (int i = 0; i < arity; ++i) {
+				row.setField(i, fieldConverters[i].convert(record.get(i)));
+			}
+			return row;
+		};
+	}
+
+	/**
+	 * Creates a runtime converter which is null safe.
+	 */
+	private DeserializationRuntimeConverter createNullableConverter(LogicalType type) {
+		final DeserializationRuntimeConverter converter = createConverter(type);
+		return avroObject -> {
+			if (avroObject == null) {
+				return null;
+			}
+			return converter.convert(avroObject);
+		};
+	}
+
+	/**
+	 * Creates a runtime converter which assuming input object is not null.
+	 */
+	private DeserializationRuntimeConverter createConverter(LogicalType type) {
+		switch (type.getTypeRoot()) {
+			case NULL:
+				return avroObject -> null;
+			case BOOLEAN: // boolean
+			case TINYINT: // short
+			case SMALLINT: // int
+			case INTEGER: // int
+			case INTERVAL_YEAR_MONTH: // long
+			case BIGINT: // long
+			case INTERVAL_DAY_TIME: // long
+			case FLOAT: // float
+			case DOUBLE: // double
+				return avroObject -> avroObject;
+			case DATE:
+				return this::convertToDate;
+			case TIME_WITHOUT_TIME_ZONE:
+				return this::convertToTime;
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				return this::convertToTimestamp;
+			case CHAR:
+			case VARCHAR:
+				return avroObject -> StringData.fromString(avroObject.toString());
+			case BINARY:
+			case VARBINARY:
+				return this::convertToBytes;
+			case DECIMAL:
+				return createDecimalConverter((DecimalType) type);
+			case ARRAY:
+				return createArrayConverter((ArrayType) type);
+			case ROW:
+				return createRowConverter((RowType) type);
+			case MAP:
+			case MULTISET:
+				return createMapConverter(type);
+			case RAW:
+			default:
+				throw new UnsupportedOperationException("Unsupported type: " + type);
+		}
+	}
+
+	private DeserializationRuntimeConverter createDecimalConverter(DecimalType decimalType) {
+		final int precision = decimalType.getPrecision();
+		final int scale = decimalType.getScale();
+		return avroObject -> {
+			final byte[] bytes;
+			if (avroObject instanceof GenericFixed) {
+				bytes = ((GenericFixed) avroObject).bytes();
+			} else if (avroObject instanceof ByteBuffer) {
+				ByteBuffer byteBuffer = (ByteBuffer) avroObject;
+				bytes = new byte[byteBuffer.remaining()];
+				byteBuffer.get(bytes);
+			} else {
+				bytes = (byte[]) avroObject;
+			}
+			return DecimalData.fromUnscaledBytes(bytes, precision, scale);
+		};
+	}
+
+	private DeserializationRuntimeConverter createArrayConverter(ArrayType arrayType) {
+		final DeserializationRuntimeConverter elementConverter = createNullableConverter(arrayType.getElementType());
+		final Class<?> elementClass = LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
+
+		return avroObject -> {
+			final List<?> list = (List<?>) avroObject;
+			final int length = list.size();
+			final Object[] array = (Object[]) Array.newInstance(elementClass, length);
+			for (int i = 0; i < length; ++i) {
+				array[i] = elementConverter.convert(list.get(i));
+			}
+			return new GenericArrayData(array);
+		};
+	}
+
+	private DeserializationRuntimeConverter createMapConverter(LogicalType type) {
+		final DeserializationRuntimeConverter keyConverter = createConverter(
+				DataTypes.STRING().getLogicalType());
+		final DeserializationRuntimeConverter valueConverter = createConverter(
+				extractValueTypeToAvroMap(type));
+
+		return avroObject -> {
+			final Map<?, ?> map = (Map<?, ?>) avroObject;
+			Map<Object, Object> result = new HashMap<>();
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				Object key = keyConverter.convert(entry.getKey());
+				Object value = valueConverter.convert(entry.getValue());
+				result.put(key, value);
+			}
+			return new GenericMapData(result);
+		};
+	}
+
+	private TimestampData convertToTimestamp(Object object) {
+		final long millis;
+		if (object instanceof Long) {
+			millis = (Long) object;
+		} else {
+			// use 'provided' Joda time
+			final DateTime value = (DateTime) object;
+			millis = value.toDate().getTime();
+		}
+		return toTimestampData(millis);
+	}
+
+	private int convertToDate(Object object) {
+		if (object instanceof Integer) {
+			return (Integer) object;
+		} else {
+			// use 'provided' Joda time
+			final LocalDate value = (LocalDate) object;
+			return (int) (toTimestampData(value.toDate().getTime()).getMillisecond() / MILLIS_PER_DAY);
+		}
+	}
+
+	private static TimestampData toTimestampData(long timeZoneMills) {
+		return TimestampData.fromTimestamp(new Timestamp(timeZoneMills));
+	}
+
+	private int convertToTime(Object object) {
+		final int millis;
+		if (object instanceof Integer) {
+			millis = (Integer) object;
+		} else {
+			// use 'provided' Joda time
+			final org.joda.time.LocalTime value = (org.joda.time.LocalTime) object;
+			millis = value.get(DateTimeFieldType.millisOfDay());
+		}
+		return millis;
+	}
+
+	private byte[] convertToBytes(Object object) {
+		if (object instanceof GenericFixed) {
+			return ((GenericFixed) object).bytes();
+		} else if (object instanceof ByteBuffer) {
+			ByteBuffer byteBuffer = (ByteBuffer) object;
+			byte[] bytes = new byte[byteBuffer.remaining()];
+			byteBuffer.get(bytes);
+			return bytes;
+		} else {
+			return (byte[]) object;
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.util.Utf8;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.formats.avro.typeutils.AvroSchemaConverter.extractValueTypeToAvroMap;
+
+/**
+ * Serialization schema that serializes {@link RowData} into Avro bytes.
+ *
+ * <p>Serializes objects that are represented in (nested) Flink RowData. It support types that
+ * are compatible with Flink's Table & SQL API.
+ *
+ * <p>Note: Changes in this class need to be kept in sync with the corresponding runtime
+ * class {@link AvroRowDataDeserializationSchema} and schema converter {@link AvroSchemaConverter}.
+ */
+public class AvroRowDataSerializationSchema implements SerializationSchema<RowData> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Logical type describing the input type.
+	 */
+	private final RowType rowType;
+
+	/**
+	 * Runtime instance that performs the actual work.
+	 */
+	private final SerializationRuntimeConverter runtimeConverter;
+
+	/**
+	 * Writer to serialize Avro record into a Avro bytes.
+	 */
+	private transient DatumWriter<IndexedRecord> datumWriter;
+
+	/**
+	 * Output stream to serialize records into byte array.
+	 */
+	private transient ByteArrayOutputStream arrayOutputStream;
+
+	/**
+	 * Low-level class for serialization of Avro values.
+	 */
+	private transient Encoder encoder;
+
+	/**
+	 * Creates an Avro serialization schema for the given specific record class.
+	 */
+	public AvroRowDataSerializationSchema(RowType rowType) {
+		this.rowType = Preconditions.checkNotNull(rowType, "RowType cannot be null.");
+		this.runtimeConverter = createRowConverter(rowType);
+	}
+
+	@Override
+	public void open(InitializationContext context) throws Exception {
+		final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+		datumWriter = new SpecificDatumWriter<>(schema);
+		arrayOutputStream = new ByteArrayOutputStream();
+		encoder = EncoderFactory.get().binaryEncoder(arrayOutputStream, null);
+	}
+
+	@Override
+	public byte[] serialize(RowData row) {
+		try {
+			// convert to record
+			final GenericRecord record = (GenericRecord) runtimeConverter.convert(row);
+			arrayOutputStream.reset();
+			datumWriter.write(record, encoder);
+			encoder.flush();
+			return arrayOutputStream.toByteArray();
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to serialize row.", e);
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final AvroRowDataSerializationSchema that = (AvroRowDataSerializationSchema) o;
+		return Objects.equals(rowType, that.rowType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(rowType);
+	}
+
+	// --------------------------------------------------------------------------------
+	// Runtime Converters
+	// --------------------------------------------------------------------------------
+
+	/**
+	 * Runtime converter that converts objects of Flink Table & SQL internal data structures
+	 * to corresponding Avro data structures.
+	 */
+	private interface SerializationRuntimeConverter extends Serializable {
+		Object convert(Object object);
+	}
+
+	private SerializationRuntimeConverter createRowConverter(RowType rowType) {
+		final SerializationRuntimeConverter[] fieldConverters = rowType.getChildren().stream()
+			.map(this::createConverter)
+			.toArray(SerializationRuntimeConverter[]::new);
+		final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+		final LogicalType[] fieldTypes = rowType.getFields().stream()
+			.map(RowType.RowField::getType)
+			.toArray(LogicalType[]::new);
+		final int length = rowType.getFieldCount();
+
+		return object -> {
+			final RowData row = (RowData) object;
+			final GenericRecord record = new GenericData.Record(schema);
+			for (int i = 0; i < length; ++i) {
+				record.put(i, fieldConverters[i].convert(RowData.get(row, i, fieldTypes[i])));
+			}
+			return record;
+		};
+	}
+
+	private SerializationRuntimeConverter createConverter(LogicalType type) {
+		switch (type.getTypeRoot()) {
+			case NULL:
+				return object -> null;
+			case BOOLEAN: // boolean
+			case INTEGER: // int
+			case INTERVAL_YEAR_MONTH: // long
+			case BIGINT: // long
+			case INTERVAL_DAY_TIME: // long
+			case FLOAT: // float
+			case DOUBLE: // double
+			case TIME_WITHOUT_TIME_ZONE: // int
+			case DATE: // int
+				return avroObject -> avroObject;
+			case CHAR:
+			case VARCHAR:
+				return object -> new Utf8(object.toString());
+			case BINARY:
+			case VARBINARY:
+				return object -> ByteBuffer.wrap((byte[]) object);
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				return object -> ((TimestampData) object).toTimestamp().getTime();
+			case DECIMAL:
+				return object -> ByteBuffer.wrap(((DecimalData) object).toUnscaledBytes());
+			case ARRAY:
+				return createArrayConverter((ArrayType) type);
+			case ROW:
+				return createRowConverter((RowType) type);
+			case MAP:
+			case MULTISET:
+				return createMapConverter(type);
+			case RAW:
+			default:
+				throw new UnsupportedOperationException("Unsupported type: " + type);
+		}
+	}
+
+	private SerializationRuntimeConverter createArrayConverter(ArrayType arrayType) {
+		final SerializationRuntimeConverter elementConverter = createConverter(arrayType.getElementType());
+		final LogicalType elementType = arrayType.getElementType();
+
+		return object -> {
+			ArrayData arrayData = (ArrayData) object;
+			List<Object> list = new ArrayList<>();
+			for (int i = 0; i < arrayData.size(); ++i) {
+				list.add(elementConverter.convert(ArrayData.get(arrayData, i, elementType)));
+			}
+			return list;
+		};
+	}
+
+	private SerializationRuntimeConverter createMapConverter(LogicalType type) {
+		LogicalType valueType = extractValueTypeToAvroMap(type);
+		final SerializationRuntimeConverter valueConverter = createConverter(valueType);
+
+		return object -> {
+			final MapData mapData = (MapData) object;
+			final ArrayData keyArray = mapData.keyArray();
+			final ArrayData valueArray = mapData.valueArray();
+			final Map<Object, Object> map = new HashMap<>(mapData.size());
+			for (int i = 0; i < mapData.size(); ++i) {
+				final String key = keyArray.getString(i).toString();
+				final Object value = valueConverter.convert(ArrayData.get(valueArray, i, valueType));
+				map.put(key, value);
+			}
+			return map;
+		};
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
@@ -144,13 +144,13 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
 	 * Runtime converter that converts objects of Flink Table & SQL internal data structures
 	 * to corresponding Avro data structures.
 	 */
-	private interface SerializationRuntimeConverter extends Serializable {
+	interface SerializationRuntimeConverter extends Serializable {
 		Object convert(Object object);
 	}
 
-	private SerializationRuntimeConverter createRowConverter(RowType rowType) {
+	static SerializationRuntimeConverter createRowConverter(RowType rowType) {
 		final SerializationRuntimeConverter[] fieldConverters = rowType.getChildren().stream()
-			.map(this::createConverter)
+			.map(AvroRowDataSerializationSchema::createConverter)
 			.toArray(SerializationRuntimeConverter[]::new);
 		final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
 		final LogicalType[] fieldTypes = rowType.getFields().stream()
@@ -168,7 +168,7 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
 		};
 	}
 
-	private SerializationRuntimeConverter createConverter(LogicalType type) {
+	private static SerializationRuntimeConverter createConverter(LogicalType type) {
 		switch (type.getTypeRoot()) {
 			case NULL:
 				return object -> null;
@@ -205,7 +205,7 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
 		}
 	}
 
-	private SerializationRuntimeConverter createArrayConverter(ArrayType arrayType) {
+	private static SerializationRuntimeConverter createArrayConverter(ArrayType arrayType) {
 		final SerializationRuntimeConverter elementConverter = createConverter(arrayType.getElementType());
 		final LogicalType elementType = arrayType.getElementType();
 
@@ -219,7 +219,7 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
 		};
 	}
 
-	private SerializationRuntimeConverter createMapConverter(LogicalType type) {
+	private static SerializationRuntimeConverter createMapConverter(LogicalType type) {
 		LogicalType valueType = extractValueTypeToAvroMap(type);
 		final SerializationRuntimeConverter valueConverter = createConverter(valueType);
 

--- a/flink-formats/flink-avro/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-formats/flink-avro/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.formats.avro.AvroRowFormatFactory
+org.apache.flink.formats.avro.AvroFileSystemFormatFactory

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemITCase.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * ITCase to test avro format for {@link AvroFileSystemFormatFactory} in batch mode.
+ */
+@RunWith(Parameterized.class)
+public class AvroFilesystemITCase extends BatchFileSystemITCaseBase {
+
+	private final boolean configure;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Boolean> parameters() {
+		return Arrays.asList(false, true);
+	}
+
+	public AvroFilesystemITCase(boolean configure) {
+		this.configure = configure;
+	}
+
+	@Override
+	public String[] formatProperties() {
+		List<String> ret = new ArrayList<>();
+		ret.add("'format'='avro'");
+		if (configure) {
+			ret.add("'format.avro.codec'='snappy'");
+		}
+		return ret.toArray(new String[0]);
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemStreamITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemStreamITCase.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ITCase to test avro format for {@link AvroFileSystemFormatFactory} in stream mode.
+ */
+public class AvroFilesystemStreamITCase extends FsStreamingSinkITCaseBase {
+
+	@Override
+	public String[] additionalProperties() {
+		List<String> ret = new ArrayList<>();
+		ret.add("'format'='avro'");
+		ret.add("'format.avro.codec'='snappy'");
+		return ret.toArray(new String[0]);
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.generated.JodaTimeRecord;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.api.DataTypes.ARRAY;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.BOOLEAN;
+import static org.apache.flink.table.api.DataTypes.BYTES;
+import static org.apache.flink.table.api.DataTypes.DATE;
+import static org.apache.flink.table.api.DataTypes.DECIMAL;
+import static org.apache.flink.table.api.DataTypes.DOUBLE;
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.FLOAT;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.MAP;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.DataTypes.TIME;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Test for the Avro serialization and deserialization schema.
+ */
+public class AvroRowDataDeSerializationSchemaTest {
+
+	@Test
+	public void testSerializeDeserialize() throws Exception {
+		final DataType dataType = ROW(
+			FIELD("bool", BOOLEAN()),
+			FIELD("int", INT()),
+			FIELD("bigint", BIGINT()),
+			FIELD("float", FLOAT()),
+			FIELD("double", DOUBLE()),
+			FIELD("name", STRING()),
+			FIELD("bytes", BYTES()),
+			FIELD("decimal", DECIMAL(19, 6)),
+			FIELD("doubles", ARRAY(DOUBLE())),
+			FIELD("time", TIME(0)),
+			FIELD("date", DATE()),
+			FIELD("timestamp3", TIMESTAMP(3)),
+			FIELD("timestamp3_2", TIMESTAMP(3)),
+			FIELD("map", MAP(STRING(), BIGINT())),
+			FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))),
+			FIELD("map2array", MAP(STRING(), ARRAY(INT()))));
+		final RowType rowType = (RowType) dataType.getLogicalType();
+		final TypeInformation<RowData> typeInfo = new RowDataTypeInfo(rowType);
+
+		final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+		final GenericRecord record = new GenericData.Record(schema);
+		record.put(0, true);
+		record.put(1, 33);
+		record.put(2, 44L);
+		record.put(3, 12.34F);
+		record.put(4, 23.45);
+		record.put(5, "hello avro");
+		record.put(6, ByteBuffer.wrap(new byte[]{1, 2, 4, 5, 6, 7, 8, 12}));
+
+		record.put(7, ByteBuffer.wrap(
+				BigDecimal.valueOf(123456789, 6).unscaledValue().toByteArray()));
+
+		List<Double> doubles = new ArrayList<>();
+		doubles.add(1.2);
+		doubles.add(3.4);
+		doubles.add(567.8901);
+		record.put(8, doubles);
+
+		record.put(9, 18397);
+		record.put(10, 10087);
+		record.put(11, 1589530213123L);
+		record.put(12, 1589530213122L);
+
+		Map<String, Long> map = new HashMap<>();
+		map.put("flink", 12L);
+		map.put("avro", 23L);
+		record.put(13, map);
+
+		Map<String, Map<String, Integer>> map2map = new HashMap<>();
+		Map<String, Integer> innerMap = new HashMap<>();
+		innerMap.put("inner_key1", 123);
+		innerMap.put("inner_key2", 234);
+		map2map.put("outer_key", innerMap);
+		record.put(14, map2map);
+
+		List<Integer> list1 = Arrays.asList(1, 2, 3, 4, 5, 6);
+		List<Integer> list2 = Arrays.asList(11, 22, 33, 44, 55);
+		Map<String, List<Integer>> map2list = new HashMap<>();
+		map2list.put("list1", list1);
+		map2list.put("list2", list2);
+		record.put(15, map2list);
+
+		AvroRowDataSerializationSchema serializationSchema = new AvroRowDataSerializationSchema(rowType);
+		serializationSchema.open(null);
+		AvroRowDataDeserializationSchema deserializationSchema =
+			new AvroRowDataDeserializationSchema(rowType, typeInfo);
+		deserializationSchema.open(null);
+
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(schema);
+		Encoder encoder = EncoderFactory.get().binaryEncoder(byteArrayOutputStream, null);
+		datumWriter.write(record, encoder);
+		encoder.flush();
+		byte[] input = byteArrayOutputStream.toByteArray();
+
+		RowData rowData = deserializationSchema.deserialize(input);
+		byte[] output = serializationSchema.serialize(rowData);
+
+		assertArrayEquals(input, output);
+	}
+
+	@Test
+	public void testSpecificType() throws Exception {
+		JodaTimeRecord record = new JodaTimeRecord();
+		record.setTypeTimestampMillis(DateTime.parse("2010-06-30T01:20:20"));
+		record.setTypeDate(LocalDate.parse("2014-03-01"));
+		record.setTypeTimeMillis(LocalTime.parse("12:12:12"));
+		SpecificDatumWriter<JodaTimeRecord> datumWriter = new SpecificDatumWriter<>(JodaTimeRecord.class);
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		Encoder encoder = EncoderFactory.get().binaryEncoder(byteArrayOutputStream, null);
+		datumWriter.write(record, encoder);
+		encoder.flush();
+		byte[] input = byteArrayOutputStream.toByteArray();
+
+		DataType dataType = ROW(
+				FIELD("type_timestamp_millis", TIMESTAMP(3)),
+				FIELD("type_date", DATE()),
+				FIELD("type_time_millis", TIME(3)));
+		final RowType rowType = (RowType) dataType.getLogicalType();
+		final TypeInformation<RowData> typeInfo = new RowDataTypeInfo(rowType);
+		AvroRowDataSerializationSchema serializationSchema = new AvroRowDataSerializationSchema(rowType);
+		serializationSchema.open(null);
+		AvroRowDataDeserializationSchema deserializationSchema =
+				new AvroRowDataDeserializationSchema(rowType, typeInfo);
+		deserializationSchema.open(null);
+
+		RowData rowData = deserializationSchema.deserialize(input);
+		byte[] output = serializationSchema.serialize(rowData);
+		RowData rowData2 = deserializationSchema.deserialize(output);
+		Assert.assertEquals(rowData, rowData2);
+		Assert.assertEquals("2010-06-30T01:20:20", rowData.getTimestamp(0, 3).toString());
+		Assert.assertEquals("2014-03-01", DataFormatConverters.LocalDateConverter.INSTANCE.toExternal(
+				rowData.getInt(1)).toString());
+		Assert.assertEquals("12:12:12", DataFormatConverters.LocalTimeConverter.INSTANCE.toExternal(
+				rowData.getInt(2)).toString());
+	}
+}

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -99,4 +99,13 @@
       {"name": "otherField4", "type": ["null", "float"], "default": null},
       {"name": "otherField5", "type": ["null", "int"], "default": null}
   ]
-}]
+},
+  {"namespace": "org.apache.flink.formats.avro.generated",
+   "type": "record",
+   "name": "JodaTimeRecord",
+   "fields": [
+       {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+       {"name": "type_date", "type": {"type": "int", "logicalType": "date"}},
+       {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}}
+   ]
+ }]

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -221,10 +221,6 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
 	// Runtime Converters
 	// -------------------------------------------------------------------------------------
 
-	// -------------------------------------------------------------------------------------
-	// Runtime Converters
-	// -------------------------------------------------------------------------------------
-
 	/**
 	 * Runtime converter that converts {@link JsonNode}s into objects of Flink Table & SQL
 	 * internal data structures.


### PR DESCRIPTION

## What is the purpose of the change

Integrate avro to file system connector.
Introduce `AvroFileSystemFormatFactory`.

## Brief change log

- Introduce `AvroFileSystemFormatFactory`.
- Introduce `RowDataAvroInputFormat`.
- Introduce `RowDataAvroWriterFactory`.

This based on https://github.com/apache/flink/pull/12133 and https://github.com/apache/flink/pull/11385

## Verifying this change

`AvroFilesystemITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
