### PR TITLE
draft: [FLINK-17971] [Runtime/StateBackends] Add RocksDB SST ingestion for batch writes

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBTestUtils;
+import org.apache.flink.contrib.streaming.state.writer.WriteBatchMechanism;
 import org.apache.flink.queryablestate.client.VoidNamespace;
 import org.apache.flink.queryablestate.client.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.internal.InternalListState;
@@ -32,6 +33,11 @@ import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Additional tests for the serialization and deserialization using the KvStateSerializer with a
@@ -39,7 +45,17 @@ import org.junit.rules.TemporaryFolder;
  */
 public final class KVStateRequestSerializerRocksDBTest {
 
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@Parameters(name = "WriteBatchMechanism={0}")
+	public static List<Object> writeBatchMechanisms() {
+		return Arrays.asList(WriteBatchMechanism.values());
+	}
+
+	@Parameter
+	public WriteBatchMechanism writeBatchMechanism;
+
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     /**
      * Tests list serialization and deserialization match.
@@ -53,7 +69,7 @@ public final class KVStateRequestSerializerRocksDBTest {
 
         final RocksDBKeyedStateBackend<Long> longHeapKeyedStateBackend =
                 RocksDBTestUtils.builderForTestDefaults(
-                                temporaryFolder.getRoot(), LongSerializer.INSTANCE)
+                                temporaryFolder.getRoot(), LongSerializer.INSTANCE, writeBatchMechanism)
                         .build();
 
         longHeapKeyedStateBackend.setCurrentKey(key);
@@ -80,7 +96,7 @@ public final class KVStateRequestSerializerRocksDBTest {
         // objects for RocksDB state list serialisation
         final RocksDBKeyedStateBackend<Long> longHeapKeyedStateBackend =
                 RocksDBTestUtils.builderForTestDefaults(
-                                temporaryFolder.getRoot(), LongSerializer.INSTANCE)
+                                temporaryFolder.getRoot(), LongSerializer.INSTANCE, writeBatchMechanism)
                         .build();
 
         longHeapKeyedStateBackend.setCurrentKey(key);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -65,6 +65,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 
     protected final V defaultValue;
 
+    // @lgo: should this be moved elsewhere?
     protected final WriteOptions writeOptions;
 
     protected final DataOutputSerializer dataOutputView;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBCachingPriorityQueueSet.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBCachingPriorityQueueSet.java
@@ -19,6 +19,7 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriteBatchWrapper;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.contrib.streaming.state.writer.WriteBatchMechanism;
 
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.InfoLogLevel;
@@ -193,4 +194,23 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .withDescription(
                             "The max size of the consumed memory for RocksDB batch write, "
                                     + "will flush just based on item count if this config set to 0.");
+
+    public static final ConfigOption<WriteBatchMechanism> WRITE_BATCH_MECHANISM =
+            key("state.backend.rocksdb.experimental.write-batch-mechanism")
+                    .enumType(WriteBatchMechanism.class)
+                    .defaultValue(WriteBatchMechanism.SST_INGEST)
+                    .withDescription(
+                            String.format(
+                                    "The write batch mechanism to use when writing to RocksDB. Options are %s and %s (default).",
+                                    WriteBatchMechanism.SST_INGEST.name(),
+                                    WriteBatchMechanism.WRITE_BATCH.name()));
+
+    public static final ConfigOption<MemorySize> SST_WRITER_SST_MAX_SIZE =
+            key("state.backend.rocksdb.experimental.sst-writer.sst-max-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("16mb"))
+                    .withDescription(
+                            String.format(
+                                    "The max size to use for writing SST files using the %s batch writing mechanism.",
+                                    WriteBatchMechanism.SST_INGEST.name()));
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -182,6 +182,10 @@ public class RocksDBConfigurableOptions implements Serializable {
                             "The amount of the cache for data blocks in RocksDB. "
                                     + "RocksDB has default block-cache size as '8MB'.");
 
+    // --------------------------------------------------------------------------
+    // Provided configurable write batch options for RocksDB
+    // --------------------------------------------------------------------------
+
     public static final ConfigOption<MemorySize> WRITE_BATCH_SIZE =
             key("state.backend.rocksdb.write-batch-size")
                     .memoryType()

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -751,7 +751,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
         Snapshot rocksDBSnapshot = db.getSnapshot();
         try (RocksIteratorWrapper iterator =
                         RocksDBOperationUtils.getRocksIterator(db, stateMetaInfo.f0, readOptions);
-                RocksDBWriter writer = writeFactory.defaultPutWriter(db, getWriteOptions())) {
+                // @lgo: fixme plumb through envOptions.
+                RocksDBWriter writer =
+                        writeFactory.defaultPutWriter(
+                                db, optionsContainer.getOptions(), null, this.getWriteOptions())) {
             iterator.seekToFirst();
 
             DataInputDeserializer serializedValueInput = new DataInputDeserializer();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -113,9 +113,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 
     private RocksDBNativeMetricOptions nativeMetricOptions;
     private int numberOfTransferingThreads;
-    private long writeBatchSize =
-            RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes();
-    private RocksDBWriterFactory writeFactory;
+    private final RocksDBWriterFactory writeFactory;
 
     private RocksDB injectedTestDB; // for testing
     private ColumnFamilyHandle injectedDefaultColumnFamilyHandle; // for testing
@@ -233,12 +231,8 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 
     RocksDBKeyedStateBackendBuilder<K> setWriteBatchSize(long writeBatchSize) {
         checkArgument(writeBatchSize >= 0, "Write batch size should be non negative.");
-        this.writeBatchSize = writeBatchSize;
+        this.writeFactory.setWriteBatchSize(writeBatchSize);
         return this;
-    }
-
-    private long getWriteBatchSize() {
-        return writeBatchSize;
     }
 
     private RocksDBWriterFactory getWriterFactory() {
@@ -452,7 +446,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                     restoreStateHandles,
                     ttlCompactFiltersManager,
                     optionsContainer.getWriteBufferManagerCapacity(),
-                    this.getWriterFactory());
+                    getWriterFactory());
         } else {
             return new RocksDBFullRestoreOperation<>(
                     keyGroupRange,
@@ -471,7 +465,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                     restoreStateHandles,
                     ttlCompactFiltersManager,
                     optionsContainer.getWriteBufferManagerCapacity(),
-                    this.getWriterFactory());
+                    getWriterFactory());
         }
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriteBatchWrapper;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriter;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
@@ -144,16 +146,15 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
             return;
         }
 
-        try (RocksDBWriteBatchWrapper writeBatchWrapper =
-                new RocksDBWriteBatchWrapper(
-                        backend.db, writeOptions, backend.getWriteBatchSize())) {
+        try (RocksDBWriter writer =
+                backend.getWriteFactory().writeBatchWriter(backend.db, writeOptions)) {
             for (Map.Entry<UK, UV> entry : map.entrySet()) {
                 byte[] rawKeyBytes =
                         serializeCurrentKeyWithGroupAndNamespacePlusUserKey(
                                 entry.getKey(), userKeySerializer);
                 byte[] rawValueBytes =
                         serializeValueNullSensitive(entry.getValue(), userValueSerializer);
-                writeBatchWrapper.put(columnFamily, rawKeyBytes, rawValueBytes);
+                writer.put(columnFamily, rawKeyBytes, rawValueBytes);
             }
         }
     }
@@ -282,11 +283,9 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
             try (RocksIteratorWrapper iterator =
                             RocksDBOperationUtils.getRocksIterator(
                                     backend.db, columnFamily, backend.getReadOptions());
-                    RocksDBWriteBatchWrapper rocksDBWriteBatchWrapper =
-                            new RocksDBWriteBatchWrapper(
-                                    backend.db,
-                                    backend.getWriteOptions(),
-                                    backend.getWriteBatchSize())) {
+                    RocksDBWriteBatchWrapper writer =
+                            backend.getWriteFactory()
+                                    .writeBatchWriter(backend.db, backend.getWriteOptions())) {
 
                 final byte[] keyPrefixBytes = serializeCurrentKeyWithGroupAndNamespace();
                 iterator.seek(keyPrefixBytes);
@@ -294,7 +293,7 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
                 while (iterator.isValid()) {
                     byte[] keyBytes = iterator.key();
                     if (startWithKeyPrefix(keyPrefixBytes, keyBytes)) {
-                        rocksDBWriteBatchWrapper.remove(columnFamily, keyBytes);
+                        writer.remove(columnFamily, keyBytes);
                     } else {
                         break;
                     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriteBatchWrapper;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.state.KeyExtractorFunction;
@@ -108,7 +109,7 @@ public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
         final ColumnFamilyHandle columnFamilyHandle = stateCFHandle.columnFamilyHandle;
 
-        return new KeyGroupPartitionedPriorityQueue<>(
+        return new KeyGroupPartitionedPriorityQueue<T, RocksDBCachingPriorityQueueSet<T>>(
                 KeyExtractorFunction.forKeyedObjects(),
                 PriorityComparator.forPriorityComparableObjects(),
                 new KeyGroupPartitionedPriorityQueue.PartitionQueueSetFactory<

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -26,6 +26,7 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Cache;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.TableFormatConfig;
 import org.rocksdb.WriteOptions;
@@ -79,6 +80,13 @@ public final class RocksDBResourceContainer implements AutoCloseable {
         this.optionsFactory = optionsFactory;
         this.sharedResources = sharedResources;
         this.handlesToClose = new ArrayList<>();
+    }
+
+    /** Gets the RocksDB {@link Options} to be used for RocksDB operations. */
+    public Options getOptions() {
+        Options opt = new Options(getDbOptions(), getColumnOptions());
+        handlesToClose.add(opt);
+        return opt;
     }
 
     /** Gets the RocksDB {@link DBOptions} to be used for RocksDB instances. */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriteBatchWrapper;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
@@ -562,6 +564,7 @@ public class RocksDBStateBackend extends AbstractManagedMemoryStateBackend
         }
         final RocksDBResourceContainer resourceContainer =
                 createOptionsAndResourceContainer(sharedResources);
