### PR TITLE
[FLINK-17936][table] Introduce new type inference for AS

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.util.Preconditions;
 
 import java.lang.reflect.Field;
@@ -35,6 +36,11 @@ import java.util.Set;
 import static org.apache.flink.table.functions.FunctionKind.AGGREGATE;
 import static org.apache.flink.table.functions.FunctionKind.OTHER;
 import static org.apache.flink.table.functions.FunctionKind.SCALAR;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.OUTPUT_IF_NULL;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.and;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.logical;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.or;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.varyingSequence;
 
 /**
  * Dictionary of function definitions for all built-in functions.
@@ -886,7 +892,12 @@ public final class BuiltInFunctionDefinitions {
 		new BuiltInFunctionDefinition.Builder()
 			.name("as")
 			.kind(OTHER)
-			.outputTypeStrategy(TypeStrategies.MISSING)
+			.inputTypeStrategy(
+				varyingSequence(
+					or(OUTPUT_IF_NULL, InputTypeStrategies.ANY),
+					and(InputTypeStrategies.LITERAL, logical(LogicalTypeFamily.CHARACTER_STRING)),
+					and(InputTypeStrategies.LITERAL, logical(LogicalTypeFamily.CHARACTER_STRING))))
+			.outputTypeStrategy(TypeStrategies.argument(0))
 			.build();
 	public static final BuiltInFunctionDefinition STREAM_RECORD_TIMESTAMP =
 		new BuiltInFunctionDefinition.Builder()

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -24,14 +24,18 @@ import org.apache.flink.table.types.inference.strategies.AndArgumentTypeStrategy
 import org.apache.flink.table.types.inference.strategies.AnyArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ArrayInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ExplicitArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.FamilyArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.LiteralArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.MapInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.OrArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.OrInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.OutputArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.RootArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.SequenceInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.VaryingSequenceInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.WildcardInputTypeStrategy;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import java.util.Arrays;
 import java.util.List;
@@ -167,6 +171,38 @@ public final class InputTypeStrategies {
 	 */
 	public static ExplicitArgumentTypeStrategy explicit(DataType expectedDataType) {
 		return new ExplicitArgumentTypeStrategy(expectedDataType);
+	}
+
+	/**
+	 * Strategy for an argument that corresponds to a given {@link LogicalTypeRoot}.
+	 * Implicit casts will be inserted if possible.
+	 */
+	public static RootArgumentTypeStrategy logical(LogicalTypeRoot expectedRoot) {
+		return new RootArgumentTypeStrategy(expectedRoot, true);
+	}
+
+	/**
+	 * Strategy for an argument that corresponds to a given {@link LogicalTypeRoot} and nullability.
+	 * Implicit casts will be inserted if possible.
+	 */
+	public static RootArgumentTypeStrategy logical(LogicalTypeRoot expectedRoot, boolean expectedNullability) {
+		return new RootArgumentTypeStrategy(expectedRoot, expectedNullability);
+	}
+
+	/**
+	 * Strategy for an argument that corresponds to a given {@link LogicalTypeFamily}.
+	 * Implicit casts will be inserted if possible.
+	 */
+	public static FamilyArgumentTypeStrategy logical(LogicalTypeFamily expectedFamily) {
+		return new FamilyArgumentTypeStrategy(expectedFamily, true);
+	}
+
+	/**
+	 * Strategy for an argument that corresponds to a given {@link LogicalTypeFamily} and nullability.
+	 * Implicit casts will be inserted if possible.
+	 */
+	public static FamilyArgumentTypeStrategy logical(LogicalTypeFamily expectedFamily, boolean expectedNullability) {
+		return new FamilyArgumentTypeStrategy(expectedFamily, expectedNullability);
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -178,7 +178,7 @@ public final class InputTypeStrategies {
 	 * Implicit casts will be inserted if possible.
 	 */
 	public static RootArgumentTypeStrategy logical(LogicalTypeRoot expectedRoot) {
-		return new RootArgumentTypeStrategy(expectedRoot, true);
+		return new RootArgumentTypeStrategy(expectedRoot, null);
 	}
 
 	/**
@@ -194,7 +194,7 @@ public final class InputTypeStrategies {
 	 * Implicit casts will be inserted if possible.
 	 */
 	public static FamilyArgumentTypeStrategy logical(LogicalTypeFamily expectedFamily) {
-		return new FamilyArgumentTypeStrategy(expectedFamily, true);
+		return new FamilyArgumentTypeStrategy(expectedFamily, null);
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FamilyArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FamilyArgumentTypeStrategy.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.table.types.inference.strategies.RootArgumentTypeStrategy.findDataType;
+
+/**
+ * Strategy for an argument that corresponds to a given {@link LogicalTypeFamily} and nullability.
+ *
+ * <p>Implicit casts will be inserted if possible.
+ */
+@Internal
+public final class FamilyArgumentTypeStrategy implements ArgumentTypeStrategy {
+
+	private final LogicalTypeFamily expectedFamily;
+
+	private final boolean expectedNullability;
+
+	private static final Map<LogicalTypeFamily, LogicalTypeRoot> familyToRoot = new HashMap<>();
+	static {
+		// commonly used type roots for families
+		familyToRoot.put(LogicalTypeFamily.NUMERIC, LogicalTypeRoot.INTEGER);
+		familyToRoot.put(LogicalTypeFamily.EXACT_NUMERIC, LogicalTypeRoot.INTEGER);
+		familyToRoot.put(LogicalTypeFamily.CHARACTER_STRING, LogicalTypeRoot.VARCHAR);
+		familyToRoot.put(LogicalTypeFamily.BINARY_STRING, LogicalTypeRoot.BINARY);
+		familyToRoot.put(LogicalTypeFamily.APPROXIMATE_NUMERIC, LogicalTypeRoot.DOUBLE);
+		familyToRoot.put(LogicalTypeFamily.TIMESTAMP, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE);
+		familyToRoot.put(LogicalTypeFamily.TIME, LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE);
+	}
+
+	public FamilyArgumentTypeStrategy(LogicalTypeFamily expectedFamily, boolean expectedNullability) {
+		Preconditions.checkArgument(
+			familyToRoot.containsKey(expectedFamily),
+			"Unsupported family for argument type strategy.");
+		this.expectedFamily = expectedFamily;
+		this.expectedNullability = expectedNullability;
+	}
+
+	@Override
+	public Optional<DataType> inferArgumentType(CallContext callContext, int argumentPos, boolean throwOnFailure) {
+		final DataType actualDataType = callContext.getArgumentDataTypes().get(argumentPos);
+		final LogicalType actualType = actualDataType.getLogicalType();
+
+		if (!expectedNullability && actualType.isNullable()) {
+			if (throwOnFailure) {
+				throw callContext.newValidationError(
+					"Unsupported argument type. Expected nullable type of family '%s' but actual type was '%s'.",
+					expectedFamily,
+					actualType);
+			}
+			return Optional.empty();
+		}
+
+		// type is part of the family
+		if (actualType.getTypeRoot().getFamilies().contains(expectedFamily)) {
+			return Optional.of(actualDataType);
+		}
+
+		// find a type for the family
+		final LogicalTypeRoot expectedRoot = familyToRoot.get(expectedFamily);
+		final Optional<DataType> inferredDataType = findDataType(
+			callContext,
+			false,
+			actualDataType,
+			expectedRoot,
+			expectedNullability);
+		if (!inferredDataType.isPresent() && throwOnFailure) {
+			throw callContext.newValidationError(
+					"Unsupported argument type. Expected type of family '%s' but actual type was '%s'.",
+					expectedFamily,
+					actualType);
+		}
+		return inferredDataType;
+	}
+
+	@Override
+	public Signature.Argument getExpectedArgument(FunctionDefinition functionDefinition, int argumentPos) {
+		// "< ... >" to indicate that this is not a type
+		if (!expectedNullability) {
+			return Signature.Argument.of("<" + expectedFamily + " NOT NULL>");
+		}
+		return Signature.Argument.of("<" + expectedFamily + ">");
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		FamilyArgumentTypeStrategy that = (FamilyArgumentTypeStrategy) o;
+		return expectedNullability == that.expectedNullability && expectedFamily == that.expectedFamily;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(expectedFamily, expectedNullability);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RootArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RootArgumentTypeStrategy.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.APPROXIMATE_NUMERIC;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.EXACT_NUMERIC;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BINARY;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.CHAR;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsImplicitCast;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getLength;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+
+/**
+ * Strategy for an argument that corresponds to a given {@link LogicalTypeRoot} and nullability.
+ *
+ * <p>Implicit casts will be inserted if possible.
+ */
+@Internal
+public final class RootArgumentTypeStrategy implements ArgumentTypeStrategy {
+
+	private final LogicalTypeRoot expectedRoot;
+
+	private final boolean expectedNullability;
+
+	public RootArgumentTypeStrategy(LogicalTypeRoot expectedRoot, boolean expectedNullability) {
+		this.expectedRoot = Preconditions.checkNotNull(expectedRoot);
+		this.expectedNullability = expectedNullability;
+	}
+
+	@Override
+	public Optional<DataType> inferArgumentType(CallContext callContext, int argumentPos, boolean throwOnFailure) {
+		final DataType actualDataType = callContext.getArgumentDataTypes().get(argumentPos);
+		final LogicalType actualType = actualDataType.getLogicalType();
+
+		if (!expectedNullability && actualType.isNullable()) {
+			if (throwOnFailure) {
+				throw callContext.newValidationError(
+					"Unsupported argument type. Expected nullable type of root '%s' but actual type was '%s'.",
+					expectedRoot,
+					actualType);
+			}
+			return Optional.empty();
+		}
+
+		return findDataType(
+			callContext,
+			throwOnFailure,
+			actualDataType,
+			expectedRoot,
+			expectedNullability);
+	}
+
+	@Override
+	public Argument getExpectedArgument(FunctionDefinition functionDefinition, int argumentPos) {
+		// "< ... >" to indicate that this is not a type
+		if (!expectedNullability) {
+			return Argument.of("<" + expectedRoot + " NOT NULL>");
+		}
+		return Argument.of("<" + expectedRoot + ">");
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		RootArgumentTypeStrategy that = (RootArgumentTypeStrategy) o;
+		return expectedNullability == that.expectedNullability &&
+			expectedRoot == that.expectedRoot;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(expectedRoot, expectedNullability);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Finds a data type that is close to the given data type in terms of nullability and conversion
+	 * class but of the given logical root.
+	 *
+	 * <p>This method is shared with {@link FamilyArgumentTypeStrategy}.
+	 */
+	static Optional<DataType> findDataType(
+			CallContext callContext,
+			boolean throwOnFailure,
+			DataType actualDataType,
+			LogicalTypeRoot expectedRoot,
+			boolean expectedNullability) {
+		final LogicalType actualType = actualDataType.getLogicalType();
+		return Optional.ofNullable(findDataTypeOfRoot(actualDataType, expectedRoot))
+			// set nullability
+			.map(newDataType -> {
+				if (expectedNullability) {
+					return newDataType.nullable();
+				} else {
+					return newDataType.notNull();
+				}
+			})
+			// preserve bridging class if possible
+			.map(newDataType -> {
+				final Class<?> clazz = actualDataType.getConversionClass();
+				final LogicalType newType = newDataType.getLogicalType();
+				if (newType.supportsInputConversion(clazz) || newType.supportsOutputConversion(clazz)) {
+					return newDataType.bridgedTo(clazz);
+				}
+				return newDataType;
+			})
+			// check if type can be implicitly casted
+			.filter(newDataType -> {
+				if (supportsImplicitCast(actualType, newDataType.getLogicalType())) {
+					return true;
+				}
+				if (throwOnFailure) {
+					throw callContext.newValidationError(
+						"Unsupported argument type. Expected type root '%s' but actual type was '%s'.",
+						expectedRoot,
+						actualType);
+				}
+				return false;
+			});
+	}
+
+	/**
+	 * Returns a data type for the given data type and expected root.
+	 *
+	 * <p>This method is aligned with {@link LogicalTypeCasts#supportsImplicitCast(LogicalType, LogicalType)}.
+	 *
+	 * <p>The default output of this method represents the default data type for a NULL literal. Thus,
+	 * the output of this method needs to be checked again if an implicit cast is supported.
+	 */
+	private static @Nullable DataType findDataTypeOfRoot(
+			DataType actualDataType,
+			LogicalTypeRoot expectedRoot) {
+		final LogicalType actualType = actualDataType.getLogicalType();
+		if (hasRoot(actualType, expectedRoot)) {
+			return actualDataType;
+		}
+		switch (expectedRoot) {
+			case CHAR:
+				return DataTypes.CHAR(CharType.DEFAULT_LENGTH);
+			case VARCHAR:
+				if (hasRoot(actualType, CHAR)) {
+					return DataTypes.VARCHAR(getLength(actualType));
+				}
+				return DataTypes.VARCHAR(VarCharType.DEFAULT_LENGTH);
+			case BOOLEAN:
+				return DataTypes.BOOLEAN();
+			case BINARY:
+				return DataTypes.BINARY(BinaryType.DEFAULT_LENGTH);
+			case VARBINARY:
+				if (hasRoot(actualType, BINARY)) {
+					return DataTypes.VARBINARY(getLength(actualType));
+				}
+				return DataTypes.VARBINARY(VarBinaryType.DEFAULT_LENGTH);
+			case DECIMAL:
+				if (hasFamily(actualType, EXACT_NUMERIC)) {
+					return DataTypes.DECIMAL(getPrecision(actualType), getScale(actualType));
+				} else if (hasFamily(actualType, APPROXIMATE_NUMERIC)) {
+					final int precision = getPrecision(actualType);
+					// we don't know where the precision occurs (before or after the dot)
+					return DataTypes.DECIMAL(precision * 2, precision);
+				}
+				return DataTypes.DECIMAL(DecimalType.MIN_PRECISION, DecimalType.MIN_SCALE);
+			case TINYINT:
+				return DataTypes.TINYINT();
+			case SMALLINT:
+				return DataTypes.SMALLINT();
+			case INTEGER:
+				return DataTypes.INT();
+			case BIGINT:
+				return DataTypes.BIGINT();
+			case FLOAT:
+				return DataTypes.FLOAT();
+			case DOUBLE:
+				return DataTypes.DOUBLE();
+			case DATE:
+				return DataTypes.DATE();
+			case TIME_WITHOUT_TIME_ZONE:
+				if (hasRoot(actualType, TIMESTAMP_WITHOUT_TIME_ZONE)) {
+					return DataTypes.TIME(getPrecision(actualType));
+				}
+				return DataTypes.TIME();
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				return DataTypes.TIMESTAMP();
+			case TIMESTAMP_WITH_TIME_ZONE:
+				return DataTypes.TIMESTAMP_WITH_TIME_ZONE();
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE();
+			case INTERVAL_YEAR_MONTH:
+				return DataTypes.INTERVAL(DataTypes.MONTH());
+			case INTERVAL_DAY_TIME:
+				return DataTypes.INTERVAL(DataTypes.SECOND());
+			case NULL:
+				return DataTypes.NULL();
+			case ARRAY:
+			case MULTISET:
+			case MAP:
+			case ROW:
+			case DISTINCT_TYPE:
+			case STRUCTURED_TYPE:
+			case RAW:
+			case SYMBOL:
+			case UNRESOLVED:
+			default:
+				return null;
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RootArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RootArgumentTypeStrategy.java
@@ -18,20 +18,13 @@
 package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.Signature.Argument;
-import org.apache.flink.table.types.logical.BinaryType;
-import org.apache.flink.table.types.logical.CharType;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.VarBinaryType;
-import org.apache.flink.table.types.logical.VarCharType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -39,17 +32,7 @@ import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.apache.flink.table.types.logical.LogicalTypeFamily.APPROXIMATE_NUMERIC;
-import static org.apache.flink.table.types.logical.LogicalTypeFamily.EXACT_NUMERIC;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.BINARY;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.CHAR;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsImplicitCast;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getLength;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+import static org.apache.flink.table.types.inference.strategies.StrategyUtils.findDataType;
 
 /**
  * Strategy for an argument that corresponds to a given {@link LogicalTypeRoot} and nullability.
@@ -61,9 +44,9 @@ public final class RootArgumentTypeStrategy implements ArgumentTypeStrategy {
 
 	private final LogicalTypeRoot expectedRoot;
 
-	private final boolean expectedNullability;
+	private final @Nullable Boolean expectedNullability;
 
-	public RootArgumentTypeStrategy(LogicalTypeRoot expectedRoot, boolean expectedNullability) {
+	public RootArgumentTypeStrategy(LogicalTypeRoot expectedRoot, @Nullable Boolean expectedNullability) {
 		this.expectedRoot = Preconditions.checkNotNull(expectedRoot);
 		this.expectedNullability = expectedNullability;
 	}
@@ -73,7 +56,7 @@ public final class RootArgumentTypeStrategy implements ArgumentTypeStrategy {
 		final DataType actualDataType = callContext.getArgumentDataTypes().get(argumentPos);
 		final LogicalType actualType = actualDataType.getLogicalType();
 
-		if (!expectedNullability && actualType.isNullable()) {
+		if (Objects.equals(expectedNullability, Boolean.FALSE) && actualType.isNullable()) {
 			if (throwOnFailure) {
 				throw callContext.newValidationError(
 					"Unsupported argument type. Expected nullable type of root '%s' but actual type was '%s'.",
@@ -94,7 +77,9 @@ public final class RootArgumentTypeStrategy implements ArgumentTypeStrategy {
 	@Override
 	public Argument getExpectedArgument(FunctionDefinition functionDefinition, int argumentPos) {
 		// "< ... >" to indicate that this is not a type
-		if (!expectedNullability) {
+		if (Objects.equals(expectedNullability, Boolean.TRUE)) {
+			return Argument.of("<" + expectedRoot + " NULL>");
+		} else if (Objects.equals(expectedNullability, Boolean.FALSE)) {
 			return Argument.of("<" + expectedRoot + " NOT NULL>");
 		}
 		return Argument.of("<" + expectedRoot + ">");
@@ -108,147 +93,13 @@ public final class RootArgumentTypeStrategy implements ArgumentTypeStrategy {
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-		RootArgumentTypeStrategy that = (RootArgumentTypeStrategy) o;
-		return expectedNullability == that.expectedNullability &&
-			expectedRoot == that.expectedRoot;
+		RootArgumentTypeStrategy strategy = (RootArgumentTypeStrategy) o;
+		return expectedRoot == strategy.expectedRoot &&
+			Objects.equals(expectedNullability, strategy.expectedNullability);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(expectedRoot, expectedNullability);
-	}
-
-	// --------------------------------------------------------------------------------------------
-
-	/**
-	 * Finds a data type that is close to the given data type in terms of nullability and conversion
-	 * class but of the given logical root.
-	 *
-	 * <p>This method is shared with {@link FamilyArgumentTypeStrategy}.
-	 */
-	static Optional<DataType> findDataType(
-			CallContext callContext,
-			boolean throwOnFailure,
-			DataType actualDataType,
-			LogicalTypeRoot expectedRoot,
-			boolean expectedNullability) {
-		final LogicalType actualType = actualDataType.getLogicalType();
-		return Optional.ofNullable(findDataTypeOfRoot(actualDataType, expectedRoot))
-			// set nullability
-			.map(newDataType -> {
-				if (expectedNullability) {
-					return newDataType.nullable();
-				} else {
-					return newDataType.notNull();
-				}
-			})
-			// preserve bridging class if possible
-			.map(newDataType -> {
-				final Class<?> clazz = actualDataType.getConversionClass();
-				final LogicalType newType = newDataType.getLogicalType();
-				if (newType.supportsInputConversion(clazz) || newType.supportsOutputConversion(clazz)) {
-					return newDataType.bridgedTo(clazz);
-				}
-				return newDataType;
-			})
-			// check if type can be implicitly casted
-			.filter(newDataType -> {
-				if (supportsImplicitCast(actualType, newDataType.getLogicalType())) {
-					return true;
-				}
-				if (throwOnFailure) {
-					throw callContext.newValidationError(
-						"Unsupported argument type. Expected type root '%s' but actual type was '%s'.",
-						expectedRoot,
-						actualType);
-				}
-				return false;
-			});
-	}
-
-	/**
-	 * Returns a data type for the given data type and expected root.
-	 *
-	 * <p>This method is aligned with {@link LogicalTypeCasts#supportsImplicitCast(LogicalType, LogicalType)}.
-	 *
-	 * <p>The default output of this method represents the default data type for a NULL literal. Thus,
-	 * the output of this method needs to be checked again if an implicit cast is supported.
-	 */
-	private static @Nullable DataType findDataTypeOfRoot(
-			DataType actualDataType,
-			LogicalTypeRoot expectedRoot) {
-		final LogicalType actualType = actualDataType.getLogicalType();
-		if (hasRoot(actualType, expectedRoot)) {
-			return actualDataType;
-		}
-		switch (expectedRoot) {
-			case CHAR:
-				return DataTypes.CHAR(CharType.DEFAULT_LENGTH);
-			case VARCHAR:
-				if (hasRoot(actualType, CHAR)) {
-					return DataTypes.VARCHAR(getLength(actualType));
-				}
-				return DataTypes.VARCHAR(VarCharType.DEFAULT_LENGTH);
-			case BOOLEAN:
-				return DataTypes.BOOLEAN();
-			case BINARY:
-				return DataTypes.BINARY(BinaryType.DEFAULT_LENGTH);
-			case VARBINARY:
-				if (hasRoot(actualType, BINARY)) {
-					return DataTypes.VARBINARY(getLength(actualType));
-				}
-				return DataTypes.VARBINARY(VarBinaryType.DEFAULT_LENGTH);
-			case DECIMAL:
-				if (hasFamily(actualType, EXACT_NUMERIC)) {
-					return DataTypes.DECIMAL(getPrecision(actualType), getScale(actualType));
-				} else if (hasFamily(actualType, APPROXIMATE_NUMERIC)) {
-					final int precision = getPrecision(actualType);
-					// we don't know where the precision occurs (before or after the dot)
-					return DataTypes.DECIMAL(precision * 2, precision);
-				}
-				return DataTypes.DECIMAL(DecimalType.MIN_PRECISION, DecimalType.MIN_SCALE);
-			case TINYINT:
-				return DataTypes.TINYINT();
-			case SMALLINT:
-				return DataTypes.SMALLINT();
-			case INTEGER:
-				return DataTypes.INT();
-			case BIGINT:
-				return DataTypes.BIGINT();
-			case FLOAT:
-				return DataTypes.FLOAT();
-			case DOUBLE:
-				return DataTypes.DOUBLE();
-			case DATE:
-				return DataTypes.DATE();
-			case TIME_WITHOUT_TIME_ZONE:
-				if (hasRoot(actualType, TIMESTAMP_WITHOUT_TIME_ZONE)) {
-					return DataTypes.TIME(getPrecision(actualType));
-				}
-				return DataTypes.TIME();
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				return DataTypes.TIMESTAMP();
-			case TIMESTAMP_WITH_TIME_ZONE:
-				return DataTypes.TIMESTAMP_WITH_TIME_ZONE();
-			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-				return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE();
-			case INTERVAL_YEAR_MONTH:
-				return DataTypes.INTERVAL(DataTypes.MONTH());
-			case INTERVAL_DAY_TIME:
-				return DataTypes.INTERVAL(DataTypes.SECOND());
-			case NULL:
-				return DataTypes.NULL();
-			case ARRAY:
-			case MULTISET:
-			case MAP:
-			case ROW:
-			case DISTINCT_TYPE:
-			case STRUCTURED_TYPE:
-			case RAW:
-			case SYMBOL:
-			case UNRESOLVED:
-			default:
-				return null;
-		}
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/StrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/StrategyUtils.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.APPROXIMATE_NUMERIC;
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.EXACT_NUMERIC;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BINARY;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.CHAR;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsImplicitCast;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getLength;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+
+/**
+ * Utilities for shared logic in classes of this package.
+ */
+final class StrategyUtils {
+
+	/**
+	 * Finds a data type that is close to the given data type in terms of nullability and conversion
+	 * class but of the given logical root.
+	 */
+	static Optional<DataType> findDataType(
+			CallContext callContext,
+			boolean throwOnFailure,
+			DataType actualDataType,
+			LogicalTypeRoot expectedRoot,
+			@Nullable Boolean expectedNullability) {
+		final LogicalType actualType = actualDataType.getLogicalType();
+		return Optional.ofNullable(findDataTypeOfRoot(actualDataType, expectedRoot))
+			// set nullability
+			.map(newDataType -> {
+				if (Objects.equals(expectedNullability, Boolean.TRUE)) {
+					return newDataType.nullable();
+				} else if (Objects.equals(expectedNullability, Boolean.FALSE)) {
+					return newDataType.notNull();
+				}
+				return newDataType;
+			})
+			// preserve bridging class if possible
+			.map(newDataType -> {
+				final Class<?> clazz = actualDataType.getConversionClass();
+				final LogicalType newType = newDataType.getLogicalType();
+				if (newType.supportsInputConversion(clazz)) {
+					return newDataType.bridgedTo(clazz);
+				}
+				return newDataType;
+			})
+			// check if type can be implicitly casted
+			.filter(newDataType -> {
+				if (supportsImplicitCast(actualType, newDataType.getLogicalType())) {
+					return true;
+				}
+				if (throwOnFailure) {
+					throw callContext.newValidationError(
+						"Unsupported argument type. Expected type root '%s' but actual type was '%s'.",
+						expectedRoot,
+						actualType);
+				}
+				return false;
+			});
+	}
+
+	/**
+	 * Returns a data type for the given data type and expected root.
+	 *
+	 * <p>This method is aligned with {@link LogicalTypeCasts#supportsImplicitCast(LogicalType, LogicalType)}.
+	 *
+	 * <p>The "fallback" data type for each root represents the default data type for a NULL literal. NULL
+	 * literals will receive the smallest precision possible for having little impact when finding a common
+	 * type. The output of this method needs to be checked again if an implicit cast is supported.
+	 */
+	private static @Nullable DataType findDataTypeOfRoot(
+			DataType actualDataType,
+			LogicalTypeRoot expectedRoot) {
+		final LogicalType actualType = actualDataType.getLogicalType();
+		if (hasRoot(actualType, expectedRoot)) {
+			return actualDataType;
+		}
+		switch (expectedRoot) {
+			case CHAR:
+				return DataTypes.CHAR(CharType.DEFAULT_LENGTH);
+			case VARCHAR:
+				if (hasRoot(actualType, CHAR)) {
+					return DataTypes.VARCHAR(getLength(actualType));
+				}
+				return DataTypes.VARCHAR(VarCharType.DEFAULT_LENGTH);
+			case BOOLEAN:
+				return DataTypes.BOOLEAN();
+			case BINARY:
+				return DataTypes.BINARY(BinaryType.DEFAULT_LENGTH);
+			case VARBINARY:
+				if (hasRoot(actualType, BINARY)) {
+					return DataTypes.VARBINARY(getLength(actualType));
+				}
+				return DataTypes.VARBINARY(VarBinaryType.DEFAULT_LENGTH);
+			case DECIMAL:
+				if (hasFamily(actualType, EXACT_NUMERIC)) {
+					return DataTypes.DECIMAL(getPrecision(actualType), getScale(actualType));
+				} else if (hasFamily(actualType, APPROXIMATE_NUMERIC)) {
+					final int precision = getPrecision(actualType);
+					// we don't know where the precision occurs (before or after the dot)
+					return DataTypes.DECIMAL(precision * 2, precision);
+				}
+				return DataTypes.DECIMAL(DecimalType.MIN_PRECISION, DecimalType.MIN_SCALE);
+			case TINYINT:
+				return DataTypes.TINYINT();
+			case SMALLINT:
+				return DataTypes.SMALLINT();
+			case INTEGER:
+				return DataTypes.INT();
+			case BIGINT:
+				return DataTypes.BIGINT();
+			case FLOAT:
+				return DataTypes.FLOAT();
+			case DOUBLE:
+				return DataTypes.DOUBLE();
+			case DATE:
+				return DataTypes.DATE();
+			case TIME_WITHOUT_TIME_ZONE:
+				if (hasRoot(actualType, TIMESTAMP_WITHOUT_TIME_ZONE)) {
+					return DataTypes.TIME(getPrecision(actualType));
+				}
+				return DataTypes.TIME();
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+				return DataTypes.TIMESTAMP();
+			case TIMESTAMP_WITH_TIME_ZONE:
+				return DataTypes.TIMESTAMP_WITH_TIME_ZONE();
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE();
+			case INTERVAL_YEAR_MONTH:
+				return DataTypes.INTERVAL(DataTypes.MONTH());
+			case INTERVAL_DAY_TIME:
+				return DataTypes.INTERVAL(DataTypes.SECOND());
+			case NULL:
+				return DataTypes.NULL();
+			case ARRAY:
+			case MULTISET:
+			case MAP:
+			case ROW:
+			case DISTINCT_TYPE:
+			case STRUCTURED_TYPE:
+			case RAW:
+			case SYMBOL:
+			case UNRESOLVED:
+			default:
+				return null;
+		}
+	}
+
+	private StrategyUtils() {
+		// no instantiation
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/StrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/StrategyUtils.java
@@ -70,14 +70,16 @@ final class StrategyUtils {
 					return newDataType.nullable();
 				} else if (Objects.equals(expectedNullability, Boolean.FALSE)) {
 					return newDataType.notNull();
+				} else if (actualType.isNullable()) {
+					return newDataType.nullable();
 				}
-				return newDataType;
+				return newDataType.notNull();
 			})
 			// preserve bridging class if possible
 			.map(newDataType -> {
 				final Class<?> clazz = actualDataType.getConversionClass();
 				final LogicalType newType = newDataType.getLogicalType();
-				if (newType.supportsInputConversion(clazz)) {
+				if (newType.supportsOutputConversion(clazz)) {
 					return newDataType.bridgedTo(clazz);
 				}
 				return newDataType;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
@@ -33,6 +33,8 @@ import java.util.Set;
 @PublicEvolving
 public final class DoubleType extends LogicalType {
 
+	public static final int PRECISION = 15;
+
 	private static final String FORMAT = "DOUBLE";
 
 	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DoubleType.java
@@ -33,7 +33,7 @@ import java.util.Set;
 @PublicEvolving
 public final class DoubleType extends LogicalType {
 
-	public static final int PRECISION = 15;
+	public static final int PRECISION = 15; // adopted from Calcite
 
 	private static final String FORMAT = "DOUBLE";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
@@ -33,6 +33,8 @@ import java.util.Set;
 @PublicEvolving
 public final class FloatType extends LogicalType {
 
+	public static final int PRECISION = 7;
+
 	private static final String FORMAT = "FLOAT";
 
 	private static final Set<String> NULL_OUTPUT_CONVERSION = conversionSet(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/FloatType.java
@@ -33,7 +33,7 @@ import java.util.Set;
 @PublicEvolving
 public final class FloatType extends LogicalType {
 
-	public static final int PRECISION = 7;
+	public static final int PRECISION = 7; // adopted from Calcite
 
 	private static final String FORMAT = "FLOAT";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -279,6 +281,16 @@ public final class LogicalTypeChecks {
 		@Override
 		public Integer visit(BigIntType bigIntType) {
 			return BigIntType.PRECISION;
+		}
+
+		@Override
+		public Integer visit(FloatType floatType) {
+			return FloatType.PRECISION;
+		}
+
+		@Override
+		public Integer visit(DoubleType doubleType) {
+			return DoubleType.PRECISION;
 		}
 
 		@Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -491,7 +491,7 @@ public class InputTypeStrategiesTest {
 					"Logical type roots instead of concrete data types",
 					sequence(
 						logical(LogicalTypeRoot.VARCHAR),
-						logical(LogicalTypeRoot.DECIMAL),
+						logical(LogicalTypeRoot.DECIMAL, true),
 						logical(LogicalTypeRoot.DECIMAL),
 						logical(LogicalTypeRoot.BOOLEAN),
 						logical(LogicalTypeRoot.INTEGER, false)))
@@ -502,12 +502,12 @@ public class InputTypeStrategiesTest {
 					DataTypes.BOOLEAN().notNull(),
 					DataTypes.INT().notNull())
 				.expectSignature(
-					"f(<VARCHAR>, <DECIMAL>, <DECIMAL>, <BOOLEAN>, <INTEGER NOT NULL>)")
+					"f(<VARCHAR>, <DECIMAL NULL>, <DECIMAL>, <BOOLEAN>, <INTEGER NOT NULL>)")
 				.expectArgumentTypes(
 					DataTypes.VARCHAR(1),
 					DataTypes.DECIMAL(10, 0),
 					DataTypes.DECIMAL(30, 15),
-					DataTypes.BOOLEAN(),
+					DataTypes.BOOLEAN().notNull(),
 					DataTypes.INT().notNull()),
 
 			TestSpec
@@ -532,22 +532,34 @@ public class InputTypeStrategiesTest {
 				.forStrategy(
 					"Logical type family instead of concrete data types",
 					sequence(
-						logical(LogicalTypeFamily.CHARACTER_STRING),
+						logical(LogicalTypeFamily.CHARACTER_STRING, true),
 						logical(LogicalTypeFamily.EXACT_NUMERIC),
+						logical(LogicalTypeFamily.APPROXIMATE_NUMERIC),
 						logical(LogicalTypeFamily.APPROXIMATE_NUMERIC),
 						logical(LogicalTypeFamily.APPROXIMATE_NUMERIC, false)))
 				.calledWithArgumentTypes(
 					DataTypes.NULL(),
 					DataTypes.TINYINT(),
 					DataTypes.INT(),
+					DataTypes.BIGINT(),
 					DataTypes.DECIMAL(10, 2).notNull())
 				.expectSignature(
-					"f(<CHARACTER_STRING>, <EXACT_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC NOT NULL>)")
+					"f(<CHARACTER_STRING NULL>, <EXACT_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC NOT NULL>)")
 				.expectArgumentTypes(
 					DataTypes.VARCHAR(1),
 					DataTypes.TINYINT(),
 					DataTypes.DOUBLE(),
-					DataTypes.DOUBLE().notNull())
+					DataTypes.DOUBLE(),
+					DataTypes.DOUBLE().notNull()),
+
+			TestSpec
+				.forStrategy(
+					"Logical type family with invalid type",
+					sequence(logical(LogicalTypeFamily.EXACT_NUMERIC)))
+				.calledWithArgumentTypes(DataTypes.FLOAT())
+				.expectSignature("f(<EXACT_NUMERIC>)")
+				.expectErrorMessage(
+					"Unsupported argument type. Expected type of family 'EXACT_NUMERIC' but actual type was 'FLOAT'.")
 		);
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -494,20 +494,23 @@ public class InputTypeStrategiesTest {
 						logical(LogicalTypeRoot.DECIMAL, true),
 						logical(LogicalTypeRoot.DECIMAL),
 						logical(LogicalTypeRoot.BOOLEAN),
-						logical(LogicalTypeRoot.INTEGER, false)))
+						logical(LogicalTypeRoot.INTEGER, false),
+						logical(LogicalTypeRoot.INTEGER)))
 				.calledWithArgumentTypes(
 					DataTypes.NULL(),
 					DataTypes.INT(),
 					DataTypes.DOUBLE(),
 					DataTypes.BOOLEAN().notNull(),
+					DataTypes.INT().notNull(),
 					DataTypes.INT().notNull())
 				.expectSignature(
-					"f(<VARCHAR>, <DECIMAL NULL>, <DECIMAL>, <BOOLEAN>, <INTEGER NOT NULL>)")
+					"f(<VARCHAR>, <DECIMAL NULL>, <DECIMAL>, <BOOLEAN>, <INTEGER NOT NULL>, <INTEGER>)")
 				.expectArgumentTypes(
 					DataTypes.VARCHAR(1),
 					DataTypes.DECIMAL(10, 0),
 					DataTypes.DECIMAL(30, 15),
 					DataTypes.BOOLEAN().notNull(),
+					DataTypes.INT().notNull(),
 					DataTypes.INT().notNull()),
 
 			TestSpec
@@ -541,15 +544,15 @@ public class InputTypeStrategiesTest {
 					DataTypes.NULL(),
 					DataTypes.TINYINT(),
 					DataTypes.INT(),
-					DataTypes.BIGINT(),
+					DataTypes.BIGINT().notNull(),
 					DataTypes.DECIMAL(10, 2).notNull())
 				.expectSignature(
 					"f(<CHARACTER_STRING NULL>, <EXACT_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC NOT NULL>)")
 				.expectArgumentTypes(
 					DataTypes.VARCHAR(1),
 					DataTypes.TINYINT(),
-					DataTypes.DOUBLE(),
-					DataTypes.DOUBLE(),
+					DataTypes.DOUBLE(), // widening with preserved nullability
+					DataTypes.DOUBLE().notNull(), // widening with preserved nullability
 					DataTypes.DOUBLE().notNull()),
 
 			TestSpec

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -149,14 +149,6 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
       case fd: FunctionDefinition =>
         fd match {
 
-          case AS =>
-            assert(args.size >= 2)
-            val name = getValue[String](args(1))
-            val extraNames = args
-              .drop(2)
-              .map(e => getValue[String](e))
-            Alias(args.head, name, extraNames)
-
           case FLATTEN =>
             assert(args.size == 1)
             Flattening(args.head)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/fieldExpression.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/fieldExpression.scala
@@ -80,49 +80,6 @@ case class PlannerResolvedFieldReference(
   }
 }
 
-case class Alias(child: PlannerExpression, name: String, extraNames: Seq[String] = Seq())
-    extends UnaryExpression with NamedExpression {
-
-  override def toString = s"$child as '$name"
-
-  override private[flink] def resultType: TypeInformation[_] = child.resultType
-
-  override private[flink] def makeCopy(anyRefs: Array[AnyRef]): this.type = {
-    val child: PlannerExpression = anyRefs.head.asInstanceOf[PlannerExpression]
-    copy(child, name, extraNames).asInstanceOf[this.type]
-  }
-
-  override private[flink] def toAttribute: Attribute = {
-    if (valid) {
-      PlannerResolvedFieldReference(name, child.resultType)
-    } else {
-      UnresolvedFieldReference(name)
-    }
-  }
-
-  override private[flink] def validateInput(): ValidationResult = {
-    if (name == "*") {
-      ValidationFailure("Alias can not accept '*' as name.")
-    } else {
-      ValidationSuccess
-    }
-  }
-}
-
-case class UnresolvedAlias(child: PlannerExpression) extends UnaryExpression with NamedExpression {
-
-  override private[flink] def name: String =
-    throw new UnresolvedException("Invalid call to name on UnresolvedAlias")
-
-  override private[flink] def toAttribute: Attribute =
-    throw new UnresolvedException("Invalid call to toAttribute on UnresolvedAlias")
-
-  override private[flink] def resultType: TypeInformation[_] =
-    throw new UnresolvedException("Invalid call to resultType on UnresolvedAlias")
-
-  override private[flink] lazy val valid = false
-}
-
 case class WindowReference(name: String, tpe: Option[TypeInformation[_]] = None) extends Attribute {
 
   override private[flink] def resultType: TypeInformation[_] =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/CalcValidationTest.scala
@@ -85,14 +85,6 @@ class CalcValidationTest extends TableTestBase {
     }
 
     try {
-      util.addTableSource[(Int, Long, String)]("Table2")
-      .select('_1 as '*, '_2 as 'b, '_1 as 'c)
-      fail("ValidationException expected")
-    } catch {
-      case _: ValidationException => //ignore
-    }
-
-    try {
       util.addTableSource[(Int, Long, String)]("Table3").as("*", "b", "c")
       fail("ValidationException expected")
     } catch {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/CalcValidationTest.scala
@@ -103,14 +103,6 @@ class CalcValidationTest extends TableTestBase {
     }
 
     try {
-      util.addTable[(Int, Long, String)]("Table2")
-      .select('_1 as '*, '_2 as 'b, '_1 as 'c)
-      fail("ValidationException expected")
-    } catch {
-      case _: ValidationException => //ignore
-    }
-
-    try {
       util.addTable[(Int, Long, String)]("Table3").as("*", "b", "c")
       fail("ValidationException expected")
     } catch {


### PR DESCRIPTION
## What is the purpose of the change

Implements a new type inference for AS. The PR contains the last missing pieces required to start porting the other expressions for a consistent API behavior. 

## Brief change log

See commit messages.

## Verifying this change

This change is already covered by existing tests. Tests have been added to `InputTypeStrategiesTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
