### PR TITLE
[FLINK-17788][scala-shell] scala shell in yarn mode is broken

### DIFF
--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -257,6 +257,9 @@ object FlinkShell {
         .deploySessionCluster(clusterSpecification)
         .getClusterClient
     } finally {
+      // remove target when deploying flink cluster, otherwise it would be as yarn-per-job
+      // which is not correct. It would be set to yarn-session after deployment
+      executorConfig.removeConfig(DeploymentOptions.TARGET)
       clusterDescriptor.close()
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The root cause of scala shell broken in yarn mode is that target is set as `yarn-per-job` which is not correct. This PR fix this issue by removing `target` after deploying yarn session cluster.

## Verifying this change

Verify it manually, start scala shell and run the following sample code.

```
val dataStream = senv.fromElements(1, 2, 3, 4)
dataStream.countWindowAll(2).sum(0).print()
senv.execute("My streaming program")
```

Before this PR, this piece of code will start another yarn app and fail to run this flink job.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
