### PR TITLE
[FLINK-15792][k8s] Make Flink logs accessible via kubectl logs per default

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -28,7 +28,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.container-start-command-template</h5></td>
-            <td style="word-wrap: break-word;">"%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args% %redirects%"</td>
+            <td style="word-wrap: break-word;">"%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args%"</td>
             <td>String</td>
             <td>Template for the kubernetes jobmanager and taskmanager container start invocation.</td>
         </tr>

--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -154,8 +154,8 @@ $ kubectl delete deployment/<ClusterID>
 
 ## Log Files
 
-By default, the JobManager and TaskManager will output the logs to console and `/opt/flink/log` in each pod simultaneously.
-The STDOUT and STDERR will only be redirected to console. You could check for them via `kubectl logs <PodName>`.
+By default, the JobManager and TaskManager will output the logs to the console and `/opt/flink/log` in each pod simultaneously.
+The STDOUT and STDERR will only be redirected to the console. You can access them via `kubectl logs <PodName>`.
 
 If the pod is running, you can also use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process.
 

--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -154,23 +154,10 @@ $ kubectl delete deployment/<ClusterID>
 
 ## Log Files
 
-By default, the JobManager and TaskManager only store logs under `/opt/flink/log` in each pod.
-If you want to use `kubectl logs <PodName>` to view the logs, you must perform the following:
+By default, the JobManager and TaskManager will output the logs to console and `/opt/flink/log` in each pod simultaneously.
+The STDOUT and STDERR will only be redirected to console. You could check for them via `kubectl logs <PodName>`.
 
-1. Add a new appender to the log4j.properties in the Flink client.
-2. Add the following 'appenderRef' the rootLogger in log4j.properties `rootLogger.appenderRef.console.ref = ConsoleAppender`.
-3. Remove the redirect args by adding config option `-Dkubernetes.container-start-command-template="%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args%"`.
-4. Stop and start your session again. Now you could use `kubectl logs` to view your logs.
-
-{% highlight bash %}
-# Log all infos to the console
-appender.console.name = ConsoleAppender
-appender.console.type = CONSOLE
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
-{% endhighlight %}
-
-If the pod is running, you can use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process.
+If the pod is running, you can also use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process.
 
 ## Flink Kubernetes Application
 

--- a/docs/ops/deployment/native_kubernetes.zh.md
+++ b/docs/ops/deployment/native_kubernetes.zh.md
@@ -151,23 +151,10 @@ $ kubectl delete deployment/<ClusterID>
 
 ## 日志文件
 
-默认情况下，JobManager 和 TaskManager 只把日志存储在每个 pod 中的 `/opt/flink/log` 下。
-如果要使用 `kubectl logs <PodName>` 查看日志，必须执行以下操作：
+默认情况下，JobManager 和 TaskManager 会把日志同时输出到console和每个 pod 中的 `/opt/flink/log` 下。
+STDOUT 和 STDERR 只会输出到console。你可以使用 `kubectl logs <PodName>` 来访问它们。
 
