### PR TITLE
[FLINK-16144] get client.timeout for the client, with a fallback to the akka.client…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -46,7 +46,6 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.core.execution.DefaultExecutorServiceLoader;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginUtils;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -141,7 +140,7 @@ public class CliFrontend {
 			customCommandLine.addRunOptions(customCommandLineOptions);
 		}
 
-		this.clientTimeout = AkkaUtils.getClientTimeout(this.configuration);
+		this.clientTimeout = ClientOptions.getClientTimeout(this.configuration);
 		this.defaultParallelism = configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ClientOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ClientOptions.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.TimeUtils;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Describes a client configuration parameter.
+ */
+public class ClientOptions {
+
+	public static final ConfigOption<Duration> CLIENT_TIMEOUT =
+			ConfigOptions.key("client.timeout")
+					.durationType()
+					.defaultValue(Duration.ofSeconds(60))
+					.withDescription("Timeout on the client side.");
+
+	public static final ConfigOption<Duration> CLIENT_RETRY_PERIOD =
+			ConfigOptions.key("client.retry-period")
+					.durationType()
+					.defaultValue(Duration.ofMillis(2000))
+					.withDescription("The interval (in ms) between consecutive retries of failed attempts to execute " +
+							"commands through the CLI or Flink's clients, wherever retry is supported (default 2sec).");
+
+	public static Duration getClientTimeout(Configuration configuration) {
+		Optional<Duration> timeoutOptional = configuration.getOptional(CLIENT_TIMEOUT);
+		if (timeoutOptional.isPresent()) {
+			return timeoutOptional.get();
+		} else {
+			Optional<String> akkaClientTimeout = configuration.getOptional(AkkaOptions.CLIENT_TIMEOUT);
+			if (akkaClientTimeout.isPresent()) {
+				return TimeUtils.parseDuration(akkaClientTimeout.get());
+			} else {
+				return CLIENT_TIMEOUT.defaultValue();
+			}
+		}
+	}
+
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
@@ -23,11 +23,11 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.client.ClientUtils;
+import org.apache.flink.client.cli.ClientOptions;
 import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
 import org.apache.flink.client.deployment.application.executors.EmbeddedExecutorServiceLoader;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.runtime.client.JobCancellationException;
@@ -263,8 +263,8 @@ public class ApplicationDispatcherBootstrap extends AbstractDispatcherBootstrap 
 			final JobID jobId,
 			final ScheduledExecutor scheduledExecutor) {
 
-		final Time timeout = Time.milliseconds(configuration.get(ExecutionOptions.EMBEDDED_RPC_TIMEOUT).toMillis());
-		final Time retryPeriod = Time.milliseconds(configuration.get(ExecutionOptions.EMBEDDED_RPC_RETRY_PERIOD).toMillis());
+		final Time timeout = Time.milliseconds(ClientOptions.getClientTimeout(configuration).toMillis());
+		final Time retryPeriod = Time.milliseconds(configuration.get(ClientOptions.CLIENT_RETRY_PERIOD).toMillis());
 
 		return JobStatusPollingUtils.getJobResult(
 						dispatcherGateway, jobId, scheduledExecutor, timeout, retryPeriod);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
@@ -22,9 +22,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.client.cli.ClientOptions;
 import org.apache.flink.client.deployment.executors.PipelineExecutorUtils;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.PipelineExecutor;
@@ -103,7 +103,7 @@ public class EmbeddedExecutor implements PipelineExecutor {
 	}
 
 	private CompletableFuture<JobClient> submitAndGetJobClientFuture(final Pipeline pipeline, final Configuration configuration) throws MalformedURLException {
-		final Time timeout = Time.milliseconds(configuration.get(ExecutionOptions.EMBEDDED_RPC_TIMEOUT).toMillis());
+		final Time timeout = Time.milliseconds(ClientOptions.getClientTimeout(configuration).toMillis());
 
 		final JobGraph jobGraph = PipelineExecutorUtils.getJobGraph(pipeline, configuration);
 		final JobID actualJobId = jobGraph.getJobID();

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
@@ -21,9 +21,9 @@ package org.apache.flink.client.deployment.application.executors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.cli.ClientOptions;
 import org.apache.flink.client.deployment.application.EmbeddedJobClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -80,7 +80,7 @@ public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
 				submittedJobIds,
 				dispatcherGateway,
 				jobId -> {
-					final Time timeout = Time.milliseconds(configuration.get(ExecutionOptions.EMBEDDED_RPC_TIMEOUT).toMillis());
+					final Time timeout = Time.milliseconds(ClientOptions.getClientTimeout(configuration).toMillis());
 					return new EmbeddedJobClient(jobId, dispatcherGateway, retryExecutor, timeout);
 				});
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/ClientOptionsTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/ClientOptionsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * unit test for ClientOptions.
+ */
+@RunWith(JUnit4.class)
+public class ClientOptionsTest {
+
+	@Test
+	public void testGetClientTimeout() {
+		Configuration configuration = new Configuration();
+		configuration.set(ClientOptions.CLIENT_TIMEOUT, Duration.ofSeconds(10));
+
+		assertEquals(ClientOptions.getClientTimeout(configuration), Duration.ofSeconds(10));
+
+		configuration = new Configuration();
+		configuration.set(AkkaOptions.CLIENT_TIMEOUT, "20 s");
+		assertEquals(ClientOptions.getClientTimeout(configuration), Duration.ofSeconds(20));
+
+		configuration = new Configuration();
+		assertEquals(ClientOptions.getClientTimeout(configuration), ClientOptions.CLIENT_TIMEOUT.defaultValue());
+	}
+
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -156,7 +156,10 @@ public class AkkaOptions {
 
 	/**
 	 * Timeout for all blocking calls on the client side.
+	 *
+	 * @deprecated Use the {@code ClientOptions.CLIENT_TIMEOUT} instead.
 	 */
+	@Deprecated
 	public static final ConfigOption<String> CLIENT_TIMEOUT = ConfigOptions
 		.key("akka.client.timeout")
 		.stringType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -56,18 +56,5 @@ public class ExecutionOptions {
 				)
 				.build());
 
-	public static final ConfigOption<Duration> EMBEDDED_RPC_TIMEOUT =
-		ConfigOptions.key("execution.embedded-rpc-timeout")
-			.durationType()
-			.defaultValue(Duration.ofMillis(60 * 60 * 1000))
-			.withDescription("The rpc timeout (in ms) when executing applications in \"Application Mode\". " +
-					"This affects all rpc's available through the Job Client and job submission.");
-
-	public static final ConfigOption<Duration> EMBEDDED_RPC_RETRY_PERIOD =
-		ConfigOptions.key("execution.embedded-rpc-retry-period")
-			.durationType()
-			.defaultValue(Duration.ofMillis(2000))
-			.withDescription("The retry period (in ms) between consecutive attempts to get the job status " +
-					"when executing applications in \"Application Mode\".");
 
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -793,10 +793,6 @@ object AkkaUtils {
     TimeUtils.parseDuration(config.getString(AkkaOptions.LOOKUP_TIMEOUT))
   }
 
-  def getClientTimeout(config: Configuration): time.Duration = {
-    TimeUtils.parseDuration(config.getString(AkkaOptions.CLIENT_TIMEOUT))
-  }
-
   /** Returns the address of the given [[ActorSystem]]. The [[Address]] object contains
     * the port and the host under which the actor system is reachable
     *

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -105,7 +105,7 @@ class AkkaUtilsTest
     val IPv4AddressString = "192.168.0.1"
     val port = 1234
     val address = new InetSocketAddress(IPv4AddressString, port)
-    
+
     val url = s"akka://flink@$IPv4AddressString:$port/user/jobmanager"
 
     val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)


### PR DESCRIPTION
<!--
## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add client.timeout setting and use that for CLI operations

## Brief change log

Currently, the Cli uses the akka.client.timeout setting. This has historical reasons but can be very confusing for users. We should introduce a new setting client.timeout that is used for the client, with a fallback to the previous akka.client.timeout


## Verifying this change


AkkaUtilsTest.test("get client.timeout for the client, with a fallback to the akka.client.timeout.") 
passed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
