### PR TITLE
[FLINK-17946][python] fix the bug that the config option 'pipeline.jars' doesn't work.

### DIFF
--- a/docs/dev/table/python/common_questions.md
+++ b/docs/dev/table/python/common_questions.md
@@ -69,11 +69,11 @@ A PyFlink job may depend on jar files, i.e. connectors, Java UDFs, etc.
 You can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command-line arguments</a> directly when submitting the job.
 
 {% highlight python %}
-# NOTE: Only local file URLs (start with "file://") are supported.
-table_env.get_config().set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# NOTE: Only local file URLs (start with "file:") are supported.
+table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
-# NOTE: The Paths must specify a protocol (e.g. file://) and users should ensure that the URLs are accessible on both the client and the cluster.
-table_env.get_config().set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# NOTE: The Paths must specify a protocol (e.g. "file") and users should ensure that the URLs are accessible on both the client and the cluster.
+table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
 For details about the APIs of adding Java dependency, you can refer to [the relevant documentation]({{ site.baseurl }}/dev/table/python/dependency_management.html##java-dependency)

--- a/docs/dev/table/python/common_questions.zh.md
+++ b/docs/dev/table/python/common_questions.zh.md
@@ -69,11 +69,11 @@ A PyFlink job may depend on jar files, i.e. connectors, Java UDFs, etc.
 You can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/zh/ops/cli.html#usage">command-line arguments</a> directly when submitting the job.
 
 {% highlight python %}
-# NOTE: Only local file URLs (start with "file://") are supported.
-table_env.get_config().set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# NOTE: Only local file URLs (start with "file:") are supported.
+table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
-# NOTE: The Paths must specify a protocol (e.g. file://) and users should ensure that the URLs are accessible on both the client and the cluster.
-table_env.get_config().set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# NOTE: The Paths must specify a protocol (e.g. "file") and users should ensure that the URLs are accessible on both the client and the cluster.
+table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
 For details about the APIs of adding Java dependency, you can refer to [the relevant documentation]({{ site.baseurl }}/zh/dev/table/python/dependency_management.html##java-dependency)

--- a/flink-python/pyflink/ml/api/base.py
+++ b/flink-python/pyflink/ml/api/base.py
@@ -110,7 +110,7 @@ class JavaTransformer(Transformer):
         :returns: the transformed table
         """
         self._convert_params_to_java(self._j_obj)
-        return Table(self._j_obj.transform(table_env._j_tenv, table._j_table))
+        return Table(self._j_obj.transform(table_env._j_tenv, table._j_table), table_env)
 
 
 class Model(Transformer):

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
 from pyflink.table.table_result import TableResult
 from pyflink.util.utils import to_j_explain_detail_arr
 

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
+from pyflink.table.table_result import TableResult
 from pyflink.util.utils import to_j_explain_detail_arr
 
 __all__ = ['StatementSet']
@@ -34,8 +34,9 @@ class StatementSet(object):
 
     """
 
-    def __init__(self, _j_statement_set):
+    def __init__(self, _j_statement_set, t_env):
         self._j_statement_set = _j_statement_set
+        self._t_env = t_env
 
     def add_insert_sql(self, stmt):
         """
@@ -89,5 +90,5 @@ class StatementSet(object):
 
         :return: execution result.
         """
-        # TODO convert java TableResult to python TableResult once FLINK-17303 is finished
-        return self._j_statement_set.execute()
+        self._t_env._before_execute()
+        return TableResult(self._j_statement_set.execute())

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -22,6 +22,7 @@ from py4j.java_gateway import get_method
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table.serializers import ArrowSerializer
+from pyflink.table.table_result import TableResult
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import create_arrow_schema
 from pyflink.table.utils import tz_convert_from_internal
@@ -62,8 +63,9 @@ class Table(object):
     the expression syntax.
     """
 
-    def __init__(self, j_table):
+    def __init__(self, j_table, t_env):
         self._j_table = j_table
+        self._t_env = t_env
 
     def select(self, fields):
         """
@@ -80,7 +82,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.select(fields))
+        return Table(self._j_table.select(fields), self._t_env)
 
     def alias(self, field, *fields):
         """
@@ -101,7 +103,7 @@ class Table(object):
         """
         gateway = get_gateway()
         extra_fields = to_jarray(gateway.jvm.String, fields)
-        return Table(get_method(self._j_table, "as")(field, extra_fields))
+        return Table(get_method(self._j_table, "as")(field, extra_fields), self._t_env)
 
     def filter(self, predicate):
         """
@@ -118,7 +120,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.filter(predicate))
+        return Table(self._j_table.filter(predicate), self._t_env)
 
     def where(self, predicate):
         """
@@ -135,7 +137,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.where(predicate))
+        return Table(self._j_table.where(predicate), self._t_env)
 
     def group_by(self, fields):
         """
@@ -152,7 +154,7 @@ class Table(object):
         :return: The grouped table.
         :rtype: pyflink.table.GroupedTable
         """
