### PR TITLE
[FLINK-17819][yarn] Fix error msg for yarn deployments when hadoop not in classpath

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -176,22 +176,25 @@ public class CliFrontend {
 		final Options commandOptions = CliFrontendParser.getRunCommandOptions();
 		final CommandLine commandLine = getCommandLine(commandOptions, args, true);
 
-		final ProgramOptions programOptions = new ProgramOptions(commandLine);
-
 		if (commandLine.hasOption(HELP_OPTION.getOpt())) {
 			CliFrontendParser.printHelpForRun(customCommandLines);
 			return;
 		}
+
+		final CustomCommandLine activeCommandLine =
+				validateAndGetActiveCommandLine(checkNotNull(commandLine));
+
+		final ProgramOptions programOptions = new ProgramOptions(commandLine);
 
 		final ApplicationDeployer deployer =
 				new ApplicationClusterDeployer(clusterClientServiceLoader);
 
 		programOptions.validate();
 		final URI uri = PackagedProgramUtils.resolveURI(programOptions.getJarFilePath());
-		final Configuration effectiveConfiguration =
-			getEffectiveConfiguration(commandLine, programOptions, Collections.singletonList(uri.toString()));
+		final Configuration effectiveConfiguration = getEffectiveConfiguration(
+				activeCommandLine, commandLine, programOptions, Collections.singletonList(uri.toString()));
 		final ApplicationConfiguration applicationConfiguration =
-			new ApplicationConfiguration(programOptions.getProgramArgs(), programOptions.getEntryPointClassName());
+				new ApplicationConfiguration(programOptions.getProgramArgs(), programOptions.getEntryPointClassName());
 		deployer.run(effectiveConfiguration, applicationConfiguration);
 	}
 
