### PR TITLE
[FLINK-18055] [sql-client] Fix catalog/database does not exist in sql client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -132,11 +132,10 @@ public final class SqlCommandParser {
 			cmd = SqlCommand.DROP_CATALOG;
 		} else if (operation instanceof UseCatalogOperation) {
 			cmd = SqlCommand.USE_CATALOG;
-			operands = new String[] { String.format("`%s`", ((UseCatalogOperation) operation).getCatalogName()) };
+			operands = new String[] { ((UseCatalogOperation) operation).getCatalogName() };
 		} else if (operation instanceof UseDatabaseOperation) {
 			cmd = SqlCommand.USE;
-			UseDatabaseOperation op = ((UseDatabaseOperation) operation);
-			operands = new String[] { String.format("`%s`.`%s`", op.getCatalogName(), op.getDatabaseName()) };
+			operands = new String[] { ((UseDatabaseOperation) operation).getDatabaseName() };
 		} else if (operation instanceof ShowCatalogsOperation) {
 			cmd = SqlCommand.SHOW_CATALOGS;
 			operands = new String[0];

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -134,8 +134,8 @@ public class SqlCommandParserTest {
 				// drop catalog xx
 				TestItem.validSql("drop CATALOG c1", SqlCommand.DROP_CATALOG, "drop CATALOG c1"),
 				// use xx
-				TestItem.validSql("USE CATALOG catalog1;", SqlCommand.USE_CATALOG, "`catalog1`"),
-				TestItem.validSql("use `default`;", SqlCommand.USE, "`default_catalog`.`default`"),
+				TestItem.validSql("USE CATALOG catalog1;", SqlCommand.USE_CATALOG, "catalog1"),
+				TestItem.validSql("use `default`;", SqlCommand.USE, "default"),
 				TestItem.invalidSql("use catalog "), // no catalog name
 				// create database xx
 				TestItem.validSql("create database db1;", SqlCommand.CREATE_DATABASE, "create database db1"),


### PR DESCRIPTION

## What is the purpose of the change

*When executing `use catalog hive` in sql client, CatalogException will occur. The reason is SqlCommandParser adds `` for catalog name, which is unnecessary. similar case for use database command *


## Brief change log

  - *ignore `` for catalog name in SqlCommandParser*
  - *only return database name for use database command in SqlCommandParser*


## Verifying this change


This change added tests and can be verified as follows:

  - *Update existing test: SqlCommandParserTest*
  - *Added test methods in CliClientTest to for e2e test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
