### PR TITLE
[FLINK-17466][table-planner-blink] Fix toRetractStream doesn't work correctly with Pojo conversion class

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
@@ -54,22 +54,22 @@ object SinkCodeGenerator {
       sink.getConsumedDataType,
       inputRowType,
       withChangeFlag)
+    val physicalTypeInfo = fromDataTypeToTypeInfo(physicalOutputType)
 
     val outputTypeInfo = if (withChangeFlag) {
-      val typeInfo = fromDataTypeToTypeInfo(physicalOutputType)
       val consumedClass = sink.getConsumedDataType.getConversionClass
       if (consumedClass == classOf[(_, _)]) {
-        createTuple2TypeInformation(Types.BOOLEAN, typeInfo)
+        createTuple2TypeInformation(Types.BOOLEAN, physicalTypeInfo)
       } else if (consumedClass == classOf[JTuple2[_, _]]) {
-        new TupleTypeInfo(Types.BOOLEAN, typeInfo)
+        new TupleTypeInfo(Types.BOOLEAN, physicalTypeInfo)
       }
     } else {
-      fromDataTypeToTypeInfo(physicalOutputType)
+      physicalTypeInfo
     }
 
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
     var afterIndexModify = inputTerm
-    val fieldIndexProcessCode = outputTypeInfo match {
+    val fieldIndexProcessCode = physicalTypeInfo match {
       case pojo: PojoTypeInfo[_] =>
         val mapping = pojo.getFieldNames.map { name =>
           val index = inputRowType.getFieldIndex(name)

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaPojos.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaPojos.java
@@ -123,4 +123,28 @@ public class JavaPojos {
 				'}';
 		}
 	}
+
+	/**
+	 * A POJO class.
+	 */
+	public static class Person {
+		public String name;
+		public int age;
+
+		public Person() {
+		}
+
+		public Person(String name, int age) {
+			this.name = name;
+			this.age = age;
+		}
+
+		@Override
+		public String toString() {
+			return "Person{" +
+				"name='" + name + '\'' +
+				", age=" + age +
+				'}';
+		}
+	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamTableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamTableEnvironmentITCase.scala
@@ -22,9 +22,8 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
-import org.apache.flink.table.planner.runtime.utils.JavaPojos.{Device, Order, ProductItem}
+import org.apache.flink.table.planner.runtime.utils.JavaPojos.{Device, Order, Person, ProductItem}
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, StringSink}
-
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -81,7 +80,7 @@ class StreamTableEnvironmentITCase extends StreamingTestBase {
     ))
 
     // register DataStream as Table
-    tEnv.createTemporaryView("devices", devices,'deviceId, 'deviceName, 'metrics)
+    tEnv.createTemporaryView("devices", devices, 'deviceId, 'deviceName, 'metrics)
 
     val result = tEnv.sqlQuery("SELECT * FROM devices WHERE deviceId >= 2")
     val sink = new StringSink[Device]()
@@ -92,6 +91,27 @@ class StreamTableEnvironmentITCase extends StreamingTestBase {
     val expected = List(
       "Device{deviceId=2, deviceName='device2', metrics={}}",
       "Device{deviceId=3, deviceName='device3', metrics={B=20}}")
+    assertEquals(expected.sorted, sink.getResults.sorted)
+  }
+
+  @Test
+  def testToRetractStreamWithPojoType(): Unit = {
+    val persons = env.fromCollection(Seq(
+      new Person("bob", 1),
+      new Person("Liz", 2),
+      new Person("Jack", 3)
+    ))
+
+    tEnv.createTemporaryView("person", persons)
+    val sink = new StringSink[(Boolean, Person)]()
+    // reorder the fields (fields order in PojoTypeInfo is [age, name])
+    tEnv.sqlQuery("select name, age from person").toRetractStream[Person].addSink(sink)
+    env.execute()
+
+    val expected = List(
+      "(true,Person{name='bob', age=1})",
+      "(true,Person{name='Liz', age=2})",
+      "(true,Person{name='Jack', age=3})")
     assertEquals(expected.sorted, sink.getResults.sorted)
   }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The `toRetractStream(table, Pojo.class)` does not map the query columns properly to the pojo fields. This either leads to exceptions due to type incompatibility or simply incorrect results. `toAppendStream` doesn't have this problem.

The root cause is that we only code generate with fields mapping when there is no change flag in `SinkCodeGenerator`. So the fix is very simple.

## Brief change log

- Fix SinkCodeGenerator to codegen with fields mapping for POJO types, no matter there is change flag or not. 


## Verifying this change

- Added a `StreamTableEnvironmentITCase#testToRetractStreamWithPojoType` test which can reproduce this problem.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
