### PR TITLE
[FLINK-17831][doc] Add documentation for the new Kafka connector

### DIFF
--- a/docs/dev/table/connectors/index.md
+++ b/docs/dev/table/connectors/index.md
@@ -52,7 +52,7 @@ Flink natively support various connectors. The following tables list all availab
     </thead>
     <tbody>
     <tr>
-      <td>Filesystem</td>
+      <td><a href="{{ site.baseurl }}/dev/table/connectors/filesystem.html">Apache HBase</a></td>
       <td></td>
       <td>Bounded and Unbounded Scan, Lookup</td>
       <td>Streaming Sink, Batch Sink</td>
@@ -64,7 +64,7 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
-      <td>Apache Kafka</td>
+      <td><a href="{{ site.baseurl }}/dev/table/connectors/kafka.html">Apache Kafka</a></td>
       <td>0.10+</td>
       <td>Unbounded Scan</td>
       <td>Streaming Sink, Batch Sink</td>

--- a/docs/dev/table/connectors/index.md
+++ b/docs/dev/table/connectors/index.md
@@ -52,7 +52,7 @@ Flink natively support various connectors. The following tables list all availab
     </thead>
     <tbody>
     <tr>
-      <td><a href="{{ site.baseurl }}/dev/table/connectors/filesystem.html">Apache HBase</a></td>
+      <td><a href="{{ site.baseurl }}/dev/table/connectors/filesystem.html">Filesystem</a></td>
       <td></td>
       <td>Bounded and Unbounded Scan, Lookup</td>
       <td>Streaming Sink, Batch Sink</td>

--- a/docs/dev/table/connectors/index.zh.md
+++ b/docs/dev/table/connectors/index.zh.md
@@ -64,7 +64,7 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
-      <td>Apache Kafka</td>
+      <td>[Apache Kafka]({{ site.baseurl }}/dev/table/connectors/kafka.html)</td>
       <td>0.10+</td>
       <td>Unbounded Scan</td>
       <td>Streaming Sink, Batch Sink</td>

--- a/docs/dev/table/connectors/index.zh.md
+++ b/docs/dev/table/connectors/index.zh.md
@@ -52,7 +52,7 @@ Flink natively support various connectors. The following tables list all availab
     </thead>
     <tbody>
     <tr>
-      <td>Filesystem</td>
+      <td><a href="{{ site.baseurl }}/dev/table/connectors/filesystem.html">Filesystem</a></td>
       <td></td>
       <td>Bounded and Unbounded Scan, Lookup</td>
       <td>Streaming Sink, Batch Sink</td>

