### PR TITLE
[FLINK-17823][network] Resolve the race condition while releasing RemoteInputChannel

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
@@ -168,7 +169,6 @@ public class RemoteInputChannel extends InputChannel {
 
 	@Override
 	Optional<BufferAndAvailability> getNextBuffer() throws IOException {
-		checkState(!isReleased.get(), "Queried for a buffer after channel has been closed.");
 		checkState(partitionRequestClient != null, "Queried for a buffer before requesting a queue.");
 
 		checkError();
@@ -179,6 +179,14 @@ public class RemoteInputChannel extends InputChannel {
 		synchronized (receivedBuffers) {
 			next = receivedBuffers.poll();
 			moreAvailable = !receivedBuffers.isEmpty();
+		}
+
+		if (next == null) {
+			if (isReleased.get()) {
+				throw new CancelTaskException("Queried for a buffer after channel has been released.");
+			} else {
+				throw new IllegalStateException("There should always have queued buffers for unreleased channel.");
+			}
 		}
 
 		numBytesIn.inc(next.getSize());
@@ -242,9 +250,10 @@ public class RemoteInputChannel extends InputChannel {
 	void releaseAllResources() throws IOException {
 		if (isReleased.compareAndSet(false, true)) {
 
-			ArrayDeque<Buffer> releasedBuffers;
+			final ArrayDeque<Buffer> releasedBuffers;
 			synchronized (receivedBuffers) {
-				releasedBuffers = receivedBuffers;
+				releasedBuffers = new ArrayDeque<>(receivedBuffers);
+				receivedBuffers.clear();
 			}
 			bufferManager.releaseAllBuffers(releasedBuffers);
 


### PR DESCRIPTION
## What is the purpose of the change

RemoteInputChannel#releaseAllResources might be called by canceler thread. Meanwhile, the task thread can also call RemoteInputChannel#getNextBuffer.
There probably cause two potential problems:

- Task thread might get null buffer after canceler thread already released all the buffers, then it might cause misleading NPE in getNextBuffer.
- Task thread and canceler thread might pull the same buffer concurrently, which causes unexpected exception when the same buffer is recycled twice.

The solution is to properly synchronize the buffer queue in release method to avoid the same buffer pulled by both canceler thread and task thread. 
And in getNextBuffer method, we add some explicit checks to avoid misleading NPE and hint some valid exceptions.

## Brief change log

- Fix the synchronized receivedBuffers in RemoteInputChannel#releaseAllResources
- check the released state and give proper exceptions in RemoteInputChannel#getNextBuffer

## Verifying this change

New unit test in `RemoteInputChannelTest#testConcurrentGetNextBufferAndRelease`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
