### PR TITLE
[FLINK-18082][jdbc] UnsignedTypeConversionITCase stalls in ch.vorburer.mariadb4j.DB.stop

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -124,6 +124,12 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>2.5.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>8.0.20</version>


### PR DESCRIPTION
## What is the purpose of the change

* This pull request try to fix unstable UnsignedTypeConversionITCase which use `mariadb4j` 


## Brief change log

  - Bump test dependency `mariadb-java-client` from version 2.3.0 to 2.5.3 which fix a few notable bugs [mariadb-java-client release note](https://mariadb.com/kb/en/mariadb-connector-j-release-notes/), and the lower version may cause the test stability issue.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
