### PR TITLE
[FLINK-17917][yarn] Ignore the external resource with a value of 0 in…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
@@ -166,15 +167,20 @@ class WorkerSpecContainerResourceAdapter {
 	 * This class is for {@link WorkerSpecContainerResourceAdapter} internal usages only, to overcome the problem that
 	 * hash codes are calculated inconsistently across different {@link Resource} implementations.
 	 */
-	private static final class InternalContainerResource {
+	@VisibleForTesting
+	static final class InternalContainerResource {
 		private final int memory;
 		private final int vcores;
 		private final Map<String, Long> externalResources;
 
-		private InternalContainerResource(final int memory, final int vcores, final Map<String, Long> externalResources) {
+		@VisibleForTesting
+		InternalContainerResource(final int memory, final int vcores, final Map<String, Long> externalResources) {
 			this.memory = memory;
 			this.vcores = vcores;
-			this.externalResources = externalResources;
+			this.externalResources = externalResources.entrySet()
+						.stream()
+						.filter(entry -> !entry.getValue().equals(0L))
+						.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 		}
 
 		private InternalContainerResource(final Resource resource) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapterTest.java
@@ -29,12 +29,15 @@ import org.apache.hadoop.yarn.api.records.impl.pb.ResourcePBImpl;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -236,6 +239,24 @@ public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
 
 		assertThat(adapter.getEquivalentContainerResource(resourceImpl2, strategy), contains(resourceImpl1));
 		assertThat(adapter.getWorkerSpecs(resourceImpl2, strategy), contains(workerSpec));
+	}
+
+	@Test
+	public void testMatchInternalContainerResourceWithZeroValueExternalResource() {
+		final Map<String, Long> externalResources1 = new HashMap<>();
+		final Map<String, Long> externalResources2 = new HashMap<>();
+
+		externalResources1.put("foo", 0L);
+		externalResources1.put("bar", 1L);
+		externalResources2.put("zoo", 0L);
+		externalResources2.put("bar", 1L);
+
+		final WorkerSpecContainerResourceAdapter.InternalContainerResource internalContainerResource1 =
+			new WorkerSpecContainerResourceAdapter.InternalContainerResource(1024, 1, externalResources1);
+		final WorkerSpecContainerResourceAdapter.InternalContainerResource internalContainerResource2 =
+			new WorkerSpecContainerResourceAdapter.InternalContainerResource(1024, 1, externalResources2);
+
+		assertEquals(internalContainerResource1, internalContainerResource2);
 	}
 
 	private Configuration getConfigProcessSpecEqualsWorkerSpec() {


### PR DESCRIPTION
… ResourceInformationReflector#getExternalResources

## What is the purpose of the change

ResourceInformationReflector#getExternalResources should ignore the external resource with a value of 0.

## Brief change log

ResourceInformationReflector#getExternalResources should ignore the external resource with a value of 0.

## Verifying this change

This change added tests and can be verified as follows:
- `ResourceInformationReflectorTest#testGetResourceInformationIgnoreResourceWithZeroValue`

I also manually verify it with Yarn 3.1.0.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no