### PR TITLE
[FLINK-17895] Default value of rows-per-second in datagen is changed …

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
@@ -56,10 +56,11 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 
 	public static final String IDENTIFIER = "datagen";
+	public static final Long ROWS_PER_SECOND_DEFAULT_VALUE = 10000L;
 
 	public static final ConfigOption<Long> ROWS_PER_SECOND = key("rows-per-second")
 			.longType()
-			.defaultValue(Long.MAX_VALUE)
+			.defaultValue(ROWS_PER_SECOND_DEFAULT_VALUE)
 			.withDescription("Rows per second to control the emit rate.");
 
 	public static final String FIELDS = "fields";


### PR DESCRIPTION
## What is the purpose of the change

Default value of rows-per-second in datagen is changed from Long.MAX_VALUE to 10000L.

## Brief change log

Default value of rows-per-second in datagen is changed from Long.MAX_VALUE to 10000L.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
