### PR TITLE
[FLINK-17351] [runtime] Increase `continuousFailureCounter` in `CheckpointFailureManager` for CHECKPOINT_EXPIRED

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -117,7 +117,6 @@ public class CheckpointFailureManager {
 			case CHECKPOINT_DECLINED_INPUT_END_OF_STREAM:
 
 			case EXCEPTION:
-			case CHECKPOINT_EXPIRED:
 			case TASK_FAILURE:
 			case TASK_CHECKPOINT_FAILURE:
 			case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:
@@ -127,6 +126,7 @@ public class CheckpointFailureManager {
 				break;
 
 			case CHECKPOINT_DECLINED:
+			case CHECKPOINT_EXPIRED:
 				//we should make sure one checkpoint only be counted once
 				if (countedCheckpointIds.add(checkpointId)) {
 					continuousFailureCounter.incrementAndGet();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -76,7 +76,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
 			failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
 		}
 
-		assertEquals(1, callback.getInvokeCounter());
+		assertEquals(2, callback.getInvokeCounter());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Before this PR, `CHECKPOINT_EXPIRED` was not counted in `continuousFailureCounter`. Hence,
if the failure of checkpointing is detected after checkpoint times out, the failure gets ignored since
the `PendingCheckpoint` has already been discarded, leading the job unable to restart automatically in theory, unless something else fails.

This PR counts `CHECKPOINT_EXPIRED` in `continuousFailureCounter`.


## Brief change log

- `CHECKPOINT_EXPIRED` is counted in `CheckpointFailureManager#continuousFailureCounter`.

## Verifying this change
unit tests 
`CheckpointCoordinatorTest#testExpiredCheckpointExceedsTolerableFailureNumber`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: Checkpointing
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not applicable 
