### PR TITLE
[FLINK-17729] Make mandatory to have lib/, plugin/ and dist in yarn.provided.lib.dirs

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -188,29 +188,11 @@ public class CliFrontend {
 
 		programOptions.validate();
 		final URI uri = PackagedProgramUtils.resolveURI(programOptions.getJarFilePath());
-		// Build the packaged program when the user jar is a local file
-		if (uri.getScheme().equals("file")) {
-			final PackagedProgram program =
-				getPackagedProgram(programOptions);
-
-			final ApplicationConfiguration applicationConfiguration =
-				new ApplicationConfiguration(program.getArguments(), program.getMainClassName());
-
-			try {
-				final List<URL> jobJars = program.getJobJarAndDependencies();
-				final Configuration effectiveConfiguration =
-					getEffectiveConfiguration(commandLine, programOptions, jobJars);
-				deployer.run(effectiveConfiguration, applicationConfiguration);
-			} finally {
-				program.deleteExtractedLibraries();
-			}
-		} else {
-			final Configuration effectiveConfiguration =
-				getEffectiveConfiguration(commandLine, programOptions, Collections.singletonList(uri.toString()));
-			final ApplicationConfiguration applicationConfiguration =
-				new ApplicationConfiguration(programOptions.getProgramArgs(), programOptions.getEntryPointClassName());
-			deployer.run(effectiveConfiguration, applicationConfiguration);
-		}
+		final Configuration effectiveConfiguration =
+			getEffectiveConfiguration(commandLine, programOptions, Collections.singletonList(uri.toString()));
+		final ApplicationConfiguration applicationConfiguration =
+			new ApplicationConfiguration(programOptions.getProgramArgs(), programOptions.getEntryPointClassName());
+		deployer.run(effectiveConfiguration, applicationConfiguration);
 	}
 
 	/**

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterEntryPoint.java
@@ -42,6 +42,7 @@ import org.apache.flink.util.FlinkException;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
@@ -114,11 +115,12 @@ public final class StandaloneApplicationClusterEntryPoint extends ApplicationClu
 	private static PackagedProgramRetriever getPackagedProgramRetriever(
 			final String[] programArguments,
 			@Nullable final String jobClassName) throws IOException {
+		final File userLibDir = tryFindUserLibDirectory().orElse(null);
 		final ClassPathPackagedProgramRetriever.Builder retrieverBuilder =
 				ClassPathPackagedProgramRetriever
 						.newBuilder(programArguments)
+						.setUserLibDirectory(userLibDir)
 						.setJobClassName(jobClassName);
-		tryFindUserLibDirectory().ifPresent(retrieverBuilder::setUserLibDirectory);
 		return retrieverBuilder.build();
 	}
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
@@ -104,12 +104,14 @@ public final class KubernetesApplicationClusterEntrypoint extends ApplicationClu
 		final List<File> pipelineJars = KubernetesUtils.checkJarFileForApplicationMode(configuration);
 		Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
 
+		final File userLibDir = tryFindUserLibDirectory().orElse(null);
+
 		final ClassPathPackagedProgramRetriever.Builder retrieverBuilder =
 			ClassPathPackagedProgramRetriever
 				.newBuilder(programArguments)
+				.setUserLibDirectory(userLibDir)
 				.setJarFile(pipelineJars.get(0))
 				.setJobClassName(jobClassName);
-		tryFindUserLibDirectory().ifPresent(retrieverBuilder::setUserLibDirectory);
 		return retrieverBuilder.build();
 	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
@@ -71,6 +71,16 @@ public class YARNApplicationITCase extends YarnTestBase {
 				createDefaultConfiguration(getTestingJar(), YarnConfigOptions.UserJarInclusion.DISABLED)));
 	}
 
+	@Test
+	public void testApplicationClusterWithRemoteUserJar() throws Exception {
+		final Path testingJar = getTestingJar();
+		final Path remoteJar = new Path(miniDFSCluster.getFileSystem().getHomeDirectory(), testingJar.getName());
+		miniDFSCluster.getFileSystem().copyFromLocalFile(testingJar, remoteJar);
+		runTest(
+			() -> deployApplication(
+				createDefaultConfiguration(remoteJar, YarnConfigOptions.UserJarInclusion.DISABLED)));
+	}
+
 	private void deployApplication(Configuration configuration) throws Exception {
 		try (final YarnClusterDescriptor yarnClusterDescriptor = createYarnClusterDescriptor(configuration)) {
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.deployment.application.ApplicationConfiguration;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+import org.apache.flink.yarn.configuration.YarnDeploymentTarget;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR;
+import static org.apache.flink.yarn.util.YarnTestUtils.getTestJarPath;
+
+/**
+ * Test cases for the deployment of Yarn Flink application clusters.
+ */
+public class YARNApplicationITCase extends YarnTestBase {
+
+	private static final Duration yarnAppTerminateTimeout = Duration.ofSeconds(30);
+	private static final int sleepIntervalInMS = 100;
+
+	@BeforeClass
+	public static void setup() {
+		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-application");
+		startYARNWithConfig(YARN_CONFIGURATION, true);
+	}
+
+	@Test
+	public void testApplicationClusterWithLocalUserJarAndFirstUserJarInclusion() throws Exception {
+		runTest(
+			() -> deployApplication(
+				createDefaultConfiguration(getTestingJar(), YarnConfigOptions.UserJarInclusion.FIRST)));
+	}
+
+	@Test
+	public void testApplicationClusterWithLocalUserJarAndDisableUserJarInclusion() throws Exception {
+		runTest(
+			() -> deployApplication(
+				createDefaultConfiguration(getTestingJar(), YarnConfigOptions.UserJarInclusion.DISABLED)));
+	}
+
+	private void deployApplication(Configuration configuration) throws Exception {
+		try (final YarnClusterDescriptor yarnClusterDescriptor = createYarnClusterDescriptor(configuration)) {
+
+			final int masterMemory = yarnClusterDescriptor.getFlinkConfiguration().get(JobManagerOptions.TOTAL_PROCESS_MEMORY).getMebiBytes();
+			final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+				.setMasterMemoryMB(masterMemory)
+				.setTaskManagerMemoryMB(1024)
+				.setSlotsPerTaskManager(1)
+				.createClusterSpecification();
+
+			try (ClusterClient<ApplicationId> clusterClient = yarnClusterDescriptor
+					.deployApplicationCluster(
+							clusterSpecification,
+							ApplicationConfiguration.fromConfiguration(configuration))
+					.getClusterClient()) {
+
+				ApplicationId applicationId = clusterClient.getClusterId();
+
+				waitApplicationFinishedElseKillIt(
+					applicationId, yarnAppTerminateTimeout, yarnClusterDescriptor, sleepIntervalInMS);
+			}
+		}
+	}
+
+	private Path getTestingJar() throws FileNotFoundException {
+		return new Path(getTestJarPath("StreamingWordCount.jar").toURI());
+	}
+
+	private Configuration createDefaultConfiguration(Path userJar, YarnConfigOptions.UserJarInclusion userJarInclusion) {
+		Configuration configuration = new Configuration();
+		configuration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(768));
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
+		configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
+		configuration.set(DeploymentOptions.TARGET, YarnDeploymentTarget.APPLICATION.getName());
+		configuration.setString(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion.toString());
+		configuration.set(PipelineOptions.JARS, Collections.singletonList(userJar.toString()));
+
+		return configuration;
+	}
+}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -72,21 +72,24 @@ public class YARNITCase extends YarnTestBase {
 	public void testPerJobModeWithEnableSystemClassPathIncludeUserJar() throws Exception {
 		runTest(() -> deployPerJob(
 			createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.FIRST),
-			getTestingJobGraph()));
+			getTestingJobGraph(),
+			true));
 	}
 
 	@Test
 	public void testPerJobModeWithDisableSystemClassPathIncludeUserJar() throws Exception {
 		runTest(() -> deployPerJob(
 			createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.DISABLED),
-			getTestingJobGraph()));
+			getTestingJobGraph(),
+			true));
 	}
 
 	@Test
 	public void testPerJobModeWithDistributedCache() throws Exception {
 		runTest(() -> deployPerJob(
 			createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.DISABLED),
-			YarnTestCacheJob.getDistributedCacheJobGraph(tmp.newFolder())));
+			YarnTestCacheJob.getDistributedCacheJobGraph(tmp.newFolder()),
+			true));
 	}
 
 	@Test
