### PR TITLE
[FLINK-17802][kafka] Set offset commit only if group id is configured for new Kafka Table source

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -1115,7 +1115,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	}
 
 	@VisibleForTesting
-	boolean getEnableCommitOnCheckpoints() {
+	public boolean getEnableCommitOnCheckpoints() {
 		return enableCommitOnCheckpoints;
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSourceBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSourceBase.java
@@ -209,6 +209,7 @@ public abstract class KafkaDynamicSourceBase implements ScanTableSource {
 				kafkaConsumer.setStartFromTimestamp(startupTimestampMillis);
 				break;
 			}
+		kafkaConsumer.setCommitOffsetsOnCheckpoints(properties.getProperty("group.id") != null);
 		return kafkaConsumer;
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -170,24 +170,23 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		final StreamExecutionEnvironmentMock mock = new StreamExecutionEnvironmentMock();
 		actualKafkaSource.getDataStream(mock);
 		assertTrue(getExpectedFlinkKafkaConsumer().isAssignableFrom(mock.sourceFunction.getClass()));
+		// Test commitOnCheckpoints flag should be true when set consumer group.
 		assertTrue(((FlinkKafkaConsumerBase) mock.sourceFunction).getEnableCommitOnCheckpoints());
+	}
 
-		Properties propsWithoutGroupId = new Properties();
-		propsWithoutGroupId.setProperty("bootstrap.servers", "dummy");
-
-		final KafkaTableSourceBase sourceWithoutGroupId = getExpectedKafkaTableSource(
-			schema,
-			Optional.of(PROC_TIME),
-			rowtimeAttributeDescriptors,
-			fieldMapping,
-			TOPIC,
-			propsWithoutGroupId,
-			deserializationSchema,
-			StartupMode.LATEST,
-			new HashMap<>(),
-			0L);
-
-		sourceWithoutGroupId.getDataStream(mock);
+	@Test
+	public void testTableSourceCommitOnCheckpointsDisabled() {
+		Map<String, String> propertiesMap = new HashMap<>();
+		createKafkaSourceProperties().forEach((k, v) -> {
+			if (!k.equals("connector.properties.group.id")) {
+				propertiesMap.put(k, v);
+			}
+		});
+		final TableSource<?> tableSource = TableFactoryService.find(StreamTableSourceFactory.class, propertiesMap)
+			.createStreamTableSource(propertiesMap);
+		final StreamExecutionEnvironmentMock mock = new StreamExecutionEnvironmentMock();
+		// Test commitOnCheckpoints flag should be false when do not set consumer group.
+		((KafkaTableSourceBase) tableSource).getDataStream(mock);
 		assertTrue(mock.sourceFunction instanceof FlinkKafkaConsumerBase);
 		assertFalse(((FlinkKafkaConsumerBase) mock.sourceFunction).getEnableCommitOnCheckpoints());
 	}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request set `enableCommitOnCheckpoints` to be false if `group.id` was not specified.*


## Brief change log
update file:
 * org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
 * org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSourceBase.java

## Verifying this change

Add unit case to cover

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
