### PR TITLE
[FLINK-17753] [table-planner-blink] Fix watermark defined in ddl does not work in Table api

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -72,6 +72,7 @@ import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXE
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.apache.flink.table.api.Expressions.$;
 
 /**
  * IT case for HiveCatalog.
@@ -281,6 +282,32 @@ public class HiveCatalogITCase {
 	}
 
 	private void testReadWriteCsvWithProctime(boolean isStreaming) {
+		TableEnvironment tableEnv = prepareTable(isStreaming);
+		ArrayList<Row> rows = Lists.newArrayList(
+				tableEnv.executeSql("SELECT * FROM proctime_src").collect());
+		Assert.assertEquals(5, rows.size());
+		tableEnv.executeSql("DROP TABLE proctime_src");
+	}
+
+	@Test
+	public void testTableApiWithProctimeForBatch() {
+		testTableApiWithProctime(false);
+	}
+
+	@Test
+	public void testTableApiWithProctimeForStreaming() {
+		testTableApiWithProctime(true);
+	}
+
+	private void testTableApiWithProctime(boolean isStreaming) {
+		TableEnvironment tableEnv = prepareTable(isStreaming);
+		ArrayList<Row> rows = Lists.newArrayList(
+				tableEnv.from("proctime_src").select($("price"), $("ts"), $("l_proctime")).execute().collect());
+		Assert.assertEquals(5, rows.size());
+		tableEnv.executeSql("DROP TABLE proctime_src");
+	}
+
+	private TableEnvironment prepareTable(boolean isStreaming) {
 		EnvironmentSettings.Builder builder = EnvironmentSettings.newInstance().useBlinkPlanner();
 		if (isStreaming) {
 			builder = builder.inStreamingMode();
@@ -308,10 +335,7 @@ public class HiveCatalogITCase {
 						"'connector.path' = 'file://%s'," +
 						"'format.type' = 'csv')", srcPath));
 
-		ArrayList<Row> rows = Lists.newArrayList(
-				tableEnv.executeSql("SELECT * FROM proctime_src").collect());
-		Assert.assertEquals(5, rows.size());
-		tableEnv.executeSql("DROP TABLE proctime_src");
+		return tableEnv;
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -68,11 +68,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.apache.flink.table.api.Expressions.$;
 
 /**
  * IT case for HiveCatalog.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -57,6 +57,7 @@ import org.apache.flink.table.client.gateway.local.result.ChangelogResult;
 import org.apache.flink.table.client.gateway.local.result.DynamicResult;
 import org.apache.flink.table.client.gateway.local.result.MaterializedResult;
 import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
@@ -472,6 +473,11 @@ public class LocalExecutor implements Executor {
 			@Override
 			public UnresolvedIdentifier parseIdentifier(String identifier) {
 				return context.wrapClassLoader(() -> parser.parseIdentifier(identifier));
+			}
+
+			@Override
+			public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
+				return context.wrapClassLoader(() -> parser.parseSqlExpression(sqlExpression, inputSchema));
 			}
 		};
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CatalogTableSchemaResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CatalogTableSchemaResolver.java
@@ -41,6 +41,8 @@ import org.apache.flink.table.types.utils.TypeConversions;
 @Internal
 public class CatalogTableSchemaResolver {
 	private final Parser parser;
+	// A flag to indicate the table environment should work in a batch or streaming
+	// TODO remove this once FLINK-18180 is finished
 	private final boolean isStreamingMode;
 
 	public CatalogTableSchemaResolver(Parser parser, boolean isStreamingMode) {
@@ -76,7 +78,7 @@ public class CatalogTableSchemaResolver {
 			DataType fieldType = fieldTypes[i];
 			if (tableColumn.isGenerated() && isProctimeType(tableColumn.getExpr().get(), tableSchema)) {
 				if (fieldNames[i].equals(rowtime)) {
-					throw new TableException("proctime can't be defined on watermark spec.");
+					throw new TableException("Watermark can not be defined for a processing time attribute column.");
 				}
 				TimestampType originalType = (TimestampType) fieldType.getLogicalType();
 				LogicalType proctimeType = new TimestampType(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CatalogTableSchemaResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CatalogTableSchemaResolver.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.Arrays;
+
+/**
+ * The {@link CatalogTableSchemaResolver} is used to derive correct result type of computed column,
+ * because the date type of computed column from catalog table is not trusted.
+ *
+ * <p>Such as `proctime()` function, its type in given TableSchema is Timestamp(3),
+ * but its correct type is Timestamp(3) *PROCTIME*.
+ */
+@Internal
+public class CatalogTableSchemaResolver {
+	public final Parser parser;
+
+	public CatalogTableSchemaResolver(Parser parser) {
+		this.parser = parser;
+	}
+
+	/**
+	 * Resolve the computed column's type for the given schema.
+	 *
+	 * @param tableSchema Table schema to derive table field names and data types
+	 * @param isStreamingMode Flag to determine whether the schema of a stream or batch table is created
+	 * @return the resolved TableSchema
+	 */
+	public TableSchema resolve(TableSchema tableSchema, boolean isStreamingMode) {
+		final String rowtime;
+		if (!tableSchema.getWatermarkSpecs().isEmpty()) {
+			// TODO: [FLINK-14473] we only support top-level rowtime attribute right now
+			rowtime = tableSchema.getWatermarkSpecs().get(0).getRowtimeAttribute();
+			if (rowtime.contains(".")) {
+				throw new ValidationException(
+						String.format("Nested field '%s' as rowtime attribute is not supported right now.", rowtime));
+			}
+		} else {
+			rowtime = null;
+		}
+
+		String[] fieldNames = tableSchema.getFieldNames();
+		DataType[] fieldTypes = Arrays.copyOf(tableSchema.getFieldDataTypes(), tableSchema.getFieldCount());
+
+		for (int i = 0; i < tableSchema.getFieldCount(); ++i) {
+			TableColumn tableColumn = tableSchema.getTableColumns().get(i);
+			if (tableColumn.isGenerated() && isProctimeType(tableColumn.getExpr().get(), tableSchema)) {
+				if (fieldNames[i].equals(rowtime)) {
+					throw new TableException("proctime can't be defined on watermark spec.");
+				}
+				TimestampType originalType = (TimestampType) fieldTypes[i].getLogicalType();
+				LogicalType proctimeType = new TimestampType(
+						originalType.isNullable(),
+						TimestampKind.PROCTIME,
+						originalType.getPrecision());
+				fieldTypes[i] = TypeConversions.fromLogicalToDataType(proctimeType);
+			} else if (isStreamingMode && fieldNames[i].equals(rowtime)) {
+				TimestampType originalType = (TimestampType) fieldTypes[i].getLogicalType();
+				LogicalType rowtimeType = new TimestampType(
+						originalType.isNullable(),
+						TimestampKind.ROWTIME,
+						originalType.getPrecision());
+				fieldTypes[i] = TypeConversions.fromLogicalToDataType(rowtimeType);
+			}
+		}
+
+		TableSchema.Builder builder = TableSchema.builder().fields(fieldNames, fieldTypes);
+		tableSchema.getWatermarkSpecs().forEach(builder::watermark);
+		tableSchema.getPrimaryKey().ifPresent(
+				pk -> builder.primaryKey(pk.getName(), pk.getColumns().toArray(new String[0])));
+		return builder.build();
+	}
+
+	private boolean isProctimeType(String expr, TableSchema tableSchema) {
+		ResolvedExpression resolvedExpr = parser.parseSqlExpression(expr, tableSchema);
+		if (resolvedExpr == null) {
+			return false;
+		}
+		LogicalType type = resolvedExpr.getOutputDataType().getLogicalType();
+		return type instanceof TimestampType && ((TimestampType) type).getKind() == TimestampKind.PROCTIME;
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -199,6 +199,8 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			Planner planner,
 			boolean isStreamingMode) {
 		this.catalogManager = catalogManager;
+		this.catalogManager.setCatalogTableSchemaResolver(
+				new CatalogTableSchemaResolver(planner.getParser(), isStreamingMode));
 		this.moduleManager = moduleManager;
 		this.execEnv = executor;
 
@@ -491,9 +493,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 		ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(identifier);
 
 		return catalogManager.getTable(tableIdentifier).map(t -> {
-			CatalogTableSchemaResolver resolver = new CatalogTableSchemaResolver(parser);
-			TableSchema newTableSchema = resolver.resolve(t.getTable().getSchema(), isStreamingMode);
-			return new CatalogQueryOperation(tableIdentifier, newTableSchema);
+			return new CatalogQueryOperation(tableIdentifier, t.getTable().getSchema());
 		});
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -490,8 +490,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	private Optional<CatalogQueryOperation> scanInternal(UnresolvedIdentifier identifier) {
 		ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(identifier);
 
-		return catalogManager.getTable(tableIdentifier)
-			.map(t -> new CatalogQueryOperation(tableIdentifier, t.getTable().getSchema()));
+		return catalogManager.getTable(tableIdentifier).map(t -> {
+			CatalogTableSchemaResolver resolver = new CatalogTableSchemaResolver(parser);
+			TableSchema newTableSchema = resolver.resolve(t.getTable().getSchema(), isStreamingMode);
+			return new CatalogQueryOperation(tableIdentifier, newTableSchema);
+		});
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -23,12 +23,15 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.CatalogNotExistException;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
@@ -36,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -69,6 +73,8 @@ public final class CatalogManager {
 	private String currentCatalogName;
 
 	private String currentDatabaseName;
+
+	private CatalogTableSchemaResolver schemaResolver;
 
 	// The name of the built-in catalog
 	private final String builtInCatalogName;
@@ -144,6 +150,10 @@ public final class CatalogManager {
 				defaultCatalog,
 				new DataTypeFactoryImpl(classLoader, config, executionConfig));
 		}
+	}
+
+	public void setCatalogTableSchemaResolver(CatalogTableSchemaResolver schemaResolver) {
+		this.schemaResolver = schemaResolver;
 	}
 
 	/**
@@ -336,12 +346,28 @@ public final class CatalogManager {
 	 * @return table that the path points to.
 	 */
 	public Optional<TableLookupResult> getTable(ObjectIdentifier objectIdentifier) {
+		Preconditions.checkNotNull(schemaResolver, "schemaResolver should not be null");
 		CatalogBaseTable temporaryTable = temporaryTables.get(objectIdentifier);
 		if (temporaryTable != null) {
-			return Optional.of(TableLookupResult.temporary(temporaryTable));
+			return Optional.of(TableLookupResult.temporary(resolveTableSchema(temporaryTable)));
 		} else {
-			return getPermanentTable(objectIdentifier);
+			Optional<TableLookupResult> result = getPermanentTable(objectIdentifier);
+			return result.map(tableLookupResult ->
+					TableLookupResult.permanent(resolveTableSchema(tableLookupResult.getTable())));
 		}
+	}
+
+	private CatalogBaseTable resolveTableSchema(CatalogBaseTable table) {
+		if (!(table instanceof CatalogTableImpl)) {
+			return table;
+		}
+		CatalogTableImpl catalogTableImpl = (CatalogTableImpl) table;
+		TableSchema newTableSchema = schemaResolver.resolve(catalogTableImpl.getSchema());
+		return new CatalogTableImpl(
+				newTableSchema,
+				new ArrayList<>(catalogTableImpl.getPartitionKeys()),
+				new HashMap<>(catalogTableImpl.getProperties()),
+				catalogTableImpl.getComment());
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
@@ -88,6 +88,14 @@ public class CatalogTableImpl extends AbstractCatalogTable {
 		return new CatalogTableImpl(getSchema(), getPartitionKeys(), options, getComment());
 	}
 
+	public CatalogTable copy(TableSchema tableSchema) {
+		return new CatalogTableImpl(
+				tableSchema.copy(),
+				new ArrayList<>(getPartitionKeys()),
+				new HashMap<>(getProperties()),
+				getComment());
+	}
+
 	/**
 	 * Construct a {@link CatalogTableImpl} from complete properties that contains table schema.
 	 */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Parser.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Parser.java
@@ -19,7 +19,9 @@
 package org.apache.flink.table.delegation;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 
@@ -54,4 +56,14 @@ public interface Parser {
 	 * @throws org.apache.flink.table.api.SqlParserException when failed to parse the identifier
 	 */
 	UnresolvedIdentifier parseIdentifier(String identifier);
+
+	/**
+	 * Entry point for parse sql expression expressed as a String.
+	 *
+	 * @param sqlExpression the SQL expression to parse
+	 * @param inputSchema the schema of the fields in sql expression
+	 * @return resolved expression
+	 * @throws org.apache.flink.table.api.SqlParserException when failed to parse the sql expression
+	 */
+	ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Parser.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Parser.java
@@ -58,7 +58,7 @@ public interface Parser {
 	UnresolvedIdentifier parseIdentifier(String identifier);
 
 	/**
-	 * Entry point for parse sql expression expressed as a String.
+	 * Entry point for parsing sql expression expressed as a String.
 	 *
 	 * @param sqlExpression the SQL expression to parse
 	 * @param inputSchema the schema of the fields in sql expression

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ParserMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ParserMock.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.table.utils;
 
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.operations.Operation;
 
 import java.util.List;
@@ -36,5 +38,10 @@ public class ParserMock implements Parser {
 	@Override
 	public UnresolvedIdentifier parseIdentifier(String identifier) {
 		return UnresolvedIdentifier.of(identifier);
+	}
+
+	@Override
+	public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
+		return null;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.CatalogManager;
 
 import org.apache.calcite.linq4j.tree.Expression;
@@ -43,18 +42,13 @@ public class CatalogCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
-	// The CatalogTableSchemaResolver is used to derive correct result type of computed column,
-	// because the date type of computed column from catalog table is not trusted.
-	private final CatalogTableSchemaResolver schemaResolver;
 
 	public CatalogCalciteSchema(
 			String catalogName,
 			CatalogManager catalog,
-			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreamingMode) {
 		this.catalogName = catalogName;
 		this.catalogManager = catalog;
-		this.schemaResolver = schemaResolver;
 		this.isStreamingMode = isStreamingMode;
 	}
 
@@ -67,7 +61,7 @@ public class CatalogCalciteSchema extends FlinkSchema {
 	@Override
 	public Schema getSubSchema(String schemaName) {
 		if (catalogManager.schemaExists(catalogName, schemaName)) {
-			return new DatabaseCalciteSchema(schemaName, catalogName, catalogManager, schemaResolver, isStreamingMode);
+			return new DatabaseCalciteSchema(schemaName, catalogName, catalogManager, isStreamingMode);
 		} else {
 			return null;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.schema.Schema;
@@ -43,18 +43,18 @@ public class CatalogCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
-	// The SQL expression converter factory is used to derive correct result type of computed column,
+	// The CatalogTableSchemaResolver is used to derive correct result type of computed column,
 	// because the date type of computed column from catalog table is not trusted.
-	private final SqlExprToRexConverterFactory converterFactory;
+	private final CatalogTableSchemaResolver schemaResolver;
 
 	public CatalogCalciteSchema(
 			String catalogName,
 			CatalogManager catalog,
-			SqlExprToRexConverterFactory converterFactory,
+			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreamingMode) {
 		this.catalogName = catalogName;
 		this.catalogManager = catalog;
-		this.converterFactory = converterFactory;
+		this.schemaResolver = schemaResolver;
 		this.isStreamingMode = isStreamingMode;
 	}
 
@@ -67,8 +67,7 @@ public class CatalogCalciteSchema extends FlinkSchema {
 	@Override
 	public Schema getSubSchema(String schemaName) {
 		if (catalogManager.schemaExists(catalogName, schemaName)) {
-			return new DatabaseCalciteSchema(
-					schemaName, catalogName, catalogManager, converterFactory, isStreamingMode);
+			return new DatabaseCalciteSchema(schemaName, catalogName, catalogManager, schemaResolver, isStreamingMode);
 		} else {
 			return null;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
@@ -19,9 +19,9 @@
 package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.schema.Schema;
@@ -45,17 +45,17 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
-	// The SQL expression converter factory is used to derive correct result type of computed column,
+	// The CatalogTableSchemaResolver is used to derive correct result type of computed column,
 	// because the date type of computed column from catalog table is not trusted.
-	private final SqlExprToRexConverterFactory converterFactory;
+	private final CatalogTableSchemaResolver schemaResolver;
 
 	public CatalogManagerCalciteSchema(
 			CatalogManager catalogManager,
-			SqlExprToRexConverterFactory converterFactory,
+			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreamingMode) {
 		this.catalogManager = catalogManager;
 		this.isStreamingMode = isStreamingMode;
-		this.converterFactory = converterFactory;
+		this.schemaResolver = schemaResolver;
 	}
 
 	@Override
@@ -71,7 +71,7 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
 	@Override
 	public Schema getSubSchema(String name) {
 		if (catalogManager.schemaExists(name)) {
-			return new CatalogCalciteSchema(name, catalogManager, converterFactory, isStreamingMode);
+			return new CatalogCalciteSchema(name, catalogManager, schemaResolver, isStreamingMode);
 		} else {
 			return null;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
 
@@ -45,17 +44,12 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
 	private final CatalogManager catalogManager;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
-	// The CatalogTableSchemaResolver is used to derive correct result type of computed column,
-	// because the date type of computed column from catalog table is not trusted.
-	private final CatalogTableSchemaResolver schemaResolver;
 
 	public CatalogManagerCalciteSchema(
 			CatalogManager catalogManager,
-			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreamingMode) {
 		this.catalogManager = catalogManager;
 		this.isStreamingMode = isStreamingMode;
-		this.schemaResolver = schemaResolver;
 	}
 
 	@Override
@@ -71,7 +65,7 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
 	@Override
 	public Schema getSubSchema(String name) {
 		if (catalogManager.schemaExists(name)) {
-			return new CatalogCalciteSchema(name, catalogManager, schemaResolver, isStreamingMode);
+			return new CatalogCalciteSchema(name, catalogManager, isStreamingMode);
 		} else {
 			return null;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -36,6 +35,7 @@ import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.factories.TableSourceFactoryContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.sources.TableSourceUtil;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.sources.TableSourceValidation;
@@ -69,7 +69,6 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	private final ObjectIdentifier tableIdentifier;
 	private final CatalogBaseTable catalogBaseTable;
 	private final FlinkStatistic statistic;
-	private final CatalogTableSchemaResolver schemaResolver;
 	private final boolean isStreamingMode;
 	private final boolean isTemporary;
 	private final Catalog catalog;
@@ -83,9 +82,6 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	 * @param catalogBaseTable CatalogBaseTable instance which exists in the catalog
 	 * @param statistic Table statistics
 	 * @param catalog The catalog which the schema table belongs to
-	 * @param schemaResolver The CatalogTableSchemaResolver is used to derive correct result
-	 *                       type of computed column, because the date type of computed column
-	 *                       from catalog table is not trusted.
 	 * @param isStreaming If the table is for streaming mode
 	 * @param isTemporary If the table is temporary
 	 */
@@ -94,14 +90,12 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 			CatalogBaseTable catalogBaseTable,
 			FlinkStatistic statistic,
 			Catalog catalog,
-			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreaming,
 			boolean isTemporary) {
 		this.tableIdentifier = tableIdentifier;
 		this.catalogBaseTable = catalogBaseTable;
 		this.statistic = statistic;
 		this.catalog = catalog;
-		this.schemaResolver = schemaResolver;
 		this.isStreamingMode = isStreaming;
 		this.isTemporary = isTemporary;
 	}
@@ -185,8 +179,11 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 			}
 		}
 
-		TableSchema newTableSchema = schemaResolver.resolve(tableSchema, isStreamingMode);
-		return flinkTypeFactory.buildRelNodeRowType(newTableSchema);
+		return TableSourceUtil.getSourceRowType(
+				flinkTypeFactory,
+				tableSchema,
+				scala.Option.empty(),
+				isStreamingMode);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -34,9 +35,7 @@ import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.factories.TableSourceFactoryContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
-import org.apache.flink.table.planner.sources.TableSourceUtil;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.sources.TableSourceValidation;
@@ -70,7 +69,7 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	private final ObjectIdentifier tableIdentifier;
 	private final CatalogBaseTable catalogBaseTable;
 	private final FlinkStatistic statistic;
-	private final SqlExprToRexConverterFactory converterFactory;
+	private final CatalogTableSchemaResolver schemaResolver;
 	private final boolean isStreamingMode;
 	private final boolean isTemporary;
 	private final Catalog catalog;
@@ -84,9 +83,9 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	 * @param catalogBaseTable CatalogBaseTable instance which exists in the catalog
 	 * @param statistic Table statistics
 	 * @param catalog The catalog which the schema table belongs to
-	 * @param converterFactory The SQL expression converter factory is used to derive correct result
-	 *                         type of computed column, because the date type of computed column
-	 *                         from catalog table is not trusted.
+	 * @param schemaResolver The CatalogTableSchemaResolver is used to derive correct result
+	 *                       type of computed column, because the date type of computed column
+	 *                       from catalog table is not trusted.
 	 * @param isStreaming If the table is for streaming mode
 	 * @param isTemporary If the table is temporary
 	 */
@@ -95,14 +94,14 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 			CatalogBaseTable catalogBaseTable,
 			FlinkStatistic statistic,
 			Catalog catalog,
-			SqlExprToRexConverterFactory converterFactory,
+			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreaming,
 			boolean isTemporary) {
 		this.tableIdentifier = tableIdentifier;
 		this.catalogBaseTable = catalogBaseTable;
 		this.statistic = statistic;
 		this.catalog = catalog;
-		this.converterFactory = converterFactory;
+		this.schemaResolver = schemaResolver;
 		this.isStreamingMode = isStreaming;
 		this.isTemporary = isTemporary;
 	}
@@ -186,11 +185,8 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 			}
 		}
 
