### PR TITLE
[FLINK-17816] Change Latency Marker to work with scheduleAtFixedDelay

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -180,7 +180,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 				final OperatorID operatorId,
 				final int subtaskIndex) {
 
-			latencyMarkTimer = processingTimeService.scheduleAtFixedRate(
+			latencyMarkTimer = processingTimeService.scheduleWithFixedDelay(
 				new ProcessingTimeCallback() {
 					@Override
 					public void onProcessingTime(long timestamp) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Latency marker is triggered with fixed rate, which means it may be sent immediately again if the source task is blocking. (which dosen't help a lot to the latency metrics)

## Brief change log

* switch `scheduleAtFixedRate` with `scheduleWithFixedDelay`.


## Verifying this change

* existing unit testing should cover this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
