### PR TITLE
[FLINK-17727][task] don't create output stream with no channel state (unaligned checkpoints)

### DIFF
--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -73,7 +74,17 @@ public class StatefulStreamJobUpgradeTestProgram {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		setupEnvironment(env, pt);
+		env.getCheckpointConfig().enableUnalignedCheckpoints();
 
+		if (isOriginalJobVariant(pt)) {
+			executeOriginalVariant(env, pt);
+		}
+		else {
+			executeUpgradedVariant(env, pt);
+		}
+	}
+
+	private static void executeOriginalVariant(StreamExecutionEnvironment env, ParameterTool pt) throws Exception {
 		KeyedStream<Event, Integer> source = env.addSource(createEventSource(pt))
 			.name("EventSource")
 			.uid("EventSource")
@@ -83,11 +94,34 @@ public class StatefulStreamJobUpgradeTestProgram {
 		List<TypeSerializer<ComplexPayload>> stateSer =
 			Collections.singletonList(new KryoSerializer<>(ComplexPayload.class, env.getConfig()));
 
-		KeyedStream<Event, Integer> afterStatefulOperations = isOriginalJobVariant(pt) ?
-			applyOriginalStatefulOperations(source, stateSer, Collections.emptyList()) :
+		KeyedStream<Event, Integer> afterStatefulOperations =
+			applyOriginalStatefulOperations(source, stateSer, Collections.emptyList());
+
+		afterStatefulOperations
+			.flatMap(createSemanticsCheckMapper(pt))
+			.name("SemanticsCheckMapper")
+			.addSink(new PrintSinkFunction<>());
+
+		env.execute("General purpose test job");
+	}
+
+	private static void executeUpgradedVariant(StreamExecutionEnvironment env, ParameterTool pt) throws Exception {
+		KeyedStream<UpgradedEvent, Integer> source = env.addSource(createEventSource(pt))
+			.name("EventSource")
+			.uid("EventSource")
+			.assignTimestampsAndWatermarks(createTimestampExtractor(pt))
+			.map(new UpgradeEvent())
+			.keyBy(UpgradedEvent::getKey);
+
+		List<TypeSerializer<ComplexPayload>> stateSer =
+			Collections.singletonList(new KryoSerializer<>(ComplexPayload.class, env.getConfig()));
+
+		KeyedStream<UpgradedEvent, Integer> afterStatefulOperations =
 			applyUpgradedStatefulOperations(source, stateSer, Collections.emptyList());
 
 		afterStatefulOperations
+			.map(new DowngradeEvent())
+			.keyBy(Event::getKey)
 			.flatMap(createSemanticsCheckMapper(pt))
 			.name("SemanticsCheckMapper")
 			.addSink(new PrintSinkFunction<>());
@@ -115,15 +149,6 @@ public class StatefulStreamJobUpgradeTestProgram {
 		return applyTestStatefulOperator("stateMap2", lastStateUpdate("stateMap2"), source, stateSer, stateClass);
 	}
 
-	private static KeyedStream<Event, Integer> applyUpgradedStatefulOperations(
-			KeyedStream<Event, Integer> source,
-			List<TypeSerializer<ComplexPayload>> stateSer,
-			List<Class<ComplexPayload>> stateClass) {
-		source = applyTestStatefulOperator("stateMap2", simpleStateUpdate("stateMap2"), source, stateSer, stateClass);
-		source = applyTestStatefulOperator("stateMap1", lastStateUpdate("stateMap1"), source, stateSer, stateClass);
-		return applyTestStatefulOperator("stateMap3", simpleStateUpdate("stateMap3"), source, stateSer, stateClass);
-	}
-
 	private static KeyedStream<Event, Integer> applyTestStatefulOperator(
 			String name,
 			JoinFunction<Event, ComplexPayload, ComplexPayload> stateFunc,
@@ -138,10 +163,40 @@ public class StatefulStreamJobUpgradeTestProgram {
 			.keyBy(Event::getKey);
 	}
 
+	private static KeyedStream<UpgradedEvent, Integer> applyUpgradedStatefulOperations(
+			KeyedStream<UpgradedEvent, Integer> source,
+			List<TypeSerializer<ComplexPayload>> stateSer,
+			List<Class<ComplexPayload>> stateClass) {
+		source = applyUpgradedTestStatefulOperator("stateMap2", simpleUpgradedStateUpdate("stateMap2"), source, stateSer, stateClass);
+		source = applyUpgradedTestStatefulOperator("stateMap1", lastUpgradedStateUpdate("stateMap1"), source, stateSer, stateClass);
+		return applyUpgradedTestStatefulOperator("stateMap3", simpleUpgradedStateUpdate("stateMap3"), source, stateSer, stateClass);
+	}
+
+	private static KeyedStream<UpgradedEvent, Integer> applyUpgradedTestStatefulOperator(
+			String name,
+			JoinFunction<UpgradedEvent, ComplexPayload, ComplexPayload> stateFunc,
+			KeyedStream<UpgradedEvent, Integer> source,
+			List<TypeSerializer<ComplexPayload>> stateSer,
+			List<Class<ComplexPayload>> stateClass) {
+		return source
+			.map(createArtificialKeyedStateMapper(e -> e, stateFunc, stateSer, stateClass))
+			.name(name)
+			.uid(name)
+			.returns(UpgradedEvent.class)
+			.keyBy(UpgradedEvent::getKey);
+	}
+
 	private static JoinFunction<Event, ComplexPayload, ComplexPayload> simpleStateUpdate(String strPayload) {
 		return (Event first, ComplexPayload second) -> {
 			verifyState(strPayload, second);
 			return new ComplexPayload(first, strPayload);
+		};
+	}
+
+	private static JoinFunction<UpgradedEvent, ComplexPayload, ComplexPayload> simpleUpgradedStateUpdate(String strPayload) {
+		return (UpgradedEvent first, ComplexPayload second) -> {
+			verifyState(strPayload, second);
+			return new ComplexPayload(first.event, strPayload);
 		};
 	}
 
@@ -153,9 +208,45 @@ public class StatefulStreamJobUpgradeTestProgram {
 		};
 	}
 
+	private static JoinFunction<UpgradedEvent, ComplexPayload, ComplexPayload> lastUpgradedStateUpdate(String strPayload) {
+		return (UpgradedEvent first, ComplexPayload second) -> {
+			verifyState(strPayload, second);
+			boolean isLastEvent = second != null && first.event.getEventTime() <= second.getEventTime();
+			return isLastEvent ? second : new ComplexPayload(first.event, strPayload);
+		};
+	}
+
 	private static void verifyState(String strPayload, ComplexPayload state) {
 		if (state != null && !state.getStrPayload().equals(strPayload)) {
 			System.out.println("State is set or restored incorrectly");
+		}
+	}
+
+	private static class UpgradeEvent implements MapFunction<Event, UpgradedEvent> {
+		@Override
+		public UpgradedEvent map(Event event) {
+			return new UpgradedEvent(event);
+		}
+	}
+
+	private static class UpgradedEvent {
+		public final Event event;
+		public final String randomPayload;
+
+		public UpgradedEvent(Event event) {
+			this.event = event;
+			this.randomPayload = event.getPayload().toUpperCase();
+		}
+
+		public int getKey() {
+			return event.getKey();
+		}
+	}
+
+	private static class DowngradeEvent implements MapFunction<UpgradedEvent, Event> {
+		@Override
+		public Event map(UpgradedEvent value) throws Exception {
+			return value.event;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 
+import static java.util.Collections.emptyList;
 import static org.apache.flink.runtime.state.CheckpointedStateScope.EXCLUSIVE;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -150,6 +151,12 @@ class ChannelStateCheckpointWriter {
 	}
 
 	private void finishWriteAndResult() throws IOException {
+		if (inputChannelOffsets.isEmpty() && resultSubpartitionOffsets.isEmpty()) {
+			dataStream.close();
+			result.inputChannelStateHandles.complete(emptyList());
+			result.resultSubpartitionStateHandles.complete(emptyList());
+			return;
+		}
 		dataStream.flush();
 		StreamStateHandle underlying = checkpointStream.closeAndGetHandle();
 		complete(


### PR DESCRIPTION
## What is the purpose of the change

With Unaligned checkpoints enabled, when there are no channel state handles, the underlying FS stream is still created. On discard it is not deleted because it's not referenced by any state handles.
This prevents checkpoint from being subsumed.

This was causing e2e test `test_stateful_stream_job_upgrade.sh` to fail (which is re-enabled in this PR).

## Brief change log

 - add a check for emptyness of handles before creating an underlying stream
 - add unit test
 - revert reverse of [FLINK-17467][task][e2e] Modify existing upgrade test to verify aligned savepoints

## Verifying this change

This change added tests and can be verified as follows:

 - Added unit test: `ChannelStateCheckpointWriterTest.testEmptyState`
 - Re-enabled e2e test: `test_stateful_stream_job_upgrade.sh`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
