### PR TITLE
[FLINK-17865][checkpoint] Increase default size of 'state.backend.fs.memory-threshold'

### DIFF
--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -22,9 +22,9 @@
         </tr>
         <tr>
             <td><h5>state.backend.fs.memory-threshold</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>Integer</td>
-            <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file.</td>
+            <td style="word-wrap: break-word;">20 kb</td>
+            <td>MemorySize</td>
+            <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file. The max memory threshold for this configuration is 1MB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.fs.write-buffer-size</h5></td>

--- a/docs/_includes/generated/expert_state_backends_section.html
+++ b/docs/_includes/generated/expert_state_backends_section.html
@@ -16,9 +16,9 @@
         </tr>
         <tr>
             <td><h5>state.backend.fs.memory-threshold</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>Integer</td>
-            <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file.</td>
+            <td style="word-wrap: break-word;">20 kb</td>
+            <td>MemorySize</td>
+            <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file. The max memory threshold for this configuration is 1MB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.fs.write-buffer-size</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -140,11 +140,12 @@ public class CheckpointingOptions {
 	/** The minimum size of state data files. All state chunks smaller than that
 	 * are stored inline in the root checkpoint metadata file. */
 	@Documentation.Section(Documentation.Sections.EXPERT_STATE_BACKENDS)
-	public static final ConfigOption<Integer> FS_SMALL_FILE_THRESHOLD = ConfigOptions
+	public static final ConfigOption<MemorySize> FS_SMALL_FILE_THRESHOLD = ConfigOptions
 			.key("state.backend.fs.memory-threshold")
-			.defaultValue(1024)
+			.memoryType()
+			.defaultValue(MemorySize.parse("20kb"))
 			.withDescription("The minimum size of state data files. All state chunks smaller than that are stored" +
-				" inline in the root checkpoint metadata file.");
+				" inline in the root checkpoint metadata file. The max memory threshold for this configuration is 1MB.");
 
 	/**
 	 * The default size of the write buffer for the checkpoint streams that write to file systems.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SavepointOutputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SavepointOutputFormat.java
@@ -93,7 +93,7 @@ public class SavepointOutputFormat extends RichOutputFormat<CheckpointMetadata> 
 			location,
 			location,
 			reference,
-			CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue(),
+			(int) CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue().getBytes(),
 			CheckpointingOptions.FS_WRITE_BUFFER_SIZE.defaultValue());
 	}
 }

--- a/flink-python/pyflink/datastream/tests/test_state_backend.py
+++ b/flink-python/pyflink/datastream/tests/test_state_backend.py
@@ -97,7 +97,7 @@ class FsStateBackendTests(PyFlinkTestCase):
 
         state_backend = FsStateBackend("file://var/checkpoints/")
 
-        self.assertEqual(state_backend.get_min_file_size_threshold(), 1024)
+        self.assertEqual(state_backend.get_min_file_size_threshold(), 20480)
 
         state_backend = FsStateBackend("file://var/checkpoints/", file_state_size_threshold=2048)
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -227,7 +228,7 @@ public class StateBackendLoadingTest {
 		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
 		final Path expectedCheckpointsPath = new Path(checkpointDir);
 		final Path expectedSavepointsPath = new Path(savepointDir);
-		final int threshold = 1000000;
+		final MemorySize threshold = MemorySize.parse("900kb");
 		final int minWriteBufferSize = 1024;
 		final boolean async = !CheckpointingOptions.ASYNC_SNAPSHOTS.defaultValue();
 
@@ -237,7 +238,7 @@ public class StateBackendLoadingTest {
 		config1.setString(backendKey, "filesystem");
 		config1.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
 		config1.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
-		config1.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
+		config1.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
 		config1.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
 		config1.setBoolean(CheckpointingOptions.ASYNC_SNAPSHOTS, async);
 
@@ -245,7 +246,7 @@ public class StateBackendLoadingTest {
 		config2.setString(backendKey, FsStateBackendFactory.class.getName());
 		config2.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
 		config2.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
-		config2.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
+		config2.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
 		config1.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
 		config2.setBoolean(CheckpointingOptions.ASYNC_SNAPSHOTS, async);
 
@@ -262,10 +263,10 @@ public class StateBackendLoadingTest {
 		assertEquals(expectedCheckpointsPath, fs2.getCheckpointPath());
 		assertEquals(expectedSavepointsPath, fs1.getSavepointPath());
 		assertEquals(expectedSavepointsPath, fs2.getSavepointPath());
-		assertEquals(threshold, fs1.getMinFileSizeThreshold());
-		assertEquals(threshold, fs2.getMinFileSizeThreshold());
-		assertEquals(Math.max(threshold, minWriteBufferSize), fs1.getWriteBufferSize());
-		assertEquals(Math.max(threshold, minWriteBufferSize), fs2.getWriteBufferSize());
+		assertEquals(threshold.getBytes(), fs1.getMinFileSizeThreshold());
+		assertEquals(threshold.getBytes(), fs2.getMinFileSizeThreshold());
+		assertEquals(Math.max(threshold.getBytes(), minWriteBufferSize), fs1.getWriteBufferSize());
+		assertEquals(Math.max(threshold.getBytes(), minWriteBufferSize), fs2.getWriteBufferSize());
 		assertEquals(async, fs1.isUsingAsynchronousSnapshots());
 		assertEquals(async, fs2.isUsingAsynchronousSnapshots());
 	}
@@ -293,7 +294,7 @@ public class StateBackendLoadingTest {
 		config.setString(backendKey, "jobmanager"); // this should not be picked up 
 		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir); // this should not be picked up
 		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
-		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 20); // this should not be picked up
+		config.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.parse("20")); // this should not be picked up
 		config.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, 3000000); // this should not be picked up
 
 		final StateBackend loadedBackend =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -576,7 +576,7 @@ public class SavepointITCase extends TestLogger {
 			if (data == null) {
 				// We need this to be large, because we want to test with files
 				Random rand = new Random(getRuntimeContext().getIndexOfThisSubtask());
-				data = new byte[CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue() + 1];
+				data = new byte[(int) CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue().getBytes() + 1];
 				rand.nextBytes(data);
 			}
 		}
@@ -833,7 +833,7 @@ public class SavepointITCase extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
 		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
-		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 0);
+		config.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.ZERO);
 		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -29,6 +29,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -109,7 +110,7 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 
 		config.setString(CheckpointingOptions.STATE_BACKEND, "memory");
 		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
-		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 0);
+		config.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.ZERO);
 		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 		config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 300L);
 


### PR DESCRIPTION
## What is the purpose of the change

Increase the default value of state.backend.fs.memory-threshold from 1K to 20K as thread discussed.


## Brief change log

Increase default size of 'state.backend.fs.memory-threshold' from 1k to 20k


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
