### PR TITLE
[FLINK-17986] Fix check in FsCheckpointStateOutputStream.write

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -208,7 +208,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
 		@Override
 		public void write(int b) throws IOException {
-			if (outStream != null || pos >= writeBuffer.length) {
+			if (pos >= writeBuffer.length) {
 				flushToFile();
 			}
 			writeBuffer[pos++] = (byte) b;
@@ -269,7 +269,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 		 */
 		@Override
 		public void flush() throws IOException {
-			if (pos > localStateThreshold) {
+			if (outStream != null || pos > localStateThreshold) {
 				flushToFile();
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

*While implementing #12258 the check `outStream != null` was placed in `write` instead of `flush`. This PR fixes it.* 

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
