### PR TITLE
[FLINK-18075] Call open method of SerializationSchema in Kafka producer

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -759,10 +759,19 @@ public class FlinkKafkaProducer<IN>
 		}
 
 		if (kafkaSchema != null) {
-			kafkaSchema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+			kafkaSchema.open(createSerializationInitContext());
+		}
+
+		if (keyedSchema != null && keyedSchema instanceof KeyedSerializationSchemaWrapper) {
+			((KeyedSerializationSchemaWrapper<IN>) keyedSchema).getSerializationSchema()
+				.open(createSerializationInitContext());
 		}
 
 		super.open(configuration);
+	}
+
+	private SerializationSchema.InitializationContext createSerializationInitContext() {
+		return () -> getRuntimeContext().getMetricGroup().addGroup("user");
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

The open method of SerializationSchema was not called in the universal
Kafka producer.

## Verifying this change

I verified it by writing records to Kafka using KafkaDynamicTableSink and AvroRowDataSerializationSchema which initializes its state in the `open` method.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
