### PR TITLE
[FLINK-17996][table-planner-blink] NPE in CatalogTableStatisticsConverter.convertToColumnStats method

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.utils;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
@@ -61,6 +62,7 @@ public class CatalogTableStatisticsConverter {
 		return new TableStats(rowCount, columnStatsMap);
 	}
 
+	@VisibleForTesting
 	public static Map<String, ColumnStats> convertToColumnStatsMap(
 			Map<String, CatalogColumnStatisticsDataBase> columnStatisticsData) {
 		Map<String, ColumnStats> columnStatsMap = new HashMap<>();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
@@ -61,12 +61,14 @@ public class CatalogTableStatisticsConverter {
 		return new TableStats(rowCount, columnStatsMap);
 	}
 
-	private static Map<String, ColumnStats> convertToColumnStatsMap(
+	public static Map<String, ColumnStats> convertToColumnStatsMap(
 			Map<String, CatalogColumnStatisticsDataBase> columnStatisticsData) {
 		Map<String, ColumnStats> columnStatsMap = new HashMap<>();
 		for (Map.Entry<String, CatalogColumnStatisticsDataBase> entry : columnStatisticsData.entrySet()) {
-			ColumnStats columnStats = convertToColumnStats(entry.getValue());
-			columnStatsMap.put(entry.getKey(), columnStats);
+			if (entry.getValue() != null) {
+				ColumnStats columnStats = convertToColumnStats(entry.getValue());
+				columnStatsMap.put(entry.getKey(), columnStats);
+			}
 		}
 		return columnStatsMap;
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
+import org.apache.flink.table.plan.stats.ColumnStats;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link CatalogTableStatisticsConverter}.
+ */
+public class CatalogTableStatisticsConverterTest {
+
+	@Test
+	public void testConvertToColumnStatsMapWithNullColumnStatisticsData() {
+		Map<String, CatalogColumnStatisticsDataBase> columnStatisticsDataBaseMap = new HashMap<>();
+		columnStatisticsDataBaseMap.put("first", new CatalogColumnStatisticsDataString(10L, 5.2, 3L, 100L));
+		columnStatisticsDataBaseMap.put("second", null);
+		Map<String, ColumnStats> columnStatsMap = CatalogTableStatisticsConverter.convertToColumnStatsMap(columnStatisticsDataBaseMap);
+		assertNotNull(columnStatsMap);
+		assertEquals(columnStatisticsDataBaseMap.size() - 1, columnStatsMap.size());
+		assertTrue(columnStatsMap.containsKey("first"));
+		assertFalse(columnStatsMap.containsKey("second"));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*Hive catalog only supports a few kinds of column statistics, otherwise return null through `HiveStatsUtil#createTableColumnStats`. NullPointerException would occur in `CatalogTableStatisticsConverter#convertToColumnStatsMap` method which iterators the `CatalogColumnStatisticsDataBase` map.*

## Brief change log

  - *Method `CatalogTableStatisticsConverter#convertToColumnStatsMap` check `CatalogColumnStatisticsDataBase` whether is null. If `CatalogColumnStatisticsDataBase` is null, `CatalogColumnStatisticsDataBase` doesn't call `convertToColumnStats` method to convert to column stats.*

## Verifying this change

  - *Add `CatalogTableStatisticsConverterTest#testConvertToColumnStatsMapWithNullColumnStatisticsData` method to verify the null `CatalogColumnStatisticsDataBase` in column statistics data map scenario.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not** applicable / docs / JavaDocs / not documented)
