### PR TITLE
[FLINK-17847][table sql / planner] ArrayIndexOutOfBoundsException happens in StreamExecCalc operator

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1663,15 +1663,12 @@ object ScalarOperatorGens {
     s"""
         |${array.code}
         |${index.code}
-        |$resultTypeTerm $resultTerm;
-        |boolean $nullTerm;
-        |if (${idxStr} < 0 || ${idxStr} >= ${array.resultTerm}.size()) {
-        |    $nullTerm = true;
-        |    $resultTerm = $defaultTerm;
-        |} else {
-        |   $nullTerm = ${array.nullTerm} || ${index.nullTerm} || $arrayIsNull;
-        |   $resultTerm = $nullTerm ? $defaultTerm : $arrayGet;
-        |}
+        |boolean $nullTerm = ${array.nullTerm} ||
+        |   ${index.nullTerm} ||
+        |   ${idxStr} < 0 ||
+        |   ${idxStr} >= ${array.resultTerm}.size() ||
+        |   $arrayIsNull;
+        |$resultTypeTerm $resultTerm = $nullTerm ? $defaultTerm : $arrayGet;
         |""".stripMargin
     GeneratedExpression(resultTerm, nullTerm, arrayAccessCode, componentInfo)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1663,8 +1663,8 @@ object ScalarOperatorGens {
     s"""
         |${array.code}
         |${index.code}
-        |boolean $nullTerm = ${array.nullTerm} || ${index.nullTerm} || $arrayIsNull ||
-        |   ${idxStr} < 0 || ${idxStr} >= ${array.resultTerm}.size();
+        |boolean $nullTerm = ${array.nullTerm} || ${index.nullTerm} ||
+        |   $idxStr < 0 || $idxStr >= ${array.resultTerm}.size() || $arrayIsNull;
         |$resultTypeTerm $resultTerm = $nullTerm ? $defaultTerm : $arrayGet;
         |""".stripMargin
     GeneratedExpression(resultTerm, nullTerm, arrayAccessCode, componentInfo)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1663,11 +1663,8 @@ object ScalarOperatorGens {
     s"""
         |${array.code}
         |${index.code}
-        |boolean $nullTerm = ${array.nullTerm} ||
-        |   ${index.nullTerm} ||
-        |   ${idxStr} < 0 ||
-        |   ${idxStr} >= ${array.resultTerm}.size() ||
-        |   $arrayIsNull;
+        |boolean $nullTerm = ${array.nullTerm} || ${index.nullTerm} || $arrayIsNull ||
+        |   ${idxStr} < 0 || ${idxStr} >= ${array.resultTerm}.size();
         |$resultTypeTerm $resultTerm = $nullTerm ? $defaultTerm : $arrayGet;
         |""".stripMargin
     GeneratedExpression(resultTerm, nullTerm, arrayAccessCode, componentInfo)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -377,7 +377,7 @@ class ArrayTypeTest extends ArrayTypeTestBase {
   }
 
   @Test
-  def testArrayLowerIndexStaticCheckForTable(): Unit = {
+  def testArrayIndexStaticCheckForTable(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
     testTableApi('f2.at(0), "1")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -377,7 +377,7 @@ class ArrayTypeTest extends ArrayTypeTestBase {
   }
 
   @Test
-  def testArrayIndexStaticCheckForTable(): Unit = {
+  def testArrayLowerIndexStaticCheckForTable(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
     testTableApi('f2.at(0), "1")
@@ -391,11 +391,20 @@ class ArrayTypeTest extends ArrayTypeTestBase {
   }
 
   @Test
-  def testReturnNullWhenArrayIndexOutOfBounds(): Unit = {
+  def testReturnNullWhenPrimativeArrayIndexOutOfBounds(): Unit = {
     testAllApis(
       'f2.at(4),
       "f2.at(4)",
       "f2[4]",
+      "null")
+  }
+
+  @Test
+  def testReturnNullWhenArrayIndexOutOfBounds(): Unit = {
+    testAllApis(
+      'f11.at(3),
+      "f11.at(3)",
+      "f11[4]",
       "null")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -380,7 +380,7 @@ class ArrayTypeTest extends ArrayTypeTestBase {
   def testArrayIndexStaticCheckForTable(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
-    testTableApi( 'f2.at(0), "1")
+    testTableApi('f2.at(0), "1")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -375,4 +375,24 @@ class ArrayTypeTest extends ArrayTypeTestBase {
       "[1984-03-12, 1984-02-10]"
     )
   }
+
+  @Test
+  def testArrayIndexStaticCheck(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
+    testAllApis(
+      'f2.at(0),
+      "f2.at(0)",
+      "f2[0]",
+      "1")
+  }
+
+  @Test
+  def testReturnNullWhenArrayIndexOutOfBounds(): Unit = {
+    testAllApis(
+      'f2.at(4),
+      "f2.at(4)",
+      "f2[4]",
+      "null")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -377,14 +377,17 @@ class ArrayTypeTest extends ArrayTypeTestBase {
   }
 
   @Test
-  def testArrayIndexStaticCheck(): Unit = {
+  def testArrayIndexStaticCheckForTableApi(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
-    testAllApis(
-      'f2.at(0),
-      "f2.at(0)",
-      "f2[0]",
-      "1")
+    testTableApi( 'f2.at(0), "1")
+  }
+
+  @Test
+  def testArrayIndexStaticCheckForSql(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
+    testSqlApi("f2.at(0)", "1")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -377,7 +377,7 @@ class ArrayTypeTest extends ArrayTypeTestBase {
   }
 
   @Test
-  def testArrayIndexStaticCheckForTableApi(): Unit = {
+  def testArrayIndexStaticCheckForTable(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
     testTableApi( 'f2.at(0), "1")
@@ -387,7 +387,7 @@ class ArrayTypeTest extends ArrayTypeTestBase {
   def testArrayIndexStaticCheckForSql(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage("Array element access needs an index starting at 1 but was 0.")
-    testSqlApi("f2.at(0)", "1")
+    testSqlApi("f2[0]", "1")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix ArrayIndexOutOfBoundsException happens in codegen operator.
- We throw an exception in compile(codegen) phase if the index <=0;
- We follow the Calcite to return a null value when visited an invalid index in runtime.

## Brief change log

  * Update file org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala


## Verifying this change

* Add unit tests for SQL and Table API.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
