### PR TITLE
[FLINK-17719][task][checkpointing] Provide ChannelStateReader#hasStates for hints of reading channel states

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReader.java
@@ -34,6 +34,11 @@ public interface ChannelStateReader extends AutoCloseable {
 	enum ReadResult { HAS_MORE_DATA, NO_MORE_DATA }
 
 	/**
+	 * Return whether there are any channel states to be read.
+	 */
+	boolean hasChannelStates();
+
+	/**
 	 * Put data into the supplied buffer to be injected into
 	 * {@link org.apache.flink.runtime.io.network.partition.consumer.InputChannel InputChannel}.
 	 */
@@ -49,6 +54,11 @@ public interface ChannelStateReader extends AutoCloseable {
 	void close() throws Exception;
 
 	ChannelStateReader NO_OP = new ChannelStateReader() {
+
+		@Override
+		public boolean hasChannelStates() {
+			return false;
+		}
 
 		@Override
 		public ReadResult readInputData(InputChannelInfo info, Buffer buffer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImpl.java
@@ -88,6 +88,11 @@ public class ChannelStateReaderImpl implements ChannelStateReader {
 	}
 
 	@Override
+	public boolean hasChannelStates() {
+		return !(inputChannelHandleReaders.isEmpty() && resultSubpartitionHandleReaders.isEmpty());
+	}
+
+	@Override
 	public ReadResult readInputData(InputChannelInfo info, Buffer buffer) throws IOException {
 		Preconditions.checkState(!isClosed, "reader is closed");
 		log.debug("readInputData, resultSubpartitionInfo: {} , buffer {}", info, buffer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobgraph.tasks;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.util.Preconditions;
@@ -66,6 +67,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 	 * @deprecated use {@link #builder()}.
 	 */
 	@Deprecated
+	@VisibleForTesting
 	public CheckpointCoordinatorConfiguration(
 			long checkpointInterval,
 			long checkpointTimeout,
@@ -85,7 +87,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 			isExactlyOnce,
 			isPreferCheckpointForRecovery,
 			tolerableCpFailureNumber,
-			false);
+			isUnalignedCheckpoint);
 	}
 
 	private CheckpointCoordinatorConfiguration(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -88,7 +88,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
 		);
 	}
 
-	TaskStateManagerImpl(
+	public TaskStateManagerImpl(
 			@Nonnull JobID jobId,
 			@Nonnull ExecutionAttemptID executionAttemptID,
 			@Nonnull TaskLocalStateStore localStateStore,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -572,6 +572,11 @@ public class ResultPartitionTest {
 		}
 
 		@Override
+		public boolean hasChannelStates() {
+			return true;
+		}
+
+		@Override
 		public ReadResult readInputData(InputChannelInfo info, Buffer buffer) {
 			for (int state: states) {
 				buffer.asByteBuf().writeInt(state);
@@ -605,6 +610,11 @@ public class ResultPartitionTest {
 	 * {@link #readOutputData(ResultSubpartitionInfo, BufferBuilder)} and {@link #readInputData(InputChannelInfo, Buffer)}.
 	 */
 	public static final class ChannelStateReaderWithException implements ChannelStateReader {
+
+		@Override
+		public boolean hasChannelStates() {
+			return true;
+		}
 
 		@Override
 		public ReadResult readInputData(InputChannelInfo info, Buffer buffer) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.io.network.api.writer.AvailabilityTestResultPart
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.MockResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionTest;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
@@ -74,8 +75,10 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
+import org.apache.flink.runtime.state.TestTaskLocalStateStore;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
+import org.apache.flink.runtime.taskmanager.NoOpCheckpointResponder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -83,7 +86,6 @@ import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.TestTaskBuilder;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -952,7 +954,7 @@ public class StreamTaskTest extends TestLogger {
 	}
 
 	@Test
-	public void testInitializeChannelState() throws Exception {
+	public void testBeforeInvokeWithoutChannelStates() throws Exception {
 		int numWriters = 2;
 		int numGates = 2;
 		RecoveryResultPartition[] partitions = new RecoveryResultPartition[numWriters];
@@ -964,18 +966,52 @@ public class StreamTaskTest extends TestLogger {
 			gates[i] = new RecoveryInputGate(partitions);
 		}
 
-		Configuration configuration = new Configuration();
-		configuration.setBoolean(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, true);
-		MockEnvironment mockEnvironment = new MockEnvironmentBuilder().setTaskConfiguration(configuration).build();
+		MockEnvironment mockEnvironment = new MockEnvironmentBuilder().build();
 		mockEnvironment.addOutputs(Arrays.asList(partitions));
 		mockEnvironment.addInputs(Arrays.asList(gates));
 		StreamTask task = new MockStreamTaskBuilder(mockEnvironment).build();
 		try {
-			verifyResults(gates, partitions, false);
+			verifyResults(gates, partitions, false, false);
 
 			task.beforeInvoke();
 
-			verifyResults(gates, partitions, true);
+			verifyResults(gates, partitions, false, true);
+		} finally {
+			task.cleanUpInvoke();
+		}
+	}
+
+	@Test
+	public void testBeforeInvokeWithChannelStates() throws Exception {
+		int numWriters = 2;
+		int numGates = 2;
+		RecoveryResultPartition[] partitions = new RecoveryResultPartition[numWriters];
+		for (int i = 0; i < numWriters; i++) {
+			partitions[i] = new RecoveryResultPartition();
+		}
+		RecoveryInputGate[] gates = new RecoveryInputGate[numGates];
+		for (int i = 0; i < numGates; i++) {
+			gates[i] = new RecoveryInputGate(partitions);
+		}
+
+		ChannelStateReader reader = new ResultPartitionTest.FiniteChannelStateReader(1, new int[] {0});
+		TaskStateManager taskStateManager = new TaskStateManagerImpl(
+			new JobID(),
+			new ExecutionAttemptID(),
+			new TestTaskLocalStateStore(),
+			null,
+			NoOpCheckpointResponder.INSTANCE,
+			reader);
+		MockEnvironment mockEnvironment = new MockEnvironmentBuilder().setTaskStateManager(taskStateManager).build();
+		mockEnvironment.addOutputs(Arrays.asList(partitions));
+		mockEnvironment.addInputs(Arrays.asList(gates));
+		StreamTask task = new MockStreamTaskBuilder(mockEnvironment).build();
+		try {
+			verifyResults(gates, partitions, false, false);
+
+			task.beforeInvoke();
+
+			verifyResults(gates, partitions, true, false);
 
 			// execute the partition request mail inserted after input recovery completes
 			task.mailboxProcessor.drain();
@@ -988,13 +1024,13 @@ public class StreamTaskTest extends TestLogger {
 		}
 	}
 
-	private void verifyResults(RecoveryInputGate[] gates, RecoveryResultPartition[] partitions, boolean expected) {
+	private void verifyResults(RecoveryInputGate[] gates, RecoveryResultPartition[] partitions, boolean recoveryExpected, boolean requestExpected) {
 		for (RecoveryResultPartition resultPartition : partitions) {
-			assertEquals(expected, resultPartition.isStateRecovered());
+			assertEquals(recoveryExpected, resultPartition.isStateRecovered());
 		}
 		for (RecoveryInputGate inputGate : gates) {
-			assertEquals(expected, inputGate.isStateRecovered());
-			assertFalse(inputGate.isPartitionRequested());
+			assertEquals(recoveryExpected, inputGate.isStateRecovered());
+			assertEquals(requestExpected, inputGate.isPartitionRequested());
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Currently we rely on whether unaligned checkpoint is enabled to determine whether to read recovered states during task startup,  then it will block the requirements of recovery from previous unaligned states even though the current mode is aligned. 

We can make `ChannelStateReader` provide the hint whether there are any channel states to be read during startup, then we will never lose any chances to recover from them.

## Brief change log

- Provide `ChannelStateReader#hasStates` interface methods and implements it in related instances.

- Adjust the condition in `StreamTask#beforeInvoke` to reuse the new hint.

## Verifying this change

new unit test in `StreamTaskTest#testBeforeInvokeWithoutChannelStates`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
