### PR TITLE
[FLINK-18059] [sql-client] Fix create/drop catalog statement can not be executed in sql client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -313,10 +313,10 @@ public class CliClient {
 				callInsert(cmdCall);
 				break;
 			case CREATE_TABLE:
-				callCreateTable(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_TABLE_CREATED);
 				break;
 			case DROP_TABLE:
-				callDropTable(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_TABLE_REMOVED);
 				break;
 			case CREATE_VIEW:
 				callCreateView(cmdCall);
@@ -325,33 +325,37 @@ public class CliClient {
 				callDropView(cmdCall);
 				break;
 			case CREATE_FUNCTION:
-				callCreateFunction(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_FUNCTION_CREATED);
 				break;
 			case DROP_FUNCTION:
-				callDropFunction(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_FUNCTION_REMOVED);
 				break;
 			case ALTER_FUNCTION:
-				callAlterFunction(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_ALTER_FUNCTION_SUCCEEDED,
+						CliStrings.MESSAGE_ALTER_FUNCTION_FAILED);
 				break;
 			case SOURCE:
 				callSource(cmdCall);
 				break;
 			case CREATE_DATABASE:
-				callCreateDatabase(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_DATABASE_CREATED);
 				break;
 			case DROP_DATABASE:
-				callDropDatabase(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_DATABASE_REMOVED);
 				break;
 			case ALTER_DATABASE:
-				callAlterDatabase(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_DATABASE_ALTER_SUCCEEDED,
+						CliStrings.MESSAGE_DATABASE_ALTER_FAILED);
 				break;
 			case ALTER_TABLE:
-				callAlterTable(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_ALTER_TABLE_SUCCEEDED,
+						CliStrings.MESSAGE_ALTER_TABLE_FAILED);
 				break;
 			case CREATE_CATALOG:
-				callCreateCatalog(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_CATALOG_CREATED);
+				break;
 			case DROP_CATALOG:
-				callDropCatalog(cmdCall);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_CATALOG_REMOVED);
 				break;
 			default:
 				throw new SqlClientException("Unsupported command: " + cmdCall.command);
@@ -588,24 +592,6 @@ public class CliClient {
 		return true;
 	}
 
-	private void callCreateTable(SqlCommandCall cmdCall) {
-		try {
-			executor.createTable(sessionId, cmdCall.operands[0]);
-			printInfo(CliStrings.MESSAGE_TABLE_CREATED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
-		}
-	}
-
-	private void callDropTable(SqlCommandCall cmdCall) {
-		try {
-			executor.dropTable(sessionId, cmdCall.operands[0]);
-			printInfo(CliStrings.MESSAGE_TABLE_REMOVED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
-		}
-	}
-
 	private void callCreateView(SqlCommandCall cmdCall) {
 		final String name = cmdCall.operands[0];
 		final String query = cmdCall.operands[1];
@@ -646,33 +632,6 @@ public class CliClient {
 		}
 	}
 
-	private void callCreateFunction(SqlCommandCall cmdCall) {
-		try {
-			executor.executeSql(sessionId, cmdCall.operands[0]);
-			printInfo(CliStrings.MESSAGE_FUNCTION_CREATED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
-		}
-	}
-
-	private void callDropFunction(SqlCommandCall cmdCall) {
-		try {
-			executor.executeSql(sessionId, cmdCall.operands[0]);
-			printInfo(CliStrings.MESSAGE_FUNCTION_REMOVED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
-		}
-	}
-
-	private void callAlterFunction(SqlCommandCall cmdCall) {
-		try {
-			executor.executeSql(sessionId, cmdCall.operands[0]);
-			printInfo(CliStrings.MESSAGE_ALTER_FUNCTION_SUCCEEDED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(CliStrings.MESSAGE_ALTER_FUNCTION_FAILED, e);
-		}
-	}
-
 	private void callSource(SqlCommandCall cmdCall) {
 		final String pathString = cmdCall.operands[0];
 
@@ -702,63 +661,16 @@ public class CliClient {
 		call.ifPresent(this::callCommand);
 	}
 
-	private void callCreateDatabase(SqlCommandCall cmdCall) {
-		final String createDatabaseStmt = cmdCall.operands[0];
-		try {
-			executor.executeUpdate(sessionId, createDatabaseStmt);
-			printInfo(CliStrings.MESSAGE_DATABASE_CREATED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
-		}
+	private void callDdl(String ddl, String successMessage) {
+		callDdl(ddl, successMessage, null);
 	}
 
-	private void callDropDatabase(SqlCommandCall cmdCall) {
-		final String dropDatabaseStmt = cmdCall.operands[0];
+	private void callDdl(String ddl, String successMessage, String errorMessage) {
 		try {
-			executor.executeUpdate(sessionId, dropDatabaseStmt);
-			printInfo(CliStrings.MESSAGE_DATABASE_REMOVED);
+			executor.executeSql(sessionId, ddl);
+			printInfo(successMessage);
 		} catch (SqlExecutionException e) {
-			printExecutionException(e);
-		}
-	}
-
-	private void callAlterDatabase(SqlCommandCall cmdCall) {
-		final String alterDatabaseStmt = cmdCall.operands[0];
-		try {
-			executor.executeUpdate(sessionId, alterDatabaseStmt);
-			printInfo(CliStrings.MESSAGE_DATABASE_ALTER_SUCCEEDED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(CliStrings.MESSAGE_DATABASE_ALTER_FAILED, e);
-		}
-	}
-
-	private void callAlterTable(SqlCommandCall cmdCall) {
-		final String alterTableStmt = cmdCall.operands[0];
-		try {
-			executor.executeUpdate(sessionId, alterTableStmt);
-			printInfo(CliStrings.MESSAGE_ALTER_TABLE_SUCCEEDED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(CliStrings.MESSAGE_ALTER_TABLE_FAILED, e);
-		}
-	}
-
-	private void callCreateCatalog(SqlCommandCall cmdCall) {
-		final String createCatalogStmt = cmdCall.operands[0];
-		try {
-			executor.executeUpdate(sessionId, createCatalogStmt);
-			printInfo(CliStrings.MESSAGE_CATALOG_CREATED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
-		}
-	}
-
-	private void callDropCatalog(SqlCommandCall cmdCall) {
-		final String dropCatalogStmt = cmdCall.operands[0];
-		try {
-			executor.executeUpdate(sessionId, dropCatalogStmt);
-			printInfo(CliStrings.MESSAGE_CATALOG_REMOVED);
-		} catch (SqlExecutionException e) {
-			printExecutionException(e);
+			printExecutionException(errorMessage, e);
 		}
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -348,6 +348,11 @@ public class CliClient {
 			case ALTER_TABLE:
 				callAlterTable(cmdCall);
 				break;
+			case CREATE_CATALOG:
+				callCreateCatalog(cmdCall);
+			case DROP_CATALOG:
+				callDropCatalog(cmdCall);
+				break;
 			default:
 				throw new SqlClientException("Unsupported command: " + cmdCall.command);
 		}
@@ -734,6 +739,26 @@ public class CliClient {
 			printInfo(CliStrings.MESSAGE_ALTER_TABLE_SUCCEEDED);
 		} catch (SqlExecutionException e) {
 			printExecutionException(CliStrings.MESSAGE_ALTER_TABLE_FAILED, e);
+		}
+	}
+
+	private void callCreateCatalog(SqlCommandCall cmdCall) {
+		final String createCatalogStmt = cmdCall.operands[0];
+		try {
+			executor.executeUpdate(sessionId, createCatalogStmt);
+			printInfo(CliStrings.MESSAGE_CATALOG_CREATED);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+		}
+	}
+
+	private void callDropCatalog(SqlCommandCall cmdCall) {
+		final String dropCatalogStmt = cmdCall.operands[0];
+		try {
+			executor.executeUpdate(sessionId, dropCatalogStmt);
+			printInfo(CliStrings.MESSAGE_CATALOG_REMOVED);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
 		}
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -344,8 +344,8 @@ public class CliClient {
 				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_DATABASE_REMOVED);
 				break;
 			case ALTER_DATABASE:
-				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_DATABASE_ALTER_SUCCEEDED,
-						CliStrings.MESSAGE_DATABASE_ALTER_FAILED);
+				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_ALTER_DATABASE_SUCCEEDED,
+						CliStrings.MESSAGE_ALTER_DATABASE_FAILED);
 				break;
 			case ALTER_TABLE:
 				callDdl(cmdCall.operands[0], CliStrings.MESSAGE_ALTER_TABLE_SUCCEEDED,

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -168,6 +168,10 @@ public final class CliStrings {
 
 	public static final String MESSAGE_DATABASE_ALTER_FAILED = "Alter database failed!";
 
+	public static final String MESSAGE_CATALOG_CREATED = "Catalog has been created.";
+
+	public static final String MESSAGE_CATALOG_REMOVED = "Catalog has been removed.";
+
 	public static final String MESSAGE_VIEW_ALREADY_EXISTS = "A view with this name has already been defined in the current CLI session.";
 
 	public static final String MESSAGE_VIEW_NOT_FOUND = "The given view does not exist in the current CLI session. " +

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -164,9 +164,9 @@ public final class CliStrings {
 
 	public static final String MESSAGE_DATABASE_REMOVED = "Database has been removed.";
 
-	public static final String MESSAGE_DATABASE_ALTER_SUCCEEDED = "Alter database succeeded!";
+	public static final String MESSAGE_ALTER_DATABASE_SUCCEEDED = "Alter database succeeded!";
 
-	public static final String MESSAGE_DATABASE_ALTER_FAILED = "Alter database failed!";
+	public static final String MESSAGE_ALTER_DATABASE_FAILED = "Alter database failed!";
 
 	public static final String MESSAGE_CATALOG_CREATED = "Catalog has been created.";
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -240,27 +240,6 @@ public class CliClientTest extends TestLogger {
 		assertThat(executor.getNumExecuteSqlCalls(), is(1));
 	}
 
-	/**
-	 * execute a sql statement and return the terminal output as string.
-	 */
-	private String testExecuteSql(TestingExecutor executor, String sql) throws IOException {
-		InputStream inputStream = new ByteArrayInputStream((sql + "\n").getBytes());
-		ByteArrayOutputStream outputStream = new ByteArrayOutputStream(256);
-		CliClient cliClient = null;
-		SessionContext sessionContext = new SessionContext("test-session", new Environment());
-		String sessionId = executor.openSession(sessionContext);
-
-		try (Terminal terminal = new DumbTerminal(inputStream, outputStream)) {
-			cliClient = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath());
-			cliClient.open();
-			return new String(outputStream.toByteArray());
-		} finally {
-			if (cliClient != null) {
-				cliClient.close();
-			}
-		}
-	}
-
 	// --------------------------------------------------------------------------------------------
 
 	/**

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -59,8 +59,8 @@ class TestingExecutor implements Executor {
 	private int numUseDatabaseCalls = 0;
 	private BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer;
 
-	private int numExecuteUpdateCalls = 0;
-	private BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> executeUpdateConsumer;
+	private int numExecuteSqlCalls = 0;
+	private BiFunctionWithException<String, String, TableResult, SqlExecutionException> executeUpdateConsumer;
 
 	private final SqlParserHelper helper;
 
@@ -70,7 +70,7 @@ class TestingExecutor implements Executor {
 			List<SupplierWithException<List<Row>, SqlExecutionException>> resultPages,
 			BiConsumerWithException<String, String, SqlExecutionException> useCatalogConsumer,
 			BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer,
-			BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> executeUpdateConsumer) {
+			BiFunctionWithException<String, String, TableResult, SqlExecutionException> executeUpdateConsumer) {
 		this.resultChanges = resultChanges;
 		this.snapshotResults = snapshotResults;
 		this.resultPages = resultPages;
@@ -182,7 +182,8 @@ class TestingExecutor implements Executor {
 
 	@Override
 	public TableResult executeSql(String sessionId, String statement) throws SqlExecutionException {
-		return null;
+		numExecuteSqlCalls++;
+		return executeUpdateConsumer.apply(sessionId, statement);
 	}
 
 	@Override
@@ -217,8 +218,7 @@ class TestingExecutor implements Executor {
 
 	@Override
 	public ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException {
-		numExecuteUpdateCalls++;
-		return executeUpdateConsumer.apply(sessionId, statement);
+		throw new UnsupportedOperationException("Not implemented.");
 	}
 
 	public int getNumCancelCalls() {
@@ -245,7 +245,7 @@ class TestingExecutor implements Executor {
 		return numUseDatabaseCalls;
 	}
 
-	public int getNumExecuteUpdateCalls() {
-		return numExecuteUpdateCalls;
+	public int getNumExecuteSqlCalls() {
+		return numExecuteSqlCalls;
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.SupplierWithException;
 
 import java.util.List;
@@ -58,6 +59,9 @@ class TestingExecutor implements Executor {
 	private int numUseDatabaseCalls = 0;
 	private BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer;
 
+	private int numExecuteUpdateCalls = 0;
+	private BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> executeUpdateConsumer;
+
 	private final SqlParserHelper helper;
 
 	TestingExecutor(
@@ -65,12 +69,14 @@ class TestingExecutor implements Executor {
 			List<SupplierWithException<TypedResult<Integer>, SqlExecutionException>> snapshotResults,
 			List<SupplierWithException<List<Row>, SqlExecutionException>> resultPages,
 			BiConsumerWithException<String, String, SqlExecutionException> useCatalogConsumer,
-			BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer) {
+			BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer,
+			BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> executeUpdateConsumer) {
 		this.resultChanges = resultChanges;
 		this.snapshotResults = snapshotResults;
 		this.resultPages = resultPages;
 		this.useCatalogConsumer = useCatalogConsumer;
 		this.useDatabaseConsumer = useDatabaseConsumer;
+		this.executeUpdateConsumer = executeUpdateConsumer;
 		helper = new SqlParserHelper();
 		helper.registerTables();
 	}
@@ -211,7 +217,8 @@ class TestingExecutor implements Executor {
 
 	@Override
 	public ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException {
-		throw new UnsupportedOperationException("Not implemented.");
+		numExecuteUpdateCalls++;
+		return executeUpdateConsumer.apply(sessionId, statement);
 	}
 
 	public int getNumCancelCalls() {
@@ -236,5 +243,9 @@ class TestingExecutor implements Executor {
 
 	public int getNumUseDatabaseCalls() {
 		return numUseDatabaseCalls;
+	}
+
+	public int getNumExecuteUpdateCalls() {
+		return numExecuteUpdateCalls;
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
@@ -18,7 +18,7 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
@@ -40,7 +40,7 @@ class TestingExecutorBuilder {
 	private List<SupplierWithException<List<Row>, SqlExecutionException>> resultPagesSupplier = Collections.emptyList();
 	private BiConsumerWithException<String, String, SqlExecutionException> setUseCatalogConsumer = (ignoredA, ignoredB) -> {};
 	private BiConsumerWithException<String, String, SqlExecutionException> setUseDatabaseConsumer = (ignoredA, ignoredB) -> {};
-	private BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> setExecuteUpdateConsumer = (ignoredA, ignoredB) -> null;
+	private BiFunctionWithException<String, String, TableResult, SqlExecutionException> setExecuteSqlConsumer = (ignoredA, ignoredB) -> null;
 
 	@SafeVarargs
 	public final TestingExecutorBuilder setResultChangesSupplier(SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException> ... resultChangesSupplier) {
@@ -70,9 +70,9 @@ class TestingExecutorBuilder {
 		return this;
 	}
 
-	public final TestingExecutorBuilder setExecuteUpdateConsumer(
-			BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> setExecuteUpdateConsumer) {
-		this.setExecuteUpdateConsumer = setExecuteUpdateConsumer;
+	public final TestingExecutorBuilder setExecuteSqlConsumer(
+			BiFunctionWithException<String, String, TableResult, SqlExecutionException> setExecuteUpdateConsumer) {
+		this.setExecuteSqlConsumer = setExecuteUpdateConsumer;
 		return this;
 	}
 
@@ -83,6 +83,6 @@ class TestingExecutorBuilder {
 			resultPagesSupplier,
 			setUseCatalogConsumer,
 			setUseDatabaseConsumer,
-			setExecuteUpdateConsumer);
+			setExecuteSqlConsumer);
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
@@ -18,10 +18,12 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.SupplierWithException;
 
 import java.util.Arrays;
@@ -38,6 +40,7 @@ class TestingExecutorBuilder {
 	private List<SupplierWithException<List<Row>, SqlExecutionException>> resultPagesSupplier = Collections.emptyList();
 	private BiConsumerWithException<String, String, SqlExecutionException> setUseCatalogConsumer = (ignoredA, ignoredB) -> {};
 	private BiConsumerWithException<String, String, SqlExecutionException> setUseDatabaseConsumer = (ignoredA, ignoredB) -> {};
+	private BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> setExecuteUpdateConsumer = (ignoredA, ignoredB) -> null;
 
 	@SafeVarargs
 	public final TestingExecutorBuilder setResultChangesSupplier(SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException> ... resultChangesSupplier) {
@@ -67,12 +70,19 @@ class TestingExecutorBuilder {
 		return this;
 	}
 
+	public final TestingExecutorBuilder setExecuteUpdateConsumer(
+			BiFunctionWithException<String, String, ProgramTargetDescriptor, SqlExecutionException> setExecuteUpdateConsumer) {
+		this.setExecuteUpdateConsumer = setExecuteUpdateConsumer;
+		return this;
+	}
+
 	public TestingExecutor build() {
 		return new TestingExecutor(
 			resultChangesSupplier,
 			snapshotResultsSupplier,
 			resultPagesSupplier,
 			setUseCatalogConsumer,
-			setUseDatabaseConsumer);
+			setUseDatabaseConsumer,
+			setExecuteUpdateConsumer);
 	}
 }


### PR DESCRIPTION


## What is the purpose of the change

*when executing create catalog statement (e.g. create CATALOG c1 with('type'='generic_in_memory') in sql client, "SqlClientException: Unsupported command: CREATE CATALOG" will occur. The reason is CliClient class does not handle CREATE_CATALOG command. Similar case is drop catalog statement.*


## Brief change log

  - *Handle CREATE_CATALOG and DROP_CATALOG command in CliClient*
  - *Code cleanup in CliClient*


## Verifying this change


This change added tests and can be verified as follows:

  - *added testCreateCatalog method and testDropCatalog method in CliClientTest *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
