### PR TITLE
[FLINK-17017][runtime] Implements bulk allocation for physical slots

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
@@ -55,4 +55,11 @@ public interface SlotInfo {
 	 * @return the resource profile of the slot.
 	 */
 	ResourceProfile getResourceProfile();
+
+	/**
+	 * Returns whether the slot will be occupied indefinitely.
+	 *
+	 * @return true if the slot will be occupied indefinitely, otherwise false.
+	 */
+	boolean willBeOccupiedIndefinitely();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -32,27 +32,27 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * The {@code AllocatedSlot} represents a slot that the JobMaster allocated from a TaskExecutor.
  * It represents a slice of allocated resources from the TaskExecutor.
- * 
+ *
  * <p>To allocate an {@code AllocatedSlot}, the requests a slot from the ResourceManager. The
  * ResourceManager picks (or starts) a TaskExecutor that will then allocate the slot to the
  * JobMaster and notify the JobMaster.
- * 
+ *
  * <p>Note: Prior to the resource management changes introduced in (Flink Improvement Proposal 6),
  * an AllocatedSlot was allocated to the JobManager as soon as the TaskManager registered at the
- * JobManager. All slots had a default unknown resource profile. 
+ * JobManager. All slots had a default unknown resource profile.
  */
 class AllocatedSlot implements PhysicalSlot {
 
 	/** The ID under which the slot is allocated. Uniquely identifies the slot. */
 	private final AllocationID allocationId;
 
-	/** The location information of the TaskManager to which this slot belongs */
+	/** The location information of the TaskManager to which this slot belongs. */
 	private final TaskManagerLocation taskManagerLocation;
 
-	/** The resource profile of the slot provides */
+	/** The resource profile of the slot provides. */
 	private final ResourceProfile resourceProfile;
 
-	/** RPC gateway to call the TaskManager that holds this slot */
+	/** RPC gateway to call the TaskManager that holds this slot. */
 	private final TaskManagerGateway taskManagerGateway;
 
 	/** The number of the slot on the TaskManager to which slot belongs. Purely informational. */
@@ -93,9 +93,9 @@ class AllocatedSlot implements PhysicalSlot {
 
 	/**
 	 * Gets the ID of the TaskManager on which this slot was allocated.
-	 * 
-	 * <p>This is equivalent to {@link #getTaskManagerLocation()#getTaskManagerId()}.
-	 * 
+	 *
+	 * <p>This is equivalent to {@link #getTaskManagerLocation()}.{@link #getTaskManagerId()}.
+	 *
 	 * @return This slot's TaskManager's ID.
 	 */
 	public ResourceID getTaskManagerId() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -108,6 +108,11 @@ class AllocatedSlot implements PhysicalSlot {
 	}
 
 	@Override
+	public boolean willBeOccupiedIndefinitely() {
+		return isUsed() && payloadReference.get().willOccupySlotIndefinitely();
+	}
+
+	@Override
 	public TaskManagerLocation getTaskManagerLocation() {
 		return taskManagerLocation;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The bulk slot provider serves physical slot requests.
+ */
+public interface BulkSlotProvider {
+
+	/**
+	 * Starts the slot provider by initializing the main thread executor.
+	 *
+	 * @param mainThreadExecutor the main thread executor of the job master
+	 */
+	void start(ComponentMainThreadExecutor mainThreadExecutor);
+
+	/**
+	 * Allocates a bulk of physical slots. The allocation will be completed
+	 * normally only when all the requests are fulfilled.
+	 *
+	 * @param physicalSlotRequests requests for physical slots
+	 * @param timeout indicating how long it is accepted that the slot requests can be unfulfillable
+	 * @return future of the results of slot requests
+	 */
+	CompletableFuture<Collection<PhysicalSlotRequest.Result>> allocatePhysicalSlots(
+		Collection<PhysicalSlotRequest> physicalSlotRequests,
+		Time timeout);
+
+	/**
+	 * Cancels the slot request with the given {@link SlotRequestId}. If the request is already fulfilled
+	 * with a physical slot, the slot will be released.
+	 *
+	 * @param slotRequestId identifying the slot request to cancel
+	 * @param cause of the cancellation
+	 */
+	void cancelSlotRequest(SlotRequestId slotRequestId, Throwable cause);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImpl.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.util.clock.SystemClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link BulkSlotProvider}.
+ */
+class BulkSlotProviderImpl implements BulkSlotProvider {
+
+	private static final Logger LOG = LoggerFactory.getLogger(BulkSlotProviderImpl.class);
+
+	private ComponentMainThreadExecutor componentMainThreadExecutor;
+
+	private final SlotSelectionStrategy slotSelectionStrategy;
+
+	private final SlotPool slotPool;
+
+	private final PhysicalSlotRequestBulkChecker slotRequestBulkChecker;
+
+	BulkSlotProviderImpl(final SlotSelectionStrategy slotSelectionStrategy, final SlotPool slotPool) {
+		this.slotSelectionStrategy = checkNotNull(slotSelectionStrategy);
+		this.slotPool = checkNotNull(slotPool);
+
+		this.slotRequestBulkChecker = new PhysicalSlotRequestBulkChecker(
+			this::getAllSlotInfos,
+			SystemClock.getInstance());
+
+		this.componentMainThreadExecutor = new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
+			"Scheduler is not initialized with proper main thread executor. " +
+				"Call to BulkSlotProvider.start(...) required.");
+	}
+
+	@Override
+	public void start(final ComponentMainThreadExecutor mainThreadExecutor) {
+		this.componentMainThreadExecutor = mainThreadExecutor;
+
+		slotPool.disableBatchSlotRequestTimeoutCheck();
+	}
+
+	@Override
+	public void cancelSlotRequest(SlotRequestId slotRequestId, Throwable cause) {
+		componentMainThreadExecutor.assertRunningInMainThread();
+
+		slotPool.releaseSlot(slotRequestId, cause);
+	}
+
+	@Override
+	public CompletableFuture<Collection<PhysicalSlotRequest.Result>> allocatePhysicalSlots(
+			final Collection<PhysicalSlotRequest> physicalSlotRequests,
+			final Time timeout) {
+
+		componentMainThreadExecutor.assertRunningInMainThread();
+
+		LOG.debug("Received {} slot requests.", physicalSlotRequests.size());
+
+		final PhysicalSlotRequestBulk slotRequestBulk =
+			slotRequestBulkChecker.createPhysicalSlotRequestBulk(physicalSlotRequests);
+
+		final List<CompletableFuture<PhysicalSlotRequest.Result>> resultFutures = new ArrayList<>(physicalSlotRequests.size());
+		for (PhysicalSlotRequest request : physicalSlotRequests) {
+			final CompletableFuture<PhysicalSlotRequest.Result> resultFuture =
+				allocatePhysicalSlot(request).thenApply(result -> {
+					slotRequestBulk.markRequestFulfilled(
+						result.getSlotRequestId(),
+						result.getPhysicalSlot().getAllocationId());
+
+					return result;
+				});
+			resultFutures.add(resultFuture);
+		}
+
+		schedulePendingRequestBulkTimeoutCheck(slotRequestBulk, timeout);
+
+		return FutureUtils.combineAll(resultFutures);
+	}
+
+	private CompletableFuture<PhysicalSlotRequest.Result> allocatePhysicalSlot(
+			final PhysicalSlotRequest physicalSlotRequest) {
+
+		final SlotRequestId slotRequestId = physicalSlotRequest.getSlotRequestId();
+		final SlotProfile slotProfile = physicalSlotRequest.getSlotProfile();
+		final ResourceProfile resourceProfile = slotProfile.getPhysicalSlotResourceProfile();
+
+		LOG.debug("Received slot request [{}] with resource requirements: {}", slotRequestId, resourceProfile);
+
+		final Optional<PhysicalSlot> availablePhysicalSlot = tryAllocateFromAvailable(slotRequestId, slotProfile);
+
+		final CompletableFuture<PhysicalSlot> slotFuture;
+		if (availablePhysicalSlot.isPresent()) {
+			slotFuture = CompletableFuture.completedFuture(availablePhysicalSlot.get());
+		} else {
+			slotFuture = requestNewSlot(
+				slotRequestId,
+				resourceProfile,
+				physicalSlotRequest.willSlotBeOccupiedIndefinitely());
+		}
+
+		return slotFuture.thenApply(physicalSlot -> new PhysicalSlotRequest.Result(slotRequestId, physicalSlot));
+	}
+
+	private Optional<PhysicalSlot> tryAllocateFromAvailable(
+			final SlotRequestId slotRequestId,
+			final SlotProfile slotProfile) {
+
+		final Collection<SlotSelectionStrategy.SlotInfoAndResources> slotInfoList =
+			slotPool.getAvailableSlotsInformation()
+				.stream()
+				.map(SlotSelectionStrategy.SlotInfoAndResources::fromSingleSlot)
+				.collect(Collectors.toList());
+
+		final Optional<SlotSelectionStrategy.SlotInfoAndLocality> selectedAvailableSlot =
+			slotSelectionStrategy.selectBestSlotForProfile(slotInfoList, slotProfile);
+
+		return selectedAvailableSlot.flatMap(
+			slotInfoAndLocality -> slotPool.allocateAvailableSlot(
+				slotRequestId,
+				slotInfoAndLocality.getSlotInfo().getAllocationId())
+		);
+	}
+
+	private CompletableFuture<PhysicalSlot> requestNewSlot(
+			final SlotRequestId slotRequestId,
+			final ResourceProfile resourceProfile,
+			final boolean willSlotBeOccupiedIndefinitely) {
+
+		if (willSlotBeOccupiedIndefinitely) {
+			return slotPool.requestNewAllocatedSlot(slotRequestId, resourceProfile, null);
+		} else {
+			return slotPool.requestNewAllocatedBatchSlot(slotRequestId, resourceProfile);
+		}
+	}
+
+	private void schedulePendingRequestBulkTimeoutCheck(
+			final PhysicalSlotRequestBulk slotRequestBulk,
+			final Time timeout) {
+
+		componentMainThreadExecutor.schedule(() -> {
+			final PhysicalSlotRequestBulkChecker.TimeoutCheckResult result =
+				slotRequestBulkChecker.checkPhysicalSlotRequestBulkTimeout(slotRequestBulk, timeout);
+
+			switch (result) {
+				case PENDING:
+					//re-schedule the timeout check
+					schedulePendingRequestBulkTimeoutCheck(slotRequestBulk, timeout);
+					break;
+				case TIMEOUT:
+					timeoutSlotRequestBulk(slotRequestBulk);
+					break;
+				default: // no action to take
+			}
+		}, timeout.getSize(), timeout.getUnit());
+	}
+
+	private void timeoutSlotRequestBulk(final PhysicalSlotRequestBulk slotRequestBulk) {
+		final Exception cause = new TimeoutException("Slot request bulk is not fulfillable!");
+		// pending requests must be canceled first otherwise they might be fulfilled by
+		// allocated slots released from this bulk
+		for (SlotRequestId slotRequestId : slotRequestBulk.getPendingRequests().keySet()) {
+			cancelSlotRequest(slotRequestId, cause);
+		}
+		for (SlotRequestId slotRequestId : slotRequestBulk.getFulfilledRequests().keySet()) {
+			cancelSlotRequest(slotRequestId, cause);
+		}
+	}
+
+	private Set<SlotInfo> getAllSlotInfos() {
+		return Stream
+			.concat(
+				slotPool.getAvailableSlotsInformation().stream(),
+				slotPool.getAllocatedSlotsInformation().stream())
+			.collect(Collectors.toSet());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlot.java
@@ -41,10 +41,17 @@ public interface PhysicalSlot extends SlotContext {
 	interface Payload {
 
 		/**
-		 * Releases the payload
+		 * Releases the payload.
 		 *
 		 * @param cause of the payload release
 		 */
 		void release(Throwable cause);
+
+		/**
+		 * Returns whether the payload will occupy a physical slot indefinitely.
+		 *
+		 * @return true if the payload will occupy a physical slot indefinitely, otherwise false
+		 */
+		boolean willOccupySlotIndefinitely();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+
+/**
+ * Represents a request for a physical slot.
+ */
+public class PhysicalSlotRequest {
+
+	private final SlotRequestId slotRequestId;
+
+	private final SlotProfile slotProfile;
+
+	private final boolean slotWillBeOccupiedIndefinitely;
+
+	public PhysicalSlotRequest(
+			final SlotRequestId slotRequestId,
+			final SlotProfile slotProfile,
+			final boolean slotWillBeOccupiedIndefinitely) {
+
+		this.slotRequestId = slotRequestId;
+		this.slotProfile = slotProfile;
+		this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+	}
+
+	SlotRequestId getSlotRequestId() {
+		return slotRequestId;
+	}
+
+	SlotProfile getSlotProfile() {
+		return slotProfile;
+	}
+
+	boolean willSlotBeOccupiedIndefinitely() {
+		return slotWillBeOccupiedIndefinitely;
+	}
+
+	/**
+	 * Result of a {@link PhysicalSlotRequest}.
+	 */
+	public static class Result {
+
+		private final SlotRequestId slotRequestId;
+
+		private final PhysicalSlot physicalSlot;
+
+		Result(final SlotRequestId slotRequestId, final PhysicalSlot physicalSlot) {
+			this.slotRequestId = slotRequestId;
+			this.physicalSlot = physicalSlot;
+		}
+
+		public SlotRequestId getSlotRequestId() {
+			return slotRequestId;
+		}
+
+		public PhysicalSlot getPhysicalSlot() {
+			return physicalSlot;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulk.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulk.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a bulk of physical slot requests.
+ */
+class PhysicalSlotRequestBulk {
+
+	private final Map<SlotRequestId, ResourceProfile> pendingRequests;
+
+	private final Map<SlotRequestId, AllocationID> fulfilledRequests = new HashMap<>();
+
+	private long unfulfillableTimestamp = Long.MAX_VALUE;
+
+	PhysicalSlotRequestBulk(final Collection<PhysicalSlotRequest> physicalSlotRequests) {
+		this.pendingRequests = physicalSlotRequests.stream()
+			.collect(Collectors.toMap(
+				PhysicalSlotRequest::getSlotRequestId,
+				r -> r.getSlotProfile().getPhysicalSlotResourceProfile()));
+	}
+
+	void markRequestFulfilled(final SlotRequestId slotRequestId, final AllocationID allocationID) {
+		pendingRequests.remove(slotRequestId);
+		fulfilledRequests.put(slotRequestId, allocationID);
+	}
+
+	Map<SlotRequestId, ResourceProfile> getPendingRequests() {
+		return Collections.unmodifiableMap(pendingRequests);
+	}
+
+	Map<SlotRequestId, AllocationID> getFulfilledRequests() {
+		return Collections.unmodifiableMap(fulfilledRequests);
+	}
+
+	void markFulfillable() {
+		unfulfillableTimestamp = Long.MAX_VALUE;
+	}
+
+	void markUnfulfillable(final long currentTimestamp) {
+		if (isFulfillable()) {
+			unfulfillableTimestamp = currentTimestamp;
+		}
+	}
+
+	long getUnfulfillableSince() {
+		return unfulfillableTimestamp;
+	}
+
+	private boolean isFulfillable() {
+		return unfulfillableTimestamp == Long.MAX_VALUE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulkChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulkChecker.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.util.clock.Clock;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class helps to check the status of physical slot request bulks.
+ */
+class PhysicalSlotRequestBulkChecker {
+
+	private final Supplier<Set<SlotInfo>> slotsRetriever;
+
+	private final Clock clock;
+
+	PhysicalSlotRequestBulkChecker(final Supplier<Set<SlotInfo>> slotsRetriever, final Clock clock) {
+		this.slotsRetriever = checkNotNull(slotsRetriever);
+		this.clock = checkNotNull(clock);
+	}
+
+	PhysicalSlotRequestBulk createPhysicalSlotRequestBulk(final Collection<PhysicalSlotRequest> physicalSlotRequests) {
+		final PhysicalSlotRequestBulk slotRequestBulk = new PhysicalSlotRequestBulk(physicalSlotRequests);
+		slotRequestBulk.markUnfulfillable(clock.relativeTimeMillis());
+
+		return slotRequestBulk;
+	}
+
+	/**
+	 * Check the slot request bulk and timeout its requests if it has been unfulfillable for too long.
+	 * @param slotRequestBulk bulk of slot requests
+	 * @param slotRequestTimeout indicates how long a pending request can be unfulfillable
+	 * @return result of the check, indicating the bulk is fulfilled, still pending, or timed out
+	 */
+	TimeoutCheckResult checkPhysicalSlotRequestBulkTimeout(
+			final PhysicalSlotRequestBulk slotRequestBulk,
+			final Time slotRequestTimeout) {
+
+		if (slotRequestBulk.getPendingRequests().isEmpty()) {
+			return TimeoutCheckResult.FULFILLED;
+		}
+
+		final boolean fulfillable = isSlotRequestBulkFulfillable(slotRequestBulk, slotsRetriever);
+		if (fulfillable) {
+			slotRequestBulk.markFulfillable();
+		} else {
+			final long currentTimestamp = clock.relativeTimeMillis();
+
+			slotRequestBulk.markUnfulfillable(currentTimestamp);
+
+			final long unfulfillableSince = slotRequestBulk.getUnfulfillableSince();
+			if (unfulfillableSince + slotRequestTimeout.toMilliseconds() <= currentTimestamp) {
+				return TimeoutCheckResult.TIMEOUT;
+			}
+		}
+
+		return TimeoutCheckResult.PENDING;
+	}
+
+	/**
+	 * Returns whether the given bulk of slot requests are possible to be fulfilled at the same time
+	 * with all the reusable slots in the slot pool. A reusable slot means the slot is available or
+	 * will not be occupied indefinitely.
+	 *
+	 * @param slotRequestBulk bulk of slot requests to check
+	 * @param slotsRetriever supplies slots to be used for the fulfill-ability check
+	 * @return true if the slot requests are possible to be fulfilled, otherwise false
+	 */
+	@VisibleForTesting
+	static boolean isSlotRequestBulkFulfillable(
+			final PhysicalSlotRequestBulk slotRequestBulk,
+			final Supplier<Set<SlotInfo>> slotsRetriever) {
+
+		final Set<AllocationID> assignedSlots = new HashSet<>(slotRequestBulk.getFulfilledRequests().values());
+		final Set<SlotInfo> reusableSlots = getReusableSlots(slotsRetriever, assignedSlots);
+		return areRequestsFulfillableWithSlots(slotRequestBulk.getPendingRequests().values(), reusableSlots);
+	}
+
+	private static Set<SlotInfo> getReusableSlots(
+			final Supplier<Set<SlotInfo>> slotsRetriever,
+			final Set<AllocationID> slotsToExclude) {
+
+		return slotsRetriever.get().stream()
+			.filter(slotInfo -> !slotInfo.willBeOccupiedIndefinitely())
+			.filter(slotInfo -> !slotsToExclude.contains(slotInfo.getAllocationId()))
+			.collect(Collectors.toSet());
+	}
+
+	private static boolean areRequestsFulfillableWithSlots(
+			final Collection<ResourceProfile> requestResourceProfiles,
+			final Set<SlotInfo> slots) {
+
+		final Set<SlotInfo> remainingSlots = new HashSet<>(slots);
+		for (ResourceProfile requestResourceProfile : requestResourceProfiles) {
+			final Optional<SlotInfo> matchedSlot = findMatchingSlotForRequest(requestResourceProfile, remainingSlots);
+			if (matchedSlot.isPresent()) {
+				remainingSlots.remove(matchedSlot.get());
+			} else {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static Optional<SlotInfo> findMatchingSlotForRequest(
+			final ResourceProfile requestResourceProfile,
+			final Collection<SlotInfo> slots) {
+
+		return slots.stream().filter(slot -> slot.getResourceProfile().isMatching(requestResourceProfile)).findFirst();
+	}
+
+	enum TimeoutCheckResult {
+		PENDING,
+
+		FULFILLED,
+
+		TIMEOUT
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -244,18 +244,16 @@ public class SchedulerImpl implements Scheduler {
 
 		final PhysicalSlot allocatedSlot = slotAndLocality.getSlot();
 
-		final SingleLogicalSlot singleTaskSlot = new SingleLogicalSlot(
-			slotRequestId,
-			allocatedSlot,
-			null,
-			slotAndLocality.getLocality(),
-			this);
-
-		if (allocatedSlot.tryAssignPayload(singleTaskSlot)) {
+		try {
+			final SingleLogicalSlot singleTaskSlot = SingleLogicalSlot.allocateFromPhysicalSlot(
+				slotRequestId,
+				allocatedSlot,
+				slotAndLocality.getLocality(),
+				this,
+				true);
 			return singleTaskSlot;
-		} else {
-			final FlinkException flinkException =
-				new FlinkException("Could not assign payload to allocated slot " + allocatedSlot.getAllocationId() + '.');
+		} catch (Throwable t) {
+			final FlinkException flinkException = new FlinkException(t);
 			slotPool.releaseSlot(slotRequestId, flinkException);
 			throw flinkException;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -77,6 +77,8 @@ public class SchedulerImpl implements Scheduler {
 	@Nonnull
 	private final Map<SlotSharingGroupId, SlotSharingManager> slotSharingManagers;
 
+	private final BulkSlotProvider bulkSlotProvider;
+
 	public SchedulerImpl(
 		@Nonnull SlotSelectionStrategy slotSelectionStrategy,
 		@Nonnull SlotPool slotPool) {
@@ -95,11 +97,15 @@ public class SchedulerImpl implements Scheduler {
 		this.componentMainThreadExecutor = new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
 			"Scheduler is not initialized with proper main thread executor. " +
 				"Call to Scheduler.start(...) required.");
+
+		this.bulkSlotProvider = new BulkSlotProviderImpl(slotSelectionStrategy, slotPool);
 	}
 
 	@Override
 	public void start(@Nonnull ComponentMainThreadExecutor mainThreadExecutor) {
 		this.componentMainThreadExecutor = mainThreadExecutor;
+
+		bulkSlotProvider.start(mainThreadExecutor);
 	}
 
 	//---------------------------
@@ -559,5 +565,13 @@ public class SchedulerImpl implements Scheduler {
 	@Override
 	public boolean requiresPreviousExecutionGraphAllocations() {
 		return slotSelectionStrategy instanceof PreviousAllocationSlotSelectionStrategy;
+	}
+
+	@Override
+	public CompletableFuture<Collection<PhysicalSlotRequest.Result>> allocatePhysicalSlots(
+			final Collection<PhysicalSlotRequest> physicalSlotRequests,
+			final Time timeout) {
+
+		return bulkSlotProvider.allocatePhysicalSlots(physicalSlotRequests, timeout);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
@@ -70,17 +71,33 @@ public class SingleLogicalSlot implements LogicalSlot, PhysicalSlot.Payload {
 	// LogicalSlot.Payload of this slot
 	private volatile Payload payload;
 
+	/** Whether this logical slot will be occupied indefinitely. */
+	private boolean willBeOccupiedIndefinitely;
+
+	@VisibleForTesting
+	public SingleLogicalSlot(
+		SlotRequestId slotRequestId,
+		SlotContext slotContext,
+		@Nullable SlotSharingGroupId slotSharingGroupId,
+		Locality locality,
+		SlotOwner slotOwner) {
+
+		this(slotRequestId, slotContext, slotSharingGroupId, locality, slotOwner, true);
+	}
+
 	public SingleLogicalSlot(
 			SlotRequestId slotRequestId,
 			SlotContext slotContext,
 			@Nullable SlotSharingGroupId slotSharingGroupId,
 			Locality locality,
-			SlotOwner slotOwner) {
+			SlotOwner slotOwner,
+			boolean willBeOccupiedIndefinitely) {
 		this.slotRequestId = Preconditions.checkNotNull(slotRequestId);
 		this.slotContext = Preconditions.checkNotNull(slotContext);
 		this.slotSharingGroupId = slotSharingGroupId;
 		this.locality = Preconditions.checkNotNull(locality);
 		this.slotOwner = Preconditions.checkNotNull(slotOwner);
+		this.willBeOccupiedIndefinitely = willBeOccupiedIndefinitely;
 		this.releaseFuture = new CompletableFuture<>();
 
 		this.state = State.ALIVE;
@@ -166,6 +183,11 @@ public class SingleLogicalSlot implements LogicalSlot, PhysicalSlot.Payload {
 		}
 		markReleased();
 		releaseFuture.complete(null);
+	}
+
+	@Override
+	public boolean willOccupySlotIndefinitely() {
+		return willBeOccupiedIndefinitely;
 	}
 
 	private void signalPayloadRelease(Throwable cause) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
@@ -166,6 +166,28 @@ public class SingleLogicalSlot implements LogicalSlot, PhysicalSlot.Payload {
 		return slotSharingGroupId;
 	}
 
+	static SingleLogicalSlot allocateFromPhysicalSlot(
+			final SlotRequestId slotRequestId,
+			final PhysicalSlot physicalSlot,
+			final Locality locality,
+			final SlotOwner slotOwner,
+			final boolean slotWillBeOccupiedIndefinitely) {
+
+		final SingleLogicalSlot singleTaskSlot = new SingleLogicalSlot(
+			slotRequestId,
+			physicalSlot,
+			null,
+			locality,
+			slotOwner,
+			slotWillBeOccupiedIndefinitely);
+
+		if (physicalSlot.tryAssignPayload(singleTaskSlot)) {
+			return singleTaskSlot;
+		} else {
+			throw new IllegalStateException("BUG: Unexpected physical slot payload assignment failure!");
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// AllocatedSlot.Payload implementation
 	// -------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotInfoWithUtilization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotInfoWithUtilization.java
@@ -59,6 +59,11 @@ public final class SlotInfoWithUtilization implements SlotInfo {
 		return slotInfoDelegate.getResourceProfile();
 	}
 
+	@Override
+	public boolean willBeOccupiedIndefinitely() {
+		return slotInfoDelegate.willBeOccupiedIndefinitely();
+	}
+
 	public static SlotInfoWithUtilization from(SlotInfo slotInfo, double taskExecutorUtilization) {
 		return new SlotInfoWithUtilization(slotInfo, taskExecutorUtilization);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
@@ -134,6 +135,14 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	 */
 	@Nonnull
 	Collection<SlotInfoWithUtilization> getAvailableSlotsInformation();
+
+	/**
+	 * Returns a list of {@link SlotInfo} objects about all slots that are currently allocated in the slot
+	 * pool.
+	 *
+	 * @return a list of {@link SlotInfo} objects about all slots that are currently allocated in the slot pool.
+	 */
+	Collection<SlotInfo> getAllocatedSlotsInformation();
 
 	/**
 	 * Allocates the available slot with the given allocation id under the given request id. This method returns

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -191,9 +191,7 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	 * Disables batch slot request timeout check. Invoked when someone else wants to
 	 * take over the timeout check responsibility.
 	 */
-	default void disableBatchSlotRequestTimeoutCheck() {
-		throw new UnsupportedOperationException("Not properly implemented.");
-	}
+	void disableBatchSlotRequestTimeoutCheck();
 
 	/**
 	 * Create report about the allocated slots belonging to the specified task manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -170,7 +171,7 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
 		@Nonnull SlotRequestId slotRequestId,
 		@Nonnull ResourceProfile resourceProfile,
-		Time timeout);
+		@Nullable Time timeout);
 
 	/**
 	 * Requests the allocation of a new batch slot from the resource manager. Unlike the normal slot, a batch

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -187,6 +187,14 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 		@Nonnull ResourceProfile resourceProfile);
 
 	/**
+	 * Disables batch slot request timeout check. Invoked when someone else wants to
+	 * take over the timeout check responsibility.
+	 */
+	default void disableBatchSlotRequestTimeoutCheck() {
+		throw new UnsupportedOperationException("Not properly implemented.");
+	}
+
+	/**
 	 * Create report about the allocated slots belonging to the specified task manager.
 	 *
 	 * @param taskManagerId identifies the task manager

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -134,6 +134,8 @@ public class SlotPoolImpl implements SlotPool {
 
 	private ComponentMainThreadExecutor componentMainThreadExecutor;
 
+	private boolean batchSlotRequestTimeoutCheckEnabled;
+
 	// ------------------------------------------------------------------------
 
 	public SlotPoolImpl(
@@ -160,6 +162,8 @@ public class SlotPoolImpl implements SlotPool {
 		this.jobManagerAddress = null;
 
 		this.componentMainThreadExecutor = null;
+
+		this.batchSlotRequestTimeoutCheckEnabled = true;
 	}
 
 	// ------------------------------------------------------------------------
@@ -451,6 +455,11 @@ public class SlotPoolImpl implements SlotPool {
 
 		return requestNewAllocatedSlotInternal(pendingRequest)
 			.thenApply(Function.identity());
+	}
+
+	@Override
+	public void disableBatchSlotRequestTimeoutCheck() {
+		batchSlotRequestTimeoutCheckEnabled = false;
 	}
 
 	@Override
@@ -874,6 +883,10 @@ public class SlotPoolImpl implements SlotPool {
 	}
 
 	protected void checkBatchSlotTimeout() {
+		if (!batchSlotRequestTimeoutCheckEnabled) {
+			return;
+		}
+
 		final Collection<PendingRequest> pendingBatchRequests = getPendingBatchRequests();
 
 		if (!pendingBatchRequests.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -41,10 +41,10 @@ import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnfulfillableSlotRequestException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.clock.Clock;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
@@ -166,7 +166,8 @@ public class SlotPoolImpl implements SlotPool {
 	//  Getters
 	// ------------------------------------------------------------------------
 
-	private Collection<SlotInfo> getAllocatedSlotsInformation() {
+	@Override
+	public Collection<SlotInfo> getAllocatedSlotsInformation() {
 		return allocatedSlots.listSlotInfo();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -473,7 +473,9 @@ public class SlotPoolImpl implements SlotPool {
 		final PendingRequest pendingRequest = removePendingRequest(slotRequestId);
 
 		if (pendingRequest != null) {
-			failPendingRequest(pendingRequest, new FlinkException("Pending slot request with " + slotRequestId + " has been released."));
+			failPendingRequest(
+				pendingRequest,
+				new FlinkException("Pending slot request with " + slotRequestId + " has been released.", cause));
 		} else {
 			final AllocatedSlot allocatedSlot = allocatedSlots.remove(slotRequestId);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -134,7 +134,7 @@ public class SlotPoolImpl implements SlotPool {
 
 	private ComponentMainThreadExecutor componentMainThreadExecutor;
 
-	private boolean batchSlotRequestTimeoutCheckEnabled;
+	protected boolean batchSlotRequestTimeoutCheckEnabled;
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -574,6 +574,11 @@ public class SlotSharingManager {
 		}
 
 		@Override
+		public boolean willOccupySlotIndefinitely() {
+			throw new UnsupportedOperationException("Shared slot are not allowed for slot occupation check.");
+		}
+
+		@Override
 		public ResourceProfile getReservedResources() {
 			return reservedResources;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
@@ -85,4 +85,9 @@ public class SimpleSlotContext implements SlotContext {
 	public ResourceProfile getResourceProfile() {
 		return resourceProfile;
 	}
+
+	@Override
+	public boolean willBeOccupiedIndefinitely() {
+		return true;
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -585,6 +585,11 @@ public class JobMasterTest extends TestLogger {
 		}
 
 		@Override
+		public Collection<SlotInfo> getAllocatedSlotsInformation() {
+			return Collections.emptyList();
+		}
+
+		@Override
 		public Optional<PhysicalSlot> allocateAvailableSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull AllocationID allocationID) {
 			throw new UnsupportedOperationException("TestingSlotPool does not support this operation.");
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -610,6 +610,11 @@ public class JobMasterTest extends TestLogger {
 		}
 
 		@Override
+		public void disableBatchSlotRequestTimeoutCheck() {
+			// no action and no exception is expected
+		}
+
+		@Override
 		public AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId) {
 			final Collection<SlotInfo> slotInfos = registeredSlots.getOrDefault(taskManagerId, Collections.emptyList());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -596,7 +596,10 @@ public class JobMasterTest extends TestLogger {
 
 		@Nonnull
 		@Override
-		public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile, Time timeout) {
+		public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
+				@Nonnull SlotRequestId slotRequestId,
+				@Nonnull ResourceProfile resourceProfile,
+				@Nullable Time timeout) {
 			return new CompletableFuture<>();
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotOccupationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotOccupationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmanager.slots.TestingSlotOwner;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests whether the slot occupation state of {@link AllocatedSlot} is correctly.
+ */
+public class AllocatedSlotOccupationTest extends TestLogger {
+
+	@Test
+	public void testSingleTaskOccupyingSlotIndefinitely() {
+		final PhysicalSlot physicalSlot = createPhysicalSlot();
+		allocateSingleLogicalSlotFromPhysicalSlot(physicalSlot, true);
+
+		assertThat(physicalSlot.willBeOccupiedIndefinitely(), is(true));
+	}
+
+	@Test
+	public void testSingleTaskNotOccupyingSlotIndefinitely() {
+		final PhysicalSlot physicalSlot = createPhysicalSlot();
+		allocateSingleLogicalSlotFromPhysicalSlot(physicalSlot, false);
+
+		assertThat(physicalSlot.willBeOccupiedIndefinitely(), is(false));
+	}
+
+	private static PhysicalSlot createPhysicalSlot() {
+		return new AllocatedSlot(
+			new AllocationID(),
+			new LocalTaskManagerLocation(),
+			0,
+			ResourceProfile.ANY,
+			new SimpleAckingTaskManagerGateway());
+	}
+
+	private static LogicalSlot allocateSingleLogicalSlotFromPhysicalSlot(
+			final PhysicalSlot physicalSlot,
+			final boolean slotWillBeOccupiedIndefinitely) {
+
+		return SingleLogicalSlot.allocateFromPhysicalSlot(
+			new SlotRequestId(),
+			physicalSlot,
+			Locality.UNKNOWN,
+			new TestingSlotOwner(),
+			slotWillBeOccupiedIndefinitely);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImplTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link BulkSlotProviderImpl}.
+ */
+public class BulkSlotProviderImplTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.milliseconds(1000L);
+
+	private static ScheduledExecutorService singleThreadScheduledExecutorService;
+
+	private static ComponentMainThreadExecutor mainThreadExecutor;
+
+	private TestingSlotPoolImpl slotPool;
+
+	private BulkSlotProviderImpl bulkSlotProvider;
+
+	private ManualClock clock;
+
+	@BeforeClass
+	public static void setupClass() {
+		singleThreadScheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+		mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(singleThreadScheduledExecutorService);
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		if (singleThreadScheduledExecutorService != null) {
+			singleThreadScheduledExecutorService.shutdownNow();
+		}
+	}
+
+	@Before
+	public void setup() throws Exception {
+		clock = new ManualClock();
+
+		slotPool = new SlotPoolBuilder(mainThreadExecutor).build();
+
+		bulkSlotProvider = new BulkSlotProviderImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
+		bulkSlotProvider.start(mainThreadExecutor);
+	}
+
+	@After
+	public void teardown() {
+		CompletableFuture.runAsync(() -> slotPool.close(), mainThreadExecutor).join();
+	}
+
+	@Test
+	public void testBulkSlotAllocationFulfilledWithAvailableSlots() throws Exception {
+		final PhysicalSlotRequest request1 = createPhysicalSlotRequest();
+		final PhysicalSlotRequest request2 = createPhysicalSlotRequest();
+		final List<PhysicalSlotRequest> requests = Arrays.asList(request1, request2);
+
+		addSlotToSlotPool();
+		addSlotToSlotPool();
+
+		final CompletableFuture<Collection<PhysicalSlotRequest.Result>> slotFutures = allocateSlots(requests);
+
+		final Collection<PhysicalSlotRequest.Result> results = slotFutures.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+		final Collection<SlotRequestId> resultRequestIds = results.stream()
+			.map(PhysicalSlotRequest.Result::getSlotRequestId)
+			.collect(Collectors.toList());
+
+		assertThat(resultRequestIds, containsInAnyOrder(request1.getSlotRequestId(), request2.getSlotRequestId()));
+	}
+
+	@Test
+	public void testBulkSlotAllocationFulfilledWithNewSlots() {
+		final List<PhysicalSlotRequest> requests = Arrays.asList(
+			createPhysicalSlotRequest(),
+			createPhysicalSlotRequest());
+		final CompletableFuture<Collection<PhysicalSlotRequest.Result>> slotFutures = allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		assertThat(slotFutures.isDone(), is(false));
+
+		addSlotToSlotPool();
+
+		assertThat(slotFutures.isDone(), is(true));
+		assertThat(slotFutures.isCompletedExceptionally(), is(false));
+	}
+
+	@Test
+	public void testBulkSlotAllocationTimeoutsIfUnfulfillable() {
+		final Exception exception = allocateSlotsAndWaitForTimeout();
+
+		final Optional<Throwable> cause = ExceptionUtils.findThrowableWithMessage(
+			exception,
+			"Slot request bulk is not fulfillable!");
+		assertThat(cause.isPresent(), is(true));
+		assertThat(cause.get(), instanceOf(TimeoutException.class));
+	}
+
+	@Test
+	public void testFailedBulkSlotAllocationReleasesAllocatedSlot() {
+		allocateSlotsAndWaitForTimeout();
+
+		assertThat(slotPool.getAllocatedSlots().listSlotInfo(), hasSize(0));
+	}
+
+	@Test
+	public void testFailedBulkSlotAllocationClearsPendingRequests() {
+		allocateSlotsAndWaitForTimeout();
+
+		assertThat(slotPool.getPendingRequests().values(), hasSize(0));
+	}
+
+	private Exception allocateSlotsAndWaitForTimeout() {
+		final List<PhysicalSlotRequest> requests = Arrays.asList(
+			createPhysicalSlotRequest(),
+			createPhysicalSlotRequest());
+		final CompletableFuture<Collection<PhysicalSlotRequest.Result>> slotFutures = allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		assertThat(slotPool.getAllocatedSlots().listSlotInfo(), hasSize(1));
+
+		clock.advanceTime(TIMEOUT.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+
+		try {
+			// wait util the requests timed out
+			slotFutures.get();
+
+			fail("Expected that the slot futures time out.");
+			return new Exception("Unexpected");
+		} catch (Exception e) {
+			// expected
+			return e;
+		}
+	}
+
+	@Test
+	public void testIndividualBatchSlotRequestTimeoutCheckIsDisabled() {
+		assertThat(slotPool.isBatchSlotRequestTimeoutCheckEnabled(), is(false));
+	}
+
+	private void addSlotToSlotPool() {
+		SlotPoolUtils.offerSlots(slotPool, mainThreadExecutor, Collections.singletonList(ResourceProfile.ANY));
+	}
+
+	private CompletableFuture<Collection<PhysicalSlotRequest.Result>> allocateSlots(
+			final Collection<PhysicalSlotRequest> requests) {
+
+		return CompletableFuture
+			.supplyAsync(
+				() -> bulkSlotProvider.allocatePhysicalSlots(
+					requests,
+					TIMEOUT),
+				mainThreadExecutor)
+			.thenCompose(Function.identity());
+	}
+
+	private static PhysicalSlotRequest createPhysicalSlotRequest() {
+		return new PhysicalSlotRequest(
+			new SlotRequestId(),
+			SlotProfile.noLocality(ResourceProfile.UNKNOWN),
+			true);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulkCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulkCheckerTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmanager.slots.TestingSlotOwner;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link PhysicalSlotRequestBulkChecker}.
+ */
+public class PhysicalSlotRequestBulkCheckerTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.milliseconds(5000L);
+
+	private final ManualClock clock = new ManualClock();
+
+	private PhysicalSlotRequestBulkChecker bulkChecker;
+
+	private Set<PhysicalSlot> slots;
+
+	private Supplier<Set<SlotInfo>> slotsRetriever;
+
+	@Before
+	public void setup() throws Exception {
+		slots = new HashSet<>();
+		slotsRetriever = () -> new HashSet<>(slots);
+		bulkChecker = new PhysicalSlotRequestBulkChecker(slotsRetriever, clock);
+	}
+
+	@Test
+	public void testCreateBulk() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(Collections.emptyList());
+
+		assertThat(bulk.getUnfulfillableSince(), is(clock.relativeTimeMillis()));
+	}
+
+	@Test
+	public void testBulkFulfilledOnCheck() {
+		final PhysicalSlotRequest request = createPhysicalSlotRequest();
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Collections.singletonList(request));
+
+		bulk.markRequestFulfilled(request.getSlotRequestId(), new AllocationID());
+
+		assertThat(checkBulkTimeout(bulk), is(PhysicalSlotRequestBulkChecker.TimeoutCheckResult.FULFILLED));
+	}
+
+	@Test
+	public void testBulkTimeoutOnCheck() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Arrays.asList(createPhysicalSlotRequest()));
+
+		clock.advanceTime(TIMEOUT.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+		assertThat(checkBulkTimeout(bulk), is(PhysicalSlotRequestBulkChecker.TimeoutCheckResult.TIMEOUT));
+	}
+
+	@Test
+	public void testBulkPendingOnCheckIfFulfillable() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Collections.singletonList(createPhysicalSlotRequest()));
+
+		final PhysicalSlot slot = addOneSlot();
+		occupySlot(slot, false);
+
+		assertThat(checkBulkTimeout(bulk), is(PhysicalSlotRequestBulkChecker.TimeoutCheckResult.PENDING));
+	}
+
+	@Test
+	public void testBulkPendingOnCheckIfUnfulfillableButNotTimedOut() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Collections.singletonList(createPhysicalSlotRequest()));
+
+		assertThat(checkBulkTimeout(bulk), is(PhysicalSlotRequestBulkChecker.TimeoutCheckResult.PENDING));
+	}
+
+	@Test
+	public void testBulkFulfillable() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Collections.singletonList(createPhysicalSlotRequest()));
+
+		addOneSlot();
+
+		assertThat(isFulfillable(bulk), is(true));
+	}
+
+	@Test
+	public void testBulkUnfulfillableWithInsufficientSlots() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Arrays.asList(createPhysicalSlotRequest(), createPhysicalSlotRequest()));
+
+		addOneSlot();
+
+		assertThat(isFulfillable(bulk), is(false));
+	}
+
+	@Test
+	public void testBulkUnfulfillableWithSlotAlreadyAssignedToBulk() {
+		final PhysicalSlotRequest request = createPhysicalSlotRequest();
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Arrays.asList(request, createPhysicalSlotRequest()));
+
+		final PhysicalSlot slot = addOneSlot();
+
+		bulk.markRequestFulfilled(request.getSlotRequestId(), slot.getAllocationId());
+
+		assertThat(isFulfillable(bulk), is(false));
+	}
+
+	@Test
+	public void testBulkUnfulfillableWithSlotOccupiedIndefinitely() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Arrays.asList(createPhysicalSlotRequest(), createPhysicalSlotRequest()));
+
+		final PhysicalSlot slot1 = addOneSlot();
+		addOneSlot();
+
+		occupySlot(slot1, true);
+
+		assertThat(isFulfillable(bulk), is(false));
+	}
+
+	@Test
+	public void testBulkFulfillableWithSlotOccupiedTemporarily() {
+		final PhysicalSlotRequestBulk bulk = bulkChecker.createPhysicalSlotRequestBulk(
+			Arrays.asList(createPhysicalSlotRequest(), createPhysicalSlotRequest()));
+
+		final PhysicalSlot slot1 = addOneSlot();
+		addOneSlot();
+
+		occupySlot(slot1, false);
+
+		assertThat(isFulfillable(bulk), is(true));
+	}
+
+	private static PhysicalSlotRequest createPhysicalSlotRequest() {
+		return new PhysicalSlotRequest(
+			new SlotRequestId(),
+			SlotProfile.noLocality(ResourceProfile.UNKNOWN),
+			true);
+	}
+
+	private static void occupySlot(final PhysicalSlot slotToOccupy, final boolean slotWillBeOccupiedIndefinitely) {
+		SingleLogicalSlot.allocateFromPhysicalSlot(
+			new SlotRequestId(),
+			slotToOccupy,
+			Locality.UNKNOWN,
+			new TestingSlotOwner(),
+			slotWillBeOccupiedIndefinitely);
+	}
+
+	private PhysicalSlot addOneSlot() {
+		final PhysicalSlot slot = new AllocatedSlot(
+			new AllocationID(),
+			new LocalTaskManagerLocation(),
+			0,
+			ResourceProfile.ANY,
+			new SimpleAckingTaskManagerGateway());
+		slots.add(slot);
+
+		return slot;
+	}
+
+	private PhysicalSlotRequestBulkChecker.TimeoutCheckResult checkBulkTimeout(final PhysicalSlotRequestBulk bulk) {
+		return bulkChecker.checkPhysicalSlotRequestBulkTimeout(bulk, TIMEOUT);
+	}
+
+	private boolean isFulfillable(final PhysicalSlotRequestBulk bulk) {
+		return PhysicalSlotRequestBulkChecker.isSlotRequestBulkFulfillable(bulk, slotsRetriever);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequestBulkTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link PhysicalSlotRequestBulk}.
+ */
+public class PhysicalSlotRequestBulkTest extends TestLogger {
+
+	private final ManualClock clock = new ManualClock();
+
+	@Test
+	public void testMarkBulkUnfulfillable() {
+		final PhysicalSlotRequestBulk bulk = new PhysicalSlotRequestBulk(Collections.emptyList());
+
+		clock.advanceTime(456, TimeUnit.MILLISECONDS);
+		bulk.markUnfulfillable(clock.relativeTimeMillis());
+
+		assertThat(bulk.getUnfulfillableSince(), is(clock.relativeTimeMillis()));
+	}
+
+	@Test
+	public void testUnfulfillableTimestampWillNotBeOverriddenByFollowingUnfulfillableTimestamp() {
+		final PhysicalSlotRequestBulk bulk = new PhysicalSlotRequestBulk(Collections.emptyList());
+
+		final long unfulfillableSince = clock.relativeTimeMillis();
+		bulk.markUnfulfillable(unfulfillableSince);
+
+		clock.advanceTime(456, TimeUnit.MILLISECONDS);
+		bulk.markUnfulfillable(clock.relativeTimeMillis());
+
+		assertThat(bulk.getUnfulfillableSince(), is(unfulfillableSince));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
@@ -65,6 +65,10 @@ public class TestingSlotPoolImpl extends SlotPoolImpl {
 		runAsync(this::checkBatchSlotTimeout);
 	}
 
+	boolean isBatchSlotRequestTimeoutCheckEnabled() {
+		return batchSlotRequestTimeoutCheckEnabled;
+	}
+
 	@Override
 	public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
 			final SlotRequestId slotRequestId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.SystemClock;
 
+import javax.annotation.Nullable;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -67,7 +69,7 @@ public class TestingSlotPoolImpl extends SlotPoolImpl {
 	public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
 			final SlotRequestId slotRequestId,
 			final ResourceProfile resourceProfile,
-			final Time timeout) {
+			@Nullable final Time timeout) {
 
 		this.lastRequestedSlotResourceProfile = resourceProfile;
 


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a BulkSlotProvider which supports bulk slot allocation. In this way we are able to check whether the resource requirements of a slot request bulk can be fulfilled at the same time.

## Brief change log

  - *Enabled to set and get whether a physical slot will be occupied indefinitely*
  - *Introduced BulkSlotProvider and its default implementation*

## Verifying this change

  - *Added AllocatedSlotOccupationTest*
  - *Added BulkSlotAllocationTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
