### PR TITLE
[FLINK-17918][table-blink] Fix AppendOnlyTopNFunction shouldn't mutate list value of MapState

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/FailingCollectionSource.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/FailingCollectionSource.java
@@ -167,9 +167,9 @@ public class FailingCollectionSource<T>
 			if (!failedBefore) {
 				// delay a bit, if we have not failed before
 				Thread.sleep(1);
-				if (numSuccessfulCheckpoints >= 1 && lastCheckpointedEmittedNum >= failureAfterNumElements) {
-					// cause a failure if we have not failed before and have reached
-					// enough completed checkpoints and elements
+				if (numSuccessfulCheckpoints >= 1 && lastCheckpointedEmittedNum >= 1) {
+					// cause a failure if we have not failed before and have a completed checkpoint
+					// and have processed at least one element
 					failedBefore = true;
 					throw new Exception("Artificial Failure");
 				}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
@@ -18,12 +18,16 @@
 
 package org.apache.flink.table.planner.runtime.utils
 
+import org.apache.flink.api.common.state.{ListState, ListStateDescriptor}
+import org.apache.flink.api.common.typeinfo.Types
+import org.apache.flink.runtime.state.{StateInitializationContext, StateSnapshotContext}
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.operators.{AbstractStreamOperator, OneInputStreamOperator}
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
+import org.apache.flink.table.planner.JLong
 
 object TimeTestUtil {
 
@@ -52,14 +56,47 @@ object TimeTestUtil {
     }
   }
 
+  /**
+   * A streaming operator to emit records and watermark depends on the input data.
+   * The last emitted watermark will be stored in state to emit it again on recovery.
+   * This is necessary for late arrival testing with [[FailingCollectionSource]].
+   */
   class EventTimeProcessOperator[T]
     extends AbstractStreamOperator[T]
       with OneInputStreamOperator[Either[(Long, T), Long], T] {
 
+    private var currentWatermark: Long = 0L
+    private var watermarkState: ListState[JLong] = _
+
+    override def snapshotState(context: StateSnapshotContext): Unit = {
+      super.snapshotState(context)
+      watermarkState.clear()
+      watermarkState.add(currentWatermark)
+    }
+
+    override def initializeState(context: StateInitializationContext): Unit = {
+      super.initializeState(context)
+      // use union list state to get the max watermark
+      watermarkState = context.getOperatorStateStore.getUnionListState(
+        new ListStateDescriptor("watermark-state", Types.LONG))
+
+      val iterator = watermarkState.get().iterator()
+      while (iterator.hasNext) {
+        currentWatermark = Math.max(currentWatermark, iterator.next())
+      }
+
+      if (currentWatermark > 0) {
+        output.emitWatermark(new Watermark(currentWatermark))
+      }
+    }
+
     override def processElement(element: StreamRecord[Either[(Long, T), Long]]): Unit = {
       element.getValue match {
-        case Left(t) => output.collect(new StreamRecord[T](t._2, t._1))
-        case Right(w) => output.emitWatermark(new Watermark(w))
+        case Left(t) =>
+          output.collect(new StreamRecord[T](t._2, t._1))
+        case Right(w) =>
+          currentWatermark = w
+          output.emitWatermark(new Watermark(w))
       }
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
@@ -76,13 +76,13 @@ object TimeTestUtil {
 
     override def initializeState(context: StateInitializationContext): Unit = {
       super.initializeState(context)
-      // use union list state to get the max watermark
-      watermarkState = context.getOperatorStateStore.getUnionListState(
+      watermarkState = context.getOperatorStateStore.getListState(
         new ListStateDescriptor("watermark-state", Types.LONG))
 
       val iterator = watermarkState.get().iterator()
-      while (iterator.hasNext) {
-        currentWatermark = Math.max(currentWatermark, iterator.next())
+      if (iterator.hasNext) {
+        // there should be only one element in the state list, because we won't rescale in tests,
+        currentWatermark = iterator.next()
       }
 
       if (currentWatermark > 0) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
@@ -113,7 +113,10 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
 			buffer.put(sortKey, inputRowSer.copy(input));
 			Collection<RowData> inputs = buffer.get(sortKey);
 			// update data state
-			dataState.put(sortKey, (List<RowData>) inputs);
+			// copy a new collection to avoid mutating state values, see CopyOnWriteStateMap,
+			// otherwise, the result might be corrupt.
+			// don't need to perform a deep copy, because RowData elements will not be updated
+			dataState.put(sortKey, new ArrayList<>(inputs));
 			if (outputRankNumber || hasOffset()) {
 				// the without-number-algorithm can't handle topN with offset,
 				// so use the with-number-algorithm to handle offset


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

As discussed in the JIRA issue, operators shouldn't update value object of state in the other processElement call. AppendOnlyTopNFunction doesn't follow this, and I have checked all the operators in table module, this should be the only one. All others either never update value obejct of state, or follow the get-update-put operation in a single processElement. 

## Brief change log

- Always shallow copy the list value when putting it into `dataState`.
- Update `FailingCollectionSource` to fail after at least one element was checkpointed. This may uncover more failures like this one (but can't reproduce this problem all the time).

## Verifying this change

It is hard to be reproduced using existing tests. I reproduce the problem using @AHeise 
s [commit](https://github.com/apache/flink/commit/c05a0d865989c9959047cebcf2cd68b3838cc699), and verified this fix manually. 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

