### PR TITLE
[FLINK-17543][Azure] Add timestamp to log name to allow multiple uploads per module

### DIFF
--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -147,12 +147,13 @@ upload_artifacts_s3() {
 
 	# On Azure, publish ARTIFACTS_FILE as a build artifact
 	if [ ! -z "$TF_BUILD" ] ; then
+		TIMESTAMP=`date +%s` # append timestamp to name to allow multiple uploads for the same module
 		ARTIFACT_DIR="$(pwd)/artifact-dir"
 		mkdir $ARTIFACT_DIR
 		cp $ARTIFACTS_FILE $ARTIFACT_DIR/
 		
 		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$ARTIFACT_DIR"
-		echo "##vso[task.setvariable variable=ARTIFACT_NAME]$(echo $MODULE | tr -dc '[:alnum:]\n\r')"
+		echo "##vso[task.setvariable variable=ARTIFACT_NAME]$(echo $MODULE | tr -dc '[:alnum:]\n\r')-$TIMESTAMP"
 	fi
 
 	# upload to https://transfer.sh


### PR DESCRIPTION
## Brief change log
Re-running a failed stage leads to an error message on AZP, because the log artifact exists already.

With this change, we are adding a timestamp to the log file name to avoid this situation.


## Verifying this change

Tested on my personal account: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8014&view=results