### PR TITLE
[FLINK-17700][python] The callback client of JavaGatewayServer should…

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -20,14 +20,23 @@ package org.apache.flink.client.python;
 
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.util.NetUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import py4j.CallbackClient;
+import py4j.Gateway;
 import py4j.GatewayServer;
 
-import java.net.InetAddress;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A main class used to launch Python applications. It executes python as a
@@ -36,7 +45,7 @@ import java.util.List;
 public final class PythonDriver {
 	private static final Logger LOG = LoggerFactory.getLogger(PythonDriver.class);
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws ExecutionException, InterruptedException {
 		// the python job needs at least 2 args.
 		// e.g. py a.py ...
 		// e.g. pym a.b -pyfs a.zip ...
@@ -91,23 +100,36 @@ public final class PythonDriver {
 	 *
 	 * @return The created GatewayServer
 	 */
-	static GatewayServer startGatewayServer() {
-		InetAddress localhost = InetAddress.getLoopbackAddress();
-		GatewayServer gatewayServer = new GatewayServer.GatewayServerBuilder()
-			.javaPort(0)
-			.javaAddress(localhost)
-			.build();
-		Thread thread = new Thread(gatewayServer::start);
+	static GatewayServer startGatewayServer() throws InterruptedException, ExecutionException {
+		CompletableFuture<GatewayServer> gatewayServerFuture = new CompletableFuture<>();
+		Thread thread = new Thread(() -> {
+			try {
+				int freePort = NetUtils.getAvailablePort();
+				GatewayServer server = new GatewayServer.GatewayServerBuilder()
+					.gateway(new Gateway(new ConcurrentHashMap<String, Object>(), new CallbackClient(freePort)))
+					.javaPort(0)
+					.build();
+				CallbackClient callbackClient = (CallbackClient) server.getCallbackClient();
+				// The Java API of py4j does not provide approach to set "daemonize_connections" parameter.
+				// Use reflect to daemonize the connection thread.
+				Field executor = CallbackClient.class.getDeclaredField("executor");
+				executor.setAccessible(true);
+				((ScheduledExecutorService) executor.get(callbackClient)).shutdown();
+				executor.set(callbackClient, Executors.newScheduledThreadPool(1, Thread::new));
+				Method setupCleaner = CallbackClient.class.getDeclaredMethod("setupCleaner");
+				setupCleaner.setAccessible(true);
+				setupCleaner.invoke(callbackClient);
+				gatewayServerFuture.complete(server);
+				server.start(true);
+			} catch (Throwable e) {
+				gatewayServerFuture.completeExceptionally(e);
+			}
+		});
 		thread.setName("py4j-gateway");
 		thread.setDaemon(true);
 		thread.start();
-		try {
-			thread.join();
-		} catch (InterruptedException e) {
-			LOG.error("The gateway server thread join failed.", e);
-			System.exit(1);
-		}
-		return gatewayServer;
+		thread.join();
+		return gatewayServerFuture.get();
 	}
 
 	/**

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -28,13 +28,14 @@ import java.io.IOException;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Tests for the {@link PythonDriver}.
  */
 public class PythonDriverTest {
 	@Test
-	public void testStartGatewayServer() {
+	public void testStartGatewayServer() throws ExecutionException, InterruptedException {
 		GatewayServer gatewayServer = PythonDriver.startGatewayServer();
 		try {
 			Socket socket = new Socket("localhost", gatewayServer.getListeningPort());


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When starting the JavaGatewayServer, a callback client would also be created and run in a ScheduleExecutorService's thread which is non-daemon by default. Thus, we need to shut down the non-daemon thread and reset a daemon thread back to the call back client.

## Brief change log

- shut down the non-daemon thread and reset a daemon thread back to the call back client in startGatewayServer() in PythonDriver.py.


## Verifying this change

This pull request can be verified by all pyflink table API tests which need to start the communication between python process and java process.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no )
 