-		return TableSourceUtil.getSourceRowTypeFromSchema(
-				converterFactory,
-				flinkTypeFactory,
-				tableSchema,
-				isStreamingMode);
+		TableSchema newTableSchema = schemaResolver.resolve(tableSchema, isStreamingMode);
+		return flinkTypeFactory.buildRelNodeRowType(newTableSchema);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.catalog;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -32,7 +33,6 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.plan.stats.TableStats;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 
 import org.apache.calcite.linq4j.tree.Expression;
@@ -56,9 +56,9 @@ class DatabaseCalciteSchema extends FlinkSchema {
 	private final String databaseName;
 	private final String catalogName;
 	private final CatalogManager catalogManager;
-	// The SQL expression converter factory is used to derive correct result type of computed column,
+	// The CatalogTableSchemaResolver is used to derive correct result type of computed column,
 	// because the date type of computed column from catalog table is not trusted.
-	private final SqlExprToRexConverterFactory converterFactory;
+	private final CatalogTableSchemaResolver schemaResolver;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
 
@@ -66,12 +66,12 @@ class DatabaseCalciteSchema extends FlinkSchema {
 			String databaseName,
 			String catalogName,
 			CatalogManager catalog,
-			SqlExprToRexConverterFactory converterFactory,
+			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreamingMode) {
 		this.databaseName = databaseName;
 		this.catalogName = catalogName;
 		this.catalogManager = catalog;
-		this.converterFactory = converterFactory;
+		this.schemaResolver = schemaResolver;
 		this.isStreamingMode = isStreamingMode;
 	}
 
@@ -87,7 +87,7 @@ class DatabaseCalciteSchema extends FlinkSchema {
 					table,
 					statistic,
 					catalogManager.getCatalog(catalogName).orElseThrow(IllegalStateException::new),
-					converterFactory,
+					schemaResolver,
 					isStreamingMode,
 					result.isTemporary());
 			})

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.catalog;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.constraints.UniqueConstraint;
-import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -56,9 +55,6 @@ class DatabaseCalciteSchema extends FlinkSchema {
 	private final String databaseName;
 	private final String catalogName;
 	private final CatalogManager catalogManager;
-	// The CatalogTableSchemaResolver is used to derive correct result type of computed column,
-	// because the date type of computed column from catalog table is not trusted.
-	private final CatalogTableSchemaResolver schemaResolver;
 	// Flag that tells if the current planner should work in a batch or streaming mode.
 	private final boolean isStreamingMode;
 
@@ -66,12 +62,10 @@ class DatabaseCalciteSchema extends FlinkSchema {
 			String databaseName,
 			String catalogName,
 			CatalogManager catalog,
-			CatalogTableSchemaResolver schemaResolver,
 			boolean isStreamingMode) {
 		this.databaseName = databaseName;
 		this.catalogName = catalogName;
 		this.catalogManager = catalog;
-		this.schemaResolver = schemaResolver;
 		this.isStreamingMode = isStreamingMode;
 	}
 
@@ -87,7 +81,6 @@ class DatabaseCalciteSchema extends FlinkSchema {
 					table,
 					statistic,
 					catalogManager.getCatalog(catalogName).orElseThrow(IllegalStateException::new),
-					schemaResolver,
 					isStreamingMode,
 					result.isTemporary());
 			})

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
@@ -29,24 +29,19 @@ import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.SqlExprToRexConverter;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.expressions.RexNodeExpression;
 import org.apache.flink.table.planner.operations.SqlToOperationConverter;
