### PR TITLE
[FLINK-16057] Optimize ContinuousFileReaderOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
@@ -43,10 +43,22 @@ public final class MailboxExecutorImpl implements MailboxExecutor {
 
 	private final StreamTaskActionExecutor actionExecutor;
 
+	private final MailboxProcessor mailboxProcessor;
+
 	public MailboxExecutorImpl(@Nonnull TaskMailbox mailbox, int priority, StreamTaskActionExecutor actionExecutor) {
+		this(mailbox, priority, actionExecutor, null);
+	}
+
+	public MailboxExecutorImpl(@Nonnull TaskMailbox mailbox, int priority, StreamTaskActionExecutor actionExecutor, MailboxProcessor mailboxProcessor) {
 		this.mailbox = mailbox;
 		this.priority = priority;
 		this.actionExecutor = Preconditions.checkNotNull(actionExecutor);
+		this.mailboxProcessor = mailboxProcessor;
+	}
+
+	public boolean isIdle() {
+		return !mailboxProcessor.isMailboxLoopRunning() ||
+			(mailboxProcessor.isDefaultActionUnavailable() && !mailbox.hasMail() && mailbox.getState().isAcceptingMails());
 	}
 
 	@Override
@@ -85,4 +97,5 @@ public final class MailboxExecutorImpl implements MailboxExecutor {
 			return false;
 		}
 	}
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -71,9 +71,6 @@ public class MailboxProcessor implements Closeable {
 	/** Action that is repeatedly executed if no action request is in the mailbox. Typically record processing. */
 	protected final MailboxDefaultAction mailboxDefaultAction;
 
-	/** A pre-created instance of mailbox executor that executes all mails. */
-	private final MailboxExecutor mainMailboxExecutor;
-
 	/** Control flag to terminate the mailbox loop. Must only be accessed from mailbox thread. */
 	private boolean mailboxLoopRunning;
 
@@ -102,27 +99,15 @@ public class MailboxProcessor implements Closeable {
 			MailboxDefaultAction mailboxDefaultAction,
 			TaskMailbox mailbox,
 			StreamTaskActionExecutor actionExecutor) {
-		this(mailboxDefaultAction, actionExecutor, mailbox, new MailboxExecutorImpl(mailbox, MIN_PRIORITY, actionExecutor));
-	}
-
-	public MailboxProcessor(
-			MailboxDefaultAction mailboxDefaultAction,
-			StreamTaskActionExecutor actionExecutor,
-			TaskMailbox mailbox,
-			MailboxExecutor mainMailboxExecutor) {
 		this.mailboxDefaultAction = Preconditions.checkNotNull(mailboxDefaultAction);
 		this.actionExecutor = Preconditions.checkNotNull(actionExecutor);
 		this.mailbox = Preconditions.checkNotNull(mailbox);
-		this.mainMailboxExecutor = Preconditions.checkNotNull(mainMailboxExecutor);
 		this.mailboxLoopRunning = true;
 		this.suspendedDefaultAction = null;
 	}
 
-	/**
-	 * Returns a pre-created executor service that executes all mails.
-	 */
 	public MailboxExecutor getMainMailboxExecutor() {
-		return mainMailboxExecutor;
+		return new MailboxExecutorImpl(mailbox, MIN_PRIORITY, actionExecutor);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -116,7 +116,7 @@ public class MailboxProcessor implements Closeable {
 	 * @param priority the priority of the {@link MailboxExecutor}.
 	 */
 	public MailboxExecutor getMailboxExecutor(int priority) {
-		return new MailboxExecutorImpl(mailbox, priority, actionExecutor);
+		return new MailboxExecutorImpl(mailbox, priority, actionExecutor, this);
 	}
 
 	public void initMetric(TaskMetricGroup metricGroup) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
@@ -173,7 +173,16 @@ public interface TaskMailbox {
 	 * This enum represents the states of the mailbox lifecycle.
 	 */
 	enum State {
-		OPEN, QUIESCED, CLOSED
+		OPEN(true), QUIESCED(false), CLOSED(false);
+		private final boolean acceptingMails;
+
+		State(boolean acceptingMails) {
+			this.acceptingMails = acceptingMails;
+		}
+
+		public boolean isAcceptingMails() {
+			return acceptingMails;
+		}
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
@@ -311,6 +311,9 @@ public class TaskMailboxImpl implements TaskMailbox {
 	@Nonnull
 	@Override
 	public State getState() {
+		if (isMailboxThread()) {
+			return state;
+		}
 		final ReentrantLock lock = this.lock;
 		lock.lock();
 		try {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -60,7 +60,7 @@ public class MailboxExecutorImplTest {
 		this.mailbox = new TaskMailboxImpl();
 		this.mailboxExecutor = new MailboxExecutorImpl(mailbox, DEFAULT_PRIORITY, StreamTaskActionExecutor.IMMEDIATE);
 		this.otherThreadExecutor = Executors.newSingleThreadScheduledExecutor();
-		this.mailboxProcessor = new MailboxProcessor(c -> { }, StreamTaskActionExecutor.IMMEDIATE, mailbox, mailboxExecutor);
+		this.mailboxProcessor = new MailboxProcessor(c -> { }, mailbox, StreamTaskActionExecutor.IMMEDIATE);
 	}
 
 	@After


### PR DESCRIPTION
## What is the purpose of the change

Migrating `ContinuousFileReaderOperator` to mailbox execution model caused performance regression.
This PR eliminates it by avoiding going through the mailbox unnecessarily.

Local results before and after optimization (with [benchmark fix](https://github.com/dataArtisans/flink-benchmarks/pull/63) applied):
```
ContinuousFileReaderOperatorBenchmark.readFileSplit  thrpt   30  10444.184 ± 228.434  ops/ms
ContinuousFileReaderOperatorBenchmark.readFileSplit  thrpt   30  31451.848 ± 849.005  ops/ms
```
Without the fix, results are better because it then does all the job in CLOSING phase in a loop. 
So it's preferable to merge [benchmark fix](https://github.com/dataArtisans/flink-benchmarks/pull/63) first.

## Brief change log

  - loop in `ContinuousFileReaderOperator` if mailbox executor is idle
  - optimize `MailboxExecutor.isIdle`

## Verifying this change

  - correctness is covered by existing tests such as `ContinuousFileProcessingTest`
  - performance if measured by http://codespeed.dak8s.net:8000/

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
