### PR TITLE
[FLINK-17866][python] Change the implementation of the LocalFileSystem#pathToFile to fix the test case failure of PyFlink when running on Windows.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -49,7 +49,6 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -311,7 +310,7 @@ public class LocalFileSystem extends FileSystem {
 	 * Converts the given Path to a File for this file system.
 	 */
 	public File pathToFile(Path path) {
-		return Paths.get(path.getPath()).toFile();
+		return new File(path.getPath());
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*This pull request changes the implementation of the LocalFileSystem#pathToFile to fix the test case failure of PyFlink when running on Windows.*

## Brief change log

  - *Use "new File(path.getPath())" instead of "Paths.get(path.getPath()).toFile()".*

## Verifying this change

This change is already covered by existing tests, such as *test_dependency.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
