### PR TITLE
[FLINK-17945][python] Improve the error message when instantiating non-existing Java class

### DIFF
--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -28,7 +28,7 @@ from threading import RLock
 from py4j.java_gateway import (java_import, logger, JavaGateway, GatewayParameters,
                                CallbackServerParameters)
 from pyflink.pyflink_gateway_server import launch_gateway_server_process
-from pyflink.util.exceptions import install_exception_handler
+from pyflink.util.exceptions import install_exception_handler, install_py4j_hooks
 
 _gateway = None
 _lock = RLock()
@@ -69,6 +69,7 @@ def get_gateway():
             # import the flink view
             import_flink_view(_gateway)
             install_exception_handler()
+            install_py4j_hooks()
             _gateway.entry_point.put("PythonFunctionFactory", PythonFunctionFactory())
             _gateway.entry_point.put("Watchdog", Watchdog())
     return _gateway

--- a/flink-python/pyflink/util/exceptions.py
+++ b/flink-python/pyflink/util/exceptions.py
@@ -172,3 +172,15 @@ def install_exception_handler():
     patched = capture_java_exception(original)
     # only patch the one used in py4j.java_gateway (call Java API)
     py4j.java_gateway.get_return_value = patched
+
+
+def install_py4j_hooks():
+    """
+    Hook the classes such as JavaPackage, etc of Py4j to improve the exception message.
+    """
+    def wrapped_call(self, *args, **kwargs):
+        raise TypeError(
+            "Could not found the Java class '%s'. The Java dependencies could be specified via "
+            "command line argument '--jarfile' or the config option 'pipeline.jars'" % self._fqn)
+
+    setattr(py4j.java_gateway.JavaPackage, '__call__', wrapped_call)


### PR DESCRIPTION
## What is the purpose of the change

This pull request improves the exception message when instantiating non-existing Java class.
It reports the following error before this PR:
TypeError: 'JavaPackage' object is not callable

It will report the following error after this PR:
TypeError: Could not found the Java class 'ElasticSearch'. The Java dependencies could be specified via command line argument '--jarfile' or the config option 'pipeline.jars'

## Brief change log

  - *Hook the method py4j.java_gateway.JavaPackage.__call__ to improve the exception message*

## Verifying this change

Verified manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
