### PR TITLE
[hotfix][formatting] Fix the checkstyle issue of missing a javadoc comment in DummyNoOpOperator

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/DummyNoOpOperator.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/DummyNoOpOperator.java
@@ -40,6 +40,9 @@ public class DummyNoOpOperator<IN> extends NoOpOperator<IN> {
 		setInput(input);
 	}
 
+	/**
+	 * Dummy file input format implementation.
+	 */
 	public static class DummyInputFormat<IN> extends FileInputFormat<IN> {
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Fix the checkstyle issue of missing a javadoc comment in DummyNoOpOperator, which would break the creation of release-1.11-rc1.

## Brief change log

Add javadoc comment for DummyNoOpOperator

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
