### PR TITLE
[FLINK-18069] [scala, docs] Scaladocs 2.12 fails to recognize inner interfaces

### DIFF
--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
@@ -103,7 +103,7 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
 	}
 
 	@Override
-	protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<T> newSerializer) {
+	protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<T> newSerializer) {
 		return (Objects.equals(type, newSerializer.getTupleClass()))
 			? OuterSchemaCompatibility.COMPATIBLE_AS_IS
 			: OuterSchemaCompatibility.INCOMPATIBLE;

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
@@ -98,7 +98,7 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
 	}
 
 	@Override
-	protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(TraversableSerializer<T, E> newSerializer) {
+	protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility resolveOuterSchemaCompatibility(TraversableSerializer<T, E> newSerializer) {
 		return (cbfCode.equals(newSerializer.cbfCode()))
 			? OuterSchemaCompatibility.COMPATIBLE_AS_IS
 			: OuterSchemaCompatibility.INCOMPATIBLE;

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
@@ -95,7 +95,7 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
 	}
 
 	@Override
-	protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<Tuple2<T1, T2>> newSerializer) {
+	protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<Tuple2<T1, T2>> newSerializer) {
 		return (Objects.equals(type, newSerializer.getTupleClass()))
 			? OuterSchemaCompatibility.COMPATIBLE_AS_IS
 			: OuterSchemaCompatibility.INCOMPATIBLE;


### PR DESCRIPTION
This is a similar issue as reported here: scala/bug#10509.

This seems to be a problem with Scaladocs 2.12.x. The only workaround, it seems from the issue reports, is to redundantly add the full-length qualifiers for such interfaces.

## Verifying this change

Verified this by doing the following steps

- Build the project: `mvn clean install -DskipTests`
- Build the Javadocs: `mvn javadoc:aggregate -Paggregate-scaladoc`
- Build the Scaladocs: `cd flink-scala/ && mvn scala:doc`