-        return GroupedTable(self._j_table.groupBy(fields))
+        return GroupedTable(self._j_table.groupBy(fields), self._t_env)
 
     def distinct(self):
         """
@@ -166,7 +168,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.distinct())
+        return Table(self._j_table.distinct(), self._t_env)
 
     def join(self, right, join_predicate=None):
         """
@@ -193,9 +195,9 @@ class Table(object):
         :rtype: pyflink.table.Table
         """
         if join_predicate is not None:
-            return Table(self._j_table.join(right._j_table, join_predicate))
+            return Table(self._j_table.join(right._j_table, join_predicate), self._t_env)
         else:
-            return Table(self._j_table.join(right._j_table))
+            return Table(self._j_table.join(right._j_table), self._t_env)
 
     def left_outer_join(self, right, join_predicate=None):
         """
@@ -222,9 +224,9 @@ class Table(object):
         :rtype: pyflink.table.Table
         """
         if join_predicate is None:
-            return Table(self._j_table.leftOuterJoin(right._j_table))
+            return Table(self._j_table.leftOuterJoin(right._j_table), self._t_env)
         else:
-            return Table(self._j_table.leftOuterJoin(right._j_table, join_predicate))
+            return Table(self._j_table.leftOuterJoin(right._j_table, join_predicate), self._t_env)
 
     def right_outer_join(self, right, join_predicate):
         """
@@ -249,7 +251,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.rightOuterJoin(right._j_table, join_predicate))
+        return Table(self._j_table.rightOuterJoin(right._j_table, join_predicate), self._t_env)
 
     def full_outer_join(self, right, join_predicate):
         """
@@ -274,7 +276,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.fullOuterJoin(right._j_table, join_predicate))
+        return Table(self._j_table.fullOuterJoin(right._j_table, join_predicate), self._t_env)
 
     def join_lateral(self, table_function_call, join_predicate=None):
         """
@@ -297,9 +299,10 @@ class Table(object):
         :rtype: pyflink.table.Table
         """
         if join_predicate is None:
-            return Table(self._j_table.joinLateral(table_function_call))
+            return Table(self._j_table.joinLateral(table_function_call), self._t_env)
         else:
-            return Table(self._j_table.joinLateral(table_function_call, join_predicate))
+            return Table(self._j_table.joinLateral(table_function_call, join_predicate),
+                         self._t_env)
 
     def left_outer_join_lateral(self, table_function_call, join_predicate=None):
         """
@@ -323,9 +326,10 @@ class Table(object):
         :rtype: pyflink.table.Table
         """
         if join_predicate is None:
-            return Table(self._j_table.leftOuterJoinLateral(table_function_call))
+            return Table(self._j_table.leftOuterJoinLateral(table_function_call), self._t_env)
         else:
-            return Table(self._j_table.leftOuterJoinLateral(table_function_call, join_predicate))
+            return Table(self._j_table.leftOuterJoinLateral(table_function_call, join_predicate),
+                         self._t_env)
 
     def minus(self, right):
         """
@@ -348,7 +352,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.minus(right._j_table))
+        return Table(self._j_table.minus(right._j_table), self._t_env)
 
     def minus_all(self, right):
         """
@@ -372,7 +376,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.minusAll(right._j_table))
+        return Table(self._j_table.minusAll(right._j_table), self._t_env)
 
     def union(self, right):
         """
