### PR TITLE
[FLINK-17824][e2e] Introduce timeout to 'resume savepoint' test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -799,3 +799,32 @@ function extract_job_id_from_job_submission_return() {
     echo "$JOB_ID"
 }
 
+
+#
+# NOTE: This function requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
+#
+
+run_test_with_timeout() {
+  TEST_TIMEOUT_SECONDS=$1
+  shift
+  TEST_COMMAND=$@
+
+  kill_test_watchdog() {
+      local watchdog_pid=`cat $TEST_DATA_DIR/job_watchdog.pid`
+      echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
+      kill $watchdog_pid
+  }
+  on_exit kill_test_watchdog
+
+  (
+      cmdpid=$BASHPID
+      (sleep $TEST_TIMEOUT_SECONDS # set a timeout for this test
+      echo "Test (pid: $cmdpid) did not finish after $TEST_TIMEOUT_SECONDS seconds."
+      echo "Printing Flink logs and killing it:"
+      cat ${FLINK_DIR}/log/*
+      kill "$cmdpid") & watchdog_pid=$!
+      echo $watchdog_pid > $TEST_DATA_DIR/job_watchdog.pid
+      # invoke
+      $TEST_COMMAND
+  )
+}

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -24,7 +24,7 @@ source "$(dirname "$0")"/common_ha.sh
 # NOTE: This script requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
 #
 
-TEST_TIMEOUT_SECONDS=540
+TEST_TIMEOUT_SECONDS=900
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar
 
@@ -115,7 +115,7 @@ on_exit kill_test_watchdog
 
 ( 
     cmdpid=$BASHPID; 
-    (sleep $TEST_TIMEOUT_SECONDS; # set a timeout of 10 minutes for this test
+    (sleep $TEST_TIMEOUT_SECONDS; # set a timeout for this test
     echo "Test (pid: $cmdpid) did not finish after $TEST_TIMEOUT_SECONDS seconds."
     echo "Printing Flink logs and killing it:"
     cat ${FLINK_DIR}/log/* 

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -20,7 +20,6 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_ha.sh
 
-TEST_TIMEOUT_SECONDS=900
 TEST_PROGRAM_JAR_NAME=DataStreamAllroundTestProgram.jar
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/${TEST_PROGRAM_JAR_NAME}
 FLINK_LIB_DIR=${FLINK_DIR}/lib
@@ -153,23 +152,4 @@ STATE_BACKEND_TYPE=${1:-file}
 STATE_BACKEND_FILE_ASYNC=${2:-true}
 STATE_BACKEND_ROCKS_INCREMENTAL=${3:-false}
 
-function kill_test_watchdog() {
-    local watchdog_pid=`cat $TEST_DATA_DIR/job_watchdog.pid`
-    echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
-    kill $watchdog_pid
-}
-on_exit kill_test_watchdog
-
-( 
-    cmdpid=$BASHPID; 
-    (sleep $TEST_TIMEOUT_SECONDS; # set a timeout for this test
-    echo "Test (pid: $cmdpid) did not finish after $TEST_TIMEOUT_SECONDS seconds."
-    echo "Printing Flink logs and killing it:"
-    cat ${FLINK_DIR}/log/* 
-    kill "$cmdpid") & watchdog_pid=$!
-    echo $watchdog_pid > $TEST_DATA_DIR/job_watchdog.pid
-    
-    run_ha_test 4 ${STATE_BACKEND_TYPE} ${STATE_BACKEND_FILE_ASYNC} ${STATE_BACKEND_ROCKS_INCREMENTAL}
-)
-
-
+run_test_with_timeout 900 run_ha_test 4 ${STATE_BACKEND_TYPE} ${STATE_BACKEND_FILE_ASYNC} ${STATE_BACKEND_ROCKS_INCREMENTAL}

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -20,7 +20,7 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_ha.sh
 
-TEST_TIMEOUT_SECONDS=540
+TEST_TIMEOUT_SECONDS=900
 TEST_PROGRAM_JAR_NAME=DataStreamAllroundTestProgram.jar
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/${TEST_PROGRAM_JAR_NAME}
 FLINK_LIB_DIR=${FLINK_DIR}/lib
@@ -162,7 +162,7 @@ on_exit kill_test_watchdog
 
 ( 
     cmdpid=$BASHPID; 
-    (sleep $TEST_TIMEOUT_SECONDS; # set a timeout of 10 minutes for this test
+    (sleep $TEST_TIMEOUT_SECONDS; # set a timeout for this test
     echo "Test (pid: $cmdpid) did not finish after $TEST_TIMEOUT_SECONDS seconds."
     echo "Printing Flink logs and killing it:"
     cat ${FLINK_DIR}/log/* 

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -43,82 +43,106 @@ fi
 
 source "$(dirname "$0")"/common.sh
 
+TEST_TIMEOUT_SECONDS=900
+
 ORIGINAL_DOP=$1
 NEW_DOP=$2
 STATE_BACKEND_TYPE=${3:-file}
 STATE_BACKEND_FILE_ASYNC=${4:-true}
 STATE_BACKEND_ROCKS_TIMER_SERVICE_TYPE=${5:-rocks}
 
-if (( $ORIGINAL_DOP >= $NEW_DOP )); then
-  NUM_SLOTS=$ORIGINAL_DOP
-else
-  NUM_SLOTS=$NEW_DOP
-fi
 
-set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
+function run_resume_savepoint_test() {
+  if (( $ORIGINAL_DOP >= $NEW_DOP )); then
+    NUM_SLOTS=$ORIGINAL_DOP
+  else
+    NUM_SLOTS=$NEW_DOP
+  fi
 
-if [ $STATE_BACKEND_ROCKS_TIMER_SERVICE_TYPE == 'heap' ]; then
-  set_config_key "state.backend.rocksdb.timer-service.factory" "heap"
-fi
-set_config_key "metrics.fetcher.update-interval" "2000"
+  set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
 
-setup_flink_slf4j_metric_reporter
+  if [ $STATE_BACKEND_ROCKS_TIMER_SERVICE_TYPE == 'heap' ]; then
+    set_config_key "state.backend.rocksdb.timer-service.factory" "heap"
+  fi
+  set_config_key "metrics.fetcher.update-interval" "2000"
 
-start_cluster
+  setup_flink_slf4j_metric_reporter
 
-CHECKPOINT_DIR="file://$TEST_DATA_DIR/savepoint-e2e-test-chckpt-dir"
+  start_cluster
 
-# run the DataStream allroundjob
-TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar
-DATASTREAM_JOB=$($FLINK_DIR/bin/flink run -d -p $ORIGINAL_DOP $TEST_PROGRAM_JAR \
-  --test.semantics exactly-once \
-  --environment.parallelism $ORIGINAL_DOP \
-  --state_backend $STATE_BACKEND_TYPE \
-  --state_backend.checkpoint_directory $CHECKPOINT_DIR \
-  --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
-  --sequence_generator_source.sleep_time 15 \
-  --sequence_generator_source.sleep_after_elements 1 \
-  | grep "Job has been submitted with JobID" | sed 's/.* //g')
+  CHECKPOINT_DIR="file://$TEST_DATA_DIR/savepoint-e2e-test-chckpt-dir"
 
-wait_job_running $DATASTREAM_JOB
+  # run the DataStream allroundjob
+  TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar
+  DATASTREAM_JOB=$($FLINK_DIR/bin/flink run -d -p $ORIGINAL_DOP $TEST_PROGRAM_JAR \
+    --test.semantics exactly-once \
+    --environment.parallelism $ORIGINAL_DOP \
+    --state_backend $STATE_BACKEND_TYPE \
+    --state_backend.checkpoint_directory $CHECKPOINT_DIR \
+    --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
+    --sequence_generator_source.sleep_time 15 \
+    --sequence_generator_source.sleep_after_elements 1 \
+    | grep "Job has been submitted with JobID" | sed 's/.* //g')
 
-wait_oper_metric_num_in_records SemanticsCheckMapper.0 200
+  wait_job_running $DATASTREAM_JOB
 
-# take a savepoint of the state machine job
-SAVEPOINT_PATH=$(stop_with_savepoint $DATASTREAM_JOB $TEST_DATA_DIR \
-  | grep "Savepoint completed. Path:" | sed 's/.* //g')
+  wait_oper_metric_num_in_records SemanticsCheckMapper.0 200
 
-wait_job_terminal_state "${DATASTREAM_JOB}" "FINISHED"
+  # take a savepoint of the state machine job
+  SAVEPOINT_PATH=$(stop_with_savepoint $DATASTREAM_JOB $TEST_DATA_DIR \
+    | grep "Savepoint completed. Path:" | sed 's/.* //g')
 
-# isolate the path without the scheme ("file:") and do the necessary checks
-SAVEPOINT_DIR=${SAVEPOINT_PATH#"file:"}
+  wait_job_terminal_state "${DATASTREAM_JOB}" "FINISHED"
 
-if [ -z "$SAVEPOINT_DIR" ]; then
-  echo "Savepoint location was empty. This may mean that the stop-with-savepoint failed."
-  exit 1
-elif [ ! -d "$SAVEPOINT_DIR" ]; then
-  echo "Savepoint $SAVEPOINT_PATH does not exist."
-  exit 1
-fi
+  # isolate the path without the scheme ("file:") and do the necessary checks
+  SAVEPOINT_DIR=${SAVEPOINT_PATH#"file:"}
 
-# Since it is not possible to differentiate reporter output between the first and second execution,
-# we remember the number of metrics sampled in the first execution so that they can be ignored in the following monitorings
-OLD_NUM_METRICS=$(get_num_metric_samples)
+  if [ -z "$SAVEPOINT_DIR" ]; then
+    echo "Savepoint location was empty. This may mean that the stop-with-savepoint failed."
+    exit 1
+  elif [ ! -d "$SAVEPOINT_DIR" ]; then
+    echo "Savepoint $SAVEPOINT_PATH does not exist."
+    exit 1
+  fi
 
-# resume state machine job with savepoint
-DATASTREAM_JOB=$($FLINK_DIR/bin/flink run -s $SAVEPOINT_PATH -p $NEW_DOP -d $TEST_PROGRAM_JAR \
-  --test.semantics exactly-once \
-  --environment.parallelism $NEW_DOP \
-  --state_backend $STATE_BACKEND_TYPE \
-  --state_backend.checkpoint_directory $CHECKPOINT_DIR \
-  --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
-  --sequence_generator_source.sleep_time 15 \
-  --sequence_generator_source.sleep_after_elements 1 \
-  | grep "Job has been submitted with JobID" | sed 's/.* //g')
+  # Since it is not possible to differentiate reporter output between the first and second execution,
+  # we remember the number of metrics sampled in the first execution so that they can be ignored in the following monitorings
+  OLD_NUM_METRICS=$(get_num_metric_samples)
 
-wait_job_running $DATASTREAM_JOB
+  # resume state machine job with savepoint
+  DATASTREAM_JOB=$($FLINK_DIR/bin/flink run -s $SAVEPOINT_PATH -p $NEW_DOP -d $TEST_PROGRAM_JAR \
+    --test.semantics exactly-once \
+    --environment.parallelism $NEW_DOP \
+    --state_backend $STATE_BACKEND_TYPE \
+    --state_backend.checkpoint_directory $CHECKPOINT_DIR \
+    --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
+    --sequence_generator_source.sleep_time 15 \
+    --sequence_generator_source.sleep_after_elements 1 \
+    | grep "Job has been submitted with JobID" | sed 's/.* //g')
 
-wait_oper_metric_num_in_records SemanticsCheckMapper.0 200
+  wait_job_running $DATASTREAM_JOB
 
-# if state is errorneous and the state machine job produces alerting state transitions,
-# output would be non-empty and the test will not pass
+  wait_oper_metric_num_in_records SemanticsCheckMapper.0 200
+
+  # if state is errorneous and the state machine job produces alerting state transitions,
+  # output would be non-empty and the test will not pass
+}
+
+function kill_test_watchdog() {
+    local watchdog_pid=`cat $TEST_DATA_DIR/job_watchdog.pid`
+    echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
+    kill $watchdog_pid
+}
+on_exit kill_test_watchdog
+
+( 
+    cmdpid=$BASHPID; 
+    (sleep $TEST_TIMEOUT_SECONDS; # set a timeout for this test
+    echo "Test (pid: $cmdpid) did not finish after $TEST_TIMEOUT_SECONDS seconds."
+    echo "Printing Flink logs and killing it:"
+    cat ${FLINK_DIR}/log/* 
+    kill "$cmdpid") & watchdog_pid=$!
+    echo $watchdog_pid > $TEST_DATA_DIR/job_watchdog.pid
+    
+    run_resume_savepoint_test
+)


### PR DESCRIPTION
## What is the purpose of the change

We observed 1 failure of test_resume_savepoint.sh so far. Due to the implementation of this test, we can not see the Flink logs.
With this change, the logs will be made available if this error ever happens again.

## Brief change log

- Copied the "watchdog" code from the HA tests
- this PR also includes a hotfix to increase the timeout from 9 to 15 minutes for the HA tests. I want to find out if the HA tests are sometimes just slow. 9 minutes used to be the timeout because travis would have killed the e2e after 10 minutes anyways.