@@ -98,11 +101,13 @@ public class YARNITCase extends YarnTestBase {
 		final Configuration flinkConfig = createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.DISABLED);
 		flinkConfig.set(YarnConfigOptions.PROVIDED_LIB_DIRS, Collections.singletonList(remoteLib.toString()));
 
-		runTest(() -> deployPerJob(flinkConfig, getTestingJobGraph()));
+		runTest(() -> deployPerJob(flinkConfig, getTestingJobGraph(), false));
 	}
 
-	private void deployPerJob(Configuration configuration, JobGraph jobGraph) throws Exception {
-		try (final YarnClusterDescriptor yarnClusterDescriptor = createYarnClusterDescriptor(configuration)) {
+	private void deployPerJob(Configuration configuration, JobGraph jobGraph, boolean withDist) throws Exception {
+		try (final YarnClusterDescriptor yarnClusterDescriptor = withDist
+				? createYarnClusterDescriptor(configuration)
+				: createYarnClusterDescriptorWithoutLibDir(configuration)) {
 
 			final int masterMemory = yarnClusterDescriptor.getFlinkConfiguration().get(JobManagerOptions.TOTAL_PROCESS_MEMORY).getMebiBytes();
 			final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -330,6 +330,12 @@ public abstract class YarnTestBase extends TestLogger {
 
 	@Nonnull
 	YarnClusterDescriptor createYarnClusterDescriptor(org.apache.flink.configuration.Configuration flinkConfiguration) {
+		final YarnClusterDescriptor yarnClusterDescriptor = createYarnClusterDescriptorWithoutLibDir(flinkConfiguration);
+		yarnClusterDescriptor.addShipFiles(Collections.singletonList(flinkLibFolder));
+		return yarnClusterDescriptor;
+	}
+
+	YarnClusterDescriptor createYarnClusterDescriptorWithoutLibDir(org.apache.flink.configuration.Configuration flinkConfiguration) {
 		final YarnClusterDescriptor yarnClusterDescriptor = YarnTestUtils.createClusterDescriptorWithLogging(
 				tempConfPathForSecureRun.getAbsolutePath(),
 				flinkConfiguration,
@@ -337,7 +343,6 @@ public abstract class YarnTestBase extends TestLogger {
 				yarnClient,
 				true);
 		yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.toURI()));
-		yarnClusterDescriptor.addShipFiles(Collections.singletonList(flinkLibFolder));
 		return yarnClusterDescriptor;
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -492,6 +492,11 @@ public final class Utils {
 		return ctx;
 	}
 
+	static boolean isRemotePath(String path) throws IOException {
+		org.apache.flink.core.fs.Path flinkPath = new org.apache.flink.core.fs.Path(path);
+		return flinkPath.getFileSystem().isDistributedFS();
+	}
+
 	private static List<YarnLocalResourceDescriptor> decodeYarnLocalResourceDescriptorListFromString(String resources) throws Exception {
 		final List<YarnLocalResourceDescriptor> resourceDescriptors = new ArrayList<>();
 		for (String shipResourceDescStr : resources.split(LOCAL_RESOURCE_DESCRIPTOR_SEPARATOR)) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -19,8 +19,10 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.function.FunctionUtils;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -285,9 +287,13 @@ class YarnApplicationFileUploader implements AutoCloseable {
 		return classPaths;
 	}
 
-	public YarnLocalResourceDescriptor uploadFlinkDist(final Path localJarPath) throws IOException {
+	public YarnLocalResourceDescriptor uploadFlinkDist(final Path localJarPath) throws IOException, ClusterDeploymentException {
 		if (flinkDist != null) {
 			return flinkDist;
+		} else if (!providedSharedLibs.isEmpty()) {
+			throw new ClusterDeploymentException("The \"" + YarnConfigOptions.PROVIDED_LIB_DIRS.key() + "\"" +
+					" has to also include the lib/, plugin/ and flink-dist jar." +
+					" In other case, it cannot be used.");
 		}
 
 		flinkDist = registerSingleLocalResource(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.deployment.ClusterDeploymentException;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.function.FunctionUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -326,9 +327,9 @@ class YarnApplicationFileUploader implements AutoCloseable {
 					remotePaths.add(filePath);
 					envShipResourceList.add(descriptor);
 
-					if (!isFlinkDistJar(fileName) && !isPlugin(fileStatus.getPath())) {
+					if (!isFlinkDistJar(filePath.getName()) && !isPlugin(filePath)) {
 						classPaths.add(fileName);
-					} else if (isFlinkDistJar(fileName)) {
+					} else if (isFlinkDistJar(filePath.getName())) {
 						flinkDist = descriptor;
 					}
 				});
@@ -389,7 +390,7 @@ class YarnApplicationFileUploader implements AutoCloseable {
 	private static boolean isPlugin(Path path) {
 		Path parent = path.getParent();
 		while (parent != null) {
-			if (parent.getName().equals("plugins")) {
+			if (ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS.equals(parent.getName())) {
 				return true;
 			}
 			parent = parent.getParent();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -103,7 +103,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -255,7 +254,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * Adds the given files to the list of files to ship.
 	 *
 	 * <p>Note that any file matching "<tt>flink-dist*.jar</tt>" will be excluded from the upload by
-	 * {@link YarnApplicationFileUploader#registerMultipleLocalResources(Collection, List, String, List, int)}
+	 * {@link YarnApplicationFileUploader#registerMultipleLocalResources(Collection, String)}
 	 * since we upload the Flink uber jar ourselves and do not need to deploy it multiple times.
 	 *
 	 * @param shipFiles files to ship
@@ -684,8 +683,11 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			configuration, YarnConfigOptions.PROVIDED_LIB_DIRS, Path::new);
 
 		final YarnApplicationFileUploader fileUploader = YarnApplicationFileUploader.from(
-				fs, fs.getHomeDirectory(), providedLibDirs, appContext.getApplicationId()
-		);
+			fs,
+			fs.getHomeDirectory(),
+			providedLibDirs,
+			appContext.getApplicationId(),
+			getFileReplication());
 
 		// The files need to be shipped and added to classpath.
 		Set<File> systemShipFiles = new HashSet<>(shipFiles.size());
@@ -746,10 +748,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			userJarFiles.addAll(jarUrls.stream().map(Path::new).collect(Collectors.toSet()));
 		}
 
-		int yarnFileReplication = yarnConfiguration.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
-		int fileReplication = configuration.getInteger(YarnConfigOptions.FILE_REPLICATION);
-		fileReplication = fileReplication > 0 ? fileReplication : yarnFileReplication;
-
 		// only for per job mode
 		if (jobGraph != null) {
 			for (Map.Entry<String, DistributedCache.DistributedCacheEntry> entry : jobGraph.getUserArtifacts().entrySet()) {
@@ -757,7 +755,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				if (Utils.isRemotePath(entry.getValue().filePath)) {
 					Path localPath = new Path(entry.getValue().filePath);
 					Tuple2<Path, Long> remoteFileInfo =
-							fileUploader.uploadLocalFileToRemote(localPath, entry.getKey(), fileReplication);
+							fileUploader.uploadLocalFileToRemote(localPath, entry.getKey());
 					jobGraph.setUserArtifactRemotePath(entry.getKey(), remoteFileInfo.f0.toString());
 				}
 			}
@@ -765,38 +763,24 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			jobGraph.writeUserArtifactEntriesToConfiguration();
 		}
 
-		// list of remote paths (after upload)
-		final List<Path> paths = new ArrayList<>(2 + systemShipFiles.size() + userJarFiles.size());
-		// ship list that enables reuse of resources for task manager containers
-		final List<YarnLocalResourceDescriptor> envShipResourceList = new ArrayList<>();
-
 		// Register all files in provided lib dirs as local resources with public visibility
 		// and upload the remaining dependencies as local resources with APPLICATION visibility.
 		final List<String> systemClassPaths = fileUploader.registerProvidedLocalResources();
 		final List<String> uploadedDependencies = fileUploader.registerMultipleLocalResources(
 			systemShipFiles.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
-			paths,
-			Path.CUR_DIR,
-			envShipResourceList,
-			fileReplication);
+			Path.CUR_DIR);
 		systemClassPaths.addAll(uploadedDependencies);
 
 		// upload and register ship-only files
 		fileUploader.registerMultipleLocalResources(
 			shipOnlyFiles.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
-			paths,
-			Path.CUR_DIR,
-			envShipResourceList,
-			fileReplication);
+			Path.CUR_DIR);
 
 		// Upload and register user jars
 		final List<String> userClassPaths = fileUploader.registerMultipleLocalResources(
 			userJarFiles,
-			paths,
 			userJarInclusion == YarnConfigOptions.UserJarInclusion.DISABLED ?
-				ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR : Path.CUR_DIR,
-			envShipResourceList,
-			fileReplication);
+				ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR : Path.CUR_DIR);
 
 		if (userJarInclusion == YarnConfigOptions.UserJarInclusion.ORDER) {
 			systemClassPaths.addAll(userClassPaths);
@@ -819,12 +803,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		// Setup jar for ApplicationMaster
 		final YarnLocalResourceDescriptor localResourceDescFlinkJar = fileUploader.registerSingleLocalResource(
-				flinkJarPath.getName(),
-				flinkJarPath,
-				"",
-				fileReplication);
+			flinkJarPath.getName(),
+			flinkJarPath,
+			"",
+			true,
+			false);
 
-		paths.add(localResourceDescFlinkJar.getPath());
 		classPathBuilder.append(flinkJarPath.getName()).append(File.pathSeparator);
 
 		// write job graph to tmp file and add it to local resource
@@ -841,12 +825,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				final String jobGraphFilename = "job.graph";
 				configuration.setString(JOB_GRAPH_FILE_PATH, jobGraphFilename);
 
-				Path pathFromYarnURL = fileUploader.registerSingleLocalResource(
-						jobGraphFilename,
-						new Path(tmpJobGraphFile.toURI()),
-						"",
-						fileReplication).getPath();
-				paths.add(pathFromYarnURL);
+				fileUploader.registerSingleLocalResource(
+					jobGraphFilename,
+					new Path(tmpJobGraphFile.toURI()),
+					"",
+					true,
+					false);
 				classPathBuilder.append(jobGraphFilename).append(File.pathSeparator);
 			} catch (Exception e) {
 				LOG.warn("Add job graph to local resource fail.");
@@ -866,13 +850,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			BootstrapTools.writeConfiguration(configuration, tmpConfigurationFile);
 
 			String flinkConfigKey = "flink-conf.yaml";
-			final YarnLocalResourceDescriptor localResourceDescConf = fileUploader.registerSingleLocalResource(
+			fileUploader.registerSingleLocalResource(
 				flinkConfigKey,
 				new Path(tmpConfigurationFile.getAbsolutePath()),
 				"",
-				fileReplication);
-			envShipResourceList.add(localResourceDescConf);
-			paths.add(localResourceDescConf.getPath());
+				true,
+				true);
 			classPathBuilder.append("flink-conf.yaml").append(File.pathSeparator);
 		} finally {
 			if (tmpConfigurationFile != null && !tmpConfigurationFile.delete()) {
@@ -898,10 +881,11 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			LOG.info("Adding Yarn configuration {} to the AM container local resource bucket", f.getAbsolutePath());
 			Path yarnSitePath = new Path(f.getAbsolutePath());
 			remoteYarnSiteXmlPath = fileUploader.registerSingleLocalResource(
-					Utils.YARN_SITE_FILE_NAME,
-					yarnSitePath,
-					"",
-					fileReplication).getPath();
+				Utils.YARN_SITE_FILE_NAME,
+				yarnSitePath,
+				"",
+				false,
+				false).getPath();
 
 			String krb5Config = System.getProperty("java.security.krb5.conf");
 			if (krb5Config != null && krb5Config.length() != 0) {
@@ -909,10 +893,11 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				LOG.info("Adding KRB5 configuration {} to the AM container local resource bucket", krb5.getAbsolutePath());
 				Path krb5ConfPath = new Path(krb5.getAbsolutePath());
 				remoteKrb5Path = fileUploader.registerSingleLocalResource(
-						Utils.KRB5_FILE_NAME,
-						krb5ConfPath,
-						"",
-						fileReplication).getPath();
+					Utils.KRB5_FILE_NAME,
+					krb5ConfPath,
+					"",
+					false,
+					false).getPath();
 				hasKrb5 = true;
 			}
 		}
@@ -930,7 +915,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					localizedKeytabPath,
 					new Path(keytab),
 					"",
-					fileReplication).getPath();
+					false,
+					false).getPath();
 			} else {
 				// // Assume Keytab is pre-installed in the container.
 				localizedKeytabPath = flinkConfiguration.getString(YarnConfigOptions.LOCALIZED_KEYTAB_PATH);
@@ -949,7 +935,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		if (UserGroupInformation.isSecurityEnabled()) {
 			// set HDFS delegation tokens when security is enabled
 			LOG.info("Adding delegation token to the AM container.");
-			Utils.setTokensFor(amContainer, paths, yarnConfiguration);
+			Utils.setTokensFor(amContainer, fileUploader.getRemotePaths(), yarnConfiguration);
 		}
 
 		amContainer.setLocalResources(fileUploader.getRegisteredLocalResources());
@@ -967,7 +953,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		appMasterEnv.put(YarnConfigKeys.FLINK_DIST_JAR, localResourceDescFlinkJar.toString());
 		appMasterEnv.put(YarnConfigKeys.ENV_APP_ID, appId.toString());
 		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_HOME_DIR, fileUploader.getHomeDir().toString());
-		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_SHIP_FILES, encodeYarnLocalResourceDescriptorListToString(envShipResourceList));
+		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_SHIP_FILES, encodeYarnLocalResourceDescriptorListToString(fileUploader.getEnvShipResourceList()));
 		appMasterEnv.put(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE, getZookeeperNamespace());
 		appMasterEnv.put(YarnConfigKeys.FLINK_YARN_FILES, fileUploader.getApplicationDir().toUri().toString());
 
@@ -1072,6 +1058,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		// since deployment was successful, remove the hook
 		ShutdownHookUtil.removeShutdownHook(deploymentFailureHook, getClass().getSimpleName(), LOG);
 		return report;
+	}
+
+	private int getFileReplication() {
+		final int yarnFileReplication = yarnConfiguration.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
+		final int fileReplication = flinkConfiguration.getInteger(YarnConfigOptions.FILE_REPLICATION);
+		return fileReplication > 0 ? fileReplication : yarnFileReplication;
 	}
 
 	private static String encodeYarnLocalResourceDescriptorListToString(List<YarnLocalResourceDescriptor> resources) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -403,6 +403,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		applicationConfiguration.applyToConfiguration(flinkConfiguration);
 
+		final List<String> pipelineJars = flinkConfiguration.getOptional(PipelineOptions.JARS).orElse(Collections.emptyList());
+		Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
+
 		final String configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
 		YarnLogConfigUtil.setLogConfigFileInConfig(flinkConfiguration, configurationDirectory);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -690,8 +690,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		// The files need to be shipped and added to classpath.
 		Set<File> systemShipFiles = new HashSet<>(shipFiles.size());
-		// The files only need to be shipped.
-		Set<File> shipOnlyFiles = new HashSet<>();
 		for (File file : shipFiles) {
 			systemShipFiles.add(file.getAbsoluteFile());
 		}
@@ -700,11 +698,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		if (logConfigFilePath != null) {
 			systemShipFiles.add(new File(logConfigFilePath));
 		}
-
-		addLibFoldersToShipFiles(systemShipFiles);
-
-		// Plugin files only need to be shipped and should not be added to classpath.
-		addPluginsFoldersToShipFiles(shipOnlyFiles);
 
 		// Set-up ApplicationSubmissionContext for the application
 
@@ -762,6 +755,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			jobGraph.writeUserArtifactEntriesToConfiguration();
 		}
 
