### PR TITLE
[FLINK-17463][tests] Avoid concurrent directory creation and deletion

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
@@ -122,6 +122,10 @@ public abstract class AbstractBlobCache implements Closeable {
 		this.serverAddress = serverAddress;
 	}
 
+	public File getStorageDir() {
+		return storageDir;
+	}
+
 	/**
 	 * Returns local copy of the file for the BLOB with the given key.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -213,6 +213,10 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 	//  Path Accessors
 	// --------------------------------------------------------------------------------------------
 
+	public File getStorageDir() {
+		return storageDir;
+	}
+
 	/**
 	 * Returns a file handle to the file associated with the given blob key on the blob
 	 * server.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -204,20 +204,22 @@ public class BlobServerCleanupTest extends TestLogger {
 		int numFiles = 0;
 
 		for (BlobKey key : keys) {
-			final File blobFile;
+			final File storageDir;
 			if (blobService instanceof BlobServer) {
 				BlobServer server = (BlobServer) blobService;
-				blobFile = server.getStorageLocation(jobId, key);
+				storageDir = server.getStorageDir();
 			} else if (blobService instanceof PermanentBlobCache) {
 				PermanentBlobCache cache = (PermanentBlobCache) blobService;
-				blobFile = cache.getStorageLocation(jobId, key);
+				storageDir = cache.getStorageDir();
 			} else if (blobService instanceof TransientBlobCache) {
 				TransientBlobCache cache = (TransientBlobCache) blobService;
-				blobFile = cache.getStorageLocation(jobId, key);
+				storageDir = cache.getStorageDir();
 			} else {
 				throw new UnsupportedOperationException(
 					"unsupported BLOB service class: " + blobService.getClass().getCanonicalName());
 			}
+
+			final File blobFile = new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId, key));
 			if (blobFile.exists()) {
 				++numFiles;
 			} else if (doThrow) {


### PR DESCRIPTION
## What is the purpose of the change

*See commit*


## Brief change log

  - *See commit*

## Verifying this change

This change is already covered by existing tests, such as *BlobCacheCleanupTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
