### PR TITLE
[FLINK-17565][k8s] Bump fabric8 version from 4.5.2 to 4.9.2

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -73,8 +73,7 @@ function start_kubernetes_if_not_running {
         # here.
         # Similarly, the kubelets are marking themself as "low disk space",
         # causing Flink to avoid this node (again, failing the test)
-        # Use fixed version v1.16.9 because fabric8 kubernetes-client could not work with higher version under jdk 8u252
-        sudo CHANGE_MINIKUBE_NONE_USER=true minikube start --kubernetes-version v1.16.9 --vm-driver=none \
+        sudo CHANGE_MINIKUBE_NONE_USER=true minikube start --vm-driver=none \
             --extra-config=kubelet.image-gc-high-threshold=99 \
             --extra-config=kubelet.image-gc-low-threshold=98 \
             --extra-config=kubelet.minimum-container-ttl-duration=120m \

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<kubernetes.client.version>4.5.2</kubernetes.client.version>
+		<kubernetes.client.version>4.9.2</kubernetes.client.version>
 	</properties>
 
 	<!-- Set dependency version for transitive dependencies -->
@@ -128,6 +128,7 @@ under the License.
 									<include>com.fasterxml.jackson.core:jackson-annotations</include>
 									<include>com.fasterxml.jackson.core:jackson-databind</include>
 									<include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
+									<include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
 									<include>com.squareup.okhttp3:*</include>
 									<include>com.squareup.okio:okio</include>
 									<include>org.yaml:*</include>

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -10,13 +10,14 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.1
 - com.github.mifmif:generex:1.0.2
 - com.squareup.okhttp3:logging-interceptor:3.12.0
 - com.squareup.okhttp3:okhttp:3.12.1
 - com.squareup.okio:okio:1.15.0
-- io.fabric8:kubernetes-client:4.5.2
-- io.fabric8:kubernetes-model:4.5.2
-- io.fabric8:kubernetes-model-common:4.5.2
+- io.fabric8:kubernetes-client:4.9.2
+- io.fabric8:kubernetes-model:4.9.2
+- io.fabric8:kubernetes-model-common:4.9.2
 - io.fabric8:zjsonpatch:0.3.0
 - org.yaml:snakeyaml:1.23
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -209,10 +209,10 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
 			.get(0);
 
 		assertEquals(
-			clusterSpecification.getMasterMemoryMB() + Constants.RESOURCE_UNIT_MB,
+			String.valueOf(clusterSpecification.getMasterMemoryMB()),
 			jmContainer.getResources().getRequests().get(Constants.RESOURCE_NAME_MEMORY).getAmount());
 		assertEquals(
-			clusterSpecification.getMasterMemoryMB() + Constants.RESOURCE_UNIT_MB,
+			String.valueOf(clusterSpecification.getMasterMemoryMB()),
 			jmContainer.getResources().getLimits().get(Constants.RESOURCE_NAME_MEMORY).getAmount());
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -114,11 +114,11 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
 
 		final Map<String, Quantity> requests = resourceRequirements.getRequests();
 		assertEquals(Double.toString(JOB_MANAGER_CPU), requests.get("cpu").getAmount());
-		assertEquals(JOB_MANAGER_MEMORY + "Mi", requests.get("memory").getAmount());
+		assertEquals(String.valueOf(JOB_MANAGER_MEMORY), requests.get("memory").getAmount());
 
 		final Map<String, Quantity> limits = resourceRequirements.getLimits();
 		assertEquals(Double.toString(JOB_MANAGER_CPU), limits.get("cpu").getAmount());
-		assertEquals(JOB_MANAGER_MEMORY + "Mi", limits.get("memory").getAmount());
+		assertEquals(String.valueOf(JOB_MANAGER_MEMORY), limits.get("memory").getAmount());
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -127,11 +127,11 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 
 		final Map<String, Quantity> requests = resourceRequirements.getRequests();
 		assertEquals(Double.toString(TASK_MANAGER_CPU), requests.get("cpu").getAmount());
-		assertEquals(TOTAL_PROCESS_MEMORY + "Mi", requests.get("memory").getAmount());
+		assertEquals(String.valueOf(TOTAL_PROCESS_MEMORY), requests.get("memory").getAmount());
 
 		final Map<String, Quantity> limits = resourceRequirements.getLimits();
 		assertEquals(Double.toString(TASK_MANAGER_CPU), limits.get("cpu").getAmount());
-		assertEquals(TOTAL_PROCESS_MEMORY + "Mi", limits.get("memory").getAmount());
+		assertEquals(String.valueOf(TOTAL_PROCESS_MEMORY), limits.get("memory").getAmount());
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -133,7 +133,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 
 		final Map<String, Quantity> requests = resultedMainContainer.getResources().getRequests();
 		assertEquals(Double.toString(JOB_MANAGER_CPU), requests.get("cpu").getAmount());
-		assertEquals(JOB_MANAGER_MEMORY + "Mi", requests.get("memory").getAmount());
+		assertEquals(String.valueOf(JOB_MANAGER_MEMORY), requests.get("memory").getAmount());
 
 		assertEquals(1, resultedMainContainer.getCommand().size());
 		assertEquals(3, resultedMainContainer.getArgs().size());


### PR DESCRIPTION
## What is the purpose of the change

Bump fabric8 kubernetes-client from 4.5.2 to 4.9.2.

It is expected that v4.9.2 fixes the issues as follows:

1. [FLINK-17566](https://issues.apache.org/jira/browse/FLINK-17566)
2. [FLINK-17416](https://issues.apache.org/jira/browse/FLINK-17416)

## Brief change log

  - Update pom.xml about the `kubernetes.client.version` property.
  - Update the NOTICE file.
  - Update all the test cases which previously expect the method of `Quantity#getAmount` returns **${memoryAmount}${memoryFormat}**.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
