### PR TITLE
[FLINK-17805][networ] Fix ArrayIndexOutOfBound for rotated input gate indexes     

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -228,4 +228,9 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 	public InputChannel getChannel(int channelIndex) {
 		return inputGate.getChannel(channelIndex);
 	}
+
+	@VisibleForTesting
+	CheckpointBarrierHandler getCheckpointBarrierHandler() {
+		return barrierHandler;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -66,7 +66,7 @@ public class InputProcessorUtil {
 	 * @return a pair of {@link CheckpointedInputGate} created for two corresponding
 	 * {@link InputGate}s supplied as parameters.
 	 */
-	public static CheckpointedInputGate[] createCheckpointedInputGatePair(
+	public static CheckpointedInputGate[] createCheckpointedMultipleInputGate(
 			AbstractInvokable toNotifyOnCheckpoint,
 			StreamConfig config,
 			ChannelStateWriter channelStateWriter,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -91,7 +91,7 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			headOperator instanceof InputSelectable ? (InputSelectable) headOperator : null,
 			inputGates.length);
 
-		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedInputGatePair(
+		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedMultipleInputGate(
 			this,
 			getConfiguration(),
 			getChannelStateWriter(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -54,7 +54,7 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			headOperator instanceof InputSelectable ? (InputSelectable) headOperator : null);
 
 		// create an input instance for each input
-		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedInputGatePair(
+		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedMultipleInputGate(
 			this,
 			getConfiguration(),
 			getChannelStateWriter(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -33,8 +33,16 @@ import java.util.concurrent.ExecutorService;
  * Mock {@link IndexedInputGate}.
  */
 public class MockIndexedInputGate extends IndexedInputGate {
+	private final int gateIndex;
+	private final int numberOfInputChannels;
 
 	public MockIndexedInputGate() {
+		this(0, 1);
+	}
+
+	public MockIndexedInputGate(int gateIndex, int numberOfInputChannels) {
+		this.gateIndex = gateIndex;
+		this.numberOfInputChannels = numberOfInputChannels;
 	}
 
 	@Override
@@ -56,7 +64,7 @@ public class MockIndexedInputGate extends IndexedInputGate {
 
 	@Override
 	public int getNumberOfInputChannels() {
-		return 1;
+		return numberOfInputChannels;
 	}
 
 	@Override
@@ -93,6 +101,6 @@ public class MockIndexedInputGate extends IndexedInputGate {
 
 	@Override
 	public int getGateIndex() {
-		return 0;
+		return gateIndex;
 	}
 }


### PR DESCRIPTION
It's possible that indexes of passed InputGates are not monotonic - that left input has higher input gate index. This commit fixes an ArrayIndexOutOfBound caused by this.

## Verifying this change

This PR adds a dedicated unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
