### PR TITLE
[FLINK-15620] Remove deprecated enable default background cleanup

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -282,7 +282,7 @@ public class StateTtlConfig implements Serializable {
 		 * https://github.com/facebook/rocksdb/blob/master/include/rocksdb/compaction_filter.h#L69
 		 * It means that the TTL filter should be tested for List state taking into account this caveat.
 		 *
-		 * @deprecated Use more general configuration method {@link #cleanupInBackground()} instead
+		 * @deprecated Use more general configuration method {@link #cleanupInRocksdbCompactFilter(long)} instead
 		 */
 		@Nonnull
 		@Deprecated
@@ -305,22 +305,6 @@ public class StateTtlConfig implements Serializable {
 			strategies.put(
 				CleanupStrategies.Strategies.ROCKSDB_COMPACTION_FILTER,
 				new RocksdbCompactFilterCleanupStrategy(queryTimeAfterNumEntries));
-			return this;
-		}
-
-		/**
-		 * Enable default cleanup of expired state in background (enabled by default).
-		 *
-		 * <p>Depending on actually used backend, the corresponding default cleanup will kick in if supported.
-		 * If some specific cleanup is also configured, e.g. {@link #cleanupIncrementally(int, boolean)} or
-		 * {@link #cleanupInRocksdbCompactFilter()}, then the specific one will kick in instead of default.
-		 *
-		 * @deprecated enabled by default, no need to enable it manually
-		 */
-		@Nonnull
-		@Deprecated
-		public Builder cleanupInBackground() {
-			isCleanupInBackground = true;
 			return this;
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/StateTtlConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/StateTtlConfigTest.java
@@ -59,7 +59,6 @@ public class StateTtlConfigTest {
 	public void testStateTtlConfigBuildWithCleanupInBackground() {
 		StateTtlConfig ttlConfig = StateTtlConfig
 			.newBuilder(Time.seconds(1))
-			.cleanupInBackground()
 			.build();
 
 		assertThat(ttlConfig.getCleanupStrategies(), notNullValue());

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
@@ -58,7 +58,6 @@ public class DataStreamStateTTLTestProgram {
 		TtlTestConfig config = TtlTestConfig.fromArgs(pt);
 		StateTtlConfig ttlConfig = StateTtlConfig.newBuilder(config.ttl)
 			.cleanupFullSnapshot()
-			.cleanupInBackground()
 			.build();
 
 		env

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
@@ -99,7 +99,6 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
 		}
 
 		StateDescriptor<?, ?> stateDesc = initTest(getConfBuilder(TTL)
-			.cleanupInBackground()
 			.setStateVisibility(StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp)
 			.build());
 


### PR DESCRIPTION
## What is the purpose of the change

Follow-up for [FLINK-15620](https://issues.apache.org/jira/browse/FLINK-15620). Remove deprecated `cleanupInBackground` in `StateTtlConfig`.


## Brief change log

Remove deprecated `cleanupInBackground` in `StateTtlConfig`.


## Verifying this change

This should be covered by existing unit testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes but already deprecated since release 1.10
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
