### PR TITLE
[FLINK-17878][filesystem] StreamingFileWriter currentWatermark attrib…

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
@@ -78,7 +78,7 @@ public class StreamingFileCommitter extends AbstractStreamOperator<Void>
 
 	private transient TaskTracker taskTracker;
 
-	private transient long currentWatermark = Long.MIN_VALUE;
+	private transient long currentWatermark;
 
 	private transient List<PartitionCommitPolicy> policies;
 
@@ -98,6 +98,7 @@ public class StreamingFileCommitter extends AbstractStreamOperator<Void>
 	@Override
 	public void initializeState(StateInitializationContext context) throws Exception {
 		super.initializeState(context);
+		currentWatermark = Long.MIN_VALUE;
 		FileSystem fileSystem = locationPath.getFileSystem();
 		this.trigger = PartitionCommitTrigger.create(
 				context.isRestored(),

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
@@ -61,7 +61,7 @@ public class StreamingFileWriter extends AbstractStreamOperator<CommitMessage>
 
 	private transient StreamingFileSinkHelper<RowData> helper;
 
-	private transient long currentWatermark = Long.MIN_VALUE;
+	private transient long currentWatermark;
 
 	private transient Set<String> inactivePartitions;
 
@@ -87,6 +87,7 @@ public class StreamingFileWriter extends AbstractStreamOperator<CommitMessage>
 				bucketCheckInterval);
 
 		inactivePartitions = new HashSet<>();
+		currentWatermark = Long.MIN_VALUE;
 		listener.setInactiveConsumer(b -> inactivePartitions.add(b));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
as discussed in FLINK-17878 ，the transient value of currentWatermark in StreamingFileWriter is reseted after serialization. we need to init the value in runtime


## Brief change log

move the value initialization to the initState function


## Verifying this change

This change is a trivial rework 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no 
  - The runtime per-record code paths (performance sensitive):  no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable 
