### PR TITLE
[FLINK-16021][table-common] DescriptorProperties.putTableSchema does …

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
@@ -53,7 +53,6 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -158,9 +157,8 @@ public abstract class ElasticsearchUpsertTableSinkFactoryBase implements StreamT
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
 		// table constraint
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		// format wildcard
 		properties.add(FORMAT + ".*");

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
@@ -53,7 +53,8 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -149,12 +150,17 @@ public abstract class ElasticsearchUpsertTableSinkFactoryBase implements StreamT
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 		// computed column
-		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + EXPR);
 
 		// watermark
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+		// table constraint
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		// format wildcard
 		properties.add(FORMAT + ".*");

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/HBaseTableFactory.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/HBaseTableFactory.java
@@ -55,7 +55,8 @@ import java.util.Map;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -192,12 +193,18 @@ public class HBaseTableFactory implements StreamTableSourceFactory<Row>, StreamT
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 		// computed column
-		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + EXPR);
 
 		// watermark
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+		// table constraint
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		return properties;
 	}

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/HBaseTableFactory.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/HBaseTableFactory.java
@@ -55,7 +55,6 @@ import java.util.Map;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -201,10 +200,8 @@ public class HBaseTableFactory implements StreamTableSourceFactory<Row>, StreamT
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
 		// table constraint
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		return properties;
 	}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -67,14 +67,11 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * IT case for HiveCatalog.

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -27,9 +27,11 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.constraints.UniqueConstraint;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableBuilder;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.descriptors.FileSystem;
 import org.apache.flink.table.descriptors.FormatDescriptor;
 import org.apache.flink.table.descriptors.OldCsv;
@@ -60,13 +62,19 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * IT case for HiveCatalog.
@@ -307,6 +315,47 @@ public class HiveCatalogITCase {
 				tableEnv.executeSql("SELECT * FROM proctime_src").collect());
 		Assert.assertEquals(5, rows.size());
 		tableEnv.executeSql("DROP TABLE proctime_src");
+	}
+
+	@Test
+	public void testTableWithPrimaryKey() {
+		EnvironmentSettings.Builder builder = EnvironmentSettings.newInstance().useBlinkPlanner();
+		EnvironmentSettings settings = builder.build();
+		TableEnvironment tableEnv = TableEnvironment.create(settings);
+		tableEnv.getConfig().getConfiguration().setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+
+		tableEnv.registerCatalog("catalog1", hiveCatalog);
+		tableEnv.useCatalog("catalog1");
+
+		final String createTable = "CREATE TABLE pk_src (\n" +
+				"  uuid varchar(40) not null,\n" +
+				"  price DECIMAL(10, 2),\n" +
+				"  currency STRING,\n" +
+				"  ts6 TIMESTAMP(6),\n" +
+				"  ts AS CAST(ts6 AS TIMESTAMP(3)),\n" +
+				"  WATERMARK FOR ts AS ts,\n" +
+				"  constraint ct1 PRIMARY KEY(uuid) NOT ENFORCED)\n" +
+				"  WITH (\n" +
+				"    'connector.type' = 'filesystem'," +
+				"    'connector.path' = 'file://fakePath'," +
+				"    'format.type' = 'csv')";
+
+		tableEnv.executeSql(createTable);
+
+		TableSchema tableSchema = tableEnv.getCatalog(tableEnv.getCurrentCatalog())
+				.map(catalog -> {
+					try {
+						final ObjectPath tablePath = ObjectPath.fromString(catalog.getDefaultDatabase() + '.' + "pk_src");
+						return catalog.getTable(tablePath).getSchema();
+					} catch (TableNotExistException e) {
+						return null;
+					}
+				}).orElse(null);
+		assertNotNull(tableSchema);
+		assertEquals(
+				tableSchema.getPrimaryKey(),
+				Optional.of(UniqueConstraint.primaryKey("ct1", Collections.singletonList("uuid"))));
+		tableEnv.executeSql("DROP TABLE pk_src");
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
@@ -42,7 +42,6 @@ import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -128,10 +127,8 @@ public class JdbcTableSourceSinkFactory implements
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
 		// table constraint
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		return properties;
 	}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
@@ -42,7 +42,8 @@ import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -119,12 +120,18 @@ public class JdbcTableSourceSinkFactory implements
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 		// computed column
-		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + EXPR);
 
 		// watermark
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+		// table constraint
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		return properties;
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -52,7 +52,8 @@ import java.util.Properties;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -131,7 +132,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 		properties.add(SCHEMA + ".#." + SCHEMA_FROM);
 		// computed column
