### PR TITLE
[FLINK-17687][tests] Collect TM log files before tearing down Mesos

### DIFF
--- a/flink-jepsen/src/jepsen/flink/mesos.clj
+++ b/flink-jepsen/src/jepsen/flink/mesos.clj
@@ -22,6 +22,7 @@
              [util :as util :refer [meh]]]
             [jepsen.control.util :as cu]
             [jepsen.os.debian :as debian]
+            [jepsen.flink.utils :as fu]
             [jepsen.flink.utils :refer [create-supervised-service! stop-supervised-service!]]
             [jepsen.flink.zookeeper :refer [zookeeper-uri]]))
 
@@ -195,4 +196,6 @@
       (stop-marathon! test node))
     db/LogFiles
     (log-files [_ test node]
-      (if (cu/exists? log-dir) (cu/ls-full log-dir) []))))
+      (concat
+        (if (cu/exists? log-dir) (cu/ls-full log-dir) [])
+        (fu/find-files! slave-dir "*.log")))))

--- a/flink-jepsen/src/jepsen/flink/mesos.clj
+++ b/flink-jepsen/src/jepsen/flink/mesos.clj
@@ -197,5 +197,5 @@
     db/LogFiles
     (log-files [_ test node]
       (concat
-        (if (cu/exists? log-dir) (cu/ls-full log-dir) [])
+        (fu/find-files! log-dir)
         (fu/find-files! slave-dir "*.log")))))

--- a/flink-jepsen/src/jepsen/flink/utils.clj
+++ b/flink-jepsen/src/jepsen/flink/utils.clj
@@ -58,16 +58,17 @@
 (defn find-files!
   "Lists files recursively given a directory. If the directory does not exist, an empty collection
   is returned."
-  [dir]
+  ([dir] (find-files! dir "*"))
+  ([dir name]
   (let [files (try
-                (c/exec :find dir :-type :f)
+                (c/exec :find dir :-type :f :-name (c/lit (str "\"" name "\"")))
                 (catch Exception e
                   (if (.contains (.getMessage e) "No such file or directory")
                     ""
                     (throw e))))]
     (->>
       (clojure.string/split files #"\n")
-      (remove clojure.string/blank?))))
+      (remove clojure.string/blank?)))))
 
 ;;; runit process supervisor (http://smarden.org/runit/)
 


### PR DESCRIPTION
## What is the purpose of the change

*This enables TaskManager log collection for Flink Jepsen Mesos tests.*


## Brief change log

  - *See commits*

## Verifying this change

This change is already covered by existing tests, such as *flink-jepsen*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
