### PR TITLE
[FLINK-16694][ci] Limit number of dumped log lines

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -365,8 +365,8 @@ function check_logs_for_errors {
       | grep -v "error_prone_annotations" \
       | grep -ic "error" || true)
   if [[ ${error_count} -gt 0 ]]; then
-    echo "Found error in log files:"
-    cat $FLINK_DIR/log/*
+    echo "Found error in log files; printing first 500 lines; see full logs for details:"
+    find $FLINK_DIR/log/ -exec head --lines=500 {} \;
     EXIT_CODE=1
   else
     echo "No errors in log files."
@@ -401,8 +401,8 @@ function check_logs_for_exceptions {
    | grep -v "org.apache.flink.runtime.JobException: Recovery is suppressed" \
    | grep -ic "exception" || true)
   if [[ ${exception_count} -gt 0 ]]; then
-    echo "Found exception in log files:"
-    cat $FLINK_DIR/log/*
+    echo "Found exception in log files; printing first 500 lines; see full logs for details:"
+    find $FLINK_DIR/log/ -exec head --lines=500 {} \;
     EXIT_CODE=1
   else
     echo "No exceptions in log files."
@@ -423,8 +423,8 @@ function check_logs_for_non_empty_out_files {
     $FLINK_DIR/log/*.out\
    | grep "." \
    > /dev/null; then
-    echo "Found non-empty .out files:"
-    cat $FLINK_DIR/log/*.out
+    echo "Found non-empty .out files; printing first 500 lines; see full logs for details:"
+    find $FLINK_DIR/log/ -name '*.out' -exec head --lines=500 {} \;
     EXIT_CODE=1
   else
     echo "No non-empty .out files."


### PR DESCRIPTION
With this PR we only print 500 from each log file if an error/exception etc was found.

This is to prevent issues with ungodly long log files caused by some tests. This is usually only an error on Travis (so it only really applies to 1.10/1.9), but I think there could be value in restricting this at all times.