### PR TITLE
[FLINK-18069][CI] Test if Java/Scaladocs builds are passing in the compile stage

### DIFF
--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -43,7 +43,7 @@ echo "==========================================================================
 EXIT_CODE=0
 
 run_mvn clean install $MAVEN_OPTS -Dflink.convergence.phase=install -Pcheck-convergence -Dflink.forkCount=2 \
-    -Dflink.forkCountTestPackage=2 -U -DskipTests
+    -Dflink.forkCountTestPackage=2 -Dmaven.javadoc.skip=true -U -DskipTests
 
 EXIT_CODE=$?
 
@@ -54,10 +54,22 @@ if [ $EXIT_CODE != 0 ]; then
     exit $EXIT_CODE
 fi
 
-echo "============ Checking Scaladocs ============"
+echo "============ Checking Javadocs and Scaladocs ============"
+
+# use the same invocation as on buildbot (https://svn.apache.org/repos/infra/infrastructure/buildbot/aegis/buildmaster/master1/projects/flink.conf)
+run_mvn javadoc:aggregate -Paggregate-scaladoc -DadditionalJOption='-Xdoclint:none' \
+      -Dmaven.javadoc.failOnError=false -Dcheckstyle.skip=true -Denforcer.skip=true \
+      -Dheader=someTestHeader || exit $?
 
 cd flink-scala
-run_mvn scala:doc || exit $?
+run_mvn scala:doc 2> scaladoc.out
+EXIT_CODE=$?
+if [ $EXIT_CODE != 0 ] ; then
+  echo "ERROR in Scaladocs. Printing full output:"
+  cat scaladoc.out
+  rm scaladoc.out
+  exit $EXIT_CODE
+fi
 cd ..
 
 echo "============ Checking scala suffixes ============"

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -54,20 +54,27 @@ if [ $EXIT_CODE != 0 ]; then
     exit $EXIT_CODE
 fi
 
-echo "============ Checking Javadocs and Scaladocs ============"
+echo "============ Checking Javadocs ============"
 
 # use the same invocation as on buildbot (https://svn.apache.org/repos/infra/infrastructure/buildbot/aegis/buildmaster/master1/projects/flink.conf)
 run_mvn javadoc:aggregate -Paggregate-scaladoc -DadditionalJOption='-Xdoclint:none' \
       -Dmaven.javadoc.failOnError=false -Dcheckstyle.skip=true -Denforcer.skip=true \
-      -Dheader=someTestHeader || exit $?
+      -Dheader=someTestHeader > javadoc.out
+EXIT_CODE=$?
+if [ $EXIT_CODE != 0 ] ; then
+  echo "ERROR in Javadocs. Printing full output:"
+  cat javadoc.out ; rm javadoc.out
+  exit $EXIT_CODE
+fi
+
+echo "============ Checking Scaladocs ============"
 
 cd flink-scala
 run_mvn scala:doc 2> scaladoc.out
 EXIT_CODE=$?
 if [ $EXIT_CODE != 0 ] ; then
   echo "ERROR in Scaladocs. Printing full output:"
-  cat scaladoc.out
-  rm scaladoc.out
+  cat scaladoc.out ; rm scaladoc.out
   exit $EXIT_CODE
 fi
 cd ..


### PR DESCRIPTION
# What is the purpose of the change

We are currently only checking if the Scaladocs are passing when building the flink docs on buildbot.
With this change, we are checking if generating the scaladocs is successful.

