### PR TITLE
[FLINK-15621] Remove deprecated option and method to disable TTL compaction filter

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -271,28 +271,6 @@ public class StateTtlConfig implements Serializable {
 		/**
 		 * Cleanup expired state while Rocksdb compaction is running.
 		 *
-		 * <p>RocksDB runs periodic compaction of state updates and merges them to free storage.
-		 * During this process, the TTL filter checks timestamp of state entries and drops expired ones.
-		 * The feature has to be activated in RocksDb backend firstly
-		 * using the following Flink configuration option:
-		 * state.backend.rocksdb.ttl.compaction.filter.enabled.
-		 *
-		 * <p>Due to specifics of RocksDB compaction filter,
-		 * cleanup is not properly guaranteed if put and merge operations are used at the same time:
-		 * https://github.com/facebook/rocksdb/blob/master/include/rocksdb/compaction_filter.h#L69
-		 * It means that the TTL filter should be tested for List state taking into account this caveat.
-		 *
-		 * @deprecated Use more general configuration method {@link #cleanupInRocksdbCompactFilter(long)} instead
-		 */
-		@Nonnull
-		@Deprecated
-		public Builder cleanupInRocksdbCompactFilter() {
-			return cleanupInRocksdbCompactFilter(1000L);
-		}
-
-		/**
-		 * Cleanup expired state while Rocksdb compaction is running.
-		 *
 		 * <p>RocksDB compaction filter will query current timestamp,
 		 * used to check expiration, from Flink every time after processing {@code queryTimeAfterNumEntries} number of state entries.
 		 * Updating the timestamp more often can improve cleanup speed
@@ -312,7 +290,7 @@ public class StateTtlConfig implements Serializable {
 		 * Disable default cleanup of expired state in background (enabled by default).
 		 *
 		 * <p>If some specific cleanup is configured, e.g. {@link #cleanupIncrementally(int, boolean)} or
-		 * {@link #cleanupInRocksdbCompactFilter()}, this setting does not disable it.
+		 * {@link #cleanupInRocksdbCompactFilter(long)}, this setting does not disable it.
 		 */
 		@Nonnull
 		public Builder disableCleanupInBackground() {

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.tests;
 
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
@@ -81,9 +80,6 @@ public class DataStreamStateTTLTestProgram {
 		final MonotonicTTLTimeProvider ttlTimeProvider = new MonotonicTTLTimeProvider();
 
 		final StateBackend configuredBackend = env.getStateBackend();
-		if (configuredBackend instanceof RocksDBStateBackend) {
-			((RocksDBStateBackend) configuredBackend).enableTtlCompactionFilter();
-		}
 		final StateBackend stubBackend = new StubStateBackend(configuredBackend, ttlTimeProvider);
 		env.setStateBackend(stubBackend);
 	}

--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-import warnings
-
 from abc import ABCMeta
 
 from py4j.java_gateway import get_java_class
@@ -558,49 +556,6 @@ class RocksDBStateBackend(StateBackend):
         :return: True if incremental checkpoints are enabled, false otherwise.
         """
         return self._j_rocks_db_state_backend.isIncrementalCheckpointsEnabled()
-
-    def is_ttl_compaction_filter_enabled(self):
-        """
-        Gets whether compaction filter to cleanup state with TTL is enabled.
-
-        :return: True if enabled, false otherwise.
-
-        .. note:: Deprecated in 1.10. Enabled by default and will be removed in the future.
-        """
-        warnings.warn(
-            "Deprecated in 1.10. Enabled by default and will be removed in the future.",
-            DeprecationWarning)
-        return self._j_rocks_db_state_backend.isTtlCompactionFilterEnabled()
-
-    def enable_ttl_compaction_filter(self):
-        """
-        Enable compaction filter to cleanup state with TTL.
-
-        .. note::
-            User can still decide in state TTL configuration in state descriptor
-            whether the filter is active for particular state or not.
-
-        .. note:: Deprecated in 1.10. Enabled by default and will be removed in the future.
-        """
-        warnings.warn(
-            "Deprecated in 1.10. Enabled by default and will be removed in the future.",
-            DeprecationWarning)
-        self._j_rocks_db_state_backend.enableTtlCompactionFilter()
-
-    def disable_ttl_compaction_filter(self):
-        """
-        Disable compaction filter to cleanup state with TTL.
-
-        .. note::
-            This is an advanced option and the method should only be used
-            when experiencing serious performance degradations during compaction in RocksDB.
-
-        .. note:: Deprecated in 1.10. Enabled by default and will be removed in the future.
-        """
-        warnings.warn(
-            "Deprecated in 1.10. Enabled by default and will be removed in the future.",
-            DeprecationWarning)
-        self._j_rocks_db_state_backend.disableTtlCompactionFilter()
 
     def set_predefined_options(self, options):
         """

--- a/flink-python/pyflink/datastream/tests/test_state_backend.py
+++ b/flink-python/pyflink/datastream/tests/test_state_backend.py
@@ -154,16 +154,6 @@ class RocksDBStateBackendTests(PyFlinkTestCase):
         state_backend.set_db_storage_paths(*storage_path)
         self.assertEqual(state_backend.get_db_storage_paths(), expected)
 
-    def test_get_set_ttl_compaction_filter(self):
-
-        state_backend = RocksDBStateBackend("file://var/checkpoints/")
-
-        self.assertTrue(state_backend.is_ttl_compaction_filter_enabled())
-
-        state_backend.disable_ttl_compaction_filter()
-
-        self.assertFalse(state_backend.is_ttl_compaction_filter_enabled())
-
     def test_get_set_predefined_options(self):
 
         state_backend = RocksDBStateBackend("file://var/checkpoints/")

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -108,8 +108,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 
 	/** True if incremental checkpointing is enabled. */
 	private boolean enableIncrementalCheckpointing;
-	/** True if ttl compaction filter is enabled. */
-	private boolean enableTtlCompactionFilter;
+
 	private RocksDBNativeMetricOptions nativeMetricOptions;
 	private int numberOfTransferingThreads;
 	private long writeBatchSize = RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes();
@@ -211,11 +210,6 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 		return this;
 	}
 
-	RocksDBKeyedStateBackendBuilder<K> setEnableTtlCompactionFilter(boolean enableTtlCompactionFilter) {
-		this.enableTtlCompactionFilter = enableTtlCompactionFilter;
-		return this;
-	}
-
 	RocksDBKeyedStateBackendBuilder<K> setNativeMetricOptions(RocksDBNativeMetricOptions nativeMetricOptions) {
 		this.nativeMetricOptions = nativeMetricOptions;
 		return this;
@@ -254,7 +248,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 		RocksDB db = null;
 		AbstractRocksDBRestoreOperation restoreOperation = null;
 		RocksDbTtlCompactFiltersManager ttlCompactFiltersManager =
-			new RocksDbTtlCompactFiltersManager(enableTtlCompactionFilter, ttlTimeProvider);
+			new RocksDbTtlCompactFiltersManager(ttlTimeProvider);
 
 		ResourceGuard rocksDBResourceGuard = new ResourceGuard();
 		SnapshotStrategy<K> snapshotStrategy;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -66,19 +66,6 @@ public class RocksDBOptions {
 		.withDescription("The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.");
 
 	/**
-	 * This determines if compaction filter to cleanup state with TTL is enabled.
-	 *
-	 * @deprecated the option will be removed in the future and should only be used
-	 * when experiencing serious performance degradations.
-	 */
-	@Deprecated
-	public static final ConfigOption<Boolean> TTL_COMPACT_FILTER_ENABLED = ConfigOptions
-		.key("state.backend.rocksdb.ttl.compaction.filter.enabled")
-		.defaultValue(true)
-		.withDescription("This determines if compaction filter to cleanup state with TTL is enabled for backend. " +
-			"Note: User can still decide in state TTL configuration in state descriptor " +
-			"whether the filter is active for particular state or not.");
-	/**
 	 * The predefined settings for RocksDB DBOptions and ColumnFamilyOptions by Flink community.
 	 */
 	@Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -74,7 +74,6 @@ import java.util.UUID;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BATCH_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM;
 import static org.apache.flink.contrib.streaming.state.RocksDBOptions.TIMER_SERVICE_FACTORY;
-import static org.apache.flink.contrib.streaming.state.RocksDBOptions.TTL_COMPACT_FILTER_ENABLED;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -140,14 +139,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 	/** Thread number used to transfer (download and upload) state, default value: 1. */
 	private int numberOfTransferThreads;
-
-	/**
-	 * This determines if compaction filter to cleanup state with TTL is enabled.
-	 *
-	 * <p>Note: User can still decide in state TTL configuration in state descriptor
-	 * whether the filter is active for particular state or not.
-	 */
-	private TernaryBoolean enableTtlCompactionFilter;
 
 	/** The configuration for memory settings (pool sizes, etc.). */
 	private final RocksDBMemoryConfiguration memoryConfiguration;
@@ -276,7 +267,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
 		this.numberOfTransferThreads = UNDEFINED_NUMBER_OF_TRANSFER_THREADS;
 		this.defaultMetricOptions = new RocksDBNativeMetricOptions();
-		this.enableTtlCompactionFilter = TernaryBoolean.UNDEFINED;
 		this.memoryConfiguration = new RocksDBMemoryConfiguration();
 		this.writeBatchSize = UNDEFINED_WRITE_BATCH_SIZE;
 	}
@@ -326,8 +316,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		} else {
 			this.writeBatchSize = original.writeBatchSize;
 		}
-		this.enableTtlCompactionFilter = original.enableTtlCompactionFilter
-			.resolveUndefined(config.get(TTL_COMPACT_FILTER_ENABLED));
 
 		this.memoryConfiguration = RocksDBMemoryConfiguration.fromOtherAndConfiguration(original.memoryConfiguration, config);
 		this.memoryConfiguration.validate();
@@ -541,7 +529,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			cancelStreamRegistry
 		)
 			.setEnableIncrementalCheckpointing(isIncrementalCheckpointsEnabled())
