### PR TITLE
[FLINK-17375][hotfix] Fix print_stacktraces multiline-behavior

### DIFF
--- a/tools/ci/controller_utils.sh
+++ b/tools/ci/controller_utils.sh
@@ -47,9 +47,9 @@ print_stacktraces () {
 	echo "=============================================================================="
 
 	JAVA_PROCESSES=`jps`
-	echo $JAVA_PROCESSES
+	echo "$JAVA_PROCESSES"
 
-	local pids=( $(echo $JAVA_PROCESSES | awk '{print $1}') )
+	local pids=( $(echo "$JAVA_PROCESSES" | awk '{print $1}') )
 
 	for pid in "${pids[@]}"; do
 		echo "=============================================================================="


### PR DESCRIPTION
## What is the purpose of the change

```bash
echo $VAR   # does not preserve newlines
echo "$VAR" # does print newlines as well
```