--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -23,13 +23,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Flink provides an [Apache Kafka](https://kafka.apache.org) connector for reading data from and writing data to Kafka topics with exactly-once guaruntees.
-
 <span class="label label-primary">Scan Source: Unbounded</span>
 <span class="label label-primary">Sink: Streaming Append Mode</span>
 
 * This will be replaced by the TOC
 {:toc}
+
+Flink provides an [Apache Kafka](https://kafka.apache.org) connector for reading data from and writing data to Kafka topics.
 
 Dependencies
 ------------
@@ -42,20 +42,15 @@ For most users the universal Kafka connector is the most appropriate.
 However, for Kafka versions 0.11.x and 0.10.x, we recommend using the dedicated ``0.11`` and ``0.10`` connectors, respectively.
 For details on Kafka compatibility, please refer to the official [Kafka documentation](https://kafka.apache.org/protocol.html#protocol_compatibility).
 
-{% if site.is_stable %}
-
 | Kafka Version       | Maven dependency                                          | SQL Client JAR         |
 | :------------------ | :-------------------------------------------------------- | :----------------------|
-| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
+| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
+| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
 
-<span class="label label-danger">Attention</span> The ``0.10`` sink does not support exactly-once writes to Kafka.
-{% else %}
+<span class="label label-danger">Attention</span> The Kafka SQL sink does not support exactly-once writes to Kafka.
 
-The dependency table is only available for stable releases.
-
-{% endif %}
+The dependency downloading links is only available for stable releases.
 
 Flink's streaming connectors are not currently part of the binary distribution.
 See how to link with them for cluster execution [here]({{ site.baseurl}}/dev/projectsetup/dependencies.html).
@@ -66,14 +61,18 @@ How to create a Kafka table
 <div data-lang="SQL" markdown="1">
 {% highlight sql %}
 CREATE TABLE kafkaTable (
- ...
+ user_id BIGINT,
+ item_id BIGINT,
+ category_id BIGINT,
+ behavior STRING,
+ ts TIMESTAMP(3)
 ) WITH (
  'connector' = 'kafka',
- 'topic' = 'topic_name',
+ 'topic' = 'user_behavior',
  'properties.bootstrap.server' = 'localhost:9092',
  'properties.group.id' = 'testGroup',
  'format' = 'csv',
- 'scan.startup.mode' = 'group-offsets'
+ 'scan.startup.mode' = 'earliest-offset'
 )
 {% endhighlight %}
 </div>
@@ -84,13 +83,13 @@ Connector Options
 
 <table class="table table-bordered">
     <thead>
-      <tr>
-        <th class="text-left" style="width: 25%">Option</th>
-        <th class="text-center" style="width: 8%">Required</th>
-        <th class="text-center" style="width: 7%">Default</th>
-        <th class="text-center" style="width: 10%">Type</th>
-        <th class="text-center" style="width: 50%">Description</th>
-      </tr>
+    <tr>
+      <th class="text-left" style="width: 25%">Option</th>
+      <th class="text-center" style="width: 8%">Required</th>
+      <th class="text-center" style="width: 7%">Default</th>
+      <th class="text-center" style="width: 10%">Type</th>
+      <th class="text-center" style="width: 50%">Description</th>
+    </tr>
     </thead>
     <tbody>
     <tr>
@@ -105,45 +104,45 @@ Connector Options
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Required topic name from which the table is read.</td>
+      <td>Topic name from which the table is read.</td>
     </tr>
     <tr>
       <td><h5>properties.bootstrap.servers</h5></td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Required Kafka server connection string.</td>
+      <td>Kafka server connection string.</td>
     </tr>
     <tr>
-    <td><h5>format</h5></td>
-    <td>required</td>
-    <td style="word-wrap: break-word;">(none)</td>
-    <td>String</td>
-    <td>Kafka connector requires to specify a format,
-    the supported formats are 'csv', 'json' and 'avro'.
-    Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
-    </td>
-        </tr>
-    <tr>
       <td><h5>properties.group.id</h5></td>
-      <td>optional</td>
+      <td>required by source</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Required consumer group in Kafka consumer, no need for Kafka producer</td>
+      <td>Consumer group in Kafka consumer, no need for Kafka producer</td>
+    </tr>
+    <tr>
+      <td><h5>format</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Kafka connector requires to specify a format,
+      the supported formats are 'csv', 'json' and 'avro'.
+      Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+      </td>
     </tr>
     <tr>
       <td><h5>scan.startup.mode</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">group-offsets</td>
       <td>String</td>
-      <td>Optional startup mode for Kafka consumer, valid enumerations are 'earliest-offset', 'latest-offset', 'group-offsets', 'timestamp' or 'specific-offsets'.</td>
+      <td>Startup mode for Kafka consumer, valid enumerations are <code>'earliest-offset'</code>, <code>'latest-offset'</code>, <code>'group-offsets'</code>, <code>'timestamp'</code> or <code>'specific-offsets'</code>.</td>
     </tr>
     <tr>
       <td><h5>scan.startup.specific-offsets</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Optional offsets used in case of 'specific-offsets' startup mode.
+      <td>Specifies offsets for each partition in case of 'specific-offsets' startup mode, e.g. `partition:0,offset:42;partition:1,offset:300`.
       </td>
     </tr>
     <tr>
@@ -151,25 +150,64 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>Long</td>
-      <td>Optional timestamp used in case of 'timestamp' startup mode.</td>
+      <td>Timestamp used in case of 'timestamp' startup mode, the 'timestamp' represents the milliseconds that have passed since January 1, 1970 00:00:00.000 GMT, e.g. '1591776274000' for '2020-06-10 16:04:34 +08:00'.</td>
     </tr>
     <tr>
       <td><h5>sink.partitioner</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Optional output partitioning from Flink's partitions into Kafka's partitions. Valid enumerations are
-      'fixed': (each Flink partition ends up in at most one Kafka partition),
-      'round-robin': (a Flink partition is distributed to Kafka partitions round-robin)
-      'custom class name': (use a custom FlinkKafkaPartitioner subclass).
+      <td>Output partitioning from Flink's partitions into Kafka's partitions. Valid enumerations are
+      <ul>
+        <li><span markdown="span">`fixed`</span>: each Flink partition ends up in at most one Kafka partition.</li>
+        <li><span markdown="span">`round-robin`</span>: a Flink partition is distributed to Kafka partitions round-robin.</li>
+        <li><span markdown="span">`custom class name`</span>: use a custom FlinkKafkaPartitioner subclass.</li>
+      </ul>
       </td>
     </tr>
     </tbody>
 </table>
 
+Features
+----------------
+
+### Specify the Start Reading Position
+The config option `scan.startup.mode` specifies the startup mode for Kafka consumer. The valid enumerations are:
+<ul>
+<li><span markdown="span">`group-offsets`</span>: start from committed offsets in ZK / Kafka brokers of a specific consumer group.</li>
+<li><span markdown="span">`earliest-offset`</span>: start from the earliest offset possible.</li>
+<li><span markdown="span">`latest-offset`</span>: start from the latest offset.</li>
+<li><span markdown="span">`timestamp`</span>: start from user-supplied timestamp for each partition.</li>
+<li><span markdown="span">`specific-offsets`</span>: start from user-supplied specific offsets for each partition.</li>
+</ul>
+
+The default option value is `group-offsets` which indicates to consume from last committed offsets in ZK / Kafka brokers.
+
+If `timestamp` is specified, another config option `scan.startup.timestamp-millis` is required to specify a specific startup timestamp in milliseconds since January 1, 1970 00:00:00.000 GMT.
+
+If `specific-offsets` is specified, another config option `scan.startup.specific-offsets` is required to specify specific startup offsets for each partition,
+e.g. an option value `partition:0,offset:42;partition:1,offset:300` indicates offset `42` for partition `0` and offset `300` for partition `1`.
+
+### Sink Partitioning
+The config option `sink.partitioner` specifies output partitioning from Flink's partitions into Kafka's partitions. The valid enumerations are:
+<ul>
+<li><span markdown="span">`fixed`</span>: each Flink partition ends up in at most one Kafka partition.</li>
+<li><span markdown="span">`round-robin`</span>: a Flink partition is distributed to Kafka partitions round-robin.</li>
+<li><span markdown="span">`custom class name`</span>: use a custom FlinkKafkaPartitioner subclass.</li>
+</ul>
+
+<span class="label label-danger">Note</span> If the option value it neither `fixed` nor `round-robin`, then Flink would try to parse as
+the `custom class name`, if that is not a full class name that implements `FlinkKafkaPartitioner`, an exception would be thrown.
+
+If config option `sink.partitioner` is not specified, a partition will be assigned in a round-robin fashion.
+
+### Consistency guarantees
+The Kafka SQL sink only supports at-least-once writes now, for exactly-once writes, use the `DataStream` connector, see
+[Kafka Producers And Fault Tolerance]({{ site.baseurl }}/dev/connectors/kafka.html#kafka-producers-and-fault-tolerance) for more details.
+
 Data Type Mapping
 ----------------
 Kafka connector requires to specify a format, thus the supported data types are decided by the specific formats it specifies.
-Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connectors/formats/index.html) section for more details.
 
 {% top %}

--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -1,0 +1,175 @@
+---
+title: "Apache Kafka SQL Connector"
+nav-title: Kafka
+nav-parent_id: sql-connectors
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Flink provides an [Apache Kafka](https://kafka.apache.org) connector for reading data from and writing data to Kafka topics with exactly-once guaruntees.
+
+<span class="label label-primary">Scan Source: Unbounded</span>
+<span class="label label-primary">Sink: Streaming Append Mode</span>
+
+* This will be replaced by the TOC
+{:toc}
+
+Dependencies
+------------
+
+Apache Flink ships with multiple Kafka connectors: universal, 0.10, and 0.11.
+This universal Kafka connector attempts to track the latest version of the Kafka client.
+The version of the client it uses may change between Flink releases.
+Modern Kafka clients are backwards compatible with broker versions 0.10.0 or later.
+For most users the universal Kafka connector is the most appropriate.
+However, for Kafka versions 0.11.x and 0.10.x, we recommend using the dedicated ``0.11`` and ``0.10`` connectors, respectively.
+For details on Kafka compatibility, please refer to the official [Kafka documentation](https://kafka.apache.org/protocol.html#protocol_compatibility).
+
+{% if site.is_stable %}
+
+| Kafka Version       | Maven dependency                                          | SQL Client JAR         |
+| :------------------ | :-------------------------------------------------------- | :----------------------|
+| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+
+<span class="label label-danger">Attention</span> The ``0.10`` sink does not support exactly-once writes to Kafka.
+{% else %}
+
+The dependency table is only available for stable releases.
+
+{% endif %}
+
+Flink's streaming connectors are not currently part of the binary distribution.
+See how to link with them for cluster execution [here]({{ site.baseurl}}/dev/projectsetup/dependencies.html).
+
+How to create a Kafka table
+----------------
+<div class="codetabs" markdown="1">
+<div data-lang="SQL" markdown="1">
+{% highlight sql %}
+CREATE TABLE kafkaTable (
+ ...
+) WITH (
+ 'connector' = 'kafka',
+ 'topic' = 'topic_name',
+ 'properties.bootstrap.server' = 'localhost:9092',
+ 'properties.group.id' = 'testGroup',
+ 'format' = 'csv',
+ 'scan.startup.mode' = 'group-offsets'
+)
+{% endhighlight %}
+</div>
+</div>
+
+Connector Options
+----------------
+
+<table class="table table-bordered">
+    <thead>
+      <tr>
+        <th class="text-left" style="width: 25%">Option</th>
+        <th class="text-center" style="width: 8%">Required</th>
+        <th class="text-center" style="width: 7%">Default</th>
+        <th class="text-center" style="width: 10%">Type</th>
+        <th class="text-center" style="width: 50%">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><h5>connector</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Specify what connector to use, for Kafka the options are: 'kafka', 'kafka-0.11', 'kafka-0.10'.</td>
+    </tr>
+    <tr>
+      <td><h5>topic</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Required topic name from which the table is read.</td>
+    </tr>
+    <tr>
+      <td><h5>properties.bootstrap.servers</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Required Kafka server connection string.</td>
+    </tr>
+    <tr>
+    <td><h5>format</h5></td>
+    <td>required</td>
+    <td style="word-wrap: break-word;">(none)</td>
+    <td>String</td>
+    <td>Kafka connector requires to specify a format,
+    the supported formats are 'csv', 'json' and 'avro'.
+    Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+    </td>
+        </tr>
+    <tr>
+      <td><h5>properties.group.id</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Required consumer group in Kafka consumer, no need for Kafka producer</td>
+    </tr>
+    <tr>
+      <td><h5>scan.startup.mode</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">group-offsets</td>
+      <td>String</td>
+      <td>Optional startup mode for Kafka consumer, valid enumerations are 'earliest-offset', 'latest-offset', 'group-offsets', 'timestamp' or 'specific-offsets'.</td>
+    </tr>
+    <tr>
+      <td><h5>scan.startup.specific-offsets</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Optional offsets used in case of 'specific-offsets' startup mode.
+      </td>
+    </tr>
+    <tr>
+      <td><h5>scan.startup.timestamp-millis</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Long</td>
+      <td>Optional timestamp used in case of 'timestamp' startup mode.</td>
+    </tr>
+    <tr>
+      <td><h5>sink.partitioner</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Optional output partitioning from Flink's partitions into Kafka's partitions. Valid enumerations are
+      'fixed': (each Flink partition ends up in at most one Kafka partition),
+      'round-robin': (a Flink partition is distributed to Kafka partitions round-robin)
+      'custom class name': (use a custom FlinkKafkaPartitioner subclass).
+      </td>
+    </tr>
+    </tbody>
+</table>
+
+Data Type Mapping
+----------------
+Kafka connector requires to specify a format, thus the supported data types are decided by the specific formats it specifies.
+Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+
+{% top %}

--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -44,13 +44,9 @@ For details on Kafka compatibility, please refer to the official [Kafka document
 
 | Kafka Version       | Maven dependency                                          | SQL Client JAR         |
 | :------------------ | :-------------------------------------------------------- | :----------------------|
-| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
-| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
-| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
-
-<span class="label label-danger">Attention</span> The Kafka SQL sink does not support exactly-once writes to Kafka.
-
-The dependency downloading links is only available for stable releases.
+| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %} |
+| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %} |
+| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %} |
 
 Flink's streaming connectors are not currently part of the binary distribution.
 See how to link with them for cluster execution [here]({{ site.baseurl}}/dev/projectsetup/dependencies.html).
@@ -203,11 +199,11 @@ If config option `sink.partitioner` is not specified, a partition will be assign
 
 ### Consistency guarantees
 The Kafka SQL sink only supports at-least-once writes now, for exactly-once writes, use the `DataStream` connector, see
-[Kafka Producers And Fault Tolerance]({{ site.baseurl }}/dev/connectors/kafka.html#kafka-producers-and-fault-tolerance) for more details.
+<a href="{{ site.baseurl }}/dev/connectors/kafka.html#kafka-producers-and-fault-tolerance">Kafka Producers And Fault Tolerance</a> for more details.
 
 Data Type Mapping
 ----------------
 Kafka connector requires to specify a format, thus the supported data types are decided by the specific formats it specifies.
-Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connectors/formats/index.html) section for more details.
+Please refer to <a href="{{ site.baseurl }}/dev/table/connectors/formats/index.html">Table Formats</a> section for more details.
 
 {% top %}

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -23,13 +23,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Flink provides an [Apache Kafka](https://kafka.apache.org) connector for reading data from and writing data to Kafka topics with exactly-once guaruntees.
-
 <span class="label label-primary">Scan Source: Unbounded</span>
 <span class="label label-primary">Sink: Streaming Append Mode</span>
 
 * This will be replaced by the TOC
 {:toc}
+
+Flink provides an [Apache Kafka](https://kafka.apache.org) connector for reading data from and writing data to Kafka topics.
 
 Dependencies
 ------------
@@ -42,20 +42,15 @@ For most users the universal Kafka connector is the most appropriate.
 However, for Kafka versions 0.11.x and 0.10.x, we recommend using the dedicated ``0.11`` and ``0.10`` connectors, respectively.
 For details on Kafka compatibility, please refer to the official [Kafka documentation](https://kafka.apache.org/protocol.html#protocol_compatibility).
 
-{% if site.is_stable %}
-
 | Kafka Version       | Maven dependency                                          | SQL Client JAR         |
 | :------------------ | :-------------------------------------------------------- | :----------------------|
-| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
+| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
+| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
 
-<span class="label label-danger">Attention</span> The ``0.10`` sink does not support exactly-once writes to Kafka.
-{% else %}
+<span class="label label-danger">Attention</span> The Kafka SQL sink does not support exactly-once writes to Kafka.
 
-The dependency table is only available for stable releases.
-
-{% endif %}
+The dependency downloading links is only available for stable releases.
 
 Flink's streaming connectors are not currently part of the binary distribution.
 See how to link with them for cluster execution [here]({{ site.baseurl}}/dev/projectsetup/dependencies.html).
@@ -66,14 +61,18 @@ How to create a Kafka table
 <div data-lang="SQL" markdown="1">
 {% highlight sql %}
 CREATE TABLE kafkaTable (
- ...
+ user_id BIGINT,
+ item_id BIGINT,
+ category_id BIGINT,
+ behavior STRING,
+ ts TIMESTAMP(3)
 ) WITH (
  'connector' = 'kafka',
- 'topic' = 'topic_name',
+ 'topic' = 'user_behavior',
  'properties.bootstrap.server' = 'localhost:9092',
  'properties.group.id' = 'testGroup',
  'format' = 'csv',
- 'scan.startup.mode' = 'group-offsets'
+ 'scan.startup.mode' = 'earliest-offset'
 )
 {% endhighlight %}
 </div>
@@ -84,13 +83,13 @@ Connector Options
 
 <table class="table table-bordered">
     <thead>
-      <tr>
-        <th class="text-left" style="width: 25%">Option</th>
-        <th class="text-center" style="width: 8%">Required</th>
-        <th class="text-center" style="width: 7%">Default</th>
-        <th class="text-center" style="width: 10%">Type</th>
-        <th class="text-center" style="width: 50%">Description</th>
-      </tr>
+    <tr>
+      <th class="text-left" style="width: 25%">Option</th>
+      <th class="text-center" style="width: 8%">Required</th>
+      <th class="text-center" style="width: 7%">Default</th>
+      <th class="text-center" style="width: 10%">Type</th>
+      <th class="text-center" style="width: 50%">Description</th>
+    </tr>
     </thead>
     <tbody>
     <tr>
@@ -105,45 +104,45 @@ Connector Options
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Required topic name from which the table is read.</td>
+      <td>Topic name from which the table is read.</td>
     </tr>
     <tr>
       <td><h5>properties.bootstrap.servers</h5></td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Required Kafka server connection string.</td>
+      <td>Kafka server connection string.</td>
     </tr>
     <tr>
-    <td><h5>format</h5></td>
-    <td>required</td>
-    <td style="word-wrap: break-word;">(none)</td>
-    <td>String</td>
-    <td>Kafka connector requires to specify a format,
-    the supported formats are 'csv', 'json' and 'avro'.
-    Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
-    </td>
-        </tr>
-    <tr>
       <td><h5>properties.group.id</h5></td>
-      <td>optional</td>
+      <td>required by source</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Required consumer group in Kafka consumer, no need for Kafka producer</td>
+      <td>Consumer group in Kafka consumer, no need for Kafka producer</td>
+    </tr>
+    <tr>
+      <td><h5>format</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Kafka connector requires to specify a format,
+      the supported formats are 'csv', 'json' and 'avro'.
+      Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+      </td>
     </tr>
     <tr>
       <td><h5>scan.startup.mode</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">group-offsets</td>
       <td>String</td>
-      <td>Optional startup mode for Kafka consumer, valid enumerations are 'earliest-offset', 'latest-offset', 'group-offsets', 'timestamp' or 'specific-offsets'.</td>
+      <td>Startup mode for Kafka consumer, valid enumerations are <code>'earliest-offset'</code>, <code>'latest-offset'</code>, <code>'group-offsets'</code>, <code>'timestamp'</code> or <code>'specific-offsets'</code>.</td>
     </tr>
     <tr>
       <td><h5>scan.startup.specific-offsets</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Optional offsets used in case of 'specific-offsets' startup mode.
+      <td>Specifies offsets for each partition in case of 'specific-offsets' startup mode, e.g. `partition:0,offset:42;partition:1,offset:300`.
       </td>
     </tr>
     <tr>
@@ -151,25 +150,64 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>Long</td>
-      <td>Optional timestamp used in case of 'timestamp' startup mode.</td>
+      <td>Timestamp used in case of 'timestamp' startup mode, the 'timestamp' represents the milliseconds that have passed since January 1, 1970 00:00:00.000 GMT, e.g. '1591776274000' for '2020-06-10 16:04:34 +08:00'.</td>
     </tr>
     <tr>
       <td><h5>sink.partitioner</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Optional output partitioning from Flink's partitions into Kafka's partitions. Valid enumerations are
-      'fixed': (each Flink partition ends up in at most one Kafka partition),
-      'round-robin': (a Flink partition is distributed to Kafka partitions round-robin)
-      'custom class name': (use a custom FlinkKafkaPartitioner subclass).
+      <td>Output partitioning from Flink's partitions into Kafka's partitions. Valid enumerations are
+      <ul>
+        <li><span markdown="span">`fixed`</span>: each Flink partition ends up in at most one Kafka partition.</li>
+        <li><span markdown="span">`round-robin`</span>: a Flink partition is distributed to Kafka partitions round-robin.</li>
+        <li><span markdown="span">`custom class name`</span>: use a custom FlinkKafkaPartitioner subclass.</li>
+      </ul>
       </td>
     </tr>
     </tbody>
 </table>
 
+Features
+----------------
+
+### Specify the Start Reading Position
+The config option `scan.startup.mode` specifies the startup mode for Kafka consumer. The valid enumerations are:
+<ul>
+<li><span markdown="span">`group-offsets`</span>: start from committed offsets in ZK / Kafka brokers of a specific consumer group.</li>
+<li><span markdown="span">`earliest-offset`</span>: start from the earliest offset possible.</li>
+<li><span markdown="span">`latest-offset`</span>: start from the latest offset.</li>
+<li><span markdown="span">`timestamp`</span>: start from user-supplied timestamp for each partition.</li>
+<li><span markdown="span">`specific-offsets`</span>: start from user-supplied specific offsets for each partition.</li>
+</ul>
+
+The default option value is `group-offsets` which indicates to consume from last committed offsets in ZK / Kafka brokers.
+
+If `timestamp` is specified, another config option `scan.startup.timestamp-millis` is required to specify a specific startup timestamp in milliseconds since January 1, 1970 00:00:00.000 GMT.
+
+If `specific-offsets` is specified, another config option `scan.startup.specific-offsets` is required to specify specific startup offsets for each partition,
+e.g. an option value `partition:0,offset:42;partition:1,offset:300` indicates offset `42` for partition `0` and offset `300` for partition `1`.
+
+### Sink Partitioning
+The config option `sink.partitioner` specifies output partitioning from Flink's partitions into Kafka's partitions. The valid enumerations are:
+<ul>
+<li><span markdown="span">`fixed`</span>: each Flink partition ends up in at most one Kafka partition.</li>
+<li><span markdown="span">`round-robin`</span>: a Flink partition is distributed to Kafka partitions round-robin.</li>
+<li><span markdown="span">`custom class name`</span>: use a custom FlinkKafkaPartitioner subclass.</li>
+</ul>
+
+<span class="label label-danger">Note</span> If the option value it neither `fixed` nor `round-robin`, then Flink would try to parse as
+the `custom class name`, if that is not a full class name that implements `FlinkKafkaPartitioner`, an exception would be thrown.
+
+If config option `sink.partitioner` is not specified, a partition will be assigned in a round-robin fashion.
+
+### Consistency guarantees
+The Kafka SQL sink only supports at-least-once writes now, for exactly-once writes, use the `DataStream` connector, see
+[Kafka Producers And Fault Tolerance]({{ site.baseurl }}/dev/connectors/kafka.html#kafka-producers-and-fault-tolerance) for more details.
+
 Data Type Mapping
 ----------------
 Kafka connector requires to specify a format, thus the supported data types are decided by the specific formats it specifies.
-Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connectors/formats/index.html) section for more details.
 
 {% top %}

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -1,0 +1,175 @@
+---
+title: "Apache Kafka SQL Connector"
+nav-title: Kafka
+nav-parent_id: sql-connectors
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Flink provides an [Apache Kafka](https://kafka.apache.org) connector for reading data from and writing data to Kafka topics with exactly-once guaruntees.
+
+<span class="label label-primary">Scan Source: Unbounded</span>
+<span class="label label-primary">Sink: Streaming Append Mode</span>
+
+* This will be replaced by the TOC
+{:toc}
+
+Dependencies
+------------
+
+Apache Flink ships with multiple Kafka connectors: universal, 0.10, and 0.11.
+This universal Kafka connector attempts to track the latest version of the Kafka client.
+The version of the client it uses may change between Flink releases.
+Modern Kafka clients are backwards compatible with broker versions 0.10.0 or later.
+For most users the universal Kafka connector is the most appropriate.
+However, for Kafka versions 0.11.x and 0.10.x, we recommend using the dedicated ``0.11`` and ``0.10`` connectors, respectively.
+For details on Kafka compatibility, please refer to the official [Kafka documentation](https://kafka.apache.org/protocol.html#protocol_compatibility).
+
+{% if site.is_stable %}
+
+| Kafka Version       | Maven dependency                                          | SQL Client JAR         |
+| :------------------ | :-------------------------------------------------------- | :----------------------|
+| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) |
+
+<span class="label label-danger">Attention</span> The ``0.10`` sink does not support exactly-once writes to Kafka.
+{% else %}
+
+The dependency table is only available for stable releases.
+
+{% endif %}
+
+Flink's streaming connectors are not currently part of the binary distribution.
+See how to link with them for cluster execution [here]({{ site.baseurl}}/dev/projectsetup/dependencies.html).
+
+How to create a Kafka table
+----------------
+<div class="codetabs" markdown="1">
+<div data-lang="SQL" markdown="1">
+{% highlight sql %}
+CREATE TABLE kafkaTable (
+ ...
+) WITH (
+ 'connector' = 'kafka',
+ 'topic' = 'topic_name',
+ 'properties.bootstrap.server' = 'localhost:9092',
+ 'properties.group.id' = 'testGroup',
+ 'format' = 'csv',
+ 'scan.startup.mode' = 'group-offsets'
+)
+{% endhighlight %}
+</div>
+</div>
+
+Connector Options
+----------------
+
+<table class="table table-bordered">
+    <thead>
+      <tr>
+        <th class="text-left" style="width: 25%">Option</th>
+        <th class="text-center" style="width: 8%">Required</th>
+        <th class="text-center" style="width: 7%">Default</th>
+        <th class="text-center" style="width: 10%">Type</th>
+        <th class="text-center" style="width: 50%">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><h5>connector</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Specify what connector to use, for Kafka the options are: 'kafka', 'kafka-0.11', 'kafka-0.10'.</td>
+    </tr>
+    <tr>
+      <td><h5>topic</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Required topic name from which the table is read.</td>
+    </tr>
+    <tr>
+      <td><h5>properties.bootstrap.servers</h5></td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Required Kafka server connection string.</td>
+    </tr>
+    <tr>
+    <td><h5>format</h5></td>
+    <td>required</td>
+    <td style="word-wrap: break-word;">(none)</td>
+    <td>String</td>
+    <td>Kafka connector requires to specify a format,
+    the supported formats are 'csv', 'json' and 'avro'.
+    Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+    </td>
+        </tr>
+    <tr>
+      <td><h5>properties.group.id</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Required consumer group in Kafka consumer, no need for Kafka producer</td>
+    </tr>
+    <tr>
+      <td><h5>scan.startup.mode</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">group-offsets</td>
+      <td>String</td>
+      <td>Optional startup mode for Kafka consumer, valid enumerations are 'earliest-offset', 'latest-offset', 'group-offsets', 'timestamp' or 'specific-offsets'.</td>
+    </tr>
+    <tr>
+      <td><h5>scan.startup.specific-offsets</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Optional offsets used in case of 'specific-offsets' startup mode.
+      </td>
+    </tr>
+    <tr>
+      <td><h5>scan.startup.timestamp-millis</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Long</td>
+      <td>Optional timestamp used in case of 'timestamp' startup mode.</td>
+    </tr>
+    <tr>
+      <td><h5>sink.partitioner</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Optional output partitioning from Flink's partitions into Kafka's partitions. Valid enumerations are
+      'fixed': (each Flink partition ends up in at most one Kafka partition),
+      'round-robin': (a Flink partition is distributed to Kafka partitions round-robin)
+      'custom class name': (use a custom FlinkKafkaPartitioner subclass).
+      </td>
+    </tr>
+    </tbody>
+</table>
+
+Data Type Mapping
+----------------
+Kafka connector requires to specify a format, thus the supported data types are decided by the specific formats it specifies.
+Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connect.html#table-formats) section for more details.
+
+{% top %}

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -44,13 +44,9 @@ For details on Kafka compatibility, please refer to the official [Kafka document
 
 | Kafka Version       | Maven dependency                                          | SQL Client JAR         |
 | :------------------ | :-------------------------------------------------------- | :----------------------|
-| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
-| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
-| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% endif %} |
-
-<span class="label label-danger">Attention</span> The Kafka SQL sink does not support exactly-once writes to Kafka.
-
-The dependency downloading links is only available for stable releases.
+| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %} |
+| 0.11.x              | `flink-connector-kafka-011{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-011{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %} |
+| 0.10.x              | `flink-connector-kafka-010{{site.scala_version_suffix}}`  | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kafka-010{{site.scala_version_suffix}}/{{site.version}}/flink-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %} |
 
 Flink's streaming connectors are not currently part of the binary distribution.
 See how to link with them for cluster execution [here]({{ site.baseurl}}/dev/projectsetup/dependencies.html).
@@ -203,11 +199,11 @@ If config option `sink.partitioner` is not specified, a partition will be assign
 
 ### Consistency guarantees
 The Kafka SQL sink only supports at-least-once writes now, for exactly-once writes, use the `DataStream` connector, see
-[Kafka Producers And Fault Tolerance]({{ site.baseurl }}/dev/connectors/kafka.html#kafka-producers-and-fault-tolerance) for more details.
+<a href="{{ site.baseurl }}/dev/connectors/kafka.html#kafka-producers-and-fault-tolerance">Kafka Producers And Fault Tolerance</a> for more details.
 
 Data Type Mapping
 ----------------
 Kafka connector requires to specify a format, thus the supported data types are decided by the specific formats it specifies.
-Please refer to [Table Formats]({{ site.baseurl }}/dev/table/connectors/formats/index.html) section for more details.
+Please refer to <a href="{{ site.baseurl }}/dev/table/connectors/formats/index.html">Table Formats</a> section for more details.
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

Add document for new Kafka SQL connector


## Brief change log

  - Add document page.


## Verifying this change

Build the website locally and validates it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
