### PR TITLE
[FLINK-13553][tests][qs] Improve Logging to debug Test Instability

### DIFF
--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
@@ -110,6 +110,7 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 			final MessageType msgType = MessageSerializer.deserializeHeader(buf);
 
 			requestId = MessageSerializer.getRequestId(buf);
+			LOG.trace("Handling request with ID {}", requestId);
 
 			if (msgType == MessageType.REQUEST) {
 
@@ -263,6 +264,7 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 					write.addListener(new RequestWriteListener());
 
 				} catch (BadRequestException e) {
+					LOG.debug("Bad request (request ID = {})", requestId, e);
 					try {
 						stats.reportFailedRequest();
 						final ByteBuf err = MessageSerializer.serializeRequestFailure(ctx.alloc(), requestId, e);
@@ -271,6 +273,7 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 						LOG.error("Failed to respond with the error after failed request", io);
 					}
 				} catch (Throwable t) {
+					LOG.error("Error while handling request with ID {}", requestId, t);
 					try {
 						stats.reportFailedRequest();
 

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
@@ -308,7 +308,7 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 					LOG.debug("Request {} was successfully answered after {} ms.", request, durationMillis);
 					stats.reportSuccessfulRequest(durationMillis);
 				} else {
-					LOG.debug("Request {} failed after {} ms due to: {}", request, durationMillis, future.cause());
+					LOG.debug("Request {} failed after {} ms", request, durationMillis, future.cause());
 					stats.reportFailedRequest();
 				}
 			}

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.ServerBootstrap;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
@@ -97,7 +98,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for {@link Client}.
  */
-public class ClientTest {
+public class ClientTest extends TestLogger {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClientTest.class);
 

--- a/tools/log4j-travis.properties
+++ b/tools/log4j-travis.properties
@@ -68,3 +68,8 @@ logger.zkclient.level = INFO
 logger.zkclient.appenderRef.out.ref = ConsoleAppender
 logger.consumer.name = org.apache.flink.streaming.connectors.kafka.internals.SimpleConsumerThread
 logger.consumer.level = OFF
+
+# Enable TRACE logging to debug FLINK-13553
+logger.queryablestate.name = org.apache.flink.queryablestate
+logger.queryablestate.level = TRACE
+logger.queryablestate.appenderRef.out.ref = ConsoleAppender


### PR DESCRIPTION
## What is the purpose of the change

*This improves logging in AbstractServerHandler to debug a test instability (timeouts in `KvStateServerHandlerTest`; see FLINK-13553)*


## Brief change log

  - *See commits*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
