### PR TITLE
[FLINK-17861][task][checkpointing] Split channel state handles sent to JM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImpl.java
@@ -65,7 +65,7 @@ public class ChannelStateReaderImpl implements ChannelStateReader {
 		this(snapshot, new ChannelStateSerializerImpl());
 	}
 
-	ChannelStateReaderImpl(TaskStateSnapshot snapshot, ChannelStateDeserializer serializer) {
+	ChannelStateReaderImpl(TaskStateSnapshot snapshot, ChannelStateSerializer serializer) {
 		RefCountingFSDataInputStreamFactory streamFactory = new RefCountingFSDataInputStreamFactory(serializer);
 		final HashMap<InputChannelInfo, ChannelStateStreamReader> inputChannelHandleReadersTmp = new HashMap<>();
 		final HashMap<ResultSubpartitionInfo, ChannelStateStreamReader> resultSubpartitionHandleReadersTmp = new HashMap<>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateSerializer.java
@@ -39,9 +39,6 @@ interface ChannelStateSerializer {
 	void writeHeader(DataOutputStream dataStream) throws IOException;
 
 	void writeData(DataOutputStream stream, Buffer... flinkBuffers) throws IOException;
-}
-
-interface ChannelStateDeserializer {
 
 	void readHeader(InputStream stream) throws IOException;
 
@@ -128,7 +125,7 @@ interface ChannelStateByteBuffer {
 	}
 }
 
-class ChannelStateSerializerImpl implements ChannelStateSerializer, ChannelStateDeserializer {
+class ChannelStateSerializerImpl implements ChannelStateSerializer {
 	private static final int SERIALIZATION_VERSION = 0;
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateStreamReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateStreamReader.java
@@ -45,7 +45,7 @@ import static org.apache.flink.runtime.checkpoint.channel.ChannelStateReader.Rea
 class ChannelStateStreamReader implements Closeable {
 
 	private final RefCountingFSDataInputStream stream;
-	private final ChannelStateDeserializer serializer;
+	private final ChannelStateSerializer serializer;
 	private final Queue<Long> offsets;
 	private int remainingBytes = -1;
 	private boolean closed = false;
@@ -54,7 +54,7 @@ class ChannelStateStreamReader implements Closeable {
 		this(streamFactory.getOrCreate(handle), handle.getOffsets(), streamFactory.getSerializer());
 	}
 
-	private ChannelStateStreamReader(RefCountingFSDataInputStream stream, List<Long> offsets, ChannelStateDeserializer serializer) {
+	private ChannelStateStreamReader(RefCountingFSDataInputStream stream, List<Long> offsets, ChannelStateSerializer serializer) {
 		this.stream = stream;
 		this.stream.incRef();
 		this.serializer = serializer;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RefCountingFSDataInputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RefCountingFSDataInputStream.java
@@ -39,13 +39,13 @@ class RefCountingFSDataInputStream extends FSDataInputStream {
 
 	private final SupplierWithException<FSDataInputStream, IOException> streamSupplier;
 	private FSDataInputStream stream;
-	private final ChannelStateDeserializer serializer;
+	private final ChannelStateSerializer serializer;
 	private int refCount = 0;
 	private State state = State.NEW;
 
 	private RefCountingFSDataInputStream(
 			SupplierWithException<FSDataInputStream, IOException> streamSupplier,
-			ChannelStateDeserializer serializer) {
+			ChannelStateSerializer serializer) {
 		this.streamSupplier = checkNotNull(streamSupplier);
 		this.serializer = checkNotNull(serializer);
 	}
@@ -105,9 +105,9 @@ class RefCountingFSDataInputStream extends FSDataInputStream {
 	@NotThreadSafe
 	static class RefCountingFSDataInputStreamFactory {
 		private final Map<StreamStateHandle, RefCountingFSDataInputStream> streams = new HashMap<>(); // not clearing: expecting short life
-		private final ChannelStateDeserializer serializer;
+		private final ChannelStateSerializer serializer;
 
-		RefCountingFSDataInputStreamFactory(ChannelStateDeserializer serializer) {
+		RefCountingFSDataInputStreamFactory(ChannelStateSerializer serializer) {
 			this.serializer = checkNotNull(serializer);
 		}
 
@@ -121,7 +121,7 @@ class RefCountingFSDataInputStream extends FSDataInputStream {
 			return stream;
 		}
 
-		ChannelStateDeserializer getSerializer() {
+		ChannelStateSerializer getSerializer() {
 			return serializer;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A handle to the partitioned stream operator state after it has been checkpointed. This state
@@ -115,6 +116,11 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
 	@Override
 	public FSDataInputStream openInputStream() throws IOException {
 		return stateHandle.openInputStream();
+	}
+
+	@Override
+	public Optional<byte[]> asBytesIfInMemory() {
+		return stateHandle.asBytesIfInMemory();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStreamStateHandle.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * State handle for partitionable operator state. Besides being a {@link StreamStateHandle}, this also provides a
@@ -64,6 +65,11 @@ public class OperatorStreamStateHandle implements OperatorStateHandle {
 	@Override
 	public FSDataInputStream openInputStream() throws IOException {
 		return delegateStateHandle.openInputStream();
+	}
+
+	@Override
+	public Optional<byte[]> asBytesIfInMemory() {
+		return delegateStateHandle.asBytesIfInMemory();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
+import java.util.Optional;
+
 /**
  * A placeholder state handle for shared state that will replaced by an original that was
  * created in a previous checkpoint. So we don't have to send a state handle twice, e.g. in
@@ -38,6 +40,12 @@ public class PlaceholderStreamStateHandle implements StreamStateHandle {
 	public FSDataInputStream openInputStream() {
 		throw new UnsupportedOperationException(
 			"This is only a placeholder to be replaced by a real StreamStateHandle in the checkpoint coordinator.");
+	}
+
+	@Override
+	public Optional<byte[]> asBytesIfInMemory() {
+		throw new UnsupportedOperationException(
+				"This is only a placeholder to be replaced by a real StreamStateHandle in the checkpoint coordinator.");
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * Wrapper around a {@link StreamStateHandle} to make the referenced state object retrievable trough a simple get call.
@@ -62,6 +63,11 @@ public class RetrievableStreamStateHandle<T extends Serializable> implements
 	@Override
 	public FSDataInputStream openInputStream() throws IOException {
 		return wrappedStreamStateHandle.openInputStream();
+	}
+
+	@Override
+	public Optional<byte[]> asBytesIfInMemory() {
+		return wrappedStreamStateHandle.asBytesIfInMemory();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamStateHandle.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.core.fs.FSDataInputStream;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A {@link StateObject} that represents state that was written to a stream. The data can be read
@@ -33,4 +34,9 @@ public interface StreamStateHandle extends StateObject {
 	 * was previously written to the stream.
 	 */
 	FSDataInputStream openInputStream() throws IOException;
+
+	/**
+	 * @return Content of this handle as bytes array if it is already in memory.
+	 */
+	Optional<byte[]> asBytesIfInMemory();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -66,6 +67,11 @@ public class FileStateHandle implements StreamStateHandle {
 	@Override
 	public FSDataInputStream openInputStream() throws IOException {
 		return getFileSystem().open(filePath);
+	}
+
+	@Override
+	public Optional<byte[]> asBytesIfInMemory() {
+		return Optional.empty();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A state handle that contains stream state in a byte array.
@@ -53,6 +54,11 @@ public class ByteStreamStateHandle implements StreamStateHandle {
 	@Override
 	public FSDataInputStream openInputStream() throws IOException {
 		return new ByteStateHandleInputStream(data);
+	}
+
+	@Override
+	public Optional<byte[]> asBytesIfInMemory() {
+		return Optional.of(getData());
 	}
 
 	public byte[] getData() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
@@ -18,7 +18,9 @@
 package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.core.memory.HeapMemorySegment;
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.ChannelStateWriteResult;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
@@ -42,6 +44,7 @@ import java.util.Random;
 
 import static org.apache.flink.core.fs.Path.fromLocalFile;
 import static org.apache.flink.core.fs.local.LocalFileSystem.getSharedInstance;
+import static org.apache.flink.core.memory.MemorySegmentFactory.wrap;
 import static org.apache.flink.runtime.state.CheckpointedStateScope.EXCLUSIVE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -147,7 +150,7 @@ public class ChannelStateCheckpointWriterTest {
 		Map<InputChannelInfo, Integer> offsetCounts = new HashMap<>();
 		offsetCounts.put(new InputChannelInfo(1, 1), 1);
 		offsetCounts.put(new InputChannelInfo(1, 2), 2);
-		offsetCounts.put(new InputChannelInfo(1, 3), 99);
+		offsetCounts.put(new InputChannelInfo(1, 3), 5);
 
 		ChannelStateWriteResult result = new ChannelStateWriteResult();
 		ChannelStateCheckpointWriter writer = createWriter(result);
@@ -172,8 +175,8 @@ public class ChannelStateCheckpointWriterTest {
 	}
 
 	private void write(ChannelStateCheckpointWriter writer, InputChannelInfo channelInfo, byte[] data) throws Exception {
-		NetworkBuffer buffer = new NetworkBuffer(HeapMemorySegment.FACTORY.allocateUnpooledSegment(data.length, null), FreeingBufferRecycler.INSTANCE);
-		buffer.setBytes(0, data);
+		MemorySegment segment = wrap(data);
+		NetworkBuffer buffer = new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, Buffer.DataType.DATA_BUFFER, segment.size());
 		writer.writeInput(channelInfo, buffer);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImplTest.java
@@ -128,28 +128,19 @@ public class ChannelStateReaderImplTest {
 		return buf;
 	}
 
-	private ChannelStateDeserializer deserializer(byte[] data) {
-		return new ChannelStateDeserializer() {
-			@Override
-			public void readHeader(InputStream stream) {
-			}
-
-			@Override
-			public int readLength(InputStream stream) {
-				return data.length;
-			}
-
-			@Override
-			public int readData(InputStream stream, ChannelStateByteBuffer buffer, int bytes) throws IOException {
-				return buffer.writeBytes(stream, bytes);
-			}
-		};
-	}
-
 	private ChannelStateReaderImpl getReader(InputChannelInfo channel, byte[] data) {
 		return new ChannelStateReaderImpl(
 			taskStateSnapshot(singletonList(new InputChannelStateHandle(channel, new ByteStreamStateHandle("", data), singletonList(0L)))),
-			deserializer(DATA));
+			new ChannelStateSerializerImpl() {
+				@Override
+				public void readHeader(InputStream stream) {
+				}
+
+				@Override
+				public int readLength(InputStream stream) {
+					return data.length;
+				}
+			});
 	}
 
 	private void readAndVerify(int bufferSize, InputChannelInfo channelInfo, byte[] data, ChannelStateReader reader) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateSerializerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateSerializerImplTest.java
@@ -74,7 +74,7 @@ public class ChannelStateSerializerImplTest {
 		}
 		out.close();
 
-		ChannelStateDeserializer d = new ChannelStateSerializerImpl();
+		ChannelStateSerializer d = new ChannelStateSerializerImpl();
 		ByteArrayInputStream is = new ByteArrayInputStream(baos.toByteArray());
 		d.readHeader(is);
 		for (int count : numBuffersToWriteAtOnce) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Random;
 
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
@@ -125,6 +126,11 @@ public class CheckpointMessagesTest {
 		@Override
 		public FSDataInputStream openInputStream() throws IOException {
 			return null;
+		}
+
+		@Override
+		public Optional<byte[]> asBytesIfInMemory() {
+			return Optional.empty();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -124,6 +125,11 @@ public class SharedStateRegistryTest {
 		@Override
 		public FSDataInputStream openInputStream() throws IOException {
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Optional<byte[]> asBytesIfInMemory() {
+			return Optional.empty();
 		}
 
 		public boolean isDiscarded() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/EmptyStreamStateHandle.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/EmptyStreamStateHandle.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A simple dummy implementation of a stream state handle that can be passed in tests.
@@ -59,6 +60,11 @@ public class EmptyStreamStateHandle implements StreamStateHandle {
 				return -1;
 			}
 		};
+	}
+
+	@Override
+	public Optional<byte[]> asBytesIfInMemory() {
+		return Optional.empty();
 	}
 
 	@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 
@@ -63,6 +64,11 @@ public class RocksDBStateDownloaderTest extends TestLogger {
 			@Override
 			public FSDataInputStream openInputStream() throws IOException {
 				throw expectedException;
+			}
+
+			@Override
+			public Optional<byte[]> asBytesIfInMemory() {
+				return Optional.empty();
 			}
 
 			@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -88,6 +88,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
@@ -326,6 +327,11 @@ public class InterruptSensitiveRestoreTest {
 			};
 
 			return is;
+		}
+
+		@Override
+		public Optional<byte[]> asBytesIfInMemory() {
+			return Optional.empty();
 		}
 
 		private void block() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1779,6 +1779,11 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
+		public Optional<byte[]> asBytesIfInMemory() {
+			return Optional.empty();
+		}
+
+		@Override
 		public StreamStateHandle getDelegateStateHandle() {
 			throw new UnsupportedOperationException("Not implemented.");
 		}


### PR DESCRIPTION
## What is the purpose of the change

If Unaligned checkpoints are enabled, channel state is written as state handles. Each channel has a handle and each such handle references the same underlying `streamStateHandle` (this is done to have a single file per subtask).
But, if the state is less then `state.backend.fs.memory-threshold`, the data is sent directly to JM as a byteStreamHandle. This causes each channel state handle to hold the whole subtask state. 

This PR solves this by extracting relevant potions of the underlying handles if they are `byteStreamHandle`s.

Another approach would be to move the underlying state handle one level up (`OperatorSubtaskState`) and not store references to it in `channelStateHandles`. It would be more effective (less data duplication) but also more error-prone (implicit structure), less flexible (re-scaling), and require more changes.

## Verifying this change

This change is already covered by existing tests, such as:
 - `ChannelStateCheckpointWriterTest.testRecordingOffsets` (the test was corrected)
 - `ChannelPersistenceITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
