### PR TITLE
[BP-1.11][FLINK-18012] Deactivate slot timeout when calling TaskSlotTable.tryMarkSlotActive

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
@@ -320,18 +320,22 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
 		TaskSlot<T> taskSlot = getTaskSlot(allocationId);
 
 		if (taskSlot != null) {
-			if (taskSlot.markActive()) {
-				// unregister a potential timeout
-				LOG.info("Activate slot {}.", allocationId);
-
-				timerService.unregisterTimeout(allocationId);
-
-				return true;
-			} else {
-				return false;
-			}
+			return markExistingSlotActive(taskSlot);
 		} else {
 			throw new SlotNotFoundException(allocationId);
+		}
+	}
+
+	private boolean markExistingSlotActive(TaskSlot<T> taskSlot) {
+		if (taskSlot.markActive()) {
+			// unregister a potential timeout
+			LOG.info("Activate slot {}.", taskSlot.getAllocationId());
+
+			timerService.unregisterTimeout(taskSlot.getAllocationId());
+
+			return true;
+		} else {
+			return false;
 		}
 	}
 
@@ -428,7 +432,7 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
 		TaskSlot<T> taskSlot = getTaskSlot(allocationId);
 
 		if (taskSlot != null && taskSlot.isAllocated(jobId, allocationId)) {
-			return taskSlot.markActive();
+			return markExistingSlotActive(taskSlot);
 		} else {
 			return false;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Tests for the {@link TaskSlotTable}.
  */
-public class TaskSlotTableTest extends TestLogger {
+public class TaskSlotTableImplTest extends TestLogger {
 	private static final Time SLOT_TIMEOUT = Time.seconds(100L);
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableTest.java
@@ -211,8 +211,10 @@ public class TaskSlotTableTest extends TestLogger {
 	public void testAllocateSlot() throws Exception {
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
-		try (final TaskSlotTable<TaskSlotPayload> taskSlotTable =
-				 createTaskSlotTableWithAllocatedSlot(jobId, allocationId, new TestingSlotActionsBuilder().build())) {
+		try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableWithAllocatedSlot(
+				jobId,
+				allocationId,
+				new TestingSlotActionsBuilder().build())) {
 			Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
 			TaskSlot<TaskSlotPayload> nextSlot = allocatedSlots.next();
 			assertThat(nextSlot.getIndex(), is(0));


### PR DESCRIPTION
Backport of #12388 for `release-1.11`.