### PR TITLE
[FLINK-18076][table sql / client] Sql client uses wrong class loader when parsing queries

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -50,10 +50,8 @@ import org.apache.flink.table.factories.CatalogFactory;
 import org.apache.flink.table.factories.ModuleFactory;
 import org.apache.flink.table.module.Module;
 import org.apache.flink.table.operations.Operation;
-import org.apache.flink.table.planner.operations.PlannerQueryOperation;
 import org.apache.flink.table.types.DataType;
 
-import org.apache.calcite.plan.RelOptUtil;
 import org.junit.Test;
 
 import java.net.URL;
@@ -105,20 +103,15 @@ public class DependencyTest {
 	}
 
 	@Test
-	public void testSqlParseWithUserClassloader() throws Exception {
+	public void testSqlParseWithUserClassLoader() throws Exception {
 		final LocalExecutor executor = createExecutor();
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		try {
-			String expectedPlan = "LogicalProject(IntegerField1=[$0], StringField1=[$1])\n" +
-				"  LogicalTableScan(table=[[default_catalog, default_database, TableNumber1, source: [TestTableSource]]])\n";
 			final Parser sqlParser = executor.getSqlParser(sessionId);
 			List<Operation> operations = sqlParser.parse("SELECT IntegerField1, StringField1 FROM TableNumber1");
 
 			assertTrue(operations != null && operations.size() == 1);
-			String actualPlan = RelOptUtil.toString(((PlannerQueryOperation) operations.get(0)).getCalciteTree());
-
-			assertEquals(expectedPlan, actualPlan);
 		} finally {
 			executor.closeSession(sessionId);
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -44,12 +44,16 @@ import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
 import org.apache.flink.table.client.gateway.utils.TestTableSinkFactoryBase;
 import org.apache.flink.table.client.gateway.utils.TestTableSourceFactoryBase;
+import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.CatalogFactory;
 import org.apache.flink.table.factories.ModuleFactory;
 import org.apache.flink.table.module.Module;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.planner.operations.PlannerQueryOperation;
 import org.apache.flink.table.types.DataType;
 
+import org.apache.calcite.plan.RelOptUtil;
 import org.junit.Test;
 
 import java.net.URL;
@@ -65,6 +69,7 @@ import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATA
 import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_TYPE;
 import static org.apache.flink.table.descriptors.ModuleDescriptorValidator.MODULE_TYPE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Dependency tests for {@link LocalExecutor}. Mainly for testing classloading of dependencies.
@@ -82,6 +87,44 @@ public class DependencyTest {
 
 	@Test
 	public void testTableFactoryDiscovery() throws Exception {
+		final LocalExecutor executor = createExecutor();
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		try {
+			final TableSchema result = executor.getTableSchema(sessionId, "TableNumber1");
+			final TableSchema expected = TableSchema.builder()
+				.field("IntegerField1", Types.INT())
+				.field("StringField1", Types.STRING())
+				.field("rowtimeField", Types.SQL_TIMESTAMP())
+				.build();
+
+			assertEquals(expected, result);
+		} finally {
+			executor.closeSession(sessionId);
+		}
+	}
+
+	@Test
+	public void testSqlParseWithUserClassloader() throws Exception {
+		final LocalExecutor executor = createExecutor();
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		try {
+			String expectedPlan = "LogicalProject(IntegerField1=[$0], StringField1=[$1])\n" +
+				"  LogicalTableScan(table=[[default_catalog, default_database, TableNumber1, source: [TestTableSource]]])\n";
+			final Parser sqlParser = executor.getSqlParser(sessionId);
+			List<Operation> operations = sqlParser.parse("SELECT IntegerField1, StringField1 FROM TableNumber1");
+
+			assertTrue(operations != null && operations.size() == 1);
+			String actualPlan = RelOptUtil.toString(((PlannerQueryOperation) operations.get(0)).getCalciteTree());
+
+			assertEquals(expectedPlan, actualPlan);
+		} finally {
+			executor.closeSession(sessionId);
+		}
+	}
+
+	private LocalExecutor createExecutor() throws Exception {
 		// create environment
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_CONNECTOR_TYPE", CONNECTOR_TYPE_VALUE);
@@ -91,24 +134,12 @@ public class DependencyTest {
 
 		// create executor with dependencies
 		final URL dependency = Paths.get("target", TABLE_FACTORY_JAR_FILE).toUri().toURL();
-		final LocalExecutor executor = new LocalExecutor(
+		return new LocalExecutor(
 			env,
 			Collections.singletonList(dependency),
 			new Configuration(),
 			new DefaultCLI(new Configuration()),
 			new DefaultClusterClientServiceLoader());
-
-		final SessionContext session = new SessionContext("test-session", new Environment());
-		String sessionId = executor.openSession(session);
-
-		final TableSchema result = executor.getTableSchema(sessionId, "TableNumber1");
-		final TableSchema expected = TableSchema.builder()
-			.field("IntegerField1", Types.INT())
-			.field("StringField1", Types.STRING())
-			.field("rowtimeField", Types.SQL_TIMESTAMP())
-			.build();
-
-		assertEquals(expected, result);
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the wrong class loader in sql client(sqlParser).*


## Brief change log
- In FLINK-17728, sql client supports parser statements via sql parser, sql parser should use user's class loader which may contains user's jar from `-j` or `-l` commands

## Verifying this change

* Has existed tests and passed an e2e test in local environment.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