+		if (providedLibDirs == null || providedLibDirs.isEmpty()) {
+			addLibFoldersToShipFiles(systemShipFiles);
+		}
+
 		// Register all files in provided lib dirs as local resources with public visibility
 		// and upload the remaining dependencies as local resources with APPLICATION visibility.
 		final List<String> systemClassPaths = fileUploader.registerProvidedLocalResources();
@@ -771,9 +768,14 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		systemClassPaths.addAll(uploadedDependencies);
 
 		// upload and register ship-only files
-		fileUploader.registerMultipleLocalResources(
-			shipOnlyFiles.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
-			Path.CUR_DIR);
+		// Plugin files only need to be shipped and should not be added to classpath.
+		if (providedLibDirs == null || providedLibDirs.isEmpty()) {
+			Set<File> shipOnlyFiles = new HashSet<>();
+			addPluginsFoldersToShipFiles(shipOnlyFiles);
+			fileUploader.registerMultipleLocalResources(
+					shipOnlyFiles.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
+					Path.CUR_DIR);
+		}
 
 		// Upload and register user jars
 		final List<String> userClassPaths = fileUploader.registerMultipleLocalResources(
@@ -801,14 +803,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		}
 
 		// Setup jar for ApplicationMaster
-		final YarnLocalResourceDescriptor localResourceDescFlinkJar = fileUploader.registerSingleLocalResource(
-			flinkJarPath.getName(),
-			flinkJarPath,
-			"",
-			true,
-			false);
-
-		classPathBuilder.append(flinkJarPath.getName()).append(File.pathSeparator);
+		final YarnLocalResourceDescriptor localResourceDescFlinkJar = fileUploader.uploadFlinkDist(flinkJarPath);
+		classPathBuilder.append(localResourceDescFlinkJar.getResourceKey()).append(File.pathSeparator);
 
 		// write job graph to tmp file and add it to local resource
 		// TODO: server use user main method to generate job graph

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.util.FlinkException;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
@@ -97,6 +98,21 @@ class YarnLocalResourceDescriptor {
 		} else {
 			throw new FlinkException("Error to parse YarnLocalResourceDescriptor from " + desc);
 		}
