### PR TITLE
[FLINK-18045] Fix Kerberos credentials checking

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/HadoopUtilsTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/HadoopUtilsTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
+import org.apache.hadoop.security.token.Token;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.apache.flink.runtime.util.HadoopUtils.HDFS_DELEGATION_TOKEN_KIND;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Unit tests for Hadoop utils.
+ */
+public class HadoopUtilsTest {
+
+	@BeforeClass
+	public static void setPropertiesToEnableKerberosConfigInit() {
+		System.setProperty("java.security.krb5.realm", "");
+		System.setProperty("java.security.krb5.kdc", "");
+		System.setProperty("java.security.krb5.conf", "/dev/null");
+	}
+
+	@Test
+	public void testShouldReturnFalseWhenNoKerberosCredentialsOrDelegationTokens() {
+		UserGroupInformation.setConfiguration(getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
+		UserGroupInformation userWithoutCredentialsOrTokens = createTestUser(AuthenticationMethod.KERBEROS);
+		assumeFalse(userWithoutCredentialsOrTokens.hasKerberosCredentials());
+
+		boolean result = HadoopUtils.isKerberosCredentialsConfigured(userWithoutCredentialsOrTokens, true);
+
+		assertFalse(result);
+	}
+
+	@Test
+	public void testShouldReturnTrueWhenDelegationTokenIsPresent() {
+		UserGroupInformation.setConfiguration(getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
+		UserGroupInformation userWithoutCredentialsButHavingToken = createTestUser(AuthenticationMethod.KERBEROS);
+		userWithoutCredentialsButHavingToken.addToken(getHDFSDelegationToken());
+		assumeFalse(userWithoutCredentialsButHavingToken.hasKerberosCredentials());
+
+		boolean result = HadoopUtils.isKerberosCredentialsConfigured(userWithoutCredentialsButHavingToken, true);
+
+		assertTrue(result);
+	}
+
+	@Test
+	public void testShouldReturnTrueWhenKerberosCredentialsArePresent() {
+		UserGroupInformation.setConfiguration(getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
+		UserGroupInformation userWithCredentials = Mockito.mock(UserGroupInformation.class);
+		Mockito.when(userWithCredentials.getAuthenticationMethod()).thenReturn(AuthenticationMethod.KERBEROS);
+		Mockito.when(userWithCredentials.hasKerberosCredentials()).thenReturn(true);
+
+		boolean result = HadoopUtils.isKerberosCredentialsConfigured(userWithCredentials, true);
+
+		assertTrue(result);
+	}
+
+	@Test
+	public void testShouldNotCheckKerberosCredentialsForOtherAuthMethods() {
+		UserGroupInformation.setConfiguration(getHadoopConfigWithAuthMethod(AuthenticationMethod.PROXY));
+		UserGroupInformation userWithAuthMethodOtherThanKerberos = createTestUser(AuthenticationMethod.PROXY);
+
+		boolean result = HadoopUtils.isKerberosCredentialsConfigured(userWithAuthMethodOtherThanKerberos, true);
+
+		assertTrue(result);
+	}
+
+	@Test
+	public void testShouldReturnTrueIfTicketCacheIsNotUsed() {
+		UserGroupInformation.setConfiguration(getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
+		UserGroupInformation user = createTestUser(AuthenticationMethod.KERBEROS);
+
+		boolean result = HadoopUtils.isKerberosCredentialsConfigured(user, false);
+
+		assertTrue(result);
+	}
+
+	@Test
+	public void testShouldCheckIfTheUserHasHDFSDelegationToken() {
+		UserGroupInformation userWithToken = createTestUser(AuthenticationMethod.KERBEROS);
+		userWithToken.addToken(getHDFSDelegationToken());
+
+		boolean result = HadoopUtils.hasHDFSDelegationToken(userWithToken);
+
+		assertTrue(result);
+	}
+
+	@Test
+	public void testShouldReturnFalseIfTheUserHasNoHDFSDelegationToken() {
+		UserGroupInformation userWithoutToken = createTestUser(AuthenticationMethod.KERBEROS);
+		assumeTrue(userWithoutToken.getTokens().isEmpty());
+
+		boolean result = HadoopUtils.hasHDFSDelegationToken(userWithoutToken);
+
+		assertFalse(result);
+	}
+
+	private static Configuration getHadoopConfigWithAuthMethod(AuthenticationMethod authenticationMethod) {
+		Configuration conf = new Configuration(true);
+		conf.set("hadoop.security.authentication", authenticationMethod.name());
+		return conf;
+	}
+
+	private static UserGroupInformation createTestUser(AuthenticationMethod authenticationMethod) {
+		UserGroupInformation user = UserGroupInformation.createRemoteUser("test-user");
+		user.setAuthenticationMethod(authenticationMethod);
+		return user;
+	}
+
+	private static Token<DelegationTokenIdentifier> getHDFSDelegationToken() {
+		Token<DelegationTokenIdentifier> token = new Token<>();
+		token.setKind(HDFS_DELEGATION_TOKEN_KIND);
+		return token;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -137,7 +137,7 @@ public class HadoopModule implements SecurityModule {
 				loginUser = UserGroupInformation.getLoginUser();
 			}
 
-			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(
+			boolean isCredentialsConfigured = HadoopUtils.isKerberosCredentialsConfigured(
 				loginUser, securityConfig.useTicketCache());
 
 			LOG.info("Hadoop user set to {}, credentials check status: {}", loginUser, isCredentialsConfigured);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -137,11 +137,13 @@ public class HadoopModule implements SecurityModule {
 				loginUser = UserGroupInformation.getLoginUser();
 			}
 
-			boolean isCredentialsConfigured = HadoopUtils.isKerberosCredentialsConfigured(
-				loginUser, securityConfig.useTicketCache());
+			LOG.info("Hadoop user set to {}", loginUser);
 
-			LOG.info("Hadoop user set to {}, credentials check status: {}", loginUser, isCredentialsConfigured);
+			if (HadoopUtils.isKerberosSecurityEnabled(loginUser)) {
+				boolean isCredentialsConfigured = HadoopUtils.areKerberosCredentialsValid(loginUser, securityConfig.useTicketCache());
 
+				LOG.info("Kerberos security is enabled and credentials are {}.", isCredentialsConfigured ? "valid" : "invalid");
+			}
 		} catch (Throwable ex) {
 			throw new SecurityInstallException("Unable to set the Hadoop login user", ex);
 		}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -474,7 +474,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			// so we check only in ticket cache scenario.
 			boolean useTicketCache = flinkConfiguration.getBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
 
-			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(
+			boolean isCredentialsConfigured = HadoopUtils.isKerberosCredentialsConfigured(
 				UserGroupInformation.getCurrentUser(), useTicketCache);
 			if (!isCredentialsConfigured) {
 				throw new RuntimeException("Hadoop security with Kerberos is enabled but the login user " +

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -468,15 +468,11 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			@Nullable JobGraph jobGraph,
 			boolean detached) throws Exception {
 
-		if (UserGroupInformation.isSecurityEnabled()) {
-			// note: UGI::hasKerberosCredentials inaccurately reports false
-			// for logins based on a keytab (fixed in Hadoop 2.6.1, see HADOOP-10786),
-			// so we check only in ticket cache scenario.
+		final UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
+		if (HadoopUtils.isKerberosSecurityEnabled(currentUser)) {
 			boolean useTicketCache = flinkConfiguration.getBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
 
-			boolean isCredentialsConfigured = HadoopUtils.isKerberosCredentialsConfigured(
-				UserGroupInformation.getCurrentUser(), useTicketCache);
-			if (!isCredentialsConfigured) {
+			if (!HadoopUtils.areKerberosCredentialsValid(currentUser, useTicketCache)) {
 				throw new RuntimeException("Hadoop security with Kerberos is enabled but the login user " +
 					"does not have Kerberos credentials or delegation tokens!");
 			}

--- a/pom.xml
+++ b/pom.xml
@@ -1007,6 +1007,7 @@ under the License.
 								<arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
 								<arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
 								<arg>--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED</arg>
+								<arg>--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED</arg>
 							</compilerArgs>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
## What is the purpose of the change

This pull request brings back checking if the enabled security method is Kerberos, that's an old bug reintroduced during some refactoring.
Code assuming that the enabled security method is Kerberos caused problems on MapR secured clusters when deploying on YARN.

## Brief change log

  - Checking if the auth method is Kerberos was added to `org.apache.flink.runtime.util.HadoopUtils.isCredentialsConfigured` method.

## Verifying this change
This change added tests and can be verified as follows:

  - Added a test that validates that the modified method doesn't check for Kerberos credentials when auth method is other than Kerberos

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
