### PR TITLE
[FLINK-13782][table-api] Fix checking comparision of nested distinct/structured/raw types

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ComparableTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ComparableTypeStrategy.java
@@ -80,7 +80,7 @@ public final class ComparableTypeStrategy implements InputTypeStrategy {
 			LogicalType firstType = argumentDataTypes.get(i).getLogicalType();
 			LogicalType secondType = argumentDataTypes.get(i + 1).getLogicalType();
 
-			if (!areComparable(firstType.copy(true), secondType.copy(true))) {
+			if (!areComparable(firstType, secondType)) {
 				if (throwOnFailure) {
 					throw callContext.newValidationError(
 						"All types in a comparison should support %s comparison with each other. Can not compare" +
@@ -99,6 +99,10 @@ public final class ComparableTypeStrategy implements InputTypeStrategy {
 	}
 
 	private boolean areComparable(LogicalType firstType, LogicalType secondType) {
+		return areComparableWithNormalizedNullability(firstType.copy(true), secondType.copy(true));
+	}
+
+	private boolean areComparableWithNormalizedNullability(LogicalType firstType, LogicalType secondType) {
 		// A hack to support legacy types. To be removed when we drop the legacy types.
 		if (firstType instanceof LegacyTypeInformationType ||
 				secondType instanceof LegacyTypeInformationType) {
@@ -169,8 +173,7 @@ public final class ComparableTypeStrategy implements InputTypeStrategy {
 	}
 
 	private boolean areStructuredTypesComparable(LogicalType firstType, LogicalType secondType) {
-		return firstType.equals(secondType) &&
-			hasRequiredComparision((StructuredType) firstType);
+		return firstType.equals(secondType) && hasRequiredComparision((StructuredType) firstType);
 	}
 
 	private boolean areCollectionsComparable(LogicalType firstType, LogicalType secondType) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/ComparableInputTypeStrategyTests.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/ComparableInputTypeStrategyTests.java
@@ -171,6 +171,27 @@ public class ComparableInputTypeStrategyTests extends InputTypeStrategiesTestBas
 
 			TestSpec
 				.forStrategy(
+					"Comparable arrays of structured types",
+					InputTypeStrategies.TWO_EQUALS_COMPARABLE)
+				.calledWithArgumentTypes(
+					DataTypes.ARRAY(
+						structuredType("type", singletonList(DataTypes.INT()), StructuredComparision.EQUALS).notNull()
+					),
+					DataTypes.ARRAY(
+						structuredType("type", singletonList(DataTypes.INT()), StructuredComparision.EQUALS).nullable()
+					)
+				)
+				.expectArgumentTypes(
+					DataTypes.ARRAY(
+						structuredType("type", singletonList(DataTypes.INT()), StructuredComparision.EQUALS).notNull()
+					),
+					DataTypes.ARRAY(
+						structuredType("type", singletonList(DataTypes.INT()), StructuredComparision.EQUALS).nullable()
+					)
+				),
+
+			TestSpec
+				.forStrategy(
 					"Distinct types are comparable if the source type is comparable",
 					InputTypeStrategies.TWO_EQUALS_COMPARABLE)
 				.calledWithArgumentTypes(
@@ -180,6 +201,27 @@ public class ComparableInputTypeStrategyTests extends InputTypeStrategiesTestBas
 				.expectArgumentTypes(
 					distinctType("type", DataTypes.INT()).notNull(),
 					distinctType("type", DataTypes.INT()).nullable()
+				),
+
+			TestSpec
+				.forStrategy(
+					"Comparable multisets of distinct types",
+					InputTypeStrategies.TWO_EQUALS_COMPARABLE)
+				.calledWithArgumentTypes(
+					DataTypes.MULTISET(
+						distinctType("type", DataTypes.INT()).notNull()
+					),
+					DataTypes.MULTISET(
+						distinctType("type", DataTypes.INT()).nullable()
+					)
+				)
+				.expectArgumentTypes(
+					DataTypes.MULTISET(
+						distinctType("type", DataTypes.INT()).notNull()
+					),
+					DataTypes.MULTISET(
+						distinctType("type", DataTypes.INT()).nullable()
+					)
 				),
 
 			TestSpec
@@ -206,6 +248,31 @@ public class ComparableInputTypeStrategyTests extends InputTypeStrategiesTestBas
 				.expectArgumentTypes(
 					rawType(ComparableClass.class).notNull(),
 					rawType(ComparableClass.class).nullable()
+				),
+
+			TestSpec
+				.forStrategy(
+					"Comparable map of raw types",
+					InputTypeStrategies.TWO_EQUALS_COMPARABLE)
+				.calledWithArgumentTypes(
+					DataTypes.MAP(
+						rawType(ComparableClass.class).notNull(),
+						rawType(ComparableClass.class)
+					),
+					DataTypes.MAP(
+						rawType(ComparableClass.class).nullable(),
+						rawType(ComparableClass.class)
+					)
+				)
+				.expectArgumentTypes(
+					DataTypes.MAP(
+						rawType(ComparableClass.class).notNull(),
+						rawType(ComparableClass.class)
+					),
+					DataTypes.MAP(
+						rawType(ComparableClass.class).nullable(),
+						rawType(ComparableClass.class)
+					)
 				),
 
 			TestSpec


### PR DESCRIPTION
## What is the purpose of the change

The nullability was not normalized when checking distinct/structured/raw types nested in other type.

## Verifying this change
Added tests in `ComparableInputTypeStrategyTests`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