+	}
+
+	static YarnLocalResourceDescriptor fromFileStatus(
+			final String key,
+			final FileStatus fileStatus,
+			final LocalResourceVisibility visibility) {
+		checkNotNull(key);
+		checkNotNull(fileStatus);
+		checkNotNull(visibility);
+		return new YarnLocalResourceDescriptor(
+				key,
+				fileStatus.getPath(),
+				fileStatus.getLen(),
+				fileStatus.getModificationTime(),
+				visibility);
 	}
 
 	@Override

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationFileUploaderTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationFileUploaderTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.hamcrest.Matchers;
@@ -61,7 +62,8 @@ public class YarnApplicationFileUploaderTest extends TestLogger {
 				FileSystem.get(new YarnConfiguration()),
 				new Path(temporaryFolder.getRoot().toURI()),
 				Collections.singletonList(new Path(flinkLibDir.toURI())),
-				ApplicationId.newInstance(0, 0))) {
+				ApplicationId.newInstance(0, 0),
+				DFSConfigKeys.DFS_REPLICATION_DEFAULT)) {
 
 			yarnApplicationFileUploader.registerProvidedLocalResources();
 
@@ -88,7 +90,8 @@ public class YarnApplicationFileUploaderTest extends TestLogger {
 						fileSystem,
 						new Path(temporaryFolder.getRoot().toURI()),
 						Arrays.asList(new Path(flinkLibDir1.toURI()), new Path(flinkLibDir2.toURI())),
-						ApplicationId.newInstance(0, 0)));
+						ApplicationId.newInstance(0, 0),
+						DFSConfigKeys.DFS_REPLICATION_DEFAULT));
 		} finally {
 			IOUtils.closeQuietly(fileSystem);
 		}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -210,14 +210,15 @@ public class YarnFileStageTest extends TestLogger {
 
 			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
 			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.from(
-					targetFileSystem, targetDir, Collections.emptyList(), applicationId);
+				targetFileSystem,
+				targetDir,
+				Collections.emptyList(),
+				applicationId,
+				DFSConfigKeys.DFS_REPLICATION_DEFAULT);
 
 			final List<String> classpath = uploader.registerMultipleLocalResources(
 				Collections.singletonList(srcPath),
-				remotePaths,
-				localResourceDirectory,
-				new ArrayList<>(),
-				DFSConfigKeys.DFS_REPLICATION_DEFAULT);
+				localResourceDirectory);
 
 			final Path basePath = new Path(localResourceDirectory, srcPath.getName());
 			final Path nestedPath = new Path(basePath, "nested");
