### PR TITLE
[FLINK-17902][python] Support the new interfaces about temporary functions in PyFlink

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -155,9 +155,7 @@ class TableEnvironment(object):
         ValidationException is thrown when there is already a module with the same name.
 
         :param module_name: Name of the :class:`~pyflink.table.Module`.
-        :type module_name: str
         :param module: The module instance.
-        :type module: pyflink.table.Module
 
         .. versionadded:: 1.12.0
         """
@@ -169,7 +167,6 @@ class TableEnvironment(object):
         ValidationException is thrown when there is no module with the given name.
 
         :param module_name: Name of the :class:`~pyflink.table.Module`.
-        :type module_name: str
 
         .. versionadded:: 1.12.0
         """
@@ -179,9 +176,10 @@ class TableEnvironment(object):
         """
         Registers a java user defined function class as a temporary system function.
 
-        Compared to .. seealso:: :func:`create_temporary_function`, system functions are identified
-        by a global name that is independent of the current catalog and current database. Thus,
-        this method allows to extend the set of built-in system functions like TRIM, ABS, etc.
+        Compared to .. seealso:: :func:`create_java_temporary_function`, system functions are
+        identified by a global name that is independent of the current catalog and current
+        database. Thus, this method allows to extend the set of built-in system functions like
+        TRIM, ABS, etc.
 
         Temporary functions can shadow permanent ones. If a permanent function under a given name
         exists, it will be inaccessible in the current session. To make the permanent function
@@ -194,12 +192,10 @@ class TableEnvironment(object):
             ...     "java.user.defined.function.class.name")
 
         :param name: The name under which the function will be registered globally.
-        :type name: str
         :param function_class_name: The java full qualified class name of the function class
                                     containing the implementation. The function must have a
                                     public no-argument constructor and can be founded in current
                                     Java classloader.
-        :type function_class_name: str
 
         .. versionadded:: 1.12.0
         """
@@ -240,18 +236,16 @@ class TableEnvironment(object):
             ...     "subtract_one", udf(SubtractOne(), DataTypes.BIGINT(), DataTypes.BIGINT()))
 
         :param name: The name under which the function will be registered globally.
-        :type name: str
         :param function: The function class containing the implementation. The function must have a
                          public no-argument constructor and can be founded in current Java
                          classloader.
-        :type function: pyflink.table.udf.UserDefinedFunctionWrapper
 
         .. versionadded:: 1.12.0
         """
         java_function = function.java_user_defined_function()
         self._j_tenv.createTemporarySystemFunction(name, java_function)
 
-    def drop_temporary_system_function(self, name: str):
+    def drop_temporary_system_function(self, name: str) -> bool:
         """
         Drops a temporary system function registered under the given name.
 
@@ -259,9 +253,7 @@ class TableEnvironment(object):
         queries that reference this name.
 
         :param name: The name under which the function has been registered globally.
-        :type name: str
         :return: true if a function existed under the given name and was removed.
-        :rtype: bool
 
         .. versionadded:: 1.12.0
         """
@@ -285,15 +277,12 @@ class TableEnvironment(object):
         :param path: The path under which the function will be registered.
                      See also the :class:`~pyflink.table.TableEnvironment` class description for
                      the format of the path.
-        :type path: str
         :param function_class_name: The java full qualified class name of the function class
                                     containing the implementation. The function must have a
                                     public no-argument constructor and can be founded in current
                                     Java classloader.
-        :type function_class_name: str
         :param ignore_if_exists: If a function exists under the given path and this flag is set,
                                  no operation is executed. An exception is thrown otherwise.
-        :type ignore_if_exists: bool
 
         .. versionadded:: 1.12.0
         """
@@ -305,16 +294,14 @@ class TableEnvironment(object):
         else:
             self._j_tenv.createFunction(path, java_function, ignore_if_exists)
 
-    def drop_function(self, path):
+    def drop_function(self, path) -> bool:
         """
         Drops a catalog function registered in the given path.
 
         :param path: The path under which the function will be registered.
                      See also the :class:`~pyflink.table.TableEnvironment` class description for
                      the format of the path.
-        :type path: str
         :return: true if a function existed in the given path and was removed.
-        :rtype: bool
 
         .. versionadded:: 1.12.0
         """
