### PR TITLE
[FLINK-17820][task][checkpointing] Don't flush channel state to disk explicitly

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.ChannelStateWriteResult;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory.MemoryCheckpointOutputStream;
@@ -57,13 +58,7 @@ public class ChannelStateCheckpointWriterTest {
 				return null;
 			}
 		};
-		ChannelStateCheckpointWriter writer = new ChannelStateCheckpointWriter(
-				1L,
-				new ChannelStateWriteResult(),
-				stream,
-				new ChannelStateSerializerImpl(),
-				NO_OP_RUNNABLE
-		);
+		ChannelStateCheckpointWriter writer = createWriter(new ChannelStateWriteResult(), stream);
 		writer.completeOutput();
 		writer.completeInput();
 		assertTrue(stream.isClosed());
@@ -155,13 +150,11 @@ public class ChannelStateCheckpointWriterTest {
 	}
 
 	private ChannelStateCheckpointWriter createWriter(ChannelStateWriteResult result) throws Exception {
-		return new ChannelStateCheckpointWriter(
-			1L,
-			result,
-			new MemoryCheckpointOutputStream(1000),
-			new ChannelStateSerializerImpl(),
-			NO_OP_RUNNABLE
-		);
+		return createWriter(result, new MemoryCheckpointOutputStream(1000));
+	}
+
+	private ChannelStateCheckpointWriter createWriter(ChannelStateWriteResult result, CheckpointStateOutputStream stream) throws Exception {
+		return new ChannelStateCheckpointWriter(1L, result, stream, new ChannelStateSerializerImpl(), NO_OP_RUNNABLE);
 	}
 
 }


### PR DESCRIPTION
## What is the purpose of the change

See FLINK-17820 for full problem description. In short, Flink ignores `state.backend.fs.memory-threshold` and always creates a file per subtask per checkpoint.

This PR wraps `OutputStream` in `ChannelStateWriter` into a non-flushing one; so that data can be flushed from `DataOutputStream`, but not to disk.
This solution was chosen:
- over changing the original stream because of lower risk
- over not flushing in `ChannelStateWriter` because that could lead to data loss in `DataOutputStream`

## Verifying this change

Added `ChannelStateCheckpointWriterTest.testSmallFilesNotWritten`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicabl
