### PR TITLE
[FLINK-17990][python] Fix the test of ArrowSourceFunctionTestBase.testParallelProcessing to use synchronized list

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTestBase.java
@@ -47,6 +47,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -174,7 +175,7 @@ public abstract class ArrowSourceFunctionTestBase<T> {
 		final Throwable[] error = new Throwable[2];
 		final OneShotLatch latch = new OneShotLatch();
 		final AtomicInteger numOfEmittedElements = new AtomicInteger(0);
-		final List<T> results = new ArrayList<>();
+		final List<T> results = Collections.synchronizedList(new ArrayList<>());
 
 		// run the source asynchronously
 		Thread runner = new Thread(() -> {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the test of ArrowSourceFunctionTestBase.testParallelProcessing. It uses ArrayList which is not thread safe.*

## Brief change log

  - *Change ArrayList to synchronized list*

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
