### PR TITLE
[FLINK-17952][python] Fix the bug that exception was thrown when creating BatchTableEnvironment via EnvironmentSettings with old planner.

### DIFF
--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -573,6 +573,14 @@ class BatchTableEnvironmentTests(TableEnvironmentTest, PyFlinkBatchTableTestCase
         self.assertEqual(readed_table_config.get_max_generated_code_length(), 32000)
         self.assertEqual(readed_table_config.get_local_timezone(), "Asia/Shanghai")
 
+    def test_create_table_environment_with_old_planner(self):
+        t_env = BatchTableEnvironment.create(
+            environment_settings=EnvironmentSettings.new_instance().in_batch_mode()
+            .use_old_planner().build())
+        self.assertEqual(
+            t_env._j_tenv.getClass().getName(),
+            "org.apache.flink.table.api.bridge.java.internal.BatchTableEnvironmentImpl")
+
     def test_create_table_environment_with_blink_planner(self):
         t_env = BatchTableEnvironment.create(
             environment_settings=EnvironmentSettings.new_instance().in_batch_mode()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request refactors the create() method to support creating BatchTableEnvironment with old planner via EnvironmentSettings.*

## Brief change log

  - *Refactor the create() method to support creating BatchTableEnvironment with old planner via EnvironmentSettings.*

## Verifying this change

This change is already covered by existing tests, such as *test_table_environment_api.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