-import org.apache.flink.table.planner.utils.JavaScalaConversionUtil$;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
 import org.apache.flink.table.types.utils.TypeConversions;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Implementation of {@link Parser} that uses Calcite.
@@ -60,20 +55,17 @@ public class ParserImpl implements Parser {
 	// multiple statements parsing
 	private final Supplier<FlinkPlannerImpl> validatorSupplier;
 	private final Supplier<CalciteParser> calciteParserSupplier;
-	private final Supplier<SqlExprToRexConverterFactory> sqlExprToRexConverterSupplier;
-	private final Supplier<FlinkTypeFactory> typeFactorySupplier;
+	private final Function<TableSchema, SqlExprToRexConverter> sqlExprToRexConverterCreator;
 
 	public ParserImpl(
 			CatalogManager catalogManager,
 			Supplier<FlinkPlannerImpl> validatorSupplier,
 			Supplier<CalciteParser> calciteParserSupplier,
-			Supplier<SqlExprToRexConverterFactory> sqlExprToRexConverterSupplier,
-			Supplier<FlinkTypeFactory> typeFactorySupplier) {
+			Function<TableSchema, SqlExprToRexConverter> sqlExprToRexConverterCreator) {
 		this.catalogManager = catalogManager;
 		this.validatorSupplier = validatorSupplier;
 		this.calciteParserSupplier = calciteParserSupplier;
-		this.sqlExprToRexConverterSupplier = sqlExprToRexConverterSupplier;
-		this.typeFactorySupplier = typeFactorySupplier;
+		this.sqlExprToRexConverterCreator = sqlExprToRexConverterCreator;
 	}
 
 	@Override
@@ -97,15 +89,7 @@ public class ParserImpl implements Parser {
 
 	@Override
 	public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
-		FlinkTypeFactory typeFactory = typeFactorySupplier.get();
-		List<String> fieldNames = Arrays.asList(inputSchema.getFieldNames());
-		List<LogicalType> fieldTypes = Arrays.stream(inputSchema.getFieldDataTypes())
-				.map(LogicalTypeDataTypeConverter::toLogicalType)
-				.collect(Collectors.toList());
-		RelDataType inputType = typeFactory.buildRelNodeRowType(
-				JavaScalaConversionUtil$.MODULE$.toScala(fieldNames),
-				JavaScalaConversionUtil$.MODULE$.toScala(fieldTypes));
-		SqlExprToRexConverter sqlExprToRexConverter = sqlExprToRexConverterSupplier.get().create(inputType);
+		SqlExprToRexConverter sqlExprToRexConverter = sqlExprToRexConverterCreator.apply(inputSchema);
 		RexNode rexNode = sqlExprToRexConverter.convertToRexNode(sqlExpression);
 		LogicalType logicalType = FlinkTypeFactory.toLogicalType(rexNode.getType());
 		return new RexNodeExpression(rexNode, TypeConversions.fromLogicalToDataType(logicalType));

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -55,7 +55,7 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.tools.FrameworkConfig
 
 import java.util
-import java.util.function.{Supplier => JSupplier}
+import java.util.function.{Function => JFunction, Supplier => JSupplier}
 
 import _root_.scala.collection.JavaConversions._
 
@@ -100,11 +100,10 @@ abstract class PlannerBase(
     new JSupplier[CalciteParser] {
       override def get(): CalciteParser = plannerContext.createCalciteParser()
     },
-    new JSupplier[SqlExprToRexConverterFactory] {
-      override def get(): SqlExprToRexConverterFactory = sqlExprToRexConverterFactory
-    },
-    new JSupplier[FlinkTypeFactory] {
-      override def get(): FlinkTypeFactory = plannerContext.getTypeFactory
+    new JFunction[TableSchema, SqlExprToRexConverter] {
+      override def apply(t: TableSchema): SqlExprToRexConverter = {
+        sqlExprToRexConverterFactory.create(plannerContext.getTypeFactory.buildRelNodeRowType(t))
+      }
     }
   )
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.api.internal.CatalogTableSchemaResolver
 import org.apache.flink.table.api.{TableConfig, TableEnvironment, TableException, TableSchema}
 import org.apache.flink.table.catalog._
 import org.apache.flink.table.connector.sink.DynamicTableSink
@@ -115,8 +114,7 @@ abstract class PlannerBase(
       config,
       functionCatalog,
       catalogManager,
-      asRootSchema(new CatalogManagerCalciteSchema(
-        catalogManager, new CatalogTableSchemaResolver(parser), isStreamingMode)),
+      asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),
       getTraitDefs.toList
     )
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
@@ -161,6 +161,36 @@ object TableSourceUtil {
   }
 
   /**
+   * Returns schema of the selected fields of the given [[TableSource]].
+   *
+   * <p> The watermark strategy specifications should either come from the [[TableSchema]]
+   * or [[TableSource]].
+   *
+   * @param typeFactory Type factory to create the type
+   * @param tableSchema Table schema to derive table field names and data types
+   * @param tableSource Table source to derive watermark strategies
+   * @param streaming Flag to determine whether the schema of a stream or batch table is created
+   * @return The row type for the selected fields of the given [[TableSource]], this type would
+   *         also be patched with time attributes defined in the give [[WatermarkSpec]]
+   */
+  def getSourceRowType(
+      typeFactory: FlinkTypeFactory,
+      tableSchema: TableSchema,
+      tableSource: Option[TableSource[_]],
+      streaming: Boolean): RelDataType = {
+
+    val fieldNames = tableSchema.getFieldNames
+    val fieldDataTypes = tableSchema.getFieldDataTypes
+
+    if (tableSource.isDefined) {
+      getSourceRowTypeFromSource(typeFactory, tableSource.get, streaming)
+    } else {
+      val fieldTypes = fieldDataTypes.map(fromDataTypeToLogicalType)
+      typeFactory.buildRelNodeRowType(fieldNames, fieldTypes)
+    }
+  }
+
+  /**
     * Returns the [[RowtimeAttributeDescriptor]] of a [[TableSource]].
     *
     * @param tableSource The [[TableSource]] for which the [[RowtimeAttributeDescriptor]] is

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
@@ -18,14 +18,12 @@
 
 package org.apache.flink.table.planner.sources
 
-import org.apache.flink.table.api.{DataTypes, TableColumn, TableSchema, ValidationException, WatermarkSpec}
+import org.apache.flink.table.api.{DataTypes, TableSchema, ValidationException, WatermarkSpec}
 import org.apache.flink.table.expressions.ApiExpressionUtils.{typeLiteral, valueLiteral}
 import org.apache.flink.table.expressions.{CallExpression, Expression, ResolvedExpression, ResolvedFieldReference}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
-import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, SqlExprToRexConverterFactory}
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter
-import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
-import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.runtime.types.DataTypePrecisionFixer
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
@@ -39,7 +37,7 @@ import org.apache.calcite.plan.RelOptCluster
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.LogicalValues
-import org.apache.calcite.rex.{RexCall, RexNode}
+import org.apache.calcite.rex.RexNode
 import org.apache.calcite.tools.RelBuilder
 
 import _root_.java.sql.Timestamp
@@ -116,67 +114,6 @@ object TableSourceUtil {
     tableSource
       .getProducedDataType
       .accept(new DataTypePrecisionFixer(correspondingLogicalType))
-  }
-
-  /**
-    * Returns schema of the selected fields of the given [[TableSchema]].
-    *
-    * @param converterFactory converter to convert computed columns.
-    * @param typeFactory Type factory to create the type
-    * @param tableSchema Table schema to derive table field names and data types
-    * @param streaming Flag to determine whether the schema of a stream or batch table is created
-    * @return The row type for the selected fields of the given [[TableSchema]], this type would
-    *         also be patched with time attributes defined in the give [[WatermarkSpec]]
-    */
-  def getSourceRowTypeFromSchema(
-      converterFactory: SqlExprToRexConverterFactory,
-      typeFactory: FlinkTypeFactory,
-      tableSchema: TableSchema,
-      streaming: Boolean): RelDataType = {
-    val fieldNames = tableSchema.getFieldNames
-    var fieldTypes = tableSchema.getFieldDataTypes.map(fromDataTypeToLogicalType)
-
-    // TODO: [FLINK-14473] we only support top-level rowtime attribute right now
-    val rowTimeIdx = if (tableSchema.getWatermarkSpecs.nonEmpty) {
-      val rowtime = tableSchema.getWatermarkSpecs.head.getRowtimeAttribute
-      if (rowtime.contains(".")) {
-        throw new ValidationException(
-          s"Nested field '$rowtime' as rowtime attribute is not supported right now.")
-      }
-      Some(fieldNames.indexOf(rowtime))
-    } else {
-      None
-    }
-
-    val converter = converterFactory.create(
-      typeFactory.buildRelNodeRowType(fieldNames, fieldTypes))
-    def isProctime(column: TableColumn): Boolean = {
-      toScala(column.getExpr).exists { expr =>
-        converter.convertToRexNode(expr) match {
-          case call: RexCall => call.getOperator == FlinkSqlOperatorTable.PROCTIME
-          case _ => false
-        }
-      }
-    }
-
-    fieldTypes = fieldTypes.zipWithIndex.map {
-      case (originalType, i) =>
-        if (streaming && rowTimeIdx.exists(_.equals(i))) {
-          new TimestampType(
-            originalType.isNullable,
-            TimestampKind.ROWTIME,
-            originalType.asInstanceOf[TimestampType].getPrecision)
-        } else if (isProctime(tableSchema.getTableColumn(i).get())) {
-          new TimestampType(
-            originalType.isNullable,
-            TimestampKind.PROCTIME,
-            originalType.asInstanceOf[TimestampType].getPrecision)
-        } else {
-          originalType
-        }
-    }
-
-    typeFactory.buildRelNodeRowType(fieldNames, fieldTypes)
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -103,6 +103,7 @@ import static org.junit.Assert.assertThat;
  * Test cases for {@link SqlToOperationConverter}.
  */
 public class SqlToOperationConverterTest {
+	private final boolean isStreamingMode = false;
 	private final TableConfig tableConfig = new TableConfig();
 	private final Catalog catalog = new GenericInMemoryCatalog("MockCatalog",
 		"default");
@@ -128,8 +129,7 @@ public class SqlToOperationConverterTest {
 		new PlannerContext(tableConfig,
 			functionCatalog,
 			catalogManager,
-			asRootSchema(new CatalogManagerCalciteSchema(
-				catalogManager, new CatalogTableSchemaResolver(parser), false)),
+			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),
 			new ArrayList<>());
 
 	private PlannerContext getPlannerContext() {
@@ -141,6 +141,7 @@ public class SqlToOperationConverterTest {
 
 	@Before
 	public void before() throws TableAlreadyExistException, DatabaseNotExistException {
+		catalogManager.setCatalogTableSchemaResolver(new CatalogTableSchemaResolver(parser, isStreamingMode));
 		final ObjectPath path1 = new ObjectPath(catalogManager.getCurrentDatabase(), "t1");
 		final ObjectPath path2 = new ObjectPath(catalogManager.getCurrentDatabase(), "t2");
 		final TableSchema tableSchema = TableSchema.builder()

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -123,8 +123,8 @@ public class SqlToOperationConverterTest {
 		catalogManager,
 		plannerSupplier,
 		() -> plannerSupplier.get().parser(),
-		() -> t -> getPlannerContext().createSqlExprToRexConverter(t),
-		() -> getPlannerContext().getTypeFactory());
+		t -> getPlannerContext().createSqlExprToRexConverter(
+				getPlannerContext().getTypeFactory().buildRelNodeRowType(t)));
 	private final PlannerContext plannerContext =
 		new PlannerContext(tableConfig,
 			functionCatalog,

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogFunction;
@@ -41,6 +42,7 @@ import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
@@ -56,9 +58,8 @@ import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.planner.calcite.CalciteParser;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverter;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
+import org.apache.flink.table.planner.delegation.ParserImpl;
 import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.planner.expressions.utils.Func0$;
 import org.apache.flink.table.planner.expressions.utils.Func1$;
@@ -67,7 +68,6 @@ import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctio
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlNode;
 import org.junit.After;
 import org.junit.Before;
@@ -84,6 +84,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
@@ -113,16 +114,26 @@ public class SqlToOperationConverterTest {
 		tableConfig,
 		catalogManager,
 		moduleManager);
-	private SqlExprToRexConverterFactory sqlExprToRexConverterFactory = this::createSqlExprToRexConverter;
+	private final Supplier<FlinkPlannerImpl> plannerSupplier =
+		() -> getPlannerContext().createFlinkPlanner(
+				catalogManager.getCurrentCatalog(),
+				catalogManager.getCurrentDatabase());
+	private final Parser parser = new ParserImpl(
+		catalogManager,
+		plannerSupplier,
+		() -> plannerSupplier.get().parser(),
+		() -> t -> getPlannerContext().createSqlExprToRexConverter(t),
+		() -> getPlannerContext().getTypeFactory());
 	private final PlannerContext plannerContext =
 		new PlannerContext(tableConfig,
 			functionCatalog,
 			catalogManager,
-			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, sqlExprToRexConverterFactory, false)),
+			asRootSchema(new CatalogManagerCalciteSchema(
+				catalogManager, new CatalogTableSchemaResolver(parser), false)),
 			new ArrayList<>());
 
-	private SqlExprToRexConverter createSqlExprToRexConverter(RelDataType t) {
-		return plannerContext.createSqlExprToRexConverter(t);
+	private PlannerContext getPlannerContext() {
+		return plannerContext;
 	}
 
 	@Rule

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.plan;
 
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
@@ -78,7 +77,6 @@ public class FlinkCalciteCatalogReaderTest {
 			ConnectorCatalogTable.source(new TestTableSource(true, TableSchema.builder().build()), true),
 			FlinkStatistic.UNKNOWN(),
 			null,
-			new CatalogTableSchemaResolver(null), // parser is not needed here
 			true,
 			false);
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
@@ -19,11 +19,11 @@
 package org.apache.flink.table.planner.plan;
 
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverter;
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable;
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
@@ -34,7 +34,6 @@ import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
 import org.junit.Before;
@@ -76,22 +75,10 @@ public class FlinkCalciteCatalogReaderTest {
 		// Mock CatalogSchemaTable.
 		CatalogSchemaTable mockTable = new CatalogSchemaTable(
 			ObjectIdentifier.of("a", "b", "c"),
-			ConnectorCatalogTable.source(
-				new TestTableSource(true, TableSchema.builder().build()),
-				true),
+			ConnectorCatalogTable.source(new TestTableSource(true, TableSchema.builder().build()), true),
 			FlinkStatistic.UNKNOWN(),
 			null,
-			tableRowType -> new SqlExprToRexConverter() {
-				@Override
-				public RexNode convertToRexNode(String expr) {
-					return null;
-				}
-
-				@Override
-				public RexNode[] convertToRexNodes(String[] exprs) {
-					return new RexNode[0];
-				}
-			},
+			new CatalogTableSchemaResolver(null), // parser is not needed here
 			true,
 			false);
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
@@ -60,8 +60,7 @@ public class PlannerMocks {
 				catalogManager,
 				() -> planner,
 				planner::parser,
-				() -> plannerContext::createSqlExprToRexConverter,
-				plannerContext::getTypeFactory
+				t -> plannerContext.createSqlExprToRexConverter(plannerContext.getTypeFactory().buildRelNodeRowType(t))
 		);
 		catalogManager.setCatalogTableSchemaResolver(new CatalogTableSchemaResolver(parser, isStreamingMode));
 		return planner;

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -40,24 +40,24 @@ Calc(select=[id, deepNested.nested1.name AS nestedName, nested.value AS nestedVa
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testProcTimeTableSourceSimple">
+  <TestCase name="testProjectOnlyRowtime">
     <Resource name="sql">
-      <![CDATA[SELECT pTime, id, name, val FROM procTimeT]]>
+      <![CDATA[SELECT rtime FROM T]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(pTime=[$3], id=[$0], name=[$2], val=[$1])
-+- LogicalWatermarkAssigner(rowtime=[pTime], watermark=[$3])
-   +- LogicalProject(id=[$0], val=[$1], name=[$2], pTime=[PROCTIME()])
-      +- LogicalTableScan(table=[[default_catalog, default_database, procTimeT]])
+LogicalProject(rtime=[$1])
++- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
+   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[pTime, id, name, val])
-+- WatermarkAssigner(rowtime=[pTime], watermark=[pTime])
-   +- Calc(select=[id, val, name, PROCTIME() AS pTime])
-      +- TableSourceScan(table=[[default_catalog, default_database, procTimeT]], fields=[id, val, name])
+Calc(select=[rtime])
++- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
+   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
+      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
 ]]>
     </Resource>
   </TestCase>
@@ -77,48 +77,6 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
 GroupAggregate(select=[COUNT(*) AS EXPR$0])
 +- Exchange(distribution=[single])
    +- TableSourceScan(table=[[default_catalog, default_database, T, project=[]]], fields=[])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectWithoutRowtime">
-    <Resource name="sql">
-      <![CDATA[SELECT ptime, name, val, id FROM T]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(ptime=[$4], name=[$3], val=[$2], id=[$0])
-+- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
-   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
-      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
-+- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
-   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
-      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectWithRowtimeProctime">
-    <Resource name="sql">
-      <![CDATA[SELECT name, val, id FROM T]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(name=[$3], val=[$2], id=[$0])
-+- LogicalWatermarkAssigner(rowtime=[ptime], watermark=[$4])
-   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
-      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[name, val, id])
-+- WatermarkAssigner(rowtime=[ptime], watermark=[ptime])
-   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
-      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
 ]]>
     </Resource>
   </TestCase>
@@ -153,6 +111,27 @@ Calc(select=[name, w$end AS EXPR$1, EXPR$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectWithoutProctime">
+    <Resource name="sql">
+      <![CDATA[select name, val, rtime, id from T]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$3], val=[$2], rtime=[$1], id=[$0])
++- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
+   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, val, rtime, id])
++- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
+   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
+      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTableSourceWithTimestampRowTimeField">
     <Resource name="sql">
       <![CDATA[SELECT rowtime, id, name, val FROM rowTimeT]]>
@@ -169,6 +148,27 @@ LogicalProject(rowtime=[$1], id=[$0], name=[$3], val=[$2])
 Calc(select=[rowtime, id, name, val])
 +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
    +- TableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutRowtime">
+    <Resource name="sql">
+      <![CDATA[SELECT ptime, name, val, id FROM T]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ptime=[$4], name=[$3], val=[$2], id=[$0])
++- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
+   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
++- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
+   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
+      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/LegacyTableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/LegacyTableSourceTest.xml
@@ -61,6 +61,34 @@ Calc(select=[PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, val])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectOnlyProctime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ptime=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, rtime, val, name)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, rtime, val, name)]]], fields=[id, rtime, val, ptime, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectOnlyRowtime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(rtime=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, rtime, val, name)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[rtime])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, rtime, val, name)]]], fields=[id, rtime, val, ptime, name])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProjectWithMapping">
     <Resource name="planBefore">
       <![CDATA[
@@ -72,34 +100,6 @@ LogicalProject(name=[$4], rtime=[$1], val=[$2])
       <![CDATA[
 Calc(select=[name, rtime, val])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: p-rtime, p-id, p-name, p-val)]]], fields=[id, rtime, val, ptime, name])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectWithoutRowtime">
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(ptime=[$3], name=[$4], val=[$2], id=[$0])
-+- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]], fields=[id, rtime, val, ptime, name])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectWithRowtimeProctime">
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(name=[$4], val=[$2], id=[$0])
-+- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[name, val, id])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]], fields=[id, rtime, val, ptime, name])
 ]]>
     </Resource>
   </TestCase>