@@ -206,20 +209,23 @@ public class CliFrontend {
 		final Options commandOptions = CliFrontendParser.getRunCommandOptions();
 		final CommandLine commandLine = getCommandLine(commandOptions, args, true);
 
-		final ProgramOptions programOptions = ProgramOptions.create(commandLine);
-
 		// evaluate help flag
 		if (commandLine.hasOption(HELP_OPTION.getOpt())) {
 			CliFrontendParser.printHelpForRun(customCommandLines);
 			return;
 		}
 
+		final CustomCommandLine activeCommandLine =
+				validateAndGetActiveCommandLine(checkNotNull(commandLine));
+
+		final ProgramOptions programOptions = ProgramOptions.create(commandLine);
+
 		final PackagedProgram program =
 				getPackagedProgram(programOptions);
 
 		final List<URL> jobJars = program.getJobJarAndDependencies();
-		final Configuration effectiveConfiguration =
-				getEffectiveConfiguration(commandLine, programOptions, jobJars);
+		final Configuration effectiveConfiguration = getEffectiveConfiguration(
+				activeCommandLine, commandLine, programOptions, jobJars);
 
 		LOG.debug("Effective executor configuration: {}", effectiveConfiguration);
 
@@ -242,16 +248,18 @@ public class CliFrontend {
 	}
 
 	private <T> Configuration getEffectiveConfiguration(
+			final CustomCommandLine activeCustomCommandLine,
 			final CommandLine commandLine,
 			final ProgramOptions programOptions,
 			final List<T> jobJars) throws FlinkException {
 
-		final CustomCommandLine customCommandLine = getActiveCustomCommandLine(checkNotNull(commandLine));
 		final ExecutionConfigAccessor executionParameters = ExecutionConfigAccessor.fromProgramOptions(
 				checkNotNull(programOptions),
 				checkNotNull(jobJars));
 
-		final Configuration executorConfig = customCommandLine.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = checkNotNull(activeCustomCommandLine)
+				.applyCommandLineOptionsToConfiguration(commandLine);
+
 		final Configuration effectiveConfiguration = new Configuration(executorConfig);
 
 		executionParameters.applyToConfiguration(effectiveConfiguration);
@@ -292,8 +300,11 @@ public class CliFrontend {
 
 			LOG.info("Creating program plan dump");
 
-			final Configuration effectiveConfiguration =
-					getEffectiveConfiguration(commandLine, programOptions, program.getJobJarAndDependencies());
+			final CustomCommandLine activeCommandLine =
+					validateAndGetActiveCommandLine(checkNotNull(commandLine));
+
+			final Configuration effectiveConfiguration = getEffectiveConfiguration(
+					activeCommandLine, commandLine, programOptions, program.getJobJarAndDependencies());
 
 			Pipeline pipeline = PackagedProgramUtils.getPipelineFromProgram(program, effectiveConfiguration, parallelism, true);
 			String jsonPlan = FlinkPipelineTranslationUtil.translateToJSONExecutionPlan(pipeline);
@@ -356,7 +367,7 @@ public class CliFrontend {
 			showAll = listOptions.showAll();
 		}
 
-		final CustomCommandLine activeCommandLine = getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine activeCommandLine = validateAndGetActiveCommandLine(commandLine);
 
 		runClusterAction(
 			activeCommandLine,
@@ -473,7 +484,7 @@ public class CliFrontend {
 
 		logAndSysout((advanceToEndOfEventTime ? "Draining job " : "Suspending job ") + "\"" + jobId + "\" with a savepoint.");
 
-		final CustomCommandLine activeCommandLine = getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine activeCommandLine = validateAndGetActiveCommandLine(commandLine);
 		runClusterAction(
 			activeCommandLine,
 			commandLine,
@@ -507,7 +518,7 @@ public class CliFrontend {
 			return;
 		}
 
-		final CustomCommandLine activeCommandLine = getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine activeCommandLine = validateAndGetActiveCommandLine(commandLine);
 
 		final String[] cleanedArgs = cancelOptions.getArgs();
 
@@ -597,7 +608,7 @@ public class CliFrontend {
 			return;
 		}
 
-		final CustomCommandLine activeCommandLine = getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine activeCommandLine = validateAndGetActiveCommandLine(commandLine);
 
 		if (savepointOptions.isDispose()) {
 			runClusterAction(
@@ -1048,7 +1059,14 @@ public class CliFrontend {
 					"y",
 					"yarn"));
 		} catch (NoClassDefFoundError | Exception e) {
-			LOG.warn("Could not load CLI class {}.", flinkYarnSessionCLI, e);
+			final String errorYarnSessionCLI = "org.apache.flink.yarn.cli.FallbackYarnSessionCli";
+			try {
+				LOG.info("Loading FallbackYarnSessionCli");
+				customCommandLines.add(
+						loadCustomCommandLine(errorYarnSessionCLI, configuration));
+			} catch (Exception exception) {
+				LOG.warn("Could not load CLI class {}.", flinkYarnSessionCLI, e);
+			}
 		}
 
 		//	Tips: DefaultCLI must be added at last, because getActiveCustomCommandLine(..) will get the
@@ -1067,7 +1085,7 @@ public class CliFrontend {
 	 * @param commandLine The input to the command-line.
 	 * @return custom command-line which is active (may only be one at a time)
 	 */
-	public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
+	public CustomCommandLine validateAndGetActiveCommandLine(CommandLine commandLine) {
 		LOG.debug("Custom commandlines: {}", customCommandLines);
 		for (CustomCommandLine cli : customCommandLines) {
 			LOG.debug("Checking custom commandline {}, isActive: {}", cli, cli.isActive(commandLine));
@@ -1075,7 +1093,11 @@ public class CliFrontend {
 				return cli;
 			}
 		}
-		throw new IllegalStateException("No command-line ran.");
+
+		throw new IllegalStateException(
+				"No valid command-line found. If you were targeting a Yarn cluster, please make sure to have " +
+				"hadoop in your classpath. For more information refer to the \"Deployment &  Operations\" section " +
+				"of the official Apache Flink documentation ");
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1093,11 +1093,7 @@ public class CliFrontend {
 				return cli;
 			}
 		}
-
-		throw new IllegalStateException(
-				"No valid command-line found. If you were targeting a Yarn cluster, please make sure to have " +
-				"hadoop in your classpath. For more information refer to the \"Deployment &  Operations\" section " +
-				"of the official Apache Flink documentation ");
+		throw new IllegalStateException("No valid command-line found.");
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
@@ -70,6 +70,14 @@ public class DefaultClusterClientServiceLoader implements ClusterClientServiceLo
 			throw new IllegalStateException("Multiple compatible client factories found for:\n" + String.join("\n", configStr) + ".");
 		}
 
-		return compatibleFactories.isEmpty() ? null : (ClusterClientFactory<ClusterID>) compatibleFactories.get(0);
+		if (compatibleFactories.isEmpty()) {
+			throw new IllegalStateException(
+					"No ClusterClientFactory found to execute the application." +
+					" If you were targeting a Yarn cluster, please make sure to have " +
+					"hadoop in your classpath. For more information refer to the " +
+					"\"Deployment &  Operations\" section of the official Apache Flink documentation.");
+		}
+
+		return (ClusterClientFactory<ClusterID>) compatibleFactories.get(0);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
@@ -72,10 +72,10 @@ public class DefaultClusterClientServiceLoader implements ClusterClientServiceLo
 
 		if (compatibleFactories.isEmpty()) {
 			throw new IllegalStateException(
-					"No ClusterClientFactory found to execute the application." +
-					" If you were targeting a Yarn cluster, please make sure to have " +
-					"hadoop in your classpath. For more information refer to the " +
-					"\"Deployment &  Operations\" section of the official Apache Flink documentation.");
+					"No ClusterClientFactory found. If you were targeting a Yarn cluster, " +
+					"please make sure to export the HADOOP_CLASSPATH environment variable or have hadoop in your " +
+					"classpath. For more information refer to the \"Deployment & Operations\" section of the official " +
+					"Apache Flink documentation.");
 		}
 
 		return (ClusterClientFactory<ClusterID>) compatibleFactories.get(0);

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
@@ -32,7 +32,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -85,13 +84,12 @@ public class ClusterClientServiceLoaderTest {
 		fail();
 	}
 
-	@Test
+	@Test(expected = IllegalStateException.class)
 	public void testNoFactoriesFound() {
 		final Configuration config = new Configuration();
 		config.setString(DeploymentOptions.TARGET, NON_EXISTING_TARGET);
 
 		final ClusterClientFactory<Integer> factory = serviceLoaderUnderTest.getClusterClientFactory(config);
-		assertNull(factory);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
@@ -81,7 +81,11 @@ public class DefaultExecutorServiceLoader implements PipelineExecutorServiceLoad
 			throw new IllegalStateException("Multiple compatible client factories found for:\n" + configStr + ".");
 		}
 
-		return compatibleFactories.isEmpty() ? null : compatibleFactories.get(0);
+		if (compatibleFactories.isEmpty()) {
+			throw new IllegalStateException("No ExecutorFactory found to execute the application.");
+		}
+
+		return compatibleFactories.get(0);
 	}
 
 	@Override

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -244,7 +244,7 @@ object FlinkShell {
       frontend.getCustomCommandLineOptions)
     val commandLine = CliFrontendParser.parse(commandLineOptions, args, true)
 
-    val customCLI = frontend.getActiveCustomCommandLine(commandLine)
+    val customCLI = frontend.validateAndGetActiveCommandLine(commandLine)
     val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine)
 
     val serviceLoader = new DefaultClusterClientServiceLoader
@@ -283,7 +283,7 @@ object FlinkShell {
       frontend.getCustomCommandLineOptions)
     val commandLine = CliFrontendParser.parse(commandLineOptions, args, true)
 
-    val customCLI = frontend.getActiveCustomCommandLine(commandLine)
+    val customCLI = frontend.validateAndGetActiveCommandLine(commandLine)
     val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine);
 
     (executorConfig, None)

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FallbackYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FallbackYarnSessionCli.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.cli;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.cli.AbstractCustomCommandLine;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+import org.apache.flink.yarn.configuration.YarnDeploymentTarget;
+import org.apache.flink.yarn.executors.YarnJobClusterExecutor;
+import org.apache.flink.yarn.executors.YarnSessionClusterExecutor;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+/**
+ * A stub Yarn Command Line to throw an exception with the correct
+ * message when the {@code HADOOP_CLASSPATH} is not set.
+ */
+@Internal
+public class FallbackYarnSessionCli extends AbstractCustomCommandLine {
+
+	public static final String ID = "yarn-cluster";
+
+	private final Option applicationId;
+
+	public FallbackYarnSessionCli(Configuration configuration) {
+		super(configuration);
+		applicationId = new Option("yid", "yarnapplicationId", true, "Attach to running YARN session");
+	}
+
+	@Override
+	public void addGeneralOptions(Options baseOptions) {
+		super.addGeneralOptions(baseOptions);
+		baseOptions.addOption(applicationId);
+	}
+
+	@Override
+	public boolean isActive(CommandLine commandLine) {
+		if (originalIsActive(commandLine)) {
+			throw new IllegalStateException(YarnDeploymentTarget.ERROR_MESSAGE);
+		}
+		return false;
+	}
+
+	private boolean originalIsActive(CommandLine commandLine) {
+		final String jobManagerOption = commandLine.getOptionValue(addressOption.getOpt(), null);
+		final boolean yarnJobManager = ID.equals(jobManagerOption);
+		final boolean hasYarnAppId = commandLine.hasOption(applicationId.getOpt())
+				|| configuration.getOptional(YarnConfigOptions.APPLICATION_ID).isPresent();
+		final boolean hasYarnExecutor = YarnSessionClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET))
+				|| YarnJobClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
+		return hasYarnExecutor || yarnJobManager || hasYarnAppId;
+	}
+
+	@Override
+	public String getId() {
+		return ID;
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnDeploymentTarget.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnDeploymentTarget.java
@@ -37,6 +37,11 @@ public enum YarnDeploymentTarget {
 	SESSION("yarn-session"),
 	APPLICATION("yarn-application");
 
+	public static final String ERROR_MESSAGE =
+			"No Executor found. Please make sure to have hadoop in your classpath. " +
+			"For more information on how to do so refer to the \"Deployment & Operations\"" +
+			" section of the official Apache Flink documentation.";
+
 	private final String name;
 
 	YarnDeploymentTarget(final String name) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnDeploymentTarget.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnDeploymentTarget.java
@@ -38,9 +38,9 @@ public enum YarnDeploymentTarget {
 	APPLICATION("yarn-application");
 
 	public static final String ERROR_MESSAGE =
-			"No Executor found. Please make sure to have hadoop in your classpath. " +
-			"For more information on how to do so refer to the \"Deployment & Operations\"" +
-			" section of the official Apache Flink documentation.";
+			"No Executor found. Please make sure to export the HADOOP_CLASSPATH environment variable " +
+			"or have hadoop in your classpath. For more information refer to the \"Deployment & Operations\" " +
+			"section of the official Apache Flink documentation.";
 
 	private final String name;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
@@ -39,7 +39,7 @@ public class YarnJobClusterExecutorFactory implements PipelineExecutorFactory {
 	}
 
 	@Override
-	public boolean isCompatibleWith(@	Nonnull final Configuration configuration) {
+	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
 		return YarnJobClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
+import org.apache.flink.yarn.configuration.YarnDeploymentTarget;
 
 import javax.annotation.Nonnull;
 
@@ -38,12 +39,16 @@ public class YarnJobClusterExecutorFactory implements PipelineExecutorFactory {
 	}
 
 	@Override
-	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
+	public boolean isCompatibleWith(@	Nonnull final Configuration configuration) {
 		return YarnJobClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}
 
 	@Override
 	public PipelineExecutor getExecutor(@Nonnull final Configuration configuration) {
-		return new YarnJobClusterExecutor();
+		try {
+			return new YarnJobClusterExecutor();
+		} catch (NoClassDefFoundError e) {
+			throw new IllegalStateException(YarnDeploymentTarget.ERROR_MESSAGE);
+		}
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
+import org.apache.flink.yarn.configuration.YarnDeploymentTarget;
 
 import javax.annotation.Nonnull;
 
@@ -44,6 +45,10 @@ public class YarnSessionClusterExecutorFactory implements PipelineExecutorFactor
 
 	@Override
 	public PipelineExecutor getExecutor(@Nonnull final Configuration configuration) {
-		return new YarnSessionClusterExecutor();
+		try {
+			return new YarnSessionClusterExecutor();
+		} catch (NoClassDefFoundError e) {
+			throw new IllegalStateException(YarnDeploymentTarget.ERROR_MESSAGE);
+		}
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FallbackYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FallbackYarnSessionCliTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.yarn.cli.FallbackYarnSessionCli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for the {@link FallbackYarnSessionCliTest}.
+ */
+public class FallbackYarnSessionCliTest {
+
+	@Test(expected = IllegalStateException.class)
+	public void testExceptionWhenActiveWithYarnApplicationId() throws ParseException {
+		checkIfYarnFallbackCLIisActiveWithCLIArgs(
+				"run",
+				"-yid", ApplicationId.newInstance(0L, 0).toString());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testExceptionWhenActiveWithExplicitClusterType() throws ParseException {
+		checkIfYarnFallbackCLIisActiveWithCLIArgs(
+				"run",
+				"-m", FallbackYarnSessionCli.ID);
+	}
+
+	@Test
+	public void testFalseWhenNotActive() throws ParseException {
+		final boolean isActive = checkIfYarnFallbackCLIisActiveWithCLIArgs("run");
+		assertFalse(isActive);
+	}
+
+	private boolean checkIfYarnFallbackCLIisActiveWithCLIArgs(final String... args) throws ParseException {
+		final Options options = new Options();
+		final FallbackYarnSessionCli cliUnderTest =
+				new FallbackYarnSessionCli(new Configuration());
+		cliUnderTest.addGeneralOptions(options);
+
+		final CommandLineParser parser = new DefaultParser();
+		final CommandLine cmd = parser.parse(options, args);
+		return cliUnderTest.isActive(cmd);
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -193,7 +193,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 				argsUnderTest,
 				true);
 
-		final CustomCommandLine customCommandLine = cli.getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine customCommandLine = cli.validateAndGetActiveCommandLine(commandLine);
 		assertTrue(customCommandLine instanceof ExecutorCLI);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR simply changes the error message presented to the user when he/she is trying to submit to Yarn but hadoop is not in the classpath. The new message will be:

```
No Executor found. Please make sure to have hadoop in your classpath. For more information on how to do so refer to the "Deployment & Operations" section of the official Apache Flink documentation.
```

## Brief change log

The changes are:
 1. a `FallbackYarnSessionCli` that will be loaded by the `CliFrontend` in case there is a loading error when the frontend tries to load the actual `FlinkYarnSessionCli`. This cli will simply throw an exception with the above message when it detects that the `FlinkYarnSessionCli` would be used but it failed to be loaded (the `isActive` method).
 2. change of the error message in the `YarnJobClusterExecutorFactory` and the `YarnSessionClusterExecutorFactory` when the executor cannot be instantiated. This is to cover for the case where the user tries to access a Yarn cluster through the `ExecutorCLI`.

## Verifying this change

Was verified manually and also added the `FallbackYarnSessionCliTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