@@ -393,7 +397,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.union(right._j_table))
+        return Table(self._j_table.union(right._j_table), self._t_env)
 
     def union_all(self, right):
         """
@@ -414,7 +418,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.unionAll(right._j_table))
+        return Table(self._j_table.unionAll(right._j_table), self._t_env)
 
     def intersect(self, right):
         """
@@ -438,7 +442,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.intersect(right._j_table))
+        return Table(self._j_table.intersect(right._j_table), self._t_env)
 
     def intersect_all(self, right):
         """
@@ -462,7 +466,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.intersectAll(right._j_table))
+        return Table(self._j_table.intersectAll(right._j_table), self._t_env)
 
     def order_by(self, fields):
         """
@@ -479,7 +483,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.orderBy(fields))
+        return Table(self._j_table.orderBy(fields), self._t_env)
 
     def offset(self, offset):
         """
@@ -502,7 +506,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.offset(offset))
+        return Table(self._j_table.offset(offset), self._t_env)
 
     def fetch(self, fetch):
         """
@@ -529,7 +533,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.fetch(fetch))
+        return Table(self._j_table.fetch(fetch), self._t_env)
 
     def window(self, window):
         """
@@ -566,7 +570,7 @@ class Table(object):
         :return: A group windowed table.
         :rtype: GroupWindowedTable
         """
-        return GroupWindowedTable(self._j_table.window(window._java_window))
+        return GroupWindowedTable(self._j_table.window(window._java_window), self._t_env)
 
     def over_window(self, *over_windows):
         """
@@ -600,7 +604,7 @@ class Table(object):
         gateway = get_gateway()
         window_array = to_jarray(gateway.jvm.OverWindow,
                                  [item._java_over_window for item in over_windows])
-        return OverWindowedTable(self._j_table.window(window_array))
+        return OverWindowedTable(self._j_table.window(window_array), self._t_env)
 
     def add_columns(self, fields):
         """
@@ -618,7 +622,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.addColumns(fields))
+        return Table(self._j_table.addColumns(fields), self._t_env)
 
     def add_or_replace_columns(self, fields):
         """
@@ -637,7 +641,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.addOrReplaceColumns(fields))
+        return Table(self._j_table.addOrReplaceColumns(fields), self._t_env)
 
     def rename_columns(self, fields):
         """
@@ -654,7 +658,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.renameColumns(fields))
+        return Table(self._j_table.renameColumns(fields), self._t_env)
 
     def drop_columns(self, fields):
         """
@@ -670,7 +674,7 @@ class Table(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.dropColumns(fields))
+        return Table(self._j_table.dropColumns(fields), self._t_env)
 
     def insert_into(self, table_path):
         """
@@ -709,6 +713,7 @@ class Table(object):
 
         :return: the result pandas DataFrame.
         """
+        self._t_env._before_execute()
         gateway = get_gateway()
         max_arrow_batch_size = self._j_table.getTableEnvironment().getConfig().getConfiguration()\
             .getInteger(gateway.jvm.org.apache.flink.python.PythonOptions.MAX_ARROW_BATCH_SIZE)
@@ -770,8 +775,8 @@ class Table(object):
         :type overwrite: bool
         :return: The table result.
         """
-        # TODO convert java TableResult to python TableResult once FLINK-17303 is finished
-        self._j_table.executeInsert(table_path, overwrite)
+        self._t_env._before_execute()
+        return TableResult(self._j_table.executeInsert(table_path, overwrite))
 
     def execute(self):
         """
@@ -784,8 +789,8 @@ class Table(object):
 
         :return: The content of the table.
         """
-        # TODO convert java TableResult to python TableResult once FLINK-17303 is finished
-        self._j_table.execute()
+        self._t_env._before_execute()
+        return TableResult(self._j_table.execute())
 
     def explain(self, *extra_details):
         """
@@ -809,8 +814,9 @@ class GroupedTable(object):
     A table that has been grouped on a set of grouping keys.
     """
 
-    def __init__(self, java_table):
+    def __init__(self, java_table, t_env):
         self._j_table = java_table
