### PR TITLE
[FLINK-17916][API] Provide API to separate KafkaShuffle's Producer and Consumer to different environments

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
@@ -31,10 +31,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.util.concurrent.CompletableFuture;
+
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.IngestionTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.ProcessingTime;
 import static org.apache.flink.test.util.TestUtils.tryExecute;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Failure Recovery IT Test for KafkaShuffle.
@@ -45,118 +48,205 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
 	public final Timeout timeout = Timeout.millis(600000L);
 
 	/**
-	 * Failure Recovery after processing 2/3 data with time characteristic: ProcessingTime.
+	 * Failure Recovery after processing 1/3 data with time characteristic: ProcessingTime.
 	 *
 	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testFailureRecoveryProcessingTime() throws Exception {
-		testKafkaShuffleFailureRecovery(1000, ProcessingTime);
+	public void testFailureRecoveryProcessingTimeSameEnv() throws Exception {
+		testKafkaShuffleFailureRecovery(1000, ProcessingTime, true);
 	}
 
 	/**
-	 * Failure Recovery after processing 2/3 data with time characteristic: IngestionTime.
+	 * Failure Recovery after processing 1/3 data with time characteristic: ProcessingTime.
 	 *
 	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in different environments
 	 */
 	@Test
-	public void testFailureRecoveryIngestionTime() throws Exception {
-		testKafkaShuffleFailureRecovery(1000, IngestionTime);
+	public void testFailureRecoveryProcessingTimeDifferentEnv() throws Exception {
+		testKafkaShuffleFailureRecovery(1000, ProcessingTime, false);
 	}
 
 	/**
-	 * Failure Recovery after processing 2/3 data with time characteristic: EventTime.
+	 * Failure Recovery after processing 1/3 data with time characteristic: IngestionTime.
 	 *
 	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testFailureRecoveryEventTime() throws Exception {
-		testKafkaShuffleFailureRecovery(1000, EventTime);
+	public void testFailureRecoveryIngestionTimeSameEnv() throws Exception {
+		testKafkaShuffleFailureRecovery(1000, IngestionTime, true);
+	}
+
+	/**
+	 * Failure Recovery after processing 1/3 data with time characteristic: IngestionTime.
+	 *
+	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testFailureRecoveryIngestionTimeDifferentEnv() throws Exception {
+		testKafkaShuffleFailureRecovery(1000, IngestionTime, false);
+	}
+
+	/**
+	 * Failure Recovery after processing 1/3 data with time characteristic: EventTime.
+	 *
+	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in the same environment
+	 */
+	@Test
+	public void testFailureRecoveryEventTimeSameEnv() throws Exception {
+		testKafkaShuffleFailureRecovery(1000, EventTime, true);
+	}
+
+	/**
+	 * Failure Recovery after processing 1/3 data with time characteristic: EventTime.
+	 *
+	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testFailureRecoveryEventTimeDifferentEnv() throws Exception {
+		testKafkaShuffleFailureRecovery(1000, EventTime, false);
 	}
 
 	/**
 	 * Failure Recovery after data is repartitioned with time characteristic: ProcessingTime.
 	 *
 	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testAssignedToPartitionFailureRecoveryProcessingTime() throws Exception {
-		testAssignedToPartitionFailureRecovery(500, ProcessingTime);
+	public void testAssignedToPartitionFailureRecoveryProcessingTimeSameEnv() throws Exception {
+		testAssignedToPartitionFailureRecovery(500, ProcessingTime, true);
+	}
+
+	/**
+	 * Failure Recovery after data is repartitioned with time characteristic: ProcessingTime.
+	 *
+	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testAssignedToPartitionFailureRecoveryProcessingTimeDifferentEnv() throws Exception {
+		testAssignedToPartitionFailureRecovery(500, ProcessingTime, false);
 	}
 
 	/**
 	 * Failure Recovery after data is repartitioned with time characteristic: IngestionTime.
 	 *
 	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testAssignedToPartitionFailureRecoveryIngestionTime() throws Exception {
-		testAssignedToPartitionFailureRecovery(500, IngestionTime);
+	public void testAssignedToPartitionFailureRecoveryIngestionTimeSameEnv() throws Exception {
+		testAssignedToPartitionFailureRecovery(500, IngestionTime, true);
+	}
+
+	/**
+	 * Failure Recovery after data is repartitioned with time characteristic: IngestionTime.
+	 *
+	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testAssignedToPartitionFailureRecoveryIngestionTimeDifferentEnv() throws Exception {
+		testAssignedToPartitionFailureRecovery(500, IngestionTime, false);
 	}
 
 	/**
 	 * Failure Recovery after data is repartitioned with time characteristic: EventTime.
 	 *
 	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testAssignedToPartitionFailureRecoveryEventTime() throws Exception {
-		testAssignedToPartitionFailureRecovery(500, EventTime);
+	public void testAssignedToPartitionFailureRecoveryEventTimeSameEnv() throws Exception {
+		testAssignedToPartitionFailureRecovery(500, EventTime, true);
 	}
 
 	/**
-	 * To test failure recovery after processing 2/3 data.
+	 * Failure Recovery after data is repartitioned with time characteristic: EventTime.
+	 *
+	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testAssignedToPartitionFailureRecoveryEventTimeDifferentEnv() throws Exception {
+		testAssignedToPartitionFailureRecovery(500, EventTime, false);
+	}
+
+	/**
+	 * To test failure recovery after processing 1/3 data.
 	 *
 	 * <p>Schema: (key, timestamp, source instance Id).
 	 * Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1
 	 */
 	private void testKafkaShuffleFailureRecovery(
 			int numElementsPerProducer,
-			TimeCharacteristic timeCharacteristic) throws Exception {
-
-		String topic = topic("failure_recovery", timeCharacteristic);
+			TimeCharacteristic timeCharacteristic,
+			boolean sameEnvironment) throws Exception {
+		String topic = topic("failure_recovery", timeCharacteristic, sameEnvironment);
 		final int numberOfPartitions = 1;
 		final int producerParallelism = 1;
-		final int failAfterElements = numElementsPerProducer * numberOfPartitions * 2 / 3;
+		final int failAfterElements = numElementsPerProducer * numberOfPartitions / 3;
 
 		createTestTopic(topic, numberOfPartitions, 1);
 
-		final StreamExecutionEnvironment env =
-			createEnvironment(producerParallelism, timeCharacteristic).enableCheckpointing(500);
+		final StreamExecutionEnvironment writeEnv = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment readEnv =
+			sameEnvironment ? writeEnv : createEnvironment(producerParallelism, timeCharacteristic);
 
 		createKafkaShuffle(
-			env, topic, numElementsPerProducer, producerParallelism, timeCharacteristic, numberOfPartitions)
+			writeEnv, readEnv, topic, numElementsPerProducer, producerParallelism, timeCharacteristic, numberOfPartitions)
 			.map(new FailingIdentityMapper<>(failAfterElements)).setParallelism(1)
 			.map(new ToInteger(producerParallelism)).setParallelism(1)
 			.addSink(new ValidatingExactlyOnceSink(numElementsPerProducer * producerParallelism)).setParallelism(1);
 
 		FailingIdentityMapper.failedBefore = false;
 
-		tryExecute(env, topic);
+		CompletableFuture<String> completableFuture = CompletableFuture.completedFuture("Failed");
+		if (!sameEnvironment) {
+			completableFuture = asyncExecute(writeEnv);
+		}
+
+		tryExecute(readEnv, topic);
+
+		if (!sameEnvironment) {
+			String result = completableFuture.get();
+			assertEquals("Succeed", result);
+		}
 
 		deleteTestTopic(topic);
 	}
 
 	/**
-	 * To test failure recovery with partition assignment after processing 2/3 data.
+	 * To test failure recovery with partition assignment after processing 1/3 data.
 	 *
 	 * <p>Schema: (key, timestamp, source instance Id).
 	 * Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3
 	 */
 	private void testAssignedToPartitionFailureRecovery(
 			int numElementsPerProducer,
-			TimeCharacteristic timeCharacteristic) throws Exception {
-		String topic = topic("partition_failure_recovery", timeCharacteristic);
+			TimeCharacteristic timeCharacteristic,
+			boolean sameEnvironment) throws Exception {
+		String topic = topic("partition_failure_recovery", timeCharacteristic, sameEnvironment);
 		final int numberOfPartitions = 3;
 		final int producerParallelism = 2;
-		final int failAfterElements = numElementsPerProducer * producerParallelism * 2 / 3;
+		final int failAfterElements = numElementsPerProducer * producerParallelism / 3;
 
 		createTestTopic(topic, numberOfPartitions, 1);
 
-		final StreamExecutionEnvironment env = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment writeEnv = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment readEnv =
+			sameEnvironment ? writeEnv : createEnvironment(producerParallelism, timeCharacteristic);
 
 		KeyedStream<Tuple3<Integer, Long, Integer>, Tuple> keyedStream = createKafkaShuffle(
-			env,
+			writeEnv,
+			readEnv,
 			topic,
 			numElementsPerProducer,
 			producerParallelism,
@@ -171,7 +261,17 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
 
 		FailingIdentityMapper.failedBefore = false;
 
-		tryExecute(env, topic);
+		CompletableFuture<String> completableFuture = CompletableFuture.completedFuture("Failed");
+		if (!sameEnvironment) {
+			completableFuture = asyncExecute(writeEnv);
+		}
+
+		tryExecute(readEnv, topic);
+
+		if (!sameEnvironment) {
+			String result = completableFuture.get();
+			assertEquals("Succeed", result);
+		}
 
 		deleteTestTopic(topic);
 	}
@@ -179,10 +279,17 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
 	private StreamExecutionEnvironment createEnvironment(
 			int producerParallelism,
 			TimeCharacteristic timeCharacteristic) {
+		return createEnvironment(producerParallelism, timeCharacteristic, 1);
+	}
+
+	private StreamExecutionEnvironment createEnvironment(
+			int producerParallelism,
+			TimeCharacteristic timeCharacteristic,
+			int numberOfRestart) {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(producerParallelism);
 		env.setStreamTimeCharacteristic(timeCharacteristic);
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(numberOfRestart, 0));
 		env.setBufferTimeout(0);
 		env.enableCheckpointing(500);
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.IngestionTime;
@@ -56,6 +57,7 @@ import static org.apache.flink.streaming.api.TimeCharacteristic.ProcessingTime;
 import static org.apache.flink.streaming.connectors.kafka.shuffle.FlinkKafkaShuffle.PARTITION_NUMBER;
 import static org.apache.flink.streaming.connectors.kafka.shuffle.FlinkKafkaShuffle.PRODUCER_PARALLELISM;
 import static org.apache.flink.test.util.TestUtils.tryExecute;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -69,71 +71,155 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 	/**
 	 * To test no data is lost or duplicated end-2-end with the default time characteristic: ProcessingTime.
 	 *
-	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1;
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testSimpleProcessingTime() throws Exception {
-		testKafkaShuffle(200000, ProcessingTime);
+	public void testSimpleProcessingTimeSameEnv() throws Exception {
+		testKafkaShuffle(200000, ProcessingTime, true);
+	}
+
+	/**
+	 * To test no data is lost or duplicated end-2-end with the default time characteristic: ProcessingTime.
+	 *
+	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1;
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testSimpleProcessingTimeDifferentEnv() throws Exception {
+		testKafkaShuffle(200000, ProcessingTime, false);
 	}
 
 	/**
 	 * To test no data is lost or duplicated end-2-end with time characteristic: IngestionTime.
 	 *
 	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testSimpleIngestionTime() throws Exception {
-		testKafkaShuffle(200000, IngestionTime);
+	public void testSimpleIngestionTimeSameEnv() throws Exception {
+		testKafkaShuffle(200000, IngestionTime, true);
+	}
+
+	/**
+	 * To test no data is lost or duplicated end-2-end with time characteristic: IngestionTime.
+	 *
+	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testSimpleIngestionTimeDifferentEnv() throws Exception {
+		testKafkaShuffle(200000, IngestionTime, false);
 	}
 
 	/**
 	 * To test no data is lost or duplicated end-2-end with time characteristic: EventTime.
 	 *
 	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testSimpleEventTime() throws Exception {
-		testKafkaShuffle(100000, EventTime);
+	public void testSimpleEventTimeSameEnv() throws Exception {
+		testKafkaShuffle(100000, EventTime, true);
+	}
+
+	/**
+	 * To test no data is lost or duplicated end-2-end with time characteristic: EventTime.
+	 *
+	 * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testSimpleEventTimeDifferentEnv() throws Exception {
+		testKafkaShuffle(100000, EventTime, false);
 	}
 
 	/**
 	 * To test data is partitioned to the right partition with time characteristic: ProcessingTime.
 	 *
 	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testAssignedToPartitionProcessingTime() throws Exception {
-		testAssignedToPartition(300000, ProcessingTime);
+	public void testAssignedToPartitionProcessingTimeSameEnv() throws Exception {
+		testAssignedToPartition(300000, ProcessingTime, true);
+	}
+
+	/**
+	 * To test data is partitioned to the right partition with time characteristic: ProcessingTime.
+	 *
+	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testAssignedToPartitionProcessingTimeDifferentEnv() throws Exception {
+		testAssignedToPartition(300000, ProcessingTime, false);
 	}
 
 	/**
 	 * To test data is partitioned to the right partition with time characteristic: IngestionTime.
 	 *
 	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testAssignedToPartitionIngestionTime() throws Exception {
-		testAssignedToPartition(300000, IngestionTime);
+	public void testAssignedToPartitionIngestionTimeSameEnv() throws Exception {
+		testAssignedToPartition(300000, IngestionTime, true);
+	}
+
+	/**
+	 * To test data is partitioned to the right partition with time characteristic: IngestionTime.
+	 *
+	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testAssignedToPartitionIngestionTimeDifferentEnv() throws Exception {
+		testAssignedToPartition(300000, IngestionTime, false);
 	}
 
 	/**
 	 * To test data is partitioned to the right partition with time characteristic: EventTime.
 	 *
 	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testAssignedToPartitionEventTime() throws Exception {
-		testAssignedToPartition(100000, EventTime);
+	public void testAssignedToPartitionEventTimeSameEnv() throws Exception {
+		testAssignedToPartition(100000, EventTime, true);
+	}
+
+	/**
+	 * To test data is partitioned to the right partition with time characteristic: EventTime.
+	 *
+	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testAssignedToPartitionEventTimeDifferentEnv() throws Exception {
+		testAssignedToPartition(100000, EventTime, false);
 	}
 
 	/**
 	 * To test watermark is monotonically incremental with randomized watermark.
 	 *
 	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in the same environment
 	 */
 	@Test
-	public void testWatermarkIncremental() throws Exception {
-		testWatermarkIncremental(100000);
+	public void testWatermarkIncrementalSameEnv() throws Exception {
+		testWatermarkIncremental(100000, true);
+	}
+
+	/**
+	 * To test watermark is monotonically incremental with randomized watermark.
+	 *
+	 * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
+	 * producer and consumer run in different environments
+	 */
+	@Test
+	public void testWatermarkIncrementalDifferentEnv() throws Exception {
+		testWatermarkIncremental(100000, false);
 	}
 
 	/**
@@ -240,16 +326,21 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 	 */
 	private void testKafkaShuffle(
 			int numElementsPerProducer,
-			TimeCharacteristic timeCharacteristic) throws Exception {
-		String topic = topic("test_simple", timeCharacteristic);
+			TimeCharacteristic timeCharacteristic,
+			boolean sameEnvironment) throws Exception {
+		String topic = topic("test_simple", timeCharacteristic, sameEnvironment);
 		final int numberOfPartitions = 1;
 		final int producerParallelism = 1;
 
 		createTestTopic(topic, numberOfPartitions, 1);
 
-		final StreamExecutionEnvironment env = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment writeEnv = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment readEnv =
+			sameEnvironment ? writeEnv : createEnvironment(producerParallelism, timeCharacteristic);
+
 		createKafkaShuffle(
-				env,
+				writeEnv,
+				readEnv,
 				topic,
 				numElementsPerProducer,
 				producerParallelism,
@@ -258,7 +349,17 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 			.map(new ElementCountNoMoreThanValidator(numElementsPerProducer * producerParallelism)).setParallelism(1)
 			.map(new ElementCountNoLessThanValidator(numElementsPerProducer * producerParallelism)).setParallelism(1);
 
-		tryExecute(env, topic);
+		CompletableFuture<String> completableFuture = CompletableFuture.completedFuture("Failed");
+		if (!sameEnvironment) {
+			completableFuture = asyncExecute(writeEnv);
+		}
+
+		tryExecute(readEnv, topic);
+
+		if (!sameEnvironment) {
+			String result = completableFuture.get();
+			assertEquals("Succeed", result);
+		}
 
 		deleteTestTopic(topic);
 	}
@@ -271,17 +372,21 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 	 */
 	private void testAssignedToPartition(
 			int numElementsPerProducer,
-			TimeCharacteristic timeCharacteristic) throws Exception {
-		String topic = topic("test_assigned_to_partition", timeCharacteristic);
+			TimeCharacteristic timeCharacteristic,
+			boolean sameEnvironment) throws Exception {
+		String topic = topic("test_assigned_to_partition", timeCharacteristic, sameEnvironment);
 		final int numberOfPartitions = 3;
 		final int producerParallelism = 2;
 
 		createTestTopic(topic, numberOfPartitions, 1);
 
-		final StreamExecutionEnvironment env = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment writeEnv = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment readEnv =
+			sameEnvironment ? writeEnv : createEnvironment(producerParallelism, timeCharacteristic);
 
 		KeyedStream<Tuple3<Integer, Long, Integer>, Tuple> keyedStream = createKafkaShuffle(
-			env,
+			writeEnv,
+			readEnv,
 			topic,
 			numElementsPerProducer,
 			producerParallelism,
@@ -293,7 +398,17 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 			.map(new ElementCountNoMoreThanValidator(numElementsPerProducer * producerParallelism)).setParallelism(1)
 			.map(new ElementCountNoLessThanValidator(numElementsPerProducer * producerParallelism)).setParallelism(1);
 
-		tryExecute(env, topic);
+		CompletableFuture<String> completableFuture = CompletableFuture.completedFuture("Failed");
+		if (!sameEnvironment) {
+			completableFuture = asyncExecute(writeEnv);
+		}
+
+		tryExecute(readEnv, topic);
+
+		if (!sameEnvironment) {
+			String result = completableFuture.get();
+			assertEquals("Succeed", result);
+		}
 
 		deleteTestTopic(topic);
 	}
@@ -304,18 +419,21 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 	 * <p>Schema: (key, timestamp, source instance Id).
 	 * Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3
 	 */
-	private void testWatermarkIncremental(int numElementsPerProducer) throws Exception {
+	private void testWatermarkIncremental(int numElementsPerProducer, boolean sameEnvironment) throws Exception {
 		TimeCharacteristic timeCharacteristic = EventTime;
-		String topic = topic("test_watermark_incremental", timeCharacteristic);
+		String topic = topic("test_watermark_incremental", timeCharacteristic, sameEnvironment);
 		final int numberOfPartitions = 3;
 		final int producerParallelism = 2;
 
 		createTestTopic(topic, numberOfPartitions, 1);
 
-		final StreamExecutionEnvironment env = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment writeEnv = createEnvironment(producerParallelism, timeCharacteristic);
+		final StreamExecutionEnvironment readEnv =
+			sameEnvironment ? writeEnv : createEnvironment(producerParallelism, timeCharacteristic);
 
 		KeyedStream<Tuple3<Integer, Long, Integer>, Tuple> keyedStream = createKafkaShuffle(
-			env,
+			writeEnv,
+			readEnv,
 			topic,
 			numElementsPerProducer,
 			producerParallelism,
@@ -328,7 +446,17 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 			.map(new ElementCountNoMoreThanValidator(numElementsPerProducer * producerParallelism)).setParallelism(1)
 			.map(new ElementCountNoLessThanValidator(numElementsPerProducer * producerParallelism)).setParallelism(1);
 
-		tryExecute(env, topic);
+		CompletableFuture<String> completableFuture = CompletableFuture.completedFuture("Failed");
+		if (!sameEnvironment) {
+			completableFuture = asyncExecute(writeEnv);
+		}
+
+		tryExecute(readEnv, topic);
+
+		if (!sameEnvironment) {
+			String result = completableFuture.get();
+			assertEquals("Succeed", result);
+		}
 
 		deleteTestTopic(topic);
 	}


### PR DESCRIPTION
## What is the purpose of the change
Provide an API to make KafkaShuffle's Producer and Consumer run in different environments by default.

If running in the same environment, sink and a source are recovered independently according to regional failover. However, they share the same checkpoint coordinator and correspondingly, share the same global checkpoint snapshot. In that case, if the consumer fails, the producer can not commit data because of the incomplete checkpoint (the producer needs a checkpoint-complete signal to complete the second stage of two-phase commit). The same applies to the producer.

## Brief change log
- FlinkKafkaShuffle#persistentKeyBy: Adds a separate read environment

## Verifying this change
IT tests:
- KafkaShuffleExactlyOnceITCase
- KafkaShuffleITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
