### PR TITLE
[FLINK-17777][tests] Set HADOOP_CLASSPATH for Mesos TaskManagers

### DIFF
--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -303,6 +303,7 @@
     "-Djobmanager.rpc.address=$(hostname -f)"
     "-Djobmanager.rpc.port=6123"
     "-Dmesos.resourcemanager.tasks.cpus=1"
+    "-Dcontainerized.taskmanager.env.HADOOP_CLASSPATH=$(/opt/hadoop/bin/hadoop classpath)"
     "-Dtaskmanager.memory.process.size=2048m"
     "-Drest.bind-address=$(hostname -f)"))
 


### PR DESCRIPTION
## What is the purpose of the change

*This sets the `HADOOP_CLASSPATH` for Mesos TaskMangers*

## Brief change log

  - *Enable overriding Flink configuration for different Flink deployment scenarios.*
  - *Use `containerized.taskmanager.env.HADOOP_CLASSPATH` config option to set the `HADOOP_CLASSPATH` environment variable for Mesos TaskManagers.*
  - *Remove unnecessary config options from default Flink configuration.*


## Verifying this change

This change is already covered by existing tests, such as *flink-jepsen*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
