### PR TITLE
[FLINK-12428][docs-zh] Translate the "Event Time" page into Chinese

### DIFF
--- a/docs/dev/event_time.zh.md
+++ b/docs/dev/event_time.zh.md
@@ -24,18 +24,18 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-本节你将学到如何写可感知时间变化的 Flink 程序，可以先看看[及时时间流处理]({% link concepts/timely-stream-processing.zh.md %})了解相关概念。
+本节你将学到如何写可感知时间变化的 Flink 程序，可以先看看[实时流处理]({% link concepts/timely-stream-processing.zh.md %})了解相关概念。
 
-想了解如何在 Flink 程序中使用时间的信息，请参阅[窗口]({% link dev/stream/operators/windows.zh.md %})和[处理函数]({% link dev/stream/operators/process_function.zh.md %})。
+想了解如何在 Flink 程序中使用时间特性，请参阅[窗口]({% link dev/stream/operators/windows.zh.md %})和[处理函数]({% link dev/stream/operators/process_function.zh.md %})。
 
 * toc
 {:toc}
 
 ## 设置时间特征
 
-写 Flink DataStream 程序时，通常首先设置基础的时间特征，该设置定义了数据流的行为方式（例如，是否分配时间戳），以及哪种时间概念应该被诸如 `KeyedStream.timeWindow(Time.seconds(30))` 之类的窗口算子使用。
+写 Flink DataStream 程序时，通常先设置基础的*时间特性*，该设置定义了数据流的行为方式（例如，是否分配时间戳），以及窗口算子使用哪种时间概念，例如 `KeyedStream.timeWindow(Time.seconds(30))` 。
 
-以下示例展示了一个按小时聚合事件的 Flink 程序，窗口的行为与时间特征相适应。
+以下示例展示了一个按小时聚合事件的 Flink 程序，窗口的行为与时间特征相对应。
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -89,7 +89,7 @@ env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
 </div>
 </div>
 
-如果要用事件时间作为时间特征运行此示例，程序需要使用那些给数据直接定义事件时间并能自己发出水印的源，或者程序必须在收到源发出的事件流之后注入“时间戳分配器和水印生成器”，这些功能描述了访问事件时间戳的方法，以及事件流呈现的乱序程度。
+值得注意的是，如果要用*事件时间*作为时间特征运行此示例，程序需要使用那些给数据直接定义事件时间并能自己发出水印的源，或者程序必须在收到源发出的事件流之后注入“时间戳分配器和水印生成器”，这些功能描述了访问事件时间戳的方法，以及事件流呈现的乱序程度。
 
 可以参考[生成时间戳/水印]({{ site.baseurl }}/zh/dev/event_timestamps_watermarks.html)，了解如何使用 Flink DataStream API 分配时间戳和生成水印。
 
@@ -113,6 +113,6 @@ env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
 
 这个规则同样适用于 `TwoInputStreamOperator`。但是，在这种情况下，算子的当前水印被定义为两个输入的最小值。
 
-该行为具体由 `OneInputStreamOperator#processWatermark`，`TwoInputStreamOperator#processWatermark1` 和 `TwoInputStreamOperator#processWatermark2`方法定义。
+该行为具体由 `OneInputStreamOperator#processWatermark`、`TwoInputStreamOperator#processWatermark1` 和 `TwoInputStreamOperator#processWatermark2`方法定义。
 
 {% top %}

--- a/docs/dev/event_time.zh.md
+++ b/docs/dev/event_time.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "Event Time"
+title: "事件时间"
 nav-id: event_time
 nav-show_overview: true
 nav-parent_id: streaming
@@ -24,23 +24,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-In this section you will learn about writing time-aware Flink programs. Please
-take a look at [Timely Stream Processing]({% link
-concepts/timely-stream-processing.md %}) to learn about the concepts behind
-timely stream processing.
+本节你将学到如何写可感知时间变化的 Flink 程序，可以先看看[实时流处理]({% link concepts/timely-stream-processing.zh.md %})了解相关概念。
 
-For information about how to use time in Flink programs refer to
-[windowing]({% link dev/stream/operators/windows.md %}) and
-[ProcessFunction]({% link
-dev/stream/operators/process_function.md %}).
+想了解如何在 Flink 程序中使用时间特性，请参阅[窗口]({% link dev/stream/operators/windows.zh.md %})和[处理函数]({% link dev/stream/operators/process_function.zh.md %})。
 
-A prerequisite for using *event time* processing is setting the right *time
-characteristic*. That setting defines how data stream sources behave (for
-example, whether they will assign timestamps), and what notion of time should
-be used by window operations like `KeyedStream.timeWindow(Time.seconds(30))`.
+使用*事件时间*进行流处理的先决条件是设置合适的*时间特性*，该设置定义了数据流的行为方式（例如，是否分配时间戳），以及窗口算子使用哪种时间概念，例如 `KeyedStream.timeWindow(Time.seconds(30))` 。
 
