### PR TITLE
[FLINK-17817][hotfix] Fix serializer thread safe problem in CollectSinkFunction

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
@@ -321,6 +321,7 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN> implements Che
 	 */
 	private class ServerThread extends Thread {
 
+		private final TypeSerializer<IN> serializer;
 		private final ServerSocket serverSocket;
 
 		private boolean running;
@@ -330,6 +331,8 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN> implements Che
 		private DataOutputViewStreamWrapper outStream;
 
 		private ServerThread() throws Exception {
+			// serializers are not thread safe
+			this.serializer = CollectSinkFunction.this.serializer.duplicate();
 			this.serverSocket = new ServerSocket(0, 0, getBindAddress());
 			this.running = true;
 		}


### PR DESCRIPTION
## What is the purpose of the change

This is a hot fix for `CollectSinkFunction`. `TypeSerializer`s are not thread safe but currently `CollectSinkFunction` reuses them among two threads. This PR fixes this problem.

## Brief change log

- Fix serializer thread safe problem in CollectSinkFunction

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable