### PR TITLE
[FLINK-17724][python] Set working directory before running the Python helper scripts.

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
@@ -37,6 +37,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_WORKING_DIR;
+
 /**
  * Utils used to prepare the python environment.
  */
@@ -171,6 +173,9 @@ public class PythonEnvironmentManagerUtils {
 			Map<String, String> environmentVariables,
 			boolean logDetails) throws IOException {
 		ProcessBuilder pb = new ProcessBuilder(commands);
+		if (environmentVariables.containsKey(PYTHON_WORKING_DIR)) {
+			pb.directory(new File(environmentVariables.get(PYTHON_WORKING_DIR)));
+		}
 		pb.environment().putAll(environmentVariables);
 		pb.redirectErrorStream(true);
 		Process p = pb.start();


### PR DESCRIPTION
## What is the purpose of the change

*This pull request sets the working directory of the `ProcessBuilder` before running the Python helper scripts.*


## Brief change log

  - *Set the working directory of the `ProcessBuilder` before running the Python helper scripts.*


## Verifying this change

This change is already covered by existing tests, such as *pyflink e2e tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
