### PR TITLE
[FLINK-17820][task][checkpointing] Backport to 1.11: Respect fileSizeThreshold in FsCheckpointStateOutputStream.flush()

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
@@ -21,20 +21,28 @@ import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.ChannelStateWriteResult;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory.MemoryCheckpointOutputStream;
 import org.apache.flink.util.function.RunnableWithException;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import static org.apache.flink.core.fs.Path.fromLocalFile;
+import static org.apache.flink.core.fs.local.LocalFileSystem.getSharedInstance;
+import static org.apache.flink.runtime.state.CheckpointedStateScope.EXCLUSIVE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -48,6 +56,27 @@ public class ChannelStateCheckpointWriterTest {
 	};
 	private final Random random = new Random();
 
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	@SuppressWarnings("ConstantConditions")
+	public void testSmallFilesNotWritten() throws Exception {
+		int threshold = 100;
+		File checkpointsDir = temporaryFolder.newFolder("checkpointsDir");
+		File sharedStateDir = temporaryFolder.newFolder("sharedStateDir");
+		FsCheckpointStreamFactory checkpointStreamFactory = new FsCheckpointStreamFactory(getSharedInstance(), fromLocalFile(checkpointsDir), fromLocalFile(sharedStateDir), threshold, threshold);
+		ChannelStateWriteResult result = new ChannelStateWriteResult();
+		ChannelStateCheckpointWriter writer = createWriter(result, checkpointStreamFactory.createCheckpointStateOutputStream(EXCLUSIVE));
+		NetworkBuffer buffer = new NetworkBuffer(HeapMemorySegment.FACTORY.allocateUnpooledSegment(threshold / 2, null), FreeingBufferRecycler.INSTANCE);
+		writer.writeInput(new InputChannelInfo(1, 2), buffer);
+		writer.completeOutput();
+		writer.completeInput();
+		assertTrue(result.isDone());
+		assertEquals(0, checkpointsDir.list().length);
+		assertEquals(0, sharedStateDir.list().length);
+	}
+
 	@Test
 	public void testEmptyState() throws Exception {
 		MemoryCheckpointOutputStream stream = new MemoryCheckpointOutputStream(1000) {
@@ -57,13 +86,7 @@ public class ChannelStateCheckpointWriterTest {
 				return null;
 			}
 		};
-		ChannelStateCheckpointWriter writer = new ChannelStateCheckpointWriter(
-				1L,
-				new ChannelStateWriteResult(),
-				stream,
-				new ChannelStateSerializerImpl(),
-				NO_OP_RUNNABLE
-		);
+		ChannelStateCheckpointWriter writer = createWriter(new ChannelStateWriteResult(), stream);
 		writer.completeOutput();
 		writer.completeInput();
 		assertTrue(stream.isClosed());
@@ -155,13 +178,11 @@ public class ChannelStateCheckpointWriterTest {
 	}
 
 	private ChannelStateCheckpointWriter createWriter(ChannelStateWriteResult result) throws Exception {
-		return new ChannelStateCheckpointWriter(
-			1L,
-			result,
-			new MemoryCheckpointOutputStream(1000),
-			new ChannelStateSerializerImpl(),
-			NO_OP_RUNNABLE
-		);
+		return createWriter(result, new MemoryCheckpointOutputStream(1000));
+	}
+
+	private ChannelStateCheckpointWriter createWriter(ChannelStateWriteResult result, CheckpointStateOutputStream stream) throws Exception {
+		return new ChannelStateCheckpointWriter(1L, result, stream, new ChannelStateSerializerImpl(), NO_OP_RUNNABLE);
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
@@ -162,11 +162,11 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 
 		// create exclusive state
 
-		CheckpointStateOutputStream exclusiveStream =
+		FsCheckpointStateOutputStream exclusiveStream =
 				storageLocation.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
 
 		exclusiveStream.write(42);
-		exclusiveStream.flush();
+		exclusiveStream.flushToFile();
 		StreamStateHandle exclusiveHandle = exclusiveStream.closeAndGetHandle();
 
 		assertEquals(1, fs.listStatus(storageLocation.getCheckpointDirectory()).length);
@@ -174,11 +174,11 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 
 		// create shared state
 
-		CheckpointStateOutputStream sharedStream =
+		FsCheckpointStateOutputStream sharedStream =
 				storageLocation.createCheckpointStateOutputStream(CheckpointedStateScope.SHARED);
 
 		sharedStream.write(42);
-		sharedStream.flush();
+		sharedStream.flushToFile();
 		StreamStateHandle sharedHandle = sharedStream.closeAndGetHandle();
 
 		assertEquals(1, fs.listStatus(storageLocation.getCheckpointDirectory()).length);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -52,13 +52,14 @@ public class FsStateBackendEntropyTest {
 
 	@Test
 	public void testEntropyInjection() throws Exception {
+		final int fileSizeThreshold = 1024;
 		final FileSystem fs = new TestEntropyAwareFs();
 
 		final Path checkpointDir = new Path(Path.fromLocalFile(tmp.newFolder()), ENTROPY_MARKER + "/checkpoints");
 		final String checkpointDirStr = checkpointDir.toString();
 
 		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				fs, checkpointDir, null, new JobID(), 1024, 4096);
+				fs, checkpointDir, null, new JobID(), fileSizeThreshold, 4096);
 		storage.initializeBaseLocations();
 
 		final FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
@@ -71,7 +72,7 @@ public class FsStateBackendEntropyTest {
 
 		// check entropy in task-owned state
 		try (CheckpointStateOutputStream stream = storage.createTaskOwnedStateStream()) {
-			stream.flush();
+			stream.write(new byte[fileSizeThreshold + 1], 0, fileSizeThreshold + 1);
 			FileStateHandle handle = (FileStateHandle) stream.closeAndGetHandle();
 
 			assertNotNull(handle);
@@ -82,8 +83,8 @@ public class FsStateBackendEntropyTest {
 		// check entropy in the exclusive/shared state
 		try (CheckpointStateOutputStream stream =
 				location.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)) {
+			stream.write(new byte[fileSizeThreshold + 1], 0, fileSizeThreshold + 1);
 
-			stream.flush();
 			FileStateHandle handle = (FileStateHandle) stream.closeAndGetHandle();
 
 			assertNotNull(handle);


### PR DESCRIPTION
__This is a backport of #12332 to `1.11`__

## What is the purpose of the change

See FLINK-17820 for full problem description. In short, Flink ignores `state.backend.fs.memory-threshold` and always creates a file per subtask per checkpoint.

This PR makes `FsCheckpointStateOutputStream.flush()` to take `fileStateThreshold` into account.

## Verifying this change

This change added tests:
 - `FsCheckpointStreamFactoryTest.testFlushUnderThreshold`
 - `FsCheckpointStreamFactoryTest.testFlushAboveThreshold`
 - `ChannelStateCheckpointWriterTest.testSmallFilesNotWritten`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
