### PR TITLE
[FLINK-17019][runtime] Fulfill slot requests in request order

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -22,28 +22,33 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 import java.util.AbstractCollection;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * Map which stores values under two different indices.
+ * Map which stores values under two different indices. The mapping of the primary key to the
+ * value is backed by {@link LinkedHashMap} so that the iteration order over the values and
+ * the primary key set is the insertion order. Note that there is no contract of the iteration
+ * order over the secondary key set.
  *
- * @param <A> Type of key A
- * @param <B> Type of key B
+ * @param <A> Type of key A. Key A is the primary key.
+ * @param <B> Type of key B. Key B is the secondary key.
  * @param <V> Type of the value
  */
 class DualKeyLinkedMap<A, B, V> {
 
 	private final LinkedHashMap<A, Tuple2<B, V>> aMap;
 
-	private final LinkedHashMap<B, A> bMap;
+	private final Map<B, A> bMap;
 
 	private transient Collection<V> values;
 
 	DualKeyLinkedMap(int initialCapacity) {
 		this.aMap = new LinkedHashMap<>(initialCapacity);
-		this.bMap = new LinkedHashMap<>(initialCapacity);
+		this.bMap = new HashMap<>(initialCapacity);
 	}
 
 	int size() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -55,7 +55,7 @@ class DualKeyLinkedMap<A, B, V> {
 		return aMap.size();
 	}
 
-	V getKeyA(A aKey) {
+	V getValueByKeyA(A aKey) {
 		final Tuple2<B, V> value = aMap.get(aKey);
 
 		if (value != null) {
@@ -65,11 +65,25 @@ class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
-	V getKeyB(B bKey) {
+	V getValueByKeyB(B bKey) {
 		final A aKey = bMap.get(bKey);
 
 		if (aKey != null) {
 			return aMap.get(aKey).f1;
+		} else {
+			return null;
+		}
+	}
+
+	A getKeyAByKeyB(B bKey) {
+		return bMap.get(bKey);
+	}
+
+	B getKeyBByKeyA(A aKey) {
+		final Tuple2<B, V> value = aMap.get(aKey);
+
+		if (value != null) {
+			return value.f0;
 		} else {
 			return null;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * @param <B> Type of key B
  * @param <V> Type of the value
  */
-public class DualKeyLinkedMap<A, B, V> {
+class DualKeyLinkedMap<A, B, V> {
 
 	private final LinkedHashMap<A, Tuple2<B, V>> aMap;
 
@@ -41,16 +41,16 @@ public class DualKeyLinkedMap<A, B, V> {
 
 	private transient Collection<V> values;
 
-	public DualKeyLinkedMap(int initialCapacity) {
+	DualKeyLinkedMap(int initialCapacity) {
 		this.aMap = new LinkedHashMap<>(initialCapacity);
 		this.bMap = new LinkedHashMap<>(initialCapacity);
 	}
 
-	public int size() {
+	int size() {
 		return aMap.size();
 	}
 
-	public V getKeyA(A aKey) {
+	V getKeyA(A aKey) {
 		final Tuple2<B, V> value = aMap.get(aKey);
 
 		if (value != null) {
@@ -60,7 +60,7 @@ public class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
-	public V getKeyB(B bKey) {
+	V getKeyB(B bKey) {
 		final A aKey = bMap.get(bKey);
 
 		if (aKey != null) {
@@ -70,7 +70,7 @@ public class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
-	public V put(A aKey, B bKey, V value) {
+	V put(A aKey, B bKey, V value) {
 		final V removedValue = removeKeyA(aKey);
 		removeKeyB(bKey);
 
@@ -84,15 +84,15 @@ public class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
-	public boolean containsKeyA(A aKey) {
+	boolean containsKeyA(A aKey) {
 		return aMap.containsKey(aKey);
 	}
 
-	public boolean containsKeyB(B bKey) {
+	boolean containsKeyB(B bKey) {
 		return bMap.containsKey(bKey);
 	}
 
-	public V removeKeyA(A aKey) {
+	V removeKeyA(A aKey) {
 		Tuple2<B, V> aValue = aMap.remove(aKey);
 
 		if (aValue != null) {
@@ -103,7 +103,7 @@ public class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
-	public V removeKeyB(B bKey) {
+	V removeKeyB(B bKey) {
 		A aKey = bMap.remove(bKey);
 
 		if (aKey != null) {
@@ -118,7 +118,7 @@ public class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
-	public Collection<V> values() {
+	Collection<V> values() {
 		Collection<V> vs = values;
 
 		if (vs == null) {
@@ -129,15 +129,15 @@ public class DualKeyLinkedMap<A, B, V> {
 		return vs;
 	}
 
-	public Set<A> keySetA() {
+	Set<A> keySetA() {
 		return aMap.keySet();
 	}
 
-	public Set<B> keySetB() {
+	Set<B> keySetB() {
 		return bMap.keySet();
 	}
 
-	public void clear() {
+	void clear() {
 		aMap.clear();
 		bMap.clear();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -356,7 +356,7 @@ public class SlotPoolImpl implements SlotPool {
 	}
 
 	private void slotRequestToResourceManagerFailed(SlotRequestId slotRequestID, Throwable failure) {
-		final PendingRequest request = pendingRequests.getKeyA(slotRequestID);
+		final PendingRequest request = pendingRequests.getValueByKeyA(slotRequestID);
 		if (request != null) {
 			if (isBatchRequestAndFailureCanBeIgnored(request, failure)) {
 				log.debug("Ignoring failed request to the resource manager for a batch slot request.");
@@ -694,7 +694,7 @@ public class SlotPoolImpl implements SlotPool {
 
 		componentMainThreadExecutor.assertRunningInMainThread();
 
-		final PendingRequest pendingRequest = pendingRequests.getKeyB(allocationID);
+		final PendingRequest pendingRequest = pendingRequests.getValueByKeyB(allocationID);
 		if (pendingRequest != null) {
 			if (isBatchRequestAndFailureCanBeIgnored(pendingRequest, cause)) {
 				log.debug("Ignoring allocation failure for batch slot request {}.", pendingRequest.getSlotRequestId());
@@ -1050,11 +1050,11 @@ public class SlotPoolImpl implements SlotPool {
 		 * @return The allocated slot, null if we can't find a match
 		 */
 		AllocatedSlot get(final AllocationID allocationID) {
-			return allocatedSlotsById.getKeyA(allocationID);
+			return allocatedSlotsById.getValueByKeyA(allocationID);
 		}
 
 		AllocatedSlot get(final SlotRequestId slotRequestId) {
-			return allocatedSlotsById.getKeyB(slotRequestId);
+			return allocatedSlotsById.getValueByKeyB(slotRequestId);
 		}
 
 		/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
@@ -85,4 +85,34 @@ public class DualKeyLinkedMapTest extends TestLogger {
 		assertThat(map.getValueByKeyB(1), is(secondValue));
 		assertThat(map.getValueByKeyA(2), is(secondValue));
 	}
+
+	@Test
+	public void testPrimaryKeyOrderIsNotAffectedIfReInsertedWithSameSecondaryKey() {
+		final DualKeyLinkedMap<Integer, Integer, String> map = new DualKeyLinkedMap<>(2);
+
+		final String value1 = "1";
+		map.put(1, 1, value1);
+		final String value2 = "2";
+		map.put(2, 2, value2);
+
+		final String value3 = "3";
+		map.put(1, 1, value3);
+		assertThat(map.keySetA().iterator().next(), is(1));
+		assertThat(map.values().iterator().next(), is(value3));
+	}
+
+	@Test
+	public void testPrimaryKeyOrderIsNotAffectedIfReInsertedWithDifferentSecondaryKey() {
+		final DualKeyLinkedMap<Integer, Integer, String> map = new DualKeyLinkedMap<>(2);
+
+		final String value1 = "1";
+		map.put(1, 1, value1);
+		final String value2 = "2";
+		map.put(2, 2, value2);
+
+		final String value3 = "3";
+		map.put(1, 3, value3);
+		assertThat(map.keySetA().iterator().next(), is(1));
+		assertThat(map.values().iterator().next(), is(value3));
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMapTest.java
@@ -68,9 +68,9 @@ public class DualKeyLinkedMapTest extends TestLogger {
 		map.put(1, 1, "foobar");
 		map.put(1, 2, secondValue);
 
-		assertThat(map.getKeyB(1), nullValue());
-		assertThat(map.getKeyA(1), is(secondValue));
-		assertThat(map.getKeyB(2), is(secondValue));
+		assertThat(map.getValueByKeyB(1), nullValue());
+		assertThat(map.getValueByKeyA(1), is(secondValue));
+		assertThat(map.getValueByKeyB(2), is(secondValue));
 	}
 
 	@Test
@@ -81,8 +81,8 @@ public class DualKeyLinkedMapTest extends TestLogger {
 		map.put(1, 1, "foobar");
 		map.put(2, 1, secondValue);
 
-		assertThat(map.getKeyA(1), nullValue());
-		assertThat(map.getKeyB(1), is(secondValue));
-		assertThat(map.getKeyA(2), is(secondValue));
+		assertThat(map.getValueByKeyA(1), nullValue());
+		assertThat(map.getValueByKeyB(1), is(secondValue));
+		assertThat(map.getValueByKeyA(2), is(secondValue));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -33,8 +34,10 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.CheckedSupplier;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +49,9 @@ import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Tests how the {@link SlotPoolImpl} completes slot requests.
@@ -54,11 +60,18 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 
 	private static final Time TIMEOUT = Time.seconds(10L);
 
+	private TestingResourceManagerGateway resourceManagerGateway;
+
+	@Before
+	public void setUp() throws Exception {
+		resourceManagerGateway = new TestingResourceManagerGateway();
+	}
+
 	/**
 	 * Tests that the {@link SlotPoolImpl} completes slots in request order.
 	 */
 	@Test
-	public void testRequestsAreCompletedInRequestOrder() throws Exception {
+	public void testRequestsAreCompletedInRequestOrder() {
 		runSlotRequestCompletionTest(
 			CheckedSupplier.unchecked(this::setUpSlotPoolAndConnectToResourceManager),
 			slotPool -> {});
@@ -68,7 +81,7 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 	 * Tests that the {@link SlotPoolImpl} completes stashed slot requests in request order.
 	 */
 	@Test
-	public void testStashOrderMaintainsRequestOrder() throws Exception {
+	public void testStashOrderMaintainsRequestOrder() {
 		runSlotRequestCompletionTest(
 			CheckedSupplier.unchecked(this::setUpSlotPool),
 			this::connectToResourceManager);
@@ -76,12 +89,17 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 
 	private void runSlotRequestCompletionTest(
 		Supplier<SlotPoolImpl> slotPoolSupplier,
-		Consumer<SlotPoolImpl> actionAfterSlotRequest) throws Exception {
+		Consumer<SlotPoolImpl> actionAfterSlotRequest) {
 		try (final SlotPoolImpl slotPool = slotPoolSupplier.get()) {
 
-			final List<SlotRequestId> slotRequestIds = IntStream.range(0, 10)
+			final int requestNum = 10;
+
+			final List<SlotRequestId> slotRequestIds = IntStream.range(0, requestNum)
 				.mapToObj(ignored -> new SlotRequestId())
 				.collect(Collectors.toList());
+
+			final List<SlotRequest> rmReceivedSlotRequests = new ArrayList<>(requestNum);
+			resourceManagerGateway.setRequestSlotConsumer(request -> rmReceivedSlotRequests.add(request));
 
 			final List<CompletableFuture<PhysicalSlot>> slotRequests = slotRequestIds
 				.stream()
@@ -93,7 +111,9 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
 			slotPool.registerTaskManager(taskManagerLocation.getResourceID());
 
-			final SlotOffer slotOffer = new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY);
+			// create a slot offer that is initiated by the last request
+			final AllocationID lastAllocationId = rmReceivedSlotRequests.get(requestNum - 1).getAllocationId();
+			final SlotOffer slotOffer = new SlotOffer(lastAllocationId, 0, ResourceProfile.ANY);
 			final Collection<SlotOffer> acceptedSlots = slotPool.offerSlots(taskManagerLocation, new SimpleAckingTaskManagerGateway(), Collections.singleton(slotOffer));
 
 			assertThat(acceptedSlots, containsInAnyOrder(slotOffer));
@@ -103,7 +123,7 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 			// check that the slot requests get completed in sequential order
 			for (int i = 0; i < slotRequestIds.size(); i++) {
 				final CompletableFuture<PhysicalSlot> slotRequestFuture = slotRequests.get(i);
-				slotRequestFuture.get();
+				assertThat(slotRequestFuture.getNow(null), is(not(nullValue())));
 				slotPool.releaseSlot(slotRequestIds.get(i), testingReleaseException);
 			}
 		}
@@ -117,7 +137,7 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 	}
 
 	private void connectToResourceManager(SlotPoolImpl slotPool) {
-		slotPool.connectToResourceManager(new TestingResourceManagerGateway());
+		slotPool.connectToResourceManager(resourceManagerGateway);
 	}
 
 	private SlotPoolImpl setUpSlotPool() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces changes to fulfill slot requests in request order.
This is to avoid slot competitions between slot allocation bulks which can lead to resource deadlocks.

## Brief change log

  - *Fulfill slot requests in request order on offer slots*
  - *Remap orphaned slot allocation to pending slot request which lost its allocation to allow the request to fail fast on allocation failures*

## Verifying this change

  - *modified SlotPoolRequestCompletionTest *
  - *Added SlotPoolPendingRequestFailureTest#testFailingAllocationFailsRemappedPendingSlotRequests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
