### PR TITLE
[FLINK-17958][core] Fix MathUtils#divideRoundUp bug for handling zero or negative values.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
@@ -209,12 +209,18 @@ public final class MathUtils {
 
 	/**
 	 * Divide and rounding up to integer.
-	 * E.g., divideRoundUp(3, 2) returns 2.
+	 * E.g., divideRoundUp(3, 2) returns 2, divideRoundUp(0, 3) returns 0.
+	 * Note that this method does not support negative values.
 	 * @param dividend value to be divided by the divisor
 	 * @param divisor value by which the dividend is to be divided
 	 * @return the quotient rounding up to integer
 	 */
 	public static int divideRoundUp(int dividend, int divisor) {
+		Preconditions.checkArgument(dividend >= 0, "Negative dividend is not supported.");
+		Preconditions.checkArgument(divisor > 0, "Negative or zero divisor is not supported.");
+		if (dividend == 0) {
+			return 0;
+		}
 		return (dividend - 1) / divisor + 1;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
@@ -218,10 +218,7 @@ public final class MathUtils {
 	public static int divideRoundUp(int dividend, int divisor) {
 		Preconditions.checkArgument(dividend >= 0, "Negative dividend is not supported.");
 		Preconditions.checkArgument(divisor > 0, "Negative or zero divisor is not supported.");
-		if (dividend == 0) {
-			return 0;
-		}
-		return (dividend - 1) / divisor + 1;
+		return dividend == 0 ? 0 : (dividend - 1) / divisor + 1;
 	}
 
 	// ============================================================================================

--- a/flink-core/src/test/java/org/apache/flink/util/MathUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/MathUtilTest.java
@@ -21,8 +21,10 @@ package org.apache.flink.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -141,5 +143,31 @@ public class MathUtilTest {
 		Assert.assertEquals(Long.MAX_VALUE, MathUtils.flipSignBit(-1L));
 		Assert.assertEquals(42L | Long.MIN_VALUE, MathUtils.flipSignBit(42L));
 		Assert.assertEquals(-42L & Long.MAX_VALUE, MathUtils.flipSignBit(-42L));
+	}
+
+	@Test
+	public void testDivideRoundUp() {
+		assertThat(MathUtils.divideRoundUp(0, 1), is(0));
+		assertThat(MathUtils.divideRoundUp(0, 2), is(0));
+		assertThat(MathUtils.divideRoundUp(1, 1), is(1));
+		assertThat(MathUtils.divideRoundUp(1, 2), is(1));
+		assertThat(MathUtils.divideRoundUp(2, 1), is(2));
+		assertThat(MathUtils.divideRoundUp(2, 2), is(1));
+		assertThat(MathUtils.divideRoundUp(2, 3), is(1));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDivideRoundUpNegativeDividend() {
+		MathUtils.divideRoundUp(-1, 1);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDivideRoundUpNegativeDivisor() {
+		MathUtils.divideRoundUp(1, -1);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDivideRoundUpZeroDivisor() {
+		MathUtils.divideRoundUp(1, 0);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
@@ -141,10 +141,10 @@ class WorkerSpecContainerResourceAdapter {
 	}
 
 	/**
-	 * Normalize to the minimum integer that is greater or equal to 'value' and is integer multiple of 'unitValue'.
+	 * Normalize to the minimum integer that is greater or equal to 'value' and is positive integer multiple of 'unitValue'.
 	 */
 	private int normalize(final int value, final int unitValue) {
-		return MathUtils.divideRoundUp(value, unitValue) * unitValue;
+		return Math.max(MathUtils.divideRoundUp(value, unitValue), 1) * unitValue;
 	}
 
 	private boolean resourceWithinMaxAllocation(final InternalContainerResource resource) {


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the problem that `MathUtils.divideRoundUp(0, x)` returns `1` when `x > 1`. This problem causes Flink Kubernetes deployment keeps requesting for new pods even there's no pending resource requests. 

## Brief change log

- Update `MathUtils#divideRoundUp` to properly handle zero and negative values.
- Add test cases for `MathUtils#divideRoundUp`

## Verifying this change

- Add test cases in `MathUtilsTest`
- Manually verified that problem of improper requesting pod on K8s is fixed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
