### PR TITLE
[FLINK-16225] Implement user class loading exception handler

### DIFF
--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>classloader.fail-on-metaspace-oom-error</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Fail Flink JVM processes if 'OutOfMemoryError: Metaspace' is thrown while trying to load a user code class.</td>
+        </tr>
+        <tr>
             <td><h5>classloader.parent-first-patterns.additional</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/_includes/generated/expert_class_loading_section.html
+++ b/docs/_includes/generated/expert_class_loading_section.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>classloader.fail-on-metaspace-oom-error</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Fail Flink JVM processes if 'OutOfMemoryError: Metaspace' is thrown while trying to load a user code class.</td>
+        </tr>
+        <tr>
             <td><h5>classloader.parent-first-patterns.additional</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -43,6 +43,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -70,7 +71,7 @@ public enum ClientUtils {
 			configuration.getString(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
 		FlinkUserCodeClassLoaders.ResolveOrder resolveOrder =
 			FlinkUserCodeClassLoaders.ResolveOrder.fromString(classLoaderResolveOrder);
-		return FlinkUserCodeClassLoaders.create(resolveOrder, urls, parent, alwaysParentFirstLoaderPatterns);
+		return FlinkUserCodeClassLoaders.create(resolveOrder, urls, parent, alwaysParentFirstLoaderPatterns, NOOP_EXCEPTION_HANDLER);
 	}
 
 	public static JobExecutionResult submitJob(

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -110,6 +110,14 @@ public class CoreOptions {
 			" resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against" +
 			" the fully qualified class name. These patterns are appended to \"" + ALWAYS_PARENT_FIRST_LOADER_PATTERNS.key() + "\".");
 
+	@Documentation.Section(Documentation.Sections.EXPERT_CLASS_LOADING)
+	public static final ConfigOption<Boolean> FAIL_ON_USER_CLASS_LOADING_METASPACE_OOM = ConfigOptions
+		.key("classloader.fail-on-metaspace-oom-error")
+		.booleanType()
+		.defaultValue(true)
+		.withDescription("Fail Flink JVM processes if 'OutOfMemoryError: Metaspace' is " +
+			"thrown while trying to load a user code class.");
+
 	public static String[] getParentFirstLoaderPatterns(Configuration config) {
 		String base = config.getString(ALWAYS_PARENT_FIRST_LOADER_PATTERNS);
 		String append = config.getString(ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL);

--- a/flink-core/src/main/java/org/apache/flink/util/ChildFirstClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ChildFirstClassLoader.java
@@ -20,11 +20,11 @@ package org.apache.flink.util;
 
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * A variant of the URLClassLoader that first loads from the URLs and only after that from the parent.
@@ -32,7 +32,7 @@ import java.util.List;
  * <p>{@link #getResourceAsStream(String)} uses {@link #getResource(String)} internally so we
  * don't override that.
  */
-public final class ChildFirstClassLoader extends URLClassLoader {
+public final class ChildFirstClassLoader extends FlinkUserCodeClassLoader {
 
 	/**
 	 * The classes that should always go through the parent ClassLoader. This is relevant
@@ -41,14 +41,19 @@ public final class ChildFirstClassLoader extends URLClassLoader {
 	 */
 	private final String[] alwaysParentFirstPatterns;
 
-	public ChildFirstClassLoader(URL[] urls, ClassLoader parent, String[] alwaysParentFirstPatterns) {
-		super(urls, parent);
+	public ChildFirstClassLoader(
+			URL[] urls,
+			ClassLoader parent,
+			String[] alwaysParentFirstPatterns,
+			Consumer<Throwable> classLoadingExceptionHandler) {
+		super(urls, parent, classLoadingExceptionHandler);
 		this.alwaysParentFirstPatterns = alwaysParentFirstPatterns;
 	}
 
 	@Override
-	protected synchronized Class<?> loadClass(
-		String name, boolean resolve) throws ClassNotFoundException {
+	protected synchronized Class<?> loadClassWithoutExceptionHandling(
+			String name,
+			boolean resolve) throws ClassNotFoundException {
 
 		// First, check if the class has already been loaded
 		Class<?> c = findLoadedClass(name);
@@ -57,7 +62,7 @@ public final class ChildFirstClassLoader extends URLClassLoader {
 			// check whether the class should go parent-first
 			for (String alwaysParentFirstPattern : alwaysParentFirstPatterns) {
 				if (name.startsWith(alwaysParentFirstPattern)) {
-					return super.loadClass(name, resolve);
+					return super.loadClassWithoutExceptionHandling(name, resolve);
 				}
 			}
 
@@ -66,7 +71,7 @@ public final class ChildFirstClassLoader extends URLClassLoader {
 				c = findClass(name);
 			} catch (ClassNotFoundException e) {
 				// let URLClassLoader do it, which will eventually call the parent
-				c = super.loadClass(name, resolve);
+				c = super.loadClassWithoutExceptionHandling(name, resolve);
 			}
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.function.Consumer;
+
+/**
+ * This class loader accepts a custom handler if an exception occurs in {@link #loadClass(String, boolean)}.
+ */
+public abstract class FlinkUserCodeClassLoader extends URLClassLoader {
+	public static final Consumer<Throwable> NOOP_EXCEPTION_HANDLER = classLoadingException -> {};
+
+	private final Consumer<Throwable> classLoadingExceptionHandler;
+
+	protected FlinkUserCodeClassLoader(URL[] urls, ClassLoader parent) {
+		this(urls, parent, NOOP_EXCEPTION_HANDLER);
+	}
+
+	protected FlinkUserCodeClassLoader(
+			URL[] urls,
+			ClassLoader parent,
+			Consumer<Throwable> classLoadingExceptionHandler) {
+		super(urls, parent);
+		this.classLoadingExceptionHandler = classLoadingExceptionHandler;
+	}
+
+	@Override
+	protected final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+		try {
+			return loadClassWithoutExceptionHandling(name, resolve);
+		} catch (Throwable classLoadingException) {
+			classLoadingExceptionHandler.accept(classLoadingException);
+			throw classLoadingException;
+		}
+	}
+
+	/**
+	 * Same as {@link #loadClass(String, boolean)} but without exception handling.
+	 *
+	 * <p>Extending concrete class loaders should implement this instead of {@link #loadClass(String, boolean)}.
+	 */
+	protected Class<?> loadClassWithoutExceptionHandling(String name, boolean resolve) throws ClassNotFoundException {
+		return super.loadClass(name, resolve);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/util/FlinkUserCodeClassLoaderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FlinkUserCodeClassLoaderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link FlinkUserCodeClassLoader}.
+ */
+public class FlinkUserCodeClassLoaderTest extends TestLogger {
+	@Test
+	public void testExceptionHandling() {
+		RuntimeException expectedException = new RuntimeException("Expected exception");
+		AtomicReference<Throwable> handledException = new AtomicReference<>();
+		try (FlinkUserCodeClassLoader classLoaderWithErrorHandler =
+				new ThrowingURLClassLoader(handledException::set, expectedException)) {
+			classLoaderWithErrorHandler.loadClass("dummy.class");
+			fail("The expected exception is not thrown");
+		} catch (Throwable t) {
+			assertThat(handledException.get(), is(expectedException));
+			assertThat(t, is(expectedException));
+		}
+	}
+
+	private static class ThrowingURLClassLoader extends FlinkUserCodeClassLoader {
+		private final RuntimeException expectedException;
+
+		ThrowingURLClassLoader(Consumer<Throwable> classLoadingExceptionHandler, RuntimeException expectedException) {
+			super(new URL[]{}, null, classLoadingExceptionHandler);
+			this.expectedException = expectedException;
+		}
+
+		@Override
+		protected Class<?> loadClassWithoutExceptionHandling(String name, boolean resolve) {
+			throw expectedException;
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/util/TemporaryClassLoaderContextTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TemporaryClassLoaderContextTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import java.net.URL;
 
+import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
+
 /**
  * Test for {@link TemporaryClassLoaderContext}.
  */
@@ -33,7 +35,7 @@ public class TemporaryClassLoaderContextTest {
 		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
 
 		final ChildFirstClassLoader temporaryClassLoader =
-			new ChildFirstClassLoader(new URL[0], contextClassLoader, new String[0]);
+			new ChildFirstClassLoader(new URL[0], contextClassLoader, new String[0], NOOP_EXCEPTION_HANDLER);
 
 		try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(temporaryClassLoader)) {
 			Assert.assertEquals(temporaryClassLoader, Thread.currentThread().getContextClassLoader());

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoClassloadingTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoClassloadingTest.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.LinkedHashMap;
 
+import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -73,7 +74,8 @@ public class AvroKryoClassloadingTest {
 		final ClassLoader userAppClassLoader = FlinkUserCodeClassLoaders.childFirst(
 				new URL[] { avroLocation, kryoLocation },
 				parentClassLoader,
-				CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS.defaultValue().split(";"));
+				CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS.defaultValue().split(";"),
+			NOOP_EXCEPTION_HANDLER);
 
 		final Class<?> userLoadedAvroClass = Class.forName(avroClass.getName(), false, userAppClassLoader);
 		assertNotEquals(avroClass, userLoadedAvroClass);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -157,7 +157,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
 		this.jobManagerSharedServices = JobManagerSharedServices.fromConfiguration(
 			configuration,
-			blobServer);
+			blobServer,
+			fatalErrorHandler);
 
 		this.runningJobsRegistry = highAvailabilityServices.getRunningJobsRegistry();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -21,7 +21,9 @@ package org.apache.flink.runtime.execution.librarycache;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkUserCodeClassLoader;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -40,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -140,9 +143,18 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 		 */
 		private final String[] alwaysParentFirstPatterns;
 
-		private DefaultClassLoaderFactory(FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder, String[] alwaysParentFirstPatterns) {
+		/**
+		 * Class loading exception handler.
+		 */
+		private final Consumer<Throwable> classLoadingExceptionHandler;
+
+		private DefaultClassLoaderFactory(
+				FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder,
+				String[] alwaysParentFirstPatterns,
+				Consumer<Throwable> classLoadingExceptionHandler) {
 			this.classLoaderResolveOrder = classLoaderResolveOrder;
 			this.alwaysParentFirstPatterns = alwaysParentFirstPatterns;
+			this.classLoadingExceptionHandler = classLoadingExceptionHandler;
 		}
 
 		@Override
@@ -151,12 +163,29 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 				classLoaderResolveOrder,
 				libraryURLs,
 				FlinkUserCodeClassLoaders.class.getClassLoader(),
-				alwaysParentFirstPatterns);
+				alwaysParentFirstPatterns,
+				classLoadingExceptionHandler);
 		}
 	}
 
-	public static ClassLoaderFactory defaultClassLoaderFactory(FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder, String[] alwaysParentFirstPatterns) {
-		return new DefaultClassLoaderFactory(classLoaderResolveOrder, alwaysParentFirstPatterns);
+	public static ClassLoaderFactory defaultClassLoaderFactory(
+			FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder,
+			String[] alwaysParentFirstPatterns,
+			@Nullable FatalErrorHandler fatalErrorHandlerJvmMetaspaceOomError) {
+		return new DefaultClassLoaderFactory(
+			classLoaderResolveOrder,
+			alwaysParentFirstPatterns,
+			createClassLoadingExceptionHandler(fatalErrorHandlerJvmMetaspaceOomError));
+	}
+
+	private static Consumer<Throwable> createClassLoadingExceptionHandler(
+			@Nullable FatalErrorHandler fatalErrorHandlerJvmMetaspaceOomError) {
+		return fatalErrorHandlerJvmMetaspaceOomError != null ?
+			classLoadingException -> {
+				if (ExceptionUtils.isMetaspaceOutOfMemoryError(classLoadingException)) {
+					fatalErrorHandlerJvmMetaspaceOomError.onFatalError(classLoadingException);
+				}
+			} : FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -375,7 +375,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			taskManagerServicesConfiguration,
 			blobCacheService.getPermanentBlobService(),
 			taskManagerMetricGroup.f1,
-			ioExecutor);
+			ioExecutor,
+			fatalErrorHandler);
 
 		TaskManagerConfiguration taskManagerConfiguration =
 			TaskManagerConfiguration.fromConfiguration(configuration, taskExecutorResourceSpec, externalAddress);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -516,7 +516,11 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
 	private final class TestingBlobLibraryCacheManagerBuilder {
 		private PermanentBlobService permanentBlobCache;
-		private BlobLibraryCacheManager.ClassLoaderFactory classLoaderFactory = BlobLibraryCacheManager.defaultClassLoaderFactory(FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST, new String[0]);
+		private BlobLibraryCacheManager.ClassLoaderFactory classLoaderFactory = BlobLibraryCacheManager
+			.defaultClassLoaderFactory(
+				FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
+				new String[0],
+				null);
 
 		private TestingBlobLibraryCacheManagerBuilder() throws IOException {
 			final Configuration blobClientConfig = new Configuration();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -79,7 +79,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 			final BlobLibraryCacheManager.ClassLoaderFactory classLoaderFactory = BlobLibraryCacheManager.defaultClassLoaderFactory(
 				FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
-				new String[0]);
+				new String[0],
+				null);
 
 			for (int i = 0; i < server.length; i++) {
 				server[i] = new BlobServer(config, blobStoreService);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.TemporaryFolder;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.isA;
@@ -97,11 +98,9 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 		// collect the libraries / class folders with RocksDB related code: the state backend and RocksDB itself
 		final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
 
-		final URLClassLoader childClassLoader1 = FlinkUserCodeClassLoaders.parentFirst(
-				new URL[] { childCodePath }, parentClassLoader);
+		final URLClassLoader childClassLoader1 = createParentFirstClassLoader(childCodePath, parentClassLoader);
 
-		final URLClassLoader childClassLoader2 = FlinkUserCodeClassLoaders.parentFirst(
-				new URL[] { childCodePath }, parentClassLoader);
+		final URLClassLoader childClassLoader2 = createParentFirstClassLoader(childCodePath, parentClassLoader);
 
 		final String className = FlinkUserCodeClassLoadersTest.class.getName();
 
@@ -123,11 +122,9 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 		// collect the libraries / class folders with RocksDB related code: the state backend and RocksDB itself
 		final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
 
-		final URLClassLoader childClassLoader1 = FlinkUserCodeClassLoaders.childFirst(
-				new URL[] { childCodePath }, parentClassLoader, new String[0]);
+		final URLClassLoader childClassLoader1 = createChildFirstClassLoader(childCodePath, parentClassLoader);
 
-		final URLClassLoader childClassLoader2 = FlinkUserCodeClassLoaders.childFirst(
-				new URL[] { childCodePath }, parentClassLoader, new String[0]);
+		final URLClassLoader childClassLoader2 = createChildFirstClassLoader(childCodePath, parentClassLoader);
 
 		final String className = FlinkUserCodeClassLoadersTest.class.getName();
 
@@ -150,8 +147,7 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 		// collect the libraries / class folders with RocksDB related code: the state backend and RocksDB itself
 		final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
 
-		final URLClassLoader childClassLoader = FlinkUserCodeClassLoaders.childFirst(
-				new URL[] { childCodePath }, parentClassLoader, new String[0]);
+		final URLClassLoader childClassLoader = createChildFirstClassLoader(childCodePath, parentClassLoader);
 
 		final String className = FlinkUserCodeClassLoadersTest.class.getName();
 
@@ -179,7 +175,10 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 		final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
 
 		final URLClassLoader childClassLoader = FlinkUserCodeClassLoaders.childFirst(
-				new URL[] { childCodePath }, parentClassLoader, new String[] { parentFirstPattern });
+			new URL[] { childCodePath },
+			parentClassLoader,
+			new String[] { parentFirstPattern },
+			NOOP_EXCEPTION_HANDLER);
 
 		final Class<?> clazz1 = Class.forName(className, false, parentClassLoader);
 		final Class<?> clazz2 = Class.forName(className, false, childClassLoader);
@@ -191,5 +190,20 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 		assertEquals(clazz1, clazz4);
 
 		childClassLoader.close();
+	}
+
+	private static URLClassLoader createParentFirstClassLoader(URL childCodePath, ClassLoader parentClassLoader) {
+		return FlinkUserCodeClassLoaders.parentFirst(
+			new URL[] { childCodePath },
+			parentClassLoader,
+			NOOP_EXCEPTION_HANDLER);
+	}
+
+	private static URLClassLoader createChildFirstClassLoader(URL childCodePath, ClassLoader parentClassLoader) {
+		return FlinkUserCodeClassLoaders.childFirst(
+			new URL[] { childCodePath },
+			parentClassLoader,
+			new String[0],
+			NOOP_EXCEPTION_HANDLER);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -227,6 +227,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 			config,
 			VoidPermanentBlobService.INSTANCE,
 			UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
-			Executors.newDirectExecutorService());
+			Executors.newDirectExecutorService(),
+			throwable -> {});
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDbMultiClassLoaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDbMultiClassLoaderTest.java
@@ -28,6 +28,7 @@ import org.rocksdb.RocksDB;
 import java.lang.reflect.Method;
 import java.net.URL;
 
+import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
 import static org.junit.Assert.assertNotEquals;
 
 /**
@@ -47,8 +48,8 @@ public class RocksDbMultiClassLoaderTest {
 		final URL codePath2 = RocksDB.class.getProtectionDomain().getCodeSource().getLocation();
 
 		final ClassLoader parent = getClass().getClassLoader();
-		final ClassLoader loader1 = FlinkUserCodeClassLoaders.childFirst(new URL[] { codePath1, codePath2 }, parent, new String[0]);
-		final ClassLoader loader2 = FlinkUserCodeClassLoaders.childFirst(new URL[] { codePath1, codePath2 }, parent, new String[0]);
+		final ClassLoader loader1 = FlinkUserCodeClassLoaders.childFirst(new URL[] { codePath1, codePath2 }, parent, new String[0], NOOP_EXCEPTION_HANDLER);
+		final ClassLoader loader2 = FlinkUserCodeClassLoaders.childFirst(new URL[] { codePath1, codePath2 }, parent, new String[0], NOOP_EXCEPTION_HANDLER);
 
 		final String className = RocksDBStateBackend.class.getName();
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -377,10 +378,19 @@ public class ExecutionContextTest {
 	// a catalog that requires the thread context class loader to be a user code classloader during construction and opening
 	private static class TestClassLoaderCatalog extends GenericInMemoryCatalog {
 
-		private static final Class parentFirstCL = FlinkUserCodeClassLoaders.parentFirst(
-				new URL[0], TestClassLoaderCatalog.class.getClassLoader()).getClass();
-		private static final Class childFirstCL = FlinkUserCodeClassLoaders.childFirst(
-				new URL[0], TestClassLoaderCatalog.class.getClassLoader(), new String[0]).getClass();
+		private static final Class parentFirstCL = FlinkUserCodeClassLoaders
+			.parentFirst(
+				new URL[0],
+				TestClassLoaderCatalog.class.getClassLoader(),
+				NOOP_EXCEPTION_HANDLER)
+			.getClass();
+		private static final Class childFirstCL = FlinkUserCodeClassLoaders
+			.childFirst(
+				new URL[0],
+				TestClassLoaderCatalog.class.getClassLoader(),
+				new String[0],
+				NOOP_EXCEPTION_HANDLER)
+			.getClass();
 
 		TestClassLoaderCatalog(String name) {
 			super(name);


### PR DESCRIPTION
## What is the purpose of the change

Currently, if 
- the JVM Metaspace OOM happens in user class loader in user threads
- and the OOM is not handled properly and forwarded to the task thread
- or the JVM Metaspace OOM is suppressed e.g. by catching and just logging `Throwable`
then the TM will not fail, although the situation is basically unrecoverable and Flink failover should kick in.

Ideally, we should not catch broad `Throwable` exception and let errors to be handled properly in a central place for all threads. This is a big effort. Therefore, this PR suggests a smaller change for now.

We can wrap the user class loading with try/catch (because this is the most probable place for the JVM Metaspace OOM) and call the TM fatal handler on the JVM Metaspace OOM.

The PR suggests to discuss two ways to do that:
- inherit a base user class loader with error handling by existing ones (first commit)
- decorate the existing user class loaders with a wrapping class loader with error handling (second commit)

The third commit is temporary. It loops a test to exclude the test failure described in [FLINK-16917](https://issues.apache.org/jira/browse/FLINK-16917).