@@ -122,6 +122,34 @@ Calc(select=[name, EXPR$0, EXPR$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectWithoutProctime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$4], val=[$2], rtime=[$1], id=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, rtime, val, name)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, val, rtime, id])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, rtime, val, name)]]], fields=[id, rtime, val, ptime, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithRowtimeProctime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$4], val=[$2], id=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, val, id])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]], fields=[id, rtime, val, ptime, name])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTableSourceWithTimestampRowTimeField">
     <Resource name="planBefore">
       <![CDATA[
@@ -133,6 +161,20 @@ LogicalProject(rowtime=[$1], id=[$0], name=[$3], val=[$2])
       <![CDATA[
 Calc(select=[rowtime, id, name, val])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutRowtime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ptime=[$3], name=[$4], val=[$2], id=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestSource(physical fields: id, name, val, rtime)]]], fields=[id, rtime, val, ptime, name])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.xml
@@ -16,22 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testTableSourceWithTimestampRowTimeField">
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(rowtime=[$1], id=[$0], name=[$3], val=[$2])
-+- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$1])
-   +- LogicalTableScan(table=[[default_catalog, default_database, rowTimeT]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[rowtime, id, name, val])
-+- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
-   +- TableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, rowtime, val, name])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testNestedProject">
     <Resource name="planBefore">
       <![CDATA[
@@ -43,42 +27,6 @@ LogicalProject(id=[$0], nestedName=[$1.nested1.name], nestedValue=[$2.value], ne
       <![CDATA[
 Calc(select=[id, deepNested.nested1.name AS nestedName, nested.value AS nestedValue, deepNested.nested2.flag AS nestedFlag, deepNested.nested2.num AS nestedNum])
 +- TableSourceScan(table=[[default_catalog, default_database, T, project=[id, deepNested, nested]]], fields=[id, deepNested, nested])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProcTimeTableSourceSimple">
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(proctime=[$3], id=[$0], name=[$2], val=[$1])
-+- LogicalWatermarkAssigner(rowtime=[proctime], watermark=[$3])
-   +- LogicalProject(id=[$0], val=[$1], name=[$2], proctime=[PROCTIME()])
-      +- LogicalTableScan(table=[[default_catalog, default_database, procTimeT]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[proctime, id, name, val])
-+- WatermarkAssigner(rowtime=[proctime], watermark=[proctime])
-   +- Calc(select=[id, val, name, PROCTIME() AS proctime])
-      +- TableSourceScan(table=[[default_catalog, default_database, procTimeT]], fields=[id, val, name])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectWithoutRowtime">
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(ptime=[$4], name=[$3], val=[$2], id=[$0])
-+- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
-   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
-      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
-+- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
-   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
-      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
 ]]>
     </Resource>
   </TestCase>
@@ -100,21 +48,115 @@ Calc(select=[id, name, w0$o0 AS valSum], where=[>(w0$o0, 100)])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testProjectWithRowtimeProctime">
+  <TestCase name="testProjectOnlyRowtime">
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(name=[$3], val=[$2], id=[$0])
-+- LogicalWatermarkAssigner(rowtime=[ptime], watermark=[$4])
+LogicalProject(rtime=[$1])
++- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
    +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
       +- LogicalTableScan(table=[[default_catalog, default_database, T]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[name, val, id])
-+- WatermarkAssigner(rowtime=[ptime], watermark=[ptime])
+Calc(select=[rtime])
++- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
    +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
       +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRowTimeTableSourceGroupWindow">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], EXPR$0=[$2], EXPR$1=[$1])
++- LogicalWindowAggregate(group=[{3}], EXPR$1=[AVG($2)], window=[TumblingGroupWindow('w, rowtime, 600000)], properties=[EXPR$0])
+   +- LogicalFilter(condition=[>($2, 100)])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$1])
+         +- LogicalTableScan(table=[[default_catalog, default_database, rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, EXPR$0, EXPR$1])
++- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow('w, rowtime, 600000)], properties=[EXPR$0], select=[name, AVG(val) AS EXPR$1, end('w) AS EXPR$0])
+   +- Exchange(distribution=[hash[name]])
+      +- Calc(select=[id, rowtime, val, name], where=[>(val, 100)])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+            +- TableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutProctime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$3], val=[$2], rtime=[$1], id=[$0])
++- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
+   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, val, rtime, id])
++- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
+   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
+      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableSourceWithTimestampRowTimeField">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(rowtime=[$1], id=[$0], name=[$3], val=[$2])
++- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[rowtime, id, name, val])
++- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+   +- TableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithoutRowtime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(ptime=[$4], name=[$3], val=[$2], id=[$0])
++- LogicalWatermarkAssigner(rowtime=[rtime], watermark=[$1])
+   +- LogicalProject(id=[$0], rtime=[$1], val=[$2], name=[$3], ptime=[PROCTIME()])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
++- WatermarkAssigner(rowtime=[rtime], watermark=[rtime])
+   +- Calc(select=[id, rtime, val, name, PROCTIME() AS ptime])
+      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[id, rtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRowTimeTableSourceGroupWindowWithNotNullRowTimeType">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], EXPR$0=[$2], EXPR$1=[$1])
++- LogicalWindowAggregate(group=[{3}], EXPR$1=[AVG($2)], window=[TumblingGroupWindow('w, rowtime, 600000)], properties=[EXPR$0])
+   +- LogicalFilter(condition=[>($2, 100)])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($1, 5000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, EXPR$0, EXPR$1])
++- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow('w, rowtime, 600000)], properties=[EXPR$0], select=[name, AVG(val) AS EXPR$1, end('w) AS EXPR$0])
+   +- Exchange(distribution=[hash[name]])
+      +- Calc(select=[id, rowtime, val, name], where=[>(val, 100)])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 5000:INTERVAL SECOND)])
+            +- TableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, rowtime, val, name])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -1060,7 +1060,7 @@ class TableEnvironmentTest {
         Row.of("f25", "STRING", Boolean.box(false), null, null, null),
         Row.of("f26", "ROW<`f0` INT NOT NULL, `f1` INT>", Boolean.box(false),
           "PRI(f24, f26)", null, null),
-        Row.of("ts", "TIMESTAMP(3)", Boolean.box(true), null, "TO_TIMESTAMP(`f25`)",
+        Row.of("ts", "TIMESTAMP(3) *ROWTIME*", Boolean.box(true), null, "TO_TIMESTAMP(`f25`)",
           "`ts` - INTERVAL '1' SECOND")
       ).iterator(),
       tableResult1.collect())

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.codegen
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext
 import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.api.internal.CatalogTableSchemaResolver
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
 import org.apache.flink.table.data.{GenericRowData, TimestampData}
 import org.apache.flink.table.delegation.Parser
