### PR TITLE
[FLINK-17692] Keep yarn.classpath in target folder to not pollute local builds

### DIFF
--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -93,8 +93,7 @@ under the License.
 
 	<dependencies>
 		<dependency>
-			<!-- flink-yarn is required for getting the yarn classpath in the hadoop
-			bash end to end tests -->
+			<!-- this module depends on the flink-yarn-tests's "target/yarn.classpath" file -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-yarn-tests</artifactId>
 			<version>${project.version}</version>
@@ -164,30 +163,6 @@ under the License.
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-resources-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>copy-resources</id>
-						<phase>package</phase>
-						<goals>
-							<goal>copy-resources</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${basedir}/test-scripts/hadoop</outputDirectory>
-							<resources>
-								<resource>
-									<directory>../flink-yarn-tests/target/</directory>
-									<filtering>true</filtering>
-									<includes>
-										<include>yarn.classpath</include>
-									</includes>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -56,7 +56,7 @@ CURL_SSL_ARGS=""
 source "${TEST_INFRA_DIR}/common_ssl.sh"
 
 function set_hadoop_classpath {
-  YARN_CLASSPATH_LOCATION="${TEST_INFRA_DIR}/hadoop/yarn.classpath";
+  YARN_CLASSPATH_LOCATION="${TEST_INFRA_DIR}/../../flink-yarn-tests/target/yarn.classpath";
   if [ ! -f $YARN_CLASSPATH_LOCATION ]; then
     echo "File '$YARN_CLASSPATH_LOCATION' does not exist."
     exit 1


### PR DESCRIPTION
## What is the purpose of the change

Before this change, git was showing the an untracked file in `flink-end-to-end-tests/test-scripts/hadoop/yarn.classpath`.

## Brief change log

  - Get the yarn.classpath file from `flink-yarn-tests/target`.



## Verifying this change

I tested the change here: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8002&view=results
