### PR TITLE
[FLINK-18051][AZP] Fail Maven setup stage on error

### DIFF
--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -31,6 +31,7 @@ function run_mvn {
 export -f run_mvn
 
 function setup_maven {
+	set -e # fail if there was an error setting up maven
 	if [ ! -d "${MAVEN_VERSIONED_DIR}" ]; then
 	  wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip
 	  unzip -d "${MAVEN_CACHE_DIR}" -qq "apache-maven-${MAVEN_VERSION}-bin.zip"
@@ -46,6 +47,7 @@ function setup_maven {
 	fi
 
 	echo "Installed Maven ${MAVEN_VERSION} to ${M2_HOME}"
+	set +e
 }
 
 function set_mirror_config {


### PR DESCRIPTION


## What is the purpose of the change

Before this change, the e2e test were failing with a cryptic error message, when the maven setup failed (for example because the certificate of the download server was invalid).

Now, we properly fail if there's any error in the mvn setup.