-You can set the time characteristic using
-`StreamExecutionEnvironment.setStreamTimeCharacteristic()`:
+你可以调用 `StreamExecutionEnvironment.setStreamTimeCharacteristic()` 设置时间特性：
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -86,22 +76,12 @@ env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
 </div>
 </div>
 
-Note that in order to run this example in *event time*, the program needs to
-either use sources that directly define event time for the data and emit
-watermarks themselves, or the program must inject a *Timestamp Assigner &
-Watermark Generator* after the sources. Those functions describe how to access
-the event timestamps, and what degree of out-of-orderness the event stream
-exhibits.
+值得注意的是，为了能够使用*事件时间*作为时间特征运行此示例，程序需要使用那些能给数据直接定义事件时间并自己发出水印的源，或者程序必须在收到源发出的事件流之后注入“时间戳分配器和水印生成器”，这些功能描述了访问事件时间戳的方法，以及事件流呈现的乱序程度。
 
-## Where to go next?
+## 接下来看什么?
 
-* [Generating Watermarks]({% link dev/event_timestamps_watermarks.md
-  %}): Shows how to write timestamp assigners and watermark generators, which
-  are needed for event-time aware Flink applications.
-* [Builtin Watermark Generators]({% link dev/event_timestamp_extractors.md %}):
-  Gives an overview of the builtin watermark generators.
-* [Debugging Windows & Event Time]({{ site.baseurl
-  }}/monitoring/debugging_event_time.html): Show how to debug problems around
-  watermarks and timestamps in event-time Flink applications.
+* [生成水印]({% link dev/event_timestamps_watermarks.zh.md %})：描述了在写可感知事件时间的 Flink 应用程序时，如何定义时间戳分配器和水印生成器。
+* [内置水印生成器]({% link dev/event_timestamp_extractors.zh.md %})：概述了 Flink 自带的水印生成器。
+* [调试窗口&事件时间]({{ site.baseurl}}/zh/monitoring/debugging_event_time.html)：描述了在可感知事件时间的 Flink 应用程序里，如何调试水印和时间戳。
 
 {% top %}

--- a/docs/dev/event_time.zh.md
+++ b/docs/dev/event_time.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "事件时间"
+title: "Event Time"
 nav-id: event_time
 nav-show_overview: true
 nav-parent_id: streaming
@@ -24,31 +24,32 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-本节你将学到如何写可感知时间变化的 Flink 程序，可以先看看[实时流处理]({% link concepts/timely-stream-processing.zh.md %})了解相关概念。
+In this section you will learn about writing time-aware Flink programs. Please
+take a look at [Timely Stream Processing]({% link
+concepts/timely-stream-processing.md %}) to learn about the concepts behind
+timely stream processing.
 
-想了解如何在 Flink 程序中使用时间特性，请参阅[窗口]({% link dev/stream/operators/windows.zh.md %})和[处理函数]({% link dev/stream/operators/process_function.zh.md %})。
+For information about how to use time in Flink programs refer to
+[windowing]({% link dev/stream/operators/windows.md %}) and
+[ProcessFunction]({% link
+dev/stream/operators/process_function.md %}).
 
-* toc
-{:toc}
+A prerequisite for using *event time* processing is setting the right *time
+characteristic*. That setting defines how data stream sources behave (for
+example, whether they will assign timestamps), and what notion of time should
+be used by window operations like `KeyedStream.timeWindow(Time.seconds(30))`.
 
-## 设置时间特征
-
-写 Flink DataStream 程序时，通常先设置基础的*时间特性*，该设置定义了数据流的行为方式（例如，是否分配时间戳），以及窗口算子使用哪种时间概念，例如 `KeyedStream.timeWindow(Time.seconds(30))` 。
-
-以下示例展示了一个按小时聚合事件的 Flink 程序，窗口的行为与时间特征相对应。
+You can set the time characteristic using
+`StreamExecutionEnvironment.setStreamTimeCharacteristic()`:
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
 final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
-// alternatively:
-// env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime);
-// env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
-
-DataStream<MyEvent> stream = env.addSource(new FlinkKafkaConsumer010<MyEvent>(topic, schema, props));
+DataStream<MyEvent> stream = env.addSource(new FlinkKafkaConsumer<MyEvent>(topic, schema, props));
 
 stream
     .keyBy( (event) -> event.getUser() )
@@ -61,13 +62,9 @@ stream
 {% highlight scala %}
 val env = StreamExecutionEnvironment.getExecutionEnvironment
 