+        self._t_env = t_env
 
     def select(self, fields):
         """
@@ -828,7 +834,7 @@ class GroupedTable(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.select(fields))
+        return Table(self._j_table.select(fields), self._t_env)
 
 
 class GroupWindowedTable(object):
@@ -836,8 +842,9 @@ class GroupWindowedTable(object):
     A table that has been windowed for :class:`~pyflink.table.GroupWindow`.
     """
 
-    def __init__(self, java_group_windowed_table):
+    def __init__(self, java_group_windowed_table, t_env):
         self._j_table = java_group_windowed_table
+        self._t_env = t_env
 
     def group_by(self, fields):
         """
@@ -861,7 +868,7 @@ class GroupWindowedTable(object):
         :return: A window grouped table.
         :rtype: pyflink.table.WindowGroupedTable
         """
-        return WindowGroupedTable(self._j_table.groupBy(fields))
+        return WindowGroupedTable(self._j_table.groupBy(fields), self._t_env)
 
 
 class WindowGroupedTable(object):
@@ -869,8 +876,9 @@ class WindowGroupedTable(object):
     A table that has been windowed and grouped for :class:`~pyflink.table.window.GroupWindow`.
     """
 
-    def __init__(self, java_window_grouped_table):
+    def __init__(self, java_window_grouped_table, t_env):
         self._j_table = java_window_grouped_table
+        self._t_env = t_env
 
     def select(self, fields):
         """
@@ -888,7 +896,7 @@ class WindowGroupedTable(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.select(fields))
+        return Table(self._j_table.select(fields), self._t_env)
 
 
 class OverWindowedTable(object):
@@ -900,8 +908,9 @@ class OverWindowedTable(object):
     its neighboring rows.
     """
 
-    def __init__(self, java_over_windowed_table):
+    def __init__(self, java_over_windowed_table, t_env):
         self._j_table = java_over_windowed_table
+        self._t_env = t_env
 
     def select(self, fields):
         """
