### PR TITLE
[FLINK-17792][tests] Catch and log exception if jstack fails

### DIFF
--- a/flink-jepsen/src/jepsen/flink/utils.clj
+++ b/flink-jepsen/src/jepsen/flink/utils.clj
@@ -133,7 +133,10 @@
 
 (defn- write-jstack!
   [pid out-path]
-  (c/exec :jstack :-l pid :> out-path))
+  (try
+    (c/exec :jstack :-l pid :> out-path)
+    (catch Exception e
+      (warn e "Failed to invoke jstack on pid" pid))))
 
 (defn dump-jstack-by-pattern!
   "Dumps the output of jstack for all JVMs that match one of the specified patterns."


### PR DESCRIPTION
## What is the purpose of the change

*This catches and logs exceptions thrown when invoking jstack. jstack can fail if the JVM process that we want to sample exits while or before we invoke jstack. Since a JVM process is free to exit at any time, we should not propagate the exception so that we do not fail the test prematurely.*


## Brief change log

  - *See commit*

## Verifying this change

This change is already covered by existing tests, such as *flink-jepsen*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
