### PR TITLE
[FLINK-17730][CI] Increase 'no output timeout' to 15 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
     parameters: # see template file for a definition of the parameters.
       stage_name: ci_build
       test_pool_definition:
-        vmImage: 'ubuntu-latest'
+        vmImage: 'ubuntu-16.04'
       e2e_pool_definition:
         vmImage: 'ubuntu-16.04'
       environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"

--- a/tools/azure_controller.sh
+++ b/tools/azure_controller.sh
@@ -184,7 +184,7 @@ elif [ $STAGE != "$STAGE_CLEANUP" ]; then
     fi
 
 
-    TEST="$STAGE" "./tools/travis_watchdog.sh" 300
+    TEST="$STAGE" "./tools/travis_watchdog.sh" 900
     EXIT_CODE=$?
 elif [ $STAGE == "$STAGE_CLEANUP" ]; then
     echo "Cleaning up $CACHE_BUILD_DIR"

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -39,7 +39,7 @@ echo "Build for commit ${TRAVIS_COMMIT} of ${TRAVIS_REPO_SLUG} [build ID: ${TRAV
 # =============================================================================
 
 # Number of seconds w/o output before printing a stack trace and killing $MVN
-MAX_NO_OUTPUT=${1:-600}
+MAX_NO_OUTPUT=${1:-900}
 
 # Number of seconds to sleep before checking the output again
 SLEEP_TIME=20


### PR DESCRIPTION
## What is the purpose of the change

Short history lesson:
1. I introduced `run_mvn`, which broke the travis watchdog (it killed the mvn wrapper script, not maven)
2. we saw a lot of successful builds with exit code 143, and a timeout report somewhere in between
3. I opened a PR to properly kill mvn, using the default 300 seconds timeout.
4. we saw a lot of mvn invocations timing out after 300 seconds.
5. this PR is increasing the timeout to 900 seconds. It should make the build a lot more stable, at the cost of rare slow builds. 
The real underlying issue here is the network stability of our CI servers.

## Brief change log

- increase timeout to 900 seconds.


## Verifying this change

Tested on personal CI with a test that blocks for 25 minutes: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8015&view=logs&j=6e58d712-c5cc-52fb-0895-6ff7bd56c46b&t=e3cf9aa2-7cef-56d5-4b97-323ea6f63062