### PR TITLE
[FLINK-17944][sql-client] Wrong output in sql client's table mode

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -205,6 +206,11 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 	// --------------------------------------------------------------------------------------------
 
 	private void processInsert(Row row) {
+		// Always set the RowKind to INSERT, so that we can compare rows correctly in sql-client,
+		// (RowKind will be ignored). Just use the Boolean of Tuple<Boolean, Row> to figure out
+		// whether it is insert or delete.
+		row.setKind(RowKind.INSERT);
+
 		// limit the materialized table
 		if (materializedTable.size() - validRowPosition >= maxRowCount) {
 			cleanUp();
@@ -214,6 +220,11 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 	}
 
 	private void processDelete(Row row) {
+		// Always set the RowKind to INSERT, so that we can compare rows correctly here
+		// (RowKind will be ignored), just use the Boolean of Tuple<Boolean, Row> to figure out
+		// whether it is insert or delete.
+		row.setKind(RowKind.INSERT);
+
 		// delete the newest record first to minimize per-page changes
 		final Integer cachedPos = rowPositionCache.get(row);
 		final int startSearchPos;


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the issue of wrong output in sql client's table mode of stream output.

## Brief change log

This PR reset the `RowKind` in `MaterializedCollectStreamResult`, so that RowKind will be ignored when doing Row comparison.  This is a short term solution, long term solution is FLINK-17774.


## Verifying this change

Verify it manually, the output is this sql statement is now correct.
```
SELECT name, COUNT(*) AS cnt FROM (VALUES ('Bob'), ('Alice'), ('Greg'), ('Bob')) AS NameTable(name) GROUP BY name;
```

Output
```
Alice                         1
Greg                         1
Bob                          2
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
