### PR TITLE
[FLINK-18046][hive] Decimal column stats not supported for Hive table

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -31,12 +31,15 @@ import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
+import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.metastore.api.BinaryColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.Decimal;
+import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.DoubleColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.LongColumnStatsData;
@@ -50,6 +53,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -171,6 +177,22 @@ public class HiveStatsUtil {
 					stringStats.isSetAvgColLen() ? stringStats.getAvgColLen() : null,
 					stringStats.isSetNumDVs() ? stringStats.getNumDVs() : null,
 					stringStats.isSetNumDVs() ? stringStats.getNumNulls() : null);
+		} else if (stats.isSetDecimalStats()) {
+			DecimalColumnStatsData decimalStats = stats.getDecimalStats();
+			// for now, just return CatalogColumnStatisticsDataDouble for decimal columns
+			Double max = null;
+			if (decimalStats.isSetHighValue()) {
+				Decimal highVal = decimalStats.getHighValue();
+				max = HiveDecimal.create(new BigInteger(highVal.getUnscaled()), highVal.getScale()).doubleValue();
+			}
+			Double min = null;
+			if (decimalStats.isSetLowValue()) {
+				Decimal lowVal = decimalStats.getLowValue();
+				min = HiveDecimal.create(new BigInteger(lowVal.getUnscaled()), lowVal.getScale()).doubleValue();
+			}
+			Long ndv = decimalStats.isSetNumDVs() ? decimalStats.getNumDVs() : null;
+			Long nullCount = decimalStats.isSetNumNulls() ? decimalStats.getNumNulls() : null;
+			return new CatalogColumnStatisticsDataDouble(min, max, ndv, nullCount);
 		} else {
 			LOG.warn("Flink does not support converting ColumnStatisticsData '{}' for Hive column type '{}' yet.", stats, colType);
 			return null;
@@ -288,9 +310,36 @@ public class HiveStatsUtil {
 				}
 				return ColumnStatisticsData.binaryStats(hiveBinaryColumnStats);
 			}
+		} else if (type.equals(LogicalTypeRoot.DECIMAL)) {
+			if (colStat instanceof CatalogColumnStatisticsDataDouble) {
+				CatalogColumnStatisticsDataDouble flinkStats = (CatalogColumnStatisticsDataDouble) colStat;
+				DecimalColumnStatsData hiveStats = new DecimalColumnStatsData();
+				if (flinkStats.getMax() != null) {
+					// in older versions we cannot create HiveDecimal from Double, so convert Double to BigDecimal first
+					hiveStats.setHighValue(toThriftDecimal(HiveDecimal.create(BigDecimal.valueOf(flinkStats.getMax()))));
+				}
+				if (flinkStats.getMin() != null) {
+					hiveStats.setLowValue(toThriftDecimal(HiveDecimal.create(BigDecimal.valueOf(flinkStats.getMin()))));
+				}
+				if (flinkStats.getNdv() != null) {
+					hiveStats.setNumDVs(flinkStats.getNdv());
+				}
+				if (flinkStats.getNullCount() != null) {
+					hiveStats.setNumNulls(flinkStats.getNullCount());
+				}
+				return ColumnStatisticsData.decimalStats(hiveStats);
+			}
 		}
 		throw new CatalogException(String.format("Flink does not support converting ColumnStats '%s' for Hive column " +
 												"type '%s' yet", colStat, colType));
