### PR TITLE
[FLINK-15507][state backends] Activate local recovery by default

### DIFF
--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -40,7 +40,7 @@
         </tr>
         <tr>
             <td><h5>state.backend.local-recovery</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignore this option.</td>
         </tr>

--- a/docs/_includes/generated/common_state_backends_section.html
+++ b/docs/_includes/generated/common_state_backends_section.html
@@ -34,7 +34,7 @@
         </tr>
         <tr>
             <td><h5>state.backend.local-recovery</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignore this option.</td>
         </tr>

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -275,8 +275,8 @@ that the task-local state is an in-memory consisting of heap objects, and not st
 
 ### Configuring task-local recovery
 
-Task-local recovery is *deactivated by default* and can be activated through Flink's configuration with the key `state.backend.local-recovery` as specified
-in `CheckpointingOptions.LOCAL_RECOVERY`. The value for this setting can either be *true* to enable or *false* (default) to disable local recovery.
+Task-local recovery is *activated by default* and can be deactivated through Flink's configuration with the key `state.backend.local-recovery` as specified
+in `CheckpointingOptions.LOCAL_RECOVERY`. The value for this setting can either be *true* (default) to enable or *false* to disable local recovery.
 
 ### Details on task-local recovery for different state backends
 

--- a/docs/ops/state/large_state_tuning.zh.md
+++ b/docs/ops/state/large_state_tuning.zh.md
@@ -275,8 +275,8 @@ that the task-local state is an in-memory consisting of heap objects, and not st
 
 ### Configuring task-local recovery
 
-Task-local recovery is *deactivated by default* and can be activated through Flink's configuration with the key `state.backend.local-recovery` as specified
-in `CheckpointingOptions.LOCAL_RECOVERY`. The value for this setting can either be *true* to enable or *false* (default) to disable local recovery.
+Task-local recovery is *activated by default* and can be deactivated through Flink's configuration with the key `state.backend.local-recovery` as specified
+in `CheckpointingOptions.LOCAL_RECOVERY`. The value for this setting can either be *true* (default) to enable or *false* to disable local recovery.
 
 ### Details on task-local recovery for different state backends
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -88,7 +88,7 @@ public class CheckpointingOptions {
 	@Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
 	public static final ConfigOption<Boolean> LOCAL_RECOVERY = ConfigOptions
 			.key("state.backend.local-recovery")
-			.defaultValue(false)
+			.defaultValue(true)
 			.withDescription("This option configures local recovery for this state backend. By default, local recovery is " +
 				"deactivated. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does " +
 				"not support local recovery and ignore this option.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -113,7 +113,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 				localStateRootDirectories[i]);
 		}
 
-		Assert.assertFalse(taskStateManager.isLocalRecoveryEnabled());
+		Assert.assertTrue(taskStateManager.isLocalRecoveryEnabled());
 	}
 
 	/**


### PR DESCRIPTION
# What is the purpose of the change
Since local recovery for RocksDB can greatly help the recovery, and no overhead is introduced when incremental checkpoints are used. It should be activated by default.
So as not to add understanding costs for this setting to users, I simply activate the local recovery for all state backends. For FsStateBackend, it may helps the recovery when using distributed filesystem.

## Brief change log

 - set the default value of CheckpointingOptions.LOCAL_RECOVERY into *true*.
 - change the relative docs.
 - change unit test *TaskExecutorLocalStateStoresManagerTest*.

## Verifying this change

This change is already covered by existing tests, such as the *TaskExecutorLocalStateStoresManagerTest*.

I also try the WordCount streaming job with default settings and make sure the local recovery is activated by checking the local state directory.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)


CC @StephanEwen @carp84 