### PR TITLE
[hotfix] Disable Log4j's JMX for (integration)tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1539,7 +1539,7 @@ under the License.
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 						<hadoop.version>${hadoop.version}</hadoop.version>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
+					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC -Dlog4j2.disable.jmx=true</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->


### PR DESCRIPTION
## What is the purpose of the change

Disable JMX to speed up Log4j's initialization. JMX is generally not needed for our tests.