-1. 在 Flink 客户端的 log4j.properties 中增加新的 appender。
-2. 在 log4j.properties 的 rootLogger 中增加如下 'appenderRef'，`rootLogger.appenderRef.console.ref = ConsoleAppender`。
-3. 通过增加配置项 `-Dkubernetes.container-start-command-template="%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args%"` 来删除重定向的参数。
-4. 停止并重启你的 session。现在你可以使用 `kubectl logs` 查看日志了。
-
-{% highlight bash %}
-# Log all infos to the console
-appender.console.name = ConsoleAppender
-appender.console.type = CONSOLE
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
-{% endhighlight %}
-
-如果 pod 正在运行，可以使用 `kubectl exec -it <PodName> bash` 进入 pod 并查看日志或调试进程。
+如果 pod 正在运行，还可以使用 `kubectl exec -it <PodName> bash` 进入 pod 并查看日志或调试进程。
 
 ## Flink Kubernetes Application
 

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -141,10 +141,7 @@ function wait_rest_endpoint_up_k8s {
   # wait at most 30 seconds until the endpoint is up
   local TIMEOUT=30
   for i in $(seq 1 ${TIMEOUT}); do
-    QUERY_RESULT=$(kubectl logs $jm_pod_name 2> /dev/null)
-
-    # ensure the response adapts with the successful regex
-    if [[ ${QUERY_RESULT} =~ ${successful_response_regex} ]]; then
+    if check_logs_output $jm_pod_name $successful_response_regex; then
       echo "REST endpoint is up."
       return
     fi
@@ -154,6 +151,18 @@ function wait_rest_endpoint_up_k8s {
   done
   echo "REST endpoint has not started within a timeout of ${TIMEOUT} sec"
   exit 1
+}
+
+function check_logs_output {
+  local pod_name=$1
+  local successful_response_regex=$2
+  LOG_CONTENT=$(kubectl logs $pod_name 2> /dev/null)
+
+  # ensure the log content adapts with the successful regex
+  if [[ ${LOG_CONTENT} =~ ${successful_response_regex} ]]; then
+    return 0
+  fi
+  return 1
 }
 
 function cleanup {

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -165,16 +165,4 @@ function cleanup {
     stop_kubernetes
 }
 
-function setConsoleLogging {
-    cat >> $FLINK_DIR/conf/log4j.properties <<END
-rootLogger.appenderRef.console.ref = ConsoleAppender
-
-# Log all infos to the console
-appender.console.name = ConsoleAppender
-appender.console.type = CONSOLE
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %-60c %x - %m%n
-END
-}
-
 on_exit cleanup

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
@@ -29,8 +29,6 @@ function internal_cleanup {
     kubectl delete clusterrolebinding ${CLUSTER_ROLE_BINDING}
 }
 
-setConsoleLogging
-
 start_kubernetes
 
 build_image ${FLINK_IMAGE_NAME}
@@ -46,7 +44,6 @@ mkdir -p "$LOCAL_LOGS_PATH"
     -Djobmanager.memory.process.size=1088m \
     -Dkubernetes.jobmanager.cpu=0.5 \
     -Dkubernetes.taskmanager.cpu=0.5 \
-    -Dkubernetes.container-start-command-template="%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args%" \
     -Dkubernetes.rest-service.exposed.type=NodePort \
     local:///opt/flink/examples/batch/WordCount.jar
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
@@ -31,20 +31,6 @@ function internal_cleanup {
     kubectl delete clusterrolebinding ${CLUSTER_ROLE_BINDING}
 }
 
-function setConsoleLogging {
-    cat >> $FLINK_DIR/conf/log4j.properties <<END
-rootLogger.appenderRef.console.ref = ConsoleAppender
-
-# Log all infos to the console
-appender.console.name = ConsoleAppender
-appender.console.type = CONSOLE
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %-60c %x - %m%n
-END
-}
-
-setConsoleLogging
-
 start_kubernetes
 
 build_image ${FLINK_IMAGE_NAME}
@@ -59,7 +45,6 @@ mkdir -p "$(dirname $LOCAL_OUTPUT_PATH)"
     -Djobmanager.memory.process.size=1088m \
     -Dkubernetes.jobmanager.cpu=0.5 \
     -Dkubernetes.taskmanager.cpu=0.5 \
-    -Dkubernetes.container-start-command-template="%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args%" \
     -Dkubernetes.rest-service.exposed.type=NodePort
 
 kubectl wait --for=condition=Available --timeout=30s deploy/${CLUSTER_ID} || exit 1

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -102,7 +102,7 @@ public class KubernetesConfigOptions {
 	public static final ConfigOption<String> CONTAINER_START_COMMAND_TEMPLATE =
 		key("kubernetes.container-start-command-template")
 		.stringType()
-		.defaultValue("%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args% %redirects%")
+		.defaultValue("%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args%")
 		.withDescription("Template for the kubernetes jobmanager and taskmanager container start invocation.");
 
 	public static final ConfigOption<Map<String, String>> JOB_MANAGER_LABELS =

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -27,8 +27,8 @@ public class Constants {
 	public static final String API_VERSION = "v1";
 	public static final String APPS_API_VERSION = "apps/v1";
 
-	public static final String CONFIG_FILE_LOGBACK_NAME = "logback.xml";
-	public static final String CONFIG_FILE_LOG4J_NAME = "log4j.properties";
+	public static final String CONFIG_FILE_LOGBACK_NAME = "logback-console.xml";
+	public static final String CONFIG_FILE_LOG4J_NAME = "log4j-console.properties";
 
 	public static final String FLINK_CONF_VOLUME = "flink-config-volume";
 	public static final String CONFIG_MAP_PREFIX = "flink-config-";

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -213,10 +215,10 @@ public class KubernetesUtils {
 		if (hasLogback || hasLog4j) {
 			logging.append("-Dlog.file=").append(logFile);
 			if (hasLogback) {
-				logging.append(" -Dlogback.configurationFile=file:").append(confDir).append("/logback.xml");
+				logging.append(" -Dlogback.configurationFile=file:").append(confDir).append("/").append(CONFIG_FILE_LOGBACK_NAME);
 			}
 			if (hasLog4j) {
-				logging.append(" -Dlog4j.configurationFile=file:").append(confDir).append("/log4j.properties");
+				logging.append(" -Dlog4j.configurationFile=file:").append(confDir).append("/").append(CONFIG_FILE_LOG4J_NAME);
 			}
 		}
 		return logging.toString();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -177,10 +177,6 @@ public class KubernetesUtils {
 
 		startCommandValues.put("args", mainArgs != null ? mainArgs : "");
 
-		startCommandValues.put("redirects",
-			"1> " + logDirectory + "/" + logFileName + ".out " +
-			"2> " + logDirectory + "/" + logFileName + ".err");
-
 		final String commandTemplate = flinkConfig.getString(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE);
 		return BootstrapTools.getStartCommand(commandTemplate, startCommandValues);
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -218,7 +218,8 @@ public class KubernetesUtils {
 				logging.append(" -Dlogback.configurationFile=file:").append(confDir).append("/").append(CONFIG_FILE_LOGBACK_NAME);
 			}
 			if (hasLog4j) {
-				logging.append(" -Dlog4j.configurationFile=file:").append(confDir).append("/").append(CONFIG_FILE_LOG4J_NAME);
+				logging.append(" -Dlog4j.configuration=file:").append(confDir).append("/").append(CONFIG_FILE_LOG4J_NAME)
+					.append(" -Dlog4j.configurationFile=file:").append(confDir).append("/").append(CONFIG_FILE_LOG4J_NAME);
 			}
 		}
 		return logging.toString();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -87,8 +89,8 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
 	protected void onSetup() throws Exception {
 		super.onSetup();
 
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
 		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
 			.setMasterMemoryMB(JOB_MANAGER_MEMORY)

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecoratorTest.java
@@ -45,6 +45,8 @@ import java.util.Map;
 
 import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILENAME;
 import static org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator.getFlinkConfConfigMapName;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -83,8 +85,8 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 
 	@Test
 	public void testConfigMap() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final List<HasMetadata> additionalResources = flinkConfMountDecorator.buildAccompanyingKubernetesResources();
 		assertEquals(1, additionalResources.size());
@@ -98,8 +100,8 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 		assertEquals(getCommonLabels(), resultConfigMap.getMetadata().getLabels());
 
 		Map<String, String> resultDatas = resultConfigMap.getData();
-		assertEquals("some data", resultDatas.get("logback.xml"));
-		assertEquals("some data", resultDatas.get("log4j.properties"));
+		assertEquals("some data", resultDatas.get(CONFIG_FILE_LOGBACK_NAME));
+		assertEquals("some data", resultDatas.get(CONFIG_FILE_LOG4J_NAME));
 
 		final Configuration resultFlinkConfig = KubernetesTestUtils.loadConfigurationFromString(
 			resultDatas.get(FLINK_CONF_FILENAME));
@@ -138,14 +140,14 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 
 	@Test
 	public void testDecoratedFlinkPodWithLog4j() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
 		final FlinkPod resultFlinkPod = flinkConfMountDecorator.decorateFlinkPod(baseFlinkPod);
 
 		final List<KeyToPath> expectedKeyToPaths = Arrays.asList(
 			new KeyToPathBuilder()
-				.withKey("log4j.properties")
-				.withPath("log4j.properties")
+				.withKey(CONFIG_FILE_LOG4J_NAME)
+				.withPath(CONFIG_FILE_LOG4J_NAME)
 				.build(),
 			new KeyToPathBuilder()
 				.withKey(FLINK_CONF_FILENAME)
@@ -164,14 +166,14 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 
 	@Test
 	public void testDecoratedFlinkPodWithLogback() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final FlinkPod resultFlinkPod = flinkConfMountDecorator.decorateFlinkPod(baseFlinkPod);
 
 		final List<KeyToPath> expectedKeyToPaths = Arrays.asList(
 			new KeyToPathBuilder()
-				.withKey("logback.xml")
-				.withPath("logback.xml")
+				.withKey(CONFIG_FILE_LOGBACK_NAME)
+				.withPath(CONFIG_FILE_LOGBACK_NAME)
 				.build(),
 			new KeyToPathBuilder()
 				.withKey(FLINK_CONF_FILENAME)
@@ -190,19 +192,19 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 
 	@Test
 	public void testDecoratedFlinkPodWithLog4jAndLogback() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final FlinkPod resultFlinkPod = flinkConfMountDecorator.decorateFlinkPod(baseFlinkPod);
 
 		final List<KeyToPath> expectedKeyToPaths = Arrays.asList(
 			new KeyToPathBuilder()
-				.withKey("logback.xml")
-				.withPath("logback.xml")
+				.withKey(CONFIG_FILE_LOGBACK_NAME)
+				.withPath(CONFIG_FILE_LOGBACK_NAME)
 				.build(),
 			new KeyToPathBuilder()
-				.withKey("log4j.properties")
-				.withPath("log4j.properties")
+				.withKey(CONFIG_FILE_LOG4J_NAME)
+				.withPath(CONFIG_FILE_LOG4J_NAME)
 				.build(),
 			new KeyToPathBuilder()
 				.withKey(FLINK_CONF_FILENAME)

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -54,9 +56,9 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	// Logging variables
 	private static final String logback =
-			String.format("-Dlogback.configurationFile=file:%s/logback.xml", FLINK_CONF_DIR_IN_POD);
+			String.format("-Dlogback.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOGBACK_NAME);
 	private static final String log4j =
-			String.format("-Dlog4j.configurationFile=file:%s/log4j.properties", FLINK_CONF_DIR_IN_POD);
+			String.format("-Dlog4j.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOG4J_NAME);
 	private static final String jmLogfile = String.format("-Dlog.file=%s/jobmanager.log", FLINK_LOG_DIR_IN_POD);
 	private static final String jmLogRedirects =
 			String.format("1> %s/jobmanager.out 2> %s/jobmanager.err",
@@ -108,7 +110,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	@Test
 	public void testStartCommandWithLog4j() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
 		final Container resultMainContainer =
 				javaCmdJobManagerDecorator.decorateFlinkPod(baseFlinkPod).getMainContainer();
@@ -122,7 +124,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	@Test
 	public void testStartCommandWithLogback() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final Container resultMainContainer =
 				javaCmdJobManagerDecorator.decorateFlinkPod(baseFlinkPod).getMainContainer();
@@ -136,8 +138,8 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	@Test
 	public void testStartCommandWithLog4jAndLogback() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final Container resultMainContainer =
 				javaCmdJobManagerDecorator.decorateFlinkPod(baseFlinkPod).getMainContainer();
@@ -152,8 +154,8 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	@Test
 	public void testStartCommandWithLogAndJVMOpts() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		flinkConfig.set(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 		final Container resultMainContainer =
@@ -169,8 +171,8 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	@Test
 	public void testStartCommandWithLogAndJMOpts() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		flinkConfig.set(CoreOptions.FLINK_JM_JVM_OPTIONS, jvmOpts);
 		final Container resultMainContainer =
@@ -184,8 +186,8 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	@Test
 	public void testContainerStartCommandTemplate1() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
 				"%java% 1 %classpath% 2 %jvmmem% %jvmopts% %logging% %class% %args% %redirects%";
@@ -212,8 +214,8 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 	@Test
 	public void testContainerStartCommandTemplate2() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
 				"%java% %jvmmem% %logging% %jvmopts% %class% %args% %redirects%";

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
@@ -64,9 +64,6 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		FLINK_CONF_DIR_IN_POD,
 		CONFIG_FILE_LOG4J_NAME);
 	private static final String jmLogfile = String.format("-Dlog.file=%s/jobmanager.log", FLINK_LOG_DIR_IN_POD);
-	private static final String jmLogRedirects =
-			String.format("1> %s/jobmanager.out 2> %s/jobmanager.err",
-					FLINK_LOG_DIR_IN_POD, FLINK_LOG_DIR_IN_POD);
 
 	// Memory variables
 	private final String jmJvmMem = JobManagerProcessUtils.generateJvmParametersStr(
@@ -194,7 +191,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
-				"%java% 1 %classpath% 2 %jvmmem% %jvmopts% %logging% %class% %args% %redirects%";
+				"%java% 1 %classpath% 2 %jvmmem% %jvmopts% %logging% %class% %args%";
 		this.flinkConfig.set(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE,
 				containerStartCommandTemplate);
 
@@ -210,7 +207,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		final String expectedCommand = java + " 1 " + classpath + " 2 " + jmJvmMem +
 				" " + jvmOpts + " " + jmJvmOpts +
 				" " + jmLogfile + " " + logback + " " + log4j +
-				" " + ENTRY_POINT_CLASS + " " + jmLogRedirects;
+				" " + ENTRY_POINT_CLASS;
 
 		final List<String> expectedArgs = Arrays.asList("/bin/bash", "-c", expectedCommand);
 		assertEquals(resultMainContainer.getArgs(), expectedArgs);
@@ -222,7 +219,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
-				"%java% %jvmmem% %logging% %jvmopts% %class% %args% %redirects%";
+				"%java% %jvmmem% %logging% %jvmopts% %class% %args%";
 		this.flinkConfig.set(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE,
 				containerStartCommandTemplate);
 
@@ -238,7 +235,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		final String expectedCommand = java + " " + jmJvmMem +
 				" " + jmLogfile + " " + logback + " " + log4j +
 				" " + jvmOpts + " " + jmJvmOpts +
-				" " + ENTRY_POINT_CLASS + " " + jmLogRedirects;
+				" " + ENTRY_POINT_CLASS;
 
 		final List<String> expectedArgs = Arrays.asList("/bin/bash", "-c", expectedCommand);
 		assertEquals(resultMainContainer.getArgs(), expectedArgs);
@@ -248,6 +245,6 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		return java + " " + classpath + " " + jmJvmMem +
 				(jvmAllOpts.isEmpty() ? "" : " " + jvmAllOpts) +
 				(logging.isEmpty() ? "" : " " + jmLogfile + " " + logging) +
-				" " + ENTRY_POINT_CLASS + " " + jmLogRedirects;
+				" " + ENTRY_POINT_CLASS;
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
@@ -57,8 +57,12 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 	// Logging variables
 	private static final String logback =
 			String.format("-Dlogback.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOGBACK_NAME);
-	private static final String log4j =
-			String.format("-Dlog4j.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOG4J_NAME);
+	private static final String log4j = String.format(
+		"-Dlog4j.configuration=file:%s/%s -Dlog4j.configurationFile=file:%s/%s",
+		FLINK_CONF_DIR_IN_POD,
+		CONFIG_FILE_LOG4J_NAME,
+		FLINK_CONF_DIR_IN_POD,
+		CONFIG_FILE_LOG4J_NAME);
 	private static final String jmLogfile = String.format("-Dlog.file=%s/jobmanager.log", FLINK_LOG_DIR_IN_POD);
 	private static final String jmLogRedirects =
 			String.format("1> %s/jobmanager.out 2> %s/jobmanager.err",

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
@@ -61,8 +61,12 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 	// Logging variables
 	private static final String logback =
 			String.format("-Dlogback.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOGBACK_NAME);
-	private static final String log4j =
-			String.format("-Dlog4j.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOG4J_NAME);
+	private static final String log4j = String.format(
+		"-Dlog4j.configuration=file:%s/%s -Dlog4j.configurationFile=file:%s/%s",
+		FLINK_CONF_DIR_IN_POD,
+		CONFIG_FILE_LOG4J_NAME,
+		FLINK_CONF_DIR_IN_POD,
+		CONFIG_FILE_LOG4J_NAME);
 	private static final String tmLogfile =
 			String.format("-Dlog.file=%s/taskmanager.log", FLINK_LOG_DIR_IN_POD);
 	private static final String tmLogRedirects = String.format(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
@@ -69,10 +69,6 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		CONFIG_FILE_LOG4J_NAME);
 	private static final String tmLogfile =
 			String.format("-Dlog.file=%s/taskmanager.log", FLINK_LOG_DIR_IN_POD);
-	private static final String tmLogRedirects = String.format(
-			"1> %s/taskmanager.out 2> %s/taskmanager.err",
-		FLINK_LOG_DIR_IN_POD,
-		FLINK_LOG_DIR_IN_POD);
 
 	private JavaCmdTaskManagerDecorator javaCmdTaskManagerDecorator;
 
@@ -195,7 +191,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
-				"%java% 1 %classpath% 2 %jvmmem% %jvmopts% %logging% %class% %args% %redirects%";
+				"%java% 1 %classpath% 2 %jvmmem% %jvmopts% %logging% %class% %args%";
 		this.flinkConfig.set(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE,
 				containerStartCommandTemplate);
 
@@ -210,7 +206,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		final String expectedCommand = java + " 1 " + classpath + " 2 " + tmJvmMem +
 				" " + jvmOpts + " " + tmJvmOpts +
 				" " + tmLogfile + " " + logback + " " + log4j +
-				" " + mainClass + " " + mainClassArgs + " " + tmLogRedirects;
+				" " + mainClass + " " + mainClassArgs;
 		final List<String> expectedArgs = Arrays.asList("/bin/bash", "-c", expectedCommand);
 		assertEquals(resultMainContainer.getArgs(), expectedArgs);
 	}
@@ -221,7 +217,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
-				"%java% %jvmmem% %logging% %jvmopts% %class% %args% %redirects%";
+				"%java% %jvmmem% %logging% %jvmopts% %class% %args%";
 		this.flinkConfig.set(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE,
 				containerStartCommandTemplate);
 
@@ -237,7 +233,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		final String expectedCommand = java + " " + tmJvmMem +
 				" " + tmLogfile + " " + logback + " " + log4j +
 				" " + jvmOpts + " " + tmJvmOpts + " " + mainClass +
-				" " + mainClassArgs + " " + tmLogRedirects;
+				" " + mainClassArgs;
 		final List<String> expectedArgs = Arrays.asList("/bin/bash", "-c", expectedCommand);
 		assertEquals(resultMainContainer.getArgs(), expectedArgs);
 	}
@@ -246,6 +242,6 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		return java + " " + classpath + " " + tmJvmMem +
 				(jvmAllOpts.isEmpty() ? "" : " " + jvmAllOpts) +
 				(logging.isEmpty() ? "" : " " + tmLogfile + " " + logging) +
-				" " + mainClass + " " +  mainClassArgs + " " + tmLogRedirects;
+				" " + mainClass + " " +  mainClassArgs;
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
@@ -34,6 +34,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -58,9 +60,9 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	// Logging variables
 	private static final String logback =
-			String.format("-Dlogback.configurationFile=file:%s/logback.xml", FLINK_CONF_DIR_IN_POD);
+			String.format("-Dlogback.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOGBACK_NAME);
 	private static final String log4j =
-			String.format("-Dlog4j.configurationFile=file:%s/log4j.properties", FLINK_CONF_DIR_IN_POD);
+			String.format("-Dlog4j.configurationFile=file:%s/%s", FLINK_CONF_DIR_IN_POD, CONFIG_FILE_LOG4J_NAME);
 	private static final String tmLogfile =
 			String.format("-Dlog.file=%s/taskmanager.log", FLINK_LOG_DIR_IN_POD);
 	private static final String tmLogRedirects = String.format(
@@ -111,7 +113,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	@Test
 	public void testStartCommandWithLog4j() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
 		final Container resultMainContainer =
 			javaCmdTaskManagerDecorator.decorateFlinkPod(this.baseFlinkPod).getMainContainer();
@@ -125,7 +127,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	@Test
 	public void testStartCommandWithLogback() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final Container resultMainContainer =
 			javaCmdTaskManagerDecorator.decorateFlinkPod(this.baseFlinkPod).getMainContainer();
@@ -139,8 +141,8 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	@Test
 	public void testStartCommandWithLog4jAndLogback() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
 		final Container resultMainContainer =
 			javaCmdTaskManagerDecorator.decorateFlinkPod(this.baseFlinkPod).getMainContainer();
@@ -153,8 +155,8 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	@Test
 	public void testStartCommandWithLogAndJVMOpts() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		flinkConfig.set(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 		final Container resultMainContainer =
@@ -170,8 +172,8 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	@Test
 	public void testStartCommandWithLogAndJMOpts() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		flinkConfig.set(CoreOptions.FLINK_TM_JVM_OPTIONS, jvmOpts);
 		final Container resultMainContainer =
@@ -185,8 +187,8 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	@Test
 	public void testContainerStartCommandTemplate1() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
 				"%java% 1 %classpath% 2 %jvmmem% %jvmopts% %logging% %class% %args% %redirects%";
@@ -211,8 +213,8 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 	@Test
 	public void testContainerStartCommandTemplate2() throws IOException {
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 
 		final String containerStartCommandTemplate =
 				"%java% %jvmmem% %logging% %jvmopts% %class% %args% %redirects%";

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -49,6 +49,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILENAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -79,8 +81,8 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	protected void onSetup() throws Exception {
 		super.onSetup();
 
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
 		this.kubernetesJobManagerSpecification =
 			KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
@@ -212,8 +214,8 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 
 		final Map<String, String> resultDatas = resultConfigMap.getData();
 		assertEquals(3, resultDatas.size());
-		assertEquals("some data", resultDatas.get("log4j.properties"));
-		assertEquals("some data", resultDatas.get("logback.xml"));
+		assertEquals("some data", resultDatas.get(CONFIG_FILE_LOG4J_NAME));
+		assertEquals("some data", resultDatas.get(CONFIG_FILE_LOGBACK_NAME));
 		assertTrue(resultDatas.get(FLINK_CONF_FILENAME)
 			.contains(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS.key() + ": " + ENTRY_POINT_CLASS));
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -42,8 +44,8 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 	protected void onSetup() throws Exception {
 		super.onSetup();
 
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
-		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
+		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
 		setHadoopConfDirEnv();
 		generateHadoopConfFileItems();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the users could not view the JobManager/TaskManager logs via `kubectl logs` by default. It is not convenient especially for debugging(i.e. when the entrypoint failed). So this PR suggests to make the logs output to console by default. This is also aligned with standalone session/job cluster.

Note: After this change, the STDOUT/STDERR will be only accessible via `kubectl logs`. It means we could not access them in the Flink web dashboard.

## Brief change log

* Use constant logging variable to replace constant strings
* Add log4j1 configuration to JobManager and TaskManager start command
* Make Flink logs accessible via kubectl logs per default
* Remove logging section in native Kubernetes document


## Verifying this change

* Covered by existing decorator tests
* The existing `kubernetes-application.sh` could cover this change. It greps the expected logs from console.
* Manually test on a K8s cluster

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
