### PR TITLE
[FLINK-17357][table-planner-blink] add 'DROP catalog' DDL to blink pl…

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -115,6 +115,10 @@ public final class SqlCommandParser {
 			"(CREATE\\s+CATALOG\\s+.*)",
 			SINGLE_OPERAND),
 
+		DROP_CATALOG(
+			"(DROP\\s+CATALOG\\s+.*)",
+			SINGLE_OPERAND),
+
 		DESC(
 			"DESC\\s+(.*)",
 			SINGLE_OPERAND),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -90,6 +90,8 @@ public class SqlCommandParserTest {
 			new SqlCommandCall(SqlCommand.CREATE_CATALOG, new String[]{"create CATALOG c1"}));
 		testValidSqlCommand("create CATALOG c1 WITH ('k'='v')",
 			new SqlCommandCall(SqlCommand.CREATE_CATALOG, new String[]{"create CATALOG c1 WITH ('k'='v')"}));
+		testValidSqlCommand("drop CATALOG c1",
+			new SqlCommandCall(SqlCommand.DROP_CATALOG, new String[]{"drop CATALOG c1"}));
 		testValidSqlCommand("USE CATALOG default", new SqlCommandCall(SqlCommand.USE_CATALOG, new String[]{"default"}));
 		testValidSqlCommand("use default", new SqlCommandCall(SqlCommand.USE, new String[] {"default"}));
 		testInvalidSqlCommand("use catalog");

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -39,6 +39,7 @@
     "org.apache.flink.sql.parser.ddl.SqlCreateTable"
     "org.apache.flink.sql.parser.ddl.SqlCreateTable.TableCreationContext"
     "org.apache.flink.sql.parser.ddl.SqlCreateView"
+    "org.apache.flink.sql.parser.ddl.SqlDropCatalog"
     "org.apache.flink.sql.parser.ddl.SqlDropDatabase"
     "org.apache.flink.sql.parser.ddl.SqlDropFunction"
     "org.apache.flink.sql.parser.ddl.SqlDropTable"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -82,13 +82,21 @@ SqlCreate SqlCreateCatalog(Span s, boolean replace) :
 SqlDrop SqlDropCatalog(Span s, boolean replace) :
 {
     SqlIdentifier catalogName = null;
+    boolean ifExists = false;
 }
 {
     <CATALOG>
+
+    (
+        <IF> <EXISTS> { ifExists = true; }
+    |
+        { ifExists = false; }
+    )
+
     catalogName = CompoundIdentifier()
 
     {
-        return new SqlDropCatalog(s.pos(), catalogName);
+        return new SqlDropCatalog(s.pos(), catalogName, ifExists);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -79,6 +79,19 @@ SqlCreate SqlCreateCatalog(Span s, boolean replace) :
     }
 }
 
+SqlDrop SqlDropCatalog(Span s, boolean replace) :
+{
+    SqlIdentifier catalogName = null;
+}
+{
+    <CATALOG>
+    catalogName = CompoundIdentifier()
+
+    {
+        return new SqlDropCatalog(s.pos(), catalogName);
+    }
+}
+
 /**
 * Parse a "Show DATABASES" metadata query command.
 */
