### PR TITLE
[FLINK-12855] [streaming-java][window-assigners] Add functionality that staggers panes on partitions to distribute workload. 

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -46,26 +46,42 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 
 	private final long size;
 
-	private final long offset;
+	private final long globalOffset;
 
-	private TumblingProcessingTimeWindows(long size, long offset) {
+	private Long staggerOffset = null;
+
+	private final WindowStagger windowStagger;
+
+	private TumblingProcessingTimeWindows(long size, long offset, WindowStagger windowStagger) {
 		if (Math.abs(offset) >= size) {
 			throw new IllegalArgumentException("TumblingProcessingTimeWindows parameters must satisfy abs(offset) < size");
 		}
 
 		this.size = size;
-		this.offset = offset;
+		this.globalOffset = offset;
+		this.windowStagger = windowStagger;
 	}
 
 	@Override
 	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
 		final long now = context.getCurrentProcessingTime();
-		long start = TimeWindow.getWindowStartWithOffset(now, offset, size);
+		if (staggerOffset == null) {
+			staggerOffset = windowStagger.getStaggerOffset(context.getCurrentProcessingTime(), size);
+		}
+		long start = TimeWindow.getWindowStartWithOffset(now, (globalOffset + staggerOffset) % size, size);
 		return Collections.singletonList(new TimeWindow(start, start + size));
 	}
 
 	public long getSize() {
 		return size;
+	}
+
+	public long getGlobalOffset() {
+		return globalOffset;
+	}
+
+	public WindowStagger getWindowStagger() {
+		return windowStagger;
 	}
 
 	@Override
@@ -86,7 +102,7 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 	 * @return The time policy.
 	 */
 	public static TumblingProcessingTimeWindows of(Time size) {
-		return new TumblingProcessingTimeWindows(size.toMilliseconds(), 0);
+		return new TumblingProcessingTimeWindows(size.toMilliseconds(), 0, WindowStagger.ALIGNED);
 	}
 
 	/**
@@ -107,7 +123,7 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 	 * @return The time policy.
 	 */
 	public static TumblingProcessingTimeWindows of(Time size, Time offset) {
-		return new TumblingProcessingTimeWindows(size.toMilliseconds(), offset.toMilliseconds());
+		return new TumblingProcessingTimeWindows(size.toMilliseconds(), offset.toMilliseconds(), WindowStagger.ALIGNED);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -126,6 +126,21 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 		return new TumblingProcessingTimeWindows(size.toMilliseconds(), offset.toMilliseconds(), WindowStagger.ALIGNED);
 	}
 
+	/**
+	 * Creates a new {@code TumblingProcessingTimeWindows} {@link WindowAssigner} that assigns
+	 * elements to time windows based on the element timestamp, offset and a staggering offset sampled
+	 * from uniform distribution(0, window size) for each pane.
+	 *
+	 * @param size The size of the generated windows.
+	 * @param offset The offset which window start would be shifted by.
+	 * @param windowStagger The utility that produces staggering offset in runtime.
+	 *
+	 * @return The time policy.
+	 */
+	public static TumblingProcessingTimeWindows of(Time size, Time offset, WindowStagger windowStagger) throws Exception {
+		return new TumblingProcessingTimeWindows(size.toMilliseconds(), offset.toMilliseconds(), windowStagger);
+	}
+
 	@Override
 	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
 		return new TimeWindow.Serializer();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -137,7 +137,7 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 	 *
 	 * @return The time policy.
 	 */