+        final RocksDBWriterFactory writeFactory = new RocksDBWriterFactory(getWriteBatchSize());
 
         ExecutionConfig executionConfig = env.getExecutionConfig();
         StreamCompressionDecorator keyGroupCompressionDecorator =
@@ -584,12 +587,12 @@ public class RocksDBStateBackend extends AbstractManagedMemoryStateBackend
                                 metricGroup,
                                 stateHandles,
                                 keyGroupCompressionDecorator,
-                                cancelStreamRegistry)
+                                cancelStreamRegistry,
+                                writeFactory)
                         .setEnableIncrementalCheckpointing(isIncrementalCheckpointsEnabled())
                         .setNumberOfTransferingThreads(getNumberOfTransferThreads())
                         .setNativeMetricOptions(
-                                resourceContainer.getMemoryWatcherOptions(defaultMetricOptions))
-                        .setWriteBatchSize(getWriteBatchSize());
+                                resourceContainer.getMemoryWatcherOptions(defaultMetricOptions));
         return builder.build();
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/AbstractRocksDBRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/AbstractRocksDBRestoreOperation.java
@@ -25,6 +25,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricMonitor;
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBOperationUtils;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.metrics.MetricGroup;
@@ -76,6 +77,7 @@ public abstract class AbstractRocksDBRestoreOperation<K>
     protected final File instanceBasePath;
     protected final File instanceRocksDBPath;
     protected final String dbPath;
+    protected final RocksDBWriterFactory writerFactory;
     protected List<ColumnFamilyHandle> columnFamilyHandles;
     protected List<ColumnFamilyDescriptor> columnFamilyDescriptors;
     protected final StateSerializerProvider<K> keySerializerProvider;
@@ -118,7 +120,8 @@ public abstract class AbstractRocksDBRestoreOperation<K>
             MetricGroup metricGroup,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             @Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