@@ -324,9 +311,9 @@ class TableEnvironment(object):
         """
         Registers a java user defined function class as a temporary catalog function.
 
-        Compared to .. seealso:: :func:`create_temporary_system_function` with a globally defined
-        name, catalog functions are always (implicitly or explicitly) identified by a catalog and
-        database.
+        Compared to .. seealso:: :func:`create_java_temporary_system_function` with a globally
+        defined name, catalog functions are always (implicitly or explicitly) identified by a
+        catalog and database.
 
         Temporary functions can shadow permanent ones. If a permanent function under a given name
         exists, it will be inaccessible in the current session. To make the permanent function
@@ -341,12 +328,10 @@ class TableEnvironment(object):
         :param path: The path under which the function will be registered.
                      See also the :class:`~pyflink.table.TableEnvironment` class description for
                      the format of the path.
-        :type path: str
         :param function_class_name: The java full qualified class name of the function class
                                     containing the implementation. The function must have a
                                     public no-argument constructor and can be founded in current
                                     Java classloader.
-        :type function_class_name: str
 
         .. versionadded:: 1.12.0
         """
@@ -388,18 +373,16 @@ class TableEnvironment(object):
         :param path: The path under which the function will be registered.
                      See also the :class:`~pyflink.table.TableEnvironment` class description for
                      the format of the path.
-        :type path: str
         :param function: The function class containing the implementation. The function must have a
                          public no-argument constructor and can be founded in current Java
                          classloader.
-        :type function: pyflink.table.udf.UserDefinedFunctionWrapper
 
         .. versionadded:: 1.12.0
         """
         java_function = function.java_user_defined_function()
         self._j_tenv.createTemporaryFunction(path, java_function)
 
-    def drop_temporary_function(self, path):
+    def drop_temporary_function(self, path) -> bool:
         """
         Drops a temporary system function registered under the given name.
 
@@ -409,9 +392,7 @@ class TableEnvironment(object):
         :param path: The path under which the function will be registered.
                      See also the :class:`~pyflink.table.TableEnvironment` class description for
                      the format of the path.
-        :type path: str
         :return: true if a function existed in the given path and was removed.
