### PR TITLE
[FLINK-16572] [pubsub,e2e] Add check to see if adding a timeout to th…

### DIFF
--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/CheckPubSubEmulatorTest.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/CheckPubSubEmulatorTest.java
@@ -75,6 +75,13 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 			.get();
 
 		List<ReceivedMessage> receivedMessages = pubsubHelper.pullMessages(PROJECT_NAME, SUBSCRIPTION_NAME, 1);
+
+		//TODO this is just to test if we need to wait longer, or if something has gone wrong and the message will never arrive
+		if (receivedMessages.isEmpty()) {
+			LOG.error("Message did not arrive, gonna wait 60s and try to pull again.");
+			Thread.sleep(30 * 1000);
+			receivedMessages = pubsubHelper.pullMessages(PROJECT_NAME, SUBSCRIPTION_NAME, 1);
+		}
 		assertEquals(1, receivedMessages.size());
 		assertEquals("Hello World PULL", receivedMessages.get(0).getMessage().getData().toStringUtf8());
 


### PR DESCRIPTION
This MR adds some extra logging to pubsub e2e test.

Because it's quite hard to reproduce locally we want to try and see what these extra logs tells us when it naturally happens again on azure.