### PR TITLE
[FLINK-17794][tests] Tear down installed software in reverse order

### DIFF
--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -109,7 +109,7 @@
     (teardown! [_ test node]
       (c/su
         (try
-          (doseq [db dbs] (db/teardown! db test node))
+          (doseq [db (reverse dbs)] (db/teardown! db test node))
           (finally (fu/stop-all-supervised-services!)))))
     db/LogFiles
     (log-files [_ test node]


### PR DESCRIPTION
## What is the purpose of the change

*Tear down installed software in reverse order in Jepsen tests. This mitigates the issue that sometimes YARN's NodeManager directories cannot be removed using `rm -rf` because Flink processes keep running and generate files after the YARN NodeManager is shut down. `rm -r` removes files recursively but if files are created in the background concurrently, the command can still fail with a non-zero exit code.*


## Brief change log

  - *See commits*

## Verifying this change

This change is already covered by existing tests, such as *flink-jepsen*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
