### PR TITLE
[FLINK-18061] [table] TableResult#collect method should return a closeable iterator to avoid resource leak

### DIFF
--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -52,6 +52,49 @@ class TableResult(object):
         """
         Get the schema of result.
 
+        The schema of DDL, USE, SHOW, EXPLAIN:
+        ::
+
+            +-------------+-------------+----------+
+            | column name | column type | comments |
+            +-------------+-------------+----------+
+            | result      | STRING      |          |
+            +-------------+-------------+----------+
+
+        The schema of DESCRIBE:
+        ::
+
+            +------------------+-------------+-------------------------------------------------+
+            | column name      | column type |                 comments                        |
+            +------------------+-------------+-------------------------------------------------+
+            | name             | STRING      | field name                                      |
+            +------------------+-------------+-------------------------------------------------+
+            | type             | STRING      | field type expressed as a String                |
+            +------------------+-------------+-------------------------------------------------+
+            | null             | BOOLEAN     | field nullability: true if a field is nullable, |
+            |                  |             | else false                                      |
+            +------------------+-------------+-------------------------------------------------+
+            | key              | BOOLEAN     | key constraint: 'PRI' for primary keys,         |
+            |                  |             | 'UNQ' for unique keys, else null                |
+            +------------------+-------------+-------------------------------------------------+
+            | computed column  | STRING      | computed column: string expression              |
+            |                  |             | if a field is computed column, else null        |
+            +------------------+-------------+-------------------------------------------------+
+            | watermark        | STRING      | watermark: string expression if a field is      |
+            |                  |             | watermark, else null                            |
+            +------------------+-------------+-------------------------------------------------+
+
+        The schema of INSERT: (one column per one sink)
+        ::
+
+            +----------------------------+-------------+-----------------------+
+            | column name                | column type | comments              |
+            +----------------------------+-------------+-----------------------+
+            | (name of the insert table) | BIGINT      | the insert table name |
+            +----------------------------+-------------+-----------------------+
+
+        The schema of SELECT is the selected field names and types.
+
         :return: The schema of result.
         :rtype: pyflink.table.TableSchema
 
@@ -63,6 +106,9 @@ class TableResult(object):
         """
         Return the ResultKind which represents the result type.
 
+        For DDL operation and USE operation, the result kind is always SUCCESS.
+        For other operations, the result kind is always SUCCESS_WITH_CONTENT.
+
         :return: The result kind.
         :rtype: pyflink.table.ResultKind
 
@@ -73,6 +119,9 @@ class TableResult(object):
     def print(self):
         """
         Print the result contents as tableau form to client console.
+
+        NOTE: please make sure the result data to print should be small.
+        Because all data will be collected to local first, and then print them to console.
 
         .. versionadded:: 1.11.0
         """

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
@@ -22,9 +22,9 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.util.CloseableIterator;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>NOTE: After using this iterator, the close method MUST be called in order to release job related resources.
  */
