### PR TITLE
[FLINK-17969] Enhance Flink  logging to include job name as MDC

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
@@ -83,6 +83,7 @@ public final class TestTaskBuilder {
 	private Collection<PermanentBlobKey> requiredJarFileBlobKeys = Collections.emptyList();
 	private Collection<ResultPartitionDeploymentDescriptor> resultPartitions = Collections.emptyList();
 	private Collection<InputGateDeploymentDescriptor> inputGates = Collections.emptyList();
+	private String jobName = "Test Job";
 	private JobID jobId = new JobID();
 	private AllocationID allocationID = new AllocationID();
 	private ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
@@ -151,6 +152,11 @@ public final class TestTaskBuilder {
 		return this;
 	}
 
+	public TestTaskBuilder setJobName(String jobName) {
+		this.jobName = jobName;
+		return this;
+	}
+
 	public TestTaskBuilder setJobId(JobID jobId) {
 		this.jobId = jobId;
 		return this;
@@ -173,7 +179,7 @@ public final class TestTaskBuilder {
 
 		final JobInformation jobInformation = new JobInformation(
 			jobId,
-			"Test Job",
+			jobName,
 			serializedExecutionConfig,
 			new Configuration(),
 			requiredJarFileBlobKeys,


### PR DESCRIPTION
## What is the purpose of the change

* This pull request makes task instance to have jobName at the instance level and use the same for to populate MDC

## Problem statement:
We use a shared session cluster (Standalone/Yarn) to execute jobs. All logs from the cluster are shipped using log aggregation framework (Logstash/Splunk) so that application diagnostic is easier.
However, we are missing one vital information in the logline. i.e. Job name so that we can filter the logs for a single job.


## Brief change log
  - *The Task class now includes jobName filed, populated from JobInformation on construction, similar to jobId*
  - *When TaskExecutor runs Task, run method populates the jobName in MDC so that it can be used in logging pattern as %X{jobName}*
  - *ExecutorThreadFactory passes MDC context down to worker threads by wrapping runnable so MDC can be safely used on Cached Thread pool. This is the recommended way to pass the MDC from parent to Executor thread pool*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit test for Task which verifies jobName and MDC *
  - *Manually verified logging by changing WordCount Example to include %X{jobName} *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  yes
  - If yes, how is the feature documented?   not documented yet
