### PR TITLE
[FLINK-18049] the AvroRowDeserializationSchema can not read the avro …

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.java.typeutils.MapTypeInfo;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
-import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
@@ -36,8 +35,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
@@ -48,6 +47,7 @@ import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
@@ -113,9 +113,9 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
 	private transient DatumReader<IndexedRecord> datumReader;
 
 	/**
-	 * Input stream to read message from.
+	 * Avro decoder that decodes binary data.
 	 */
-	private transient MutableByteArrayInputStream inputStream;
+	private transient BinaryDecoder decoder;
 
 	/**
 	 * Creates a Avro deserialization schema for the given specific record class. Having the
@@ -131,7 +131,7 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
 		schemaString = schema.toString();
 		record = (IndexedRecord) SpecificData.newInstance(recordClazz, schema);
 		datumReader = new SpecificDatumReader<>(schema);
-		inputStream = new MutableByteArrayInputStream();
+		decoder = createBytesBinaryDecoder();
 	}
 
 	/**
@@ -149,14 +149,14 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
 		schema = new Schema.Parser().parse(avroSchemaString);
 		record = new GenericData.Record(schema);
 		datumReader = new GenericDatumReader<>(schema);
-		inputStream = new MutableByteArrayInputStream();
+		decoder = createBytesBinaryDecoder();
 	}
 
 	@Override
 	public Row deserialize(byte[] message) throws IOException {
 		try {
-			inputStream.setBuffer(message);
-			Decoder decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+			// Reuse the created decoder with allocated buffer to read the record from message.
+			decoder = DecoderFactory.get().binaryDecoder(message, decoder);
 			record = datumReader.read(record, decoder);
 			return convertAvroRecordToRow(schema, typeInfo, record);
 		} catch (Exception e) {
@@ -341,5 +341,24 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
 	private void writeObject(ObjectOutputStream outputStream) throws IOException {
 		outputStream.writeObject(recordClazz);
 		outputStream.writeUTF(schemaString);
+	}
+
+	static BinaryDecoder createBytesBinaryDecoder() {
+		return DecoderFactory.get().binaryDecoder(new byte[0], null);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void readObject(ObjectInputStream inputStream) throws ClassNotFoundException, IOException {
+		recordClazz = (Class<? extends SpecificRecord>) inputStream.readObject();
+		schemaString = inputStream.readUTF();
+		typeInfo = (RowTypeInfo) AvroSchemaConverter.<Row>convertToTypeInfo(schemaString);
+		schema = new Schema.Parser().parse(schemaString);
+		if (recordClazz != null) {
+			record = (SpecificRecord) SpecificData.newInstance(recordClazz, schema);
+		} else {
+			record = new GenericData.Record(schema);
+		}
+		datumReader = new SpecificDatumReader<>(schema);
+		decoder = createBytesBinaryDecoder();
 	}
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/MutableByteArrayInputStream.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/MutableByteArrayInputStream.java
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream;
 public final class MutableByteArrayInputStream extends ByteArrayInputStream {
 
 	public MutableByteArrayInputStream() {
-		super(new byte[0]);
+		super(new byte[0], 0, 0);
 	}
 
 	/**
@@ -41,5 +41,6 @@ public final class MutableByteArrayInputStream extends ByteArrayInputStream {
 		this.buf = buf;
 		this.pos = 0;
 		this.count = buf.length;
+		this.mark = 0;
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -23,6 +23,8 @@ import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.Fixed16;
 import org.apache.flink.formats.avro.generated.Fixed2;
+import org.apache.flink.formats.avro.generated.NewSchemaRecord;
+import org.apache.flink.formats.avro.generated.OldSchemaRecord;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.types.Row;
 
@@ -236,6 +238,31 @@ public final class AvroTestUtils {
 		t.f2 = schema;
 
 		return t;
+	}
+
+	public static Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> getOldRecordData() {
+		OldSchemaRecord oldSchemaRecord = OldSchemaRecord.newBuilder().setField1(100L).build();
+		Row row = new Row(1);
+		row.setField(0, 100L);
+
+		final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> tuple3 = new Tuple3<>();
+		tuple3.f0 = OldSchemaRecord.class;
+		tuple3.f1 = oldSchemaRecord;
+		tuple3.f2 = row;
+		return tuple3;
+	}
+
+	public static Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> getNewRecordData(long f1, String f2) {
+		NewSchemaRecord newSchemaRecord = NewSchemaRecord.newBuilder().setField1(f1).setField2(f2).build();
+		Row row = new Row(2);
+		row.setField(0, f1);
+		row.setField(1, f2);
+
+		final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> tuple3 = new Tuple3<>();
+		tuple3.f0 = NewSchemaRecord.class;
+		tuple3.f1 = newSchemaRecord;
+		tuple3.f2 = row;
+		return tuple3;
 	}
 
 	/**

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -108,4 +108,20 @@
        {"name": "type_date", "type": {"type": "int", "logicalType": "date"}},
        {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}}
    ]
- }]
+ },
+{"namespace": "org.apache.flink.formats.avro.generated",
+ "type": "record",
+ "name": "OldSchemaRecord",
+ "fields": [
+     {"name": "field1", "type": "long"}
+ ]
+},
+{"namespace": "org.apache.flink.formats.avro.generated",
+ "type": "record",
+ "name": "NewSchemaRecord",
+ "fields": [
+     {"name": "field1", "type": "long"},
+     {"name": "field2", "type": "string", "default": 0}
+ ]
+}
+]

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -121,7 +121,7 @@
  "name": "NewSchemaRecord",
  "fields": [
      {"name": "field1", "type": "long"},
-     {"name": "field2", "type": "string", "default": 0}
+     {"name": "field2", "type": "string", "default": "0"}
  ]
 }
 ]


### PR DESCRIPTION
…data when the upstream add a column.

## What is the purpose of the change

Fixing the flink stream job interruption when adding an extra column in the upstream producer ( we use avro format in Kafka). 

## Brief change log

Create a new decoder when encountered a new buffer to avoid to reuse the unread the bytes inside avro BinaryDecoder's buffer. 

## Verifying this change

This change is already covered by existing tests, such as testSchemaAddColumn.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
