### PR TITLE
[FLINK-17189][table-planner] Table with proctime attribute cannot be read from Hive catalog

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.schema.Schema;
@@ -42,10 +43,16 @@ public class CatalogCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
+	private final SqlExprToRexConverterFactory converterFactory;
 
-	public CatalogCalciteSchema(String catalogName, CatalogManager catalog, boolean isStreamingMode) {
+	public CatalogCalciteSchema(
+			String catalogName,
+			CatalogManager catalog,
+			SqlExprToRexConverterFactory converterFactory,
+			boolean isStreamingMode) {
 		this.catalogName = catalogName;
 		this.catalogManager = catalog;
+		this.converterFactory = converterFactory;
 		this.isStreamingMode = isStreamingMode;
 	}
 
@@ -58,7 +65,8 @@ public class CatalogCalciteSchema extends FlinkSchema {
 	@Override
 	public Schema getSubSchema(String schemaName) {
 		if (catalogManager.schemaExists(catalogName, schemaName)) {
-			return new DatabaseCalciteSchema(schemaName, catalogName, catalogManager, isStreamingMode);
+			return new DatabaseCalciteSchema(
+					schemaName, catalogName, catalogManager, converterFactory, isStreamingMode);
 		} else {
 			return null;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
@@ -43,6 +43,8 @@ public class CatalogCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
+	// The SQL expression converter factory is used to derive correct result type of computed column,
+	// because the date type of computed column from catalog table is not trusted.
 	private final SqlExprToRexConverterFactory converterFactory;
 
 	public CatalogCalciteSchema(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.catalog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.schema.Schema;
@@ -44,10 +45,15 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
+	private final SqlExprToRexConverterFactory converterFactory;
 
-	public CatalogManagerCalciteSchema(CatalogManager catalogManager, boolean isStreamingMode) {
+	public CatalogManagerCalciteSchema(
+			CatalogManager catalogManager,
+			SqlExprToRexConverterFactory converterFactory,
+			boolean isStreamingMode) {
 		this.catalogManager = catalogManager;
 		this.isStreamingMode = isStreamingMode;
+		this.converterFactory = converterFactory;
 	}
 
 	@Override
@@ -63,7 +69,7 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
 	@Override
 	public Schema getSubSchema(String name) {
 		if (catalogManager.schemaExists(name)) {
-			return new CatalogCalciteSchema(name, catalogManager, isStreamingMode);
+			return new CatalogCalciteSchema(name, catalogManager, converterFactory, isStreamingMode);
 		} else {
 			return null;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
@@ -45,6 +45,8 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
+	// The SQL expression converter factory is used to derive correct result type of computed column,
+	// because the date type of computed column from catalog table is not trusted.
 	private final SqlExprToRexConverterFactory converterFactory;
 
 	public CatalogManagerCalciteSchema(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.factories.TableSourceFactoryContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 import org.apache.flink.table.planner.sources.TableSourceUtil;
 import org.apache.flink.table.sources.StreamTableSource;
@@ -69,6 +70,7 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	private final ObjectIdentifier tableIdentifier;
 	private final CatalogBaseTable catalogBaseTable;
 	private final FlinkStatistic statistic;
+	private final SqlExprToRexConverterFactory converterFactory;
 	private final boolean isStreamingMode;
 	private final boolean isTemporary;
 	private final Catalog catalog;
@@ -82,6 +84,7 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	 * @param catalogBaseTable CatalogBaseTable instance which exists in the catalog
 	 * @param statistic Table statistics
 	 * @param catalog The catalog which the schema table belongs to
+	 * @param converterFactory SqlExprToRexConverterFactory to convert compute column
 	 * @param isStreaming If the table is for streaming mode
 	 * @param isTemporary If the table is temporary
 	 */
@@ -90,12 +93,14 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 			CatalogBaseTable catalogBaseTable,
 			FlinkStatistic statistic,
 			Catalog catalog,
+			SqlExprToRexConverterFactory converterFactory,
 			boolean isStreaming,
 			boolean isTemporary) {
 		this.tableIdentifier = tableIdentifier;
 		this.catalogBaseTable = catalogBaseTable;
 		this.statistic = statistic;
 		this.catalog = catalog;
+		this.converterFactory = converterFactory;
 		this.isStreamingMode = isStreaming;
 		this.isTemporary = isTemporary;
 	}
@@ -179,10 +184,11 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 			}
 		}
 
-		return TableSourceUtil.getSourceRowType(flinkTypeFactory,
-			tableSchema,
-			scala.Option.empty(),
-			isStreamingMode);
+		return TableSourceUtil.getSourceRowTypeFromSchema(
+				converterFactory,
+				flinkTypeFactory,
+				tableSchema,
+				isStreamingMode);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -84,7 +84,9 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	 * @param catalogBaseTable CatalogBaseTable instance which exists in the catalog
 	 * @param statistic Table statistics
 	 * @param catalog The catalog which the schema table belongs to
-	 * @param converterFactory SqlExprToRexConverterFactory to convert compute column
+	 * @param converterFactory The SQL expression converter factory is used to derive correct result
+	 *                         type of computed column, because the date type of computed column
+	 *                         from catalog table is not trusted.
 	 * @param isStreaming If the table is for streaming mode
 	 * @param isTemporary If the table is temporary
 	 */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -56,6 +56,8 @@ class DatabaseCalciteSchema extends FlinkSchema {
 	private final String databaseName;
 	private final String catalogName;
 	private final CatalogManager catalogManager;
+	// The SQL expression converter factory is used to derive correct result type of computed column,
+	// because the date type of computed column from catalog table is not trusted.
 	private final SqlExprToRexConverterFactory converterFactory;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 
 import org.apache.calcite.linq4j.tree.Expression;
@@ -55,13 +56,20 @@ class DatabaseCalciteSchema extends FlinkSchema {
 	private final String databaseName;
 	private final String catalogName;
 	private final CatalogManager catalogManager;
+	private final SqlExprToRexConverterFactory converterFactory;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
 
-	public DatabaseCalciteSchema(String databaseName, String catalogName, CatalogManager catalog, boolean isStreamingMode) {
+	public DatabaseCalciteSchema(
+			String databaseName,
+			String catalogName,
+			CatalogManager catalog,
+			SqlExprToRexConverterFactory converterFactory,
+			boolean isStreamingMode) {
 		this.databaseName = databaseName;
 		this.catalogName = catalogName;
 		this.catalogManager = catalog;
+		this.converterFactory = converterFactory;
 		this.isStreamingMode = isStreamingMode;
 	}
 
@@ -72,10 +80,12 @@ class DatabaseCalciteSchema extends FlinkSchema {
 			.map(result -> {
 				CatalogBaseTable table = result.getTable();
 				FlinkStatistic statistic = getStatistic(result.isTemporary(), table, identifier);
-				return new CatalogSchemaTable(identifier,
+				return new CatalogSchemaTable(
+					identifier,
 					table,
 					statistic,
 					catalogManager.getCatalog(catalogName).orElseThrow(IllegalStateException::new),
+					converterFactory,
 					isStreamingMode,
 					result.isTemporary());
 			})

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -120,7 +120,7 @@ public class PlannerContext {
 		this.cluster = FlinkRelOptClusterFactory.create(planner, new RexBuilder(typeFactory));
 	}
 
-	private SqlExprToRexConverter createSqlExprToRexConverter(RelDataType rowType) {
+	public SqlExprToRexConverter createSqlExprToRexConverter(RelDataType rowType) {
 		return new SqlExprToRexConverterImpl(
 				checkNotNull(frameworkConfig),
 				checkNotNull(typeFactory),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
@@ -462,9 +462,9 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 				tableIdentifier = catalogManager.qualifyIdentifier(UnresolvedIdentifier.of(refId));
 			}
 
-			RelDataType rowType = TableSourceUtil.getSourceRowType(relBuilder.getTypeFactory(),
-				tableSourceOperation.getTableSchema(),
-				scala.Option.apply(tableSource),
+			RelDataType rowType = TableSourceUtil.getSourceRowTypeFromSource(
+				relBuilder.getTypeFactory(),
+				tableSource,
 				!isBatch);
 			LegacyTableSourceTable<?> tableSourceTable = new LegacyTableSourceTable<>(
 				relBuilder.getRelOptSchema(),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.planner.sources
 
-import org.apache.flink.table.api.{DataTypes, TableSchema, ValidationException, WatermarkSpec}
+import org.apache.flink.table.api.{DataTypes, TableColumn, TableSchema, ValidationException, WatermarkSpec}
 import org.apache.flink.table.expressions.ApiExpressionUtils.{typeLiteral, valueLiteral}
 import org.apache.flink.table.expressions.{CallExpression, Expression, ResolvedExpression, ResolvedFieldReference}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, SqlExprToRexConverterFactory}
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.runtime.types.DataTypePrecisionFixer
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
@@ -37,7 +39,7 @@ import org.apache.calcite.plan.RelOptCluster
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.LogicalValues
-import org.apache.calcite.rex.RexNode
+import org.apache.calcite.rex.{RexCall, RexNode}
 import org.apache.calcite.tools.RelBuilder
 
 import _root_.java.sql.Timestamp
@@ -117,26 +119,86 @@ object TableSourceUtil {
   }
 
   /**
+    * Returns schema of the selected fields of the given [[TableSchema]].
+    *
+    * @param converterFactory converter to convert computed columns.
+    * @param typeFactory Type factory to create the type
+    * @param tableSchema Table schema to derive table field names and data types
+    * @param streaming Flag to determine whether the schema of a stream or batch table is created
+    * @return The row type for the selected fields of the given [[TableSchema]], this type would
+    *         also be patched with time attributes defined in the give [[WatermarkSpec]]
+    */
+  def getSourceRowTypeFromSchema(
+      converterFactory: SqlExprToRexConverterFactory,
+      typeFactory: FlinkTypeFactory,
+      tableSchema: TableSchema,
+      streaming: Boolean): RelDataType = {
+    val fieldNames = tableSchema.getFieldNames
+    var fieldTypes = tableSchema.getFieldDataTypes.map(fromDataTypeToLogicalType)
+
+    // TODO: [FLINK-14473] we only support top-level rowtime attribute right now
+    val rowTimeIdx = if (tableSchema.getWatermarkSpecs.nonEmpty) {
+      val rowtime = tableSchema.getWatermarkSpecs.head.getRowtimeAttribute
+      if (rowtime.contains(".")) {
+        throw new ValidationException(
+          s"Nested field '$rowtime' as rowtime attribute is not supported right now.")
+      }
+      Some(fieldNames.indexOf(rowtime))
+    } else {
+      None
+    }
+
+    val converter = converterFactory.create(
+      typeFactory.buildRelNodeRowType(fieldNames, fieldTypes))
+    def isProctime(column: TableColumn): Boolean = {
+      toScala(column.getExpr).exists { expr =>
+        converter.convertToRexNode(expr) match {
+          case call: RexCall => call.getOperator == FlinkSqlOperatorTable.PROCTIME
+          case _ => false
+        }
+      }
+    }
+
+    fieldTypes = fieldTypes.zipWithIndex.map {
+      case (originalType, i) =>
+        if (streaming && rowTimeIdx.exists(_.equals(i))) {
+          new TimestampType(
+            originalType.isNullable,
+            TimestampKind.ROWTIME,
+            originalType.asInstanceOf[TimestampType].getPrecision)
+        } else if (isProctime(tableSchema.getTableColumn(i).get())) {
+          new TimestampType(
+            originalType.isNullable,
+            TimestampKind.PROCTIME,
+            originalType.asInstanceOf[TimestampType].getPrecision)
+        } else {
+          originalType
+        }
+    }
+
+    typeFactory.buildRelNodeRowType(fieldNames, fieldTypes)
+  }
+
+  /**
     * Returns schema of the selected fields of the given [[TableSource]].
     *
-    * @param typeFactory    Type factory to create the type
-    * @param fieldNameArray Field names to build the row type
-    * @param fieldDataTypeArray Field data types to build the row type
-    * @param tableSource    The [[TableSource]] to derive time attributes
-    * @param streaming      Flag to determine whether the schema of
-    *                       a stream or batch table is created
-    * @return The schema for the selected fields of the given [[TableSource]]
+    * <p> The watermark strategy specifications should either come from the [[TableSchema]]
+    * or [[TableSource]].
+    *
+    * @param typeFactory Type factory to create the type
+    * @param tableSource Table source to derive watermark strategies
+    * @param streaming Flag to determine whether the schema of a stream or batch table is created
+    * @return The row type for the selected fields of the given [[TableSource]], this type would
+    *         also be patched with time attributes defined in the give [[WatermarkSpec]]
     */
-  def getSourceRowType(
+  def getSourceRowTypeFromSource(
       typeFactory: FlinkTypeFactory,
-      fieldNameArray: Array[String],
-      fieldDataTypeArray: Array[DataType],
       tableSource: TableSource[_],
       streaming: Boolean): RelDataType = {
-
-    val fieldNames = fieldNameArray
-    var fieldTypes = fieldDataTypeArray
-      .map(fromDataTypeToLogicalType)
+    val tableSchema = tableSource.getTableSchema
+    val fieldNames = tableSchema.getFieldNames
+    val fieldDataTypes = tableSchema.getFieldDataTypes
+    var fieldTypes = fieldDataTypes.map(fromDataTypeToLogicalType)
 
     if (streaming) {
       // adjust the type of time attributes for streaming tables
@@ -159,83 +221,6 @@ object TableSourceUtil {
       }
     }
     typeFactory.buildRelNodeRowType(fieldNames, fieldTypes)
-  }
-
-  /**
-    * Returns schema of the selected fields of the given [[TableSource]].
-    *
-    * @param typeFactory Type factory to create the type
-    * @param fieldNameArray Field names to build the row type
-    * @param fieldDataTypeArray Field data types to build the row type
-    * @param watermarkSpec Watermark specifications defined through DDL
-    * @param streaming Flag to determine whether the schema of a stream or batch table is created
-    * @return The row type for the selected fields of the given [[TableSource]], this type would
-    *         also be patched with time attributes defined in the give [[WatermarkSpec]]
-    */
-  def getSourceRowType(
-      typeFactory: FlinkTypeFactory,
-      fieldNameArray: Array[String],
-      fieldDataTypeArray: Array[DataType],
-      watermarkSpec: WatermarkSpec,
-      streaming: Boolean): RelDataType = {
-
-    val fieldNames = fieldNameArray
-    var fieldTypes = fieldDataTypeArray
-      .map(fromDataTypeToLogicalType)
-
-    // patch rowtime field according to WatermarkSpec
-    fieldTypes = if (streaming) {
-      // TODO: [FLINK-14473] we only support top-level rowtime attribute right now
-      val rowtime = watermarkSpec.getRowtimeAttribute
-      if (rowtime.contains(".")) {
-        throw new ValidationException(
-          s"Nested field '$rowtime' as rowtime attribute is not supported right now.")
-      }
-      val idx = fieldNames.indexOf(rowtime)
-      val originalType = fieldTypes(idx).asInstanceOf[TimestampType]
-      val rowtimeType = new TimestampType(
-        originalType.isNullable,
-        TimestampKind.ROWTIME,
-        originalType.getPrecision)
-      fieldTypes.patch(idx, Seq(rowtimeType), 1)
-    } else {
-      fieldTypes
-    }
-    typeFactory.buildRelNodeRowType(fieldNames, fieldTypes)
-  }
-
-  /**
-    * Returns schema of the selected fields of the given [[TableSource]].
-    *
-    * <p> The watermark strategy specifications should either come from the [[TableSchema]]
-    * or [[TableSource]].
-    *
-    * @param typeFactory Type factory to create the type
-    * @param tableSchema Table schema to derive table field names and data types
-    * @param tableSource Table source to derive watermark strategies
-    * @param streaming Flag to determine whether the schema of a stream or batch table is created
-    * @return The row type for the selected fields of the given [[TableSource]], this type would
-    *         also be patched with time attributes defined in the give [[WatermarkSpec]]
-    */
-  def getSourceRowType(
-      typeFactory: FlinkTypeFactory,
-      tableSchema: TableSchema,
-      tableSource: Option[TableSource[_]],
-      streaming: Boolean): RelDataType = {
-
-    val fieldNames = tableSchema.getFieldNames
-    val fieldDataTypes = tableSchema.getFieldDataTypes
-
-    if (tableSchema.getWatermarkSpecs.nonEmpty) {
-      getSourceRowType(typeFactory, fieldNames, fieldDataTypes, tableSchema.getWatermarkSpecs.head,
-        streaming)
-    } else if (tableSource.isDefined) {
-      getSourceRowType(typeFactory, fieldNames, fieldDataTypes, tableSource.get,
-        streaming)
-    } else {
-      val fieldTypes = fieldDataTypes.map(fromDataTypeToLogicalType)
-      typeFactory.buildRelNodeRowType(fieldNames, fieldTypes)
-    }
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -56,6 +56,8 @@ import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
+import org.apache.flink.table.planner.calcite.SqlExprToRexConverter;
+import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
 import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.planner.expressions.utils.Func0$;
@@ -65,6 +67,7 @@ import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctio
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlNode;
 import org.junit.After;
 import org.junit.Before;
@@ -110,12 +113,17 @@ public class SqlToOperationConverterTest {
 		tableConfig,
 		catalogManager,
 		moduleManager);
+	private SqlExprToRexConverterFactory sqlExprToRexConverterFactory = this::createSqlExprToRexConverter;
 	private final PlannerContext plannerContext =
 		new PlannerContext(tableConfig,
 			functionCatalog,
 			catalogManager,
-			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
+			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, sqlExprToRexConverterFactory, false)),
 			new ArrayList<>());
+
+	private SqlExprToRexConverter createSqlExprToRexConverter(RelDataType t) {
+		return plannerContext.createSqlExprToRexConverter(t);
+	}
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+import org.apache.flink.table.planner.calcite.SqlExprToRexConverter;
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable;
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
@@ -33,6 +34,7 @@ import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
 import org.junit.Before;
@@ -79,7 +81,17 @@ public class FlinkCalciteCatalogReaderTest {
 				true),
 			FlinkStatistic.UNKNOWN(),
 			null,
-			null,
+			tableRowType -> new SqlExprToRexConverter() {
+				@Override
+				public RexNode convertToRexNode(String expr) {
+					return null;
+				}
+
+				@Override
+				public RexNode[] convertToRexNodes(String[] exprs) {
+					return new RexNode[0];
+				}
+			},
 			true,
 			false);
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
@@ -79,6 +79,7 @@ public class FlinkCalciteCatalogReaderTest {
 				true),
 			FlinkStatistic.UNKNOWN(),
 			null,
+			null,
 			true,
 			false);
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
 
@@ -43,12 +44,15 @@ public class PlannerMocks {
 			tableConfig,
 			catalogManager,
 			moduleManager);
+		AtomicReference<PlannerContext> reference = new AtomicReference<>();
 		PlannerContext plannerContext = new PlannerContext(
 			tableConfig,
 			functionCatalog,
 			catalogManager,
-			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
+			asRootSchema(new CatalogManagerCalciteSchema(
+					catalogManager, t -> reference.get().createSqlExprToRexConverter(t), false)),
 			new ArrayList<>());
+		reference.set(plannerContext);
 		return plannerContext.createFlinkPlanner(
 			catalogManager.getCurrentCatalog(),
 			catalogManager.getCurrentDatabase());


### PR DESCRIPTION

## What is the purpose of the change

```
CREATE TABLE PROD_LINEITEM (
  ...
  L_ORDERTIME      TIMESTAMP(3),
  WATERMARK FOR L_ORDERTIME AS L_ORDERTIME - INTERVAL '5' MINUTE,
  L_PROCTIME       AS PROCTIME()
) WITH (...)
SELECT * FROM prod_lineitem;
```
Failed by `AssertionError: Conversion to relational algebra failed to preserve datatypes`.

## Brief change log

`TableSourceUtil.getSourceRowType` should not only adjust rowtime from watermarkSpec, but also adjust proctime fields from computed column.

## Verifying this change

`HiveCatalogITCase.testReadWriteCsvWithProctime`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no