### PR TITLE
[FLINK-17965][sql-parser-hive] Hive dialect needs to unescape backslash in string literals

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -252,6 +252,10 @@ public class HiveTableUtil {
 			String key = prop.equals(HiveTableRowFormat.COLLECTION_DELIM) ?
 					serdeConstants.COLLECTION_DELIM : prop.substring(SERDE_INFO_PROP_PREFIX.length());
 			sd.getSerdeInfo().getParameters().put(key, value);
+			// make sure FIELD_DELIM and SERIALIZATION_FORMAT are consistent
+			if (key.equals(serdeConstants.FIELD_DELIM)) {
+				sd.getSerdeInfo().getParameters().put(serdeConstants.SERIALIZATION_FORMAT, value);
+			}
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -172,6 +172,7 @@ public class HiveDialectITCase {
 		tableEnv.executeSql("create table tbl4 (x int,y smallint) row format delimited fields terminated by '|' lines terminated by '\n'");
 		hiveTable = hiveCatalog.getHiveTable(new ObjectPath("default", "tbl4"));
 		assertEquals("|", hiveTable.getSd().getSerdeInfo().getParameters().get(serdeConstants.FIELD_DELIM));
+		assertEquals("|", hiveTable.getSd().getSerdeInfo().getParameters().get(serdeConstants.SERIALIZATION_FORMAT));
 		assertEquals("\n", hiveTable.getSd().getSerdeInfo().getParameters().get(serdeConstants.LINE_DELIM));
 
 		tableEnv.executeSql("create table tbl5 (m map<bigint,string>) row format delimited collection items terminated by ';' " +

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
@@ -578,7 +578,7 @@ public class TableEnvHiveConnectorITCase {
 		try {
 			tableEnv.executeSql("create table db1.src (x int,y string) " +
 					"row format serde 'org.apache.hadoop.hive.serde2.RegexSerDe' " +
-					"with serdeproperties ('input.regex'='([\\d]+)\\u0001([\\S]+)')");
+					"with serdeproperties ('input.regex'='([\\\\d]+)\\u0001([\\\\S]+)')");
 			HiveTestUtils.createTextTableInserter(hiveShell, "db1", "src")
 					.addRow(new Object[]{1, "a"})
 					.addRow(new Object[]{2, "ab"})

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAddHivePartitions.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAddHivePartitions.java
@@ -43,6 +43,9 @@ public class SqlAddHivePartitions extends SqlAddPartitions {
 	public SqlAddHivePartitions(SqlParserPos pos, SqlIdentifier tableName, boolean ifNotExists,
 			List<SqlNodeList> partSpecs, List<SqlCharStringLiteral> partLocations) {
 		super(pos, tableName, ifNotExists, partSpecs, toProps(partLocations));
+		for (SqlNodeList spec : partSpecs) {
+			HiveDDLUtils.unescapePartitionSpec(spec);
+		}
 		this.partLocations = partLocations;
 	}
 

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveDatabaseProps.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveDatabaseProps.java
@@ -34,6 +34,7 @@ public class SqlAlterHiveDatabaseProps extends SqlAlterHiveDatabase {
 	public SqlAlterHiveDatabaseProps(SqlParserPos pos, SqlIdentifier databaseName, SqlNodeList propertyList)
 			throws ParseException {
 		super(pos, databaseName, HiveDDLUtils.checkReservedDBProperties(propertyList));
+		HiveDDLUtils.unescapeProperties(getPropertyList());
 	}
 
 	@Override

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHivePartitionRename.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHivePartitionRename.java
@@ -45,6 +45,8 @@ public class SqlAlterHivePartitionRename extends SqlAlterTable {
 		if (partSpec == null || newPartSpec == null) {
 			throw new ParseException("Both old and new partition spec have to be specified");
 		}
+		HiveDDLUtils.unescapePartitionSpec(partSpec);
+		HiveDDLUtils.unescapePartitionSpec(newPartSpec);
 		this.newPartSpec = newPartSpec;
 	}
 

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTableProps.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTableProps.java
@@ -38,6 +38,7 @@ public class SqlAlterHiveTableProps extends SqlAlterHiveTable {
 	public SqlAlterHiveTableProps(SqlParserPos pos, SqlIdentifier tableName, SqlNodeList propertyList)
 			throws ParseException {
 		super(CHANGE_TBL_PROPS, pos, tableName, null, HiveDDLUtils.checkReservedTableProperties(propertyList));
+		HiveDDLUtils.unescapeProperties(propertyList);
 		// remove the last property which is the ALTER_TABLE_OP
 		this.origProps = new SqlNodeList(propertyList.getList().subList(0, propertyList.size() - 1),
 				propertyList.getParserPosition());
@@ -48,7 +49,7 @@ public class SqlAlterHiveTableProps extends SqlAlterHiveTable {
 		super.unparse(writer, leftPrec, rightPrec);
 		writer.keyword("SET TBLPROPERTIES");
 		SqlWriter.Frame withFrame = writer.startList("(", ")");
-		for (SqlNode property : getPropertyList()) {
+		for (SqlNode property : origProps) {
 			printIndent(writer);
 			property.unparse(writer, leftPrec, rightPrec);
 		}

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTableSerDe.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTableSerDe.java
@@ -42,6 +42,7 @@ public class SqlAlterHiveTableSerDe extends SqlAlterHiveTable {
 	public SqlAlterHiveTableSerDe(SqlParserPos pos, SqlIdentifier tableName, SqlNodeList partitionSpec,
 			SqlNodeList propertyList, SqlCharStringLiteral serdeLib) throws ParseException {
 		super(CHANGE_SERDE_PROPS, pos, tableName, partitionSpec, HiveDDLUtils.checkReservedTableProperties(propertyList));
+		HiveDDLUtils.unescapeProperties(propertyList);
 		// remove the last property which is the ALTER_TABLE_OP
 		origSerDeProps = new SqlNodeList(propertyList.getList().subList(0, propertyList.size() - 1),
 				propertyList.getParserPosition());

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveViewProperties.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveViewProperties.java
@@ -35,6 +35,7 @@ public class SqlAlterHiveViewProperties extends SqlAlterViewProperties {
 
 	public SqlAlterHiveViewProperties(SqlParserPos pos, SqlIdentifier tableName, SqlNodeList propertyList) {
 		super(pos, tableName, propertyList);
+		HiveDDLUtils.unescapeProperties(propertyList);
 	}
 
 	@Override

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveDatabase.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveDatabase.java
@@ -47,7 +47,7 @@ public class SqlCreateHiveDatabase extends SqlCreateDatabase {
 				pos,
 				databaseName,
 				HiveDDLUtils.checkReservedDBProperties(propertyList),
-				HiveDDLUtils.unescapeLiteral(comment),
+				HiveDDLUtils.unescapeStringLiteral(comment),
 				ifNotExists
 		);
 		HiveDDLUtils.ensureNonGeneric(propertyList);

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveDatabase.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveDatabase.java
@@ -43,7 +43,13 @@ public class SqlCreateHiveDatabase extends SqlCreateDatabase {
 
 	public SqlCreateHiveDatabase(SqlParserPos pos, SqlIdentifier databaseName, SqlNodeList propertyList,
 			SqlCharStringLiteral comment, SqlCharStringLiteral location, boolean ifNotExists) throws ParseException {
-		super(pos, databaseName, HiveDDLUtils.checkReservedDBProperties(propertyList), comment, ifNotExists);
+		super(
+				pos,
+				databaseName,
+				HiveDDLUtils.checkReservedDBProperties(propertyList),
+				HiveDDLUtils.unescapeLiteral(comment),
+				ifNotExists
+		);
 		HiveDDLUtils.ensureNonGeneric(propertyList);
 		originPropList = new SqlNodeList(propertyList.getList(), propertyList.getParserPosition());
 		// mark it as a hive database

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
@@ -72,7 +72,7 @@ public class SqlCreateHiveTable extends SqlCreateTable {
 				HiveDDLUtils.checkReservedTableProperties(propertyList),
 				extractPartColIdentifiers(partColList),
 				null,
-				HiveDDLUtils.unescapeLiteral(comment),
+				HiveDDLUtils.unescapeStringLiteral(comment),
 				null,
 				isTemporary
 		);

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
@@ -64,9 +64,19 @@ public class SqlCreateHiveTable extends SqlCreateTable {
 			SqlNodeList partColList, @Nullable SqlCharStringLiteral comment, boolean isTemporary, boolean isExternal,
 			HiveTableRowFormat rowFormat, HiveTableStoredAs storedAs, SqlCharStringLiteral location) throws ParseException {
 
-		super(pos, tableName, columnList, creationContext.constraints,
-				HiveDDLUtils.checkReservedTableProperties(propertyList), extractPartColIdentifiers(partColList), null,
-				comment, null, isTemporary);
+		super(
+				pos,
+				tableName,
+				columnList,
+				creationContext.constraints,
+				HiveDDLUtils.checkReservedTableProperties(propertyList),
+				extractPartColIdentifiers(partColList),
+				null,
+				HiveDDLUtils.unescapeLiteral(comment),
+				null,
+				isTemporary
+		);
+		HiveDDLUtils.unescapeProperties(propertyList);
 
 		this.origColList = HiveDDLUtils.deepCopyColList(columnList);
 		this.origPartColList = partColList != null ?
@@ -465,6 +475,7 @@ public class SqlCreateHiveTable extends SqlCreateTable {
 					list.add(HiveDDLUtils.toTableOption(prop, delimitPropToValue.get(prop), pos));
 				}
 			}
+			HiveDDLUtils.unescapeProperties(list);
 			return list;
 		}
 

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveView.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveView.java
@@ -50,7 +50,7 @@ public class SqlCreateHiveView extends SqlCreateView {
 				false,
 				false,
 				ifNotExists,
-				HiveDDLUtils.unescapeLiteral(comment),
+				HiveDDLUtils.unescapeStringLiteral(comment),
 				properties
 		);
 		HiveDDLUtils.unescapeProperties(properties);

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveView.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveView.java
@@ -42,7 +42,18 @@ public class SqlCreateHiveView extends SqlCreateView {
 
 	public SqlCreateHiveView(SqlParserPos pos, SqlIdentifier viewName, SqlNodeList fieldList, SqlNode query,
 			boolean ifNotExists, SqlCharStringLiteral comment, SqlNodeList properties) {
-		super(pos, viewName, fieldList, query, false, false, ifNotExists, comment, properties);
+		super(
+				pos,
+				viewName,
+				fieldList,
+				query,
+				false,
+				false,
+				ifNotExists,
+				HiveDDLUtils.unescapeLiteral(comment),
+				properties
+		);
+		HiveDDLUtils.unescapeProperties(properties);
 		originPropList = new SqlNodeList(properties.getList(), properties.getParserPosition());
 		// mark it as a hive view
 		properties.add(HiveDDLUtils.toTableOption(CatalogConfig.IS_GENERIC, "false", pos));

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/dml/RichSqlHiveInsert.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/dml/RichSqlHiveInsert.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.hive.dml;
 
 import org.apache.flink.sql.parser.SqlProperty;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
+import org.apache.flink.sql.parser.hive.ddl.HiveDDLUtils;
 
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
@@ -48,6 +49,7 @@ public class RichSqlHiveInsert extends RichSqlInsert {
 			SqlNodeList staticPartitions,
 			SqlNodeList allPartKeys) {
 		super(pos, keywords, extendedKeywords, targetTable, source, columnList, staticPartitions);
+		HiveDDLUtils.unescapePartitionSpec(staticPartitions);
 		this.allPartKeys = allPartKeys;
 		partKeyToSpec = getPartKeyToSpec(staticPartitions);
 	}

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -278,8 +278,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
 						")");
 		sql("alter table tbl set serdeproperties('line.delim'='\n')")
 				.ok("ALTER TABLE `TBL` SET SERDEPROPERTIES (\n" +
-						"  'line.delim' = '\n" +
-						"'\n" +
+						"  'line.delim' = '\n'\n" +
 						")");
 	}
 
@@ -299,6 +298,15 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
 				.ok("ALTER TABLE `TBL` PARTITION (`P` = 1)\n" +
 						"RENAME TO\n" +
 						"PARTITION (`P` = 2)");
+	}
+
+	@Test
+	public void testAlterTableProperties() {
+		sql("alter table tbl set tblproperties('k1'='v1','k2'='v2')")
+				.ok("ALTER TABLE `TBL` SET TBLPROPERTIES (\n" +
+						"  'k1' = 'v1',\n" +
+						"  'k2' = 'v2'\n" +
+						")");
 	}
 
 	// TODO: support EXCHANGE PARTITION, RECOVER PARTITIONS


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

HiveQL supports escaping by backslash. But SQL CLI will escape backslashes in its input. Therefore hive dialect needs to unescape it.


## Brief change log

  - Do the unescape in these places: DB/table/view comments, DB/table/view properties, table SerDe properties, table row format delimiters, partition specs.
  - Fix an issue of unparse ALTER TABLE PROPERTY, and add test case
  - Fix an issue of setting table field terminator, add update test case.


## Verifying this change

I have manually verified the test cases (except view tests due to FLINK-17113) in `HiveDialectTest` via SQL CLI. But cannot add new tests for them since we don't have E2E tests for hive connector.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
