### PR TITLE
[FLINK-15687][runtime][test] Fix test instabilities due to concurrent access to TaskSlotTable

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.taskexecutor.rpc.RpcResultPartitionConsumableNot
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
+import org.apache.flink.runtime.taskexecutor.slot.ThreadSafeTaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -92,6 +93,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 	private final TestingHighAvailabilityServices haServices;
 	private final TemporaryFolder temporaryFolder;
 	private final TaskSlotTable<Task> taskSlotTable;
+	private final ThreadSafeTaskSlotTable<Task> threadSafeTaskSlotTable;
 	private final JobMasterId jobMasterId;
 
 	private TestingTaskExecutor taskExecutor;
@@ -167,6 +169,8 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
 		taskExecutor.start();
 		taskExecutor.waitUntilStarted();
+
+		this.threadSafeTaskSlotTable = new ThreadSafeTaskSlotTable<>(taskSlotTable, taskExecutor.getMainThreadExecutableForTesting());
 	}
 
 	static void registerJobMasterConnection(
@@ -198,7 +202,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 	}
 
 	public TaskSlotTable<Task> getTaskSlotTable() {
-		return taskSlotTable;
+		return threadSafeTaskSlotTable;
 	}
 
 	public JobMasterId getJobMasterId() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -138,20 +138,8 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 			jobMasterGateway = testingJobMasterGateway;
 		}
 
-		TaskManagerActions taskManagerActions;
-		if (taskManagerActionListeners.size() == 0) {
-			taskManagerActions = new NoOpTaskManagerActions();
-		} else {
-			TestTaskManagerActions testTaskManagerActions = new TestTaskManagerActions(taskSlotTable, jobMasterGateway);
-			for (Tuple3<ExecutionAttemptID, ExecutionState, CompletableFuture<Void>> listenerTuple : taskManagerActionListeners) {
-				testTaskManagerActions.addListener(listenerTuple.f0, listenerTuple.f1, listenerTuple.f2);
-			}
-			taskManagerActions = testTaskManagerActions;
-		}
-
 		this.testingRpcService = testingRpcService;
 		final DefaultJobTable jobTable = DefaultJobTable.create();
