### PR TITLE
[FLINK-17765] Trim stack traces 

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -106,7 +106,14 @@ public enum ClientUtils {
 				.get();
 		} catch (InterruptedException | ExecutionException e) {
 			ExceptionUtils.checkInterrupted(e);
-			throw new ProgramInvocationException("Could not run job", jobGraph.getJobID(), e);
+
+			LOG.debug("Could not run job {}.", jobGraph.getJobID(), e);
+
+			// trim exceptions for the CLI
+			ProgramInvocationException reportedException = new ProgramInvocationException("Could not run job", jobGraph.getJobID(), ExceptionUtils.stripExecutionException(e));
+			ExceptionUtils.trimStackTraces(reportedException);
+
+			throw reportedException;
 		}
 
 		try {

--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -71,6 +71,20 @@ public final class ExceptionUtils {
 		TaskManagerOptions.JVM_METASPACE.key());
 
 	/**
+	 * Removes the stack trace elements of the given exception and all causes. The string representation of the
+	 * resulting exception will usually only contain the "Caused by ..." lines.
+	 *
+	 * @param e The exception to trim.
+	 */
+	public static void trimStackTraces(final Throwable e) {
+		Throwable cause = e;
+		while (cause != null && cause != cause.getCause()) {
+			cause.setStackTrace(new StackTraceElement[]{});
+			cause = cause.getCause();
+		}
+	}
+
+	/**
 	 * Makes a string representation of the exception's stack trace, or "(null)", if the
 	 * exception is null.
 	 *


### PR DESCRIPTION
With this PR we remove the stack trace elements of all exceptions that are reported by the REST API and by the client during job submission.