### PR TITLE
[FLINK-18056][fs-connector] Hadoop path-based file writer adds UUID to in-progress file to avoid conflicts

### DIFF
--- a/flink-formats/flink-hadoop-bulk/pom.xml
+++ b/flink-formats/flink-hadoop-bulk/pom.xml
@@ -80,6 +80,43 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-hdfs</artifactId>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<version>${hadoop.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<version>${hadoop.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- This dependency is no longer shipped with the JDK since Java 9.-->
+					<groupId>jdk.tools</groupId>
+					<artifactId>jdk.tools</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-formats/flink-hadoop-bulk/src/main/java/org/apache/flink/formats/hadoop/bulk/HadoopFileCommitter.java
+++ b/flink-formats/flink-hadoop-bulk/src/main/java/org/apache/flink/formats/hadoop/bulk/HadoopFileCommitter.java
@@ -43,7 +43,7 @@ public interface HadoopFileCommitter {
 	 *
 	 * @return The path of the intermediate file to commit.
 	 */
-	Path getInProgressFilePath();
+	Path getTempFilePath();
 
 	/**
 	 * Prepares the intermediates file for committing.

--- a/flink-formats/flink-hadoop-bulk/src/main/java/org/apache/flink/formats/hadoop/bulk/HadoopFileCommitterFactory.java
+++ b/flink-formats/flink-hadoop-bulk/src/main/java/org/apache/flink/formats/hadoop/bulk/HadoopFileCommitterFactory.java
@@ -33,13 +33,25 @@ import java.io.Serializable;
 public interface HadoopFileCommitterFactory extends Serializable {
 
 	/**
-	 * Creates the corresponding Hadoop file committer according to the Hadoop
-	 * configuration and the target path.
+	 * Creates a new Hadoop file committer for writing.
 	 *
 	 * @param configuration The hadoop configuration.
-	 * @param targetFilePath The target path to commit.
+	 * @param targetFilePath The target path to commit to.
 	 * @return The corresponding Hadoop file committer.
 	 */
 	HadoopFileCommitter create(Configuration configuration, Path targetFilePath) throws IOException;
+
+	/**
+	 * Creates a Hadoop file committer for commit the pending file.
+	 *
+	 * @param configuration The hadoop configuration.
+	 * @param targetFilePath The target path to commit to.
+	 * @param inProgressPath The path of the remaining pending file.
+	 * @return The corresponding Hadoop file committer.
+	 */
+	HadoopFileCommitter recoverForCommit(
+		Configuration configuration,
+		Path targetFilePath,
+		Path inProgressPath) throws IOException;
 
 }

--- a/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/HadoopPathBasedPartFileWriterTest.java
+++ b/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/HadoopPathBasedPartFileWriterTest.java
@@ -63,7 +63,8 @@ public class HadoopPathBasedPartFileWriterTest extends AbstractTestBase {
 	@Test
 	public void testPendingFileRecoverableSerializer() throws IOException {
 		HadoopPathBasedPendingFileRecoverable recoverable = new HadoopPathBasedPendingFileRecoverable(
-			new Path("hdfs://fake/path"));
+			new Path("hdfs://fake/path"),
+			new Path("hdfs://fake/path.inprogress.uuid"));
 		HadoopPathBasedPendingFileRecoverableSerializer serializer =
 			new HadoopPathBasedPendingFileRecoverableSerializer();
 
@@ -72,7 +73,8 @@ public class HadoopPathBasedPartFileWriterTest extends AbstractTestBase {
 			serializer.getVersion(),
 			serializedBytes);
 
-		assertEquals(recoverable.getPath(), deSerialized.getPath());
+		assertEquals(recoverable.getTargetFilePath(), deSerialized.getTargetFilePath());
+		assertEquals(recoverable.getTempFilePath(), deSerialized.getTempFilePath());
 	}
 
 	@Test

--- a/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/committer/HadoopRenameCommitterHDFSTest.java
+++ b/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/committer/HadoopRenameCommitterHDFSTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.hadoop.bulk.committer;
+
+import org.apache.flink.formats.hadoop.bulk.AbstractFileCommitterTest;
+import org.apache.flink.formats.hadoop.bulk.HadoopFileCommitter;
+import org.apache.flink.formats.hadoop.bulk.committer.cluster.HDFSCluster;
+import org.apache.flink.util.OperatingSystem;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+/**
+ * Tests the behaviors of {@link HadoopRenameFileCommitter} with HDFS file system.
+ */
+public class HadoopRenameCommitterHDFSTest extends AbstractFileCommitterTest {
+
+	@ClassRule
+	public static final TemporaryFolder CLASS_TEMPORARY_FOLDER = new TemporaryFolder();
+
+	private static HDFSCluster hdfsCluster;
+
+	@BeforeClass
+	public static void createHDFS() throws Exception {
+		Assume.assumeTrue(!OperatingSystem.isWindows());
+
+		hdfsCluster = new HDFSCluster(CLASS_TEMPORARY_FOLDER.newFolder());
+	}
+
+	@AfterClass
+	public static void destroyHDFS() {
+		if (hdfsCluster != null) {
+			hdfsCluster.shutdown();
+		}
+
+		hdfsCluster = null;
+	}
+
+	public HadoopRenameCommitterHDFSTest(boolean override) throws IOException {
+		super(override);
+	}
+
+	@Override
+	protected Path getBasePath() throws IOException {
+		return hdfsCluster.newFolder();
+	}
+
+	@Override
+	protected Configuration getConfiguration() {
+		return new Configuration();
+	}
+
+	@Override
+	protected HadoopFileCommitter createNewCommitter(
+		Configuration configuration,
+		Path targetFilePath) throws IOException {
+
+		return new HadoopRenameFileCommitter(configuration, targetFilePath);
+	}
+
+	@Override
+	protected HadoopFileCommitter createPendingCommitter(
+		Configuration configuration,
+		Path targetFilePath,
+		Path tempFilePath) throws IOException {
+
+		return new HadoopRenameFileCommitter(configuration, targetFilePath, tempFilePath);
+	}
+
+	@Override
+	protected void cleanup(Configuration configuration, Path basePath) throws IOException {
+		basePath.getFileSystem(configuration).delete(basePath, true);
+	}
+}

--- a/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/committer/HadoopRenameCommitterLocalFSTest.java
+++ b/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/committer/HadoopRenameCommitterLocalFSTest.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.formats.hadoop.bulk;
+package org.apache.flink.formats.hadoop.bulk.committer;
 
-import org.apache.flink.formats.hadoop.bulk.committer.HadoopRenameFileCommitter;
+import org.apache.flink.formats.hadoop.bulk.AbstractFileCommitterTest;
+import org.apache.flink.formats.hadoop.bulk.HadoopFileCommitter;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -26,14 +27,26 @@ import org.apache.hadoop.fs.Path;
 import java.io.IOException;
 
 /**
- * The default hadoop file committer factory which always use {@link HadoopRenameFileCommitter}.
+ * Tests the behaviors of {@link HadoopRenameFileCommitter} with local file system.
  */
-public class DefaultHadoopFileCommitterFactory implements HadoopFileCommitterFactory {
+public class HadoopRenameCommitterLocalFSTest extends AbstractFileCommitterTest {
 
-	private static final long serialVersionUID = 1L;
+	public HadoopRenameCommitterLocalFSTest(boolean override) throws IOException {
+		super(override);
+	}
 
 	@Override
-	public HadoopFileCommitter create(
+	protected Path getBasePath() throws IOException {
+		return new Path(TEMPORARY_FOLDER.newFolder().toURI());
+	}
+
+	@Override
+	protected Configuration getConfiguration() {
+		return new Configuration();
+	}
+
+	@Override
+	protected HadoopFileCommitter createNewCommitter(
 		Configuration configuration,
 		Path targetFilePath) throws IOException {
 
@@ -41,11 +54,16 @@ public class DefaultHadoopFileCommitterFactory implements HadoopFileCommitterFac
 	}
 
 	@Override
-	public HadoopFileCommitter recoverForCommit(
+	protected HadoopFileCommitter createPendingCommitter(
 		Configuration configuration,
 		Path targetFilePath,
 		Path tempFilePath) throws IOException {
 
 		return new HadoopRenameFileCommitter(configuration, targetFilePath, tempFilePath);
+	}
+
+	@Override
+	public void cleanup(Configuration configuration, Path basePath) {
+		// Empty method.
 	}
 }

--- a/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/committer/cluster/HDFSCluster.java
+++ b/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/committer/cluster/HDFSCluster.java
@@ -16,36 +16,36 @@
  * limitations under the License.
  */
 
-package org.apache.flink.formats.hadoop.bulk;
-
-import org.apache.flink.formats.hadoop.bulk.committer.HadoopRenameFileCommitter;
+package org.apache.flink.formats.hadoop.bulk.committer.cluster;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.UUID;
 
 /**
- * The default hadoop file committer factory which always use {@link HadoopRenameFileCommitter}.
+ * Utility class for testing with HDFS FileSystem.
  */
-public class DefaultHadoopFileCommitterFactory implements HadoopFileCommitterFactory {
+public class HDFSCluster {
 
-	private static final long serialVersionUID = 1L;
+	public final MiniDFSCluster miniCluster;
 
-	@Override
-	public HadoopFileCommitter create(
-		Configuration configuration,
-		Path targetFilePath) throws IOException {
-
-		return new HadoopRenameFileCommitter(configuration, targetFilePath);
+	public HDFSCluster(File tmpDir) throws IOException {
+		Configuration hdfsConfig = new Configuration();
+		hdfsConfig.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tmpDir.getAbsolutePath());
+		miniCluster = new MiniDFSCluster.Builder(hdfsConfig).build();
 	}
 
-	@Override
-	public HadoopFileCommitter recoverForCommit(
-		Configuration configuration,
-		Path targetFilePath,
-		Path tempFilePath) throws IOException {
+	public void shutdown() {
+		miniCluster.shutdown();
+	}
 
-		return new HadoopRenameFileCommitter(configuration, targetFilePath, tempFilePath);
+	public Path newFolder() {
+		return new Path(
+			new Path(miniCluster.getURI() + "/"),
+			UUID.randomUUID().toString());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently the Hadoop path-based file writer uses the same in-progress file for writing the same file. If users does not override the remaining in-progress file explicitly after failover, the job will fail due to trying to recreating an existing files. This PR fixes this issue by adding UUID to the in-progress files. 

## Brief change log

-3f7e6da089bea0dd3a2f2fc2bfafb88a13aa482c adds the UUID to the in-progress file name and enhances the tests.

## Verifying this change

*(Please pick either of the following options)*

- This change is tested by extending the current rename committer test to also cover the case that the writer does not override the file.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**