### PR TITLE
[FLINK-17728] [sql-client] sql client supports parser statements via sql parser

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.cli.SqlCommandParser.SqlCommandCall;
@@ -252,7 +253,7 @@ public class CliClient {
 	// --------------------------------------------------------------------------------------------
 
 	private Optional<SqlCommandCall> parseCommand(String line) {
-		final Optional<SqlCommandCall> parsedLine = SqlCommandParser.parse(line);
+		final Optional<SqlCommandCall> parsedLine = SqlCommandParser.parse(s -> executor.parse(sessionId, s), line);
 		if (!parsedLine.isPresent()) {
 			printError(CliStrings.MESSAGE_UNKNOWN_SQL);
 		}
@@ -517,7 +518,8 @@ public class CliClient {
 	private void callExplain(SqlCommandCall cmdCall) {
 		final String explanation;
 		try {
-			explanation = executor.explainStatement(sessionId, cmdCall.operands[0]);
+			TableResult tableResult = executor.executeSql(sessionId, cmdCall.operands[0]);
+			explanation = tableResult.collect().next().getField(0).toString();
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -253,7 +253,7 @@ public class CliClient {
 	// --------------------------------------------------------------------------------------------
 
 	private Optional<SqlCommandCall> parseCommand(String line) {
-		final Optional<SqlCommandCall> parsedLine = SqlCommandParser.parse(s -> executor.parse(sessionId, s), line);
+		final Optional<SqlCommandCall> parsedLine = SqlCommandParser.parse(executor.getSqlParser(sessionId), line);
 		if (!parsedLine.isPresent()) {
 			printError(CliStrings.MESSAGE_UNKNOWN_SQL);
 		}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -18,7 +18,31 @@
 
 package org.apache.flink.table.client.cli;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.operations.CatalogSinkModifyOperation;
+import org.apache.flink.table.operations.DescribeTableOperation;
+import org.apache.flink.table.operations.ExplainOperation;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.QueryOperation;
+import org.apache.flink.table.operations.ShowCatalogsOperation;
+import org.apache.flink.table.operations.ShowDatabasesOperation;
+import org.apache.flink.table.operations.ShowFunctionsOperation;
+import org.apache.flink.table.operations.ShowTablesOperation;
+import org.apache.flink.table.operations.UseCatalogOperation;
+import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOperation;
+import org.apache.flink.table.operations.ddl.CreateCatalogOperation;
+import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
+import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.CreateViewOperation;
+import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
+import org.apache.flink.table.operations.ddl.DropTableOperation;
+import org.apache.flink.table.operations.ddl.DropViewOperation;
+
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -34,7 +58,7 @@ public final class SqlCommandParser {
 		// private
 	}
 
-	public static Optional<SqlCommandCall> parse(String stmt) {
+	public static Optional<SqlCommandCall> parse(Function<String, List<Operation>> sqlParserFunction, String stmt) {
 		// normalize
 		stmt = stmt.trim();
 		// remove ';' at the end
@@ -42,19 +66,121 @@ public final class SqlCommandParser {
 			stmt = stmt.substring(0, stmt.length() - 1).trim();
 		}
 
-		// parse
+		// parse statement via sql parser first
+		Optional<SqlCommandCall> callOpt = parseBySqlParser(sqlParserFunction, stmt);
+		if (callOpt.isPresent()) {
+			return callOpt;
+		}
+
+		// parse statement via regex match
 		for (SqlCommand cmd : SqlCommand.values()) {
-			final Matcher matcher = cmd.pattern.matcher(stmt);
-			if (matcher.matches()) {
-				final String[] groups = new String[matcher.groupCount()];
-				for (int i = 0; i < groups.length; i++) {
-					groups[i] = matcher.group(i + 1);
+			if (cmd.hasRegexPattern()) {
+				final Matcher matcher = cmd.pattern.matcher(stmt);
+				if (matcher.matches()) {
+					final String[] groups = new String[matcher.groupCount()];
+					for (int i = 0; i < groups.length; i++) {
+						groups[i] = matcher.group(i + 1);
+					}
+					return cmd.operandConverter.apply(groups)
+							.map((operands) -> {
+								String[] newOperands = operands;
+								if (cmd == SqlCommand.EXPLAIN) {
+									// convert `explain xx` to `explain plan for xx`
+									newOperands = new String[] { "EXPLAIN PLAN FOR " + operands[0] };
+								}
+								return new SqlCommandCall(cmd, newOperands);
+							});
 				}
-				return cmd.operandConverter.apply(groups)
-					.map((operands) -> new SqlCommandCall(cmd, operands));
 			}
 		}
 		return Optional.empty();
+	}
+
+	private static Optional<SqlCommandCall> parseBySqlParser(
+			Function<String, List<Operation>> sqlParserFunction, String stmt) {
+		List<Operation> operations;
+		try {
+			operations = sqlParserFunction.apply(stmt);
+		} catch (SqlExecutionException e) {
+			if (e.getCause() instanceof ValidationException) {
+				// can be parsed via sql parser, but is not validated.
+				// throw exception directly
+				throw e;
+			}
+			return Optional.empty();
+		}
+		if (operations.size() != 1) {
+			throw new SqlExecutionException("Only single statement is supported now.");
+		}
+
+		final SqlCommand cmd;
+		String[] operands = new String[0];
+		Operation operation = operations.get(0);
+		if (operation instanceof CatalogSinkModifyOperation) {
+			boolean overwrite = ((CatalogSinkModifyOperation) operation).isOverwrite();
+			cmd = overwrite ? SqlCommand.INSERT_OVERWRITE : SqlCommand.INSERT_INTO;
+			operands = new String[] { stmt };
+		} else if (operation instanceof CreateTableOperation) {
+			cmd = SqlCommand.CREATE_TABLE;
+			operands = new String[] { stmt };
+		} else if (operation instanceof DropTableOperation) {
+			cmd = SqlCommand.DROP_TABLE;
+			operands = new String[] { stmt };
+		} else if (operation instanceof AlterTableOperation) {
+			cmd = SqlCommand.ALTER_TABLE;
+			operands = new String[] { stmt };
+		} else if (operation instanceof CreateViewOperation) {
+			cmd = SqlCommand.CREATE_VIEW;
+			CreateViewOperation op = (CreateViewOperation) operation;
+			operands = new String[] { op.getViewIdentifier().asSerializableString(),
+					op.getCatalogView().getOriginalQuery() };
+		} else if (operation instanceof DropViewOperation) {
+			cmd = SqlCommand.DROP_VIEW;
+			operands = new String[] { ((DropViewOperation) operation).getViewIdentifier().asSerializableString() };
+		} else if (operation instanceof CreateDatabaseOperation) {
+			cmd = SqlCommand.CREATE_DATABASE;
+			operands = new String[] { stmt };
+		} else if (operation instanceof DropDatabaseOperation) {
+			cmd = SqlCommand.DROP_DATABASE;
+			operands = new String[] { stmt };
+		} else if (operation instanceof AlterDatabaseOperation) {
+			cmd = SqlCommand.ALTER_DATABASE;
+			operands = new String[] { stmt };
+		} else if (operation instanceof CreateCatalogOperation) {
+			cmd = SqlCommand.CREATE_CATALOG;
+			operands = new String[] { stmt };
+		} else if (operation instanceof UseCatalogOperation) {
+			cmd = SqlCommand.USE_CATALOG;
+			operands = new String[] { String.format("`%s`", ((UseCatalogOperation) operation).getCatalogName()) };
+		} else if (operation instanceof UseDatabaseOperation) {
+			cmd = SqlCommand.USE;
+			UseDatabaseOperation op = ((UseDatabaseOperation) operation);
+			operands = new String[] { String.format("`%s`.`%s`", op.getCatalogName(), op.getDatabaseName()) };
+		} else if (operation instanceof ShowCatalogsOperation) {
+			cmd = SqlCommand.SHOW_CATALOGS;
+		} else if (operation instanceof ShowDatabasesOperation) {
+			cmd = SqlCommand.SHOW_DATABASES;
+		} else if (operation instanceof ShowTablesOperation) {
+			cmd = SqlCommand.SHOW_TABLES;
+		} else if (operation instanceof ShowFunctionsOperation) {
+			cmd = SqlCommand.SHOW_FUNCTIONS;
+		} else if (operation instanceof ExplainOperation) {
+			cmd = SqlCommand.EXPLAIN;
+			operands = new String[] { stmt };
+		} else if (operation instanceof DescribeTableOperation) {
+			cmd = SqlCommand.DESCRIBE;
+			operands = new String[] { ((DescribeTableOperation) operation).getSqlIdentifier().asSerializableString() };
+		} else if (operation instanceof QueryOperation) {
+			cmd = SqlCommand.SELECT;
+			operands = new String[] { stmt };
+		} else {
+			cmd = null;
+		}
+		if (cmd == null) {
+			return Optional.empty();
+		} else {
+			return Optional.of(new SqlCommandCall(cmd, operands));
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -83,37 +209,24 @@ public final class SqlCommandParser {
 			"HELP",
 			NO_OPERANDS),
 
-		SHOW_CATALOGS(
-			"SHOW\\s+CATALOGS",
-			NO_OPERANDS),
+		SHOW_CATALOGS,
 
-		SHOW_DATABASES(
-			"SHOW\\s+DATABASES",
-			NO_OPERANDS),
+		SHOW_DATABASES,
 
-		SHOW_TABLES(
-			"SHOW\\s+TABLES",
-			NO_OPERANDS),
+		SHOW_TABLES,
 
-		SHOW_FUNCTIONS(
-			"SHOW\\s+FUNCTIONS",
-			NO_OPERANDS),
+		SHOW_FUNCTIONS,
 
+		// FLINK-17396
 		SHOW_MODULES(
 			"SHOW\\s+MODULES",
 			NO_OPERANDS),
 
-		USE_CATALOG(
-			"USE\\s+CATALOG\\s+(.*)",
-			SINGLE_OPERAND),
+		USE_CATALOG,
 
-		USE(
-			"USE\\s+(?!CATALOG)(.*)",
-			SINGLE_OPERAND),
+		USE,
 
-		CREATE_CATALOG(
-			"(CREATE\\s+CATALOG\\s+.*)",
-			SINGLE_OPERAND),
+		CREATE_CATALOG,
 
 		DROP_CATALOG(
 			"(DROP\\s+CATALOG\\s+.*)",
@@ -123,62 +236,40 @@ public final class SqlCommandParser {
 			"DESC\\s+(.*)",
 			SINGLE_OPERAND),
 
-		DESCRIBE(
-			"DESCRIBE\\s+(.*)",
-			SINGLE_OPERAND),
+		DESCRIBE,
 
+		// supports both `explain xx` and `explain plan for xx`
 		EXPLAIN(
 			"EXPLAIN\\s+(.*)",
 			SINGLE_OPERAND),
 
-		SELECT(
-			"(WITH.*SELECT.*|SELECT.*)",
-			SINGLE_OPERAND),
+		CREATE_DATABASE,
 
-		INSERT_INTO(
-			"(INSERT\\s+INTO.*)",
-			SINGLE_OPERAND),
+		DROP_DATABASE,
 
-		INSERT_OVERWRITE(
-			"(INSERT\\s+OVERWRITE.*)",
-			SINGLE_OPERAND),
+		ALTER_DATABASE,
 
-		CREATE_TABLE("(CREATE\\s+TABLE\\s+.*)", SINGLE_OPERAND),
+		CREATE_TABLE,
 
-		DROP_TABLE("(DROP\\s+TABLE\\s+.*)", SINGLE_OPERAND),
+		DROP_TABLE,
 
-		ALTER_TABLE(
-				"(ALTER\\s+TABLE\\s+.*)",
-				SINGLE_OPERAND),
+		ALTER_TABLE,
 
-		CREATE_VIEW(
-			"CREATE\\s+VIEW\\s+(\\S+)\\s+AS\\s+(.*)",
-			(operands) -> {
-				if (operands.length < 2) {
-					return Optional.empty();
-				}
-				return Optional.of(new String[]{operands[0], operands[1]});
-			}),
+		CREATE_VIEW,
 
-		DROP_VIEW("DROP\\s+VIEW\\s+(.*)", SINGLE_OPERAND),
+		DROP_VIEW,
 
-		CREATE_FUNCTION("(CREATE.+FUNCTION\\s+(\\S+)\\s+AS.+)", SINGLE_OPERAND),
+		CREATE_FUNCTION,
 
-		DROP_FUNCTION("(DROP.+FUNCTION\\s+.+)", SINGLE_OPERAND),
+		DROP_FUNCTION,
 
-		ALTER_FUNCTION("(ALTER.+FUNCTION\\s+.+)", SINGLE_OPERAND),
+		ALTER_FUNCTION,
 
-		CREATE_DATABASE(
-				"(CREATE\\s+DATABASE\\s+.*)",
-				SINGLE_OPERAND),
+		SELECT,
 
-		DROP_DATABASE(
-				"(DROP\\s+DATABASE\\s+.*)",
-				SINGLE_OPERAND),
+		INSERT_INTO,
 
-		ALTER_DATABASE(
-				"(ALTER\\s+DATABASE\\s+.*)",
-				SINGLE_OPERAND),
+		INSERT_OVERWRITE,
 
 		SET(
 			"SET(\\s+(\\S+)\\s*=(.*))?", // whitespace is only ignored on the left side of '='
@@ -202,6 +293,11 @@ public final class SqlCommandParser {
 		public final Pattern pattern;
 		public final Function<String[], Optional<String[]>> operandConverter;
 
+		SqlCommand() {
+			this.pattern = null;
+			this.operandConverter = null;
+		}
+
 		SqlCommand(String matchingRegex, Function<String[], Optional<String[]>> operandConverter) {
 			this.pattern = Pattern.compile(matchingRegex, DEFAULT_PATTERN_FLAGS);
 			this.operandConverter = operandConverter;
@@ -214,6 +310,10 @@ public final class SqlCommandParser {
 
 		public boolean hasOperands() {
 			return operandConverter != NO_OPERANDS;
+		}
+
+		public boolean hasRegexPattern() {
+			return pattern != null;
 		}
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
@@ -29,6 +29,7 @@ import org.jline.utils.AttributedString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -97,17 +98,15 @@ public class SqlCompleter implements Completer {
 	}
 
 	private static String[] getCommandHints() {
-		final SqlCommandParser.SqlCommand[] commands = SqlCommandParser.SqlCommand.values();
-		final String[] hints = new String[commands.length];
-		for (int i = 0; i < commands.length; i++) {
-			final SqlCommandParser.SqlCommand command = commands[i];
-			// add final ";" for convenience if no operands can follow
-			if (command.hasOperands()) {
-				hints[i] = command.toString();
-			} else {
-				hints[i] = command.toString() + ";";
-			}
-		}
-		return hints;
+		return Arrays.stream(SqlCommandParser.SqlCommand.values())
+				.filter(SqlCommandParser.SqlCommand::hasRegexPattern)
+				.map(cmd -> {
+					// add final ";" for convenience if no operands can follow
+					if (cmd.hasOperands()) {
+						return cmd.toString();
+					} else {
+						return cmd.toString() + ";";
+					}
+				}).toArray(String[]::new);
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.config.entries.ViewEntry;
-import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.types.Row;
 
 import java.util.List;
@@ -167,9 +167,9 @@ public interface Executor {
 	TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException;
 
 	/**
-	 * Returns a list of {@link Operation}s for the given statement.
+	 * Returns a sql parser instance.
 	 */
-	List<Operation> parse(String sessionId, String statement) throws SqlExecutionException;
+	Parser getSqlParser(String sessionId);
 
 	/**
 	 * Returns a list of completion hints for the given statement at the given position.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -177,11 +177,6 @@ public interface Executor {
 	List<String> completeStatement(String sessionId, String statement, int position);
 
 	/**
-	 * Execute a statement and return the {@link TableResult}.
-	 */
-	TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException;
-
-	/**
 	 * Submits a Flink SQL query job (detached) and returns the result descriptor.
 	 */
 	ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.config.entries.ViewEntry;
+import org.apache.flink.table.operations.Operation;
 import org.apache.flink.types.Row;
 
 import java.util.List;
@@ -166,14 +167,19 @@ public interface Executor {
 	TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException;
 
 	/**
-	 * Returns a string-based explanation about AST and execution plan of the given statement.
+	 * Returns a list of {@link Operation}s for the given statement.
 	 */
-	String explainStatement(String sessionId, String statement) throws SqlExecutionException;
+	List<Operation> parse(String sessionId, String statement) throws SqlExecutionException;
 
 	/**
 	 * Returns a list of completion hints for the given statement at the given position.
 	 */
 	List<String> completeStatement(String sessionId, String statement, int position);
+
+	/**
+	 * Execute a statement and return the {@link TableResult}.
+	 */
+	TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException;
 
 	/**
 	 * Submits a Flink SQL query job (detached) and returns the result descriptor.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -481,19 +481,6 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
-	public TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-
-		try {
-			return context.wrapClassLoader(() -> tableEnv.executeSql(stmt));
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("Failed to execute statement.", t);
-		}
-	}
-
-	@Override
 	public ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException {
 		final ExecutionContext<?> context = getExecutionContext(sessionId);
 		return executeQueryInternal(sessionId, context, query);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -55,7 +55,7 @@ import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.client.gateway.local.result.ChangelogResult;
 import org.apache.flink.table.client.gateway.local.result.DynamicResult;
 import org.apache.flink.table.client.gateway.local.result.MaterializedResult;
-import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 import org.apache.flink.table.types.utils.DataTypeUtils;
@@ -457,16 +457,10 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
-	public List<Operation> parse(String sessionId, String statement) throws SqlExecutionException {
+	public Parser getSqlParser(String sessionId) {
 		final ExecutionContext<?> context = getExecutionContext(sessionId);
 		final TableEnvironment tableEnv = context.getTableEnvironment();
-		// translate
-		try {
-			return context.wrapClassLoader(() -> ((TableEnvironmentInternal) tableEnv).getParser().parse(statement));
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("Invalid SQL statement.", t);
-		}
+		return ((TableEnvironmentInternal) tableEnv).getParser();
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.client.cli.utils.ParserUtils;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ViewEntry;
@@ -31,6 +32,7 @@ import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.operations.Operation;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.TestLogger;
 
@@ -91,9 +93,9 @@ public class CliClientTest extends TestLogger {
 
 	@Test
 	public void testSqlCompletion() throws IOException {
-		verifySqlCompletion("", 0, Arrays.asList("SELECT", "QUIT;", "RESET;"), Collections.emptyList());
-		verifySqlCompletion("SELEC", 5, Collections.singletonList("SELECT"), Collections.singletonList("QUIT;"));
-		verifySqlCompletion("SELE", 0, Collections.singletonList("SELECT"), Collections.singletonList("QUIT;"));
+		verifySqlCompletion("", 0, Arrays.asList("SOURCE", "QUIT;", "RESET;"), Collections.emptyList());
+		verifySqlCompletion("SOUR", 5, Collections.singletonList("SOURCE"), Collections.singletonList("QUIT;"));
+		verifySqlCompletion("SOUR", 0, Collections.singletonList("SOURCE"), Collections.singletonList("QUIT;"));
 		verifySqlCompletion("QU", 2, Collections.singletonList("QUIT;"), Collections.singletonList("SELECT"));
 		verifySqlCompletion("qu", 2, Collections.singletonList("QUIT;"), Collections.singletonList("SELECT"));
 		verifySqlCompletion("  qu", 2, Collections.singletonList("QUIT;"), Collections.singletonList("SELECT"));
@@ -374,8 +376,8 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
-		public String explainStatement(String sessionId, String statement) throws SqlExecutionException {
-			return null;
+		public List<Operation> parse(String sessionId, String statement) throws SqlExecutionException {
+			return ParserUtils.parse(statement);
 		}
 
 		@Override
@@ -384,6 +386,11 @@ public class CliClientTest extends TestLogger {
 			receivedStatement = statement;
 			receivedPosition = position;
 			return Arrays.asList("HintA", "Hint B");
+		}
+
+		@Override
+		public TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException {
+			return null;
 		}
 
 		@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.client.cli.utils.ParserUtils;
+import org.apache.flink.table.client.cli.utils.SqlParserHelper;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ViewEntry;
@@ -32,7 +32,6 @@ import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
-import org.apache.flink.table.operations.Operation;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.TestLogger;
 
@@ -267,16 +266,17 @@ public class CliClientTest extends TestLogger {
 		public String receivedStatement;
 		public int receivedPosition;
 		private final Map<String, SessionContext> sessionMap = new HashMap<>();
+		private final SqlParserHelper helper = new SqlParserHelper();
 
 		@Override
 		public void start() throws SqlExecutionException {
-			// nothing to do
 		}
 
 		@Override
 		public String openSession(SessionContext session) throws SqlExecutionException {
 			String sessionId = UUID.randomUUID().toString();
 			sessionMap.put(sessionId, session);
+			helper.registerTables();
 			return sessionId;
 		}
 
@@ -376,8 +376,8 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
-		public List<Operation> parse(String sessionId, String statement) throws SqlExecutionException {
-			return ParserUtils.parse(statement);
+		public org.apache.flink.table.delegation.Parser getSqlParser(String sessionId) {
+			return helper.getSqlParser();
 		}
 
 		@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -93,6 +93,7 @@ public class CliClientTest extends TestLogger {
 	@Test
 	public void testSqlCompletion() throws IOException {
 		verifySqlCompletion("", 0, Arrays.asList("SOURCE", "QUIT;", "RESET;"), Collections.emptyList());
+		verifySqlCompletion("SELE", 5, Collections.singletonList("HintA"), Collections.singletonList("QUIT;"));
 		verifySqlCompletion("SOUR", 5, Collections.singletonList("SOURCE"), Collections.singletonList("QUIT;"));
 		verifySqlCompletion("SOUR", 0, Collections.singletonList("SOURCE"), Collections.singletonList("QUIT;"));
 		verifySqlCompletion("QU", 2, Collections.singletonList("QUIT;"), Collections.singletonList("SELECT"));
@@ -100,10 +101,9 @@ public class CliClientTest extends TestLogger {
 		verifySqlCompletion("  qu", 2, Collections.singletonList("QUIT;"), Collections.singletonList("SELECT"));
 		verifySqlCompletion("set ", 3, Collections.emptyList(), Collections.singletonList("SET"));
 		verifySqlCompletion("show t ", 6, Collections.emptyList(), Collections.singletonList("SET"));
-		verifySqlCompletion("use cat", 7, Collections.singletonList("CATALOG"), Collections.singletonList("USE CATALOG"));
-		verifySqlCompletion("use ", 4, Collections.singletonList("CATALOG"), Collections.singletonList("USE CATALOG"));
-		verifySqlCompletion("use catalog", 11, Collections.emptyList(), Collections.singletonList("CATALOG"));
-
+		verifySqlCompletion("show", 7, Collections.singletonList("MODULES;"), Collections.singletonList("QUIT;"));
+		verifySqlCompletion("show ", 4, Collections.singletonList("MODULES;"), Collections.singletonList("QUIT;"));
+		verifySqlCompletion("show modules", 13, Collections.emptyList(), Collections.singletonList("QUIT;"));
 	}
 
 	@Test
@@ -386,11 +386,6 @@ public class CliClientTest extends TestLogger {
 			receivedStatement = statement;
 			receivedPosition = position;
 			return Arrays.asList("HintA", "Hint B");
-		}
-
-		@Override
-		public TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException {
-			return null;
 		}
 
 		@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
+import org.apache.flink.table.client.cli.utils.ParserUtils;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ViewEntry;
@@ -30,6 +31,7 @@ import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.operations.Operation;
 import org.apache.flink.types.Row;
 
 import org.jline.utils.AttributedString;
@@ -231,12 +233,17 @@ public class CliResultViewTest {
 		}
 
 		@Override
-		public String explainStatement(String sessionId, String statement) throws SqlExecutionException {
-			return null;
+		public List<Operation> parse(String sessionId, String statement) throws SqlExecutionException {
+			return ParserUtils.parse(statement);
 		}
 
 		@Override
 		public List<String> completeStatement(String sessionId, String statement, int position) {
+			return null;
+		}
+
+		@Override
+		public TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException {
 			return null;
 		}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -21,7 +21,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
-import org.apache.flink.table.client.cli.utils.ParserUtils;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ViewEntry;
@@ -31,7 +30,7 @@ import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
-import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.types.Row;
 
 import org.jline.utils.AttributedString;
@@ -233,8 +232,8 @@ public class CliResultViewTest {
 		}
 
 		@Override
-		public List<Operation> parse(String sessionId, String statement) throws SqlExecutionException {
-			return ParserUtils.parse(statement);
+		public Parser getSqlParser(String sessionId) {
+			return null;
 		}
 
 		@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -242,11 +242,6 @@ public class CliResultViewTest {
 		}
 
 		@Override
-		public TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
 		public ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.table.client.cli;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.client.cli.SqlCommandParser.SqlCommand;
 import org.apache.flink.table.client.cli.SqlCommandParser.SqlCommandCall;
 import org.apache.flink.table.client.cli.utils.SqlParserHelper;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.delegation.Parser;
 
 import org.junit.Before;
@@ -35,6 +37,7 @@ import java.util.Optional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -52,18 +55,16 @@ public class SqlCommandParserTest {
 	}
 
 	@Test
-	public void testCommands() {
+	public void testCommands() throws Exception {
 		List<TestItem> testItems = Arrays.asList(
 				TestItem.validSql("QUIT;", SqlCommand.QUIT).cannotParseComment(),
 				TestItem.validSql("eXiT;", SqlCommand.QUIT).cannotParseComment(),
 				TestItem.validSql("CLEAR;", SqlCommand.CLEAR).cannotParseComment(),
-				TestItem.validSql("SHOW TABLES;", SqlCommand.SHOW_TABLES),
-				TestItem.validSql("  SHOW   TABLES   ;", SqlCommand.SHOW_TABLES),
-				TestItem.validSql("SHOW FUNCTIONS;", SqlCommand.SHOW_FUNCTIONS),
-				TestItem.validSql("  SHOW    FUNCTIONS   ", SqlCommand.SHOW_FUNCTIONS),
+				// desc xx
 				TestItem.validSql("DESC MyTable", SqlCommand.DESC, "MyTable").cannotParseComment(),
 				TestItem.validSql("DESC         MyTable     ", SqlCommand.DESC, "MyTable").cannotParseComment(),
 				TestItem.invalidSql("DESC "), // no table name
+				// describe xx
 				TestItem.validSql("DESCRIBE MyTable",
 						SqlCommand.DESCRIBE,
 						"`default_catalog`.`default_database`.`MyTable`"),
@@ -71,29 +72,37 @@ public class SqlCommandParserTest {
 						SqlCommand.DESCRIBE,
 						"`default_catalog`.`default_database`.`MyTable`"),
 				TestItem.invalidSql("DESCRIBE "), // no table name
+				// explain xx
 				TestItem.validSql("EXPLAIN SELECT a FROM MyTable",
 						SqlCommand.EXPLAIN,
 						"EXPLAIN PLAN FOR SELECT a FROM MyTable").cannotParseComment(),
+				TestItem.invalidSql("EXPLAIN "), // no query
+				// explain plan for xx
 				TestItem.validSql("EXPLAIN PLAN FOR SELECT a FROM MyTable",
 						SqlCommand.EXPLAIN,
 						"EXPLAIN PLAN FOR SELECT a FROM MyTable"),
 				TestItem.validSql("EXPLAIN PLAN FOR INSERT INTO MySink(c) SELECT c FROM MyTable",
 						SqlCommand.EXPLAIN,
 						"EXPLAIN PLAN FOR INSERT INTO MySink(c) SELECT c FROM MyTable"),
-				TestItem.invalidSql("EXPLAIN "), // no query
 				TestItem.validSql("EXPLAIN PLAN FOR INSERT INTO MySink(c) SELECT c FROM MyTable",
 						SqlCommand.EXPLAIN,
 						"EXPLAIN PLAN FOR INSERT INTO MySink(c) SELECT c FROM MyTable"),
+				TestItem.sqlWithException("EXPLAIN PLAN FOR INSERT INTO MySink(c) SELECT xxx FROM MyTable",
+						SqlExecutionException.class,
+						"Column 'xxx' not found in any table"),
+				// select xx
 				TestItem.validSql("SELECT a FROM MyTable", SqlCommand.SELECT, "SELECT a FROM MyTable"),
 				TestItem.validSql("WITH t as (select a from MyTable) select a from t",
 						SqlCommand.SELECT,
 						"WITH t as (select a from MyTable) select a from t"),
+				// insert xx
 				TestItem.validSql("INSERT INTO other SELECT 1+1",
 						SqlCommand.INSERT_INTO,
 						"INSERT INTO other SELECT 1+1"),
 				TestItem.validSql("INSERT OVERWRITE other SELECT 1+1",
 						SqlCommand.INSERT_OVERWRITE,
 						"INSERT OVERWRITE other SELECT 1+1"),
+				// create view xx
 				TestItem.validSql("CREATE VIEW x AS SELECT 1+1",
 						SqlCommand.CREATE_VIEW,
 						"`default_catalog`.`default_database`.`x`", "SELECT 1 + 1"),
@@ -102,37 +111,47 @@ public class SqlCommandParserTest {
 						"`default_catalog`.`default_database`.`x`",
 						"SELECT 1 + 1\nFROM `default_catalog`.`default_database`.`MyTable` AS `MyTable`"),
 				TestItem.invalidSql("CREATE VIEW x SELECT 1+1 "), // missing AS
+				// drop view xx
 				TestItem.validSql("DROP VIEW TestView1",
 						SqlCommand.DROP_VIEW,
 						"`default_catalog`.`default_database`.`TestView1`"),
 				TestItem.invalidSql("DROP VIEW "), // missing name
+				// set
 				TestItem.validSql("SET", SqlCommand.SET).cannotParseComment(),
 				TestItem.validSql("SET x=y", SqlCommand.SET, "x", "y").cannotParseComment(),
 				TestItem.validSql("SET      x  = y", SqlCommand.SET, "x", " y").cannotParseComment(),
+				// reset
 				TestItem.validSql("reset;", SqlCommand.RESET).cannotParseComment(),
+				// source xx
 				TestItem.validSql("source /my/file;", SqlCommand.SOURCE, "/my/file").cannotParseComment(),
+				// create catalog xx
 				TestItem.validSql("create CATALOG c1 with('type'='generic_in_memory')",
 						SqlCommand.CREATE_CATALOG,
 						"create CATALOG c1 with('type'='generic_in_memory')"),
 				TestItem.validSql("create CATALOG c1 WITH ('type'='simple-catalog', 'default-database'='db1')",
 						SqlCommand.CREATE_CATALOG,
 						"create CATALOG c1 WITH ('type'='simple-catalog', 'default-database'='db1')"),
-				TestItem.validSql("drop CATALOG c1",
-						SqlCommand.DROP_CATALOG,
-						"drop CATALOG c1"),
+				// drop catalog xx
+				TestItem.validSql("drop CATALOG c1", SqlCommand.DROP_CATALOG, "drop CATALOG c1"),
+				// use xx
 				TestItem.validSql("USE CATALOG catalog1;", SqlCommand.USE_CATALOG, "`catalog1`"),
 				TestItem.validSql("use `default`;", SqlCommand.USE, "`default_catalog`.`default`"),
 				TestItem.invalidSql("use catalog "), // no catalog name
+				// create database xx
 				TestItem.validSql("create database db1;", SqlCommand.CREATE_DATABASE, "create database db1"),
+				// drop database xx
 				TestItem.validSql("drop database db1;", SqlCommand.DROP_DATABASE, "drop database db1"),
+				// alter database xx
 				TestItem.validSql("alter database default_database set ('k1' = 'a')",
 						SqlCommand.ALTER_DATABASE,
 						"alter database default_database set ('k1' = 'a')"),
+				// alter table xx
 				TestItem.validSql("alter table default_catalog.default_database.MyTable rename to tb2",
 						SqlCommand.ALTER_TABLE, "alter table default_catalog.default_database.MyTable rename to tb2"),
 				TestItem.validSql("alter table MyTable set ('k1'='v1', 'k2'='v2')",
 						SqlCommand.ALTER_TABLE,
 						"alter table MyTable set ('k1'='v1', 'k2'='v2')"),
+				// create table xx
 				TestItem.invalidSql("CREATE tables"),
 				TestItem.invalidSql("CREATE    tables"),
 				TestItem.validSql("create Table hello", SqlCommand.CREATE_TABLE, "create Table hello"),
@@ -154,6 +173,7 @@ public class SqlCommandParserTest {
 								+ ") WITH (\n"
 								+ "  'k1' = 'v1',\n"
 								+ "  'k2' = 'v2')"),
+				// drop table xx
 				TestItem.invalidSql("DROP table"),
 				TestItem.invalidSql("DROP   tables"),
 				TestItem.validSql("DROP TABLE t1", SqlCommand.DROP_TABLE, "DROP TABLE t1"),
@@ -161,6 +181,19 @@ public class SqlCommandParserTest {
 				TestItem.validSql("DROP TABLE IF EXISTS catalog1.db1.t1", SqlCommand.DROP_TABLE,
 						"DROP TABLE IF EXISTS catalog1.db1.t1"),
 				TestItem.validSql("DROP TABLE IF EXISTS db1.t1", SqlCommand.DROP_TABLE, "DROP TABLE IF EXISTS db1.t1"),
+				// show catalogs
+				TestItem.validSql("SHOW CATALOGS;", SqlCommand.SHOW_CATALOGS),
+				TestItem.validSql("  SHOW   CATALOGS   ;", SqlCommand.SHOW_CATALOGS),
+				// show databases
+				TestItem.validSql("SHOW DATABASES;", SqlCommand.SHOW_DATABASES),
+				TestItem.validSql("  SHOW   DATABASES   ;", SqlCommand.SHOW_DATABASES),
+				// show tables
+				TestItem.validSql("SHOW TABLES;", SqlCommand.SHOW_TABLES),
+				TestItem.validSql("  SHOW   TABLES   ;", SqlCommand.SHOW_TABLES),
+				// show functions
+				TestItem.validSql("SHOW FUNCTIONS;", SqlCommand.SHOW_FUNCTIONS),
+				TestItem.validSql("  SHOW    FUNCTIONS   ", SqlCommand.SHOW_FUNCTIONS),
+				// show modules
 				TestItem.validSql("SHOW MODULES", SqlCommand.SHOW_MODULES).cannotParseComment(),
 				TestItem.validSql("  SHOW    MODULES   ", SqlCommand.SHOW_MODULES).cannotParseComment(),
 				// Test create function.
@@ -176,7 +209,7 @@ public class SqlCommandParserTest {
 				TestItem.validSql("CREATE TEMPORARY SYSTEM FUNCTION catalog1.db1.func1 as 'class_name' LANGUAGE JAVA",
 						SqlCommand.CREATE_FUNCTION,
 						"CREATE TEMPORARY SYSTEM FUNCTION catalog1.db1.func1 as 'class_name' LANGUAGE JAVA"),
-				// Test drop function.
+				// drop function xx
 				TestItem.invalidSql("DROP FUNCTION "),
 				TestItem.invalidSql("DROP FUNCTIONS "),
 				TestItem.invalidSql("DROP    FUNCTIONS "),
@@ -189,47 +222,105 @@ public class SqlCommandParserTest {
 				TestItem.validSql("DROP TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.db1.func1",
 						SqlCommand.DROP_FUNCTION,
 						"DROP TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.db1.func1"),
-				// Test alter function.
+				// alter function xx
 				TestItem.invalidSql("ALTER FUNCTION "),
 				TestItem.invalidSql("ALTER FUNCTIONS "),
 				TestItem.invalidSql("ALTER    FUNCTIONS "),
 				TestItem.validSql("ALTER FUNCTION catalog1.db1.func1 as 'a.b.c.func2'",
-						SqlCommand.DROP_FUNCTION,
+						SqlCommand.ALTER_FUNCTION,
 						"ALTER FUNCTION catalog1.db1.func1 as 'a.b.c.func2'"),
 				TestItem.validSql("ALTER TEMPORARY FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'",
-						SqlCommand.DROP_FUNCTION,
+						SqlCommand.ALTER_FUNCTION,
 						"ALTER TEMPORARY FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'"),
-				TestItem.validSql("ALTER TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'",
-						SqlCommand.DROP_FUNCTION,
-						"ALTER TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'")
+				TestItem.validSql("ALTER TEMPORARY FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'",
+						SqlCommand.ALTER_FUNCTION,
+						"ALTER TEMPORARY FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'"),
+				TestItem.sqlWithException(
+						"ALTER TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'",
+						SqlExecutionException.class,
+						"Alter temporary system function is not supported")
 		);
 		for (TestItem item : testItems) {
-			if (item.isValidSqlCmd) {
-				Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(parser, item.sql);
-				if (!actualCall.isPresent()) {
-					fail("test statement: " + item.sql);
-				}
-				assertNotNull(item.expectedCmd);
-				assertEquals("test statement: " + item.sql,
-						new SqlCommandCall(item.expectedCmd, item.expectedOperands), actualCall.get());
+			runTestItem(item);
+		}
+	}
 
-				String stmtWithComment = "-- comments \n " + item.sql;
-				actualCall = SqlCommandParser.parse(parser, stmtWithComment);
-				if (item.cannotParseComment) {
-					assertFalse(actualCall.isPresent());
-				} else {
-					if (!actualCall.isPresent()) {
-						fail("test statement: " + item.sql);
-					}
-					assertEquals(item.expectedCmd, actualCall.get().command);
+	private void runTestItem(TestItem item) {
+		if (item.isValidSqlCmd) {
+			runValidSql(item);
+		} else {
+			runInvalidSql(item);
+		}
+	}
+
+	private void runValidSql(TestItem item) {
+		Tuple2<Boolean, Optional<SqlCommandCall>> checkFlagAndActualCall = parseSqlAndCheckException(item);
+		if (!checkFlagAndActualCall.f0) {
+			return;
+		}
+		Optional<SqlCommandCall> actualCall = checkFlagAndActualCall.f1;
+		if (!actualCall.isPresent()) {
+			fail("test statement: " + item.sql);
+		}
+		assertNotNull(item.expectedCmd);
+		assertEquals("test statement: " + item.sql,
+				new SqlCommandCall(item.expectedCmd, item.expectedOperands), actualCall.get());
+
+		String stmtWithComment = "-- comments \n " + item.sql;
+		actualCall = SqlCommandParser.parse(parser, stmtWithComment);
+		if (item.cannotParseComment) {
+			assertFalse(actualCall.isPresent());
+		} else {
+			if (!actualCall.isPresent()) {
+				fail("test statement: " + item.sql);
+			}
+			assertEquals(item.expectedCmd, actualCall.get().command);
+		}
+	}
+
+	public void runInvalidSql(TestItem item) {
+		Tuple2<Boolean, Optional<SqlCommandCall>> checkFlagAndActualCall = parseSqlAndCheckException(item);
+		if (!checkFlagAndActualCall.f0) {
+			return;
+		}
+		if (checkFlagAndActualCall.f1.isPresent()) {
+			fail("test statement: " + item.sql);
+		}
+	}
+
+	private Tuple2<Boolean, Optional<SqlCommandCall>> parseSqlAndCheckException(TestItem item) {
+		Optional<SqlCommandCall> call = Optional.empty();
+		Throwable actualException = null;
+		try {
+			call = SqlCommandParser.parse(parser, item.sql);
+		} catch (Throwable e) {
+			actualException = e;
+		}
+
+		if (item.expectedException == null && actualException == null) {
+			return Tuple2.of(true, call);
+		} else if (item.expectedException == null) {
+			actualException.printStackTrace();
+			fail("Failed to run sql: " + item.sql);
+		} else if (actualException == null) {
+			fail("the excepted exception: '" + item.expectedException + "' does not occur.\n" +
+					"test statement: " + item.sql);
+		} else {
+			assertTrue(actualException.getClass().isAssignableFrom(item.expectedException));
+			boolean hasExpectedExceptionMsg = false;
+			while (actualException != null) {
+				if (actualException.getMessage().contains(item.expectedExceptionMsg)) {
+					hasExpectedExceptionMsg = true;
+					break;
 				}
-			} else {
-				final Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(parser, item.sql);
-				if (actualCall.isPresent()) {
-					fail("test statement: " + item.sql);
-				}
+				actualException = actualException.getCause();
+			}
+			if (!hasExpectedExceptionMsg) {
+				fail("the excepted exception message: '" + item.expectedExceptionMsg + "' does not occur.\n" +
+						"test statement: " + item.sql);
 			}
 		}
+		return Tuple2.of(false, Optional.empty());
 	}
 
 	private static class TestItem {
@@ -239,6 +330,8 @@ public class SqlCommandParserTest {
 		private @Nullable
 		SqlCommand expectedCmd = null;
 		private String[] expectedOperands = new String[0];
+		private Class<? extends Throwable> expectedException = null;
+		private String expectedExceptionMsg = null;
 
 		private TestItem(String sql, boolean isValidSqlCmd) {
 			this.sql = sql;
@@ -255,6 +348,14 @@ public class SqlCommandParserTest {
 			testItem.expectedCmd = expectedCmd;
 			testItem.expectedOperands = expectedOperands;
 			testItem.cannotParseComment = false; // default is false
+			return testItem;
+		}
+
+		public static TestItem sqlWithException(String sql, Class<? extends Throwable> expectedException,
+				String exceptedMsg) {
+			TestItem testItem = new TestItem(sql, true);
+			testItem.expectedException = expectedException;
+			testItem.expectedExceptionMsg = exceptedMsg;
 			return testItem;
 		}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -18,14 +18,18 @@
 
 package org.apache.flink.table.client.cli;
 
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.client.cli.SqlCommandParser.SqlCommand;
 import org.apache.flink.table.client.cli.SqlCommandParser.SqlCommandCall;
+import org.apache.flink.table.client.cli.utils.ParserUtils;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
 
 import org.junit.Test;
 
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -36,34 +40,49 @@ public class SqlCommandParserTest {
 	@Test
 	public void testCommands() {
 		testValidSqlCommand("QUIT;", new SqlCommandCall(SqlCommand.QUIT));
+		testInvalidSqlCommand("-- comments \nQUIT;");
 		testValidSqlCommand("eXiT", new SqlCommandCall(SqlCommand.QUIT));
+		testInvalidSqlCommand("-- comments \nEXIT;");
 		testValidSqlCommand("CLEAR", new SqlCommandCall(SqlCommand.CLEAR));
+		testInvalidSqlCommand("-- comments \nCLEAR;");
 		testValidSqlCommand("SHOW TABLES", new SqlCommandCall(SqlCommand.SHOW_TABLES));
 		testValidSqlCommand("  SHOW   TABLES   ", new SqlCommandCall(SqlCommand.SHOW_TABLES));
+		testValidSqlCommand(" -- comments \n SHOW   TABLES   ", new SqlCommandCall(SqlCommand.SHOW_TABLES));
 		testValidSqlCommand("SHOW FUNCTIONS", new SqlCommandCall(SqlCommand.SHOW_FUNCTIONS));
 		testValidSqlCommand("  SHOW    FUNCTIONS   ", new SqlCommandCall(SqlCommand.SHOW_FUNCTIONS));
+		testValidSqlCommand(" -- comments \n SHOW    FUNCTIONS   ", new SqlCommandCall(SqlCommand.SHOW_FUNCTIONS));
 		testValidSqlCommand("DESC MyTable", new SqlCommandCall(SqlCommand.DESC, new String[]{"MyTable"}));
 		testValidSqlCommand("DESC         MyTable     ", new SqlCommandCall(SqlCommand.DESC, new String[]{"MyTable"}));
+		testInvalidSqlCommand("-- comments \n DESC MyTable");
 		testInvalidSqlCommand("DESC  "); // no table name
-		testValidSqlCommand("DESCRIBE MyTable", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"MyTable"}));
-		testValidSqlCommand("DESCRIBE         MyTable     ", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"MyTable"}));
+		testValidSqlCommand("DESCRIBE MyTable", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"`default_catalog`.`default_database`.`MyTable`"}));
+		testValidSqlCommand("DESCRIBE         MyTable     ", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"`default_catalog`.`default_database`.`MyTable`"}));
+		testValidSqlCommand("-- comments \nDESCRIBE  MyTable  ", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"`default_catalog`.`default_database`.`MyTable`"}));
 		testInvalidSqlCommand("DESCRIBE  "); // no table name
+		testValidSqlCommand("EXPLAIN SELECT a FROM MyTable", new SqlCommandCall(SqlCommand.EXPLAIN, new String[]{"EXPLAIN PLAN FOR SELECT a FROM MyTable"}));
+		testInvalidSqlCommand("-- comments \n EXPLAIN SELECT a FROM MyTable");
 		testValidSqlCommand(
-			"EXPLAIN SELECT complicated FROM table",
-			new SqlCommandCall(SqlCommand.EXPLAIN, new String[]{"SELECT complicated FROM table"}));
+				"EXPLAIN PLAN FOR SELECT a FROM MyTable",
+				new SqlCommandCall(SqlCommand.EXPLAIN, new String[]{"EXPLAIN PLAN FOR SELECT a FROM MyTable"}));
+		testInvalidSql("EXPLAIN PLAN FOR SELECT xxx FROM MyTable");
+		testValidSqlCommand(
+				"-- comments \n EXPLAIN PLAN FOR SELECT a FROM MyTable",
+				new SqlCommandCall(SqlCommand.EXPLAIN, new String[]{"-- comments \n EXPLAIN PLAN FOR SELECT a FROM MyTable"}));
+		testValidSqlCommand(
+				"EXPLAIN PLAN FOR INSERT INTO MySink(c) SELECT c FROM MyTable",
+				new SqlCommandCall(SqlCommand.EXPLAIN, new String[]{"EXPLAIN PLAN FOR INSERT INTO MySink(c) SELECT c FROM MyTable"}));
 		testInvalidSqlCommand("EXPLAIN  "); // no query
+		testValidSqlCommand("SELECT a FROM MyTable", new SqlCommandCall(SqlCommand.SELECT, new String[]{"SELECT a FROM MyTable"}));
+		testValidSqlCommand("   SELECT  a FROM MyTable    ", new SqlCommandCall(SqlCommand.SELECT, new String[]{"SELECT  a FROM MyTable"}));
 		testValidSqlCommand(
-			"SELECT complicated FROM table",
-			new SqlCommandCall(SqlCommand.SELECT, new String[]{"SELECT complicated FROM table"}));
+				"-- comments \n SELECT  a FROM MyTable    ",
+				new SqlCommandCall(SqlCommand.SELECT, new String[]{"-- comments \n SELECT  a FROM MyTable"}));
 		testValidSqlCommand(
-			"   SELECT  complicated FROM table    ",
-			new SqlCommandCall(SqlCommand.SELECT, new String[]{"SELECT  complicated FROM table"}));
+			"WITH t as (select a from MyTable) select a from t",
+			new SqlCommandCall(SqlCommand.SELECT, new String[]{"WITH t as (select a from MyTable) select a from t"}));
 		testValidSqlCommand(
-			"WITH t as (select complicated from table) select complicated from t",
-			new SqlCommandCall(SqlCommand.SELECT, new String[]{"WITH t as (select complicated from table) select complicated from t"}));
-		testValidSqlCommand(
-			"   WITH t as (select complicated from table) select complicated from t    ",
-			new SqlCommandCall(SqlCommand.SELECT, new String[]{"WITH t as (select complicated from table) select complicated from t"}));
+			"   WITH t as (select a from MyTable) select a from t    ",
+			new SqlCommandCall(SqlCommand.SELECT, new String[]{"WITH t as (select a from MyTable) select a from t"}));
 		testValidSqlCommand(
 			"INSERT INTO other SELECT 1+1",
 			new SqlCommandCall(SqlCommand.INSERT_INTO, new String[]{"INSERT INTO other SELECT 1+1"}));
@@ -71,60 +90,84 @@ public class SqlCommandParserTest {
 			"INSERT OVERWRITE other SELECT 1+1",
 			new SqlCommandCall(SqlCommand.INSERT_OVERWRITE, new String[]{"INSERT OVERWRITE other SELECT 1+1"}));
 		testValidSqlCommand(
-			"CREATE VIEW x AS SELECT 1+1",
-			new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"x", "SELECT 1+1"}));
+				"-- comments\nINSERT OVERWRITE other SELECT 1+1",
+				new SqlCommandCall(SqlCommand.INSERT_OVERWRITE, new String[]{"-- comments\nINSERT OVERWRITE other SELECT 1+1"}));
 		testValidSqlCommand(
-			"CREATE   VIEW    MyTable   AS     SELECT 1+1 FROM y",
-			new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"MyTable", "SELECT 1+1 FROM y"}));
+			"CREATE VIEW x AS SELECT 1+1",
+			new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"`default_catalog`.`default_database`.`x`", "SELECT 1 + 1"}));
+		testValidSqlCommand(
+			"CREATE   VIEW    MyView   AS     SELECT 1+1 FROM MyTable",
+			new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"`default_catalog`.`default_database`.`MyView`",
+					"SELECT 1 + 1\nFROM `default_catalog`.`default_database`.`MyTable` AS `MyTable`"}));
+		testValidSqlCommand(
+				"-- comments\nCREATE VIEW x AS SELECT 1+1",
+				new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"`default_catalog`.`default_database`.`x`", "SELECT 1 + 1"}));
 		testInvalidSqlCommand("CREATE VIEW x SELECT 1+1"); // missing AS
-		testValidSqlCommand("DROP VIEW MyTable", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"MyTable"}));
-		testValidSqlCommand("DROP VIEW  MyTable", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"MyTable"}));
+		testValidSqlCommand("DROP VIEW TestView1", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"`default_catalog`.`default_database`.`TestView1`"}));
+		testValidSqlCommand("DROP VIEW  TestView1", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"`default_catalog`.`default_database`.`TestView1`"}));
+		testValidSqlCommand("-- comments\nDROP VIEW  TestView1", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"`default_catalog`.`default_database`.`TestView1`"}));
 		testInvalidSqlCommand("DROP VIEW");
 		testValidSqlCommand("SET", new SqlCommandCall(SqlCommand.SET));
 		testValidSqlCommand("SET x=y", new SqlCommandCall(SqlCommand.SET, new String[] {"x", "y"}));
 		testValidSqlCommand("SET    x  = y", new SqlCommandCall(SqlCommand.SET, new String[] {"x", " y"}));
+		testInvalidSqlCommand("-- comments\nSET x=y");
 		testValidSqlCommand("reset;", new SqlCommandCall(SqlCommand.RESET));
+		testInvalidSqlCommand("-- comments\nreset");
 		testValidSqlCommand("source /my/file", new SqlCommandCall(SqlCommand.SOURCE, new String[] {"/my/file"}));
+		testInvalidSqlCommand("-- comments\nsource /my/file");
 		testInvalidSqlCommand("source"); // missing path
-		testValidSqlCommand("create CATALOG c1",
-			new SqlCommandCall(SqlCommand.CREATE_CATALOG, new String[]{"create CATALOG c1"}));
-		testValidSqlCommand("create CATALOG c1 WITH ('k'='v')",
-			new SqlCommandCall(SqlCommand.CREATE_CATALOG, new String[]{"create CATALOG c1 WITH ('k'='v')"}));
+		testValidSqlCommand("create CATALOG c1 with('type'='generic_in_memory')",
+				new SqlCommandCall(SqlCommand.CREATE_CATALOG, new String[]{"create CATALOG c1 with('type'='generic_in_memory')"}));
+		testValidSqlCommand("create CATALOG c1 WITH ('type'='simple-catalog', 'default-database'='db1')",
+				new SqlCommandCall(SqlCommand.CREATE_CATALOG, new String[]{"create CATALOG c1 WITH ('type'='simple-catalog', 'default-database'='db1')"}));
+		testValidSqlCommand("-- comments\ncreate CATALOG c1 with('type'='generic_in_memory')",
+				new SqlCommandCall(SqlCommand.CREATE_CATALOG, new String[]{"-- comments\ncreate CATALOG c1 with('type'='generic_in_memory')"}));
 		testValidSqlCommand("drop CATALOG c1",
 			new SqlCommandCall(SqlCommand.DROP_CATALOG, new String[]{"drop CATALOG c1"}));
 		testValidSqlCommand("USE CATALOG default", new SqlCommandCall(SqlCommand.USE_CATALOG, new String[]{"default"}));
+		testValidSqlCommand("-- comments\nUSE CATALOG catalog1", new SqlCommandCall(SqlCommand.USE_CATALOG, new String[]{"`catalog1`"}));
 		testValidSqlCommand("use default", new SqlCommandCall(SqlCommand.USE, new String[] {"default"}));
+		testValidSqlCommand("-- comments\nuse `default`", new SqlCommandCall(SqlCommand.USE, new String[] {"`default_catalog`.`default`"}));
 		testInvalidSqlCommand("use catalog");
 		testValidSqlCommand("create database db1",
 				new SqlCommandCall(SqlCommand.CREATE_DATABASE, new String[] {"create database db1"}));
+		testValidSqlCommand("-- comments\ncreate database db1",
+				new SqlCommandCall(SqlCommand.CREATE_DATABASE, new String[] {"-- comments\ncreate database db1"}));
 		testValidSqlCommand("drop database db1",
 				new SqlCommandCall(SqlCommand.DROP_DATABASE, new String[] {"drop database db1"}));
-		testValidSqlCommand("alter database db1 set ('k1' = 'a')",
-				new SqlCommandCall(SqlCommand.ALTER_DATABASE, new String[] {"alter database db1 set ('k1' = 'a')"}));
-		testValidSqlCommand("alter table cat1.db1.tb1 rename to tb2",
-				new SqlCommandCall(SqlCommand.ALTER_TABLE, new String[]{"alter table cat1.db1.tb1 rename to tb2"}));
-		testValidSqlCommand("alter table cat1.db1.tb1 set ('k1'='v1', 'k2'='v2')",
+		testValidSqlCommand("-- comments\ndrop database db1",
+				new SqlCommandCall(SqlCommand.DROP_DATABASE, new String[] {"-- comments\ndrop database db1"}));
+		testValidSqlCommand("alter database default_database set ('k1' = 'a')",
+				new SqlCommandCall(SqlCommand.ALTER_DATABASE, new String[] {"alter database default_database set ('k1' = 'a')"}));
+		testValidSqlCommand("-- comments\nalter database default_database set ('k1' = 'a')",
+				new SqlCommandCall(SqlCommand.ALTER_DATABASE, new String[] {"-- comments\nalter database default_database set ('k1' = 'a')"}));
+		testValidSqlCommand("alter table default_catalog.default_database.MyTable rename to tb2",
+				new SqlCommandCall(SqlCommand.ALTER_TABLE, new String[]{"alter table default_catalog.default_database.MyTable rename to tb2"}));
+		testValidSqlCommand("alter table MyTable set ('k1'='v1', 'k2'='v2')",
 				new SqlCommandCall(SqlCommand.ALTER_TABLE,
-						new String[]{"alter table cat1.db1.tb1 set ('k1'='v1', 'k2'='v2')"}));
+						new String[]{"alter table MyTable set ('k1'='v1', 'k2'='v2')"}));
+		testValidSqlCommand("-- comments\nalter table default_catalog.default_database.MyTable rename to tb2",
+				new SqlCommandCall(SqlCommand.ALTER_TABLE, new String[]{"-- comments\nalter table default_catalog.default_database.MyTable rename to tb2"}));
 		// Test create table.
 		testInvalidSqlCommand("CREATE tables");
 		testInvalidSqlCommand("CREATE   tables");
 		testValidSqlCommand("create Table hello", new SqlCommandCall(SqlCommand.CREATE_TABLE, new String[]{"create Table hello"}));
+		testValidSqlCommand("-- comments\ncreate Table hello", new SqlCommandCall(SqlCommand.CREATE_TABLE, new String[]{"-- comments\ncreate Table hello"}));
 		testValidSqlCommand("create Table hello(a int)", new SqlCommandCall(SqlCommand.CREATE_TABLE, new String[]{"create Table hello(a int)"}));
 		testValidSqlCommand("  CREATE TABLE hello(a int)", new SqlCommandCall(SqlCommand.CREATE_TABLE, new String[]{"CREATE TABLE hello(a int)"}));
 		testValidSqlCommand("CREATE TABLE T(\n"
 						+ "  a int,\n"
 						+ "  b varchar(20),\n"
-						+ "  c as my_udf(b),\n"
-						+ "  watermark for b as my_udf(b, 1) - INTERVAL '5' second\n"
+						+ "  c as to_timestamp(b),\n"
+						+ "  watermark for c as c - INTERVAL '5' second\n"
 						+ ") WITH (\n"
 						+ "  'k1' = 'v1',\n"
 						+ "  'k2' = 'v2')\n",
 				new SqlCommandCall(SqlCommand.CREATE_TABLE, new String[] {"CREATE TABLE T(\n"
 						+ "  a int,\n"
 						+ "  b varchar(20),\n"
-						+ "  c as my_udf(b),\n"
-						+ "  watermark for b as my_udf(b, 1) - INTERVAL '5' second\n"
+						+ "  c as to_timestamp(b),\n"
+						+ "  watermark for c as c - INTERVAL '5' second\n"
 						+ ") WITH (\n"
 						+ "  'k1' = 'v1',\n"
 						+ "  'k2' = 'v2')"}));
@@ -136,6 +179,11 @@ public class SqlCommandParserTest {
 		testValidSqlCommand("DROP TABLE IF EXISTS t1", new SqlCommandCall(SqlCommand.DROP_TABLE, new String[]{"DROP TABLE IF EXISTS t1"}));
 		testValidSqlCommand("DROP TABLE IF EXISTS catalog1.db1.t1", new SqlCommandCall(SqlCommand.DROP_TABLE, new String[]{"DROP TABLE IF EXISTS catalog1.db1.t1"}));
 		testValidSqlCommand("DROP TABLE IF EXISTS db1.t1", new SqlCommandCall(SqlCommand.DROP_TABLE, new String[]{"DROP TABLE IF EXISTS db1.t1"}));
+		testValidSqlCommand("-- comments\nDROP TABLE IF EXISTS db1.t1", new SqlCommandCall(SqlCommand.DROP_TABLE,
+				new String[]{"-- comments\nDROP TABLE IF EXISTS db1.t1"}));
+		testValidSqlCommand("SHOW MODULES", new SqlCommandCall(SqlCommand.SHOW_MODULES));
+		testValidSqlCommand("  SHOW    MODULES   ", new SqlCommandCall(SqlCommand.SHOW_MODULES));
+		testInvalidSqlCommand("-- comments\nSHOW MODULES");
 		// Test create function.
 		testInvalidSqlCommand("CREATE FUNCTION");
 		testInvalidSqlCommand("CREATE FUNCTIONS");
@@ -166,20 +214,30 @@ public class SqlCommandParserTest {
 				new SqlCommandCall(SqlCommand.ALTER_FUNCTION, new String[] {"ALTER TEMPORARY FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'"}));
 		testValidSqlCommand("ALTER TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'",
 				new SqlCommandCall(SqlCommand.ALTER_FUNCTION, new String[] {"ALTER TEMPORARY SYSTEM FUNCTION IF EXISTS catalog1.db1.func1 as 'a.b.c.func2'"}));
+
 	}
 
 	private void testInvalidSqlCommand(String stmt) {
-		final Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(stmt);
+		final Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(ParserUtils::parse, stmt);
 		if (actualCall.isPresent()) {
 			fail();
 		}
 	}
 
 	private void testValidSqlCommand(String stmt, SqlCommandCall expectedCall) {
-		final Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(stmt);
+		final Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(ParserUtils::parse, stmt);
 		if (!actualCall.isPresent()) {
 			fail();
 		}
 		assertEquals(expectedCall, actualCall.get());
+	}
+
+	private void testInvalidSql(String stmt) {
+		try {
+			SqlCommandParser.parse(ParserUtils::parse, stmt);
+			fail();
+		} catch (SqlExecutionException e) {
+			assertTrue(e.getCause() instanceof ValidationException);
+		}
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -205,11 +205,6 @@ class TestingExecutor implements Executor {
 	}
 
 	@Override
-	public TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException {
-		return null;
-	}
-
-	@Override
 	public ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException {
 		throw new UnsupportedOperationException("Not implemented.");
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.client.cli;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.client.cli.utils.ParserUtils;
+import org.apache.flink.table.client.cli.utils.SqlParserHelper;
 import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
@@ -28,7 +28,7 @@ import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
-import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.SupplierWithException;
@@ -58,6 +58,8 @@ class TestingExecutor implements Executor {
 	private int numUseDatabaseCalls = 0;
 	private BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer;
 
+	private final SqlParserHelper helper;
+
 	TestingExecutor(
 			List<SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException>> resultChanges,
 			List<SupplierWithException<TypedResult<Integer>, SqlExecutionException>> snapshotResults,
@@ -69,6 +71,8 @@ class TestingExecutor implements Executor {
 		this.resultPages = resultPages;
 		this.useCatalogConsumer = useCatalogConsumer;
 		this.useDatabaseConsumer = useDatabaseConsumer;
+		helper = new SqlParserHelper();
+		helper.registerTables();
 	}
 
 	@Override
@@ -191,8 +195,8 @@ class TestingExecutor implements Executor {
 	}
 
 	@Override
-	public List<Operation> parse(String sessionId, String statement) throws SqlExecutionException {
-		return ParserUtils.parse(statement);
+	public Parser getSqlParser(String sessionId) {
+		return helper.getSqlParser();
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.client.cli;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.client.cli.utils.ParserUtils;
 import org.apache.flink.table.client.config.entries.ViewEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
@@ -27,6 +28,7 @@ import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.operations.Operation;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.SupplierWithException;
@@ -189,13 +191,18 @@ class TestingExecutor implements Executor {
 	}
 
 	@Override
-	public String explainStatement(String sessionId, String statement) throws SqlExecutionException {
-		throw new UnsupportedOperationException("Not implemented.");
+	public List<Operation> parse(String sessionId, String statement) throws SqlExecutionException {
+		return ParserUtils.parse(statement);
 	}
 
 	@Override
 	public List<String> completeStatement(String sessionId, String statement, int position) {
 		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public TableResult executeSql(String sessionId, String stmt) throws SqlExecutionException {
+		return null;
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/ParserUtils.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/ParserUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli.utils;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableEnvironmentInternal;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.operations.Operation;
+
+import java.util.List;
+
+/**
+ * An utility class that provides abilities to parse sql statements.
+ */
+public class ParserUtils {
+
+	private static final TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+
+	static {
+		tableEnv.executeSql("create table MyTable (a int, b bigint, c varchar(32)) " +
+				"with ('connector' = 'filesystem', 'path' = '/non')");
+		tableEnv.executeSql("create table MyOtherTable (a int, b bigint) " +
+				"with ('connector' = 'filesystem', 'path' = '/non')");
+		tableEnv.executeSql("create table MySink (a int, c varchar(32)) with ('connector' = 'COLLECTION' )");
+	}
+
+	public static List<Operation> parse(String statement) throws SqlExecutionException {
+		try {
+			return ((TableEnvironmentInternal) tableEnv).getParser().parse(statement);
+		} catch (Throwable t) {
+			// catch everything such that the query does not crash the executor
+			throw new SqlExecutionException("Invalid SQL statement.", t);
+		}
+	}
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
@@ -38,11 +38,11 @@ public class SqlParserHelper {
 	 * prepare some tables for testing.
 	 */
 	public void registerTables() {
-		tableEnv.executeSql("create table MyTable (a int, b bigint, c varchar(32)) " +
+		registerTable("create table MyTable (a int, b bigint, c varchar(32)) " +
 				"with ('connector' = 'filesystem', 'path' = '/non')");
-		tableEnv.executeSql("create table MyOtherTable (a int, b bigint) " +
+		registerTable("create table MyOtherTable (a int, b bigint) " +
 				"with ('connector' = 'filesystem', 'path' = '/non')");
-		tableEnv.executeSql("create table MySink (a int, c varchar(32)) with ('connector' = 'COLLECTION' )");
+		registerTable("create table MySink (a int, c varchar(32)) with ('connector' = 'COLLECTION' )");
 	}
 
 	public void registerTable(String createTableStmt) {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
@@ -28,14 +28,14 @@ import org.apache.flink.table.delegation.Parser;
  */
 public class SqlParserHelper {
 	// return the sql parser instance hold by this table evn.
-	final TableEnvironment tableEnv;
+	private final TableEnvironment tableEnv;
 
 	public SqlParserHelper() {
 		tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
 	}
 
 	/**
-	 * prepare some tables for testing
+	 * prepare some tables for testing.
 	 */
 	public void registerTables() {
 		tableEnv.executeSql("create table MyTable (a int, b bigint, c varchar(32)) " +

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
@@ -21,19 +21,23 @@ package org.apache.flink.table.client.cli.utils;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
-import org.apache.flink.table.client.gateway.SqlExecutionException;
-import org.apache.flink.table.operations.Operation;
-
-import java.util.List;
+import org.apache.flink.table.delegation.Parser;
 
 /**
- * An utility class that provides abilities to parse sql statements.
+ * An utility class that provides pre-prepared tables and sql parser.
  */
-public class ParserUtils {
+public class SqlParserHelper {
+	// return the sql parser instance hold by this table evn.
+	final TableEnvironment tableEnv;
 
-	private static final TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+	public SqlParserHelper() {
+		tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+	}
 
-	static {
+	/**
+	 * prepare some tables for testing
+	 */
+	public void registerTables() {
 		tableEnv.executeSql("create table MyTable (a int, b bigint, c varchar(32)) " +
 				"with ('connector' = 'filesystem', 'path' = '/non')");
 		tableEnv.executeSql("create table MyOtherTable (a int, b bigint) " +
@@ -41,12 +45,11 @@ public class ParserUtils {
 		tableEnv.executeSql("create table MySink (a int, c varchar(32)) with ('connector' = 'COLLECTION' )");
 	}
 
-	public static List<Operation> parse(String statement) throws SqlExecutionException {
-		try {
-			return ((TableEnvironmentInternal) tableEnv).getParser().parse(statement);
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("Invalid SQL statement.", t);
-		}
+	public void registerTable(String createTableStmt) {
+		tableEnv.executeSql(createTableStmt);
+	}
+
+	public Parser getSqlParser() {
+		return ((TableEnvironmentInternal) tableEnv).getParser();
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

*currently, all statements in sql client are parsed via regex matching, which has many limitations, such as it can't handle comments. To avoid that limitations, we should try best to use sql parser to parse a statement. There are many statement can't be handle by sql parser, such as: set, reset. So they are still handle through regex matching.

statements handled through regex matching:
quit, exit, clear, help, desc, explain, set, reset source, show modules

statements handled through sql parser:
show catalogs, show databases, show tables, show functions, use catalog, use, describe, explain plan for, select, insert, DDLs*


## Brief change log

  - *SqlCommandParser parses a statement via sql parse, and then via regex matching*

## Verifying this change

This change added tests and can be verified as follows:

  - *extended SqlCommandParserTest to verify all cases*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