@@ -79,8 +78,7 @@ class WatermarkGeneratorCodeGenTest {
     config,
     functionCatalog,
     catalogManager,
-    asRootSchema(new CatalogManagerCalciteSchema(
-      catalogManager, new CatalogTableSchemaResolver(parser), false)),
+    asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
     Collections.singletonList(ConventionTraitDef.INSTANCE))
   val planner: FlinkPlannerImpl = plannerContext.createFlinkPlanner(
     catalogManager.getCurrentCatalog,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -79,7 +79,7 @@ class TableSourceTest extends TableTestBase {
   @Test
   def testProctimeOnWatermarkSpec(): Unit = {
     thrown.expect(classOf[ValidationException])
-    thrown.expectMessage("proctime can't be defined on watermark spec.")
+    thrown.expectMessage("Watermark can not be defined for a processing time attribute column.")
     val ddl =
       s"""
          |CREATE TABLE procTimeT (

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.stream.sql
 
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.utils._
 
 import org.junit.Test
@@ -76,7 +77,9 @@ class TableSourceTest extends TableTestBase {
   }
 
   @Test
-  def testProcTimeTableSourceSimple(): Unit = {
+  def testProctimeOnWatermarkSpec(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage("proctime can't be defined on watermark spec.")
     val ddl =
       s"""
          |CREATE TABLE procTimeT (
@@ -93,27 +96,6 @@ class TableSourceTest extends TableTestBase {
     util.tableEnv.executeSql(ddl)
 
     util.verifyPlan("SELECT pTime, id, name, val FROM procTimeT")
-  }
-
-  @Test
-  def testProjectWithRowtimeProctime(): Unit = {
-    val ddl =
-      s"""
-         |CREATE TABLE T (
-         |  id int,
-         |  rtime timestamp(3),
-         |  val bigint,
-         |  name varchar(32),
-         |  ptime as PROCTIME(),
-         |  watermark for ptime as ptime
-         |) WITH (
-         |  'connector' = 'values',
-         |  'bounded' = 'false'
-         |)
-       """.stripMargin
-    util.tableEnv.executeSql(ddl)
-
-    util.verifyPlan("SELECT name, val, id FROM T")
   }
 
   @Test
@@ -137,6 +119,7 @@ class TableSourceTest extends TableTestBase {
     util.verifyPlan("SELECT ptime, name, val, id FROM T")
   }
 
+  @Test
   def testProjectWithoutProctime(): Unit = {
     val ddl =
       s"""
@@ -157,26 +140,7 @@ class TableSourceTest extends TableTestBase {
     util.verifyPlan("select name, val, rtime, id from T")
   }
 
-  def testProjectOnlyProctime(): Unit = {
-    val ddl =
-      s"""
-         |CREATE TABLE T (
-         |  id int,
-         |  rtime timestamp(3),
-         |  val bigint,
-         |  name varchar(32),
-         |  ptime as PROCTIME(),
-         |  watermark for ptime as ptime
-         |) WITH (
-         |  'connector' = 'values',
-         |  'bounded' = 'false'
-         |)
-       """.stripMargin
-    util.tableEnv.executeSql(ddl)
-
-    util.verifyPlan("SELECT ptime FROM T")
-  }
-
+  @Test
   def testProjectOnlyRowtime(): Unit = {
     val ddl =
       s"""

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/LegacyTableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/LegacyTableSourceTest.scala
@@ -179,6 +179,7 @@ class LegacyTableSourceTest extends TableTestBase {
     util.verifyPlan(t)
   }
 
+  @Test
   def testProjectWithoutProctime(): Unit = {
     val tableSchema = new TableSchema(
       Array("id", "rtime", "val", "ptime", "name"),
@@ -198,6 +199,7 @@ class LegacyTableSourceTest extends TableTestBase {
     util.verifyPlan(t)
   }
 
+  @Test
   def testProjectOnlyProctime(): Unit = {
     val tableSchema = new TableSchema(
       Array("id", "rtime", "val", "ptime", "name"),
@@ -217,6 +219,7 @@ class LegacyTableSourceTest extends TableTestBase {
     util.verifyPlan(t)
   }
 
+  @Test
   def testProjectOnlyRowtime(): Unit = {
     val tableSchema = new TableSchema(
       Array("id", "rtime", "val", "ptime", "name"),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.plan.stream.table
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.utils.TableTestBase
 
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 class TableSourceTest extends TableTestBase {
 
@@ -48,7 +48,6 @@ class TableSourceTest extends TableTestBase {
     util.verifyPlan(t)
   }
 
-  @Ignore("remove ignore once FLINK-17753 is fixed")
   @Test
   def testRowTimeTableSourceGroupWindow(): Unit = {
     val ddl =
@@ -75,15 +74,15 @@ class TableSourceTest extends TableTestBase {
   }
 
   @Test
-  def testProcTimeTableSourceSimple(): Unit = {
+  def testRowTimeTableSourceGroupWindowWithNotNullRowTimeType(): Unit = {
     val ddl =
       s"""
-         |CREATE TABLE procTimeT (
+         |CREATE TABLE rowTimeT (
          |  id int,
+         |  rowtime timestamp(3) not null,
          |  val bigint,
          |  name varchar(32),
-         |  proctime as PROCTIME(),
-         |  watermark for proctime as proctime
+         |  watermark for rowtime as rowtime - INTERVAL '5' SECONDS
          |) WITH (
          |  'connector' = 'values',
          |  'bounded' = 'false'
@@ -91,7 +90,11 @@ class TableSourceTest extends TableTestBase {
        """.stripMargin
     util.tableEnv.executeSql(ddl)
 
-    val t = util.tableEnv.from("procTimeT").select($"proctime", $"id", $"name", $"val")
+    val t = util.tableEnv.from("rowTimeT")
+      .where($"val" > 100)
+      .window(Tumble over 10.minutes on 'rowtime as 'w)
+      .groupBy('name, 'w)
+      .select('name, 'w.end, 'val.avg)
     util.verifyPlan(t)
   }
 
@@ -119,28 +122,6 @@ class TableSourceTest extends TableTestBase {
   }
 
   @Test
-  def testProjectWithRowtimeProctime(): Unit = {
-    val ddl =
-      s"""
-         |CREATE TABLE T (
-         |  id int,
-         |  rtime timestamp(3),
-         |  val bigint,
-         |  name varchar(32),
-         |  ptime as PROCTIME(),
-         |  watermark for ptime as ptime
-         |) WITH (
-         |  'connector' = 'values',
-         |  'bounded' = 'false'
-         |)
-       """.stripMargin
-    util.tableEnv.executeSql(ddl)
-
-    val t = util.tableEnv.from("T").select('name, 'val, 'id)
-    util.verifyPlan(t)
-  }
-
-  @Test
   def testProjectWithoutRowtime(): Unit = {
     val ddl =
       s"""
@@ -162,6 +143,7 @@ class TableSourceTest extends TableTestBase {
     util.verifyPlan(t)
   }
 
+  @Test
   def testProjectWithoutProctime(): Unit = {
     val ddl =
       s"""
@@ -183,7 +165,11 @@ class TableSourceTest extends TableTestBase {
     util.verifyPlan(t)
   }
 
-  def testProjectOnlyProctime(): Unit = {
+  @Test
+  def testProctimeOnWatermarkSpec(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("proctime can't be defined on watermark spec.")
+
     val ddl =
       s"""
          |CREATE TABLE T (
@@ -204,6 +190,7 @@ class TableSourceTest extends TableTestBase {
     util.verifyPlan(t)
   }
 
+  @Test
   def testProjectOnlyRowtime(): Unit = {
     val ddl =
       s"""

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
@@ -168,7 +168,7 @@ class TableSourceTest extends TableTestBase {
   @Test
   def testProctimeOnWatermarkSpec(): Unit = {
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("proctime can't be defined on watermark spec.")
+    thrown.expectMessage("Watermark can not be defined for a processing time attribute column.")
 
     val ddl =
       s"""

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
@@ -19,11 +19,13 @@
 package org.apache.flink.table.planner;
 
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.calcite.CalciteParser;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.sqlexec.SqlToOperationConverter;
 
@@ -77,5 +79,11 @@ public class ParserImpl implements Parser {
 		CalciteParser parser = calciteParserSupplier.get();
 		SqlIdentifier sqlIdentifier = parser.parseIdentifier(identifier);
 		return UnresolvedIdentifier.of(sqlIdentifier.names);
+	}
+
+	@Override
+	public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
+		// do not support for old planner
+		return null;
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
@@ -83,7 +83,6 @@ public class ParserImpl implements Parser {
 
 	@Override
 	public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
-		// do not support for old planner
-		return null;
+		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -127,6 +127,8 @@ abstract class TableEnvImpl(
     }
   )
 
+  catalogManager.setCatalogTableSchemaResolver(new CatalogTableSchemaResolver(parser, false))
+
   def getConfig: TableConfig = config
 
   private val UNSUPPORTED_QUERY_IN_SQL_UPDATE_MSG =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -19,7 +19,9 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.utils.ParserMock;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
@@ -110,6 +112,7 @@ public class CatalogManagerTest extends TestLogger {
 			.builtin(
 				database(BUILTIN_DEFAULT_DATABASE_NAME))
 			.build();
+		manager.setCatalogTableSchemaResolver(new CatalogTableSchemaResolver(new ParserMock(), true));
 
 		CatalogTest.TestTable table = new CatalogTest.TestTable();
 		manager.createTemporaryTable(table, tempIdentifier, true);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/DatabaseCalciteSchemaTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/DatabaseCalciteSchemaTest.java
@@ -20,11 +20,13 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.catalog.TestExternalTableSourceFactory.TestExternalTableSource;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.plan.schema.TableSourceTable;
 import org.apache.flink.table.utils.CatalogManagerMocks;
+import org.apache.flink.table.utils.ParserMock;
 
 import org.apache.calcite.schema.Table;
 import org.junit.Test;
@@ -53,7 +55,10 @@ public class DatabaseCalciteSchemaTest {
 		CatalogManager catalogManager = CatalogManagerMocks.preparedCatalogManager()
 			.defaultCatalog(catalogName, catalog)
 			.build();
-		DatabaseCalciteSchema calciteSchema = new DatabaseCalciteSchema(true,
+		catalogManager.setCatalogTableSchemaResolver(new CatalogTableSchemaResolver(new ParserMock(), true));
+
+		DatabaseCalciteSchema calciteSchema = new DatabaseCalciteSchema(
+			true,
 			databaseName,
 			catalogName,
 			catalogManager,
@@ -75,6 +80,10 @@ public class DatabaseCalciteSchemaTest {
 
 		@Override
 		public CatalogTable copy() {
+			return this;
+		}
+
+		public CatalogTable copy(TableSchema tableSchema) {
 			return this;
 		}
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.calcite.CalciteParser;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.catalog.Catalog;
@@ -58,6 +59,7 @@ import org.apache.flink.table.planner.PlanningConfigurationBuilder;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.utils.CatalogManagerMocks;
+import org.apache.flink.table.utils.ParserMock;
 
 import org.apache.calcite.sql.SqlNode;
 import org.junit.After;
@@ -103,6 +105,7 @@ public class SqlToOperationConverterTest {
 
 	@Before
 	public void before() throws TableAlreadyExistException, DatabaseNotExistException {
+		catalogManager.setCatalogTableSchemaResolver(new CatalogTableSchemaResolver(new ParserMock(), true));
 		final ObjectPath path1 = new ObjectPath(catalogManager.getCurrentDatabase(), "t1");
 		final ObjectPath path2 = new ObjectPath(catalogManager.getCurrentDatabase(), "t2");
 		final TableSchema tableSchema = TableSchema.builder()


### PR DESCRIPTION


## What is the purpose of the change

*Currently, DDL + table api (with window) does not work, because the source table TableSchema (from TableEnvironment#scan/from method) does not convert the watermark spec to rowtime attribute. This pr aims to fix that*


## Brief change log

  - *convert watermark spec to rowtime attributes when executing TableEnvironment#scan/from*


## Verifying this change

This change added tests and can be verified as follows:

  - *Extended TableSourceTest for validation the fix*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
