### PR TITLE
[FLINK-17404] Make sure netty 3.10.6 is used in flink-runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,10 @@ under the License.
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 
@@ -362,6 +366,10 @@ under the License.
 					<exclusion>
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>*</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>
@@ -383,6 +391,10 @@ under the License.
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 
@@ -402,6 +414,10 @@ under the License.
 					<exclusion>
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>*</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>


### PR DESCRIPTION
Due to the recent changes in https://issues.apache.org/jira/browse/FLINK-11086 ("Add support for Hadoop 3"),
the shaded netty dependency in flink-runtime changed depending on the Hadoop dependency version.

The Hadoop 3 change affects the Netty version of flink-runtime depending on the hadoop version you are compiling Flink with:
- our akka expects netty 3.10.6
- with Hadoop 2.4.1 and Hadoop 2.8.3, flink-runtime shades netty 3.6.2 (the e2e test passes)
- with Hadoop 3.1.3 netty is at 3.10.5 (the e2e test fails reliably)
Excluding the netty dependency fixes the problem (the netty version is independent of Hadoop then).
No other shaded dependency seems to be affected by this.

