### PR TITLE
[FLINK-17027][hotfix] Rename back-off infix to backoff in new Elasticsearch properties

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1102,7 +1102,7 @@ connector:
       max-size: 42 mb           # optional: maximum size of buffered actions in bytes per bulk request
                                 #   (only MB granularity is supported)
       interval: 60000           # optional: bulk flush interval (in milliseconds)
-      back-off:                 # optional: backoff strategy ("disabled" by default)
+      backoff:                 # optional: backoff strategy ("disabled" by default)
         type: ...               #   valid strategies are "disabled", "constant", or "exponential"
         max-retries: 3          # optional: maximum number of retries
         delay: 30000            # optional: delay between each backoff attempt (in milliseconds)

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -969,11 +969,11 @@ CREATE TABLE MyUserTable (
                                               -- per bulk request
                                               -- (only MB granularity is supported)
   'connector.bulk-flush.interval' = '60000',  -- optional: bulk flush interval (in milliseconds)
-  'connector.bulk-flush.back-off.type' = '...',       -- optional: backoff strategy ("disabled" by default)
+  'connector.bulk-flush.backoff.type' = '...',       -- optional: backoff strategy ("disabled" by default)
                                                       -- valid strategies are "disabled", "constant",
                                                       -- or "exponential"
-  'connector.bulk-flush.back-off.max-retries' = '3',  -- optional: maximum number of retries
-  'connector.bulk-flush.back-off.delay' = '30000',    -- optional: delay between each backoff attempt
+  'connector.bulk-flush.backoff.max-retries' = '3',  -- optional: maximum number of retries
+  'connector.bulk-flush.backoff.delay' = '30000',    -- optional: delay between each backoff attempt
                                                       -- (in milliseconds)
 
   -- optional: connection properties to be used during REST communication to Elasticsearch
@@ -1100,7 +1100,7 @@ connector:
       max-size: 42 mb           # optional: maximum size of buffered actions in bytes per bulk request
                                 #   (only MB granularity is supported)
       interval: 60000           # optional: bulk flush interval (in milliseconds)
-      back-off:                 # optional: backoff strategy ("disabled" by default)
+      backoff:                 # optional: backoff strategy ("disabled" by default)
         type: ...               #   valid strategies are "disabled", "constant", or "exponential"
         max-retries: 3          # optional: maximum number of retries
         delay: 30000            # optional: delay between each backoff attempt (in milliseconds)

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchOptions.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchOptions.java
@@ -97,17 +97,17 @@ public class ElasticsearchOptions {
 			.noDefaultValue()
 			.withDescription("Bulk flush interval");
 	public static final ConfigOption<BackOffType> BULK_FLUSH_BACKOFF_TYPE_OPTION =
-		ConfigOptions.key("sink.bulk-flush.back-off.strategy")
+		ConfigOptions.key("sink.bulk-flush.backoff.strategy")
 			.enumType(BackOffType.class)
 			.defaultValue(BackOffType.DISABLED)
 			.withDescription("Backoff strategy");
 	public static final ConfigOption<Integer> BULK_FLUSH_BACKOFF_MAX_RETRIES_OPTION =
-		ConfigOptions.key("sink.bulk-flush.back-off.max-retries")
+		ConfigOptions.key("sink.bulk-flush.backoff.max-retries")
 			.intType()
 			.noDefaultValue()
 			.withDescription("Maximum number of retries.");
 	public static final ConfigOption<Duration> BULK_FLUSH_BACKOFF_DELAY_OPTION =
-		ConfigOptions.key("sink.bulk-flush.back-off.delay")
+		ConfigOptions.key("sink.bulk-flush.backoff.delay")
 			.durationType()
 			.noDefaultValue()
 			.withDescription("Delay between each backoff attempt.");

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactoryTest.java
@@ -122,7 +122,7 @@ public class Elasticsearch6DynamicSinkFactoryTest {
 
 		thrown.expect(ValidationException.class);
 		thrown.expectMessage(
-			"'sink.bulk-flush.back-off.max-retries' must be at least 1. Got: 0");
+			"'sink.bulk-flush.backoff.max-retries' must be at least 1. Got: 0");
 		sinkFactory.createDynamicTableSink(
 			context()
 				.withSchema(TableSchema.builder()
@@ -162,7 +162,7 @@ public class Elasticsearch6DynamicSinkFactoryTest {
 
 		thrown.expect(ValidationException.class);
 		thrown.expectMessage(
-			"Invalid value for option 'sink.bulk-flush.back-off.delay'.");
+			"Invalid value for option 'sink.bulk-flush.backoff.delay'.");
 		sinkFactory.createDynamicTableSink(
 			context()
 				.withSchema(TableSchema.builder()

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactoryTest.java
@@ -118,7 +118,7 @@ public class Elasticsearch7DynamicSinkFactoryTest {
 
 		thrown.expect(ValidationException.class);
 		thrown.expectMessage(
-			"'sink.bulk-flush.back-off.max-retries' must be at least 1. Got: 0");
+			"'sink.bulk-flush.backoff.max-retries' must be at least 1. Got: 0");
 		sinkFactory.createDynamicTableSink(
 			context()
 				.withSchema(TableSchema.builder()
@@ -156,7 +156,7 @@ public class Elasticsearch7DynamicSinkFactoryTest {
 
 		thrown.expect(ValidationException.class);
 		thrown.expectMessage(
-			"Invalid value for option 'sink.bulk-flush.back-off.delay'.");
+			"Invalid value for option 'sink.bulk-flush.backoff.delay'.");
 		sinkFactory.createDynamicTableSink(
 			context()
 				.withSchema(TableSchema.builder()


### PR DESCRIPTION
Trivial fix of a typo in an infix of es properties.