-		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + EXPR);
 
 		// time attributes
 		properties.add(SCHEMA + ".#." + SCHEMA_PROCTIME);
@@ -148,6 +149,12 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+		// table constraint
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		// format wildcard
 		properties.add(FORMAT + ".*");

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -52,7 +52,6 @@ import java.util.Properties;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -151,10 +150,8 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
 		// table constraint
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		// format wildcard
 		properties.add(FORMAT + ".*");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
+import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
 import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.sinks.AppendStreamTableSink;
@@ -37,7 +38,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -80,7 +82,7 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 		properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
-		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + EXPR);
 		properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_TYPE);
 		properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_FROM);
 		properties.add(SCHEMA + ".#." + ROWTIME_WATERMARKS_TYPE);
@@ -88,6 +90,11 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+		// table constraint
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		return properties;
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -91,10 +90,8 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 		// table constraint
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		return properties;
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -95,10 +94,8 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
 		// table constraint
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		return properties;
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
@@ -41,7 +41,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -84,7 +85,7 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
 		properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
 		properties.add(SCHEMA + ".#." + SCHEMA_NAME);
-		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + EXPR);
 		properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_TYPE);
 		properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_FROM);
 		properties.add(SCHEMA + ".#." + ROWTIME_WATERMARKS_TYPE);
@@ -92,6 +93,12 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+		// table constraint
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		return properties;
 	}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsv.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/OldCsv.java
@@ -279,8 +279,8 @@ public class OldCsv extends FormatDescriptor {
 			properties.putBoolean(FORMAT_DERIVE_SCHEMA, true);
 		} else {
 			List<String> subKeys = Arrays.asList(
-				DescriptorProperties.TABLE_SCHEMA_NAME,
-				DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
+				DescriptorProperties.NAME,
+				DescriptorProperties.DATA_TYPE);
 
 			List<List<String>> subValues = schema.entrySet().stream()
 				.map(e -> Arrays.asList(e.getKey(), e.getValue()))

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/SchemaValidator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/SchemaValidator.java
@@ -40,7 +40,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -140,7 +141,7 @@ public class SchemaValidator implements DescriptorValidator {
 		keys.add(SCHEMA + ".#." + SCHEMA_NAME);
 		keys.add(SCHEMA + ".#." + SCHEMA_FROM);
 		// computed column
-		keys.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		keys.add(SCHEMA + ".#." + EXPR);
 
 		// time attributes
 		keys.add(SCHEMA + ".#." + SCHEMA_PROCTIME);
@@ -157,6 +158,12 @@ public class SchemaValidator implements DescriptorValidator {
 		keys.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		keys.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		keys.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+		// table constraint
+		keys.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		keys.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		keys.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		return keys;
 	}
@@ -292,7 +299,7 @@ public class SchemaValidator implements DescriptorValidator {
 				boolean isRowtime = properties
 					.containsKey(SCHEMA + "." + i + "." + ROWTIME_TIMESTAMPS_TYPE);
 				boolean isGeneratedColumn = properties
-					.containsKey(SCHEMA + "." + i + "." + TABLE_SCHEMA_EXPR);
+					.containsKey(SCHEMA + "." + i + "." + EXPR);
 				// remove proctime/rowtime from mapping
 				if (isProctime || isRowtime || isGeneratedColumn) {
 					mapping.remove(name);

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/SchemaValidator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/SchemaValidator.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -160,10 +159,8 @@ public class SchemaValidator implements DescriptorValidator {
 		keys.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
 		// table constraint
-		keys.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		keys.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		keys.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		keys.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		keys.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		return keys;
 	}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSinkFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSinkFactoryBase.java
@@ -76,9 +76,9 @@ public abstract class CsvTableSinkFactoryBase implements TableFactory {
 		// connector
 		properties.add(CONNECTOR_PATH);
 		// format
-		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
-		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
-		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TYPE);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.DATA_TYPE);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.NAME);
 		properties.add(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA);
 		properties.add(FORMAT_FIELD_DELIMITER);
 		properties.add(CONNECTOR_PATH);
@@ -86,10 +86,10 @@ public abstract class CsvTableSinkFactoryBase implements TableFactory {
 		properties.add(FORMAT_NUM_FILES);
 
 		// schema
-		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
-		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
-		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
-		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.DATA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.EXPR);
 		// schema watermark
 		properties.add(SCHEMA + "." + DescriptorProperties.WATERMARK + ".*");
 		return properties;

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -101,10 +100,8 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 		// table constraint
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		return properties;
 	}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -80,9 +80,9 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		// connector
 		properties.add(CONNECTOR_PATH);
 		// format
-		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
-		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
-		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.TYPE);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.DATA_TYPE);
+		properties.add(FORMAT_FIELDS + ".#." + DescriptorProperties.NAME);
 		properties.add(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA);
 		properties.add(FORMAT_FIELD_DELIMITER);
 		properties.add(FORMAT_LINE_DELIMITER);
