### PR TITLE
[FLINK-17625] [table] Fix ArrayIndexOutOfBoundsException in AppendOnlyTopNFunction

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
@@ -222,8 +222,8 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
 				buffer.removeAll(lastKey);
 				dataState.remove(lastKey);
 			} else {
-				buffer.remove(lastKey, lastElement);
-				dataState.put(lastKey, lastList);
+				buffer.removeLast();
+				dataState.put(lastKey, new ArrayList<>(lastList));
 			}
 			if (size == 0 || input.equals(lastElement)) {
 				return;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
@@ -213,14 +213,19 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
 			RowData lastKey = lastEntry.getKey();
 			List<RowData> lastList = (List<RowData>) lastEntry.getValue();
 			// remove last one
-			RowData lastElement = lastList.remove(lastList.size() - 1);
-			if (lastList.isEmpty()) {
+			int size = lastList.size();
+			RowData lastElement = null;
+			if (size > 0) {
+				lastElement = lastList.get(size - 1);
+			}
+			if (size <= 1) {
 				buffer.removeAll(lastKey);
 				dataState.remove(lastKey);
 			} else {
+				buffer.remove(lastKey, lastElement);
 				dataState.put(lastKey, lastList);
 			}
-			if (input.equals(lastElement)) {
+			if (size == 0 || input.equals(lastElement)) {
 				return;
 			} else {
 				// lastElement shouldn't be null

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/TopNBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/TopNBuffer.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -94,12 +95,12 @@ class TopNBuffer implements Serializable {
 	}
 
 	public void remove(RowData sortKey, RowData value) {
-		Collection<RowData> list = treeMap.get(sortKey);
-		if (list != null) {
-			if (list.remove(value)) {
+		Collection<RowData> collection = treeMap.get(sortKey);
+		if (collection != null) {
+			if (collection.remove(value)) {
 				currentTopNum -= 1;
 			}
-			if (list.size() == 0) {
+			if (collection.size() == 0) {
 				treeMap.remove(sortKey);
 			}
 		}
@@ -111,9 +112,9 @@ class TopNBuffer implements Serializable {
 	 * @param sortKey key to remove
 	 */
 	void removeAll(RowData sortKey) {
-		Collection<RowData> list = treeMap.get(sortKey);
-		if (list != null) {
-			currentTopNum -= list.size();
+		Collection<RowData> collection = treeMap.get(sortKey);
+		if (collection != null) {
+			currentTopNum -= collection.size();
 			treeMap.remove(sortKey);
 		}
 	}
@@ -127,14 +128,28 @@ class TopNBuffer implements Serializable {
 		Map.Entry<RowData, Collection<RowData>> last = treeMap.lastEntry();
 		RowData lastElement = null;
 		if (last != null) {
-			Collection<RowData> list = last.getValue();
-			lastElement = getLastElement(list);
-			if (lastElement != null) {
-				if (list.remove(lastElement)) {
-					currentTopNum -= 1;
-				}
-				if (list.size() == 0) {
-					treeMap.remove(last.getKey());
+			Collection<RowData> collection = last.getValue();
+			if (collection != null) {
+				if (collection instanceof List) {
+					List<RowData> list = (List<RowData>) collection;
+					lastElement = getListLastElement(list);
+					if (lastElement != null) {
+						removeListLastElement(list);
+						currentTopNum -= 1;
+						if (list.size() == 0) {
+							treeMap.remove(last.getKey());
+						}
+					}
+				} else {
+					lastElement = getLastElement(collection);
+					if (lastElement != null) {
+						if (collection.remove(lastElement)) {
+							currentTopNum -= 1;
+						}
+						if (collection.size() == 0) {
+							treeMap.remove(last.getKey());
+						}
+					}
 				}
 			}
 		}
@@ -150,31 +165,44 @@ class TopNBuffer implements Serializable {
 	RowData getElement(int rank) {
 		int curRank = 0;
 		for (Map.Entry<RowData, Collection<RowData>> entry : treeMap.entrySet()) {
-			Collection<RowData> list = entry.getValue();
-
-			if (curRank + list.size() >= rank) {
-				for (RowData elem : list) {
+			Collection<RowData> collection = entry.getValue();
+			if (curRank + collection.size() >= rank) {
+				for (RowData elem : collection) {
 					curRank += 1;
 					if (curRank == rank) {
 						return elem;
 					}
 				}
 			} else {
-				curRank += list.size();
+				curRank += collection.size();
 			}
 		}
 		return null;
 	}
 
-	private RowData getLastElement(Collection<RowData> list) {
+	private RowData getLastElement(Collection<RowData> collection) {
 		RowData element = null;
-		if (list != null && !list.isEmpty()) {
-			Iterator<RowData> iter = list.iterator();
+		if (collection != null && !collection.isEmpty()) {
+			Iterator<RowData> iter = collection.iterator();
 			while (iter.hasNext()) {
 				element = iter.next();
 			}
 		}
 		return element;
+	}
+
+	private RowData getListLastElement(List<RowData> list) {
+		RowData element = null;
+		if (list != null && !list.isEmpty()) {
+				element = list.get(list.size() - 1);
+		}
+		return element;
+	}
+
+	private void removeListLastElement(List<RowData> list) {
+		if (list != null && !list.isEmpty()) {
+				list.remove(list.size() - 1);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change
fix the bug of ArrayIndexOutOfBoundsException in AppendOnlyTopNFunction
## Brief change log
  - *fix the bug of ArrayIndexOutOfBoundsException in AppendOnlyTopNFunction*
  - *fix the bug of currentTopNum will always increase even remove retired element  in AppendOnlyTopNFunction#processElementWithoutRowNumber method*

## Verifying this change

This change is already covered by existing tests in TopNFunctionTestBase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
