### PR TITLE
[FLINK-17435] [hive] Hive non-partitioned source supports streaming read

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ConsumeOrder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ConsumeOrder.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import java.util.Arrays;
+
+/**
+ * {@link ConsumeOrder} defines the orders to continuously consume stream source.
+ */
+public enum ConsumeOrder {
+
+	/**
+	 * create-time compare partition/file creation time,
+	 * this is not the partition create time in Hive metaStore,
+	 * but the folder/file create time in filesystem.
+	 */
+	CREATE_TIME_ORDER("create-time"),
+
+	/**
+	 * partition-time compare time represented by partition name.
+	 */
+	PARTITION_TIME_ORDER("partition-time");
+
+	private final String order;
+
+	ConsumeOrder(String order) {
+		this.order = order;
+	}
+
+	@Override
+	public String toString() {
+		return order;
+	}
+
+	/**
+	 * Get {@link ConsumeOrder} from consume order string.
+	 */
+	public static ConsumeOrder getConsumeOrder(String consumeOrderStr) {
+		for (ConsumeOrder consumeOrder : values()) {
+			if (consumeOrder.order.equalsIgnoreCase(consumeOrderStr)) {
+				return consumeOrder;
+			}
+		}
+		throw new IllegalArgumentException(
+				"Illegal value: " + consumeOrderStr + ", only " + Arrays.toString(values()) + " are supported.");
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -20,16 +20,21 @@ package org.apache.flink.connectors.hive;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connectors.hive.read.HiveContinuousMonitoringFunction;
+import org.apache.flink.connectors.hive.read.HiveTableFileInputFormat;
 import org.apache.flink.connectors.hive.read.HiveTableInputFormat;
 import org.apache.flink.connectors.hive.read.TimestampedHiveInputSplit;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileMonitoringFunction;
 import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperatorFactory;
+import org.apache.flink.streaming.api.functions.source.FileProcessingMode;
+import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -82,6 +87,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.filesystem.DefaultPartTimeExtractor.toMills;
 import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_CLASS;
 import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_KIND;
 import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
@@ -173,10 +179,10 @@ public class HiveTableSource implements
 
 		if (isStreamingSource()) {
 			if (catalogTable.getPartitionKeys().isEmpty()) {
-				throw new UnsupportedOperationException(
-						"Non-partition table does not support streaming read now.");
+				return createStreamSourceForNonPartitionTable(execEnv, typeInfo, inputFormat, allHivePartitions.get(0));
+			} else {
+				return createStreamSourceForPartitionTable(execEnv, typeInfo, inputFormat);
 			}
-			return createStreamSource(execEnv, typeInfo, inputFormat);
 		} else {
 			return createBatchSource(execEnv, typeInfo, inputFormat);
 		}
@@ -221,28 +227,20 @@ public class HiveTableSource implements
 		return source.name(explainSource());
 	}
 
-	private DataStream<RowData> createStreamSource(
+	private DataStream<RowData> createStreamSourceForPartitionTable(
 			StreamExecutionEnvironment execEnv,
 			TypeInformation<RowData> typeInfo,
 			HiveTableInputFormat inputFormat) {
-		final Map<String, String> properties = catalogTable.getOptions();
+		Configuration configuration = new Configuration();
+		catalogTable.getOptions().forEach(configuration::setString);
 
-		String consumeOrder = properties.getOrDefault(
-				STREAMING_SOURCE_CONSUME_ORDER.key(),
-				STREAMING_SOURCE_CONSUME_ORDER.defaultValue());
-		String consumeOffset = properties.getOrDefault(
-				STREAMING_SOURCE_CONSUME_START_OFFSET.key(),
-				STREAMING_SOURCE_CONSUME_START_OFFSET.defaultValue());
-		String extractorKind = properties.getOrDefault(
-				PARTITION_TIME_EXTRACTOR_KIND.key(),
-				PARTITION_TIME_EXTRACTOR_KIND.defaultValue());
-		String extractorClass = properties.get(PARTITION_TIME_EXTRACTOR_CLASS.key());
-		String extractorPattern = properties.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key());
-
-		String monitorIntervalStr = properties.get(STREAMING_SOURCE_MONITOR_INTERVAL.key());
-		Duration monitorInterval = monitorIntervalStr != null ?
-				TimeUtils.parseDuration(monitorIntervalStr) :
-				STREAMING_SOURCE_MONITOR_INTERVAL.defaultValue();
+		String consumeOrderStr = configuration.get(STREAMING_SOURCE_CONSUME_ORDER);
+		ConsumeOrder consumeOrder = ConsumeOrder.getConsumeOrder(consumeOrderStr);
+		String consumeOffset = configuration.get(STREAMING_SOURCE_CONSUME_START_OFFSET);
+		String extractorKind = configuration.get(PARTITION_TIME_EXTRACTOR_KIND);
+		String extractorClass = configuration.get(PARTITION_TIME_EXTRACTOR_CLASS);
+		String extractorPattern = configuration.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN);
+		Duration monitorInterval = configuration.get(STREAMING_SOURCE_MONITOR_INTERVAL);
 
 		HiveContinuousMonitoringFunction monitoringFunction = new HiveContinuousMonitoringFunction(
 				hiveShim,
@@ -263,6 +261,45 @@ public class HiveTableSource implements
 		String sourceName = "HiveMonitoringFunction";
 		SingleOutputStreamOperator<RowData> source = execEnv
 				.addSource(monitoringFunction, sourceName)
+				.transform("Split Reader: " + sourceName, typeInfo, factory);
+
+		return new DataStreamSource<>(source);
+	}
+
+	private DataStream<RowData> createStreamSourceForNonPartitionTable(
+			StreamExecutionEnvironment execEnv,
+			TypeInformation<RowData> typeInfo,
+			HiveTableInputFormat inputFormat,
+			HiveTablePartition hiveTable) {
+		HiveTableFileInputFormat fileInputFormat = new HiveTableFileInputFormat(inputFormat, hiveTable);
+
+		Configuration configuration = new Configuration();
+		catalogTable.getOptions().forEach(configuration::setString);
+		String consumeOrderStr = configuration.get(STREAMING_SOURCE_CONSUME_ORDER);
+		ConsumeOrder consumeOrder = ConsumeOrder.getConsumeOrder(consumeOrderStr);
+		if (consumeOrder != ConsumeOrder.CREATE_TIME_ORDER) {
+			throw new UnsupportedOperationException(
+					"Only " + ConsumeOrder.CREATE_TIME_ORDER + " is supported for non partition table.");
+		}
+
+		String consumeOffset = configuration.get(STREAMING_SOURCE_CONSUME_START_OFFSET);
+		long currentReadTime = toMills(consumeOffset);
+
+		Duration monitorInterval = configuration.get(STREAMING_SOURCE_MONITOR_INTERVAL);
+
+		ContinuousFileMonitoringFunction<RowData> monitoringFunction =
+				new ContinuousFileMonitoringFunction<>(
+						fileInputFormat,
+						FileProcessingMode.PROCESS_CONTINUOUSLY,
+						execEnv.getParallelism(),
+						monitorInterval.toMillis(),
+						currentReadTime);
+
+		ContinuousFileReaderOperatorFactory<RowData, TimestampedFileInputSplit> factory =
+				new ContinuousFileReaderOperatorFactory<>(fileInputFormat);
+
+		String sourceName = "HiveFileMonitoringFunction";
+		SingleOutputStreamOperator<RowData> source = execEnv.addSource(monitoringFunction, sourceName)
 				.transform("Split Reader: " + sourceName, typeInfo, factory);
 
 		return new DataStreamSource<>(source);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connectors.hive.ConsumeOrder;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.connectors.hive.HiveTableSource;
 import org.apache.flink.connectors.hive.JobConfWrapper;
@@ -87,9 +88,6 @@ public class HiveContinuousMonitoringFunction
 
 	private static final Logger LOG = LoggerFactory.getLogger(HiveContinuousMonitoringFunction.class);
 
-	private static final String CREATE_TIME_ORDER = "create-time";
-	private static final String PARTITION_TIME_ORDER = "partition-time";
-
 	/** The parallelism of the downstream readers. */
 	private final int readerParallelism;
 
@@ -109,7 +107,7 @@ public class HiveContinuousMonitoringFunction
 	private final DataType[] fieldTypes;
 
 	// consumer variables
-	private final String consumeOrder;
+	private final ConsumeOrder consumeOrder;
 	private final String consumeOffset;
 
 	// extractor variables
@@ -146,7 +144,7 @@ public class HiveContinuousMonitoringFunction
 			ObjectPath tablePath,
 			CatalogTable catalogTable,
 			int readerParallelism,
-			String consumeOrder,
+			ConsumeOrder consumeOrder,
 			String consumeOffset,
 			String extractorKind,
 			String extractorClass,
@@ -254,9 +252,7 @@ public class HiveContinuousMonitoringFunction
 			this.distinctPartitions.addAll(this.distinctPartsState.get().iterator().next());
 		} else {
 			LOG.info("No state to restore for the {}.", getClass().getSimpleName());
-			if (consumeOffset != null) {
-				this.currentReadTime = toMills(consumeOffset);
-			}
+			this.currentReadTime = toMills(consumeOffset);
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableFileInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableFileInputFormat.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.table.data.RowData;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * A {@link FileInputFormat} that wraps a {@link HiveTableInputFormat}.
+ *
+ * <p>We only use a {@link HiveTableInputFormat} to read the data of a {@link FileInputSplit}.
+ * `createInputSplits`, `getInputSplitAssigner` will use {@link FileInputFormat}'s logic.
+ */
+public class HiveTableFileInputFormat extends FileInputFormat<RowData> {
+
+	private final HiveTableInputFormat inputFormat;
+	private final HiveTablePartition hiveTablePartition;
+
+	public HiveTableFileInputFormat(
+			HiveTableInputFormat inputFormat,
+			HiveTablePartition hiveTablePartition) {
+		this.inputFormat = inputFormat;
+		this.hiveTablePartition = hiveTablePartition;
+		setFilePath(hiveTablePartition.getStorageDescriptor().getLocation());
+	}
+
+	@Override
+	public void open(FileInputSplit fileSplit) throws IOException {
+		URI uri = fileSplit.getPath().toUri();
+		HiveTableInputSplit split = new HiveTableInputSplit(
+				fileSplit.getSplitNumber(),
+				new FileSplit(new Path(uri), fileSplit.getStart(), fileSplit.getLength(), (String[]) null),
+				inputFormat.getJobConf(),
+				hiveTablePartition
+		);
+		inputFormat.open(split);
+	}
+
+	@Override
+	public boolean reachedEnd() throws IOException {
+		return inputFormat.reachedEnd();
+	}
+
+	@Override
+	public RowData nextRecord(RowData reuse) throws IOException {
+		return inputFormat.nextRecord(reuse);
+	}
+
+	@Override
+	public void configure(Configuration parameters) {
+		super.configure(parameters);
+		inputFormat.configure(parameters);
+	}
+
+	@Override
+	public void close() throws IOException {
+		super.close();
+		inputFormat.close();
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		inputFormat.setRuntimeContext(t);
+	}
+
+	@Override
+	public void openInputFormat() throws IOException {
+		super.openInputFormat();
+		inputFormat.openInputFormat();
+	}
+
+	@Override
+	public void closeInputFormat() throws IOException {
+		super.closeInputFormat();
+		inputFormat.closeInputFormat();
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -120,6 +120,10 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 		this.useMapRedReader = useMapRedReader;
 	}
 
+	public JobConf getJobConf() {
+		return jobConf;
+	}
+
 	@Override
 	public void configure(org.apache.flink.configuration.Configuration parameters) {
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -94,7 +94,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 	private final FileProcessingMode watchType;
 
 	/** The maximum file modification time seen so far. */
-	private volatile long globalModificationTime = Long.MIN_VALUE;
+	private volatile long globalModificationTime;
 
 	private transient Object checkpointLock;
 
@@ -103,10 +103,19 @@ public class ContinuousFileMonitoringFunction<OUT>
 	private transient ListState<Long> checkpointedState;
 
 	public ContinuousFileMonitoringFunction(
+			FileInputFormat<OUT> format,
+			FileProcessingMode watchType,
+			int readerParallelism,
+			long interval) {
+		this(format, watchType, readerParallelism, interval, Long.MIN_VALUE);
+	}
+
+	public ContinuousFileMonitoringFunction(
 		FileInputFormat<OUT> format,
 		FileProcessingMode watchType,
 		int readerParallelism,
-		long interval) {
+		long interval,
+		long globalModificationTime) {
 
 		Preconditions.checkArgument(
 			watchType == FileProcessingMode.PROCESS_ONCE || interval >= MIN_MONITORING_INTERVAL,
@@ -124,7 +133,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 		this.interval = interval;
 		this.watchType = watchType;
 		this.readerParallelism = Math.max(readerParallelism, 1);
-		this.globalModificationTime = Long.MIN_VALUE;
+		this.globalModificationTime = globalModificationTime;
 	}
 
 	@VisibleForTesting

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -33,7 +33,10 @@ public class FileSystemOptions {
 			key("streaming-source.enable")
 					.booleanType()
 					.defaultValue(false)
-					.withDescription("Enable streaming source or not.");
+					.withDescription("Enable streaming source or not.\n" +
+							"NOTES: For non-partition table, please make sure that " +
+							"each file should be put atomically into the target directory, " +
+							"otherwise the reader may get incomplete data.");
 
 	public static final ConfigOption<Duration> STREAMING_SOURCE_MONITOR_INTERVAL =
 			key("streaming-source.monitor-interval")
@@ -50,7 +53,8 @@ public class FileSystemOptions {
 							" create-time compare partition/file creation time, this is not the" +
 							" partition create time in Hive metaStore, but the folder/file create" +
 							" time in filesystem;" +
-							" partition-time compare time represented by partition name.");
+							" partition-time compare time represented by partition name.\n" +
+							"For non-partition table, this value should always be 'create-time'.");
 
 	public static final ConfigOption<String> STREAMING_SOURCE_CONSUME_START_OFFSET =
 			key("streaming-source.consume-start-offset")


### PR DESCRIPTION
## What is the purpose of the change

*for non-partitioned hive source, we can use existing continuous file processing mechanism to read new data. This pr aim let non-partitioned hive source support streaming read.*


## Brief change log
  - *A hive FileInputFormat that wraps HiveTableInputFormat*
  - *create streaming source with PROCESS_CONTINUOUSLY mode*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended HiveTableSourceTest for streaming read on non-partitioned source*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
