### PR TITLE
[FLINK-17745] Remove nested jar handling from PackagedProgram

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -222,12 +222,7 @@ public class CliFrontend {
 				getEffectiveConfiguration(commandLine, programOptions, jobJars);
 
 		LOG.debug("Effective executor configuration: {}", effectiveConfiguration);
-
-		try {
-			executeProgram(effectiveConfiguration, program);
-		} finally {
-			program.deleteExtractedLibraries();
-		}
+		executeProgram(effectiveConfiguration, program);
 	}
 
 	private PackagedProgram getPackagedProgram(ProgramOptions programOptions) throws ProgramInvocationException, CliArgsException {
@@ -284,41 +279,34 @@ public class CliFrontend {
 		LOG.info("Building program from JAR file");
 		final PackagedProgram program = buildProgram(programOptions);
 
-		try {
-			int parallelism = programOptions.getParallelism();
-			if (ExecutionConfig.PARALLELISM_DEFAULT == parallelism) {
-				parallelism = defaultParallelism;
-			}
-
-			LOG.info("Creating program plan dump");
-
-			final Configuration effectiveConfiguration =
-					getEffectiveConfiguration(commandLine, programOptions, program.getJobJarAndDependencies());
-
-			Pipeline pipeline = PackagedProgramUtils.getPipelineFromProgram(program, effectiveConfiguration, parallelism, true);
-			String jsonPlan = FlinkPipelineTranslationUtil.translateToJSONExecutionPlan(pipeline);
-
-			if (jsonPlan != null) {
-				System.out.println("----------------------- Execution Plan -----------------------");
-				System.out.println(jsonPlan);
-				System.out.println("--------------------------------------------------------------");
-			}
-			else {
-				System.out.println("JSON plan could not be generated.");
-			}
-
-			String description = program.getDescription();
-			if (description != null) {
-				System.out.println();
-				System.out.println(description);
-			}
-			else {
-				System.out.println();
-				System.out.println("No description provided.");
-			}
+		int parallelism = programOptions.getParallelism();
+		if (ExecutionConfig.PARALLELISM_DEFAULT == parallelism) {
+			parallelism = defaultParallelism;
 		}
-		finally {
-			program.deleteExtractedLibraries();
+
+		LOG.info("Creating program plan dump");
+
+		final Configuration effectiveConfiguration =
+				getEffectiveConfiguration(commandLine, programOptions, program.getJobJarAndDependencies());
+
+		Pipeline pipeline = PackagedProgramUtils.getPipelineFromProgram(program, effectiveConfiguration, parallelism, true);
+		String jsonPlan = FlinkPipelineTranslationUtil.translateToJSONExecutionPlan(pipeline);
+
+		if (jsonPlan != null) {
+			System.out.println("----------------------- Execution Plan -----------------------");
+			System.out.println(jsonPlan);
+			System.out.println("--------------------------------------------------------------");
+		} else {
+			System.out.println("JSON plan could not be generated.");
+		}
+
+		String description = program.getDescription();
+		if (description != null) {
+			System.out.println();
+			System.out.println(description);
+		} else {
+			System.out.println();
+			System.out.println("No description provided.");
 		}
 	}
 
@@ -1099,5 +1087,4 @@ public class CliFrontend {
 
 		return constructor.newInstance(params);
 	}
-
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -19,20 +19,13 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.client.cli.CliFrontendTestUtils;
-import org.apache.flink.configuration.ConfigConstants;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.nio.file.Files;
 import java.util.Collections;
-import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import static org.apache.flink.client.cli.CliFrontendTestUtils.TEST_JAR_MAIN_CLASS;
 
@@ -43,23 +36,6 @@ public class PackagedProgramTest {
 
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-	@Test
-	public void testExtractContainedLibraries() throws Exception {
-		String s = "testExtractContainedLibraries";
-		byte[] nestedJarContent = s.getBytes(ConfigConstants.DEFAULT_CHARSET);
-		File fakeJar = temporaryFolder.newFile("test.jar");
-		try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(fakeJar))) {
-			ZipEntry entry = new ZipEntry("lib/internalTest.jar");
-			zos.putNextEntry(entry);
-			zos.write(nestedJarContent);
-			zos.closeEntry();
-		}
-
-		final List<File> files = PackagedProgram.extractContainedLibraries(fakeJar.toURI().toURL());
-		Assert.assertEquals(1, files.size());
-		Assert.assertArrayEquals(nestedJarContent, Files.readAllBytes(files.iterator().next().toPath()));
-	}
 
 	@Test
 	public void testNotThrowExceptionWhenJarFileIsNull() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

The `PackagesProgram` so far was looking in the user's jar for other jars under a `lib/` directory it was extracting them, copy them to separate files, and put them in the `PipelineOptions.JARS` option during submission. 

At first, this way of submission seems counterintuitive and second,  it seems redundant, as we already ship the original jar which contains these nested jars.

This PR removes this behavior.

## Brief change log

Changes are confined in the `PackagedProgram` class and they are tested through already existing tests including the `e2e` tests that submit jobs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
