### PR TITLE
[FLINK-17896][hive] HiveCatalog can not work with new table factory because of is_generic

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.table.catalog.config.CatalogConfig.IS_GENERIC;
+
+/**
+ * A dynamic table factory implementation for Hive catalog. Now it only support generic tables.
+ * Hive tables should be resolved by {@link HiveTableFactory}.
+ */
+public class HiveDynamicTableFactory implements
+		DynamicTableSourceFactory,
+		DynamicTableSinkFactory {
+
+	@Override
+	public String factoryIdentifier() {
+		throw new UnsupportedOperationException("Hive factory is only work for catalog.");
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		throw new UnsupportedOperationException("Hive factory is only work for catalog.");
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		throw new UnsupportedOperationException("Hive factory is only work for catalog.");
+	}
+
+	private static CatalogTable removeIsGenericFlag(CatalogTable table) {
+		Map<String, String> newOptions = new HashMap<>(table.getOptions());
+		boolean isGeneric = Boolean.parseBoolean(newOptions.remove(IS_GENERIC));
+		if (!isGeneric) {
+			throw new ValidationException(
+					"Hive dynamic table factory now only work for generic table.");
+		}
+		return table.copy(newOptions);
+	}
+
+	@Override
+	public DynamicTableSink createDynamicTableSink(Context context) {
+		return FactoryUtil.createTableSink(
+				null, // we already in the factory of catalog
+				context.getObjectIdentifier(),
+				removeIsGenericFlag(context.getCatalogTable()),
+				context.getConfiguration(),
+				context.getClassLoader());
+	}
+
+	@Override
+	public DynamicTableSource createDynamicTableSource(Context context) {
+		return FactoryUtil.createTableSource(
+				null, // we already in the factory of catalog
+				context.getObjectIdentifier(),
+				removeIsGenericFlag(context.getCatalogTable()),
+				context.getConfiguration(),
+				context.getClassLoader());
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.catalog.hive;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.hadoop.mapred.utils.HadoopUtils;
+import org.apache.flink.connectors.hive.HiveDynamicTableFactory;
 import org.apache.flink.connectors.hive.HiveTableFactory;
 import org.apache.flink.sql.parser.hive.ddl.HiveDDLUtils;
 import org.apache.flink.sql.parser.hive.ddl.SqlAlterHiveTable.AlterTableOp;
@@ -69,6 +70,7 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.factories.TableFactory;
 import org.apache.flink.util.Preconditions;
@@ -235,6 +237,11 @@ public class HiveCatalog extends AbstractCatalog {
 			client = null;
 			LOG.info("Close connection to Hive metastore");
 		}
+	}
+
+	@Override
+	public Optional<Factory> getFactory() {
+		return Optional.of(new HiveDynamicTableFactory());
 	}
 
 	@Override


### PR DESCRIPTION

## What is the purpose of the change

```
[ERROR] Could not execute SQL statement. Reason:
org.apache.flink.table.api.ValidationException: Unsupported options found for connector 'print'.Unsupported options:is_genericSupported options:connector
print-identifier
property-version
standard-error
```

This's because HiveCatalog put is_generic property into generic tables, but the new factory will not delete it.

## Brief change log

- Implement `HiveDynamicTableFactory` to remove `is_generic` flag before create table source&sink

## Verifying this change

`HiveCatalogITCase.testNewTableFactory`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no