@@ -919,4 +928,4 @@ class OverWindowedTable(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
-        return Table(self._j_table.select(fields))
+        return Table(self._j_table.select(fields), self._t_env)

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -368,12 +368,101 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
         self.assert_equals(results, ['2,hi,hello\n', '3,hello,hello\n'])
 
     def test_set_jars(self):
-        self.verify_set_java_dependencies("pipeline.jars")
+        self.verify_set_java_dependencies("pipeline.jars", self.execute_with_t_env)
+
+    def test_set_jars_with_execute_sql(self):
+        self.verify_set_java_dependencies("pipeline.jars", self.execute_with_execute_sql)
+
+    def test_set_jars_with_statement_set(self):
+        self.verify_set_java_dependencies("pipeline.jars", self.execute_with_statement_set)
+
+    def test_set_jars_with_table(self):
+        self.verify_set_java_dependencies("pipeline.jars", self.execute_with_table)
+
+    def test_set_jars_with_table_execute_insert(self):
+        self.verify_set_java_dependencies("pipeline.jars", self.execute_with_table_execute_insert)
+
+    def test_set_jars_with_table_to_pandas(self):
+        self.verify_set_java_dependencies("pipeline.jars", self.execute_with_table_to_pandas)
 
     def test_set_classpaths(self):
-        self.verify_set_java_dependencies("pipeline.classpaths")
+        self.verify_set_java_dependencies("pipeline.classpaths", self.execute_with_t_env)
 
-    def verify_set_java_dependencies(self, config_key):
+    def test_set_classpaths_with_execute_sql(self):
+        self.verify_set_java_dependencies("pipeline.classpaths", self.execute_with_execute_sql)
+
+    def test_set_classpaths_with_statement_set(self):
+        self.verify_set_java_dependencies("pipeline.classpaths", self.execute_with_statement_set)
+
+    def test_set_classpaths_with_table(self):
+        self.verify_set_java_dependencies("pipeline.classpaths", self.execute_with_table)
+
+    def test_set_classpaths_with_table_execute_insert(self):
+        self.verify_set_java_dependencies(
+            "pipeline.classpaths", self.execute_with_table_execute_insert)
+
+    def test_set_classpaths_with_table_to_pandas(self):
+        self.verify_set_java_dependencies("pipeline.classpaths", self.execute_with_table_to_pandas)
+
+    def execute_with_t_env(self, t_env):
+        source = t_env.from_elements([(1, "Hi"), (2, "Hello")], ["a", "b"])
+        source.select("func1(a, b), func2(a, b)").insert_into("sink")
+        t_env.execute("test")
+        actual = source_sink_utils.results()
+        expected = ['1 and Hi,1 or Hi', '2 and Hello,2 or Hello']
+        self.assert_equals(actual, expected)
+
+    @staticmethod
+    def execute_with_execute_sql(t_env):
+        source = t_env.from_elements([(1, "Hi"), (2, "Hello")], ["a", "b"])
+        t_env.create_temporary_view("source", source)
+        t_env.execute_sql("select func1(a, b), func2(a, b) from source") \
+            .get_job_client() \
+            .get_job_execution_result(
+                get_gateway().jvm.Thread.currentThread().getContextClassLoader()) \
+            .result()
+
+    def execute_with_statement_set(self, t_env):
+        source = t_env.from_elements([(1, "Hi"), (2, "Hello")], ["a", "b"])
+        result = source.select("func1(a, b), func2(a, b)")
+        t_env.create_statement_set().add_insert("sink", result).execute() \
+            .get_job_client() \
+            .get_job_execution_result(
+                get_gateway().jvm.Thread.currentThread().getContextClassLoader()) \
+            .result()
+        actual = source_sink_utils.results()
+        expected = ['1 and Hi,1 or Hi', '2 and Hello,2 or Hello']
+        self.assert_equals(actual, expected)
+
+    @staticmethod
+    def execute_with_table(t_env):
+        source = t_env.from_elements([(1, "Hi"), (2, "Hello")], ["a", "b"])
+        result = source.select("func1(a, b), func2(a, b)")
+        result.execute() \
+            .get_job_client() \
+            .get_job_execution_result(
+                get_gateway().jvm.Thread.currentThread().getContextClassLoader()) \
+            .result()
+
+    def execute_with_table_execute_insert(self, t_env):
+        source = t_env.from_elements([(1, "Hi"), (2, "Hello")], ["a", "b"])
+        result = source.select("func1(a, b), func2(a, b)")
+        result.execute_insert("sink") \
+            .get_job_client() \
+            .get_job_execution_result(
+                get_gateway().jvm.Thread.currentThread().getContextClassLoader()) \
+            .result()
+        actual = source_sink_utils.results()
+        expected = ['1 and Hi,1 or Hi', '2 and Hello,2 or Hello']
+        self.assert_equals(actual, expected)
+
+    @staticmethod
+    def execute_with_table_to_pandas(t_env):
+        source = t_env.from_elements([(1, "Hi"), (2, "Hello")], ["a", "b"])
+        result = source.select("func1(a, b), func2(a, b)")
+        result.to_pandas()
+
+    def verify_set_java_dependencies(self, config_key, executor):
         original_class_loader = \
             get_gateway().jvm.Thread.currentThread().getContextClassLoader()
         try:
@@ -397,17 +486,13 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
 
             self.assertEqual(first_class_loader, second_class_loader)
 
-            source = self.t_env.from_elements([(1, "Hi"), (2, "Hello")], ["a", "b"])
             self.t_env.register_java_function("func1", func1_class_name)
             self.t_env.register_java_function("func2", func2_class_name)
             table_sink = source_sink_utils.TestAppendSink(
                 ["a", "b"], [DataTypes.STRING(), DataTypes.STRING()])
             self.t_env.register_table_sink("sink", table_sink)
-            source.select("func1(a, b), func2(a, b)").insert_into("sink")
-            self.t_env.execute("test")
-            actual = source_sink_utils.results()
-            expected = ['1 and Hi,1 or Hi', '2 and Hello,2 or Hello']
-            self.assert_equals(actual, expected)
+
+            executor(self.t_env)
         finally:
             get_gateway().jvm.Thread.currentThread().setContextClassLoader(original_class_loader)
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the bug that the config option 'pipeline.jars' doesn't work.*


## Brief change log

  - *Transfer the configuration of "pipeline.jars" and "pipeline.classpaths" from TableConfig to ExecEnv in every API that can execute job.*

## Verifying this change

This change is already covered by existing tests, such as *test_table_environment_api.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
