### PR TITLE
[FLINK-17843][table-api] Check the RowKind when converting a Row from object to an expression

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
@@ -90,6 +91,13 @@ public final class ApiExpressionUtils {
 		} else if (expression instanceof Expression) {
 			return (Expression) expression;
 		} else if (expression instanceof Row) {
+			RowKind kind = ((Row) expression).getKind();
+			if (kind != RowKind.INSERT) {
+				throw new ValidationException(
+					String.format(
+						"Unsupported kind '%s' of a row [%s]. Only rows with 'INSERT' kind are supported when" +
+							" converting to an expression.", kind, expression));
+			}
 			return convertRow((Row) expression);
 		} else if (expression instanceof Map) {
 			return convertJavaMap((Map<?, ?>) expression);


### PR DESCRIPTION
## What is the purpose of the change

Row constructor expression does not support a RowKind flag. It is possible to create only constant expressions of an INSERT row. This PR adds a check when converting a Row to an expression for the `RowKind`.


## Verifying this change

Added tests in `org.apache.flink.table.expressions.ObjectToExpressionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