-env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
+env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
-// alternatively:
-// env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime)
-// env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-
-val stream: DataStream[MyEvent] = env.addSource(new FlinkKafkaConsumer010[MyEvent](topic, schema, props))
+val stream: DataStream[MyEvent] = env.addSource(new FlinkKafkaConsumer[MyEvent](topic, schema, props))
 
 stream
     .keyBy( _.getUser )
@@ -89,30 +86,22 @@ env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
 </div>
 </div>
 
-值得注意的是，如果要用*事件时间*作为时间特征运行此示例，程序需要使用那些给数据直接定义事件时间并能自己发出水印的源，或者程序必须在收到源发出的事件流之后注入“时间戳分配器和水印生成器”，这些功能描述了访问事件时间戳的方法，以及事件流呈现的乱序程度。
+Note that in order to run this example in *event time*, the program needs to
+either use sources that directly define event time for the data and emit
+watermarks themselves, or the program must inject a *Timestamp Assigner &
+Watermark Generator* after the sources. Those functions describe how to access
+the event timestamps, and what degree of out-of-orderness the event stream
+exhibits.
 
-可以参考[生成时间戳/水印]({{ site.baseurl }}/zh/dev/event_timestamps_watermarks.html)，了解如何使用 Flink DataStream API 分配时间戳和生成水印。
+## Where to go next?
 
-{% top %}
-
-## 空闲源
-
-当前，对于纯粹的事件时间水印生成器，如果没有要处理的事件，水印是不会生成并下发的，无法推进。这意味着在输入数据存在间隙的情况下，事件时间将不会继续前进，例如无法触发窗口算子，因此现有窗口将无法生成任何输出数据。
-
-为了避免这种情况，可以使用周期性水印分配器，这种分配器不仅基于事件时间戳，还会在没有事件的时候产生新水印。 比如在长时间没有观测到事件流入时，可以采用系统当前时间来生成水印。
-
-可使用 `SourceFunction.SourceContext#markAsTemporarilyIdle` 标记源是空闲的，详情可参考这个方法以及 `StreamStatus` 类的 Javadoc 。
-
-## 调试水印
-
-请参考[调试窗口&事件时间]({{ site.baseurl }}/zh/monitoring/debugging_event_time.html)了解运行阶段的水印调试。
-
-## 算子如何处理水印
-
-通常，要求算子在将给定水印转发到下游之前，必须对这个水印进行完全处理。例如，`WindowOperator` 首先评估应该触发哪些窗口，然后只有在产生了由水印触发的所有输出之后，水印本身才会被发送到下游。换句话说，由水印而触发的所有元素都将在水印之前被发出。
-
-这个规则同样适用于 `TwoInputStreamOperator`。但是，在这种情况下，算子的当前水印被定义为两个输入的最小值。
-
-该行为具体由 `OneInputStreamOperator#processWatermark`、`TwoInputStreamOperator#processWatermark1` 和 `TwoInputStreamOperator#processWatermark2`方法定义。
+* [Generating Watermarks]({% link dev/event_timestamps_watermarks.md
+  %}): Shows how to write timestamp assigners and watermark generators, which
+  are needed for event-time aware Flink applications.
+* [Builtin Watermark Generators]({% link dev/event_timestamp_extractors.md %}):
+  Gives an overview of the builtin watermark generators.
+* [Debugging Windows & Event Time]({{ site.baseurl
+  }}/monitoring/debugging_event_time.html): Show how to debug problems around
+  watermarks and timestamps in event-time Flink applications.
 
 {% top %}

--- a/docs/dev/event_time.zh.md
+++ b/docs/dev/event_time.zh.md
@@ -82,6 +82,6 @@ env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
 
 * [生成水印]({% link dev/event_timestamps_watermarks.zh.md %})：描述了在写可感知事件时间的 Flink 应用程序时，如何定义时间戳分配器和水印生成器。
 * [内置水印生成器]({% link dev/event_timestamp_extractors.zh.md %})：概述了 Flink 自带的水印生成器。
-* [调试窗口&事件时间]({{ site.baseurl}}/zh/monitoring/debugging_event_time.html)：描述了在可感知事件时间的 Flink 应用程序里，如何调试水印和时间戳。
+* [调试窗口&事件时间]({% link monitoring/debugging_event_time.zh.md %})：描述了在可感知事件时间的 Flink 应用程序里，如何调试水印和时间戳。
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

Translate the "Event Time" page into Chinese
file locate  flink/docs/dev/event_time.zh.md
https://ci.apache.org/projects/flink/flink-docs-master/dev/event_time.html

## Brief change log

* translate `flink/docs/dev/event_time.zh.md`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