-        :rtype: bool
 
         .. versionadded:: 1.12.0
         """

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -95,6 +95,22 @@ class TableEnvironmentTest(object):
         self.assertEqual(table_result.get_result_kind(), ResultKind.SUCCESS_WITH_CONTENT)
         self.assert_equals(table_result.get_table_schema().get_field_names(), ['test_module'])
 
+    def test_create_drop_java_function(self):
+        t_env = self.t_env
+
+        t_env.create_temporary_system_function("scalar_func",
+                                               "org.apache.flink.table.expressions.utils.RichFunc0")
+        t_env.create_function(
+            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
+        t_env.create_temporary_function("table_func", "org.apache.flink.table.utils.TableFunc1")
+        self.assert_equals(t_env.list_user_defined_functions(),
+                           ['scalar_func', 'agg_func', 'table_func'])
+
+        t_env.drop_temporary_system_function("scalar_func")
+        t_env.drop_function("agg_func")
+        t_env.drop_temporary_function("table_func")
+        self.assert_equals(t_env.list_user_defined_functions(), [])
+
 
 class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCase):
 
@@ -683,3 +699,19 @@ class BlinkBatchTableEnvironmentTests(PyFlinkBlinkBatchTableTestCase):
         table_result = t_env.execute_sql("select concat('unload', 'load') as test_module")
         self.assertEqual(table_result.get_result_kind(), ResultKind.SUCCESS_WITH_CONTENT)
         self.assert_equals(table_result.get_table_schema().get_field_names(), ['test_module'])
+
+    def test_create_drop_java_function(self):
+        t_env = self.t_env
+
+        t_env.create_temporary_system_function("scalar_func",
+                                               "org.apache.flink.table.expressions.utils.RichFunc0")
+        t_env.create_function(
+            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
+        t_env.create_temporary_function("table_func", "org.apache.flink.table.utils.TableFunc1")
+        self.assert_equals(t_env.list_user_defined_functions(),
+                           ['scalar_func', 'agg_func', 'table_func'])
+
+        t_env.drop_temporary_system_function("scalar_func")
+        t_env.drop_function("agg_func")
+        t_env.drop_temporary_function("table_func")
+        self.assert_equals(t_env.list_user_defined_functions(), [])

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -95,14 +95,15 @@ class TableEnvironmentTest(object):
         self.assertEqual(table_result.get_result_kind(), ResultKind.SUCCESS_WITH_CONTENT)
         self.assert_equals(table_result.get_table_schema().get_field_names(), ['test_module'])
 
-    def test_create_drop_java_function(self):
+    def test_create_and_drop_java_function(self):
         t_env = self.t_env
 
-        t_env.create_temporary_system_function("scalar_func",
-                                               "org.apache.flink.table.expressions.utils.RichFunc0")
-        t_env.create_function(
+        t_env.create_java_temporary_system_function(
+            "scalar_func", "org.apache.flink.table.expressions.utils.RichFunc0")
+        t_env.create_java_function(
             "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
-        t_env.create_temporary_function("table_func", "org.apache.flink.table.utils.TableFunc1")
+        t_env.create_java_temporary_function(
+            "table_func", "org.apache.flink.table.utils.TableFunc1")
         self.assert_equals(t_env.list_user_defined_functions(),
                            ['scalar_func', 'agg_func', 'table_func'])
 
@@ -700,14 +701,15 @@ class BlinkBatchTableEnvironmentTests(PyFlinkBlinkBatchTableTestCase):
         self.assertEqual(table_result.get_result_kind(), ResultKind.SUCCESS_WITH_CONTENT)
         self.assert_equals(table_result.get_table_schema().get_field_names(), ['test_module'])
 
-    def test_create_drop_java_function(self):
+    def test_create_and_drop_java_function(self):
         t_env = self.t_env
 
-        t_env.create_temporary_system_function("scalar_func",
-                                               "org.apache.flink.table.expressions.utils.RichFunc0")
-        t_env.create_function(
+        t_env.create_java_temporary_system_function(
+            "scalar_func", "org.apache.flink.table.expressions.utils.RichFunc0")
+        t_env.create_java_function(
             "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
-        t_env.create_temporary_function("table_func", "org.apache.flink.table.utils.TableFunc1")
+        t_env.create_java_temporary_function(
+            "table_func", "org.apache.flink.table.utils.TableFunc1")
         self.assert_equals(t_env.list_user_defined_functions(),
                            ['scalar_func', 'agg_func', 'table_func'])
 

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -476,6 +476,20 @@ class UserDefinedFunctionTests(object):
                             "{1=flink, 2=pyflink},1000000000000000000.050000000000000000,"
                             "1000000000000000000.059999999999999999"])
 
+    def test_create_and_drop_function(self):
+        t_env = self.t_env
+
+        t_env.create_temporary_system_function(
+            "add_one_func", udf(lambda i: i + 1, DataTypes.BIGINT(), DataTypes.BIGINT()))
+        t_env.create_temporary_function(
+            "subtract_one_func", udf(SubtractOne(), DataTypes.BIGINT(), DataTypes.BIGINT()))
+        self.assert_equals(t_env.list_user_defined_functions(),
+                           ['add_one_func', 'subtract_one_func'])
+
+        t_env.drop_temporary_system_function("add_one_func")
+        t_env.drop_temporary_function("subtract_one_func")
+        self.assert_equals(t_env.list_user_defined_functions(), [])
+
 
 # decide whether two floats are equal
 def float_equal(a, b, rel_tol=1e-09, abs_tol=0.0):


### PR DESCRIPTION
## What is the purpose of the change

*`TableEnvironment` in PyFlink should be consistent with the interfaces such as `createTemporarySystemFunction`, `dropTemporarySystemFunction`, `createFunction`,` dropFunction`, `createTemporaryFunction`, `dropTemporaryFunction` in the Java `TableEnvironment`.*

## Brief change log

  - *`TableEnvironment` add the interfaces including `createTemporarySystemFunction`, `dropTemporarySystemFunction`, `createFunction`,` dropFunction`, `createTemporaryFunction`, `dropTemporaryFunction`.*

## Verifying this change

  - *`TableEnvironmentTest` and `BatchTableEnvironmentTests` add method `test_create_drop_java_function` to verify whether interface `createTemporarySystemFunction`, `dropTemporarySystemFunction`, `createFunction`,` dropFunction`, `createTemporaryFunction`, `dropTemporaryFunction` could work.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
