### PR TITLE
[FLINK-17889][hive] Hive can not work with filesystem connector

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -907,19 +907,19 @@ under the License.
 							<relocations>
 								<relocation>
 									<pattern>org.apache.flink.runtime.fs.hdfs</pattern>
-									<shadedPattern>org.apache.flink.connectors.hive.fs.hdfs</shadedPattern>
+									<shadedPattern>org.apache.flink.hive.shaded.fs.hdfs</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.apache.flink.formats.parquet</pattern>
-									<shadedPattern>org.apache.flink.connectors.hive.formats.parquet</shadedPattern>
+									<shadedPattern>org.apache.flink.hive.shaded.formats.parquet</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.apache.parquet</pattern>
-									<shadedPattern>org.apache.flink.shaded.org.apache.parquet</shadedPattern>
+									<shadedPattern>org.apache.flink.hive.shaded.parquet</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>shaded.parquet</pattern>
-									<shadedPattern>org.apache.flink.reshaded.parquet</shadedPattern>
+									<shadedPattern>org.apache.flink.hive.reshaded.parquet</shadedPattern>
 								</relocation>
 							</relocations>
 							<filters>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -910,6 +910,10 @@ under the License.
 									<shadedPattern>org.apache.flink.connectors.hive.fs.hdfs</shadedPattern>
 								</relocation>
 								<relocation>
+									<pattern>org.apache.flink.formats.parquet</pattern>
+									<shadedPattern>org.apache.flink.connectors.hive.formats.parquet</shadedPattern>
+								</relocation>
+								<relocation>
 									<pattern>org.apache.parquet</pattern>
 									<shadedPattern>org.apache.flink.shaded.org.apache.parquet</shadedPattern>
 								</relocation>
@@ -918,6 +922,22 @@ under the License.
 									<shadedPattern>org.apache.flink.reshaded.parquet</shadedPattern>
 								</relocation>
 							</relocations>
+							<filters>
+								<filter>
+									<artifact>org.apache.flink:flink-orc_${scala.binary.version}</artifact>
+									<excludes>
+										<exclude>META-INF/services/org.apache.flink.table.factories.Factory</exclude>
+										<exclude>META-INF/services/org.apache.flink.table.factories.TableFactory</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<artifact>org.apache.flink:flink-parquet_${scala.binary.version}</artifact>
+									<excludes>
+										<exclude>META-INF/services/org.apache.flink.table.factories.Factory</exclude>
+										<exclude>META-INF/services/org.apache.flink.table.factories.TableFactory</exclude>
+									</excludes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
## What is the purpose of the change & Brief change log

- Hive jar should not include format java SPI file. Modify hive pom to exclude SPI file.
- relocation flink-parquet, Because we have already relocated the dependency of parquet, if we use hive and FS parquet at the same time, no relocation will cause class conflict.

## Verifying this change

Manually testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no