### PR TITLE
[FLINK-18050][task][checkpointing] Fix double buffer recycling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
@@ -129,7 +129,7 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
 			info,
 			startSeqNum,
 			data == null ? 0 : data.length);
-		enqueue(write(checkpointId, info, checkBufferType(data)), false);
+		enqueue(write(checkpointId, info, data), false);
 	}
 
 	@Override
@@ -194,27 +194,6 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
 			}
 			throw wrapped;
 		}
-	}
-
-	private static Buffer[] checkBufferType(Buffer... data) {
-		if (data == null) {
-			return new Buffer[0];
-		}
-		try {
-			for (Buffer buffer : data) {
-				if (!buffer.isBuffer()) {
-					throw new IllegalArgumentException(buildBufferTypeErrorMessage(buffer));
-				}
-			}
-		} catch (Exception e) {
-			for (Buffer buffer : data) {
-				if (buffer.isBuffer()) {
-					buffer.recycleBuffer();
-				}
-			}
-			throw e;
-		}
-		return data;
 	}
 
 	private static String buildBufferTypeErrorMessage(Buffer buffer) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.ChannelStateWriteResult;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
+
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.apache.flink.util.CloseableIterator.ofElements;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link ChannelStateWriteRequestDispatcherImpl} test.
+ */
+public class ChannelStateWriteRequestDispatcherImplTest {
+
+	@Test
+	public void testPartialInputChannelStateWrite() throws Exception {
+		testBuffersRecycled(buffers -> ChannelStateWriteRequest.write(1L, new InputChannelInfo(1, 2), ofElements(Buffer::recycleBuffer, buffers)));
+	}
+
+	@Test
+	public void testPartialResultSubpartitionStateWrite() throws Exception {
+		testBuffersRecycled(buffers -> ChannelStateWriteRequest.write(1L, new ResultSubpartitionInfo(1, 2), buffers));
+	}
+
+	private void testBuffersRecycled(Function<NetworkBuffer[], ChannelStateWriteRequest> requestBuilder) throws Exception {
+		ChannelStateWriteRequestDispatcher dispatcher = new ChannelStateWriteRequestDispatcherImpl(new MemoryBackendCheckpointStorage(new JobID(), null, null, 1), new ChannelStateSerializerImpl());
+		ChannelStateWriteResult result = new ChannelStateWriteResult();
+		dispatcher.dispatch(ChannelStateWriteRequest.start(1L, result, CheckpointStorageLocationReference.getDefault()));
+
+		result.getResultSubpartitionStateHandles().completeExceptionally(new TestException());
+		result.getInputChannelStateHandles().completeExceptionally(new TestException());
+
+		NetworkBuffer[] buffers = new NetworkBuffer[]{buffer(), buffer()};
+		dispatcher.dispatch(requestBuilder.apply(buffers));
+		for (NetworkBuffer buffer : buffers) {
+			assertTrue(buffer.isRecycled());
+		}
+	}
+
+	private NetworkBuffer buffer() {
+		return new NetworkBuffer(MemorySegmentFactory.allocateUnpooledSegment(10), FreeingBufferRecycler.INSTANCE);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherTest.java
@@ -95,7 +95,7 @@ public class ChannelStateWriteRequestDispatcherTest {
 	}
 
 	private static ChannelStateWriteRequest writeOut() {
-		return write(CHECKPOINT_ID, new ResultSubpartitionInfo(1, 1));
+		return write(CHECKPOINT_ID, new ResultSubpartitionInfo(1, 1), new NetworkBuffer(MemorySegmentFactory.allocateUnpooledSegment(1), FreeingBufferRecycler.INSTANCE));
 	}
 
 	private static CheckpointStartRequest start() {


### PR DESCRIPTION
## What is the purpose of the change

Fix double buffer recycling in `ChannelStateWriteRequest.execute` and then in `cancel`.

## Verifying this change

Added unit test `ChannelStateWriteRequestDispatcherImplTest` (`testPartialInputChannelStateWrite`, `testPartialResultSubpartitionStateWrite`).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
