### PR TITLE
[FLINK-16198][core] Fix FileUtilsTest fails on MacOS

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -64,8 +64,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public final class FileUtils {
 
-	/** Global lock to prevent concurrent directory deletes under Windows. */
-	private static final Object WINDOWS_DELETE_LOCK = new Object();
+	/** Global lock to prevent concurrent directory deletes under Windows and MacOS. */
+	private static final Object DELETE_LOCK = new Object();
 
 	/** The alphabet to construct the random part of the filename from. */
 	private static final char[] ALPHABET =
@@ -255,7 +255,7 @@ public final class FileUtils {
 	public static void deleteFileOrDirectory(File file) throws IOException {
 		checkNotNull(file, "file");
 
-		guardIfWindows(FileUtils::deleteFileOrDirectoryInternal, file);
+		guardIfNotThreadSafe(FileUtils::deleteFileOrDirectoryInternal, file);
 	}
 
 	/**
@@ -273,7 +273,7 @@ public final class FileUtils {
 	public static void deleteDirectory(File directory) throws IOException {
 		checkNotNull(directory, "directory");
 
-		guardIfWindows(FileUtils::deleteDirectoryInternal, directory);
+		guardIfNotThreadSafe(FileUtils::deleteDirectoryInternal, directory);
 	}
 
 	/**
@@ -311,7 +311,7 @@ public final class FileUtils {
 	public static void cleanDirectory(File directory) throws IOException {
 		checkNotNull(directory, "directory");
 
-		guardIfWindows(FileUtils::cleanDirectoryInternal, directory);
+		guardIfNotThreadSafe(FileUtils::cleanDirectoryInternal, directory);
 	}
 
 	private static void deleteFileOrDirectoryInternal(File file) throws IOException {
@@ -386,35 +386,60 @@ public final class FileUtils {
 		}
 	}
 
-	private static void guardIfWindows(ThrowingConsumer<File, IOException> toRun, File file) throws IOException {
-		if (!OperatingSystem.isWindows()) {
-			toRun.accept(file);
+	private static void guardIfNotThreadSafe(ThrowingConsumer<File, IOException> toRun, File file) throws IOException {
+		if (OperatingSystem.isWindows()) {
+			guardIfWindows(toRun, file);
+			return;
 		}
-		else {
-			// for windows, we synchronize on a global lock, to prevent concurrent delete issues
-			// >
-			// in the future, we may want to find either a good way of working around file visibility
-			// in Windows under concurrent operations (the behavior seems completely unpredictable)
-			// or  make this locking more fine grained, for example  on directory path prefixes
-			synchronized (WINDOWS_DELETE_LOCK) {
-				for (int attempt = 1; attempt <= 10; attempt++) {
-					try {
-						toRun.accept(file);
-						break;
-					}
-					catch (AccessDeniedException e) {
-						// ah, windows...
-					}
+		if (OperatingSystem.isMac()) {
+			guardIfMac(toRun, file);
+			return;
+		}
 
-					// briefly wait and fall through the loop
-					try {
-						Thread.sleep(1);
-					} catch (InterruptedException e) {
-						// restore the interruption flag and error out of the method
-						Thread.currentThread().interrupt();
-						throw new IOException("operation interrupted");
-					}
+		toRun.accept(file);
+	}
+
+	// for Windows, we synchronize on a global lock, to prevent concurrent delete issues
+	// >
+	// in the future, we may want to find either a good way of working around file visibility
+	// under concurrent operations (the behavior seems completely unpredictable)
+	// or  make this locking more fine grained, for example  on directory path prefixes
+	private static void guardIfWindows(ThrowingConsumer<File, IOException> toRun, File file) throws IOException{
+		synchronized (DELETE_LOCK) {
+			for (int attempt = 1; attempt <= 10; attempt++) {
+				try {
+					toRun.accept(file);
+					break;
 				}
+				catch (AccessDeniedException e) {
+					// ah, windows...
+				}
+
+				// briefly wait and fall through the loop
+				try {
+					Thread.sleep(1);
+				} catch (InterruptedException e) {
+					// restore the interruption flag and error out of the method
+					Thread.currentThread().interrupt();
+					throw new IOException("operation interrupted");
+				}
+			}
+		}
+	}
+
+
+	// Guard Mac for the same reason we guard windows. Refer to guardIfWindows for details.
+	// Beside swallow access deny exception while deleting on Mac will lead to un-expected behavior
+	private static void guardIfMac(ThrowingConsumer<File, IOException> toRun, File file) throws IOException{
+		synchronized (DELETE_LOCK) {
+			toRun.accept(file);
+			// briefly wait and fall through the loop
+			try {
+				Thread.sleep(1);
+			} catch (InterruptedException e) {
+				// restore the interruption flag and error out of the method
+				Thread.currentThread().interrupt();
+				throw new IOException("operation interrupted");
 			}
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -535,7 +535,8 @@ public final class FileUtils {
 		FileSystem targetFs = target.getFileSystem();
 
 		Path absolutePath = absolutizePath(directory);
-		try (ZipOutputStream out = new ZipOutputStream(targetFs.create(target, FileSystem.WriteMode.NO_OVERWRITE))) {
+		Path absoluteTargetPath = absolutizePath(target);
+		try (ZipOutputStream out = new ZipOutputStream(targetFs.create(absoluteTargetPath, FileSystem.WriteMode.NO_OVERWRITE))) {
 			addToZip(absolutePath, sourceFs, absolutePath.getParent(), out);
 		}
 		return target;

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -409,7 +409,7 @@ public class FileUtilsTest extends TestLogger {
 	}
 
 	/**
-	 * Generate some directories in a original directory based on the {@code compressDir}.
+	 * Generate some directories in a original directory based on the {@code testDir}.
 	 * @param testDir the path of the directory where the test directories are generated
 	 * @param compressDir the path of directory to be verified
 	 * @throws IOException if I/O error occurs while generating the directories

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -249,16 +249,17 @@ public class FileUtilsTest extends TestLogger {
 
 	@Test
 	public void testCompressionOnAbsolutePath() throws IOException {
-		verifyDirectoryCompression(tmp.newFolder("compressDir").toPath());
+		final java.nio.file.Path testDir = tmp.newFolder("compressDir").toPath();
+		verifyDirectoryCompression(testDir, testDir);
 	}
 
 	@Test
 	public void testCompressionOnRelativePath() throws IOException {
-		final java.nio.file.Path compressDir = tmp.newFolder("compressDir").toPath();
+		final java.nio.file.Path testDir = tmp.newFolder("compressDir").toPath();
 		final java.nio.file.Path relativeCompressDir =
-			Paths.get(new File("").getAbsolutePath()).relativize(compressDir);
+			Paths.get(new File("").getAbsolutePath()).relativize(testDir);
 
-		verifyDirectoryCompression(relativeCompressDir);
+		verifyDirectoryCompression(testDir, relativeCompressDir);
 	}
 
 	@Test
@@ -409,10 +410,11 @@ public class FileUtilsTest extends TestLogger {
 
 	/**
 	 * Generate some directories in a original directory based on the {@code compressDir}.
-	 * @param compressDir the path of the directory where the test directories are generated
+	 * @param testDir the path of the directory where the test directories are generated
+	 * @param compressDir the path of directory to be verified
 	 * @throws IOException if I/O error occurs while generating the directories
 	 */
-	private void verifyDirectoryCompression(final java.nio.file.Path compressDir) throws IOException {
+	private void verifyDirectoryCompression(final java.nio.file.Path testDir, final java.nio.file.Path compressDir) throws IOException {
 		final String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
 			+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
 			+ "RAPHAEL: Die Sonne toent, nach alter Weise, In Brudersphaeren Wettgesang,\n"
@@ -437,14 +439,14 @@ public class FileUtilsTest extends TestLogger {
 		final java.nio.file.Path file2 = originalDir.resolve("file2");
 		final java.nio.file.Path file3 = fullSubDir.resolve("file3");
 
-		Files.createDirectory(compressDir.resolve(originalDir));
-		Files.createDirectory(compressDir.resolve(emptySubDir));
-		Files.createDirectory(compressDir.resolve(fullSubDir));
+		Files.createDirectory(testDir.resolve(originalDir));
+		Files.createDirectory(testDir.resolve(emptySubDir));
+		Files.createDirectory(testDir.resolve(fullSubDir));
 		Files.copy(
-			new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file1));
-		Files.createFile(compressDir.resolve(file2));
+			new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), testDir.resolve(file1));
+		Files.createFile(testDir.resolve(file2));
 		Files.copy(
-			new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file3));
+			new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), testDir.resolve(file3));
 
 		final Path zip = FileUtils.compressDirectory(
 			new Path(compressDir.resolve(originalDir).toString()),


### PR DESCRIPTION

## What is the purpose of the change

Fix FileUtilsTest fails on MacOS

## Brief change log

  -*Fix concurrent delete failure on MacOS*
  -*Fix relative compression path test failure*
  

## Verifying this change

This change is already covered by existing tests, such as *(FileUtilsTest.)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