-		registerJobMasterConnection(jobTable, jobId, testingRpcService, jobMasterGateway, taskManagerActions, timeout);
 
 		TaskExecutorLocalStateStoresManager localStateStoresManager = new TaskExecutorLocalStateStoresManager(
 			false,
@@ -171,6 +159,19 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 		taskExecutor.waitUntilStarted();
 
 		this.threadSafeTaskSlotTable = new ThreadSafeTaskSlotTable<>(taskSlotTable, taskExecutor.getMainThreadExecutableForTesting());
+
+		TaskManagerActions taskManagerActions;
+		if (taskManagerActionListeners.size() == 0) {
+			taskManagerActions = new NoOpTaskManagerActions();
+		} else {
+			TestTaskManagerActions testTaskManagerActions = new TestTaskManagerActions(threadSafeTaskSlotTable, jobMasterGateway);
+			for (Tuple3<ExecutionAttemptID, ExecutionState, CompletableFuture<Void>> listenerTuple : taskManagerActionListeners) {
+				testTaskManagerActions.addListener(listenerTuple.f0, listenerTuple.f1, listenerTuple.f2);
+			}
+			taskManagerActions = testTaskManagerActions;
+		}
+
+		registerJobMasterConnection(jobTable, jobId, testingRpcService, jobMasterGateway, taskManagerActions, timeout);
 	}
 
 	static void registerJobMasterConnection(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -92,7 +92,6 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
 	private final TestingHighAvailabilityServices haServices;
 	private final TemporaryFolder temporaryFolder;
-	private final TaskSlotTable<Task> taskSlotTable;
 	private final ThreadSafeTaskSlotTable<Task> threadSafeTaskSlotTable;
 	private final JobMasterId jobMasterId;
 
@@ -118,7 +117,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
 		this.jobMasterId = jobMasterId;
 
-		this.taskSlotTable = slotSize > 0 ?
+		final TaskSlotTable<Task> taskSlotTable = slotSize > 0 ?
 			TaskSlotUtils.createTaskSlotTable(slotSize) :
 			TestingTaskSlotTable
 				.<Task>newBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.MainThreadExecutable;
 import org.apache.flink.runtime.rpc.RpcService;
 
 import javax.annotation.Nullable;
@@ -79,5 +80,9 @@ class TestingTaskExecutor extends TaskExecutor {
 
 	void waitUntilStarted() {
 		startFuture.join();
+	}
+
+	MainThreadExecutable getMainThreadExecutableForTesting() {
+		return this.rpcServer;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.rpc.MainThreadExecutable;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Testing implementation of {@link TaskSlotTable}.
+ * This class wraps a given {@link TaskSlotTable}, guarantees all the accesses are invoked on the given {@link MainThreadExecutable}.
+ */
+public class ThreadSafeTaskSlotTable<T extends TaskSlotPayload> implements TaskSlotTable<T> {
+
+	private final TaskSlotTable<T> taskSlotTable;
+	private final MainThreadExecutable mainThreadExecutable;
+
+	public ThreadSafeTaskSlotTable(
+			final TaskSlotTable<T> taskSlotTable,
+			final MainThreadExecutable mainThreadExecutable) {
+		this.taskSlotTable = Preconditions.checkNotNull(taskSlotTable);
+		this.mainThreadExecutable = Preconditions.checkNotNull(mainThreadExecutable);
+	}
+
+	private void runAsync(Runnable runnable) {
+		mainThreadExecutable.runAsync(runnable);
+	}
+
+	private <V> V callAsync(Callable<V> callable) {
+		try {
+			return mainThreadExecutable.callAsync(
+				callable,
+				Time.days(1) // practically infinite timeout
+			).get();
+		} catch (InterruptedException | ExecutionException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void start(SlotActions initialSlotActions, ComponentMainThreadExecutor mainThreadExecutor) {
+		runAsync(() -> taskSlotTable.start(initialSlotActions, mainThreadExecutor));
+	}
+
+	@Override
+	public Set<AllocationID> getAllocationIdsPerJob(JobID jobId) {
+		return callAsync(() -> taskSlotTable.getAllocationIdsPerJob(jobId));
+	}
+
+	@Override
+	public SlotReport createSlotReport(ResourceID resourceId) {
+		return callAsync(() -> taskSlotTable.createSlotReport(resourceId));
+	}
+
+	@Override
+	public boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, Time slotTimeout) {
+		return callAsync(() -> taskSlotTable.allocateSlot(index, jobId, allocationId, slotTimeout));
+	}
+
+	@Override
+	public boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, ResourceProfile resourceProfile, Time slotTimeout) {
+		return callAsync(() -> taskSlotTable.allocateSlot(index, jobId, allocationId, resourceProfile, slotTimeout));
+	}
+
+	@Override
+	public boolean markSlotActive(AllocationID allocationId) throws SlotNotFoundException {
+		return callAsync(() -> taskSlotTable.markSlotActive(allocationId));
+	}
+
+	@Override
+	public boolean markSlotInactive(AllocationID allocationId, Time slotTimeout) throws SlotNotFoundException {
+		return callAsync(() -> taskSlotTable.markSlotInactive(allocationId, slotTimeout));
+	}
+
+	@Override
+	public int freeSlot(AllocationID allocationId) throws SlotNotFoundException {
+		return callAsync(() -> taskSlotTable.freeSlot(allocationId));
+	}
+
+	@Override
+	public int freeSlot(AllocationID allocationId, Throwable cause) throws SlotNotFoundException {
+		return callAsync(() -> taskSlotTable.freeSlot(allocationId, cause));
+	}
+
+	@Override
+	public boolean isValidTimeout(AllocationID allocationId, UUID ticket) {
+		return callAsync(() -> taskSlotTable.isValidTimeout(allocationId, ticket));
+	}
+
+	@Override
+	public boolean isAllocated(int index, JobID jobId, AllocationID allocationId) {
+		return callAsync(() -> taskSlotTable.isAllocated(index, jobId, allocationId));
+	}
+
+	@Override
+	public boolean tryMarkSlotActive(JobID jobId, AllocationID allocationId) {
+		return callAsync(() -> taskSlotTable.tryMarkSlotActive(jobId, allocationId));
+	}
+
+	@Override
+	public boolean isSlotFree(int index) {
+		return callAsync(() -> taskSlotTable.isSlotFree(index));
+	}
+
+	@Override
+	public boolean hasAllocatedSlots(JobID jobId) {
+		return callAsync(() -> taskSlotTable.hasAllocatedSlots(jobId));
+	}
+
+	@Override
+	public Iterator<TaskSlot<T>> getAllocatedSlots(JobID jobId) {
+		return callAsync(() -> taskSlotTable.getAllocatedSlots(jobId));
+	}
+
+	@Override
+	public Iterator<AllocationID> getActiveSlots(JobID jobId) {
+		return callAsync(() -> taskSlotTable.getActiveSlots(jobId));
+	}
+
+	@Nullable
+	@Override
+	public JobID getOwningJob(AllocationID allocationId) {
+		return callAsync(() -> taskSlotTable.getOwningJob(allocationId));
+	}
+
+	@Override
+	public boolean addTask(T task) throws SlotNotFoundException, SlotNotActiveException {
+		return callAsync(() -> taskSlotTable.addTask(task));
+	}
+
+	@Override
+	public T removeTask(ExecutionAttemptID executionAttemptID) {
+		return callAsync(() -> taskSlotTable.removeTask(executionAttemptID));
+	}
+
+	@Override
+	public T getTask(ExecutionAttemptID executionAttemptID) {
+		return callAsync(() -> taskSlotTable.getTask(executionAttemptID));
+	}
+
+	@Override
+	public Iterator<T> getTasks(JobID jobId) {
+		return callAsync(() -> taskSlotTable.getTasks(jobId));
+	}
+
+	@Override
+	public AllocationID getCurrentAllocation(int index) {
+		return callAsync(() -> taskSlotTable.getCurrentAllocation(index));
+	}
+
+	@Override
+	public MemoryManager getTaskMemoryManager(AllocationID allocationID) throws SlotNotFoundException {
+		return callAsync(() -> taskSlotTable.getTaskMemoryManager(allocationID));
+	}
+
+	@Override
+	public void notifyTimeout(AllocationID key, UUID ticket) {
+		runAsync(() -> taskSlotTable.notifyTimeout(key, ticket));
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		return callAsync(taskSlotTable::closeAsync);
+	}
+
+	@Override
+	public void close() throws Exception {
+		callAsync(() -> {
+			taskSlotTable.close();
+			return null;
+		});
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the test instabilities due to concurrent access to TaskSlotTable.

## Brief change log

Introduce `ThreadSafeTaskSlotTable` that wraps a `TaskSlotTable` and guarantees the wrapped table is always accessed in the rpc main thread, for testing purpose.

## Verifying this change

Manually verified by printing all the access thread names in `TaskSlotTableImpl`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
