### PR TITLE
[FLINK-17495][metrics][prometheus]Add custom labels on PrometheusReporter like PrometheusPushGatewayReporter's groupingKey	

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -32,6 +32,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
+import org.apache.flink.util.StringUtils;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
@@ -105,6 +106,7 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 			dimensionKeys.add(CHARACTER_FILTER.filterCharacters(key.substring(1, key.length() - 1)));
 			dimensionValues.add(labelValueCharactersFilter.filterCharacters(dimension.getValue()));
 		}
+		resolveDimensions(dimensionKeys, dimensionValues);
 
 		final String scopedMetricName = getScopedName(metricName, group);
 		final String helpString = metricName + " (scope: " + getLogicalScope(group) + ")";
@@ -128,6 +130,33 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 			addMetric(metric, dimensionValues, collector);
 			collectorsWithCountByMetricName.put(scopedMetricName, new AbstractMap.SimpleImmutableEntry<>(collector, count + 1));
 		}
+	}
+
+	protected void resolveDimensions(List<String> dimensionKeys, List<String> dimensionValues) {}
+
+	protected Map<String, String> parseLabels(final String labelConfig) {
+		if (!labelConfig.isEmpty()) {
+			Map<String, String> labels = new HashMap<>();
+			String[] kvs = labelConfig.split(";");
+			for (String kv : kvs) {
+				int idx = kv.indexOf("=");
+				if (idx < 0) {
+					log.warn("Invalid label: {}, will be ignored", kv);
+					continue;
+				}
+
+				String labelKey = kv.substring(0, idx);
+				String labelValue = kv.substring(idx + 1);
+				if (StringUtils.isNullOrWhitespaceOnly(labelKey) || StringUtils.isNullOrWhitespaceOnly(labelValue)) {
+					log.warn("Invalid label {labelKey:{}, labelValue:{}} must not be empty", labelKey, labelValue);
+					continue;
+				}
+				labels.put(labelKey, labelValue);
+			}
+
+			return labels;
+		}
+		return Collections.emptyMap();
 	}
 
 	private static String getScopedName(String metricName, MetricGroup group) {

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -33,7 +33,7 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 	@Test
 	public void testParseGroupingKey() {
 		PrometheusPushGatewayReporter reporter = new PrometheusPushGatewayReporter();
-		Map<String, String> groupingKey = reporter.parseGroupingKey("k1=v1;k2=v2");
+		Map<String, String> groupingKey = reporter.parseLabels("k1=v1;k2=v2");
 		Assert.assertNotNull(groupingKey);
 		Assert.assertEquals("v1", groupingKey.get("k1"));
 		Assert.assertEquals("v2", groupingKey.get("k2"));
@@ -42,13 +42,13 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 	@Test
 	public void testParseIncompleteGroupingKey() {
 		PrometheusPushGatewayReporter reporter = new PrometheusPushGatewayReporter();
-		Map<String, String> groupingKey = reporter.parseGroupingKey("k1=");
+		Map<String, String> groupingKey = reporter.parseLabels("k1=");
 		Assert.assertTrue(groupingKey.isEmpty());
 
-		groupingKey = reporter.parseGroupingKey("=v1");
+		groupingKey = reporter.parseLabels("=v1");
 		Assert.assertTrue(groupingKey.isEmpty());
 
-		groupingKey = reporter.parseGroupingKey("k1");
+		groupingKey = reporter.parseLabels("k1");
 		Assert.assertTrue(groupingKey.isEmpty());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

We need to add some custom labels on Prometheus, so we can query by them.
Now we can add jobName\groupingKey to PrometheusPushGatewayReporter in version 1.10, but not in PrometheusReporter.
Can we add AbstractPrometheusReporter#addDimension method to support this, so they will be no differences except for the metrics exposing mechanism pulling/pushing.

## Brief change log

- AbstractPrometheusReporter unify parseLabels method
- AbstractPrometheusReporter add resolveDimensions method into notifyOfAddedMetric

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)