-			.setEnableTtlCompactionFilter(isTtlCompactionFilterEnabled())
 			.setNumberOfTransferingThreads(getNumberOfTransferThreads())
 			.setNativeMetricOptions(resourceContainer.getMemoryWatcherOptions(defaultMetricOptions))
 			.setWriteBatchSize(getWriteBatchSize());
@@ -732,42 +719,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 */
 	public boolean isIncrementalCheckpointsEnabled() {
 		return enableIncrementalCheckpointing.getOrDefault(CheckpointingOptions.INCREMENTAL_CHECKPOINTS.defaultValue());
-	}
-
-	/**
-	 * Gets whether incremental checkpoints are enabled for this state backend.
-	 *
-	 * @deprecated enabled by default and will be removed in the future.
-	 */
-	@Deprecated
-	public boolean isTtlCompactionFilterEnabled() {
-		return enableTtlCompactionFilter.getOrDefault(TTL_COMPACT_FILTER_ENABLED.defaultValue());
-	}
-
-	/**
-	 * Enable compaction filter to cleanup state with TTL.
-	 *
-	 * <p>Note: User can still decide in state TTL configuration in state descriptor
-	 * whether the filter is active for particular state or not.
-	 *
-	 * @deprecated enabled by default and will be removed in the future.
-	 */
-	@Deprecated
-	public void enableTtlCompactionFilter() {
-		enableTtlCompactionFilter = TernaryBoolean.TRUE;
-	}
-
-	/**
-	 * Disable compaction filter to cleanup state with TTL.
-	 *
-	 * <p>Note: This is an advanced option and the method should only be used
-	 * when experiencing serious performance degradations during compaction in RocksDB.
-	 *
-	 * @deprecated enabled by default and will be removed in the future.
-	 */
-	@Deprecated
-	public void disableTtlCompactionFilter() {
-		enableTtlCompactionFilter = TernaryBoolean.FALSE;
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
@@ -38,7 +38,6 @@ import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
 
-import static org.apache.flink.contrib.streaming.state.RocksDBOptions.TTL_COMPACT_FILTER_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -70,7 +69,6 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
 		}
 		RocksDBStateBackend backend = new RocksDBStateBackend(new FsStateBackend(checkpointPath), enableIncrementalCheckpointing);
 		Configuration config = new Configuration();
-		config.setBoolean(TTL_COMPACT_FILTER_ENABLED, true);
 		backend = backend.configure(config, Thread.currentThread().getContextClassLoader());
 		backend.setDbStoragePath(dbPath);
 		return backend;


### PR DESCRIPTION
## What is the purpose of the change

Rebased on https://github.com/apache/flink/pull/12304, This change contains two commits:

1. Remove deprecated enable default background cleanup
2. Remove deprecated option and method to disable TTL compaction filter


## Brief change log

* Remove deprecated cleanupInBackground in StateTtlConfig.
* remove `enableTtlCompactionFilter` and related deprecated API in `RocksDBStateBackend`, `RocksDBKeyedStateBackend` and `CompactionFiltersManager`
* remove `TTL_COMPACT_FILTER_ENABLED` in `RocksDBOptions`
* remove compaction_filter related deprecated API in python


## Verifying this change

Existing unit testing should be able to cover this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: remove deprecated API
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
