### PR TITLE
[FLINK-17790][kafka] Fix JDK 11 compile error

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
@@ -276,7 +276,7 @@ public class KafkaOptions {
 						return Optional.empty();
 					// Default fallback to full class name of the partitioner.
 					default:
-						return Optional.of(initializePartitioner(partitioner, classLoader));
+						return Optional.<FlinkKafkaPartitioner<RowData>>of(initializePartitioner(partitioner, classLoader));
 					}
 				});
 	}


### PR DESCRIPTION
`initializePartitioner` returns a `FlinkKafkaPartitioner`, without any generic parameter, as a result of which the type of the Optional is not well-defined.