### PR TITLE
[hotfix] Remove redundant backslash in the log of GPUDriver

### DIFF
--- a/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
+++ b/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
@@ -127,7 +127,7 @@ class GPUDriver implements ExternalResourceDriver {
 			if (exitVal != 0) {
 				final String stdout = stdoutReader.lines().collect(StringBuilder::new, StringBuilder::append, StringBuilder::append).toString();
 				final String stderr = stderrReader.lines().collect(StringBuilder::new, StringBuilder::append, StringBuilder::append).toString();
-				LOG.warn("Discovery script exit with {}.\\nSTDOUT: {}\\nSTDERR: {}", exitVal, stdout, stderr);
+				LOG.warn("Discovery script exit with {}.\nSTDOUT: {}\nSTDERR: {}", exitVal, stdout, stderr);
 				throw new FlinkException(String.format("Discovery script exit with non-zero return code: %s.", exitVal));
 			}
 			Object[] stdout = stdoutReader.lines().toArray();


### PR DESCRIPTION


## What is the purpose of the change

Remove redundant backslash in the log of GPUDriver

## Brief change log

Remove redundant backslash in the log of GPUDriver

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
