### PR TITLE
[FLINK-17925][fs-connector] Fix Filesystem options to default values and types

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -182,7 +182,7 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 				TableBucketAssigner assigner = new TableBucketAssigner(partComputer);
 				TableRollingPolicy rollingPolicy = new TableRollingPolicy(
 						true,
-						conf.get(SINK_ROLLING_POLICY_FILE_SIZE),
+						conf.get(SINK_ROLLING_POLICY_FILE_SIZE).getBytes(),
 						conf.get(SINK_ROLLING_POLICY_TIME_INTERVAL).toMillis());
 
 				Optional<BulkWriter.Factory<RowData>> bulkFactory = createBulkWriterFactory(partitionColumns, sd);

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
@@ -32,7 +32,7 @@ public class CsvFilesystemStreamITCase extends FsStreamingSinkITCaseBase {
 		List<String> ret = new ArrayList<>();
 		ret.add("'format'='csv'");
 		// for test purpose
-		ret.add("'sink.rolling-policy.file-size'='1'");
+		ret.add("'sink.rolling-policy.file-size'='1b'");
 		return ret.toArray(new String[0]);
 	}
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFsStreamSinkITCase.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFsStreamSinkITCase.java
@@ -33,7 +33,7 @@ public class JsonFsStreamSinkITCase extends FsStreamingSinkITCaseBase {
 		List<String> ret = new ArrayList<>();
 		ret.add("'format'='json'");
 		// for test purpose
-		ret.add("'sink.rolling-policy.file-size'='1'");
+		ret.add("'sink.rolling-policy.file-size'='1b'");
 		return ret.toArray(new String[0]);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -79,12 +79,12 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
 
   @Test
   def testNonPart(): Unit = {
-    test(false)
+    test(partition = false)
   }
 
   @Test
   def testPart(): Unit = {
-    test(true)
+    test(partition = true)
     val basePath = new File(new URI(resultPath).getPath, "d=2020-05-03")
     Assert.assertEquals(5, basePath.list().length)
     Assert.assertTrue(new File(new File(basePath, "e=7"), "_MY_SUCCESS").exists())
@@ -94,7 +94,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
     Assert.assertTrue(new File(new File(basePath, "e=11"), "_MY_SUCCESS").exists())
   }
 
-  private def test(partition: Boolean): Unit = {
+  private def test(partition: Boolean, policy: String = "success-file"): Unit = {
     val dollar = '$'
     val ddl = s"""
                  |create table sink_table (
@@ -111,7 +111,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
                  |  '${PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()}' =
                  |      '${dollar}d ${dollar}e:00:00',
                  |  '${SINK_PARTITION_COMMIT_DELAY.key()}' = '1h',
-                 |  '${SINK_PARTITION_COMMIT_POLICY_KIND.key()}' = 'success-file',
+                 |  '${SINK_PARTITION_COMMIT_POLICY_KIND.key()}' = '$policy',
                  |  '${SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key()}' = '_MY_SUCCESS',
                  |  ${additionalProperties().mkString(",\n")}
                  |)
@@ -127,6 +127,13 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
       ddl,
       "select * from sink_table",
       data)
+  }
+
+  @Test
+  def testMetastorePolicy(): Unit = {
+    thrown.expectMessage(
+      "Can not configure a metastore partition commit policy for a table without metastore.")
+    test(partition = true, "metastore")
   }
 
   def check(ddl: String, sqlQuery: String, expectedResult: Seq[Row]): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -132,7 +132,8 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
   @Test
   def testMetastorePolicy(): Unit = {
     thrown.expectMessage(
-      "Can not configure a metastore partition commit policy for a table without metastore.")
+      "Can not configure a 'metastore' partition commit policy for a file system table." +
+          " You can only configure 'metastore' partition commit policy for a hive table.")
     test(partition = true, "metastore")
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FsStreamingSinkTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FsStreamingSinkTestCsvITCase.scala
@@ -36,7 +36,7 @@ class FsStreamingSinkTestCsvITCase(useBulkWriter: Boolean) extends FsStreamingSi
         Seq(
           "'format' = 'testcsv'",
           s"'testcsv.use-bulk-writer' = '$useBulkWriter'") ++
-        (if (useBulkWriter) Seq() else Seq("'sink.rolling-policy.file-size' = '1'"))
+        (if (useBulkWriter) Seq() else Seq("'sink.rolling-policy.file-size' = '1b'"))
   }
 }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/EmptyMetaStoreFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/EmptyMetaStoreFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.Path;
+
+import java.util.LinkedHashMap;
+import java.util.Optional;
+
+/**
+ * Empty implementation {@link TableMetaStoreFactory}.
+ */
+@Internal
+public class EmptyMetaStoreFactory implements TableMetaStoreFactory {
+
+	private final Path path;
+
+	public EmptyMetaStoreFactory(Path path) {
+		this.path = path;
+	}
+
+	@Override
+	public TableMetaStore createTableMetaStore() {
+		return new TableMetaStore() {
+
+			@Override
+			public Path getLocationPath() {
+				return path;
+			}
+
+			@Override
+			public Optional<Path> getPartition(LinkedHashMap<String, String> partitionSpec) {
+				return Optional.empty();
+			}
+
+			@Override
+			public void createOrAlterPartition(
+					LinkedHashMap<String, String> partitionSpec,
+					Path partitionPath) {
+			}
+
+			@Override
+			public void close() {
+
+			}
+		};
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.filesystem;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.MemorySize;
 
 import java.time.Duration;
 
@@ -40,9 +41,9 @@ public class FileSystemOptions {
 			.withDescription("The default partition name in case the dynamic partition" +
 					" column value is null/empty string");
 
-	public static final ConfigOption<Long> SINK_ROLLING_POLICY_FILE_SIZE = key("sink.rolling-policy.file-size")
-			.longType()
-			.defaultValue(1024L * 1024L * 128L)
+	public static final ConfigOption<MemorySize> SINK_ROLLING_POLICY_FILE_SIZE = key("sink.rolling-policy.file-size")
+			.memoryType()
+			.defaultValue(MemorySize.ofMebiBytes(128))
 			.withDescription("The maximum part file size before rolling (by default 128MB).");
 
 	public static final ConfigOption<Duration> SINK_ROLLING_POLICY_TIME_INTERVAL = key("sink.rolling-policy.time-interval")
@@ -132,12 +133,12 @@ public class FileSystemOptions {
 	public static final ConfigOption<String> SINK_PARTITION_COMMIT_TRIGGER =
 			key("sink.partition-commit.trigger")
 					.stringType()
-					.defaultValue("partition-time")
+					.defaultValue("process-time")
 					.withDescription("Trigger type for partition commit:" +
-							" 'partition-time': extract time from partition," +
-							" if 'watermark' > 'partition-time' + 'delay', will commit the partition." +
 							" 'process-time': use processing time, if 'current processing time' > " +
-							"'partition directory creation time' + 'delay', will commit the partition.");
+							"'partition directory creation time' + 'delay', will commit the partition." +
+							" 'partition-time': extract time from partition," +
+							" if 'watermark' > 'partition-time' + 'delay', will commit the partition.");
 
 	public static final ConfigOption<Duration> SINK_PARTITION_COMMIT_DELAY =
 			key("sink.partition-commit.delay")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -135,10 +135,11 @@ public class FileSystemOptions {
 					.stringType()
 					.defaultValue("process-time")
 					.withDescription("Trigger type for partition commit:" +
-							" 'process-time': use processing time, if 'current processing time' > " +
-							"'partition directory creation time' + 'delay', will commit the partition." +
+							" 'process-time': use processing time, if 'current time' > " +
+							"'partition creation time' + 'delay', will commit the partition." +
 							" 'partition-time': extract time from partition," +
-							" if 'watermark' > 'partition-time' + 'delay', will commit the partition.");
+							" if 'current event time' > 'time from partition values' + 'delay'," +
+							" will commit the partition.");
 
 	public static final ConfigOption<Duration> SINK_PARTITION_COMMIT_DELAY =
 			key("sink.partition-commit.delay")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -134,12 +134,13 @@ public class FileSystemOptions {
 			key("sink.partition-commit.trigger")
 					.stringType()
 					.defaultValue("process-time")
-					.withDescription("Trigger type for partition commit:" +
-							" 'process-time': use processing time, if 'current time' > " +
-							"'partition creation time' + 'delay', will commit the partition." +
-							" 'partition-time': extract time from partition," +
-							" if 'current event time' > 'time from partition values' + 'delay'," +
-							" will commit the partition.");
+					.withDescription("Trigger type for partition commit:\n" +
+							" 'process-time': based on the time of the local machine, it neither requires" +
+							" partition time extraction nor watermark generation. Commit partition" +
+							" once the 'current system time' passes 'partition creation system time' plus 'delay'.\n" +
+							" 'partition-time': based on the time that extracted from partition values," +
+							" it requires watermark generation. Commit partition once the 'watermark'" +
+							" passes 'event time extracted from partition values' plus 'delay'.");
 
 	public static final ConfigOption<Duration> SINK_PARTITION_COMMIT_DELAY =
 			key("sink.partition-commit.delay")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -135,12 +135,12 @@ public class FileSystemOptions {
 					.stringType()
 					.defaultValue("process-time")
 					.withDescription("Trigger type for partition commit:\n" +
-							" 'process-time': based on the time of the local machine, it neither requires" +
+							" 'process-time': based on the time of the machine, it neither requires" +
 							" partition time extraction nor watermark generation. Commit partition" +
 							" once the 'current system time' passes 'partition creation system time' plus 'delay'.\n" +
 							" 'partition-time': based on the time that extracted from partition values," +
 							" it requires watermark generation. Commit partition once the 'watermark'" +
-							" passes 'event time extracted from partition values' plus 'delay'.");
+							" passes 'time extracted from partition values' plus 'delay'.");
 
 	public static final ConfigOption<Duration> SINK_PARTITION_COMMIT_DELAY =
 			key("sink.partition-commit.delay")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -125,7 +125,7 @@ public class FileSystemTableSink implements
 				schema.getFieldDataTypes(),
 				partitionKeys.toArray(new String[0]));
 
-		TableMetaStoreFactory metaStoreFactory = createTableMetaStoreFactory(path);
+		EmptyMetaStoreFactory metaStoreFactory = new EmptyMetaStoreFactory(path);
 
 		if (isBounded) {
 			FileSystemOutputFormat.Builder<RowData> builder = new FileSystemOutputFormat.Builder<>();
@@ -146,7 +146,7 @@ public class FileSystemTableSink implements
 			TableBucketAssigner assigner = new TableBucketAssigner(computer);
 			TableRollingPolicy rollingPolicy = new TableRollingPolicy(
 					!(writer instanceof Encoder),
-					conf.get(SINK_ROLLING_POLICY_FILE_SIZE),
+					conf.get(SINK_ROLLING_POLICY_FILE_SIZE).getBytes(),
 					conf.get(SINK_ROLLING_POLICY_TIME_INTERVAL).toMillis());
 
 			BucketsBuilder<RowData, String, ? extends BucketsBuilder<RowData, ?, ?>> bucketsBuilder;
@@ -327,29 +327,6 @@ public class FileSystemTableSink implements
 			public void close() throws IOException {
 				this.output.flush();
 				this.output.close();
-			}
-		};
-	}
-
-	private static TableMetaStoreFactory createTableMetaStoreFactory(Path path) {
-		return (TableMetaStoreFactory) () -> new TableMetaStoreFactory.TableMetaStore() {
-
-			@Override
-			public Path getLocationPath() {
-				return path;
-			}
-
-			@Override
-			public Optional<Path> getPartition(LinkedHashMap<String, String> partitionSpec) {
-				return Optional.empty();
-			}
-
-			@Override
-			public void createOrAlterPartition(LinkedHashMap<String, String> partitionSpec, Path partitionPath) throws Exception {
-			}
-
-			@Override
-			public void close() {
 			}
 		};
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.filesystem;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.api.ValidationException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -104,7 +105,7 @@ public interface PartitionCommitPolicy {
 		}
 		String[] policyStrings = policyKind.split(",");
 		return Arrays.stream(policyStrings).map(name -> {
-			switch (name) {
+			switch (name.toLowerCase()) {
 				case METASTORE:
 					return new MetastoreCommitPolicy();
 				case SUCCESS_FILE:
@@ -120,5 +121,21 @@ public interface PartitionCommitPolicy {
 					throw new UnsupportedOperationException("Unsupported policy: " + name);
 			}
 		}).collect(Collectors.toList());
+	}
+
+	/**
+	 * Validate commit policy.
+	 */
+	static void validatePolicyChain(boolean isEmptyMetastore, String policyKind) {
+		if (policyKind != null) {
+			String[] policyStrings = policyKind.split(",");
+			for (String policy : policyStrings) {
+				if (isEmptyMetastore && METASTORE.equalsIgnoreCase(policy)) {
+					throw new ValidationException(
+							"Can not configure a metastore partition commit policy for" +
+									" a table without metastore.");
+				}
+			}
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
@@ -131,9 +131,9 @@ public interface PartitionCommitPolicy {
 			String[] policyStrings = policyKind.split(",");
 			for (String policy : policyStrings) {
 				if (isEmptyMetastore && METASTORE.equalsIgnoreCase(policy)) {
-					throw new ValidationException(
-							"Can not configure a metastore partition commit policy for" +
-									" a table without metastore.");
+					throw new ValidationException("Can not configure a 'metastore' partition commit" +
+							" policy for a file system table. You can only configure 'metastore'" +
+							" partition commit policy for a hive table.");
 				}
 			}
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/TableMetaStoreFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/TableMetaStoreFactory.java
@@ -47,6 +47,7 @@ public interface TableMetaStoreFactory extends Serializable {
 		/**
 		 * Get base location path of this table.
 		 */
+		@Deprecated
 		Path getLocationPath();
 
 		/**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
@@ -148,7 +148,7 @@ public class StreamingFileCommitter extends AbstractStreamOperator<Void>
 		try (TableMetaStoreFactory.TableMetaStore metaStore = metaStoreFactory.createTableMetaStore()) {
 			for (String partition : partitions) {
 				LinkedHashMap<String, String> partSpec = extractPartitionSpecFromPath(new Path(partition));
-				Path path = new Path(metaStore.getLocationPath(), generatePartitionPath(partSpec));
+				Path path = new Path(locationPath, generatePartitionPath(partSpec));
 				PartitionCommitPolicy.Context context = new PolicyContext(
 						new ArrayList<>(partSpec.values()), path);
 				for (PartitionCommitPolicy policy : policies) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.filesystem.EmptyMetaStoreFactory;
 import org.apache.flink.table.filesystem.MetastoreCommitPolicy;
 import org.apache.flink.table.filesystem.PartitionCommitPolicy;
 import org.apache.flink.table.filesystem.TableMetaStoreFactory;
@@ -93,6 +94,9 @@ public class StreamingFileCommitter extends AbstractStreamOperator<Void>
 		this.partitionKeys = partitionKeys;
 		this.metaStoreFactory = metaStoreFactory;
 		this.conf = conf;
+		PartitionCommitPolicy.validatePolicyChain(
+				metaStoreFactory instanceof EmptyMetaStoreFactory,
+				conf.get(SINK_PARTITION_COMMIT_POLICY_KIND));
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Fix Filesystem options:
- Throws unsupported exception when using metastore commit policy for filesystem table, Filesystem connector has an empty implementation in TableMetaStoreFactory. We should avoid user configuring this policy.
- Default value of "sink.partition-commit.trigger" should be "process-time". Users are hard to figure out what is wrong when they don't have watermark. We can set "sink.partition-commit.trigger" to "process-time" to have better out-of-box experience.
- The type of "sink.rolling-policy.file-size" should be MemoryType.

## Verifying this change


`FsStreamingSinkITCaseBase.testMetastorePolicy`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no