### PR TITLE
[FLINK-17700][python] The callback client of JavaGatewayServer should…

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -28,13 +28,14 @@ import java.io.IOException;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Tests for the {@link PythonDriver}.
  */
 public class PythonDriverTest {
 	@Test
-	public void testStartGatewayServer() {
+	public void testStartGatewayServer() throws ExecutionException, InterruptedException {
 		GatewayServer gatewayServer = PythonDriver.startGatewayServer();
 		try {
 			Socket socket = new Socket("localhost", gatewayServer.getListeningPort());


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When starting the JavaGatewayServer, a callback client would also be created and run in a ScheduleExecutorService's thread which is non-daemon by default. Thus, we need to shut down the non-daemon thread and reset a daemon thread back to the call back client.

## Brief change log

- shut down the non-daemon thread and reset a daemon thread back to the call back client in startGatewayServer() in PythonDriver.py.

## Verifying this change

This pull request can be verified by all pyflink table API tests which need to start the communication between python process and java process.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
