### PR TITLE
[FLINK-17765] Trim stack traces

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -71,6 +71,20 @@ public final class ExceptionUtils {
 		TaskManagerOptions.JVM_METASPACE.key());
 
 	/**
+	 * Removes the stack trace elements of the given exception and all causes. The string representation of the
+	 * resulting exception will usually only contain the "Caused by ..." lines.
+	 *
+	 * @param e The exception to trim.
+	 */
+	public static void trimStackTraces(final Throwable e) {
+		Throwable cause = e;
+		while (cause != null && cause != cause.getCause()) {
+			cause.setStackTrace(new StackTraceElement[]{});
+			cause = cause.getCause();
+		}
+	}
+
+	/**
 	 * Makes a string representation of the exception's stack trace, or "(null)", if the
 	 * exception is null.
 	 *

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -884,6 +884,7 @@ public class ExecutionEnvironment {
 			jobListeners.forEach(jobListener -> {
 				jobListener.onJobExecuted(null, ExceptionUtils.stripExecutionException(t));
 			});
+			ExceptionUtils.trimStackTraces(t);
 			ExceptionUtils.rethrowException(t);
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1803,6 +1803,7 @@ public class StreamExecutionEnvironment {
 			return jobClient;
 		} catch (Throwable t) {
 			jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(null, t));
+			ExceptionUtils.trimStackTraces(t);
 			ExceptionUtils.rethrow(t);
 
 			// make javac happy, this code path will not be reached


### PR DESCRIPTION
With this PR we now remove all stack trace elements from exceptions in the REST API or during job submission on the client.

The full exception will still be logged; this only affects the user-facing components (REST API / CLI)

Do note that this partially reverts FLINK-12781.

The following is the error a user would receive when attempting to submit a job with an non-existent savepoint:

```
 The program finished with the following exception:

org.apache.flink.client.program.ProgramInvocationException: The main method caused an error: java.util.concurrent.ExecutionException: org.apache.flink.runtime.client.JobSubmissionException: Failed to submit JobGraph.
        at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:302)
        at org.apache.flink.client.program.PackagedProgram.invokeInteractiveModeForExecution(PackagedProgram.java:198)
        at org.apache.flink.client.ClientUtils.executeProgram(ClientUtils.java:162)
        at org.apache.flink.client.cli.CliFrontend.executeProgram(CliFrontend.java:689)
        at org.apache.flink.client.cli.CliFrontend.run(CliFrontend.java:227)
        at org.apache.flink.client.cli.CliFrontend.parseParameters(CliFrontend.java:906)
        at org.apache.flink.client.cli.CliFrontend.lambda$main$10(CliFrontend.java:982)
        at org.apache.flink.runtime.security.contexts.NoOpSecurityContext.runSecured(NoOpSecurityContext.java:30)
        at org.apache.flink.client.cli.CliFrontend.main(CliFrontend.java:982)
Caused by: java.lang.RuntimeException: java.util.concurrent.ExecutionException: org.apache.flink.runtime.client.JobSubmissionException: Failed to submit JobGraph.
        at org.apache.flink.util.ExceptionUtils.rethrow(ExceptionUtils.java:304)
        at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.executeAsync(StreamExecutionEnvironment.java:1807)
        at org.apache.flink.client.program.StreamContextEnvironment.executeAsync(StreamContextEnvironment.java:104)
        at org.apache.flink.client.program.StreamContextEnvironment.execute(StreamContextEnvironment.java:71)
        at org.apache.flink.streaming.examples.wordcount.WordCount.main(WordCount.java:101)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:288)
        ... 8 more
Caused by: java.util.concurrent.ExecutionException: org.apache.flink.runtime.client.JobSubmissionException: Failed to submit JobGraph.
Caused by: org.apache.flink.runtime.client.JobSubmissionException: Failed to submit JobGraph.
Caused by: org.apache.flink.runtime.rest.util.RestClientException: [Internal server error., <Exception on server side:
org.apache.flink.runtime.client.JobSubmissionException: Failed to submit job.
Caused by: java.lang.RuntimeException: org.apache.flink.runtime.client.JobExecutionException: Could not set up JobManager
Caused by: org.apache.flink.runtime.client.JobExecutionException: Could not set up JobManager
Caused by: java.io.FileNotFoundException: Cannot find checkpoint or savepoint file/directory 'ashudasd' on file system 'file'.
```

This is intentionally not implemented for the entire CLI (e.g., exceptions during the job), because here the stacktrace might contain references to user-code where we could be removing valuable information.