-public class CollectResultIterator<T> implements Iterator<T>, AutoCloseable {
+public class CollectResultIterator<T> implements CloseableIterator<T> {
 
 	private final CollectResultFetcher<T> fetcher;
 	private T bufferedResult;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -53,7 +53,7 @@ public interface TableResult {
 	 * <p>The schema of DESCRIBE:
 	 * <pre>
 	 * +-----------------+------------+-----------------------------------------------------------------------------+
-	 * |   field name    | field type |                              comments                                       |
+	 * | field name      | field type |                              comments                                       |
 	 * +-----------------+------------+-----------------------------------------------------------------------------+
 	 * | name            | STRING     | field name                                                                  |
 	 * | type            | STRING     | field type expressed as a String                                            |

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -41,7 +41,7 @@ public interface TableResult {
 	/**
 	 * Get the schema of result.
 	 *
-	 * <p>The schema of DDL, SHOW, EXPLAIN:
+	 * <p>The schema of DDL, USE, SHOW, EXPLAIN:
 	 * <pre>
 	 * +-------------+-------------+----------+
 	 * | column name | column type | comments |
@@ -79,6 +79,9 @@ public interface TableResult {
 
 	/**
 	 * Return the {@link ResultKind} which represents the result type.
+	 *
+	 * <p>For DDL operation and USE operation, the result kind is always {@link ResultKind#SUCCESS}.
+	 * For other operations, the result kind is always {@link ResultKind#SUCCESS_WITH_CONTENT}.
 	 */
 	ResultKind getResultKind();
 
@@ -119,6 +122,9 @@ public interface TableResult {
 
 	/**
 	 * Print the result contents as tableau form to client console.
+	 *
+	 * <p><strong>NOTE:</strong> please make sure the result data to print should be small.
+	 * Because all data will be collected to local first, and then print them to console.
 	 */
 	void print();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -43,34 +43,34 @@ public interface TableResult {
 	 *
 	 * <p>The schema of DDL, SHOW, EXPLAIN:
 	 * <pre>
-	 * +------------+-----------+-----------+
-	 * | field name | field type | comments |
-	 * +------------+------------+----------+
-	 * | result     | STRING     |          |
-	 * +------------+------------+----------+
+	 * +-------------+-------------+----------+
+	 * | column name | column type | comments |
+	 * +-------------+-------------+----------+
+	 * | result      | STRING      |          |
+	 * +-------------+-------------+----------+
 	 * </pre>
 	 *
 	 * <p>The schema of DESCRIBE:
 	 * <pre>
-	 * +-----------------+------------+-----------------------------------------------------------------------------+
-	 * | field name      | field type |                              comments                                       |
-	 * +-----------------+------------+-----------------------------------------------------------------------------+
-	 * | name            | STRING     | field name                                                                  |
-	 * | type            | STRING     | field type expressed as a String                                            |
-	 * | null            | BOOLEAN    | field nullability: true if it's nullable, else false                        |
-	 * | key             | BOOLEAN    | key constraint: 'PRI' for primary keys, 'UNQ' for unique keys, else null    |
-	 * | computed column | STRING     | computed column: string expression if a field is computed column, else null |
-	 * | watermark       | STRING     | watermark: string expression if a field is a watermark, else null           |
-	 * +-----------------+------------+-----------------------------------------------------------------------------+
+	 * +------------------+-------------+-----------------------------------------------------------------------------+
+	 * | column name      | column type |                              comments                                       |
+	 * +------------------+-------------+-----------------------------------------------------------------------------+
+	 * | name             | STRING      | field name                                                                  |
+	 * | type             | STRING      | field type expressed as a String                                            |
+	 * | null             | BOOLEAN     | field nullability: true if a field is nullable, else false                  |
+	 * | key              | BOOLEAN     | key constraint: 'PRI' for primary keys, 'UNQ' for unique keys, else null    |
+	 * | computed column  | STRING      | computed column: string expression if a field is computed column, else null |
+	 * | watermark        | STRING      | watermark: string expression if a field is watermark, else null             |
+	 * +------------------+-------------+-----------------------------------------------------------------------------+
 	 * </pre>
 	 *
 	 * <p>The schema of INSERT: (one column per one sink)
 	 * <pre>
-	 * +----------------------------+------------+-----------------------------------+
-	 * | field name                 | field type |               comments            |
-	 * +----------------------------+------------+-----------------------------------+
-	 * | (name of the insert table) | BIGINT     | field name is the sink table name |
-	 * +----------------------------+------------+-----------------------------------+
+	 * +----------------------------+-------------+-----------------------+
+	 * | column name                | column type | comments              |
+	 * +----------------------------+-------------+-----------------------+
+	 * | (name of the insert table) | BIGINT      | the insert table name |
+	 * +----------------------------+-------------+-----------------------+
 	 * </pre>
 	 *
 	 * <p>The schema of SELECT is the selected field names and types.
@@ -93,16 +93,16 @@ public interface TableResult {
 	 *         Calling CloseableIterator#close method will cancel the job and release related resources.
 	 *     </li>
 	 *     <li>
-	 *          For INSERT operation, Flink does not support getting the affected row count now.
-	 *          So the affected row count is always -1 (unknown) for every sink, and the constant row
-	 *          will be will be returned after the insert job is submitted.
-	 *          Do nothing when calling CloseableIterator#close method (which will not cancel the job
-	 *          because the returned iterator does not bound to the job now).
-	 *          We can cancel the job through {@link #getJobClient()} if needed.
+	 *         For DML operation, Flink does not support getting the real affected row count now.
+	 *         So the affected row count is always -1 (unknown) for every sink, and them will be
+	 *         returned after the job is submitted.
+	 *         Do nothing when calling CloseableIterator#close method (which will not cancel the job
+	 *         because the returned iterator does not bound to the job now).
+	 *         We can cancel the job through {@link #getJobClient()} if needed.
 	 *     </li>
 	 *     <li>
-	 *         For other operations, no flink job will be submitted. So all result is bounded.
-	 *         Do nothing when calling CloseableIterator#close method.
+	 *         For other operations, no flink job will be submitted ({@link #getJobClient()} is always empty),
+	 *         and the result is bounded. Do nothing when calling CloseableIterator#close method.
 	 *     </li>
 	 * </ul>
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -57,17 +57,17 @@ public interface TableResult {
 	 *
 	 * <p>There are two approaches to close a job:
 	 * 1. close the job through JobClient, for example:
-	 <pre>{@code
+	 * <pre>{@code
 	 *  TableResult result = tEnv.execute("select ...");
 	 *  CloseableIterator<Row> it = result.collect();
 	 *  it... // collect same data
 	 *  result.getJobClient().get().cancel();
 	 * }</pre>
 	 *
-	 * 2. close the job through CloseableIterator
+	 * <p>2. close the job through CloseableIterator
 	 * (calling CloseableIterator#close method will trigger JobClient#cancel method),
 	 * for example:
-	 <pre>{@code
+	 * <pre>{@code
 	 *  TableResult result = tEnv.execute("select ...");
 	 *  // using try-with-resources statement
 	 *  try (CloseableIterator<Row> it = result.collect()) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -96,9 +96,9 @@ public interface TableResult {
 	 *         For DML operation, Flink does not support getting the real affected row count now.
 	 *         So the affected row count is always -1 (unknown) for every sink, and them will be
 	 *         returned after the job is submitted.
-	 *         Do nothing when calling CloseableIterator#close method (which will not cancel the job
-	 *         because the returned iterator does not bound to the job now).
-	 *         We can cancel the job through {@link #getJobClient()} if needed.
+	 *         Calling CloseableIterator#close method does not bind to the job.
+	 *         Therefore the `CloseableIterator#close` will not cancel the job as in the case of SELECT.
+	 *         If you need to cancel the job, you can use the {@link #getJobClient()}.
 	 *     </li>
 	 *     <li>
 	 *         For other operations, no flink job will be submitted ({@link #getJobClient()} is always empty),

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/SelectResultProvider.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/SelectResultProvider.java
@@ -21,8 +21,7 @@ package org.apache.flink.table.api.internal;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.types.Row;
-
-import java.util.Iterator;
+import org.apache.flink.util.CloseableIterator;
 
 /**
  * An internal class which helps the client to get the execute result from a specific sink.
@@ -39,5 +38,5 @@ public interface SelectResultProvider {
 	/**
 	 * Returns the select result as row iterator.
 	 */
-	Iterator<Row> getResultIterator();
+	CloseableIterator<Row> getResultIterator();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableResultImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableResultImpl.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.utils.PrintUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -51,14 +52,14 @@ class TableResultImpl implements TableResult {
 	private final JobClient jobClient;
 	private final TableSchema tableSchema;
 	private final ResultKind resultKind;
-	private final Iterator<Row> data;
+	private final CloseableIterator<Row> data;
 	private final PrintStyle printStyle;
 
 	private TableResultImpl(
 			@Nullable JobClient jobClient,
 			TableSchema tableSchema,
 			ResultKind resultKind,
-			Iterator<Row> data,
+			CloseableIterator<Row> data,
 			PrintStyle printStyle) {
 		this.jobClient = jobClient;
 		this.tableSchema = Preconditions.checkNotNull(tableSchema, "tableSchema should not be null");
@@ -83,7 +84,7 @@ class TableResultImpl implements TableResult {
 	}
 
 	@Override
-	public Iterator<Row> collect() {
+	public CloseableIterator<Row> collect() {
 		return data;
 	}
 
@@ -116,7 +117,7 @@ class TableResultImpl implements TableResult {
 		private JobClient jobClient = null;
 		private TableSchema tableSchema = null;
 		private ResultKind resultKind = null;
-		private Iterator<Row> data = null;
+		private CloseableIterator<Row> data = null;
 		private PrintStyle printStyle = PrintStyle.tableau(Integer.MAX_VALUE, PrintUtils.NULL_COLUMN, false);
 
 		private Builder() {
@@ -159,7 +160,7 @@ class TableResultImpl implements TableResult {
 		 *
 		 * @param rowIterator a row iterator as the execution result.
 		 */
-		public Builder data(Iterator<Row> rowIterator) {
+		public Builder data(CloseableIterator<Row> rowIterator) {
 			Preconditions.checkNotNull(rowIterator, "rowIterator should not be null");
 			this.data = rowIterator;
 			return this;
@@ -172,7 +173,7 @@ class TableResultImpl implements TableResult {
 		 */
 		public Builder data(List<Row> rowList) {
 			Preconditions.checkNotNull(rowList, "listRows should not be null");
-			this.data = rowList.iterator();
+			this.data = CloseableIterator.adapterForIterator(rowList.iterator());
 			return this;
 		}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -73,14 +73,14 @@ public class PrintUtils {
 	 * Displays the result in a tableau form.
 	 *
 	 * <p>For example: (printRowKind is true)
-	 * +-------------+-------------+---------+-------------+
+	 * +----------+-------------+---------+-------------+
 	 * | row_kind | boolean_col | int_col | varchar_col |
-	 * +-------------+-------------+---------+-------------+
+	 * +----------+-------------+---------+-------------+
 	 * |       +I |        true |       1 |         abc |
 	 * |       -U |       false |       2 |         def |
 	 * |       +U |       false |       3 |         def |
 	 * |       -D |      (NULL) |  (NULL) |      (NULL) |
-	 * +-------------+-------------+---------+-------------+
+	 * +----------+-------------+---------+-------------+
 	 * 4 rows in result
 	 */
 	public static void printAsTableauForm(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkBase.java
@@ -37,8 +37,8 @@ import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 
-import java.util.Iterator;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -89,16 +89,16 @@ public abstract class SelectTableSinkBase<T> implements StreamTableSink<T> {
 			}
 
 			@Override
-			public Iterator<Row> getResultIterator() {
+			public CloseableIterator<Row> getResultIterator() {
 				return new RowIteratorWrapper(iterator);
 			}
 		};
 	}
 
 	/**
-	 * An Iterator wrapper class that converts Iterator&lt;T&gt; to Iterator&lt;Row&gt;.
+	 * An Iterator wrapper class that converts CloseableIterator&lt;T&gt; to CloseableIterator&lt;Row&gt;.
 	 */
-	private class RowIteratorWrapper implements Iterator<Row>, AutoCloseable {
+	private class RowIteratorWrapper implements CloseableIterator<Row> {
 		private final CollectResultIterator<T> iterator;
 
 		public RowIteratorWrapper(CollectResultIterator<T> iterator) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/BatchSelectTableSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/BatchSelectTableSink.java
@@ -33,11 +33,11 @@ import org.apache.flink.table.api.internal.SelectResultProvider;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -89,14 +89,14 @@ public class BatchSelectTableSink implements BatchTableSink<Row> {
 			}
 
 			@Override
-			public Iterator<Row> getResultIterator() {
+			public CloseableIterator<Row> getResultIterator() {
 				Preconditions.checkNotNull(jobClient, "jobClient is null, please call setJobClient first.");
 				return collectResult(jobClient);
 			}
 		};
 	}
 
-	private Iterator<Row> collectResult(JobClient jobClient) {
+	private CloseableIterator<Row> collectResult(JobClient jobClient) {
 		JobExecutionResult jobExecutionResult;
 		try {
 			jobExecutionResult = jobClient.getJobExecutionResult(
@@ -115,7 +115,7 @@ public class BatchSelectTableSink implements BatchTableSink<Row> {
 		} catch (IOException | ClassNotFoundException e) {
 			throw new TableException("Failed to deserialize the result.", e);
 		}
-		return rowList.iterator();
+		return CloseableIterator.adapterForIterator(rowList.iterator());
 	}
 
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/StreamSelectTableSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/StreamSelectTableSink.java
@@ -34,9 +34,9 @@ import org.apache.flink.streaming.api.operators.collect.CollectStreamSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.internal.SelectResultProvider;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.types.RowKind;
 
-import java.util.Iterator;
 import java.util.UUID;
 
 /**
@@ -92,16 +92,17 @@ public class StreamSelectTableSink implements RetractStreamTableSink<Row> {
 			}
 
 			@Override
-			public Iterator<Row> getResultIterator() {
+			public CloseableIterator<Row> getResultIterator() {
 				return new RowIteratorWrapper(iterator);
 			}
 		};
 	}
 
 	/**
-	 * An Iterator wrapper class that converts Iterator&lt;Tuple2&lt;Boolean, Row&gt;&gt; to Iterator&lt;Row&gt;.
+	 * An Iterator wrapper class that converts CloseableIterator&lt;Tuple2&lt;Boolean, Row&gt;&gt;
+	 * to CloseableIterator&lt;Row&gt;.
 	 */
-	private static class RowIteratorWrapper implements Iterator<Row>, AutoCloseable {
+	private static class RowIteratorWrapper implements CloseableIterator<Row> {
 		private final CollectResultIterator<Tuple2<Boolean, Row>> iterator;
 		public RowIteratorWrapper(CollectResultIterator<Tuple2<Boolean, Row>> iterator) {
 			this.iterator = iterator;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/StreamSelectTableSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/StreamSelectTableSink.java
@@ -34,8 +34,8 @@ import org.apache.flink.streaming.api.operators.collect.CollectStreamSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.internal.SelectResultProvider;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
 
 import java.util.UUID;
 


### PR DESCRIPTION
## What is the purpose of the change

*as discussed in ML: http://mail-archives.apache.org/mod_mbox/flink-dev/202005.mbox/%3cd4ee47e1-0214-aa2f-f5ac-c9daf708e98f@apache.org%3e, we should return a closeable iterator for TableResult#collect method to avoid resource leak. This pr aims to change the return type of TableResult#collect method from Iterator&lt;Row&gt; to CloseableIterator&lt;Row&gt;*


## Brief change log

  - *change the return type of TableResult#collect method from Iterator&lt;Row&gt; to CloseableIterator&lt;Row&gt;*
  - *CollectResultIterator inherits from CloseableIterator&lt;T&gt;.*


## Verifying this change

*(Please pick either of the following options)*


This change added tests and can be verified as follows:

  - *Extended TableITCase to verify close logic*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
