### PR TITLE
[FLINK-16816][table sql/runtime] Add timestamp and date array test for DataFormatConverters.

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataFormatConvertersTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataFormatConvertersTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.types.RowKind;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -131,7 +132,9 @@ public class DataFormatConvertersTest {
 			new LegacyTypeInformationType<>(
 				LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
 				new LegacyTimestampTypeInfo(7))),
-		DataTypes.TIMESTAMP(3).bridgedTo(TimestampData.class)
+		DataTypes.TIMESTAMP(3).bridgedTo(TimestampData.class),
+		DataTypes.ARRAY(DataTypes.TIMESTAMP(3).bridgedTo(Timestamp.class)),
+		DataTypes.ARRAY(DataTypes.DATE().bridgedTo(Date.class))
 	};
 
 	private Object[] dataValues = new Object[] {
@@ -140,7 +143,9 @@ public class DataFormatConvertersTest {
 		LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123),
 		Timestamp.valueOf("1970-01-01 00:00:00.123"),
 		Timestamp.valueOf("1970-01-01 00:00:00.1234567"),
-		TimestampData.fromEpochMillis(1000L)
+		TimestampData.fromEpochMillis(1000L),
+		new Timestamp[] {Timestamp.valueOf("1970-01-01 00:00:00.123"), Timestamp.valueOf("1971-01-01 00:00:00.123")},
+		new Date[] {Date.valueOf("1970-01-01"), Date.valueOf("1971-01-01")}
 	};
 
 	private static DataFormatConverter getConverter(TypeInformation typeInfo) {


### PR DESCRIPTION
## What is the purpose of the change
* User reported that **sq.Timestamp** and **sql.Date** array can not deal properly in planner, but after we imported RowData, this bug fixed because we convert Timestamp/Date to TimestampData/Int as internal data structure rather than LocalDatetime/LocalDate.

* This pull request only add timestamp and date array test to cover this cases.


## Brief change log

  - *update file DataFormatConvertersTest.java*


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
