### PR TITLE
[FLINK-16160][table] Fix proctime()/rowtime() doesn't work for TableE…

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
@@ -117,7 +117,7 @@ public class ConnectorCatalogTable<T1, T2> extends AbstractCatalogTable {
 		return Optional.empty();
 	}
 
-	private static <T1> TableSchema calculateSourceSchema(TableSource<T1> source, boolean isBatch) {
+	public static <T1> TableSchema calculateSourceSchema(TableSource<T1> source, boolean isBatch) {
 		TableSchema tableSchema = source.getTableSchema();
 		if (isBatch) {
 			return tableSchema;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/ConnectTableDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/ConnectTableDescriptor.java
@@ -140,7 +140,12 @@ public abstract class ConnectTableDescriptor
 		TableSchema tableSchema = getTableSchema(schemaProperties);
 
 		Map<String, String> properties = new HashMap<>(toProperties());
-		schemaProperties.keySet().forEach(properties::remove);
+
+		// DescriptorProperties#putTableSchema and getTableSchema are not symmetrical
+		// We should retain time attribute properties when remove table schema properties
+		DescriptorProperties descriptorProperties = new DescriptorProperties();
+		descriptorProperties.putTableSchema(Schema.SCHEMA, tableSchema);
+		descriptorProperties.asMap().keySet().forEach(properties::remove);
 
 		CatalogTableImpl catalogTable = new CatalogTableImpl(
 			tableSchema,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSourceValidation.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSourceValidation.java
@@ -75,6 +75,15 @@ public class TableSourceValidation {
 		return !getRowtimeAttributes(tableSource).isEmpty();
 	}
 
+	/**
+	 * Checks if the given {@link TableSource} defines a proctime attribute.
+	 * @param tableSource The table source to check.
+	 * @return true if the given table source defines proctime attribute.
+	 */
+	public static boolean hasProctimeAttribute(TableSource<?> tableSource) {
+		return getProctimeAttribute(tableSource).isPresent();
+	}
+
 	private static void validateSingleRowtimeAttribute(List<RowtimeAttributeDescriptor> rowtimeAttributes) {
 		if (rowtimeAttributes.size() > 1) {
 			throw new ValidationException("Currently, only a single rowtime attribute is supported. " +

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -18,3 +18,4 @@ org.apache.flink.table.planner.runtime.batch.sql.TestPartitionableSinkFactory
 org.apache.flink.table.planner.utils.TestPartitionableSourceFactory
 org.apache.flink.table.planner.utils.TestFilterableTableSourceFactory
 org.apache.flink.table.planner.utils.TestProjectableTableSourceFactory
+org.apache.flink.table.planner.utils.TestTableSourceWithTimeFactory

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -132,6 +132,64 @@ Calc(select=[name, w$end AS EXPR$1, EXPR$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testLegacyRowTimeTableGroupWindow">
+    <Resource name="sql">
+      <![CDATA[
+SELECT name,
+    TUMBLE_END(rowtime, INTERVAL '10' MINUTE),
+    AVG(val)
+FROM rowTimeT WHERE val > 100
+    GROUP BY name, TUMBLE(rowtime, INTERVAL '10' MINUTE)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], EXPR$1=[TUMBLE_END($1)], EXPR$2=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[AVG($2)])
+   +- LogicalProject(name=[$2], $f1=[TUMBLE($3, 600000:INTERVAL MINUTE)], val=[$1])
+      +- LogicalFilter(condition=[>($1, 100)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, w$end AS EXPR$1, EXPR$2])
++- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow('w$, rowtime, 600000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[name, AVG(val) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[name]])
+      +- Calc(select=[name, rowtime, val], where=[>(val, 100)])
+         +- TableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, val, name, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLegacyProcTimeTableGroupWindow">
+    <Resource name="sql">
+      <![CDATA[
+SELECT name,
+    TUMBLE_END(proctime, INTERVAL '10' MINUTE),
+    AVG(val)
+FROM procTimeT WHERE val > 100
+    GROUP BY name, TUMBLE(proctime, INTERVAL '10' MINUTE)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], EXPR$1=[TUMBLE_END($1)], EXPR$2=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[AVG($2)])
+   +- LogicalProject(name=[$2], $f1=[TUMBLE($3, 600000:INTERVAL MINUTE)], val=[$1])
+      +- LogicalFilter(condition=[>($1, 100)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, procTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, w$end AS EXPR$1, EXPR$2])
++- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow('w$, proctime, 600000)], properties=[w$start, w$end, w$proctime], select=[name, AVG(val) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[name]])
+      +- Calc(select=[name, proctime, val], where=[>(val, 100)])
+         +- TableSourceScan(table=[[default_catalog, default_database, procTimeT]], fields=[id, val, name, proctime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFilterFullyPushDown">
     <Resource name="sql">
       <![CDATA[SELECT * FROM FilterableTable WHERE amount > 2 AND amount < 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -21,13 +21,15 @@ package org.apache.flink.table.planner.plan.stream.sql
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types, ValidationException}
+import org.apache.flink.table.descriptors.{ConnectorDescriptor, Rowtime, Schema}
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.utils.{DateTimeTestUtil, TableTestBase, TestFilterableTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestTableSource, TestTableSourceWithTime}
 import org.apache.flink.table.sources.TableSource
 import org.apache.flink.table.types.DataType
 import org.apache.flink.types.Row
-
 import org.junit.{Before, Test}
+
+import _root_.java.util.{Collections, Map => JMap}
 
 class TableSourceTest extends TableTestBase {
 
@@ -128,6 +130,63 @@ class TableSourceTest extends TableTestBase {
       """.stripMargin
 
     util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testLegacyRowTimeTableGroupWindow(): Unit = {
+    util.tableEnv.connect(
+      new ConnectorDescriptor("TestTableSourceWithTime", 1, false) {
+        override protected def toConnectorProperties: JMap[String, String] = {
+          Collections.emptyMap()
+        }
+      }
+    ).withSchema(
+      new Schema()
+        .field("id", DataTypes.INT())
+        .field("val", DataTypes.BIGINT())
+        .field("name", DataTypes.STRING())
+        .field("rowtime", DataTypes.TIMESTAMP(3))
+        .rowtime(new Rowtime().timestampsFromField("rowtime").watermarksPeriodicBounded(1000))
+    ).createTemporaryTable("rowTimeT")
+
+    val sql =
+      """
+        |SELECT name,
+        |    TUMBLE_END(rowtime, INTERVAL '10' MINUTE),
+        |    AVG(val)
+        |FROM rowTimeT WHERE val > 100
+        |    GROUP BY name, TUMBLE(rowtime, INTERVAL '10' MINUTE)
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testLegacyProcTimeTableGroupWindow(): Unit = {
+    util.tableEnv.connect(
+      new ConnectorDescriptor("TestTableSourceWithTime", 1, false) {
+        override protected def toConnectorProperties: JMap[String, String] = {
+          Collections.emptyMap()
+        }
+      }
+    ).withSchema(
+      new Schema()
+        .field("id", DataTypes.INT())
+        .field("val", DataTypes.BIGINT())
+        .field("name", DataTypes.STRING())
+        .field("proctime", DataTypes.TIMESTAMP(3)).proctime()
+    ).createTemporaryTable("procTimeT")
+
+    val sql =
+      """
+        |SELECT name,
+        |    TUMBLE_END(proctime, INTERVAL '10' MINUTE),
+        |    AVG(val)
+        |FROM procTimeT WHERE val > 100
+        |    GROUP BY name, TUMBLE(proctime, INTERVAL '10' MINUTE)
+      """.stripMargin
+
+    util.verifyPlan(sql)
   }
 
   @Test


### PR DESCRIPTION
…nvironment.connect().createTemporaryTable()


## What is the purpose of the change

Since FLINK-14490 , proctime()/rowtime() doesn't work for TableEnvironment.connect().createTemporaryTable(), The root cause is described on jira ticket.

## Brief change log

- instantiate the TableSource in CatalogSchemaTable and check if it's a DefinedRowtimeAttributes/DefinedProctimeAttribute instance. If so, rewrite the TableSchema to patch the time indicator(as it is in ConnectorCatalogTable#calculateSourceSchema)
- avoid erasing time indicator in CatalogSourceTable if the TableSource is a DefinedRowtimeAttributes/DefinedProctimeAttribute instance

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
