### PR TITLE
[FLINK-17520] [core] Extend CompositeTypeSerializerSnapshot to support migration

### DIFF
--- a/docs/dev/stream/state/custom_serialization.md
+++ b/docs/dev/stream/state/custom_serialization.md
@@ -309,7 +309,7 @@ the nested element serializer.
 In these cases, an additional three methods need to be implemented on the `CompositeTypeSerializerSnapshot`:
  * `#writeOuterSnapshot(DataOutputView)`: defines how the outer snapshot information is written.
  * `#readOuterSnapshot(int, DataInputView, ClassLoader)`: defines how the outer snapshot information is read.
- * `#isOuterSnapshotCompatible(TypeSerializer)`: checks whether the outer snapshot information remains identical.
+ * `#resolveOuterSchemaCompatibility(TypeSerializer)`: checks the compatibility based on the outer snapshot information.
 
 By default, the `CompositeTypeSerializerSnapshot` assumes that there isn't any outer snapshot information to
 read / write, and therefore have empty default implementations for the above methods. If the subclass
@@ -351,8 +351,10 @@ public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerial
     }
 
     @Override
-    protected boolean isOuterSnapshotCompatible(GenericArraySerializer newSerializer) {
-        return this.componentClass == newSerializer.getComponentClass();
+    protected boolean resolveOuterSchemaCompatibility(GenericArraySerializer newSerializer) {
+        return (this.componentClass == newSerializer.getComponentClass())
+            ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+            : OuterSchemaCompatibility.INCOMPATIBLE;
     }
 
     @Override

--- a/docs/dev/stream/state/custom_serialization.zh.md
+++ b/docs/dev/stream/state/custom_serialization.zh.md
@@ -87,7 +87,7 @@ type and the *serialized binary format* of a state type. The schema, generally s
  1. Data schema of the state type has evolved, i.e. adding or removing a field from a POJO that is used as state.
  2. Generally speaking, after a change to the data schema, the serialization format of the serializer will need to be upgraded.
  3. Configuration of the serializer has changed.
-
+ 
 In order for the new execution to have information about the *written schema* of state and detect whether or not the
 schema has changed, upon taking a savepoint of an operator's state, a *snapshot* of the state serializer needs to be
 written along with the state bytes. This is abstracted a `TypeSerializerSnapshot`, explained in the next subsection.
@@ -108,10 +108,10 @@ public interface TypeSerializerSnapshot<T> {
 
 <div data-lang="java" markdown="1">
 {% highlight java %}
-public abstract class TypeSerializer<T> {
-
+public abstract class TypeSerializer<T> {    
+    
     // ...
-
+    
     public abstract TypeSerializerSnapshot<T> snapshotConfiguration();
 }
 {% endhighlight %}
@@ -140,7 +140,7 @@ which can be one of the following:
  2. **`TypeSerializerSchemaCompatibility.compatibleAfterMigration()`**: this result signals that the new serializer has a
  different serialization schema, and it is possible to migrate from the old schema by using the previous serializer
  (which recognizes the old schema) to read bytes into state objects, and then rewriting the object back to bytes with
- the new serializer (which recognizes the new schema).
+ the new serializer (which recognizes the new schema). 
  3. **`TypeSerializerSchemaCompatibility.incompatible()`**: this result signals that the new serializer has a
  different serialization schema, but it is not possible to migrate from the old schema.
 
@@ -170,13 +170,13 @@ to the implementation of state serializers and their serializer snapshots.
   - Upon receiving the new serializer, it is provided to the restored previous serializer's snapshot via the
   `TypeSerializer#resolveSchemaCompatibility` to check for schema compatibility.
  4. **Migrate state bytes in backend from schema _A_ to schema _B_**
-  - If the compatibility resolution reflects that the schema has changed and migration is possible, schema migration is
+  - If the compatibility resolution reflects that the schema has changed and migration is possible, schema migration is 
   performed. The previous state serializer which recognizes schema _A_ will be obtained from the serializer snapshot, via
    `TypeSerializerSnapshot#restoreSerializer()`, and is used to deserialize state bytes to objects, which in turn
    are re-written again with the new serializer, which recognizes schema _B_ to complete the migration. All entries
    of the accessed state is migrated all-together before processing continues.
   - If the resolution signals incompatibility, then the state access fails with an exception.
-
+ 
 #### Heap state backends (e.g. `MemoryStateBackend`, `FsStateBackend`)
 
  1. **Register new state with a state serializer that has schema _A_**
@@ -218,7 +218,7 @@ as your serializer's snapshot class:
 
  - `TypeSerializerSchemaCompatibility.compatibleAsIs()`, if the new serializer class remains identical, or
  - `TypeSerializerSchemaCompatibility.incompatible()`, if the new serializer class is different then the previous one.
-
+ 
 Below is an example of how the `SimpleTypeSerializerSnapshot` is used, using Flink's `IntSerializer` as an example:
 <div data-lang="java" markdown="1">
 {% highlight java %}
@@ -309,7 +309,7 @@ the nested element serializer.
 In these cases, an additional three methods need to be implemented on the `CompositeTypeSerializerSnapshot`:
  * `#writeOuterSnapshot(DataOutputView)`: defines how the outer snapshot information is written.
  * `#readOuterSnapshot(int, DataInputView, ClassLoader)`: defines how the outer snapshot information is read.
- * `#isOuterSnapshotCompatible(TypeSerializer)`: checks whether the outer snapshot information remains identical.
+ * `#resolveOuterSchemaCompatibility(TypeSerializer)`: checks the compatibility based on the outer snapshot information.
 
 By default, the `CompositeTypeSerializerSnapshot` assumes that there isn't any outer snapshot information to
 read / write, and therefore have empty default implementations for the above methods. If the subclass
@@ -351,8 +351,10 @@ public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerial
     }
 
     @Override
-    protected boolean isOuterSnapshotCompatible(GenericArraySerializer newSerializer) {
-        return this.componentClass == newSerializer.getComponentClass();
+    protected boolean resolveOuterSchemaCompatibility(GenericArraySerializer newSerializer) {
+        return (this.componentClass == newSerializer.getComponentClass())
+            ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+            : OuterSchemaCompatibility.INCOMPATIBLE;
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
@@ -78,8 +78,10 @@ public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerial
 	}
 
 	@Override
-	protected boolean isOuterSnapshotCompatible(GenericArraySerializer<C> newSerializer) {
-		return this.componentClass == newSerializer.getComponentClass();
+	protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(GenericArraySerializer<C> newSerializer) {
+		return (this.componentClass == newSerializer.getComponentClass())
+			? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+			: OuterSchemaCompatibility.INCOMPATIBLE;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
@@ -348,8 +348,10 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
 		}
 
 		@Override
-		protected boolean isOuterSnapshotCompatible(NullableSerializer<T> newSerializer) {
-			return nullPaddingLength == newSerializer.nullPaddingLength();
+		protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(NullableSerializer<T> newSerializer) {
+			return (nullPaddingLength == newSerializer.nullPaddingLength())
+				? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+				: OuterSchemaCompatibility.INCOMPATIBLE;
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot.OuterSchemaCompatibility;
+
 /**
  * Test suite for the {@link CompositeTypeSerializerSnapshot}.
  */
@@ -41,7 +43,6 @@ public class CompositeTypeSerializerSnapshotTest {
 
 	@Test
 	public void testIncompatiblePrecedence() throws IOException {
-		final String OUTER_CONFIG = "outer-config";
 		final TypeSerializer<?>[] testNestedSerializers = {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AFTER_MIGRATION),
@@ -53,15 +54,13 @@ public class CompositeTypeSerializerSnapshotTest {
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
 				testNestedSerializers,
-				OUTER_CONFIG,
-				OUTER_CONFIG);
+				OuterSchemaCompatibility.COMPATIBLE_AS_IS);
 
 		Assert.assertTrue(compatibility.isIncompatible());
 	}
 
 	@Test
 	public void testCompatibleAfterMigrationPrecedence() throws IOException {
-		final String OUTER_CONFIG = "outer-config";
 		TypeSerializer<?>[] testNestedSerializers = {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AFTER_MIGRATION),
@@ -73,15 +72,13 @@ public class CompositeTypeSerializerSnapshotTest {
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
 				testNestedSerializers,
-				OUTER_CONFIG,
-				OUTER_CONFIG);
+				OuterSchemaCompatibility.COMPATIBLE_AS_IS);
 
 		Assert.assertTrue(compatibility.isCompatibleAfterMigration());
 	}
 
 	@Test
 	public void testCompatibleWithReconfiguredSerializerPrecedence() throws IOException {
-		final String OUTER_CONFIG = "outer-config";
 		TypeSerializer<?>[] testNestedSerializers = {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_WITH_RECONFIGURED_SERIALIZER),
@@ -92,8 +89,7 @@ public class CompositeTypeSerializerSnapshotTest {
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
 				testNestedSerializers,
-				OUTER_CONFIG,
-				OUTER_CONFIG);
+				OuterSchemaCompatibility.COMPATIBLE_AS_IS);
 
 		Assert.assertTrue(compatibility.isCompatibleWithReconfiguredSerializer());
 
@@ -108,7 +104,6 @@ public class CompositeTypeSerializerSnapshotTest {
 
 	@Test
 	public void testCompatibleAsIsPrecedence() throws IOException {
-		final String OUTER_CONFIG = "outer-config";
 		TypeSerializer<?>[] testNestedSerializers = {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
@@ -118,16 +113,13 @@ public class CompositeTypeSerializerSnapshotTest {
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
 				testNestedSerializers,
-				OUTER_CONFIG,
-				OUTER_CONFIG);
+				OuterSchemaCompatibility.COMPATIBLE_AS_IS);
 
 		Assert.assertTrue(compatibility.isCompatibleAsIs());
 	}
 
 	@Test
 	public void testOuterSnapshotCompatibilityPrecedence() throws IOException {
-		final String INIT_OUTER_CONFIG = "outer-config";
-		final String INCOMPAT_OUTER_CONFIG = "incompat-outer-config";
 		TypeSerializer<?>[] testNestedSerializers = {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
 		};
@@ -136,8 +128,7 @@ public class CompositeTypeSerializerSnapshotTest {
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
 				testNestedSerializers,
-				INIT_OUTER_CONFIG,
-				INCOMPAT_OUTER_CONFIG);
+				OuterSchemaCompatibility.INCOMPATIBLE);
 
 		// even though nested serializers are compatible, incompatibility of the outer
 		// snapshot should have higher precedence in the final result
@@ -146,8 +137,6 @@ public class CompositeTypeSerializerSnapshotTest {
 
 	@Test
 	public void testNestedFieldSerializerArityMismatchPrecedence() throws IOException {
-		final String OUTER_CONFIG = "outer-config";
-
 		final TypeSerializer<?>[] initialNestedSerializers = {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
 		};
@@ -162,8 +151,7 @@ public class CompositeTypeSerializerSnapshotTest {
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				initialNestedSerializers,
 				newNestedSerializers,
-				OUTER_CONFIG,
-				OUTER_CONFIG);
+				OuterSchemaCompatibility.COMPATIBLE_AS_IS);
 
 		// arity mismatch in the nested serializers should return incompatible as the result
 		Assert.assertTrue(compatibility.isIncompatible());
@@ -172,10 +160,9 @@ public class CompositeTypeSerializerSnapshotTest {
 	private TypeSerializerSchemaCompatibility<String> snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 			TypeSerializer<?>[] initialNestedSerializers,
 			TypeSerializer<?>[] newNestedSerializer,
-			String initialOuterConfiguration,
-			String newOuterConfiguration) throws IOException {
+			OuterSchemaCompatibility mockOuterSchemaCompatibilityResult) throws IOException {
 		TestCompositeTypeSerializer testSerializer =
-			new TestCompositeTypeSerializer(initialOuterConfiguration, initialNestedSerializers);
+			new TestCompositeTypeSerializer(initialNestedSerializers);
 
 		TypeSerializerSnapshot<String> testSerializerSnapshot = testSerializer.snapshotConfiguration();
 
@@ -187,7 +174,7 @@ public class CompositeTypeSerializerSnapshotTest {
 			in, Thread.currentThread().getContextClassLoader());
 
 		TestCompositeTypeSerializer newTestSerializer =
-			new TestCompositeTypeSerializer(newOuterConfiguration, newNestedSerializer);
+			new TestCompositeTypeSerializer(mockOuterSchemaCompatibilityResult, newNestedSerializer);
 		return testSerializerSnapshot.resolveSchemaCompatibility(newTestSerializer);
 	}
 
@@ -205,7 +192,7 @@ public class CompositeTypeSerializerSnapshotTest {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AFTER_MIGRATION)
 		};
 
-		TestCompositeTypeSerializer testSerializer = new TestCompositeTypeSerializer("outer-config", testNestedSerializers);
+		TestCompositeTypeSerializer testSerializer = new TestCompositeTypeSerializer(testNestedSerializers);
 
 		TypeSerializerSnapshot<String> testSerializerSnapshot = testSerializer.snapshotConfiguration();
 
@@ -238,19 +225,24 @@ public class CompositeTypeSerializerSnapshotTest {
 
 		private static final StringSerializer delegateSerializer = StringSerializer.INSTANCE;
 
-		private final String outerConfiguration;
+		private final OuterSchemaCompatibility mockOuterSchemaCompatibility;
 
 		private final TypeSerializer<?>[] nestedSerializers;
 
-		TestCompositeTypeSerializer(
-				String outerConfiguration,
-				TypeSerializer<?>[] nestedSerializers) {
-			this.outerConfiguration = outerConfiguration;
+		TestCompositeTypeSerializer(TypeSerializer<?>[] nestedSerializers) {
+			this.mockOuterSchemaCompatibility = OuterSchemaCompatibility.COMPATIBLE_AS_IS;
 			this.nestedSerializers = nestedSerializers;
 		}
 
-		public String getOuterConfiguration() {
-			return outerConfiguration;
+		TestCompositeTypeSerializer(
+				OuterSchemaCompatibility mockOuterSchemaCompatibility,
+				TypeSerializer<?>[] nestedSerializers) {
+			this.mockOuterSchemaCompatibility = mockOuterSchemaCompatibility;
+			this.nestedSerializers = nestedSerializers;
+		}
+
+		public OuterSchemaCompatibility getMockOuterSchemaCompatibility() {
+			return mockOuterSchemaCompatibility;
 		}
 
 		TypeSerializer<?>[] getNestedSerializers() {
@@ -335,7 +327,7 @@ public class CompositeTypeSerializerSnapshotTest {
 	 */
 	public static class TestCompositeTypeSerializerSnapshot extends CompositeTypeSerializerSnapshot<String, TestCompositeTypeSerializer> {
 
-		private String outerConfiguration;
+		private OuterSchemaCompatibility mockOuterSchemaCompatibility;
 
 		public TestCompositeTypeSerializerSnapshot() {
 			super(TestCompositeTypeSerializer.class);
@@ -343,12 +335,12 @@ public class CompositeTypeSerializerSnapshotTest {
 
 		TestCompositeTypeSerializerSnapshot(TestCompositeTypeSerializer serializer) {
 			super(serializer);
-			this.outerConfiguration = serializer.getOuterConfiguration();
+			this.mockOuterSchemaCompatibility = serializer.getMockOuterSchemaCompatibility();
 		}
 
 		@Override
 		protected TestCompositeTypeSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
-			return new TestCompositeTypeSerializer(outerConfiguration, nestedSerializers);
+			return new TestCompositeTypeSerializer(mockOuterSchemaCompatibility, nestedSerializers);
 		}
 
 		@Override
@@ -358,18 +350,18 @@ public class CompositeTypeSerializerSnapshotTest {
 
 		@Override
 		protected void writeOuterSnapshot(DataOutputView out) throws IOException {
-			out.writeUTF(outerConfiguration);
+			out.writeInt(mockOuterSchemaCompatibility.ordinal());
 		}
 
 		@Override
 		public void readOuterSnapshot(int readOuterSnapshotVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
 			Assert.assertEquals(getCurrentOuterSnapshotVersion(), readOuterSnapshotVersion);
-			this.outerConfiguration = in.readUTF();
+			this.mockOuterSchemaCompatibility = OuterSchemaCompatibility.values()[in.readInt()];
 		}
 
 		@Override
-		protected boolean isOuterSnapshotCompatible(TestCompositeTypeSerializer newSerializer) {
-			return outerConfiguration.equals(newSerializer.getOuterConfiguration());
+		protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(TestCompositeTypeSerializer newSerializer) {
+			return newSerializer.getMockOuterSchemaCompatibility();
 		}
 
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
@@ -119,7 +119,7 @@ public class CompositeTypeSerializerSnapshotTest {
 	}
 
 	@Test
-	public void testOuterSnapshotCompatibilityPrecedence() throws IOException {
+	public void testOuterSnapshotIncompatiblePrecedence() throws IOException {
 		TypeSerializer<?>[] testNestedSerializers = {
 			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
 		};
@@ -133,6 +133,23 @@ public class CompositeTypeSerializerSnapshotTest {
 		// even though nested serializers are compatible, incompatibility of the outer
 		// snapshot should have higher precedence in the final result
 		Assert.assertTrue(compatibility.isIncompatible());
+	}
+
+	@Test
+	public void testOuterSnapshotRequiresMigrationPrecedence() throws IOException {
+		TypeSerializer<?>[] testNestedSerializers = {
+			new NestedSerializer(TargetCompatibility.COMPATIBLE_WITH_RECONFIGURED_SERIALIZER),
+		};
+
+		TypeSerializerSchemaCompatibility<String> compatibility =
+			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
+				testNestedSerializers,
+				testNestedSerializers,
+				OuterSchemaCompatibility.COMPATIBLE_AFTER_MIGRATION);
+
+		// even though nested serializers can be compatible with reconfiguration, the outer
+		// snapshot requiring migration should have higher precedence in the final result
+		Assert.assertTrue(compatibility.isCompatibleAfterMigration());
 	}
 
 	@Test

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
@@ -103,7 +103,9 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
 	}
 
 	@Override
-	protected boolean isOuterSnapshotCompatible(ScalaCaseClassSerializer<T> newSerializer) {
-		return Objects.equals(type, newSerializer.getTupleClass());
+	protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<T> newSerializer) {
+		return (Objects.equals(type, newSerializer.getTupleClass()))
+			? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+			: OuterSchemaCompatibility.INCOMPATIBLE;
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
@@ -98,7 +98,9 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
 	}
 
 	@Override
-	protected boolean isOuterSnapshotCompatible(TraversableSerializer<T, E> newSerializer) {
-		return cbfCode.equals(newSerializer.cbfCode());
+	protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(TraversableSerializer<T, E> newSerializer) {
+		return (cbfCode.equals(newSerializer.cbfCode()))
+			? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+			: OuterSchemaCompatibility.INCOMPATIBLE;
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
@@ -95,8 +95,10 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
 	}
 
 	@Override
-	protected boolean isOuterSnapshotCompatible(ScalaCaseClassSerializer<Tuple2<T1, T2>> newSerializer) {
-		return Objects.equals(type, newSerializer.getTupleClass());
+	protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<Tuple2<T1, T2>> newSerializer) {
+		return (Objects.equals(type, newSerializer.getTupleClass()))
+			? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+			: OuterSchemaCompatibility.INCOMPATIBLE;
 	}
 
 	private static <T1, T2> Class<ScalaCaseClassSerializer<scala.Tuple2<T1, T2>>> correspondingSerializerClass() {


### PR DESCRIPTION
## What is the purpose of the change

Previously, the abstraction provided by `CompositeTypeSerializerSnapshot` only allows a mismatch in the outer configuration of composite serializers to be resolved as incompatible (restore fails) or compatible (restore continues as is). The resolution logic is captured as a `isOuterSnapshotCompatible` method, returning a flag.

A requirement to additionally allow migration based on the outer configuration has came up in https://issues.apache.org/jira/browse/FLINK-16998.

This PR extends functionality of the abstraction by deprecating the old `boolean isOuterSnapshotCompatible(serializer)`, in favor of a new `OuterSchemaCompatibility resolveOuterSchemaCompatibility(serializer)`.

The change is backwards compatible - existing subclasses are not broken API / behaviour wise.

## Brief change log

- 2454f70 Deprecates old method in favor of new `resolveOuterSchemaCompatibility` method
- 56f21c3 (not main change) Simplifies `CompositeTypeSerializerSnapshotTest`
- 43c1758 Adds new unit test to verify that migration due to outer snapshot is respected
- 1a2747b Remove all implementations of deprecated `isOuterSnapshotCompatible` in Flink
- c91cdd3 Update docs

## Verifying

Existing tests (e.g. subclasses of `TypeSerializerUpgradeTestBase`) should cover this change.
An additional unit test in `CompositeTypeSerializerSnapshotTest` was also added for this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): NO
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **YES**
  - The serializers: **YES**
  - The runtime per-record code paths (performance sensitive): NO
  - Anything that affects deployment or recovery: NO
  - The S3 file system connector: NO

## Documentation

  - Does this pull request introduce a new feature? YES
  - If yes, how is the feature documented? DOCS + JAVADOCS