+	}
+
+	private static Decimal toThriftDecimal(HiveDecimal hiveDecimal) {
+		// the constructor signature changed in 3.x. use default constructor and set each field...
+		Decimal res = new Decimal();
+		res.setUnscaled(ByteBuffer.wrap(hiveDecimal.unscaledValue().toByteArray()));
+		res.setScale((short) hiveDecimal.scale());
+		return res;
 	}
 
 	public static int parsePositiveIntStat(Map<String, String> parameters, String key) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -182,13 +182,11 @@ public class HiveStatsUtil {
 			// for now, just return CatalogColumnStatisticsDataDouble for decimal columns
 			Double max = null;
 			if (decimalStats.isSetHighValue()) {
-				Decimal highVal = decimalStats.getHighValue();
-				max = HiveDecimal.create(new BigInteger(highVal.getUnscaled()), highVal.getScale()).doubleValue();
+				max = toHiveDecimal(decimalStats.getHighValue()).doubleValue();
 			}
 			Double min = null;
 			if (decimalStats.isSetLowValue()) {
-				Decimal lowVal = decimalStats.getLowValue();
-				min = HiveDecimal.create(new BigInteger(lowVal.getUnscaled()), lowVal.getScale()).doubleValue();
+				min = toHiveDecimal(decimalStats.getLowValue()).doubleValue();
 			}
 			Long ndv = decimalStats.isSetNumDVs() ? decimalStats.getNumDVs() : null;
 			Long nullCount = decimalStats.isSetNumNulls() ? decimalStats.getNumNulls() : null;
@@ -340,6 +338,10 @@ public class HiveStatsUtil {
 		res.setUnscaled(ByteBuffer.wrap(hiveDecimal.unscaledValue().toByteArray()));
 		res.setScale((short) hiveDecimal.scale());
 		return res;
+	}
+
+	private static HiveDecimal toHiveDecimal(Decimal decimal) {
+		return HiveDecimal.create(new BigInteger(decimal.getUnscaled()), decimal.getScale());
 	}
 
 	public static int parsePositiveIntStat(Map<String, String> parameters, String key) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -123,9 +123,10 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 				.field("third", DataTypes.BOOLEAN())
 				.field("fourth", DataTypes.DOUBLE())
 				.field("fifth", DataTypes.BIGINT())
-				.field("sixth", DataTypes.BYTES());
+				.field("sixth", DataTypes.BYTES())
+				.field("seventh", DataTypes.DECIMAL(10, 3));
 		if (supportDateStats) {
-			builder.field("seventh", DataTypes.DATE());
+			builder.field("eighth", DataTypes.DATE());
 		}
 		TableSchema tableSchema = builder.build();
 		CatalogTable catalogTable = new CatalogTableImpl(tableSchema, getBatchTableProperties(), TEST_COMMENT);
@@ -137,8 +138,9 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 		columnStatisticsDataBaseMap.put("fourth", new CatalogColumnStatisticsDataDouble(15.02, 20.01, 3L, 10L));
 		columnStatisticsDataBaseMap.put("fifth", new CatalogColumnStatisticsDataLong(0L, 20L, 3L, 2L));
 		columnStatisticsDataBaseMap.put("sixth", new CatalogColumnStatisticsDataBinary(150L, 20D, 3L));
+		columnStatisticsDataBaseMap.put("seventh", new CatalogColumnStatisticsDataDouble(1.23, 99.456, 100L, 0L));
 		if (supportDateStats) {
-			columnStatisticsDataBaseMap.put("seventh", new CatalogColumnStatisticsDataDate(
+			columnStatisticsDataBaseMap.put("eighth", new CatalogColumnStatisticsDataDate(
 					new Date(71L), new Date(17923L), 132L, 0L));
 		}
 		CatalogColumnStatistics catalogColumnStatistics = new CatalogColumnStatistics(columnStatisticsDataBaseMap);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -124,9 +124,10 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 				.field("fourth", DataTypes.DOUBLE())
 				.field("fifth", DataTypes.BIGINT())
 				.field("sixth", DataTypes.BYTES())
-				.field("seventh", DataTypes.DECIMAL(10, 3));
+				.field("seventh", DataTypes.DECIMAL(10, 3))
+				.field("eighth", DataTypes.DECIMAL(30, 3));
 		if (supportDateStats) {
-			builder.field("eighth", DataTypes.DATE());
+			builder.field("ninth", DataTypes.DATE());
 		}
 		TableSchema tableSchema = builder.build();
 		CatalogTable catalogTable = new CatalogTableImpl(tableSchema, getBatchTableProperties(), TEST_COMMENT);
@@ -139,8 +140,9 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 		columnStatisticsDataBaseMap.put("fifth", new CatalogColumnStatisticsDataLong(0L, 20L, 3L, 2L));
 		columnStatisticsDataBaseMap.put("sixth", new CatalogColumnStatisticsDataBinary(150L, 20D, 3L));
 		columnStatisticsDataBaseMap.put("seventh", new CatalogColumnStatisticsDataDouble(1.23, 99.456, 100L, 0L));
+		columnStatisticsDataBaseMap.put("eighth", new CatalogColumnStatisticsDataDouble(0.123, 123456.789, 5723L, 19L));
 		if (supportDateStats) {
-			columnStatisticsDataBaseMap.put("eighth", new CatalogColumnStatisticsDataDate(
+			columnStatisticsDataBaseMap.put("ninth", new CatalogColumnStatisticsDataDate(
 					new Date(71L), new Date(17923L), 132L, 0L));
 		}
 		CatalogColumnStatistics catalogColumnStatistics = new CatalogColumnStatistics(columnStatisticsDataBaseMap);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the issue that Hive table decimal column stats is not supported


## Brief change log

  - Return `CatalogColumnStatisticsDataDouble` for decimal columns
  - Add test


## Verifying this change

Added test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
