### PR TITLE
[FLINK-17474][parquet][hive] Parquet reader should be case insensitive for hive

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
@@ -63,6 +63,7 @@ public class HiveVectorizedParquetSplitReader implements SplitReader {
 
 		this.reader = ParquetSplitReaderUtil.genPartColumnarRowReader(
 				hiveVersion.startsWith("3"),
+				false, // hive case insensitive
 				conf,
 				fieldNames,
 				fieldTypes,

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.CatalogTest;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
@@ -124,6 +125,17 @@ public class HiveTestUtils {
 		StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
 		tableEnv.getConfig().getConfiguration().setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM.key(), 1);
 		return tableEnv;
+	}
+
+	public static TableEnvironment createTableEnvWithHiveCatalog(HiveCatalog catalog) {
+		TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+		tableEnv.registerCatalog(catalog.getName(), catalog);
+		tableEnv.useCatalog(catalog.getName());
+		return tableEnv;
+	}
+
+	public static void waitForJobFinish(TableResult tableResult) throws Exception {
+		tableResult.getJobClient().get().getJobExecutionResult(Thread.currentThread().getContextClassLoader()).get();
 	}
 
 	// Insert into a single partition of a text table.

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileSystemFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileSystemFormatFactory.java
@@ -172,6 +172,7 @@ public class ParquetFileSystemFormatFactory implements FileSystemFormatFactory {
 
 			this.reader = ParquetSplitReaderUtil.genPartColumnarRowReader(
 					utcTimestamp,
+					true,
 					conf.conf(),
 					fullFieldNames,
 					fullFieldTypes,

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
@@ -83,6 +83,7 @@ public class ParquetSplitReaderUtil {
 	 */
 	public static ParquetColumnarRowSplitReader genPartColumnarRowReader(
 			boolean utcTimestamp,
+			boolean caseSensitive,
 			Configuration conf,
 			String[] fullFieldNames,
 			DataType[] fullFieldTypes,
@@ -119,6 +120,7 @@ public class ParquetSplitReaderUtil {
 
 		return new ParquetColumnarRowSplitReader(
 				utcTimestamp,
+				caseSensitive,
 				conf,
 				Arrays.stream(selParquetFields)
 						.mapToObj(i -> fullFieldTypes[i].getLogicalType())

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
@@ -139,6 +139,7 @@ public class ParquetRowDataWriterTest {
 		// verify
 		ParquetColumnarRowSplitReader reader = ParquetSplitReaderUtil.genPartColumnarRowReader(
 				utcTimestamp,
+				true,
 				conf,
 				ROW_TYPE.getFieldNames().toArray(new String[0]),
 				ROW_TYPE.getChildren().stream()

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
@@ -205,6 +205,7 @@ public class ParquetColumnarRowSplitReaderTest {
 
 		ParquetColumnarRowSplitReader reader = new ParquetColumnarRowSplitReader(
 				false,
+				true,
 				new Configuration(),
 				fieldTypes,
 				new String[] {
@@ -402,6 +403,7 @@ public class ParquetColumnarRowSplitReaderTest {
 				new IntType()};
 		ParquetColumnarRowSplitReader reader = new ParquetColumnarRowSplitReader(
 				false,
+				true,
 				new Configuration(),
 				fieldTypes,
 				new String[] {"f7", "f2", "f4"},
@@ -494,6 +496,7 @@ public class ParquetColumnarRowSplitReaderTest {
 				new VarCharType(VarCharType.MAX_LENGTH)};
 		ParquetColumnarRowSplitReader reader = ParquetSplitReaderUtil.genPartColumnarRowReader(
 				false,
+				true,
 				new Configuration(),
 				IntStream.range(0, 28).mapToObj(i -> "f" + i).toArray(String[]::new),
 				Arrays.stream(fieldTypes)


### PR DESCRIPTION

## What is the purpose of the change

This is cherry-pick version for https://github.com/apache/flink/pull/12241

Parquet reader should be case insensitive field names for hive

## Brief change log

- Introduce case sensitive flag to parquet reader
- For hive, the case sensitive flag is false

## Verifying this change

`HiveTableSourceTest.testParquetCaseInsensitive`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no