-            Long writeBufferManagerCapacity) {
+            Long writeBufferManagerCapacity,
+            @Nonnull RocksDBWriterFactory writerFactory) {
         this.keyGroupRange = keyGroupRange;
         this.keyGroupPrefixBytes = keyGroupPrefixBytes;
         this.numberOfTransferringThreads = numberOfTransferringThreads;
@@ -138,6 +141,7 @@ public abstract class AbstractRocksDBRestoreOperation<K>
         this.columnFamilyHandles = new ArrayList<>(1);
         this.columnFamilyDescriptors = Collections.emptyList();
         this.writeBufferManagerCapacity = writeBufferManagerCapacity;
+        this.writerFactory = writerFactory;
     }
 
     void openDB() throws IOException {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
@@ -39,6 +39,7 @@ import org.apache.flink.util.StateMigrationException;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
 import org.rocksdb.RocksDBException;
 
 import javax.annotation.Nonnull;
@@ -141,8 +142,10 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
             ThrowingIterator<KeyGroup> keyGroups, List<ColumnFamilyHandle> columnFamilies)
             throws IOException, RocksDBException, StateMigrationException {
         // for all key-groups in the current state handle...
-        // @lgo: fixme plumb through the optionsContainer for writeOptions.
-        try (RocksDBWriter writer = writerFactory.defaultPutWriter(db, null)) {
+        try (ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
+                Options options = new Options(dbOptions, columnFamilyOptions);
+                // @lgo: fixme plumb through the optionsContainer for writeOptions.
+                RocksDBWriter writer = writerFactory.defaultPutWriter(db, options, null, null)) {
             while (keyGroups.hasNext()) {
                 KeyGroup keyGroup = keyGroups.next();
                 try (ThrowingIterator<KeyGroupEntry> groupEntries = keyGroup.getKeyGroupEntries()) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
@@ -20,8 +20,9 @@ package org.apache.flink.contrib.streaming.state.restore;
 
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricOptions;
-import org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapper;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriter;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -40,7 +41,6 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDBException;
 
-import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 import java.io.File;
@@ -51,13 +51,9 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
-
 /** Encapsulates the process of restoring a RocksDB instance from a full snapshot. */
 public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperation<K> {
     private final FullSnapshotRestoreOperation<K> savepointRestoreOperation;
-    /** Write batch size used in {@link RocksDBWriteBatchWrapper}. */
-    private final long writeBatchSize;
 
     public RocksDBFullRestoreOperation(
             KeyGroupRange keyGroupRange,
@@ -75,8 +71,8 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
             MetricGroup metricGroup,
             @Nonnull Collection<KeyedStateHandle> restoreStateHandles,
             @Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
-            @Nonnegative long writeBatchSize,
-            Long writeBufferManagerCapacity) {
+            Long writeBufferManagerCapacity,
+            @Nonnull RocksDBWriterFactory writerFactory) {
         super(
                 keyGroupRange,
                 keyGroupPrefixBytes,
@@ -93,9 +89,8 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
                 metricGroup,
                 restoreStateHandles,
                 ttlCompactFiltersManager,
-                writeBufferManagerCapacity);
-        checkArgument(writeBatchSize >= 0, "Write batch size have to be no negative.");
-        this.writeBatchSize = writeBatchSize;
+                writeBufferManagerCapacity,
+                writerFactory);
         this.savepointRestoreOperation =
                 new FullSnapshotRestoreOperation<>(
                         keyGroupRange,
@@ -146,15 +141,15 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
             ThrowingIterator<KeyGroup> keyGroups, List<ColumnFamilyHandle> columnFamilies)
             throws IOException, RocksDBException, StateMigrationException {
         // for all key-groups in the current state handle...
-        try (RocksDBWriteBatchWrapper writeBatchWrapper =
-                new RocksDBWriteBatchWrapper(db, writeBatchSize)) {
+        // @lgo: fixme plumb through the optionsContainer for writeOptions.
+        try (RocksDBWriter writer = writerFactory.defaultPutWriter(db, null)) {
             while (keyGroups.hasNext()) {
                 KeyGroup keyGroup = keyGroups.next();
                 try (ThrowingIterator<KeyGroupEntry> groupEntries = keyGroup.getKeyGroupEntries()) {
                     while (groupEntries.hasNext()) {
                         KeyGroupEntry groupEntry = groupEntries.next();
                         ColumnFamilyHandle handle = columnFamilies.get(groupEntry.getKvStateId());
-                        writeBatchWrapper.put(handle, groupEntry.getKey(), groupEntry.getValue());
+                        writer.put(handle, groupEntry.getKey(), groupEntry.getValue());
                     }
                 }
             }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -52,6 +52,7 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -329,7 +330,10 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
                                     (IncrementalRemoteKeyedStateHandle) rawStateHandle,
                                     temporaryRestoreInstancePath);
                     // @lgo: fixme plumb through the optionsContainer for writeOptions.
-                    RocksDBWriter writer = writerFactory.defaultPutWriter(this.db, null)) {
+                    ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
+                    Options options = new Options(dbOptions, columnFamilyOptions);
+                    RocksDBWriter writer =
+                            writerFactory.defaultPutWriter(this.db, options, null, null)) {
 
                 List<ColumnFamilyDescriptor> tmpColumnFamilyDescriptors =
                         tmpRestoreDBInfo.columnFamilyDescriptors;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBNoneRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBNoneRestoreOperation.java
@@ -21,6 +21,7 @@ package org.apache.flink.contrib.streaming.state.restore;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricOptions;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -55,7 +56,8 @@ public class RocksDBNoneRestoreOperation<K> extends AbstractRocksDBRestoreOperat
             MetricGroup metricGroup,
             @Nonnull Collection<KeyedStateHandle> restoreStateHandles,
             @Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
-            Long writeBufferManagerCapacity) {
+            Long writeBufferManagerCapacity,
+            @Nonnull RocksDBWriterFactory writeFactory) {
         super(
                 keyGroupRange,
                 keyGroupPrefixBytes,
@@ -72,7 +74,8 @@ public class RocksDBNoneRestoreOperation<K> extends AbstractRocksDBRestoreOperat
                 metricGroup,
                 restoreStateHandles,
                 ttlCompactFiltersManager,
-                writeBufferManagerCapacity);
+                writeBufferManagerCapacity,
+                writeFactory);
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTIngestWriter.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTIngestWriter.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.writer;
+
+import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.IOUtils;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.EnvOptions;
+import org.rocksdb.IngestExternalFileOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * {@link RocksDBSSTIngestWriter} implements {@link RocksDBWriter}, providing writes by creating sst
+ * files and instructing {@link RocksDB} to ingest them (via {@link
+ * RocksDB#ingestExternalFile(ColumnFamilyHandle, List, IngestExternalFileOptions)}). It supports
+ * writing to multiple {@link ColumnFamilyHandle}, assuming the writes within a {@link
+ * ColumnFamilyHandle} are ordered.
+ *
+ * <p>IMPORTANT: This class is not thread safe.
+ *
+ * <p>It uses {@link RocksDBSSTWriter} for creating the sst file of a {@link ColumnFamilyHandle}.
+ *
+ * <p>{@link RocksDBSSTIngestWriter} is for batch write operations. It produces and ingests
+ * individual files throughout put operations, so it will not atomically commit data.
+ */
+public class RocksDBSSTIngestWriter implements RocksDBWriter {
+
+    /**
+     * {@code INGEST_EXTERNAL_FILE_OPTIONS} are the {@link IngestExternalFileOptions} provided to
+     * RocksDB when calling {@link RocksDB#ingestExternalFile(ColumnFamilyHandle, List,
+     * IngestExternalFileOptions)}. We only use one set of options, so we use a singleton that is
+     * not closed.
+     */
+    // @lgo: because flink is using the JNI 5.14, the API for IngestExternalFileOptions is pretty
+    // bad and the builder-pattern does not exist.
+    private static final IngestExternalFileOptions INGEST_EXTERNAL_FILE_OPTIONS =
+            new IngestExternalFileOptions(
+                    // Move files rather than copying them. Because we are generating
+                    // one-off files for import, it does not matter if the are moved and
+                    // import fails.
+                    //
+                    // @lgo: fixme ensure this does not cause stray RocksDB sst files on a host when
+                    // ingestion
+                    // fails.
+                    /* moveFiles */ true,
+
+                    // Set to the default (true).
+                    /* snapshotConsistency */ true,
+
+                    // Set to the default (true).
+                    /* allowGlobalSeqNo */ true,
+
+                    // By disallowing a blocking flush, ingestion loudly fails when it
+                    // has keys that overlap the RocksDB memtable.
+                    /* allowBlockingFlush */ false);
+
+    /** {@code maxSstSize} is the maximum size of an sst file before flushing it. */
+    private final long maxSstSize;
+
+    /**
+     * {@code envOptions} are the {@link EnvOptions} provided to the underlying {@link
+     * RocksDBSSTWriter}.
+     */
+    // @lgo: plumb through the options into the constructor
+    // and set sane options.
+    private final EnvOptions envOptions;
+
+    /**
+     * {@code options} are the {@link Options} provided to the underlying {@link RocksDBSSTWriter}.
+     */
+    // @lgo: plumb through the options into the constructor
+    // and set sane options.
+    private final Options options;
+
+    /** {@code db} is the active RocksDB database to write files to. */
+    private final RocksDB db;
+
+    /**
+     * {@code sstFileWriters} contains the currently open {@link RocksDBSSTWriter} for each {@link
+     * ColumnFamilyHandle}.
+     */
+    private final HashMap<Integer, RocksDBSSTWriter> columnFamilyWriters = new HashMap<>();
+
+    /**
+     * {@code sstFileSizes} contains the current byte-sizes for the currently opened {@link
+     * RocksDBSSTWriter}, for each {@link ColumnFamilyHandle}.
+     */
+    private final HashMap<Integer, Long> sstFileSizes = new HashMap<>();
+
+    /**
+     * {@code ingestionTempDir} is the directory used to write temporary sst files before ingesting
+     * them into {@link RocksDB}.
+     */
+    private final File ingestionTempDir;
+
+    public RocksDBSSTIngestWriter(
+            @Nonnull RocksDB rocksDB,
+            @Nonnegative long maxSstSize,
+            @Nullable EnvOptions envOptions,
+            @Nullable Options options,
+            @Nullable File tempDir)
+            throws IOException {
+        this.db = rocksDB;
+        this.maxSstSize = maxSstSize;
+        this.envOptions = envOptions;
+        this.options = options;
+
+        // Set up a temporary directory for writing generated SST files.
+        // Either, use the provided temporary directory (such as during tests), or create a new one.
+        if (tempDir != null) {
+            this.ingestionTempDir = tempDir;
+        } else {
+            // @lgo: clean the temporary folder up. This may not actually be bad considering
+            // ingestion will move the temporary sst files out.
+            this.ingestionTempDir = Files.createTempDirectory("rocksdb-sst-writer-temp-").toFile();
+        }
+        maxSstSize = 0;
+    }
+
+    public void put(
+            @Nonnull ColumnFamilyHandle columnFamilyHandle,
+            @Nonnull byte[] key,
+            @Nonnull byte[] value)
+            throws RocksDBException, IOException {
+        // Get the sst writer for the column family.
+        RocksDBSSTWriter writer = ensureSSTableWriter(columnFamilyHandle);
+        // Insert the k/v.
+        writer.put(key, value);
+        // Record the byte-size for the written key and value.
+        long currentSize = sstFileSizes.getOrDefault(columnFamilyHandle.getID(), 0L);
+        currentSize += key.length + value.length;
+        sstFileSizes.put(columnFamilyHandle.getID(), currentSize);
+        // Flush the sst and ingest it, if it needs to be flushed.
+        flushIfNeeded(columnFamilyHandle, writer);
+    }
+
+    private RocksDBSSTWriter ensureSSTableWriter(@Nonnull ColumnFamilyHandle columnFamilyHandle)
+            throws RocksDBException, IOException {
+        // Return an existing writer if there is one, Otherwise prepare a new one.
+        if (columnFamilyWriters.containsKey(columnFamilyHandle.getID())) {
+            return columnFamilyWriters.get(columnFamilyHandle.getID());
+        }
+
+        // Create a new sst file in the temporary folder.
+        final String sstFileName = "ingest_" + new AbstractID() + ".sst";
+        File sstFile = new File(ingestionTempDir, sstFileName);
+
+        // Initialize the sst writer.
+        RocksDBSSTWriter writer =
+                new RocksDBSSTWriter(envOptions, options, columnFamilyHandle, sstFile);
+
+        // Store the new writer for the column family.
+        columnFamilyWriters.put(columnFamilyHandle.getID(), writer);
+
+        return writer;
+    }
+
+    /**
+     * Flushes the data for a particular {@link RocksDBSSTWriter} into the {@link RocksDB} instance.
+     * After flushing, the {@link ColumnFamilyHandle} will not have an active {@link
+     * RocksDBSSTWriter}, and it will need to be initialized by {@link
+     * #ensureSSTableWriter(ColumnFamilyHandle)}.
+     *
+     * @throws RocksDBException
+     */
+    private void flushAndCloseWriter(@Nonnull RocksDBSSTWriter writer) throws RocksDBException {
+        // Finish the sst writer.
+        writer.finish();
+
+        // Instruct RocksDB to ingest the sst files. Because all of the ingested files are
+        // for different column families and the JNI SstFileWriter does not allow setting the
+        // ColumnFamilyHeader when writing the file, need to call ingestExternalFile for one
+        // sst file at a time.
+        //
+        // Because the IngestExternalFileOptions specifies to move the sst file, we do not need
+        // to clean up the written file.
+        List<String> files = Collections.singletonList(writer.getFile().getAbsolutePath());
+        db.ingestExternalFile(writer.getColumnFamilyHandle(), files, INGEST_EXTERNAL_FILE_OPTIONS);
+
+        // Close the writer and remove it from the list of open writers.
+        writer.close();
+    }
+
+    /**
+     * Flushes all in-progress sst and ingests them.
+     *
+     * @throws RocksDBException
+     */
+    public void flush() throws RocksDBException {
+        for (RocksDBSSTWriter writer : columnFamilyWriters.values()) {
+            flushAndCloseWriter(writer);
+        }
+        columnFamilyWriters.clear();
+    }
+
+    @Override
+    public void close() throws RocksDBException {
+        flush();
+        IOUtils.closeAllQuietly(columnFamilyWriters.values());
+    }
+
+    /**
+     * Conditionally flushes the data for a particular {@link ColumnFamilyHandle} into the {@link
+     * RocksDB} instance, if needed. The data will only be flushed if the in-progress {@link
+     * RocksDBSSTWriter} exceeds the thresholds for flushing.
+     *
+     * @param handle to conditionally flush and ingest.
+     * @throws RocksDBException
+     */
+    private void flushIfNeeded(ColumnFamilyHandle handle, RocksDBSSTWriter writer)
+            throws RocksDBException {
+        // @lgo: fixme this may not be necessary.
+        // - sst writer automatically invalidates the pages for the file writer
+        //   every 1mb.
+        // https://github.com/facebook/rocksdb/blob/096beb787eed5837a2e38a9681ee834e9268c881/table/sst_file_writer.cc#L102
+        // - the underlying block builder will flush based on the policy RocksDB
+        //   was set up with:
+        // https://github.com/facebook/rocksdb/blob/096beb787eed5837a2e38a9681ee834e9268c881/table/block_based/block_based_table_builder.cc#L773
+        // - based on table_options.block_size (and block_size_deviation), the FS automatically
+        // flushes.
+        //
+        // I could not actually find where/how this is configured.
+        return;
+        //		if (sstFileSizes.getOrDefault(handle.getID(), 0L) > maxSstSize) {
+        //			flushAndCloseWriter(writer);
+        //			columnFamilyWriters.remove(writer.getColumnFamilyHandle().getID());
+        //			sstFileSizes.remove(writer.getColumnFamilyHandle().getID());
+        //		}
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTWriter.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTWriter.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.writer;
+
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.EnvOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.SstFileWriter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * {@link RocksDBSSTWriter} provides a way to write and RocksDB's SST files. It only supports
+ * writing k/v for a single {@link ColumnFamilyHandle}. If you are looking to write multiple {@link
+ * ColumnFamilyHandle} and then ingest them into {@link RocksDB}, see {@link
+ * RocksDBSSTIngestWriter}.
+ *
+ * <p>IMPORTANT: This class is not thread safe.
+ */
+class RocksDBSSTWriter implements AutoCloseable {
+
+    // @lgo: use better defaults for the options.
+
+    /**
+     * {@code DEFAULT_OPTIONS} provides the default RocksDB {@link Options} for {@link
+     * SstFileWriter}. It is a singleton so it does not need to be closed.
+     */
+    private static final Options DEFAULT_OPTIONS = new Options();
+
+    /**
+     * {@code DEFAULT_ENV_OPTIONS} provides the default RocksDB {@link EnvOptions} for {@link
+     * SstFileWriter}. It is a singleton so it does not need to be closed.
+     */
+    private static final EnvOptions DEFAULT_ENV_OPTIONS = new EnvOptions();
+
+    /**
+     * {@code handle} is the {@link ColumnFamilyHandle} that {@code writer} is using for inserts.
+     */
+    private final ColumnFamilyHandle handle;
+
+    /** {@code writer} is the active {@link SstFileWriter} that k/v are written to. */
+    private final SstFileWriter writer;
+
+    /** {@code file} is the file the {@code writer} is using. */
+    private final File file;
+
+    /** {@code finished} indicates whether the {@link RocksDBSSTWriter} has been finished. */
+    private boolean finished = false;
+
+    /**
+     * Initializes a {@link RocksDBSSTWriter}, for writing SST files.
+     *
+     * @param envOptions to provide to {@link SstFileWriter}.
+     * @param options to provide to {@link SstFileWriter}.
+     * @param handle to use for writing with {@link SstFileWriter}.
+     * @param file to write to.
+     * @throws IOException if {@code file} does not exist.
+     */
+    public RocksDBSSTWriter(
+            @Nullable EnvOptions envOptions,
+            @Nullable Options options,
+            @Nonnull ColumnFamilyHandle handle,
+            @Nonnull File file)
+            throws IOException, RocksDBException {
+        if (envOptions == null) {
+            envOptions = DEFAULT_ENV_OPTIONS;
+        }
+
+        if (options == null) {
+            options = DEFAULT_OPTIONS;
+        }
+
+        // Ensure the file is valid for writing.
+        if (file.exists()) {
+            throw new IOException(
+                    "File provided for sst "
+                            + "writing \""
+                            + file.getAbsolutePath()
+                            + "\" already exists.");
+        }
+
+        if (!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
+            throw new IOException(
+                    "File provided for sst writing \""
+                            + file.getAbsolutePath()
+                            + "\" could not be used. The parent directory does not exist and could not be created.");
+        }
+
+        this.file = file;
+
+        this.writer = new SstFileWriter(envOptions, options);
+        this.writer.open(file.getAbsolutePath());
+
+        // Because the rocks jni API does not support initializing the SstFileWriter with a column
+        // family handle, we just retain it on the writer class.
+        this.handle = handle;
+    }
+
+    public void put(@Nonnull byte[] key, @Nonnull byte[] value) throws RocksDBException {
+        Preconditions.checkState(
+                !finished,
+                "attempted to `put` on RocksDBSSTWriter after calling `finish` (or closing)");
+        writer.put(key, value);
+    }
+
+    /**
+     * Finishes the underlying sst and closes the writer.
+     *
+     * @throws RocksDBException
+     */
+    public void finish() throws RocksDBException {
+        if (finished) {
+            return;
+        }
+        // Finish the sst writer.
+        writer.finish();
+        finished = true;
+    }
+
+    @Override
+    public void close() throws RocksDBException {
+        IOUtils.closeQuietly(writer);
+    }
+
+    /** @return the {@link File} of the sst being written. */
+    public File getFile() {
+        return file;
+    }
+
+    /** @return the {@link ColumnFamilyHandle} for the sst file. */
+    public ColumnFamilyHandle getColumnFamilyHandle() {
+        return handle;
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriteBatchWrapper.java
@@ -33,12 +33,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * It's a wrapper class around RocksDB's {@link WriteBatch} for writing in bulk.
+ * {@link RocksDBWriteBatchWrapper} is a wrapper class around RocksDB's {@link WriteBatch} for
+ * writing in bulk.
  *
  * <p>IMPORTANT: This class is not thread safe.
  *
- * <p>@lgo: TODO describe in detail what this writer is good for: all non-puts, small amounts of
- * batching.
+ * <p>Use {@link RocksDBWriteBatchWrapper} for general purpose writes to RocksDB. It is ideal for
+ * synchronous path writes where a few writes ae being done. When doing batch writes of ordered
+ * data, prefer {@link RocksDBSSTIngestWriter}.
  */
 public class RocksDBWriteBatchWrapper implements RocksDBWriter {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriteBatchWrapper.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.contrib.streaming.state;
+package org.apache.flink.contrib.streaming.state.writer;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.IOUtils;
@@ -36,8 +36,11 @@ import javax.annotation.Nullable;
  * It's a wrapper class around RocksDB's {@link WriteBatch} for writing in bulk.
  *
  * <p>IMPORTANT: This class is not thread safe.
+ *
+ * <p>@lgo: TODO describe in detail what this writer is good for: all non-puts, small amounts of
+ * batching.
  */
-public class RocksDBWriteBatchWrapper implements AutoCloseable {
+public class RocksDBWriteBatchWrapper implements RocksDBWriter {
 
     private static final int MIN_CAPACITY = 100;
     private static final int MAX_CAPACITY = 1000;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriter.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.writer;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+
+/**
+ * {@link RocksDBWriter} is an interface for providing batch writing to RocksDB.
+ *
+ * <p>IMPORTANT: Implementations of this interface are implemented as thread-safe.
+ */
+public interface RocksDBWriter extends AutoCloseable {
+
+    /**
+     * Puts data into the underlying {@link org.rocksdb.RocksDB}.
+     *
+     * @param key to put
+     * @param value to put
+     * @throws RocksDBException
+     */
+    void put(
+            @Nonnull ColumnFamilyHandle columnFamilyHandle,
+            @Nonnull byte[] key,
+            @Nonnull byte[] value)
+            throws RocksDBException, IOException;
+
+    /**
+     * Flushes all data that has been written using {@link #put(ColumnFamilyHandle, byte[],
+     * byte[])}.
+     *
+     * @throws RocksDBException
+     */
+    void flush() throws RocksDBException;
+
+    /**
+     * Overrides {@link AutoCloseable} to specify that only {@link RocksDBException} is thrown. This
+     * also flushes in-progress data.
+     *
+     * @throws RocksDBException
+     */
+    @Override
+    void close() throws RocksDBException;
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriterFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriterFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.writer;
+
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BATCH_SIZE;
+
+/**
+ * {@link RocksDBWriterFactory} creates writers for {@link RocksDB}. It is initialized from an
+ * application's configuration, and provides a default {@link RocksDBWriter} (for Put operations),
+ * as well as specific constructors {@link RocksDBWriteBatchWrapper}.
+ */
+public class RocksDBWriterFactory {
+
+    private final long writeBatchSize;
+
+    private final File tempDir = null;
+
+    /** Provides a factory for {@link RocksDBWriter}. */
+    public RocksDBWriterFactory(long writeBatchSize) {
+        this.writeBatchSize = writeBatchSize;
+    }
+
+    // @lgo: fixme used for tests that pull all default configured values.
+    public RocksDBWriterFactory() {
+        this.writeBatchSize = WRITE_BATCH_SIZE.defaultValue().getBytes();
+    }
+
+    /**
+     * Returns a new {@link RocksDBWriter}, using the user-configured parameters.
+     *
+     * @param db the {@link RocksDB} instance to write to.
+     * @param writeOptions the {@link WriteOptions} to use when writing (only applicable for {@link
+     *     RocksDBWriteBatchWrapper})
+     * @return a new {@link RocksDBWriter} for {@code put} writes to the database.
+     */
+    public RocksDBWriter defaultPutWriter(@Nonnull RocksDB db, @Nullable WriteOptions writeOptions)
+            throws IOException {
+        return writeBatchWriter(db, writeOptions);
+    }
+
+    /**
+     * Returns a new {@link RocksDBWriteBatchWrapper}, using the user-configured parameters. The
+     * type {@link RocksDBWriteBatchWrapper} is exposed directly because it provides additional
+     * {@link RocksDB} write operations.
+     *
+     * @param db the {@link RocksDB} instance to write to.
+     * @return a new {@link RocksDBWriteBatchWrapper} for writing to the {@code db}.
+     */
+    public RocksDBWriteBatchWrapper writeBatchWriter(@Nonnull RocksDB db) {
+        return new RocksDBWriteBatchWrapper(db, writeBatchSize);
+    }
+
+    /**
+     * Returns a new {@link RocksDBWriteBatchWrapper}.
+     *
+     * @param db the {@link RocksDB} instance to write to.
+     * @param writeOptions the {@link WriteOptions} to use for writing.
+     * @return a new {@link RocksDBWriteBatchWrapper} for writing to the {@code db}.
+     * @see #writeBatchWriter(RocksDB, WriteOptions)
+     */
+    public RocksDBWriteBatchWrapper writeBatchWriter(
+            @Nonnull RocksDB db, @Nullable WriteOptions writeOptions) {
+        return new RocksDBWriteBatchWrapper(db, writeOptions, writeBatchSize);
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriterFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriterFactory.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.contrib.streaming.state.writer;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.Preconditions;
+
+import org.rocksdb.EnvOptions;
+import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.WriteOptions;
 
@@ -32,35 +37,79 @@ import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOption
 /**
  * {@link RocksDBWriterFactory} creates writers for {@link RocksDB}. It is initialized from an
  * application's configuration, and provides a default {@link RocksDBWriter} (for Put operations),
- * as well as specific constructors {@link RocksDBWriteBatchWrapper}.
+ * as well as specific constructors for {@link RocksDBSSTIngestWriter} and {@link
+ * RocksDBWriteBatchWrapper} which each provide different capabilities.
+ *
+ * <p>See {@link RocksDBSSTIngestWriter} and {@link RocksDBWriteBatchWrapper} for details about the
+ * writers, and when they should be used.
  */
 public class RocksDBWriterFactory {
 
-    private final long writeBatchSize;
+    private final WriteBatchMechanism mechanism;
+    private long writeBatchSize;
 
-    private final File tempDir = null;
+    private final File tempDir;
 
-    /** Provides a factory for {@link RocksDBWriter}. */
-    public RocksDBWriterFactory(long writeBatchSize) {
+    /**
+     * Provides a factory for {@link RocksDBWriter}, including {@link RocksDBWriteBatchWrapper} and
+     * {@link RocksDBSSTIngestWriter}. The factory also provides a "default" writer, determined by
+     * configuration parameters, so that factory callers do not need to be concerned with the
+     * implementation.
+     *
+     * @param mechanism The {@link WriteBatchMechanism} which determines the default writer returned
+     *     by {@link #defaultPutWriter(RocksDB, Options, EnvOptions, WriteOptions)}.
+     * @param writeBatchSize A parameter for {@link RocksDBWriteBatchWrapper}.
+     * @param tempDir THe temporary directory to write sst files to.
+     */
+    public RocksDBWriterFactory(
+            WriteBatchMechanism mechanism, long writeBatchSize, String tempDir) {
+        this.mechanism = mechanism;
         this.writeBatchSize = writeBatchSize;
-    }
-
-    // @lgo: fixme used for tests that pull all default configured values.
-    public RocksDBWriterFactory() {
-        this.writeBatchSize = WRITE_BATCH_SIZE.defaultValue().getBytes();
+        this.tempDir = new File(tempDir);
     }
 
     /**
-     * Returns a new {@link RocksDBWriter}, using the user-configured parameters.
+     * Provides a factory for {@link RocksDBWriter}.
+     *
+     * <p>This is only used in tests, where the tests pull some default configuration values but
+     * provide the mechanism being tested. Tests should parameterize {@link WriteBatchMechanism}.
+     */
+    @VisibleForTesting
+    public RocksDBWriterFactory(WriteBatchMechanism writeBatchMechanism) {
+        this.mechanism = writeBatchMechanism;
+        this.writeBatchSize = WRITE_BATCH_SIZE.defaultValue().getBytes();
+        this.tempDir = null;
+    }
+
+    /**
+     * Returns a new {@link RocksDBWriter}, using the user-configured parameters. Depending on the
+     * configuration, a {@link RocksDBWriteBatchWrapper} or {@link RocksDBSSTIngestWriter} may be
+     * used.
      *
      * @param db the {@link RocksDB} instance to write to.
+     * @param options the {@link Options} to use when writing (only applicable for {@link
+     *     RocksDBSSTIngestWriter})
+     * @param envOptions the {@link EnvOptions} to use when writing (only applicable for {@link
+     *     RocksDBSSTIngestWriter})
      * @param writeOptions the {@link WriteOptions} to use when writing (only applicable for {@link
      *     RocksDBWriteBatchWrapper})
      * @return a new {@link RocksDBWriter} for {@code put} writes to the database.
      */
-    public RocksDBWriter defaultPutWriter(@Nonnull RocksDB db, @Nullable WriteOptions writeOptions)
+    public RocksDBWriter defaultPutWriter(
+            @Nonnull RocksDB db,
+            @Nullable Options options,
+            @Nullable EnvOptions envOptions,
+            @Nullable WriteOptions writeOptions)
             throws IOException {
-        return writeBatchWriter(db, writeOptions);
+        switch (mechanism) {
+            case WRITE_BATCH:
+                return writeBatchWriter(db, writeOptions);
+            case SST_INGEST:
+                return sstIngestWriter(db, options, envOptions);
+            default:
+                Preconditions.checkState(false, "unexpected WriteBatchMechanism option");
+                return null;
+        }
     }
 
     /**
@@ -86,5 +135,51 @@ public class RocksDBWriterFactory {
     public RocksDBWriteBatchWrapper writeBatchWriter(
             @Nonnull RocksDB db, @Nullable WriteOptions writeOptions) {
         return new RocksDBWriteBatchWrapper(db, writeOptions, writeBatchSize);
+    }
+
+    /**
+     * Returns a new {@link RocksDBSSTIngestWriter}, using the user-configured parameters.
+     *
+     * @param db the {@link RocksDB} instance to write to.
+     * @param options the {@link Options} to use for writing.
+     * @param envOptions the {@link EnvOptions} to use for writing.
+     * @return a new {@link RocksDBSSTIngestWriter} for writing to the {@code db}.
+     */
+    public RocksDBSSTIngestWriter sstIngestWriter(
+            @Nonnull RocksDB db, @Nullable Options options, @Nullable EnvOptions envOptions)
+            throws IOException {
+        // @lgo: plumb through parameters.
+        final int maxSstSize = 10;
+        return new RocksDBSSTIngestWriter(db, maxSstSize, envOptions, options, this.tempDir);
+    }
+
+    /**
+     * Returns a new {@link RocksDBSSTIngestWriter}, using the user-configured parameters.
+     *
+     * @param db the {@link RocksDB} instance to write to.
+     * @param options the {@link Options} to use for writing.
+     * @param envOptions the {@link EnvOptions} to use for writing.
+     * @param tempDir the temporary directory to use when constructing sst files.
+     * @return a new {@link RocksDBSSTIngestWriter} for writing to the {@code db}.
+     */
+    public RocksDBSSTIngestWriter sstIngestWriter(
+            @Nonnull RocksDB db,
+            @Nullable Options options,
+            @Nullable EnvOptions envOptions,
+            @Nonnull File tempDir)
+            throws IOException {
+        // @lgo: plumb through parameters.
+        final int maxSstSize = 10;
+        return new RocksDBSSTIngestWriter(db, maxSstSize, envOptions, options, tempDir);
+    }
+
+    /**
+     * Sets the write batch size parameter of the factory for constructing {@link
+     * RocksDBWriteBatchWrapper}.
+     *
+     * @param writeBatchSize to use for building {@link RocksDBWriteBatchWrapper}.
+     */
+    public void setWriteBatchSize(long writeBatchSize) {
+        this.writeBatchSize = writeBatchSize;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/WriteBatchMechanism.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/writer/WriteBatchMechanism.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.writer;
+
+/**
+ * Write batching mechanism for use with {@link org.apache.flink.contrib.streaming.state} RocksDB
+ * implementation.
+ *
+ * @lgo: TODO make this a public (externally documented) enum.
+ */
+public enum WriteBatchMechanism {
+
+    /**
+     * Use {@link RocksDBWriteBatchWrapper} for batching writes. This mechanism uses the RocksDB
+     * operator {@code writeBatch}.
+     */
+    WRITE_BATCH,
+
+    /**
+     * Use {@link RocksDBSSTIngestWriter} for batching writes. This mechanism generates SST files
+     * and uses the RocksDB operator {@code ingestExternalFile}.
+     */
+    SST_INGEST
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
@@ -62,6 +63,7 @@ public class KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest
                     CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(
                             numKeyGroups);
             TreeOrderedSetCache orderedSetCache = new TreeOrderedSetCache(32);
+            RocksDBWriterFactory writeFactory = new RocksDBWriterFactory();
             return new RocksDBCachingPriorityQueueSet<>(
                     keyGroupId,
                     keyGroupPrefixBytes,
@@ -71,7 +73,7 @@ public class KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest
                     TestElementSerializer.INSTANCE,
                     outputStreamWithPos,
                     inputStreamWithPos,
-                    rocksDBResource.getBatchWrapper(),
+                    writeFactory.writeBatchWriter(rocksDBResource.getRocksDB()),
                     orderedSetCache);
         };
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.state.heap.KeyGroupPartitionedPriorityQueue;
 
 import org.junit.Rule;
 
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BATCH_MECHANISM;
+
 /**
  * Test of {@link KeyGroupPartitionedPriorityQueue} powered by a {@link
  * RocksDBCachingPriorityQueueSet}.
@@ -63,7 +65,8 @@ public class KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest
                     CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(
                             numKeyGroups);
             TreeOrderedSetCache orderedSetCache = new TreeOrderedSetCache(32);
-            RocksDBWriterFactory writeFactory = new RocksDBWriterFactory();
+            RocksDBWriterFactory writeFactory =
+                    new RocksDBWriterFactory(WRITE_BATCH_MECHANISM.defaultValue());
             return new RocksDBCachingPriorityQueueSet<>(
                     keyGroupId,
                     keyGroupPrefixBytes,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -129,6 +130,10 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
             int keyGroupPrefixBytes)
             throws RocksDBException, IOException {
 
+        RocksDBWriterFactory writerFactory =
+                new RocksDBWriterFactory(
+                        RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes());
+
         try (RocksDB rocksDB = RocksDB.open(tmp.newFolder().getAbsolutePath());
                 ColumnFamilyHandle columnFamilyHandle =
                         rocksDB.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()))) {
@@ -169,7 +174,7 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
                     targetGroupRange,
                     currentGroupRange,
                     keyGroupPrefixBytes,
-                    RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes());
+                    writerFactory);
 
             for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
                 for (int j = 0; j < 100; ++j) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -132,7 +132,7 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
 
         RocksDBWriterFactory writerFactory =
                 new RocksDBWriterFactory(
-                        RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes());
+                        RocksDBConfigurableOptions.WRITE_BATCH_MECHANISM.defaultValue());
 
         try (RocksDB rocksDB = RocksDB.open(tmp.newFolder().getAbsolutePath());
                 ColumnFamilyHandle columnFamilyHandle =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
@@ -140,10 +140,6 @@ public class RocksDBResource extends ExternalResource {
         return batchWrapper;
     }
 
-    public RocksDBWriterFactory getWriteFactory() {
-        return writeFactory;
-    }
-
     /** Creates and returns a new column family with the given name. */
     public ColumnFamilyHandle createNewColumnFamily(String name) {
         try {
@@ -185,7 +181,6 @@ public class RocksDBResource extends ExternalResource {
                                         "default".getBytes(), columnFamilyOptions)),
                         columnFamilyHandles);
         this.batchWrapper = new RocksDBWriteBatchWrapper(rocksDB, writeOptions);
-        this.writeFactory = new RocksDBWriterFactory();
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriteBatchWrapper;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 
@@ -72,6 +74,9 @@ public class RocksDBResource extends ExternalResource {
 
     /** Wrapper for batched writes to the RocksDB instance. */
     private RocksDBWriteBatchWrapper batchWrapper;
+
+    /** Factory for RocksDB writers. */
+    private RocksDBWriterFactory writeFactory;
 
     /** Resources to close. */
     private ArrayList<AutoCloseable> handlesToClose = new ArrayList<>();
@@ -135,6 +140,10 @@ public class RocksDBResource extends ExternalResource {
         return batchWrapper;
     }
 
+    public RocksDBWriterFactory getWriteFactory() {
+        return writeFactory;
+    }
+
     /** Creates and returns a new column family with the given name. */
     public ColumnFamilyHandle createNewColumnFamily(String name) {
         try {
@@ -176,6 +185,7 @@ public class RocksDBResource extends ExternalResource {
                                         "default".getBytes(), columnFamilyOptions)),
                         columnFamilyHandles);
         this.batchWrapper = new RocksDBWriteBatchWrapper(rocksDB, writeOptions);
+        this.writeFactory = new RocksDBWriterFactory();
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
+import org.apache.flink.contrib.streaming.state.writer.WriteBatchMechanism;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -44,10 +45,12 @@ import java.util.Collections;
 public final class RocksDBTestUtils {
 
     public static <K> RocksDBKeyedStateBackendBuilder<K> builderForTestDefaults(
-            File instanceBasePath, TypeSerializer<K> keySerializer) {
+            File instanceBasePath,
+            TypeSerializer<K> keySerializer,
+            WriteBatchMechanism writeBatchMechanism) {
 
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
-        RocksDBWriterFactory writerFactory = new RocksDBWriterFactory();
+        RocksDBWriterFactory writerFactory = new RocksDBWriterFactory(writeBatchMechanism);
         return new RocksDBKeyedStateBackendBuilder<>(
                 "no-op",
                 ClassLoader.getSystemClassLoader(),
@@ -74,7 +77,8 @@ public final class RocksDBTestUtils {
             TypeSerializer<K> keySerializer,
             RocksDB db,
             ColumnFamilyHandle defaultCFHandle,
-            ColumnFamilyOptions columnFamilyOptions) {
+            ColumnFamilyOptions columnFamilyOptions,
+            WriteBatchMechanism writeBatchMechanism) {
 
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
@@ -98,7 +102,7 @@ public final class RocksDBTestUtils {
                 db,
                 defaultCFHandle,
                 new CloseableRegistry(),
-                new RocksDBWriterFactory());
+                new RocksDBWriterFactory(writeBatchMechanism));
     }
 
     public static <K> RocksDBKeyedStateBackend<K> createKeyedStateBackend(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -46,7 +47,7 @@ public final class RocksDBTestUtils {
             File instanceBasePath, TypeSerializer<K> keySerializer) {
 
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
-
+        RocksDBWriterFactory writerFactory = new RocksDBWriterFactory();
         return new RocksDBKeyedStateBackendBuilder<>(
                 "no-op",
                 ClassLoader.getSystemClassLoader(),
@@ -64,7 +65,8 @@ public final class RocksDBTestUtils {
                 new UnregisteredMetricsGroup(),
                 Collections.emptyList(),
                 UncompressedStreamCompressionDecorator.INSTANCE,
-                new CloseableRegistry());
+                new CloseableRegistry(),
+                writerFactory);
     }
 
     public static <K> RocksDBKeyedStateBackendBuilder<K> builderForTestDB(
@@ -95,13 +97,13 @@ public final class RocksDBTestUtils {
                 UncompressedStreamCompressionDecorator.INSTANCE,
                 db,
                 defaultCFHandle,
-                new CloseableRegistry());
+                new CloseableRegistry(),
+                new RocksDBWriterFactory());
     }
 
     public static <K> RocksDBKeyedStateBackend<K> createKeyedStateBackend(
             RocksDBStateBackend rocksDbBackend, Environment env, TypeSerializer<K> keySerializer)
             throws IOException {
-
         return (RocksDBKeyedStateBackend<K>)
                 rocksDbBackend.createKeyedStateBackend(
                         env,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.benchmark;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriteBatchWrapper;
+import org.apache.flink.testutils.junit.RetryOnFailure;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.NativeLibraryLoader;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test that validates that the performance of RocksDB's WriteBatch as expected.
+ *
+ * <p>Benchmarking: Computer: MacbookPro (Mid 2015), Flash Storage, Processor 2.5GHz Intel Core i5,
+ * Memory 16GB 1600MHz DDR3
+ *
+ * <p>With disableWAL is false Number of values added | time for Put | time for WriteBach |
+ * performance improvement of WriteBatch over Put 1000 10146397 ns 3546287 ns 2.86x 10000 118227077
+ * ns 26040222 ns 4.54x 100000 1838593196 ns 375053755 ns 4.9x 1000000 8844612079 ns 2014077396 ns
+ * 4.39x
+ *
+ * <p>With disableWAL is true 1000 3955204 ns 2429725 ns 1.62x 10000 25618237 ns 16440113 ns 1.55x
+ * 100000 289153346 ns 183712685 ns 1.57x 1000000 2886298967 ns 1768688571 ns 1.63x
+ *
+ * <p>In summary:
+ *
+ * <p>WriteBatch gives users 2.5x-5x performance improvements when disableWAL is false(This is
+ * useful when restoring from savepoint, because we need to set disableWAL=true to avoid segfault
+ * bug, see FLINK-8859 for detail).
+ *
+ * <p>Write gives user 1.5x performance improvements when disableWAL is true, this is useful for
+ * batch writing scenario, e.g. RocksDBMapState.putAll(Map) & RocksDBMapState.clear().
+ */
+public class RocksDBWriteBatchPerformanceTest extends TestLogger {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    private static final String KEY_PREFIX = "key";
+
+    private static final String VALUE =
+            "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ7890654321";
+
+    @Test(timeout = 2000)
+    @RetryOnFailure(times = 3)
+    public void benchMark() throws Exception {
+
+        int num = 10000;
+
+        List<Tuple2<byte[], byte[]>> data = new ArrayList<>(num);
+        for (int i = 0; i < num; ++i) {
+            data.add(new Tuple2<>((KEY_PREFIX + i).getBytes(), VALUE.getBytes()));
+        }
+
+        log.info("--------------> put VS WriteBatch with disableWAL=false <--------------");
+
+        long t1 = benchMarkHelper(data, false, WRITETYPE.PUT);
+        long t2 = benchMarkHelper(data, false, WRITETYPE.WRITE_BATCH);
+
+        log.info("Single Put with disableWAL is false for {} records costs {}", num, t1);
+        log.info("WriteBatch with disableWAL is false for {} records costs {}", num, t2);
+
+        log.info("--------------> put VS WriteBatch with disableWAL=true <--------------");
+
+        t1 = benchMarkHelper(data, true, WRITETYPE.PUT);
+        t2 = benchMarkHelper(data, true, WRITETYPE.WRITE_BATCH);
+
+        log.info("Single Put with disableWAL is true for {} records costs {}", num, t1);
+        log.info("WriteBatch with disableWAL is true for {} records costs {}", num, t2);
+    }
+
+    private enum WRITETYPE {
+        PUT,
+        WRITE_BATCH
+    }
+
+    private long benchMarkHelper(
+            List<Tuple2<byte[], byte[]>> data, boolean disableWAL, WRITETYPE type)
+            throws Exception {
+        final File rocksDir = folder.newFolder();
+
+        // ensure the RocksDB library is loaded to a distinct location each retry
+        NativeLibraryLoader.getInstance().loadLibrary(rocksDir.getAbsolutePath());
+
+        switch (type) {
+            case PUT:
+                try (RocksDB db = RocksDB.open(rocksDir.getAbsolutePath());
+                        WriteOptions options = new WriteOptions().setDisableWAL(disableWAL);
+                        ColumnFamilyHandle handle =
+                                db.createColumnFamily(
+                                        new ColumnFamilyDescriptor("test".getBytes()))) {
+                    long t1 = System.nanoTime();
+                    for (Tuple2<byte[], byte[]> item : data) {
+                        db.put(handle, options, item.f0, item.f1);
+                    }
+                    return System.nanoTime() - t1;
+                }
+            case WRITE_BATCH:
+                try (RocksDB db = RocksDB.open(rocksDir.getAbsolutePath());
+                        WriteOptions options = new WriteOptions().setDisableWAL(disableWAL);
+                        ColumnFamilyHandle handle =
+                                db.createColumnFamily(
+                                        new ColumnFamilyDescriptor("test".getBytes()));
+                        RocksDBWriteBatchWrapper writeBatchWrapper =
+                                new RocksDBWriteBatchWrapper(db, options)) {
+                    long t1 = System.nanoTime();
+                    for (Tuple2<byte[], byte[]> item : data) {
+                        writeBatchWrapper.put(handle, item.f0, item.f1);
+                    }
+                    writeBatchWrapper.flush();
+                    return System.nanoTime() - t1;
+                }
+            default:
+                throw new RuntimeException("Unknown benchmark type:" + type);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
@@ -33,6 +33,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder;
 import org.apache.flink.contrib.streaming.state.RocksDBResourceContainer;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -125,7 +126,8 @@ public class StateBackendBenchmarkUtils {
                         new UnregisteredMetricsGroup(),
                         Collections.emptyList(),
                         AbstractStateBackend.getCompressionDecorator(executionConfig),
-                        new CloseableRegistry());
+                        new CloseableRegistry(),
+                        new RocksDBWriterFactory());
         try {
             return builder.build();
         } catch (Exception e) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
@@ -34,6 +34,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder;
 import org.apache.flink.contrib.streaming.state.RocksDBResourceContainer;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.writer.RocksDBWriterFactory;
+import org.apache.flink.contrib.streaming.state.writer.WriteBatchMechanism;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -69,13 +70,19 @@ public class StateBackendBenchmarkUtils {
 
     public static KeyedStateBackend<Long> createKeyedStateBackend(StateBackendType backendType)
             throws IOException {
+        return createKeyedStateBackend(backendType, WriteBatchMechanism.WRITE_BATCH);
+    }
+
+    public static KeyedStateBackend<Long> createKeyedStateBackend(
+            StateBackendType backendType, WriteBatchMechanism writeBatchMechanism)
+            throws IOException {
         switch (backendType) {
             case HEAP:
                 rootDir = prepareDirectory(rootDirName, null);
                 return createHeapKeyedStateBackend(rootDir);
             case ROCKSDB:
                 rootDir = prepareDirectory(rootDirName, null);
-                return createRocksDBKeyedStateBackend(rootDir);
+                return createRocksDBKeyedStateBackend(rootDir, writeBatchMechanism);
             case BATCH_EXECUTION:
                 return createBatchExecutionStateBackend();
             default:
@@ -99,8 +106,8 @@ public class StateBackendBenchmarkUtils {
                         null);
     }
 
-    private static RocksDBKeyedStateBackend<Long> createRocksDBKeyedStateBackend(File rootDir)
-            throws IOException {
+    private static RocksDBKeyedStateBackend<Long> createRocksDBKeyedStateBackend(
+            File rootDir, WriteBatchMechanism writeBatchMechanism) throws IOException {
         File recoveryBaseDir = prepareDirectory(recoveryDirName, rootDir);
         File dbPathFile = prepareDirectory(dbDirName, rootDir);
         ExecutionConfig executionConfig = new ExecutionConfig();
@@ -127,7 +134,7 @@ public class StateBackendBenchmarkUtils {
                         Collections.emptyList(),
                         AbstractStateBackend.getCompressionDecorator(executionConfig),
                         new CloseableRegistry(),
-                        new RocksDBWriterFactory());
+                        new RocksDBWriterFactory(writeBatchMechanism));
         try {
             return builder.build();
         } catch (Exception e) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/FullSnapshotRocksDbTtlStateTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/FullSnapshotRocksDbTtlStateTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.flink.contrib.streaming.state.ttl;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.contrib.streaming.state.writer.WriteBatchMechanism;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.TernaryBoolean;
 
@@ -25,6 +29,11 @@ import org.apache.flink.util.TernaryBoolean;
 public class FullSnapshotRocksDbTtlStateTest extends RocksDBTtlStateTestBase {
     @Override
     StateBackend createStateBackend() {
-        return createStateBackend(TernaryBoolean.FALSE);
+        RocksDBStateBackend backend = createStateBackend(TernaryBoolean.FALSE);
+        Configuration config = new Configuration();
+        config.set(
+                RocksDBConfigurableOptions.WRITE_BATCH_MECHANISM, WriteBatchMechanism.WRITE_BATCH);
+        backend = backend.configure(config, Thread.currentThread().getContextClassLoader());
+        return backend;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/FullSnapshotSstIngestRocksDbTtlStateTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/FullSnapshotSstIngestRocksDbTtlStateTest.java
@@ -25,20 +25,15 @@ import org.apache.flink.contrib.streaming.state.writer.WriteBatchMechanism;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.TernaryBoolean;
 
-/** Test suite for rocksdb state TTL with incremental snapshot strategy. */
-public class IncSnapshotRocksDbTtlStateTest extends RocksDBTtlStateTestBase {
+/** Test suite for rocksdb state TTL with full snapshot strategy. */
+public class FullSnapshotSstIngestRocksDbTtlStateTest extends RocksDBTtlStateTestBase {
     @Override
     StateBackend createStateBackend() {
-        RocksDBStateBackend backend = createStateBackend(TernaryBoolean.TRUE);
+        RocksDBStateBackend backend = createStateBackend(TernaryBoolean.FALSE);
         Configuration config = new Configuration();
         config.set(
-                RocksDBConfigurableOptions.WRITE_BATCH_MECHANISM, WriteBatchMechanism.WRITE_BATCH);
+                RocksDBConfigurableOptions.WRITE_BATCH_MECHANISM, WriteBatchMechanism.SST_INGEST);
         backend = backend.configure(config, Thread.currentThread().getContextClassLoader());
         return backend;
-    }
-
-    @Override
-    public boolean fullSnapshot() {
-        return false;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/IncSnapshotSstIngestRocksDbTtlStateTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/IncSnapshotSstIngestRocksDbTtlStateTest.java
@@ -26,13 +26,13 @@ import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.TernaryBoolean;
 
 /** Test suite for rocksdb state TTL with incremental snapshot strategy. */
-public class IncSnapshotRocksDbTtlStateTest extends RocksDBTtlStateTestBase {
+public class IncSnapshotSstIngestRocksDbTtlStateTest extends RocksDBTtlStateTestBase {
     @Override
     StateBackend createStateBackend() {
         RocksDBStateBackend backend = createStateBackend(TernaryBoolean.TRUE);
         Configuration config = new Configuration();
         config.set(
-                RocksDBConfigurableOptions.WRITE_BATCH_MECHANISM, WriteBatchMechanism.WRITE_BATCH);
+                RocksDBConfigurableOptions.WRITE_BATCH_MECHANISM, WriteBatchMechanism.SST_INGEST);
         backend = backend.configure(config, Thread.currentThread().getContextClassLoader());
         return backend;
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
@@ -58,7 +58,7 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
 
     abstract StateBackend createStateBackend();
 
-    StateBackend createStateBackend(TernaryBoolean enableIncrementalCheckpointing) {
+    RocksDBStateBackend createStateBackend(TernaryBoolean enableIncrementalCheckpointing) {
         String dbPath;
         String checkpointPath;
         try {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTIngestWriterTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTIngestWriterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.writer;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Tests for {@link RocksDBSSTIngestWriterTest}. */
+public class RocksDBSSTIngestWriterTest {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Tests the basic functionality of {@link RocksDBSSTIngestWriter} for writing k/v to {@link
+     * RocksDB}, including using multiple column families.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void basicTest() throws Exception {
+        List<Tuple2<byte[], byte[]>> firstColumnFamilyData = new ArrayList<>(10000);
+        for (int i = 0; i < 10000; ++i) {
+            firstColumnFamilyData.add(
+                    new Tuple2<>(
+                            // Pad the key integer so data is in ascending key-order.
+                            (String.format("family-1-key:%010d", i)).getBytes(),
+                            ("value:" + i).getBytes()));
+        }
+
+        List<Tuple2<byte[], byte[]>> secondColumnFamilyData = new ArrayList<>(10000);
+        for (int i = 0; i < 10000; ++i) {
+            secondColumnFamilyData.add(
+                    new Tuple2<>(
+                            // Pad the key integer so data is in ascending key-order.
+                            (String.format("family-2-key:%010d", i)).getBytes(),
+                            ("value:" + i).getBytes()));
+        }
+
+        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+                // @lgo: fixme: plumb through options and ingestOptions.
+                WriteOptions options = new WriteOptions().setDisableWAL(true);
+                ColumnFamilyHandle firstHandle =
+                        db.createColumnFamily(
+                                new ColumnFamilyDescriptor("test-handle-1".getBytes()));
+                ColumnFamilyHandle secondHandle =
+                        db.createColumnFamily(
+                                new ColumnFamilyDescriptor("test-handle-2".getBytes()));
+                RocksDBWriter writer =
+                        new RocksDBSSTIngestWriter(db, 200, null, null, folder.newFolder())) {
+
+            // insert data into the first column family.
+            for (Tuple2<byte[], byte[]> item : firstColumnFamilyData) {
+                writer.put(firstHandle, item.f0, item.f1);
+            }
+
+            // insert data into the second column family.
+            for (Tuple2<byte[], byte[]> item : secondColumnFamilyData) {
+                writer.put(secondHandle, item.f0, item.f1);
+            }
+
+            // flush all of the data
+            writer.flush();
+
+            // validate the results for the first column family.
+            for (Tuple2<byte[], byte[]> item : firstColumnFamilyData) {
+                Assert.assertArrayEquals(item.f1, db.get(firstHandle, item.f0));
+            }
+
+            // validate the results for the second column family.
+            for (Tuple2<byte[], byte[]> item : secondColumnFamilyData) {
+                Assert.assertArrayEquals(item.f1, db.get(secondHandle, item.f0));
+            }
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTWriterTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/writer/RocksDBSSTWriterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.writer;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.IngestExternalFileOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Tests for {@link RocksDBSSTWriter}. */
+public class RocksDBSSTWriterTest {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void basicTest() throws Exception {
+        List<Tuple2<byte[], byte[]>> data = new ArrayList<>(10000);
+        for (int i = 0; i < 10000; ++i) {
+            data.add(
+                    new Tuple2<>(
+                            // Pad the key integer so data is in ascending key-order.
+                            (String.format("key:%010d", i)).getBytes(), ("value:" + i).getBytes()));
+        }
+
+        File sstCreationFolder = folder.newFolder();
+        File sstFile = new File(sstCreationFolder, "test.sst");
+
+        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+                WriteOptions options = new WriteOptions().setDisableWAL(true);
+                IngestExternalFileOptions ingestOptions = new IngestExternalFileOptions();
+                ColumnFamilyHandle handle =
+                        db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
+                RocksDBSSTWriter writer = new RocksDBSSTWriter(null, null, handle, sstFile)) {
+
+            // insert data
+            for (Tuple2<byte[], byte[]> item : data) {
+                writer.put(item.f0, item.f1);
+            }
+            writer.finish();
+
+            // add the sst file to the RocksDB database
+            List<String> sstFiles = Collections.singletonList(sstFile.getAbsolutePath());
+            db.ingestExternalFile(handle, sstFiles, ingestOptions);
+
+            // validate the results
+            for (Tuple2<byte[], byte[]> item : data) {
+                Assert.assertArrayEquals(item.f1, db.get(handle, item.f0));
+            }
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriteBatchWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/writer/RocksDBWriteBatchWrapperTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.contrib.streaming.state;
+package org.apache.flink.contrib.streaming.state.writer;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 


### PR DESCRIPTION
## WIP

I was hoping to get a first round of feedback for this implementation. This branch is currently passing tests, but there was additional work to clean it up:

- [x] More testing of the new implementation.
  - There are plenty of tests in the branch that all pass! We could do testing with an application if necessary, but this seemed sufficient.
- [ ] Add benchmarking to RocksDB for the two implementations used here.
- [x] Add more configuration parameters to pass through to the writers.
  - The configuration for which writer to choose was added.
  - [ ] Now that there is an `optionsContainer` availalbe, the other RocksDB options should be passed through via that.
- [ ] Compare performance of save-point recovery on our production instanace, as it has a large state.

## What is the purpose of the change

This adds a new mode of bulk writing data into RocksDB, via `RocksDBSSTIngestWriter`. This implementation should provide a considerable performance improvement to operations such as save-point recovery and state migrations (but, has yet to be perf tested).

This is in reference to the discussion on the users maillist I brought up, [here](http://apache-flink-user-mailing-list-archive.2336050.n4.nabble.com/RocksDB-savepoint-recovery-performance-improvements-td35238.html), as well as the previously reported ticket: [FLINK-17288](https://issues.apache.org/jira/browse/FLINK-17288). I created [FLINK-17971](https://issues.apache.org/jira/browse/FLINK-17971) for specifically SST ingestion bulk loading.

## Brief change log

(commit 1)
- Refactored the use of `RocksDBWriteBatchWrapper` into using a factory (`RocksDBWriterFactory`) and interface (`RocksDBWriter`), in preparation of adding a second implementation.

(commit 2)
- Added `RockSDBSSTWriter`, which is a basic wrapper for `SstFileWriter` in order to create `sst` files. 
- Added `RocksDBSSTIngestWriter`, which uses the `RockSDBSSTWriter`, and provides a write-interface for batch writing k/v into RocksDB. This includes flushing and handling multiple column-families.
- Added new configuration for opting into the writer, as well as tuning parameters.
- Configuration was passed through `RocksDBWriterFactory`. When the configuration is set to use sst ingestion (`WriteBatchMechanism.SST_INGEST`), the factory's `defaultPutWriter` will provide an SST ingestion writer rather than RocksDB's WriteBatch.
- Write paths doing bulk loading (full savepoint recovery, state migration) are changed to use `defaultPutWriter`, so they will use `RocksDBSSTIngestWriter` if configured.

## Verifying this change

This change is already covered by existing tests, such as:

* All existing RocksDB savepoint and checkpoint tests. I added all the code behind a configuration option so both paths can continue to be executed. The RocksDB tests are parameterized to test both the WriteBatchWrapper (current) and SstFileWriter (new) ways of writing bulk `put` operations, and for a few tests duplicated them to trigger both paths.

This change added tests and can be verified as follows:

- Added new tests for the `RocksDBSSTWriter` and `RocksDBSSTIngestWriter` paths for the new writing pathway.
- [ ] **TODO** Add more rigourous tests for the new implementation.
- [ ] **TODO** Extend existing tests to test both writer implementations. (I'd manually changed the defaulting to test the new configuration).
- [ ] **TODO** Manually verified the change running on a cluster.
- [ ] **TODO** Write benchmarks for https://github.com/facebook/rocksdb to compare the two writing methods.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **TODO: not yet documented**
