### PR TITLE
[hotfix] Remove generic row for HiveTableFactory

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
-import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -42,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A table factory implementation for Hive catalog.
  */
 public class HiveTableFactory
-		implements TableSourceFactory<RowData>, TableSinkFactory<Row> {
+		implements TableSourceFactory<RowData>, TableSinkFactory {
 
 	private final HiveConf hiveConf;
 
@@ -79,7 +78,7 @@ public class HiveTableFactory
 	}
 
 	@Override
-	public TableSink<Row> createTableSink(TableSinkFactory.Context context) {
+	public TableSink createTableSink(TableSinkFactory.Context context) {
 		CatalogTable table = checkNotNull(context.getTable());
 		Preconditions.checkArgument(table instanceof CatalogTableImpl);
 


### PR DESCRIPTION

## What is the purpose of the change

Remove generic row for HiveTableFactory, streaming sink maybe has RowData.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no