@@ -274,14 +275,15 @@ public class YarnFileStageTest extends TestLogger {
 
 			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
 			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.from(
-					targetFileSystem, targetDir, Collections.emptyList(), applicationId);
+				targetFileSystem,
+				targetDir,
+				Collections.emptyList(),
+				applicationId,
+				DFSConfigKeys.DFS_REPLICATION_DEFAULT);
 
 			final List<String> classpath = uploader.registerMultipleLocalResources(
 				Collections.singletonList(new Path(srcDir.getAbsolutePath(), localFile)),
-				remotePaths,
-				localResourceDirectory,
-				new ArrayList<>(),
-				DFSConfigKeys.DFS_REPLICATION_DEFAULT);
+				localResourceDirectory);
 
 			assertThat(classpath, containsInAnyOrder(new Path(localResourceDirectory, localFile).toString()));
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
@@ -165,8 +165,8 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 		try {
 			final Path directory = new Path(basePath, pathSuffix);
 
-			YarnFileStageTest.testCopyFromLocalRecursive(fs.getHadoopFileSystem(),
-				new org.apache.hadoop.fs.Path(directory.toUri()), Path.CUR_DIR, tempFolder, false);
+			YarnFileStageTest.testRegisterMultipleLocalResources(fs.getHadoopFileSystem(),
+				new org.apache.hadoop.fs.Path(directory.toUri()), Path.CUR_DIR, tempFolder, false, false);
 		} finally {
 			// clean up
 			fs.delete(basePath, true);


### PR DESCRIPTION
This PR builds on top of https://github.com/apache/flink/pull/12143 and adds the functionality described in the JIRA. It makes mandatory for users of the `yarn.provided.lib.dirs` option to also include the `lib/`, `plugin/` and `flink-dist jar`.

If these are not included among the shared resources, Flink will throw an exception and will inform the user to not use this feature, but ship all the dependencies of the application, as it was done previously.

If these dirs are provided, then these are going to be used to execute the application and **NOT** what the user may have locally (e.g. different flink or log4j versions).

The reason for this requirement is to avoid unpleasant surprises with classloading issues. Alternatively we could say to go case-by-case and say if the file to be shipped has the same name as one in the shared directories, then do not ship it and use the remote. But this way of doing things transparently to the user oftentimes leads to unpleasant surprises that are difficult to debug. 

## Brief change log

More of the changes are in the `YarnApplicationFileUploader`.

## Verifying this change

Partially covered by tests in the `YarnITCase` and also verified manually by me and @wangyang0918 .

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
