### PR TITLE
[FLINK-16572] Clean up PubSub connector e2e test

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -34,3 +34,9 @@ ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUT
 DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
 USE OR PERFORMANCE OF THIS SOFTWARE.
+
+The Apache Flink project contains or reuses code that is licensed under the Apache 2.0 license from the following projects:
+- Google Cloud Client Library for Java (https://github.com/googleapis/google-cloud-java) Copyright 2017 Google LLC
+
+  See: flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
+

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -93,9 +93,9 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.4</version>
 				<configuration>
 					<skipTests>${skipTests}</skipTests>
+					<forkCount>1</forkCount> <!-- Enforce single test execution -->
 				</configuration>
 				<executions>
 					<execution>

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
@@ -27,6 +27,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.flink.streaming.connectors.gcp.pubsub.emulator.GCloudEmulatorManager.getDockerIpAddress;
@@ -44,6 +45,9 @@ public class GCloudUnitTestBase implements Serializable {
 
 	@AfterClass
 	public static void terminateGCloudEmulator() throws DockerException, InterruptedException {
+		channel.shutdownNow();
+		channel.awaitTermination(1, TimeUnit.MINUTES);
+		channel = null;
 		GCloudEmulatorManager.terminateDocker();
 	}
 

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
@@ -153,7 +153,10 @@ public class PubsubHelper {
 		}
 	}
 
+	//
 	// Mostly copied from the example on https://cloud.google.com/pubsub/docs/pull
+	// Licensed under the Apache 2.0 License to "Google LLC" from https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/src/main/java/com/google/cloud/examples/pubsub/snippets/SubscriberSnippets.java.
+	//
 	public List<ReceivedMessage> pullMessages(String projectId, String subscriptionId, int maxNumberOfMessages) throws Exception {
 		SubscriberStubSettings subscriberStubSettings =
 			SubscriberStubSettings.newBuilder()

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/resources/log4j2-test.properties
@@ -16,9 +16,8 @@
 # limitations under the License.
 ################################################################################
 
-# Set root logger level to OFF to not flood build logs
-# set manually to INFO for debugging purposes
-rootLogger.level = OFF
+# Set logging level to INFO: Tests are executed as a Bash e2e test.
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/flink-end-to-end-tests/test-scripts/test_streaming_gcp_pubsub.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_gcp_pubsub.sh
@@ -17,6 +17,8 @@
 # limitations under the License.
 ################################################################################
 
+# This test is a Java end to end test, but it requires Docker. Therefore, we run it from bash.
+
 cd "${END_TO_END_DIR}/flink-connector-gcp-pubsub-emulator-tests"
 
 run_mvn test -DskipTests=false


### PR DESCRIPTION
## What is the purpose of the change

The PubSub e2e test is failing quite regularly on CI. This change is about improving the debuggability of the test. 

This change also contains some cleanups. It does not touch the main connector code.

## Brief change log

- fix licensing issue from copied code
- change test to allow "Run until failure" in IntelliJ
- log docker container output before stopping the container
- add log output


## Verifying this change

Covered by CI (I executed the test a few times here: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8123&view=logs&j=1f3ed471-1849-5d3c-a34c-19792af4ad16&t=2f5b54d0-1d28-5b01-d344-aa50ffe0cdf8) 

I could not reproduce the error in 200 runs locally.

## Does this pull request potentially affect one of the following parts:

test only change

## Documentation

test only change

