### PR TITLE
[FLINK-17960][python][docs] Improve commands in the "Common Questions" document for PyFlink

### DIFF
--- a/docs/dev/table/python/common_questions.md
+++ b/docs/dev/table/python/common_questions.md
@@ -33,10 +33,11 @@ You can download a [convenience script]({{ site.baseurl }}/downloads/setup-pyfli
 You can specify the version parameter to generate a Python virtual environment required for the corresponding PyFlink version, otherwise the most recent version will be installed.
 
 {% highlight bash %}
+$ curl -O {{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
 {% if site.is_stable %}
-$ setup-pyflink-virtual-env.sh {{ site.version }}
+$ sh setup-pyflink-virtual-env.sh {{ site.version }}
 {% else %}
-$ setup-pyflink-virtual-env.sh
+$ sh setup-pyflink-virtual-env.sh
 {% endif %}
 {% endhighlight bash %}
 

--- a/docs/dev/table/python/common_questions.md
+++ b/docs/dev/table/python/common_questions.md
@@ -33,7 +33,6 @@ You can download a [convenience script]({{ site.baseurl }}/downloads/setup-pyfli
 You can specify the version parameter to generate a Python virtual environment required for the corresponding PyFlink version, otherwise the most recent version will be installed.
 
 {% highlight bash %}
-$ curl -O https:{{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
 {% if site.is_stable %}
 $ sh setup-pyflink-virtual-env.sh {{ site.version }}
 {% else %}

--- a/docs/dev/table/python/common_questions.md
+++ b/docs/dev/table/python/common_questions.md
@@ -33,7 +33,7 @@ You can download a [convenience script]({{ site.baseurl }}/downloads/setup-pyfli
 You can specify the version parameter to generate a Python virtual environment required for the corresponding PyFlink version, otherwise the most recent version will be installed.
 
 {% highlight bash %}
-$ curl -O {{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
+$ curl -O https:{{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
 {% if site.is_stable %}
 $ sh setup-pyflink-virtual-env.sh {{ site.version }}
 {% else %}

--- a/docs/dev/table/python/common_questions.zh.md
+++ b/docs/dev/table/python/common_questions.zh.md
@@ -33,10 +33,11 @@ You can download a [convenience script]({{ site.baseurl }}/downloads/setup-pyfli
 You can specify the version parameter to generate a Python virtual environment required for the corresponding PyFlink version, otherwise the most recent version will be installed.
 
 {% highlight bash %}
+$ curl -O {{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
 {% if site.is_stable %}
-$ setup-pyflink-virtual-env.sh {{ site.version }}
+$ sh setup-pyflink-virtual-env.sh {{ site.version }}
 {% else %}
-$ setup-pyflink-virtual-env.sh
+$ sh setup-pyflink-virtual-env.sh
 {% endif %}
 {% endhighlight bash %}
 

--- a/docs/dev/table/python/common_questions.zh.md
+++ b/docs/dev/table/python/common_questions.zh.md
@@ -33,7 +33,6 @@ You can download a [convenience script]({{ site.baseurl }}/downloads/setup-pyfli
 You can specify the version parameter to generate a Python virtual environment required for the corresponding PyFlink version, otherwise the most recent version will be installed.
 
 {% highlight bash %}
-$ curl -O https:{{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
 {% if site.is_stable %}
 $ sh setup-pyflink-virtual-env.sh {{ site.version }}
 {% else %}

--- a/docs/dev/table/python/common_questions.zh.md
+++ b/docs/dev/table/python/common_questions.zh.md
@@ -33,7 +33,7 @@ You can download a [convenience script]({{ site.baseurl }}/downloads/setup-pyfli
 You can specify the version parameter to generate a Python virtual environment required for the corresponding PyFlink version, otherwise the most recent version will be installed.
 
 {% highlight bash %}
-$ curl -O {{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
+$ curl -O https:{{ site.baseurl }}/downloads/setup-pyflink-virtual-env.sh
 {% if site.is_stable %}
 $ sh setup-pyflink-virtual-env.sh {{ site.version }}
 {% else %}


### PR DESCRIPTION
## What is the purpose of the change

*Currently in "Common Questions" document, the command `$ setup-pyflink-virtual-env.sh` to run the script, which is not executable. It would be better to add download command and replace the command with `$ sh setup-pyflink-virtual-env.sh`.*

## Brief change log

  - *Modify script in `Preparing Python Virtual Environment` for "Common Questions" document with English and Chinese language.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