@@ -1302,6 +1315,8 @@ SqlDrop SqlDropExtended(Span s, boolean replace) :
         <TEMPORARY> { isTemporary = true; }
     ]
     (
+        drop = SqlDropCatalog(s, replace)
+        |
         drop = SqlDropTable(s, replace, isTemporary)
         |
         drop = SqlDropView(s, replace, isTemporary)

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateCatalog.java
@@ -96,6 +96,6 @@ public class SqlCreateCatalog extends SqlCreate {
 	}
 
 	public String catalogName() {
-		return catalogName.names.get(0);
+		return catalogName.getSimple();
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
@@ -38,10 +38,12 @@ public class SqlDropCatalog extends SqlDrop {
 	private static final SqlOperator OPERATOR = new SqlSpecialOperator("DROP CATALOG", SqlKind.OTHER_DDL);
 
 	private final SqlIdentifier catalogName;
+	private boolean ifExists;
 
-	public SqlDropCatalog(SqlParserPos pos, SqlIdentifier catalogName) {
+	public SqlDropCatalog(SqlParserPos pos, SqlIdentifier catalogName, boolean ifExists) {
 		super(OPERATOR, pos, false);
 		this.catalogName = catalogName;
+		this.ifExists = ifExists;
 	}
 
 	@Override
@@ -51,6 +53,10 @@ public class SqlDropCatalog extends SqlDrop {
 
 	public SqlIdentifier getCatalogName() {
 		return catalogName;
+	}
+
+	public boolean getIfExists() {
+		return this.ifExists;
 	}
 
 	@Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlDrop;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * DROP CATALOG DDL sql call.
+ */
+public class SqlDropCatalog extends SqlDrop {
+
+	private static final SqlOperator OPERATOR = new SqlSpecialOperator("DROP CATALOG", SqlKind.OTHER_DDL);
+
+	private final SqlIdentifier catalogName;
+
+	public SqlDropCatalog(SqlParserPos pos, SqlIdentifier catalogName) {
+		super(OPERATOR, pos, false);
+		this.catalogName = catalogName;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(catalogName);
+	}
+
+	public SqlIdentifier getCatalogName() {
+		return catalogName;
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("DROP");
+		writer.keyword("CATALOG");
+		catalogName.unparse(writer, leftPrec, rightPrec);
+	}
+
+	public String catalogName() {
+		return catalogName.names.get(0);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
@@ -38,7 +38,7 @@ public class SqlDropCatalog extends SqlDrop {
 	private static final SqlOperator OPERATOR = new SqlSpecialOperator("DROP CATALOG", SqlKind.OTHER_DDL);
 
 	private final SqlIdentifier catalogName;
-	private boolean ifExists;
+	private final boolean ifExists;
 
 	public SqlDropCatalog(SqlParserPos pos, SqlIdentifier catalogName, boolean ifExists) {
 		super(OPERATOR, pos, false);
@@ -63,6 +63,9 @@ public class SqlDropCatalog extends SqlDrop {
 	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
 		writer.keyword("DROP");
 		writer.keyword("CATALOG");
+		if (ifExists) {
+			writer.keyword("IF EXISTS");
+		}
 		catalogName.unparse(writer, leftPrec, rightPrec);
 	}
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropCatalog.java
@@ -61,6 +61,6 @@ public class SqlDropCatalog extends SqlDrop {
 	}
 
 	public String catalogName() {
-		return catalogName.names.get(0);
+		return catalogName.getSimple();
 	}
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -66,17 +66,21 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testCreateCatalog() {
-		check(
-			"create catalog c1\n" +
+		sql("create catalog c1\n" +
 				" WITH (\n" +
 				"  'key1'='value1',\n" +
 				"  'key2'='value2'\n" +
-				" )\n",
-			"CREATE CATALOG `C1` " +
-				"WITH (\n" +
-				"  'key1' = 'value1',\n" +
-				"  'key2' = 'value2'\n" +
-				")");
+				" )\n")
+			.ok("CREATE CATALOG `C1` " +
+					"WITH (\n" +
+					"  'key1' = 'value1',\n" +
+					"  'key2' = 'value2'\n" +
+					")");
+	}
+
+	@Test
+	public void testDropCatalog() {
+		sql("drop catalog c1").ok("DROP CATALOG `C1`");
 	}
 
 	@Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -105,6 +105,7 @@ import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.CreateTempSystemFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateViewOperation;
 import org.apache.flink.table.operations.ddl.DropCatalogFunctionOperation;
+import org.apache.flink.table.operations.ddl.DropCatalogOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
@@ -155,14 +156,14 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	private static final String UNSUPPORTED_QUERY_IN_SQL_UPDATE_MSG =
 			"Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
 			"INSERT, CREATE TABLE, DROP TABLE, ALTER TABLE, USE CATALOG, USE [CATALOG.]DATABASE, " +
-			"CREATE DATABASE, DROP DATABASE, ALTER DATABASE, CREATE FUNCTION, " +
-			"DROP FUNCTION, ALTER FUNCTION, CREATE CATALOG, CREATE VIEW, DROP VIEW.";
+			"CREATE DATABASE, DROP DATABASE, ALTER DATABASE, CREATE FUNCTION, DROP FUNCTION, ALTER FUNCTION, " +
+			"CREATE CATALOG, DROP CATALOG, CREATE VIEW, DROP VIEW.";
 	private static final String UNSUPPORTED_QUERY_IN_EXECUTE_SQL_MSG =
 			"Unsupported SQL query! executeSql() only accepts a single SQL statement of type " +
 			"CREATE TABLE, DROP TABLE, ALTER TABLE, CREATE DATABASE, DROP DATABASE, ALTER DATABASE, " +
-			"CREATE FUNCTION, DROP FUNCTION, ALTER FUNCTION, CREATE CATALOG, USE CATALOG, USE [CATALOG.]DATABASE, " +
-			"SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, CREATE VIEW, DROP VIEW, SHOW VIEWS, " +
-			"INSERT, DESCRIBE.";
+			"CREATE FUNCTION, DROP FUNCTION, ALTER FUNCTION, CREATE CATALOG, DROP CATALOG, " +
+			"USE CATALOG, USE [CATALOG.]DATABASE, SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, " +
+			"CREATE VIEW, DROP VIEW, SHOW VIEWS, INSERT, DESCRIBE.";
 
 	/**
 	 * Provides necessary methods for {@link ConnectTableDescriptor}.
@@ -751,6 +752,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 				operation instanceof DropTempSystemFunctionOperation ||
 				operation instanceof AlterCatalogFunctionOperation ||
 				operation instanceof CreateCatalogOperation ||
+				operation instanceof DropCatalogOperation ||
 				operation instanceof UseCatalogOperation ||
 				operation instanceof UseDatabaseOperation) {
 			executeOperation(operation);
@@ -942,6 +944,15 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			try {
 				catalogManager.registerCatalog(
 						createCatalogOperation.getCatalogName(), createCatalogOperation.getCatalog());
+				return TableResultImpl.TABLE_RESULT_OK;
+			} catch (CatalogException e) {
+				throw new ValidationException(exMsg, e);
+			}
+		} else if (operation instanceof DropCatalogOperation) {
+			DropCatalogOperation dropCatalogOperation = (DropCatalogOperation) operation;
+			String exMsg = getDDLOpExecuteErrorMsg(dropCatalogOperation.asSummaryString());
+			try {
+				catalogManager.unregisterCatalog(dropCatalogOperation.getCatalogName());
 				return TableResultImpl.TABLE_RESULT_OK;
 			} catch (CatalogException e) {
 				throw new ValidationException(exMsg, e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -952,7 +952,8 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			DropCatalogOperation dropCatalogOperation = (DropCatalogOperation) operation;
 			String exMsg = getDDLOpExecuteErrorMsg(dropCatalogOperation.asSummaryString());
 			try {
-				catalogManager.unregisterCatalog(dropCatalogOperation.getCatalogName());
+				catalogManager.unregisterCatalog(dropCatalogOperation.getCatalogName(),
+					dropCatalogOperation.isIfExists());
 				return TableResultImpl.TABLE_RESULT_OK;
 			} catch (CatalogException e) {
 				throw new ValidationException(exMsg, e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -172,6 +172,24 @@ public final class CatalogManager {
 	}
 
 	/**
+	 * Unregisters a catalog under the given name. The catalog name must be existed.
+	 *
+	 * @param catalogName name under which to unregister the given catalog
+	 * @throws CatalogException if the unregistration of the catalog under the given name failed
+	 */
+	public void unregisterCatalog(String catalogName) {
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "Catalog name cannot be null or empty.");
+
+		if (!catalogs.containsKey(catalogName)) {
+			throw new CatalogException(format("Catalog %s does not exist.", catalogName));
+		}
+
+		Catalog catalog = catalogs.get(catalogName);
+		catalog.close();
+		catalogs.remove(catalogName);
+	}
+
+	/**
 	 * Gets a catalog by name.
 	 *
 	 * @param catalogName name of the catalog to retrieve

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -156,7 +156,7 @@ public final class CatalogManager {
 	 * Registers a catalog under the given name. The catalog name must be unique.
 	 *
 	 * @param catalogName name under which to register the given catalog
-	 * @param catalog catalog to register
+	 * @param catalog     catalog to register
 	 * @throws CatalogException if the registration of the catalog under the given name failed
 	 */
 	public void registerCatalog(String catalogName, Catalog catalog) {
@@ -174,16 +174,19 @@ public final class CatalogManager {
 	/**
 	 * Unregisters a catalog under the given name. The catalog name must be existed.
 	 *
-	 * @param catalogName name under which to unregister the given catalog
+	 * @param catalogName       name under which to unregister the given catalog.
+	 * @param ignoreIfNotExists If false exception will be thrown if the table or database or catalog to be altered
+	 *                          does not exist.
 	 * @throws CatalogException if the unregistration of the catalog under the given name failed
 	 */
-	public void unregisterCatalog(String catalogName) {
+	public void unregisterCatalog(String catalogName, boolean ignoreIfNotExists) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "Catalog name cannot be null or empty.");
 
 		if (catalogs.containsKey(catalogName)) {
-			Catalog catalog = catalogs.get(catalogName);
+			Catalog catalog = catalogs.remove(catalogName);
 			catalog.close();
-			catalogs.remove(catalogName);
+		} else if (!ignoreIfNotExists) {
+			throw new CatalogException(format("Catalog %s does not exist.", catalogName));
 		}
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -180,13 +180,11 @@ public final class CatalogManager {
 	public void unregisterCatalog(String catalogName) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "Catalog name cannot be null or empty.");
 
-		if (!catalogs.containsKey(catalogName)) {
-			throw new CatalogException(format("Catalog %s does not exist.", catalogName));
+		if (catalogs.containsKey(catalogName)) {
+			Catalog catalog = catalogs.get(catalogName);
+			catalog.close();
+			catalogs.remove(catalogName);
 		}
-
-		Catalog catalog = catalogs.get(catalogName);
-		catalog.close();
-		catalogs.remove(catalogName);
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a DROP CATALOG statement.
+ */
+public class DropCatalogOperation implements DropOperation {
+	private final String catalogName;
+
+	public DropCatalogOperation(String catalogName) {
+		this.catalogName = catalogName;
+	}
+
+	public String getCatalogName() {
+		return catalogName;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("catalogName", catalogName);
+
+		return OperationUtils.formatWithChildren(
+			"DROP CATALOG",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogOperation.java
@@ -30,13 +30,19 @@ import java.util.Map;
  */
 public class DropCatalogOperation implements DropOperation {
 	private final String catalogName;
+	private final boolean ifExists;
 
-	public DropCatalogOperation(String catalogName) {
+	public DropCatalogOperation(String catalogName, boolean ifExists) {
 		this.catalogName = catalogName;
+		this.ifExists = ifExists;
 	}
 
 	public String getCatalogName() {
 		return catalogName;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -455,7 +455,7 @@ public class SqlToOperationConverter {
 	/** Convert DROP CATALOG statement. */
 	private Operation convertDropCatalog(SqlDropCatalog sqlDropCatalog) {
 		String catalogName = sqlDropCatalog.catalogName();
-		return new DropCatalogOperation(catalogName);
+		return new DropCatalogOperation(catalogName, sqlDropCatalog.getIfExists());
 	}
 
 	/** Convert use database statement. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -30,6 +30,7 @@ import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlCreateView;
+import org.apache.flink.sql.parser.ddl.SqlDropCatalog;
 import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
 import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
@@ -87,6 +88,7 @@ import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTempSystemFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateViewOperation;
 import org.apache.flink.table.operations.ddl.DropCatalogFunctionOperation;
+import org.apache.flink.table.operations.ddl.DropCatalogOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
@@ -191,6 +193,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertAlterDatabase((SqlAlterDatabase) validated));
 		} else if (validated instanceof SqlCreateCatalog) {
 			return Optional.of(converter.convertCreateCatalog((SqlCreateCatalog) validated));
+		} else if (validated instanceof SqlDropCatalog) {
+			return Optional.of(converter.convertDropCatalog((SqlDropCatalog) validated));
 		} else if (validated instanceof SqlShowCatalogs) {
 			return Optional.of(converter.convertShowCatalogs((SqlShowCatalogs) validated));
 		} else if (validated instanceof SqlShowDatabases) {
@@ -446,6 +450,12 @@ public class SqlToOperationConverter {
 
 		Catalog catalog = factory.createCatalog(catalogName, properties);
 		return new CreateCatalogOperation(catalogName, catalog);
+	}
+
+	/** Convert DROP CATALOG statement. */
+	private Operation convertDropCatalog(SqlDropCatalog sqlDropCatalog) {
+		String catalogName = sqlDropCatalog.catalogName();
+		return new DropCatalogOperation(catalogName);
 	}
 
 	/** Convert use database statement. */

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.junit.Test;
 
 import static org.apache.flink.table.descriptors.GenericInMemoryCatalogValidator.CATALOG_TYPE_VALUE_GENERIC_IN_MEMORY;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -44,6 +45,20 @@ public class CatalogITCase {
 
 		assertTrue(tableEnv.getCatalog(name).isPresent());
 		assertTrue(tableEnv.getCatalog(name).get() instanceof GenericInMemoryCatalog);
+	}
+
+	@Test
+	public void testDropCatalog() {
+		String name = "c1";
+		TableEnvironment tableEnv = getTableEnvironment();
+
+		String ddl = String.format("create catalog %s with('type'='%s')", name, CATALOG_TYPE_VALUE_GENERIC_IN_MEMORY);
+		tableEnv.executeSql(ddl);
+		assertTrue(tableEnv.getCatalog(name).isPresent());
+
+		ddl = String.format("drop catalog %s", name);
+		tableEnv.executeSql(ddl);
+		assertFalse(tableEnv.getCatalog(name).isPresent());
 	}
 
 	private TableEnvironment getTableEnvironment() {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -304,7 +304,7 @@ class TableEnvironmentTest {
   }
 
   @Test
-  def testExecuteSqlWithCreateUseCatalog(): Unit = {
+  def testExecuteSqlWithCreateUseDropCatalog(): Unit = {
     val tableResult1 = tableEnv.executeSql(
       "CREATE CATALOG my_catalog WITH('type'='generic_in_memory')")
     assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
@@ -314,6 +314,10 @@ class TableEnvironmentTest {
     val tableResult2 = tableEnv.executeSql("USE CATALOG my_catalog")
     assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
     assertEquals("my_catalog", tableEnv.getCurrentCatalog)
+
+    val tableResult3 = tableEnv.executeSql("DROP CATALOG my_catalog")
+    assertEquals(ResultKind.SUCCESS, tableResult3.getResultKind)
+    assertFalse(tableEnv.getCatalog("my_catalog").isPresent)
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

*DDL statement of table blink planner has no statement that drop catalog, this should add 'DROP catalog' DDL to blink planner.*

## Brief change log

  - *Add `DROP CATALOG` ddl statement to `SqlCommandParser` and `TableEnvironmentImpl`.*

## Verifying this change

  - *`SqlCommandParserTest` add `DROP CATALOG` statement parser test.*
  - *`FlinkSqlParserImplTest` add `DROP CATALOG` statement parser test.*
  - *`TableEnvironmentTest` add `DROP CATALOG` statement execution test.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
