### PR TITLE
[BP-1.10][FLINK-17970] Increase default value of cluster.io-pool.size from #cores to 4 * #cores

### DIFF
--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -15,10 +15,10 @@
             <td>Enable the slot spread out allocation strategy. This strategy tries to spread out the slots evenly across all available <span markdown="span">`TaskExecutors`</span>.</td>
         </tr>
         <tr>
-            <td><h5>cluster.io-executor.pool-size</h5></td>
+            <td><h5>cluster.io-pool.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The pool size of io executor for cluster entry-point and mini cluster. It's undefined by default and will use the number of CPU cores (hardware contexts) that the cluster entry-point JVM has access to.</td>
+            <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.error-delay</h5></td>

--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>cluster.io-pool.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
+            <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use 4 * the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.error-delay</h5></td>

--- a/docs/_includes/generated/expert_fault_tolerance_section.html
+++ b/docs/_includes/generated/expert_fault_tolerance_section.html
@@ -12,7 +12,7 @@
             <td><h5>cluster.io-pool.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
+            <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use 4 * the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.error-delay</h5></td>

--- a/docs/_includes/generated/expert_fault_tolerance_section.html
+++ b/docs/_includes/generated/expert_fault_tolerance_section.html
@@ -9,10 +9,10 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>cluster.io-executor.pool-size</h5></td>
+            <td><h5>cluster.io-pool.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The pool size of io executor for cluster entry-point and mini cluster. It's undefined by default and will use the number of CPU cores (hardware contexts) that the cluster entry-point JVM has access to.</td>
+            <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
         </tr>
         <tr>
             <td><h5>cluster.registration.error-delay</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -62,11 +62,12 @@ public class ClusterOptions {
 
 	@Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
 	public static final ConfigOption<Integer> CLUSTER_IO_EXECUTOR_POOL_SIZE = ConfigOptions
-		.key("cluster.io-executor.pool-size")
+		.key("cluster.io-pool.size")
 		.intType()
 		.noDefaultValue()
-		.withDescription("The pool size of io executor for cluster entry-point and mini cluster. " +
-			"It's undefined by default and will use the number of CPU cores (hardware contexts) that the cluster entry-point JVM has access to.");
+		.withDescription("The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). " +
+			"By default it will use the number of CPU cores (hardware contexts) that the cluster process has access to. " +
+			"Increasing the pool size allows to run more IO operations concurrently.");
 
 	@Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
 	public static final ConfigOption<Boolean> EVENLY_SPREAD_OUT_SLOTS_STRATEGY = ConfigOptions

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -66,7 +66,7 @@ public class ClusterOptions {
 		.intType()
 		.noDefaultValue()
 		.withDescription("The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). " +
-			"By default it will use the number of CPU cores (hardware contexts) that the cluster process has access to. " +
+			"By default it will use 4 * the number of CPU cores (hardware contexts) that the cluster process has access to. " +
 			"Increasing the pool size allows to run more IO operations concurrently.");
 
 	@Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClusterEntrypointUtils.java
@@ -70,7 +70,7 @@ public final class ClusterEntrypointUtils {
 	 * @return The legal io-executor pool size.
 	 */
 	public static int getPoolSize(Configuration config) {
-		final int poolSize = config.getInteger(ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE, Hardware.getNumberCPUCores());
+		final int poolSize = config.getInteger(ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE, 4 * Hardware.getNumberCPUCores());
 		Preconditions.checkArgument(poolSize > 0,
 			String.format("Illegal pool size (%s) of io-executor, please re-configure '%s'.",
 				poolSize, ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE.key()));


### PR DESCRIPTION
Backport of #12360 to `release-1.10`.