### PR TITLE
[FLINK-17260] Fix StreamingKafkaITCase instabilities

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
@@ -63,15 +63,16 @@ public interface KafkaResource extends ExternalResource {
 	InetSocketAddress getZookeeperAddress();
 
 	/**
-	 * Reads up to {@code maxNumMessages} from the given topic.
+	 * Reads {@code expectedNumMessages} from the given topic. If we can't read the expected number
+	 * of messages we throw an exception.
 	 *
-	 * @param maxNumMessages maximum number of messages that should be read
+	 * @param expectedNumMessages expected number of messages that should be read
 	 * @param groupId group id to identify consumer
 	 * @param topic topic name
 	 * @return read messages
 	 * @throws IOException
 	 */
-	List<String> readMessage(int maxNumMessages, String groupId, String topic) throws IOException;
+	List<String> readMessage(int expectedNumMessages, String groupId, String topic) throws IOException;
 
 	/**
 	 * Modifies the number of partitions for the given topic.

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
@@ -278,7 +278,7 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 			.setStdoutProcessor(messages::add)
 			.runNonBlocking()) {
 
-			final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(30));
+			final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(120));
 			while (deadline.hasTimeLeft() && messages.size() < expectedNumMessages) {
 				try {
 					LOG.info("Waiting for messages. Received {}/{}.", messages.size(),

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -58,6 +58,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -92,6 +93,7 @@ public class SQLClientKafkaITCase extends TestLogger {
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();
 
+	private final String kafkaVersion;
 	private final String kafkaSQLVersion;
 	private Path result;
 	private Path sqlClientSessionConf;
@@ -107,6 +109,7 @@ public class SQLClientKafkaITCase extends TestLogger {
 
 	public SQLClientKafkaITCase(String kafkaVersion, String kafkaSQLVersion, String kafkaSQLJarPattern) {
 		this.kafka = KafkaResource.get(kafkaVersion);
+		this.kafkaVersion = kafkaVersion;
 		this.kafkaSQLVersion = kafkaSQLVersion;
 
 		this.sqlConnectorKafkaJar = TestUtils.getResourceJar(kafkaSQLJarPattern);
@@ -129,8 +132,8 @@ public class SQLClientKafkaITCase extends TestLogger {
 	public void testKafka() throws Exception {
 		try (ClusterController clusterController = flink.startCluster(2)) {
 			// Create topic and send message
-			String testJsonTopic = "test-json";
-			String testAvroTopic = "test-avro";
+			String testJsonTopic = "test-json-" + kafkaVersion + "-" + UUID.randomUUID().toString();
+			String testAvroTopic = "test-avro-" + kafkaVersion + "-" + UUID.randomUUID().toString();
 			kafka.createTopic(1, 1, testJsonTopic);
 			String[] messages = new String[]{
 					"{\"timestamp\": \"2018-03-12T08:00:00Z\", \"user\": \"Alice\", \"event\": { \"type\": \"WARNING\", \"message\": \"This is a warning.\"}}",

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.tests.util.kafka;
 
+import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.cache.DownloadCache;
 import org.apache.flink.tests.util.categories.TravisGroup1;
@@ -52,6 +53,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -234,8 +236,8 @@ public class SQLClientKafkaITCase extends TestLogger {
 
 	private void checkCsvResultFile() throws Exception {
 		boolean success = false;
-		long maxRetries = 10, duration = 5000L;
-		for (int i = 0; i < maxRetries; i++) {
+		final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(120));
+		while (!success && deadline.hasTimeLeft()) {
 			if (Files.exists(result)) {
 				byte[] bytes = Files.readAllBytes(result);
 				String[] lines = new String(bytes, Charsets.UTF_8).split("\n");
@@ -255,8 +257,8 @@ public class SQLClientKafkaITCase extends TestLogger {
 			} else {
 				LOG.info("The target CSV {} does not exist now", result);
 			}
-			Thread.sleep(duration);
+			Thread.sleep(500);
 		}
-		Assert.assertTrue("Timeout(" + (maxRetries * duration) + " sec) to read the correct CSV results.", success);
+		Assert.assertTrue("Did not get expected results before timeout.", success);
 	}
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -43,6 +43,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -65,6 +66,8 @@ public class StreamingKafkaITCase extends TestLogger {
 
 	private final Path kafkaExampleJar;
 
+	private final String kafkaVersion;
+
 	@Rule
 	public final KafkaResource kafka;
 
@@ -81,14 +84,15 @@ public class StreamingKafkaITCase extends TestLogger {
 	public StreamingKafkaITCase(final String kafkaExampleJarPattern, final String kafkaVersion) {
 		this.kafkaExampleJar = TestUtils.getResourceJar(kafkaExampleJarPattern);
 		this.kafka = KafkaResource.get(kafkaVersion);
+		this.kafkaVersion = kafkaVersion;
 	}
 
 	@Test
 	public void testKafka() throws Exception {
 		try (final ClusterController clusterController = flink.startCluster(1)) {
 
-			final String inputTopic = "test-input";
-			final String outputTopic = "test-output";
+			final String inputTopic = "test-input-" + kafkaVersion + "-" + UUID.randomUUID().toString();
+			final String outputTopic = "test-output" + kafkaVersion + "-" + UUID.randomUUID().toString();
 
 			// create the required topics
 			kafka.createTopic(1, 1, inputTopic);


### PR DESCRIPTION
This fixes two possible sources of instability:
 - not reading all the messages because of timeout
 - clashes in topic names, which lead to double counting