### PR TITLE
[FLINK-17905][docs] Fix JDBC docs (datastream api)

### DIFF
--- a/docs/dev/connectors/jdbc.md
+++ b/docs/dev/connectors/jdbc.md
@@ -26,36 +26,6 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-
----
-title: "JDBC Connector"
-nav-title: JDBC
-nav-parent_id: connectors
-nav-pos: 9
----
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
-* This will be replaced by the TOC
-{:toc}
-
-
 This connector provides a sink that writes data to a JDBC database.
 
 To use it, add the following dependency to your project (along with your JDBC-driver):

--- a/docs/dev/connectors/jdbc.zh.md
+++ b/docs/dev/connectors/jdbc.zh.md
@@ -26,36 +26,6 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-
----
-title: "JDBC Connector"
-nav-title: JDBC
-nav-parent_id: connectors
-nav-pos: 9
----
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
-* This will be replaced by the TOC
-{:toc}
-
-
 This connector provides a sink that writes data to a JDBC database.
 
 To use it, add the following dependency to your project (along with your JDBC-driver):


### PR DESCRIPTION
## What is the purpose of the change

*Fix JDBC docs: some portion of markup is duplicated.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
