### PR TITLE
[FLINK-17772][python] Fix to_pandas to make it work in JDK 11

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -199,7 +199,7 @@ public final class ArrowUtils {
 		if (System.getProperty("io.netty.tryReflectionSetAccessible") == null) {
 			System.setProperty("io.netty.tryReflectionSetAccessible", "true");
 		} else if (!io.netty.util.internal.PlatformDependent.hasDirectBufferNoCleanerConstructor()) {
-			throw new RuntimeException("Vectorized Python UDF depends on " +
+			throw new RuntimeException("Arrow depends on " +
 				"DirectByteBuffer.<init>(long, int) which is not available. Please set the " +
 				"system property 'io.netty.tryReflectionSetAccessible' to 'true'.");
 		}
@@ -610,6 +610,7 @@ public final class ArrowUtils {
 	 * Convert Flink table to Pandas DataFrame.
 	 */
 	public static CustomIterator<byte[]> collectAsPandasDataFrame(Table table, int maxArrowBatchSize) throws Exception {
+		checkArrowUsable();
 		BufferAllocator allocator = getRootAllocator().newChildAllocator("collectAsPandasDataFrame", 0, Long.MAX_VALUE);
 		RowType rowType = (RowType) table.getSchema().toRowDataType().getLogicalType();
 		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes to_pandas to make it work in JDK 11 *

## Brief change log

  - *Call ArrowUtils.checkArrowUsable in ArrowUtils.collectAsPandasDataFrame to initialize the JVM of the PythonGatewayServer to make it work in JDK 11*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
