### PR TITLE
[FLINK-17572][runtime] Remove checkpoint alignment buffered metric from webui

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1486,9 +1486,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "type" : "object",
         "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics",
         "properties" : {
-          "alignment_buffered" : {
-            "type" : "integer"
-          },
           "end_to_end_duration" : {
             "type" : "integer"
           },
@@ -1535,9 +1532,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:CompletedCheckpointStatistics",
           "properties" : {
-            "alignment_buffered" : {
-              "type" : "integer"
-            },
             "discarded" : {
               "type" : "boolean"
             },
@@ -1575,9 +1569,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "object",
                 "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics",
                 "properties" : {
-                  "alignment_buffered" : {
-                    "type" : "integer"
-                  },
                   "end_to_end_duration" : {
                     "type" : "integer"
                   },
@@ -1612,9 +1603,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:FailedCheckpointStatistics",
           "properties" : {
-            "alignment_buffered" : {
-              "type" : "integer"
-            },
             "end_to_end_duration" : {
               "type" : "integer"
             },
@@ -1686,10 +1674,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       "type" : "object",
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:Summary",
       "properties" : {
-        "alignment_buffered" : {
-          "type" : "object",
-          "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
-        },
         "end_to_end_duration" : {
           "type" : "object",
           "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
@@ -1844,9 +1828,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "type" : "object",
   "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics",
   "properties" : {
-    "alignment_buffered" : {
-      "type" : "integer"
-    },
     "end_to_end_duration" : {
       "type" : "integer"
     },
@@ -1878,9 +1859,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "type" : "object",
         "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics",
         "properties" : {
-          "alignment_buffered" : {
-            "type" : "integer"
-          },
           "end_to_end_duration" : {
             "type" : "integer"
           },
@@ -1962,9 +1940,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "type" : "object",
   "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails",
   "properties" : {
-    "alignment_buffered" : {
-      "type" : "integer"
-    },
     "end_to_end_duration" : {
       "type" : "integer"
     },

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -935,10 +935,6 @@
             "end_to_end_duration" : {
               "type" : "object",
               "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
-            },
-            "alignment_buffered" : {
-              "type" : "object",
-              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
             }
           }
         },
@@ -972,9 +968,6 @@
                 "end_to_end_duration" : {
                   "type" : "integer"
                 },
-                "alignment_buffered" : {
-                  "type" : "integer"
-                },
                 "num_subtasks" : {
                   "type" : "integer"
                 },
@@ -1001,9 +994,6 @@
                         "type" : "integer"
                       },
                       "end_to_end_duration" : {
-                        "type" : "integer"
-                      },
-                      "alignment_buffered" : {
                         "type" : "integer"
                       },
                       "num_subtasks" : {
@@ -1051,9 +1041,6 @@
                   "type" : "integer"
                 },
                 "end_to_end_duration" : {
-                  "type" : "integer"
-                },
-                "alignment_buffered" : {
                   "type" : "integer"
                 },
                 "num_subtasks" : {
@@ -1123,9 +1110,6 @@
                 "type" : "integer"
               },
               "end_to_end_duration" : {
-                "type" : "integer"
-              },
-              "alignment_buffered" : {
                 "type" : "integer"
               },
               "num_subtasks" : {
@@ -1242,9 +1226,6 @@
         "end_to_end_duration" : {
           "type" : "integer"
         },
-        "alignment_buffered" : {
-          "type" : "integer"
-        },
         "num_subtasks" : {
           "type" : "integer"
         },
@@ -1271,9 +1252,6 @@
                 "type" : "integer"
               },
               "end_to_end_duration" : {
-                "type" : "integer"
-              },
-              "alignment_buffered" : {
                 "type" : "integer"
               },
               "num_subtasks" : {
@@ -1325,9 +1303,6 @@
           "type" : "integer"
         },
         "end_to_end_duration" : {
-          "type" : "integer"
-        },
-        "alignment_buffered" : {
           "type" : "integer"
         },
         "num_subtasks" : {

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -27,7 +27,6 @@ export interface CheckPointInterface {
   summary: {
     state_size: CheckPointMinMaxAvgStatisticsInterface;
     end_to_end_duration: CheckPointMinMaxAvgStatisticsInterface;
-    alignment_buffered: CheckPointMinMaxAvgStatisticsInterface;
   };
   latest: {
     completed: CheckPointCompletedStatisticsInterface;
@@ -40,7 +39,6 @@ export interface CheckPointInterface {
       latest_ack_timestamp: number;
       state_size: number;
       end_to_end_duration: number;
-      alignment_buffered: number;
       num_subtasks: number;
       num_acknowledged_subtasks: number;
       failure_timestamp: number;
@@ -65,7 +63,6 @@ export interface CheckPointHistoryInterface {
   latest_ack_timestamp: number;
   state_size: number;
   end_to_end_duration: number;
-  alignment_buffered: number;
   num_subtasks: number;
   num_acknowledged_subtasks: number;
   task: CheckPointTaskStatisticsInterface;
@@ -85,7 +82,6 @@ export interface CheckPointCompletedStatisticsInterface {
   latest_ack_timestamp: number;
   state_size: number;
   end_to_end_duration: number;
-  alignment_buffered: number;
   num_subtasks: number;
   num_acknowledged_subtasks: number;
   tasks: CheckPointTaskStatisticsInterface;
@@ -99,7 +95,6 @@ export interface CheckPointTaskStatisticsInterface {
   latest_ack_timestamp: number;
   state_size: number;
   end_to_end_duration: number;
-  alignment_buffered: number;
   num_subtasks: number;
   num_acknowledged_subtasks: number;
 }
@@ -126,7 +121,6 @@ export interface CheckPointDetailInterface {
   end_to_end_duration: number;
   external_path: string;
   discarded: boolean;
-  alignment_buffered: number;
   failure_message?: string;
   num_subtasks: number;
   num_acknowledged_subtasks: number;
@@ -137,7 +131,6 @@ export interface CheckPointDetailInterface {
       latest_ack_timestamp: number;
       state_size: number;
       end_to_end_duration: number;
-      alignment_buffered: number;
       num_subtasks: number;
       num_acknowledged_subtasks: number;
     };
@@ -150,7 +143,6 @@ export interface CheckPointSubTaskInterface {
   latest_ack_timestamp: number;
   state_size: number;
   end_to_end_duration: number;
-  alignment_buffered: number;
   num_subtasks: number;
   num_acknowledged_subtasks: number;
   summary: {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/detail/job-checkpoints-detail.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/detail/job-checkpoints-detail.component.html
@@ -60,7 +60,6 @@
           <td *ngIf="checkPointDetail['tasks'][vertex.id]['end_to_end_duration'] >= 0">{{ checkPointDetail['tasks'][vertex.id]['end_to_end_duration'] | humanizeDuration}}</td>
           <td *ngIf="checkPointDetail['tasks'][vertex.id]['end_to_end_duration'] <0">n/a</td>
           <td>{{ checkPointDetail['tasks'][vertex.id]['state_size'] | humanizeBytes }}</td>
-          <td>{{ checkPointDetail['tasks'][vertex.id]['alignment_buffered'] | humanizeBytes }}</td>
         </tr>
         <tr [nzExpand]="vertex.expand">
           <td colspan="7" *ngIf="vertex.expand" class="collapse-td">

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -151,7 +151,6 @@
             <td *ngIf="checkpoint['end_to_end_duration'] >= 0">{{ checkpoint['end_to_end_duration'] | humanizeDuration}}</td>
             <td *ngIf="checkpoint['end_to_end_duration'] <0">n/a</td>
             <td>{{ checkpoint['state_size'] | humanizeBytes }}</td>
-            <td>{{ checkpoint['alignment_buffered'] | humanizeBytes }}</td>
           </tr>
           <tr [nzExpand]="checkpoint.expand">
             <td colspan="11" *ngIf="checkpoint.expand" class="collapse-td">
@@ -185,19 +184,16 @@
             <td><strong>Minimum</strong></td>
             <td>{{ checkPointStats['summary']['end_to_end_duration']['min'] | humanizeDuration}}</td>
             <td>{{ checkPointStats['summary']['state_size']['min'] | humanizeBytes }}</td>
-            <td>{{ checkPointStats['summary']['alignment_buffered']['min'] | humanizeBytes }}</td>
           </tr>
           <tr>
             <td><strong>Average</strong></td>
             <td>{{ checkPointStats['summary']['end_to_end_duration']['avg'] | humanizeDuration}}</td>
             <td>{{ checkPointStats['summary']['state_size']['avg'] | humanizeBytes }}</td>
-            <td>{{ checkPointStats['summary']['alignment_buffered']['avg'] | humanizeBytes }}</td>
           </tr>
           <tr>
             <td><strong>Maximum</strong></td>
             <td>{{ checkPointStats['summary']['end_to_end_duration']['max'] | humanizeDuration}}</td>
             <td>{{ checkPointStats['summary']['state_size']['max'] | humanizeBytes }}</td>
-            <td>{{ checkPointStats['summary']['alignment_buffered']['max'] | humanizeBytes }}</td>
           </tr>
         </ng-container>
       </tbody>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
@@ -105,7 +105,6 @@ public class CheckpointingStatisticsHandler extends AbstractExecutionGraphHandle
 			final CompletedCheckpointStatsSummary checkpointStatsSummary = checkpointStatsSnapshot.getSummaryStats();
 
 			final CheckpointingStatistics.Summary summary = new CheckpointingStatistics.Summary(
-				MinMaxAvgStatistics.valueOf(checkpointStatsSummary.getStateSizeStats()),
 				MinMaxAvgStatistics.valueOf(checkpointStatsSummary.getEndToEndDurationStats()),
 				new MinMaxAvgStatistics(0, 0, 0));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -131,7 +131,6 @@ public class TaskCheckpointStatisticDetailsHandler
 			taskStatistics.getLatestAckTimestamp(),
 			taskStatistics.getStateSize(),
 			taskStatistics.getEndToEndDuration(checkpointStats.getTriggerTimestamp()),
-			0,
 			taskStatistics.getNumberOfSubtasks(),
 			taskStatistics.getNumberOfAcknowledgedSubtasks(),
 			summary,
@@ -178,7 +177,6 @@ public class TaskCheckpointStatisticDetailsHandler
 						subtask.getSyncCheckpointDuration(),
 						subtask.getAsyncCheckpointDuration()),
 					new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointAlignment(
-						0,
 						subtask.getAlignmentDuration()),
 					subtask.getCheckpointStartDelay()
 				));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
@@ -75,8 +75,6 @@ public class CheckpointStatistics implements ResponseBody {
 
 	public static final String FIELD_NAME_DURATION = "end_to_end_duration";
 
-	public static final String FIELD_NAME_ALIGNMENT_BUFFERED = "alignment_buffered";
-
 	public static final String FIELD_NAME_NUM_SUBTASKS = "num_subtasks";
 
 	public static final String FIELD_NAME_NUM_ACK_SUBTASKS = "num_acknowledged_subtasks";
@@ -104,9 +102,6 @@ public class CheckpointStatistics implements ResponseBody {
 	@JsonProperty(FIELD_NAME_DURATION)
 	private final long duration;
 
-	@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED)
-	private final long alignmentBuffered;
-
 	@JsonProperty(FIELD_NAME_NUM_SUBTASKS)
 	private final int numSubtasks;
 
@@ -126,7 +121,6 @@ public class CheckpointStatistics implements ResponseBody {
 			@JsonProperty(FIELD_NAME_LATEST_ACK_TIMESTAMP) long latestAckTimestamp,
 			@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) long alignmentBuffered,
 			@JsonProperty(FIELD_NAME_NUM_SUBTASKS) int numSubtasks,
 			@JsonProperty(FIELD_NAME_NUM_ACK_SUBTASKS) int numAckSubtasks,
 			@JsonDeserialize(keyUsing = JobVertexIDKeyDeserializer.class) @JsonProperty(FIELD_NAME_TASKS) Map<JobVertexID, TaskCheckpointStatistics> checkpointStatisticsPerTask) {
@@ -137,7 +131,6 @@ public class CheckpointStatistics implements ResponseBody {
 		this.latestAckTimestamp = latestAckTimestamp;
 		this.stateSize = stateSize;
 		this.duration = duration;
-		this.alignmentBuffered = alignmentBuffered;
 		this.numSubtasks = numSubtasks;
 		this.numAckSubtasks = numAckSubtasks;
 		this.checkpointStatisticsPerTask = Preconditions.checkNotNull(checkpointStatisticsPerTask);
@@ -199,7 +192,6 @@ public class CheckpointStatistics implements ResponseBody {
 			latestAckTimestamp == that.latestAckTimestamp &&
 			stateSize == that.stateSize &&
 			duration == that.duration &&
-			alignmentBuffered == that.alignmentBuffered &&
 			numSubtasks == that.numSubtasks &&
 			numAckSubtasks == that.numAckSubtasks &&
 			status == that.status &&
@@ -208,7 +200,7 @@ public class CheckpointStatistics implements ResponseBody {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, status, savepoint, triggerTimestamp, latestAckTimestamp, stateSize, duration, alignmentBuffered, numSubtasks, numAckSubtasks, checkpointStatisticsPerTask);
+		return Objects.hash(id, status, savepoint, triggerTimestamp, latestAckTimestamp, stateSize, duration, numSubtasks, numAckSubtasks, checkpointStatisticsPerTask);
 	}
 
 	// -------------------------------------------------------------------------
@@ -234,7 +226,6 @@ public class CheckpointStatistics implements ResponseBody {
 						taskStateStat.getLatestAckTimestamp(),
 						taskStateStat.getStateSize(),
 						taskStateStat.getEndToEndDuration(checkpointStats.getTriggerTimestamp()),
-						0,
 						taskStateStat.getNumberOfSubtasks(),
 						taskStateStat.getNumberOfAcknowledgedSubtasks()));
 			}
@@ -253,7 +244,6 @@ public class CheckpointStatistics implements ResponseBody {
 				completedCheckpointStats.getLatestAckTimestamp(),
 				completedCheckpointStats.getStateSize(),
 				completedCheckpointStats.getEndToEndDuration(),
-				0,
 				completedCheckpointStats.getNumberOfSubtasks(),
 				completedCheckpointStats.getNumberOfAcknowledgedSubtasks(),
 				checkpointStatisticsPerTask,
@@ -270,7 +260,6 @@ public class CheckpointStatistics implements ResponseBody {
 				failedCheckpointStats.getLatestAckTimestamp(),
 				failedCheckpointStats.getStateSize(),
 				failedCheckpointStats.getEndToEndDuration(),
-				0,
 				failedCheckpointStats.getNumberOfSubtasks(),
 				failedCheckpointStats.getNumberOfAcknowledgedSubtasks(),
 				checkpointStatisticsPerTask,
@@ -287,7 +276,6 @@ public class CheckpointStatistics implements ResponseBody {
 				pendingCheckpointStats.getLatestAckTimestamp(),
 				pendingCheckpointStats.getStateSize(),
 				pendingCheckpointStats.getEndToEndDuration(),
-				0,
 				pendingCheckpointStats.getNumberOfSubtasks(),
 				pendingCheckpointStats.getNumberOfAcknowledgedSubtasks(),
 				checkpointStatisticsPerTask
@@ -327,7 +315,6 @@ public class CheckpointStatistics implements ResponseBody {
 			@JsonProperty(FIELD_NAME_LATEST_ACK_TIMESTAMP) long latestAckTimestamp,
 			@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) long alignmentBuffered,
 			@JsonProperty(FIELD_NAME_NUM_SUBTASKS) int numSubtasks,
 			@JsonProperty(FIELD_NAME_NUM_ACK_SUBTASKS) int numAckSubtasks,
 			@JsonDeserialize(keyUsing = JobVertexIDKeyDeserializer.class) @JsonProperty(FIELD_NAME_TASKS) Map<JobVertexID, TaskCheckpointStatistics> checkpointingStatisticsPerTask,
@@ -341,7 +328,6 @@ public class CheckpointStatistics implements ResponseBody {
 				latestAckTimestamp,
 				stateSize,
 				duration,
-				alignmentBuffered,
 				numSubtasks,
 				numAckSubtasks,
 				checkpointingStatisticsPerTask);
@@ -406,7 +392,6 @@ public class CheckpointStatistics implements ResponseBody {
 			@JsonProperty(FIELD_NAME_LATEST_ACK_TIMESTAMP) long latestAckTimestamp,
 			@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) long alignmentBuffered,
 			@JsonProperty(FIELD_NAME_NUM_SUBTASKS) int numSubtasks,
 			@JsonProperty(FIELD_NAME_NUM_ACK_SUBTASKS) int numAckSubtasks,
 			@JsonDeserialize(keyUsing = JobVertexIDKeyDeserializer.class) @JsonProperty(FIELD_NAME_TASKS) Map<JobVertexID, TaskCheckpointStatistics> checkpointingStatisticsPerTask,
@@ -420,7 +405,6 @@ public class CheckpointStatistics implements ResponseBody {
 				latestAckTimestamp,
 				stateSize,
 				duration,
-				alignmentBuffered,
 				numSubtasks,
 				numAckSubtasks,
 				checkpointingStatisticsPerTask);
@@ -474,7 +458,6 @@ public class CheckpointStatistics implements ResponseBody {
 			@JsonProperty(FIELD_NAME_LATEST_ACK_TIMESTAMP) long latestAckTimestamp,
 			@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) long alignmentBuffered,
 			@JsonProperty(FIELD_NAME_NUM_SUBTASKS) int numSubtasks,
 			@JsonProperty(FIELD_NAME_NUM_ACK_SUBTASKS) int numAckSubtasks,
 			@JsonDeserialize(keyUsing = JobVertexIDKeyDeserializer.class) @JsonProperty(FIELD_NAME_TASKS) Map<JobVertexID, TaskCheckpointStatistics> checkpointingStatisticsPerTask) {
@@ -486,7 +469,6 @@ public class CheckpointStatistics implements ResponseBody {
 				latestAckTimestamp,
 				stateSize,
 				duration,
-				alignmentBuffered,
 				numSubtasks,
 				numAckSubtasks,
 				checkpointingStatisticsPerTask);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
@@ -209,25 +209,18 @@ public class CheckpointingStatistics implements ResponseBody {
 
 		public static final String FIELD_NAME_DURATION = "end_to_end_duration";
 
-		public static final String FIELD_NAME_ALIGNMENT_BUFFERED = "alignment_buffered";
-
 		@JsonProperty(FIELD_NAME_STATE_SIZE)
 		private final MinMaxAvgStatistics stateSize;
 
 		@JsonProperty(FIELD_NAME_DURATION)
 		private final MinMaxAvgStatistics duration;
 
-		@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED)
-		private final MinMaxAvgStatistics alignmentBuffered;
-
 		@JsonCreator
 		public Summary(
 				@JsonProperty(FIELD_NAME_STATE_SIZE) MinMaxAvgStatistics stateSize,
-				@JsonProperty(FIELD_NAME_DURATION) MinMaxAvgStatistics duration,
-				@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) MinMaxAvgStatistics alignmentBuffered) {
+				@JsonProperty(FIELD_NAME_DURATION) MinMaxAvgStatistics duration) {
 			this.stateSize = stateSize;
 			this.duration = duration;
-			this.alignmentBuffered = alignmentBuffered;
 		}
 
 		public MinMaxAvgStatistics getStateSize() {
@@ -248,13 +241,12 @@ public class CheckpointingStatistics implements ResponseBody {
 			}
 			Summary summary = (Summary) o;
 			return Objects.equals(stateSize, summary.stateSize) &&
-				Objects.equals(duration, summary.duration) &&
-				Objects.equals(alignmentBuffered, summary.alignmentBuffered);
+				Objects.equals(duration, summary.duration);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(stateSize, duration, alignmentBuffered);
+			return Objects.hash(stateSize, duration);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
@@ -248,21 +248,14 @@ public class SubtaskCheckpointStatistics {
 		 */
 		public static final class CheckpointAlignment {
 
-			public static final String FIELD_NAME_ALIGNMENT_BUFFERED = "buffered";
-
 			public static final String FIELD_NAME_ALIGNMENT_DURATION = "duration";
-
-			@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED)
-			private final long alignmentBuffered;
 
 			@JsonProperty(FIELD_NAME_ALIGNMENT_DURATION)
 			private final long alignmentDuration;
 
 			@JsonCreator
 			public CheckpointAlignment(
-					@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) long alignmentBuffered,
 					@JsonProperty(FIELD_NAME_ALIGNMENT_DURATION) long alignmentDuration) {
-				this.alignmentBuffered = alignmentBuffered;
 				this.alignmentDuration = alignmentDuration;
 			}
 
@@ -279,13 +272,12 @@ public class SubtaskCheckpointStatistics {
 					return false;
 				}
 				CheckpointAlignment that = (CheckpointAlignment) o;
-				return alignmentBuffered == that.alignmentBuffered &&
-					alignmentDuration == that.alignmentDuration;
+				return alignmentDuration == that.alignmentDuration;
 			}
 
 			@Override
 			public int hashCode() {
-				return Objects.hash(alignmentBuffered, alignmentDuration);
+				return Objects.hash(alignmentDuration);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatistics.java
@@ -48,8 +48,6 @@ public class TaskCheckpointStatistics implements ResponseBody {
 
 	public static final String FIELD_NAME_DURATION = "end_to_end_duration";
 
-	public static final String FIELD_NAME_ALIGNMENT_BUFFERED = "alignment_buffered";
-
 	public static final String FIELD_NAME_NUM_SUBTASKS = "num_subtasks";
 
 	public static final String FIELD_NAME_NUM_ACK_SUBTASKS = "num_acknowledged_subtasks";
@@ -69,9 +67,6 @@ public class TaskCheckpointStatistics implements ResponseBody {
 	@JsonProperty(FIELD_NAME_DURATION)
 	private final long duration;
 
-	@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED)
-	private final long alignmentBuffered;
-
 	@JsonProperty(FIELD_NAME_NUM_SUBTASKS)
 	private final int numSubtasks;
 
@@ -85,7 +80,6 @@ public class TaskCheckpointStatistics implements ResponseBody {
 			@JsonProperty(FIELD_NAME_LATEST_ACK_TIMESTAMP) long latestAckTimestamp,
 			@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) long alignmentBuffered,
 			@JsonProperty(FIELD_NAME_NUM_SUBTASKS) int numSubtasks,
 			@JsonProperty(FIELD_NAME_NUM_ACK_SUBTASKS) int numAckSubtasks) {
 
@@ -94,7 +88,6 @@ public class TaskCheckpointStatistics implements ResponseBody {
 		this.latestAckTimestamp = latestAckTimestamp;
 		this.stateSize = stateSize;
 		this.duration = duration;
-		this.alignmentBuffered = alignmentBuffered;
 		this.numSubtasks = numSubtasks;
 		this.numAckSubtasks = numAckSubtasks;
 	}
@@ -140,7 +133,6 @@ public class TaskCheckpointStatistics implements ResponseBody {
 			latestAckTimestamp == that.latestAckTimestamp &&
 			stateSize == that.stateSize &&
 			duration == that.duration &&
-			alignmentBuffered == that.alignmentBuffered &&
 			numSubtasks == that.numSubtasks &&
 			numAckSubtasks == that.numAckSubtasks &&
 			checkpointStatus == that.checkpointStatus;
@@ -148,6 +140,6 @@ public class TaskCheckpointStatistics implements ResponseBody {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(checkpointId, checkpointStatus, latestAckTimestamp, stateSize, duration, alignmentBuffered, numSubtasks, numAckSubtasks);
+		return Objects.hash(checkpointId, checkpointStatus, latestAckTimestamp, stateSize, duration, numSubtasks, numAckSubtasks);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
@@ -50,7 +50,6 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
 			@JsonProperty(FIELD_NAME_LATEST_ACK_TIMESTAMP) long latestAckTimestamp,
 			@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 			@JsonProperty(FIELD_NAME_DURATION) long duration,
-			@JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) long alignmentBuffered,
 			@JsonProperty(FIELD_NAME_NUM_SUBTASKS) int numSubtasks,
 			@JsonProperty(FIELD_NAME_NUM_ACK_SUBTASKS) int numAckSubtasks,
 			@JsonProperty(FIELD_NAME_SUMMARY) Summary summary,
@@ -61,7 +60,6 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
 			latestAckTimestamp,
 			stateSize,
 			duration,
-			alignmentBuffered,
 			numSubtasks,
 			numAckSubtasks);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
@@ -42,8 +42,7 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 		final CheckpointingStatistics.Counts counts = new CheckpointingStatistics.Counts(1, 2, 3, 4, 5);
 		final CheckpointingStatistics.Summary summary = new CheckpointingStatistics.Summary(
 			new MinMaxAvgStatistics(1L, 1L, 1L),
-			new MinMaxAvgStatistics(2L, 2L, 2L),
-			new MinMaxAvgStatistics(3L, 3L, 3L));
+			new MinMaxAvgStatistics(2L, 2L, 2L));
 
 		final Map<JobVertexID, TaskCheckpointStatistics> checkpointStatisticsPerTask = new HashMap<>(2);
 
@@ -55,9 +54,8 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 				1L,
 				2L,
 				3L,
-				4L,
-				5,
-				6));
+				4,
+				5));
 
 		checkpointStatisticsPerTask.put(
 			new JobVertexID(),
@@ -67,9 +65,8 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 				2L,
 				3L,
 				4L,
-				5L,
-				6,
-				7));
+				5,
+				6));
 
 		final CheckpointStatistics.CompletedCheckpointStatistics completed = new CheckpointStatistics.CompletedCheckpointStatistics(
 			1L,
@@ -79,7 +76,6 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 			41L,
 			1337L,
 			1L,
-			0L,
 			10,
 			10,
 			Collections.emptyMap(),
@@ -94,7 +90,6 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 			10L,
 			43L,
 			1L,
-			0L,
 			9,
 			9,
 			checkpointStatisticsPerTask,
@@ -109,7 +104,6 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 			10L,
 			4L,
 			2L,
-			0L,
 			11,
 			9,
 			Collections.emptyMap(),
@@ -130,7 +124,6 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 			41L,
 			1337L,
 			1L,
-			0L,
 			10,
 			10,
 			Collections.emptyMap()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsTest.java
@@ -39,7 +39,6 @@ public class TaskCheckpointStatisticsTest extends RestResponseMarshallingTestBas
 			42L,
 			1L,
 			23L,
-			1337L,
 			9,
 			8);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
@@ -56,7 +56,7 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest extends RestResponse
 			13L,
 			1337L,
 			new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointDuration(1L, 2L),
-			new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointAlignment(2L, 3L),
+			new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointAlignment(2L),
 			42L));
 
 		return new TaskCheckpointStatisticsWithSubtaskDetails(
@@ -65,7 +65,6 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest extends RestResponse
 			4L,
 			1337L,
 			1L,
-			2L,
 			8,
 			9,
 			summary,


### PR DESCRIPTION
## What is the purpose of the change

*After avoid caching buffers for blocked input channels before barrier alignment, runtime never cache buffers while checkpoint barrier alignment, therefore checkpoint alignment buffered metric would always be 0, which should remove it directly in `CheckpointStatistics `, `CheckpointingStatistics`, `TaskCheckpointStatistics`, `TaskCheckpointStatisticsWithSubtaskDetails` and `SubtaskCheckpointStatistics`.*

## Brief change log

  - *Remove `alignmentBuffered` attribute in `CheckpointStatistics `, `CheckpointingStatistics`, `TaskCheckpointStatistics`, `TaskCheckpointStatisticsWithSubtaskDetails` and `SubtaskCheckpointStatistics`*
  - *Remove `alignment_buffered` in Checkpoint Detail from `job-checkpoints.component.html`.*
  - *Remove `alignment_buffered` column in document of `/jobs/:jobid/checkpoints` rest interface.*

## Verifying this change

  - *Modify test object create by `CheckpointStatistics `, `CheckpointingStatistics`, `TaskCheckpointStatistics`, `TaskCheckpointStatisticsWithSubtaskDetails` and `SubtaskCheckpointStatistics` in `CheckpointingStatisticsTest`, `TaskCheckpointStatisticsTest` and `TaskCheckpointStatisticsWithSubtaskDetailsTest`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
