### PR TITLE
[FLINK-18120] Don't expand documentation sections by default

### DIFF
--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -101,8 +101,6 @@ level is determined by 'nav-pos'.
       {%- assign active = true -%}
     {%- elsif this.nav-id and active_nav_ids contains this.nav-id -%}
       {%- assign active = true -%}
-    {%- elsif this.always-expand -%}
-      {%- assign active = true -%}
     {%- else -%}
       {%- assign active = false -%}
     {%- endif -%}
@@ -119,7 +117,7 @@ level is determined by 'nav-pos'.
       {%- if children.size > 0 -%}
         {%- assign children = (children[0].items | sort: "nav-pos") -%}
         {%- capture collapse_target -%}"#collapse-{{ i }}" data-toggle="collapse"{%- if active -%} class="active"{%- endif -%}{%- endcapture -%}
-        {%- capture expand -%}<i class="fa fa-caret-down pull-right" aria-hidden="true" style="padding-top: 4px"></i>{%- endcapture %}
+        {%- capture expand -%}{%- unless active -%} <i class="fa fa-caret-down pull-right" aria-hidden="true" style="padding-top: 4px"></i>{%- endunless -%}{%- endcapture %}
 <li><a href={{ collapse_target }}>{{ title }}{{ expand }}</a><div class="collapse{% if active %} in{% endif %}" id="collapse-{{ i }}"><ul>
         {%- if this.nav-show_overview %}
 <li><a href={{ overview_target }}>

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -6,7 +6,6 @@ nav-title: '<i class="fa fa-map-o title appetizer" aria-hidden="true"></i> Conce
 nav-parent_id: root
 nav-show_overview: true
 permalink: /concepts/index.html
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/concepts/index.zh.md
+++ b/docs/concepts/index.zh.md
@@ -6,7 +6,6 @@ nav-title: '<i class="fa fa-map-o title appetizer" aria-hidden="true"></i> æ¦‚å¿
 nav-parent_id: root
 nav-show_overview: true
 permalink: /concepts/index.html
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -5,7 +5,6 @@ nav-title: '<i class="fa fa-code title maindish" aria-hidden="true"></i> Applica
 nav-parent_id: root
 nav-pos: 5
 section-break: true
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/dev/index.zh.md
+++ b/docs/dev/index.zh.md
@@ -5,7 +5,6 @@ nav-title: '<i class="fa fa-code title maindish" aria-hidden="true"></i> 应用�
 nav-parent_id: root
 nav-pos: 5
 section-break: true
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -6,7 +6,6 @@ nav-parent_id: root
 section-break: true
 nav-show_overview: true
 nav-pos: 1
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/index.zh.md
+++ b/docs/getting-started/index.zh.md
@@ -6,7 +6,6 @@ nav-parent_id: root
 section-break: true
 nav-show_overview: true
 nav-pos: 1
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -5,7 +5,6 @@ nav-pos: 2
 nav-title: '<i class="fa fa-hand-paper-o title appetizer" aria-hidden="true"></i> Hands-on Training'
 nav-parent_id: root
 nav-show_overview: true
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/training/index.zh.md
+++ b/docs/training/index.zh.md
@@ -5,7 +5,6 @@ nav-pos: 2
 nav-title: '<i class="fa fa-hand-paper-o title appetizer" aria-hidden="true"></i> Hands-on Training'
 nav-parent_id: root
 nav-show_overview: true
-always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
This is basically a revert of FLINK-16041. The idea seemed good at the
time but with more sections being added this just looks too unwieldy
when you first open the docs