### PR TITLE
[hotfix][k8s] Remove unused constant variable

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -41,8 +41,6 @@ public class Constants {
 
 	public static final String FLINK_REST_SERVICE_SUFFIX = "-rest";
 
-	public static final String NAME_SEPARATOR = "-";
-
 	// Constants for label builder
 	public static final String LABEL_TYPE_KEY = "type";
 	public static final String LABEL_TYPE_NATIVE_TYPE = "flink-native-kubernetes";


### PR DESCRIPTION
## What is the purpose of the change

Remove unused constant variable of `Constants.NAME_SEPARATOR`.


## Verifying this change

This change is a trivial code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
