### PR TITLE
[FLINK-17857][e2e] Fix Kubernetes and docker e2e tests on Mac OS

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -35,6 +35,7 @@ function containers_health_check() {
 
 function build_image() {
     local image_name=${1:-flink-job}
+    local file_server_address=${2:-localhost}
 
     echo "Starting fileserver for Flink distribution"
     pushd ${FLINK_DIR}/..
@@ -47,7 +48,7 @@ function build_image() {
     echo "Preparing Dockeriles"
     git clone https://github.com/apache/flink-docker.git --branch dev-master --single-branch
     cd flink-docker
-    ./add-custom.sh -u localhost:9999/flink.tgz -n ${image_name}
+    ./add-custom.sh -u ${file_server_address}:9999/flink.tgz -n ${image_name}
 
     echo "Building images"
     docker build --no-cache --network="host" -t ${image_name} dev/${image_name}-debian

--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -35,7 +35,9 @@ function containers_health_check() {
 
 function build_image() {
     local image_name=${1:-flink-job}
-    local file_server_address=${2:-localhost}
+    local default_file_server_address="localhost"
+    [[ "${OS_TYPE}" != "linux" ]] && default_file_server_address="host.docker.internal"
+    local file_server_address=${2:-${default_file_server_address}}
 
     echo "Starting fileserver for Flink distribution"
     pushd ${FLINK_DIR}/..

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -94,6 +94,9 @@ function start_kubernetes {
             echo "$NON_LINUX_ENV_NOTE"
             exit 1
         fi
+        # Mount Flink dist into minikube virtual machine because we need to mount hostPath as usrlib
+        minikube mount $FLINK_DIR:$FLINK_DIR &
+        export minikube_mount_pid=$!
     else
         setup_kubernetes_for_linux
         if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} start_kubernetes_if_not_running; then
@@ -107,6 +110,7 @@ function start_kubernetes {
 function stop_kubernetes {
     if [[ "${OS_TYPE}" != "linux" ]]; then
         echo "$NON_LINUX_ENV_NOTE"
+        kill $minikube_mount_pid 2> /dev/null
     else
         echo "Stopping minikube ..."
         stop_command="sudo minikube stop"
@@ -173,6 +177,14 @@ appender.console.type = CONSOLE
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %-60c %x - %m%n
 END
+}
+
+function get_host_machine_address {
+    if [[ "${OS_TYPE}" != "linux" ]]; then
+        echo $(minikube ssh "route -n | grep ^0.0.0.0 | awk '{ print \$2 }' | tr -d '[:space:]'")
+    else
+        echo "localhost"
+    fi
 }
 
 on_exit cleanup

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
@@ -33,7 +33,7 @@ setConsoleLogging
 
 start_kubernetes
 
-build_image ${FLINK_IMAGE_NAME}
+build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)
 
 kubectl create clusterrolebinding ${CLUSTER_ROLE_BINDING} --clusterrole=edit --serviceaccount=default:default --namespace=default
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -36,7 +36,7 @@ start_kubernetes
 
 mkdir -p $OUTPUT_VOLUME
 
-build_image ${FLINK_IMAGE_NAME}
+build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)
 
 export USER_LIB=${FLINK_DIR}/examples/batch
 kubectl create -f ${CONTAINER_SCRIPTS}/job-cluster-service.yaml

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
@@ -47,7 +47,7 @@ setConsoleLogging
 
 start_kubernetes
 
-build_image ${FLINK_IMAGE_NAME}
+build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)
 
 kubectl create clusterrolebinding ${CLUSTER_ROLE_BINDING} --clusterrole=edit --serviceaccount=default:default --namespace=default
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In FLINK-17656, we migrate all the e2e tests from flink-container/docker to apache/flink-docker. After the migration, when building a docker image, we need to start a file server and then download it in the Dockerfile.

It works well in linux environment since the minikube is started in "vm-driver=none". However, it is not true in the Mac. We usually start a virtual machine for minikube and this will make "localhost" could not work.

The same case also exists for docker tests. Because "localhost" is not be accessible when building the image even we set the --network=host


## Brief change log

* Fix K8s e2e tests
* Fix docker e2e tests


## Verifying this change

The following tests could run successfully on Mac OS
* test_kubernetes_embedded_job.sh
* test_kubernetes_session.sh
* test_kubernetes_application.sh
* test_docker_embedded_job.sh

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
