### PR TITLE
[FLINK-18042][build] Bump flink-shaded to 11.0 

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
@@ -107,8 +107,8 @@ public class SecureTestEnvironment {
 
 			File keytabFile = new File(baseDirForSecureRun, "test-users.keytab");
 			testKeytab = keytabFile.getAbsolutePath();
-			testZkServerPrincipal = "zookeeper/127.0.0.1";
-			testZkClientPrincipal = "zk-client/127.0.0.1";
+			testZkServerPrincipal = "zookeeper/" + hostName;
+			testZkClientPrincipal = "zk-client/" + hostName;
 			testKafkaServerPrincipal = "kafka/" + hostName;
 			hadoopServicePrincipal = "hadoop/" + hostName;
 			testPrincipal = "client/" + hostName;

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ under the License.
 		<flink.forkCountTestPackage>${flink.forkCount}</flink.forkCountTestPackage>
 		<flink.reuseForks>true</flink.reuseForks>
 		<log4j.configuration>log4j2-test.properties</log4j.configuration>
-		<flink.shaded.version>10.0</flink.shaded.version>
+		<flink.shaded.version>11.0</flink.shaded.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.5.21</akka.version>
 		<java.version>1.8</java.version>
@@ -120,7 +120,7 @@ under the License.
 		<scala.version>2.11.12</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
-		<zookeeper.version>3.4.10</zookeeper.version>
+		<zookeeper.version>3.4.14</zookeeper.version>
 		<!-- Only the curator2 TestingServer works with ZK 3.4 -->
 		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.10.1</jackson.version>


### PR DESCRIPTION
Bumps flink-shaded to 11.0 with an implicit zookeeper bump to 3.4.14 .

Required a small change in the `SecureTestEnvironment` for the `Kafka010SecuredRunITCase` to pass; it appears that zookeeper in 3.4.13+ behaves slightly differently in regards to `127.0.0.1/localhost`; possibly related to ZOOKEEPER-2184.
It may be a good idea to verify this on MacOS, because on Windows this test still fails (due to Kafka siwtching between both hosts).
I do not know whether this has any relevance for production, but I assume no due to a lack of JIRA's on the matter.