### PR TITLE
[FLINK-17404] Make sure netty 3.10.6 is used in flink-runtime

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -155,6 +155,14 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<!-- Transitive dependency of akka-remote that we explicitly define to pin
+		 	its version (our Hadoop dependency has overridden the netty version in the past) -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty</artifactId>
+			<version>3.10.6.Final</version>
+		</dependency>
+
 		<!-- Transitive dependency of akka-remote that we explicitly define to keep it
 			visible after the shading (without relocation!) of akka-remote -->
 		<dependency>


### PR DESCRIPTION
Due to the recent changes in https://issues.apache.org/jira/browse/FLINK-11086 ("Add support for Hadoop 3"),
the shaded netty dependency in flink-runtime changed depending on the Hadoop dependency version.

The Hadoop 3 change affects the Netty version of flink-runtime depending on the hadoop version you are compiling Flink with:
- our akka expects netty 3.10.6
- with Hadoop 2.4.1 and Hadoop 2.8.3, flink-runtime shades netty 3.6.2 (the e2e test passes)
- with Hadoop 3.1.3 netty is at 3.10.5 (the e2e test fails reliably)

We add Netty 3.10.6 as a dependency to flink-runtime to make sure it is not overridden by any other dependencies.

