### PR TITLE
[FLINK-14592][connector/kafka][test-stability] Use random port for broker creation.

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -17,17 +17,14 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.streaming.connectors.kafka.testutils.ZooKeeperStringSerializer;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
-import org.apache.flink.util.NetUtils;
 
 import kafka.admin.AdminUtils;
-import kafka.common.KafkaException;
 import kafka.metrics.KafkaMetricsReporter;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
@@ -50,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -74,6 +70,7 @@ import static org.junit.Assert.fail;
 public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	protected static final Logger LOG = LoggerFactory.getLogger(KafkaTestEnvironmentImpl.class);
+	private static final int RANDOM_PORT = 0;
 	private final List<KafkaServer> brokers = new ArrayList<>();
 	private File tmpZkDir;
 	private File tmpKafkaParent;
@@ -399,45 +396,28 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 			kafkaProperties.putAll(config.getKafkaServerProperties());
 		}
 
-		final int numTries = 5;
-
-		for (int i = 1; i <= numTries; i++) {
-			int kafkaPort = NetUtils.getAvailablePort();
-			kafkaProperties.put("port", Integer.toString(kafkaPort));
-
-			if (config.isHideKafkaBehindProxy()) {
-				NetworkFailuresProxy proxy = createProxy(KAFKA_HOST, kafkaPort);
-				kafkaProperties.put("advertised.port", proxy.getLocalPort());
-			}
-
-			//to support secure kafka cluster
-			if (config.isSecureMode()) {
-				LOG.info("Adding Kafka secure configurations");
-				kafkaProperties.put("listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + kafkaPort);
-				kafkaProperties.put("advertised.listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + kafkaPort);
-				kafkaProperties.putAll(getSecureProperties());
-			}
-
-			KafkaConfig kafkaConfig = new KafkaConfig(kafkaProperties);
-
-			try {
-				scala.Option<String> stringNone = scala.Option.apply(null);
-				KafkaServer server = new KafkaServer(kafkaConfig, Time.SYSTEM, stringNone, new ArraySeq<KafkaMetricsReporter>(0));
-				server.startup();
-				return server;
-			}
-			catch (KafkaException e) {
-				if (e.getCause() instanceof BindException) {
-					// port conflict, retry...
-					LOG.info("Port conflict when starting Kafka Broker. Retrying...");
-				}
-				else {
-					throw e;
-				}
-			}
+		kafkaProperties.put("port", Integer.toString(RANDOM_PORT));
+		//to support secure kafka cluster
+		if (config.isSecureMode()) {
+			LOG.info("Adding Kafka secure configurations");
+			kafkaProperties.put("listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + RANDOM_PORT);
+			kafkaProperties.put("advertised.listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + RANDOM_PORT);
+			kafkaProperties.putAll(getSecureProperties());
 		}
 
-		throw new Exception("Could not start Kafka after " + numTries + " retries due to port conflicts.");
+		KafkaConfig kafkaConfig = new KafkaConfig(kafkaProperties);
+
+		scala.Option<String> stringNone = scala.Option.apply(null);
+		KafkaServer server = new KafkaServer(kafkaConfig, Time.SYSTEM, stringNone, new ArraySeq<KafkaMetricsReporter>(0));
+		server.startup();
+		if (config.isHideKafkaBehindProxy()) {
+			SecurityProtocol securityProtocol =
+					config.isSecureMode() ? SecurityProtocol.SASL_PLAINTEXT : SecurityProtocol.PLAINTEXT;
+			ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
+			createProxy(KAFKA_HOST, server.boundPort(listenerName));
+		}
+		return server;
+
 	}
 
 	private class KafkaOffsetHandlerImpl implements KafkaOffsetHandler {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -17,15 +17,12 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
-import org.apache.flink.util.NetUtils;
 
-import kafka.common.KafkaException;
 import kafka.metrics.KafkaMetricsReporter;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
@@ -46,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.net.BindException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,6 +71,7 @@ import static org.junit.Assert.fail;
 public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	protected static final Logger LOG = LoggerFactory.getLogger(KafkaTestEnvironmentImpl.class);
+	private static final int RANDOM_PORT = 0;
 	private final List<KafkaServer> brokers = new ArrayList<>();
 	private File tmpZkDir;
 	private File tmpKafkaParent;
@@ -377,45 +374,28 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 			kafkaProperties.putAll(config.getKafkaServerProperties());
 		}
 
-		final int numTries = 5;
-
-		for (int i = 1; i <= numTries; i++) {
-			int kafkaPort = NetUtils.getAvailablePort();
-			kafkaProperties.put("port", Integer.toString(kafkaPort));
-
-			if (config.isHideKafkaBehindProxy()) {
-				NetworkFailuresProxy proxy = createProxy(KAFKA_HOST, kafkaPort);
-				kafkaProperties.put("advertised.port", proxy.getLocalPort());
-			}
-
-			//to support secure kafka cluster
-			if (config.isSecureMode()) {
-				LOG.info("Adding Kafka secure configurations");
-				kafkaProperties.put("listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + kafkaPort);
-				kafkaProperties.put("advertised.listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + kafkaPort);
-				kafkaProperties.putAll(getSecureProperties());
-			}
-
-			KafkaConfig kafkaConfig = new KafkaConfig(kafkaProperties);
-
-			try {
-				scala.Option<String> stringNone = scala.Option.apply(null);
-				KafkaServer server = new KafkaServer(kafkaConfig, Time.SYSTEM, stringNone, new ArraySeq<KafkaMetricsReporter>(0));
-				server.startup();
-				return server;
-			}
-			catch (KafkaException e) {
-				if (e.getCause() instanceof BindException) {
-					// port conflict, retry...
-					LOG.info("Port conflict when starting Kafka Broker. Retrying...");
-				}
-				else {
-					throw e;
-				}
-			}
+		kafkaProperties.put("port", Integer.toString(RANDOM_PORT));
+		//to support secure kafka cluster
+		if (config.isSecureMode()) {
+			LOG.info("Adding Kafka secure configurations");
+			kafkaProperties.put("listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + RANDOM_PORT);
+			kafkaProperties.put("advertised.listeners", "SASL_PLAINTEXT://" + KAFKA_HOST + ":" + RANDOM_PORT);
+			kafkaProperties.putAll(getSecureProperties());
 		}
 
-		throw new Exception("Could not start Kafka after " + numTries + " retries due to port conflicts.");
+		KafkaConfig kafkaConfig = new KafkaConfig(kafkaProperties);
+		scala.Option<String> stringNone = scala.Option.apply(null);
+		KafkaServer server = new KafkaServer(kafkaConfig, Time.SYSTEM, stringNone, new ArraySeq<KafkaMetricsReporter>(0));
+		server.startup();
+
+		if (config.isHideKafkaBehindProxy()) {
+			SecurityProtocol securityProtocol =
+					config.isSecureMode() ? SecurityProtocol.SASL_PLAINTEXT : SecurityProtocol.PLAINTEXT;
+			ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
+			createProxy(KAFKA_HOST, server.boundPort(listenerName));
+		}
+
+		return server;
 	}
 
 	private class KafkaOffsetHandlerImpl implements KafkaOffsetHandler {


### PR DESCRIPTION
## What is the purpose of the change
Before this patch, Kafka brokers in the IT cases are assigned with port from `NetUtils.getAvailablePort()`. This is a little fragile because there is no guarantee that the port will not be recycled and used by someone else when the broker comes up. There was retries added to avoid the case, but we still see `BindExceptions` from time to time.

This patch solve this problem by letting the broker start the listeners with random ports.

## Brief change log
bfc52432ddb2fc1ea708230e23f449be23df0370 Let the broker pick their own random port instead of using `NetUtils.getAvailablePort()`.

## Verifying this change
Run the tests repeatedly in Intellij without seeing `BindException` anymore. Before the patch the exception is likely to be thrown after 10 - 20 runs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
