### PR TITLE
 [FLINK-17994][checkpointing] Fix the race condition between CheckpointBarrierUnaligner#processBarrier and #notifyBarrierReceived

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -545,7 +545,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		cleanUpInvoke();
 	}
 
-	protected boolean runMailboxStep() throws Exception {
+	@VisibleForTesting
+	public boolean runMailboxStep() throws Exception {
 		return mailboxProcessor.runMailboxStep();
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

The race condition happens as following:

-  CheckpointBarrierUnaligner#notifyBarrierReceived triggers an async checkpoint(ch1) in mailbox by netty thread.
-  CheckpointBarrierUnaligner#processBarrier also triggers a sync checkpoint(ch2) by task thread and executes immediately.
-  When ch1 is taken from mailbox by task thread to execute, it will cause illegal argument exception because it is smaller than the previous executed ch2.
    
For async checkpoint action, before it is actual executing, we can compare its id with previous executed checkpoint id. If it is not larger than the previous one, we should ignore it to exit directly.

## Brief change log

  - *Fix the race condition between CheckpointBarrierUnaligner#processBarrier and #notifyBarrierReceived*
  - *Recyle the buffer when exception from ChannelStateWriter.addInputData*
  - *Fix the formatting of CheckpointBarrierUnaligner*

## Verifying this change

  - *Added CheckpointBarrierUnalignerTest#testBufferRecycleOnNotifyBufferReceivedException*
  - *Added CheckpointBarrierUnalignerTest#testConcurrentProcessBarrierAndNotifyBarrierReceived*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
