### PR TITLE
[FLINK-17870]. dependent jars are missing to be shipped to cluster in scala shell

### DIFF
--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellEnvironment.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.InvalidProgramException;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
@@ -84,12 +83,6 @@ public class ScalaShellEnvironment extends ExecutionEnvironment {
 		final List<URL> allJarFiles = new ArrayList<>(jarFiles);
 		allJarFiles.add(jarUrl);
 		return allJarFiles;
-	}
-
-	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		addDependentJars();
-		return super.execute(jobName);
 	}
 
 	@Override

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.InvalidProgramException;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
@@ -71,27 +70,9 @@ public class ScalaShellStreamEnvironment extends StreamExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		addDependentJars();
-		return super.execute(streamGraph);
-	}
-
-	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		addDependentJars();
-		return super.execute(jobName);
-	}
-
-	@Override
 	public JobClient executeAsync(StreamGraph streamGraph) throws Exception {
 		addDependentJars();
 		return super.executeAsync(streamGraph);
-	}
-
-	@Override
-	public JobClient executeAsync(String jobName) throws Exception {
-		addDependentJars();
-		return super.executeAsync(jobName);
 	}
 
 	public Configuration getClientConfiguration() {

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.util.JarUtils;
@@ -71,17 +72,38 @@ public class ScalaShellStreamEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+		addDependentJars();
+		return super.execute(streamGraph);
+	}
+
+	@Override
+	public JobExecutionResult execute(String jobName) throws Exception {
+		addDependentJars();
+		return super.execute(jobName);
+	}
+
+	@Override
+	public JobClient executeAsync(StreamGraph streamGraph) throws Exception {
+		addDependentJars();
+		return super.executeAsync(streamGraph);
+	}
+
+	@Override
+	public JobClient executeAsync(String jobName) throws Exception {
+		addDependentJars();
+		return super.executeAsync(jobName);
+	}
+
+	public Configuration getClientConfiguration() {
+		return getConfiguration();
+	}
+
+	private void addDependentJars() throws Exception {
 		final Configuration configuration = getConfiguration();
 		checkState(configuration.getBoolean(DeploymentOptions.ATTACHED), "Only ATTACHED mode is supported by the scala shell.");
 
 		final List<URL> updatedJarFiles = getUpdatedJarFiles();
 		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, updatedJarFiles, URL::toString);
-
-		return super.execute(streamGraph);
-	}
-
-	public Configuration getClientConfiguration() {
-		return getConfiguration();
 	}
 
 	private List<URL> getUpdatedJarFiles() throws MalformedURLException {


### PR DESCRIPTION
## What is the purpose of the change

`executeAsync` doesn't add dependent jars which cause ClassNotFound issue. This PR does some refactoring and add dependent jars for both `execute` and `executeAsync`

## Verifying this change

Manually tested vis scala-shell

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