@@ -92,14 +92,19 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		properties.add(FORMAT_IGNORE_PARSE_ERRORS);
 		properties.add(CONNECTOR_PATH);
 		// schema
-		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
-		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
-		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
-		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.DATA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.EXPR);
 		// watermark
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+		// table constraint
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 
 		return properties;
 	}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
@@ -35,12 +35,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_EXPR;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
 
 /**
  * Mocking {@link TableSourceFactory} for tests.
@@ -87,10 +87,8 @@ public class TableSourceFactoryMock implements TableSourceFactory<Row> {
 		supportedProperties.add(Schema.SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
 		// table constraint
-		supportedProperties.add(Schema.SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-		supportedProperties.add(Schema.SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-		supportedProperties.add(Schema.SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+		supportedProperties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+		supportedProperties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
 		return supportedProperties;
 	}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
@@ -35,7 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -79,11 +80,18 @@ public class TableSourceFactoryMock implements TableSourceFactory<Row> {
 		supportedProperties.add(Schema.SCHEMA + ".#." + Schema.SCHEMA_DATA_TYPE);
 		supportedProperties.add(Schema.SCHEMA + ".#." + Schema.SCHEMA_TYPE);
 		// computed column
-		supportedProperties.add(Schema.SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		supportedProperties.add(Schema.SCHEMA + ".#." + EXPR);
 		// watermark
 		supportedProperties.add(Schema.SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 		supportedProperties.add(Schema.SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 		supportedProperties.add(Schema.SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+		// table constraint
+		supportedProperties.add(Schema.SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+		supportedProperties.add(Schema.SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+		supportedProperties.add(Schema.SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+				+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+
 		return supportedProperties;
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
@@ -31,7 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -105,7 +106,7 @@ public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T>
 			properties.add(SCHEMA + ".#." + SCHEMA_NAME);
 			properties.add(SCHEMA + ".#." + SCHEMA_FROM);
 			// computed column
-			properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+			properties.add(SCHEMA + ".#." + EXPR);
 			// time attributes
 			properties.add(SCHEMA + ".#." + SCHEMA_PROCTIME);
 			properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_TYPE);
@@ -120,6 +121,11 @@ public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T>
 			properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
 			properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 			properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+			// table constraint
+			properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
+			properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
+			properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+					+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
 		}
 		properties.addAll(supportedFormatProperties());
 		return properties;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.descriptors.DescriptorProperties.CONSTRAINT_UNIQUE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -122,10 +121,8 @@ public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T>
 			properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
 			properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 			// table constraint
-			properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME);
-			properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE);
-			properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-					+ DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS);
+			properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+			properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 		}
 		properties.addAll(supportedFormatProperties());
 		return properties;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/descriptors/DescriptorPropertiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/descriptors/DescriptorPropertiesTest.java
@@ -175,17 +175,18 @@ public class DescriptorPropertiesTest {
 	@Test
 	public void testTableSchema() {
 		TableSchema schema = TableSchema.builder()
-			.field("f0", DataTypes.BIGINT())
+			.field("f0", DataTypes.BIGINT().notNull())
 			.field("f1", DataTypes.ROW(
 				DataTypes.FIELD("q1", DataTypes.STRING()),
 				DataTypes.FIELD("q2", DataTypes.TIMESTAMP(9))))
-			.field("f2", DataTypes.STRING())
-			.field("f3", DataTypes.BIGINT(), "f0 + 1")
+			.field("f2", DataTypes.STRING().notNull())
+			.field("f3", DataTypes.BIGINT().notNull(), "f0 + 1")
 			.field("f4", DataTypes.DECIMAL(10, 3))
 			.watermark(
 				"f1.q2",
 				"`f1`.`q2` - INTERVAL '5' SECOND",
 				DataTypes.TIMESTAMP(3))
+			.primaryKey("constraint1", new String[] {"f0", "f2"})
 			.build();
 
 		DescriptorProperties properties = new DescriptorProperties();
@@ -193,19 +194,22 @@ public class DescriptorPropertiesTest {
 		Map<String, String> actual = properties.asMap();
 		Map<String, String> expected = new HashMap<>();
 		expected.put("schema.0.name", "f0");
-		expected.put("schema.0.data-type", "BIGINT");
+		expected.put("schema.0.data-type", "BIGINT NOT NULL");
 		expected.put("schema.1.name", "f1");
 		expected.put("schema.1.data-type", "ROW<`q1` VARCHAR(2147483647), `q2` TIMESTAMP(9)>");
 		expected.put("schema.2.name", "f2");
-		expected.put("schema.2.data-type", "VARCHAR(2147483647)");
+		expected.put("schema.2.data-type", "VARCHAR(2147483647) NOT NULL");
 		expected.put("schema.3.name", "f3");
-		expected.put("schema.3.data-type", "BIGINT");
+		expected.put("schema.3.data-type", "BIGINT NOT NULL");
 		expected.put("schema.3.expr", "f0 + 1");
 		expected.put("schema.4.name", "f4");
 		expected.put("schema.4.data-type", "DECIMAL(10, 3)");
 		expected.put("schema.watermark.0.rowtime", "f1.q2");
 		expected.put("schema.watermark.0.strategy.expr", "`f1`.`q2` - INTERVAL '5' SECOND");
 		expected.put("schema.watermark.0.strategy.data-type", "TIMESTAMP(3)");
+		expected.put("schema.constraint.unique.0.name", "constraint1");
+		expected.put("schema.constraint.unique.0.type", "PRIMARY_KEY");
+		expected.put("schema.constraint.unique.0.columns", "f0,f2");
 		assertEquals(expected, actual);
 
 		TableSchema restored = properties.getTableSchema("schema");

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/descriptors/DescriptorPropertiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/descriptors/DescriptorPropertiesTest.java
@@ -207,9 +207,8 @@ public class DescriptorPropertiesTest {
 		expected.put("schema.watermark.0.rowtime", "f1.q2");
 		expected.put("schema.watermark.0.strategy.expr", "`f1`.`q2` - INTERVAL '5' SECOND");
 		expected.put("schema.watermark.0.strategy.data-type", "TIMESTAMP(3)");
-		expected.put("schema.constraint.unique.0.name", "constraint1");
-		expected.put("schema.constraint.unique.0.type", "PRIMARY_KEY");
-		expected.put("schema.constraint.unique.0.columns", "f0,f2");
+		expected.put("schema.primary-key.name", "constraint1");
+		expected.put("schema.primary-key.columns", "f0,f2");
 		assertEquals(expected, actual);
 
 		TableSchema restored = properties.getTableSchema("schema");

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
@@ -25,12 +25,9 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery;
 import org.apache.flink.table.planner.utils.TableTestUtil;
-import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.BigIntType;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableSet;
 
@@ -67,7 +64,7 @@ public class CatalogConstraintTest {
 	public void testWithPrimaryKey() throws Exception {
 		TableSchema tableSchema = TableSchema.builder().fields(
 				new String[] { "a", "b", "c" },
-				new DataType[] { DataTypes.STRING(), new AtomicDataType(new BigIntType(false)), DataTypes.INT() }
+				new DataType[] { DataTypes.STRING(), DataTypes.BIGINT().notNull(), DataTypes.INT() }
 		).primaryKey("b").build();
 		Map<String, String> properties = buildCatalogTableProperties(tableSchema);
 
@@ -109,10 +106,6 @@ public class CatalogConstraintTest {
 		properties.put("format.property-version", "1");
 		properties.put("format.field-delimiter", ";");
 
-		// schema
-		DescriptorProperties descriptorProperties = new DescriptorProperties(true);
-		descriptorProperties.putTableSchema("format.fields", tableSchema);
-		properties.putAll(descriptorProperties.asMap());
 		return properties;
 	}
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
@@ -145,10 +145,8 @@ class InMemoryTableFactory(terminationCount: Int)
     properties.add(SCHEMA + ".#." + EXPR)
 
     // table constraint
-    properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME)
-    properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE)
-    properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
-      + DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS)
+    properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
+    properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
 
     properties
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
@@ -142,7 +142,14 @@ class InMemoryTableFactory(terminationCount: Int)
     properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
 
     // computed column
-    properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR)
+    properties.add(SCHEMA + ".#." + EXPR)
+
+    // table constraint
+    properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.NAME)
+    properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#." + DescriptorProperties.TYPE)
+    properties.add(SCHEMA + "." + CONSTRAINT_UNIQUE + ".#."
+      + DescriptorProperties.CONSTRAINT_UNIQUE_COLUMNS)
+
     properties
   }
 }


### PR DESCRIPTION
…not include constraints

## What is the purpose of the change

Fix the primary key constraint info loss for TableSchema SEDE with `DescriptorProperties`.