-	public static TumblingProcessingTimeWindows of(Time size, Time offset, WindowStagger windowStagger) throws Exception {
+	public static TumblingProcessingTimeWindows of(Time size, Time offset, WindowStagger windowStagger) {
 		return new TumblingProcessingTimeWindows(size.toMilliseconds(), offset.toMilliseconds(), windowStagger);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -76,14 +76,6 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 		return size;
 	}
 
-	public long getGlobalOffset() {
-		return globalOffset;
-	}
-
-	public WindowStagger getWindowStagger() {
-		return windowStagger;
-	}
-
 	@Override
 	public Trigger<Object, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
 		return ProcessingTimeTrigger.create();
@@ -128,8 +120,8 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 
 	/**
 	 * Creates a new {@code TumblingProcessingTimeWindows} {@link WindowAssigner} that assigns
-	 * elements to time windows based on the element timestamp, offset and a staggering offset sampled
-	 * from uniform distribution(0, window size) for each pane.
+	 * elements to time windows based on the element timestamp, offset and a staggering offset,
+	 * depending on the staggering policy.
 	 *
 	 * @param size The size of the generated windows.
 	 * @param offset The offset which window start would be shifted by.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A {@code WindowStagger} staggers offset in runtime for each window assignment.
+ */
+public enum WindowStagger {
+	/**
+	 * Default mode,  all panes fire at the same time across all partitions.
+	 */
+	ALIGNED {
+		@Override
+		public long getStaggerOffset(
+			final long currentProcessingTime,
+			final long size) {
+			return 0L;
+		}
+	},
+
+	/**
+	 * Stagger offset is sampled from uniform distribution U(0, WindowSize) when first event ingested in the partitioned operator.
+	 */
+	RANDOM {
+		@Override
+		public long getStaggerOffset(
+			final long currentProcessingTime,
+			final long size) {
+			return (long) (ThreadLocalRandom.current().nextDouble() * size);
+		}
+	},
+
+	/**
+	 * Stagger offset is the ingestion delay in processing time, which is the difference between first event ingestion time and its corresponding processing window start time
+	 * in the partitioned operator. In other words, each partitioned window starts when its first pane created.
+	 */
+	NATURAL {
+		@Override
+		public long getStaggerOffset(
+			final long currentProcessingTime,
+			final long size) {
+			final long currentProcessingWindowStart = TimeWindow.getWindowStartWithOffset(currentProcessingTime, 0, size);
+			return Math.max(0, currentProcessingTime - currentProcessingWindowStart);
+		}
+	};
+	public abstract long getStaggerOffset(final long currentProcessingTime, final long size);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowStagger.java
@@ -51,8 +51,9 @@ public enum WindowStagger {
 	},
 
 	/**
-	 * Stagger offset is the ingestion delay in processing time, which is the difference between first event ingestion time and its corresponding processing window start time
-	 * in the partitioned operator. In other words, each partitioned window starts when its first pane created.
+	 * When the first event is received, the partitioned operator is assigned a stagger offset,
+	 * which is the lag of that event in its corresponding un-offset processing time window,
+	 * so that the following panes are always aligned with respect to the first event.
 	 */
 	NATURAL {
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
@@ -63,7 +63,7 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
-	public void testWindowAssignmentWithOffset() {
+	public void testWindowAssignmentWithGlobalOffset() {
 		WindowAssigner.WindowAssignerContext mockContext =
 				mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -80,7 +80,7 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
-	public void testWindowAssignmentWithNegativeOffset() {
+	public void testWindowAssignmentWithNegativeGlobalOffset() {
 		WindowAssigner.WindowAssignerContext mockContext =
 			mock(WindowAssigner.WindowAssignerContext.class);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -60,6 +61,23 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 
 		when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
 		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(5000, 10000)));
+	}
+
+	@Test
+	public void testWindowAssignmentWithStagger() {
+		WindowAssigner.WindowAssignerContext mockContext =
+				mock(WindowAssigner.WindowAssignerContext.class);
+
+		TumblingProcessingTimeWindows assigner = TumblingProcessingTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(0), WindowStagger.NATURAL);
+
+		when(mockContext.getCurrentProcessingTime()).thenReturn(150L);
+		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(150, 5150)));
+
+		when(mockContext.getCurrentProcessingTime()).thenReturn(5049L);
+		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(150, 5150)));
+
+		when(mockContext.getCurrentProcessingTime()).thenReturn(5150L);
+		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(5150, 10150)));
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link WindowStagger}.
+ */
+public class WindowStaggerTest {
+	private final long sizeInMilliseconds = 5000;
+
+	@Test
+	public void testWindowStagger() {
+		assertEquals(0L, WindowStagger.ALIGNED.getStaggerOffset(500L, sizeInMilliseconds));
+		assertEquals(500L, WindowStagger.NATURAL.getStaggerOffset(5500L, sizeInMilliseconds));
+		assertTrue(0 < WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds));
+		assertTrue(sizeInMilliseconds > WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds));
+	}
+}


### PR DESCRIPTION
> ## What is the purpose of the change
> Flink triggers all panes belonging to one window at the same time. In other words, all panes are aligned and their triggers all fire simultaneously, causing the spiking workload effect. This pull request adds WindowStagger to generate staggering offset for each window assignment at runtime, so the workloads are distributed across time. Hence each window assignment is based on window size, window offset and staggering offset (generated in runtime).
> 
> This change only modifies TumblingProcessingTimeWindows, will send out other windows change in other PRs.
> 
> ## Brief change log
> * _Add WindowStagger for generating staggering offsets_
> * _Enable TumblingProcessingTimeWindows to generate staggering offsets if user enabled_
> 
> ## Verifying this change
> This change is already covered by existing tests, such as _TumblingProcessingTimeWindowsTest_.
> 
> This change added tests and can be verified as follows:
> 
> * _Added unit tests for WindowStagger_
> * _Validated the change by running in our clusters with 3500 task managers in total on a stateful streaming program using sliding and tumbling windowing. Some dashboards are shown below_
> 
> ![](https://camo.githubusercontent.com/298c26fefe598c1b4605a83f84451adfde4fae50/68747470733a2f2f6973737565732e6170616368652e6f72672f6a6972612f7365637572652f6174746163686d656e742f31323937313835362f737461676765725f77696e646f775f64656c61792e706e67)
> ![](https://camo.githubusercontent.com/3c4769bd8b7352c8860eaaa4bc6bbffc64104975/68747470733a2f2f6973737565732e6170616368652e6f72672f6a6972612f7365637572652f6174746163686d656e742f31323937313835372f737461676765725f77696e646f775f7468726f7567687075742e706e67)
> ![](https://camo.githubusercontent.com/5fd01124c4c21d9388eab78c498c928ff6a651db/68747470733a2f2f6973737565732e6170616368652e6f72672f6a6972612f7365637572652f6174746163686d656e742f31323937313835392f737461676765725f77696e646f772e706e67)
> 
> _some system metrics_
> 
> ![buffers_in_queue](https://user-images.githubusercontent.com/10646097/60139232-00f29d80-9762-11e9-84f4-3bfbde28c028.png)
> ![buffer_usage](https://user-images.githubusercontent.com/10646097/60139234-03ed8e00-9762-11e9-99d1-de845d02a8c6.png)
> ![output_record_rate](https://user-images.githubusercontent.com/10646097/60139237-064fe800-9762-11e9-959d-2db96c7f7bf6.png)
> 
> ## Does this pull request potentially affect one of the following parts:
> * Dependencies (does it add or upgrade a dependency): no
> * The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, TumblingProcessingTimeWindows(potentially all WindowAssigners)
> * The serializers: no
> * The runtime per-record code paths (performance sensitive): don't know, probably no ?
> * Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
> * The S3 file system connector: no
> 
> ## Documentation
> * Does this pull request introduce a new feature? yes
> * If yes, how is the feature documented? JavaDocs
