### PR TITLE
[FLINK-17737][task] Fix AlternatingCheckpointBarrierHandler

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
@@ -93,16 +93,19 @@ class AlternatingCheckpointBarrierHandler extends CheckpointBarrierHandler {
 
 	@Override
 	public boolean hasInflightData(long checkpointId, int channelIndex) {
-		return activeHandler.hasInflightData(checkpointId, channelIndex);
+		// should only be called for unaligned checkpoint
+		return unalignedHandler.hasInflightData(checkpointId, channelIndex);
 	}
 
 	@Override
 	public CompletableFuture<Void> getAllBarriersReceivedFuture(long checkpointId) {
-		return activeHandler.getAllBarriersReceivedFuture(checkpointId);
+		// should only be called for unaligned checkpoint
+		return unalignedHandler.getAllBarriersReceivedFuture(checkpointId);
 	}
 
 	@Override
 	public Optional<BufferReceivedListener> getBufferReceivedListener() {
+		// should only be used for handling unaligned checkpoints
 		return unalignedHandler.getBufferReceivedListener();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
@@ -36,6 +36,7 @@ class AlternatingCheckpointBarrierHandler extends CheckpointBarrierHandler {
 	private final CheckpointBarrierAligner alignedHandler;
 	private final CheckpointBarrierUnaligner unalignedHandler;
 	private CheckpointBarrierHandler activeHandler;
+	private long lastSeenBarrierId;
 
 	AlternatingCheckpointBarrierHandler(CheckpointBarrierAligner alignedHandler, CheckpointBarrierUnaligner unalignedHandler, AbstractInvokable invokable) {
 		super(invokable);
@@ -55,6 +56,10 @@ class AlternatingCheckpointBarrierHandler extends CheckpointBarrierHandler {
 
 	@Override
 	public void processBarrier(CheckpointBarrier receivedBarrier, int channelIndex) throws Exception {
+		if (receivedBarrier.getId() < lastSeenBarrierId) {
+			return;
+		}
+		lastSeenBarrierId = receivedBarrier.getId();
 		CheckpointBarrierHandler previousHandler = activeHandler;
 		activeHandler = receivedBarrier.isCheckpoint() ? unalignedHandler : alignedHandler;
 		abortPreviousIfNeeded(receivedBarrier, previousHandler);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 
+import org.apache.flink.shaded.guava18.com.google.common.io.Closer;
+
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -112,5 +114,14 @@ class AlternatingCheckpointBarrierHandler extends CheckpointBarrierHandler {
 	@Override
 	protected boolean isCheckpointPending() {
 		return activeHandler.isCheckpointPending();
+	}
+
+	@Override
+	public void close() throws IOException {
+		try (Closer closer = Closer.create()) {
+			closer.register(alignedHandler);
+			closer.register(unalignedHandler);
+			closer.register(super::close);
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Always use `unalignedHandler` in `AlternatingCheckpointBarrierHandler` for methods related to UC because they can be called before barrier is processed by the task stream and the active handler is switched.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test: `testHasInflightDataBeforeProcessBarrier`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
