### PR TITLE
[FLINK-17610][state] Align the behavior of result of internal map state to return empty iterator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -28,6 +28,7 @@ import org.apache.flink.queryablestate.client.state.serialization.KvStateSeriali
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -140,25 +141,25 @@ class HeapMapState<K, N, UK, UV>
 	@Override
 	public Iterable<Map.Entry<UK, UV>> entries() {
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
-		return userMap == null ? null : userMap.entrySet();
+		return userMap == null ? Collections.emptySet() : userMap.entrySet();
 	}
 
 	@Override
 	public Iterable<UK> keys() {
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
-		return userMap == null ? null : userMap.keySet();
+		return userMap == null ? Collections.emptySet() : userMap.keySet();
 	}
 
 	@Override
 	public Iterable<UV> values() {
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
-		return userMap == null ? null : userMap.values();
+		return userMap == null ? Collections.emptySet() : userMap.values();
 	}
 
 	@Override
 	public Iterator<Map.Entry<UK, UV>> iterator() {
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
-		return userMap == null ? null : userMap.entrySet().iterator();
+		return userMap == null ? Collections.emptyIterator() : userMap.entrySet().iterator();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -2875,7 +2875,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 				VoidNamespaceSerializer.INSTANCE, kvId);
 
 		backend.setCurrentKey(1);
-		assertNull(state.entries());
+		assertNotNull(state.entries());
+		assertFalse(state.entries().iterator().hasNext());
 
 		state.put("Ciao", "Hello");
 		state.put("Bello", "Nice");
@@ -2885,7 +2886,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		assertEquals(state.get("Bello"), "Nice");
 
 		state.clear();
-		assertNull(state.entries());
+		assertNotNull(state.entries());
+		assertFalse(state.entries().iterator().hasNext());
 
 		backend.dispose();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateAllEntriesTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateAllEntriesTestContext.java
@@ -19,11 +19,13 @@
 package org.apache.flink.runtime.state.ttl;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -65,5 +67,10 @@ class TtlMapStateAllEntriesTestContext extends
 	@Override
 	public Object getOriginal() throws Exception {
 		return ttlState.original.entries() == null ? Collections.emptySet() : ttlState.original.entries();
+	}
+
+	@Override
+	public boolean isOriginalEmptyValue() throws Exception {
+		return Objects.equals(emptyValue, Sets.newHashSet(((Iterable<?>) getOriginal()).iterator()));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -44,6 +44,7 @@ import static org.apache.flink.runtime.state.ttl.StateBackendTestContext.NUMBER_
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -208,7 +209,7 @@ public abstract class TtlStateTestBase {
 
 		timeProvider.time = 300;
 		assertEquals(EXPIRED_UNAVAIL, ctx().emptyValue, ctx().get());
-		assertEquals("Original state should be cleared on access", ctx().emptyValue, ctx().getOriginal());
+		assertTrue("Original state should be cleared on access", ctx().isOriginalEmptyValue());
 	}
 
 	@Test
@@ -222,7 +223,7 @@ public abstract class TtlStateTestBase {
 
 		timeProvider.time = 120;
 		assertEquals(EXPIRED_AVAIL, ctx().getUpdateEmpty, ctx().get());
-		assertEquals("Original state should be cleared on access", ctx().emptyValue, ctx().getOriginal());
+		assertTrue("Original state should be cleared on access", ctx().isOriginalEmptyValue());
 		assertEquals("Expired state should be cleared on access", ctx().emptyValue, ctx().get());
 	}
 
@@ -247,7 +248,7 @@ public abstract class TtlStateTestBase {
 
 		timeProvider.time = 250;
 		assertEquals(EXPIRED_UNAVAIL, ctx().emptyValue, ctx().get());
-		assertEquals("Original state should be cleared on access", ctx().emptyValue, ctx().getOriginal());
+		assertTrue("Original state should be cleared on access", ctx().isOriginalEmptyValue());
 	}
 
 	@Test
@@ -509,7 +510,7 @@ public abstract class TtlStateTestBase {
 	private void checkExpiredKeys(int startKey, int endKey) throws Exception {
 		for (int i = startKey; i < endKey; i++) {
 			sbetc.setCurrentKey(Integer.toString(i));
-			assertEquals("Original state should be cleared", ctx().emptyValue, ctx().getOriginal());
+			assertTrue("Original state should be cleared", ctx().isOriginalEmptyValue());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestContextBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestContextBase.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 
+import java.util.Objects;
+
 /** Base class for state TTL test context. */
 public abstract class TtlStateTestContextBase<S extends InternalKvState<?, String, ?>, UV, GV> {
 	public S ttlState;
@@ -45,6 +47,10 @@ public abstract class TtlStateTestContextBase<S extends InternalKvState<?, Strin
 	public abstract GV get() throws Exception;
 
 	public abstract Object getOriginal() throws Exception;
+
+	public boolean isOriginalEmptyValue() throws Exception {
+		return Objects.equals(emptyValue, getOriginal());
+	}
 
 	public String getName() {
 		return this.getClass().getSimpleName();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -164,14 +164,7 @@ class RocksDBMapState<K, N, UK, UV>
 
 	@Override
 	public Iterable<Map.Entry<UK, UV>> entries() {
-		final Iterator<Map.Entry<UK, UV>> iterator = iterator();
-
-		// Return null to make the behavior consistent with other states.
-		if (!iterator.hasNext()) {
-			return null;
-		} else {
-			return () -> iterator;
-		}
+		return this::iterator;
 	}
 
 	@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /** Base test suite for rocksdb state TTL. */
 public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
@@ -158,11 +159,11 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
 
 		setTimeAndCompact(stateDesc, 170L);
 		sbetc.setCurrentKey("k1");
-		assertEquals("Expired original state should be unavailable", ctx().emptyValue, ctx().getOriginal());
+		assertTrue("Expired original state should be unavailable", ctx().isOriginalEmptyValue());
 		assertEquals(EXPIRED_UNAVAIL, ctx().emptyValue, ctx().get());
 
 		sbetc.setCurrentKey("k2");
-		assertEquals("Expired original state should be unavailable", ctx().emptyValue, ctx().getOriginal());
+		assertTrue("Expired original state should be unavailable", ctx().isOriginalEmptyValue());
 		assertEquals("Expired state should be unavailable", ctx().emptyValue, ctx().get());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*There are different behaviors of result of internal map state. For `HeapMapState`, #entries(), #keys(), #values(), and #iterator() would all return null. However, for `RocksDBMapState`, #entries() would return null, while #keys(), #values(), #iterator() would return empty iterator. UserFacingMapState would align behaviors to empty iterator instead of null.*

## Brief change log

  - *Modify result of `HeapMapState` #entries(), #keys(), #values(), and #iterator() method to empty iterator.*
  - *Modify result of `RocksDBMapState` #entries() method to empty iterator.*

## Verifying this change

  - *Modify `testMapStateDefaultValue()` method of `StateBackendTestBase` to verify the empty iterator return result of `entries()` behavior.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)