### PR TITLE
[FLINK-15813][runtime] Set default value of config “jobmanager.execution.failover-strategy” to “region”

### DIFF
--- a/docs/_includes/generated/all_jobmanager_section.html
+++ b/docs/_includes/generated/all_jobmanager_section.html
@@ -22,7 +22,7 @@
         </tr>
         <tr>
             <td><h5>jobmanager.execution.failover-strategy</h5></td>
-            <td style="word-wrap: break-word;">region</td>
+            <td style="word-wrap: break-word;">"region"</td>
             <td>String</td>
             <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li></ul></td>
         </tr>

--- a/docs/_includes/generated/expert_fault_tolerance_section.html
+++ b/docs/_includes/generated/expert_fault_tolerance_section.html
@@ -58,7 +58,7 @@
         </tr>
         <tr>
             <td><h5>jobmanager.execution.failover-strategy</h5></td>
-            <td style="word-wrap: break-word;">region</td>
+            <td style="word-wrap: break-word;">"region"</td>
             <td>String</td>
             <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li></ul></td>
         </tr>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -28,7 +28,7 @@
         </tr>
         <tr>
             <td><h5>jobmanager.execution.failover-strategy</h5></td>
-            <td style="word-wrap: break-word;">region</td>
+            <td style="word-wrap: break-word;">"region"</td>
             <td>String</td>
             <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li></ul></td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -234,10 +234,10 @@ public class JobManagerOptions {
 	 * This option specifies the failover strategy, i.e. how the job computation recovers from task failures.
 	 */
 	@Documentation.Section({Documentation.Sections.ALL_JOB_MANAGER, Documentation.Sections.EXPERT_FAULT_TOLERANCE})
-	@Documentation.OverrideDefault("region")
 	public static final ConfigOption<String> EXECUTION_FAILOVER_STRATEGY =
 		key("jobmanager.execution.failover-strategy")
-			.defaultValue("full")
+			.stringType()
+			.defaultValue("region")
 			.withDescription(Description.builder()
 				.text("This option specifies how the job computation recovers from task failures. " +
 					"Accepted values are:")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyLoader.java
@@ -41,7 +41,9 @@ public class FailoverStrategyLoader {
 	 * Loads a FailoverStrategy Factory from the given configuration.
 	 */
 	public static FailoverStrategy.Factory loadFailoverStrategy(Configuration config, @Nullable Logger logger) {
-		final String strategyParam = config.getString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY);
+		final String strategyParam = config.getString(
+			JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
+			FULL_RESTART_STRATEGY_NAME);
 
 		if (StringUtils.isNullOrWhitespaceOnly(strategyParam)) {
 			if (logger != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
@@ -47,13 +47,7 @@ public final class FailoverStrategyFactoryLoader {
 	public static FailoverStrategy.Factory loadFailoverStrategyFactory(final Configuration config) {
 		checkNotNull(config);
 
-		// the default NG failover strategy is the region failover strategy.
-		// TODO: Remove the overridden default value when removing legacy scheduler
-		//  and change the default value of JobManagerOptions.EXECUTION_FAILOVER_STRATEGY
-		//  to be "region"
-		final String strategyParam = config.getString(
-			JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
-			PIPELINED_REGION_RESTART_STRATEGY_NAME);
+		final String strategyParam = config.getString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY);
 
 		switch (strategyParam.toLowerCase()) {
 			case FULL_RESTART_STRATEGY_NAME:


### PR DESCRIPTION
## What is the purpose of the change

This PR is to set the default value of jobmanager.execution.failover-strategy to region.
The DefaultScheduler now already uses "region" as the default value so it does not cause any behavior change in production.

## Brief change log

See commits.

## Verifying this change

This change is already covered by existing tests, such as *FailoverStrategyFactoryLoaderTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
