### PR TITLE
[FLINK-17799][network] Fix performance regression in the network stack

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
@@ -41,6 +41,8 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 
 	private RecordDeserializer<T> currentRecordDeserializer;
 
+	private boolean requestedPartitions;
+
 	private boolean isFinished;
 
 	/**
@@ -66,7 +68,10 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 		// The action of partition request was removed from InputGate#setup since FLINK-16536, and this is the only
 		// unified way for launching partition request for batch jobs. In order to avoid potential performance concern,
 		// we might consider migrating this action back to the setup based on some condition judgement future.
-		inputGate.requestPartitions();
+		if (!requestedPartitions) {
+			inputGate.requestPartitions();
+			requestedPartitions = true;
+		}
 
 		if (isFinished) {
 			return false;


### PR DESCRIPTION
FLINK-16536 (re) introduced requestPartitions on critical path of AbstractRecordReader, which
amounts to couple of viritual calls, one lock acquisition and one volatile read. This overhead
is what's cuasing performance drop.

We can avoid subsequentional redundant calls, by checking against a local variable if we have
already requested partitions or not.

Benchmark: networkThroughput: (channelsFlushTimeout = 100,100ms)
results after the fix:
~49000 ops/ms
before:
~11000 ops/ms

## Verifying this change

This change is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
