### PR TITLE
[hotfix][flink-core and docs] fix typos

### DIFF
--- a/docs/_includes/generated/optimizer_configuration.html
+++ b/docs/_includes/generated/optimizer_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>compiler.delimited-informat.max-line-samples</h5></td>
             <td style="word-wrap: break-word;">10</td>
             <td>Integer</td>
-            <td>he maximum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters.</td>
+            <td>The maximum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters.</td>
         </tr>
         <tr>
             <td><h5>compiler.delimited-informat.max-sample-len</h5></td>

--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -66,7 +66,7 @@
             <td><h5>state.backend.rocksdb.writebuffer.count</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>Tne maximum number of write buffers that are built up in memory. RocksDB has default configuration as '2'.</td>
+            <td>The maximum number of write buffers that are built up in memory. RocksDB has default configuration as '2'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.writebuffer.number-to-merge</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/OptimizerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/OptimizerOptions.java
@@ -35,7 +35,7 @@ public class OptimizerOptions {
 	public static final ConfigOption<Integer> DELIMITED_FORMAT_MAX_LINE_SAMPLES =
 		key("compiler.delimited-informat.max-line-samples")
 			.defaultValue(10)
-			.withDescription("he maximum number of line samples taken by the compiler for delimited inputs. The samples" +
+			.withDescription("The maximum number of line samples taken by the compiler for delimited inputs. The samples" +
 				" are used to estimate the number of records. This value can be overridden for a specific input with the" +
 				" input format’s parameters.");
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -110,7 +110,7 @@ public class RocksDBConfigurableOptions implements Serializable {
 		key("state.backend.rocksdb.writebuffer.count")
 			.intType()
 			.noDefaultValue()
-			.withDescription("Tne maximum number of write buffers that are built up in memory. " +
+			.withDescription("The maximum number of write buffers that are built up in memory. " +
 				"RocksDB has default configuration as '2'.");
 
 	public static final ConfigOption<Integer> MIN_WRITE_BUFFER_NUMBER_TO_MERGE =


### PR DESCRIPTION
## What is the purpose of the change

*Fix typos in OptimizerOptions.java and docs*


## Brief change log

*Fix typos in OptimizerOptions.java and docs*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
