### PR TITLE
[FLINK-18127][tests] Streamline manual execution of Java E2E tests

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
@@ -66,7 +66,7 @@ public enum TestUtils {
 				case 0:
 					throw new RuntimeException(
 						new FileNotFoundException(
-							String.format("No jar could be found that matches the pattern %s.", jarNameRegex)
+							String.format("No jar could be found that matches the pattern %s. This could mean that the test module must be rebuilt via maven.", jarNameRegex)
 						)
 					);
 				case 1:

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.tests.util;
 
-import org.apache.flink.util.Preconditions;
+import org.apache.flink.tests.util.parameters.ParameterProperty;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -43,6 +43,8 @@ import java.util.stream.Stream;
 public enum TestUtils {
 	;
 
+	private static final ParameterProperty<Path> MODULE_DIRECTORY = new ParameterProperty<>("moduleDir", Paths::get);
+
 	/**
 	 * Searches for a jar matching the given regex in the given directory. This method is primarily intended to be used
 	 * for the initialization of static {@link Path} fields for jars that reside in the modules {@code target} directory.
@@ -52,10 +54,11 @@ public enum TestUtils {
 	 * @throws RuntimeException if none or multiple jars could be found
 	 */
 	public static Path getResourceJar(final String jarNameRegex) {
-		String moduleDirProp = System.getProperty("moduleDir");
-		Preconditions.checkNotNull(moduleDirProp, "The moduleDir property was not set, You can set it when running maven via -DmoduleDir=<path>");
+		// if the property is not set then we are most likely running in the IDE, where the working directory is the
+		// module of the test that is currently running, which is exactly what we want
+		Path moduleDirectory = MODULE_DIRECTORY.get(Paths.get("").toAbsolutePath());
 
-		try (Stream<Path> dependencyJars = Files.walk(Paths.get(moduleDirProp))) {
+		try (Stream<Path> dependencyJars = Files.walk(moduleDirectory)) {
 			final List<Path> matchingJars = dependencyJars
 				.filter(jar -> Pattern.compile(jarNameRegex).matcher(jar.toAbsolutePath().toString()).find())
 				.collect(Collectors.toList());

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
@@ -66,6 +66,7 @@ public class LocalStandaloneFlinkResource implements FlinkResource {
 	private FlinkDistribution distribution;
 
 	LocalStandaloneFlinkResource(Path distributionDirectory, @Nullable Path logBackupDirectory, FlinkResourceSetup setup) {
+		LOG.info("Using distribution {}.", distributionDirectory);
 		this.distributionDirectory = distributionDirectory;
 		this.logBackupDirectory = logBackupDirectory;
 		this.setup = setup;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
@@ -19,12 +19,16 @@
 package org.apache.flink.tests.util.flink;
 
 import org.apache.flink.tests.util.parameters.ParameterProperty;
+import org.apache.flink.util.FileUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -33,6 +37,7 @@ import java.util.Optional;
 public final class LocalStandaloneFlinkResourceFactory implements FlinkResourceFactory {
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStandaloneFlinkResourceFactory.class);
 
+	private static final ParameterProperty<Path> PROJECT_ROOT_DIRECTORY = new ParameterProperty<>("rootDir", Paths::get);
 	private static final ParameterProperty<Path> DISTRIBUTION_DIRECTORY = new ParameterProperty<>("distDir", Paths::get);
 	private static final ParameterProperty<Path> DISTRIBUTION_LOG_BACKUP_DIRECTORY = new ParameterProperty<>("logBackupDir", Paths::get);
 
@@ -40,7 +45,33 @@ public final class LocalStandaloneFlinkResourceFactory implements FlinkResourceF
 	public FlinkResource create(FlinkResourceSetup setup) {
 		Optional<Path> distributionDirectory = DISTRIBUTION_DIRECTORY.get();
 		if (!distributionDirectory.isPresent()) {
-			throw new IllegalArgumentException("The distDir property was not set. You can set it when running maven via -DdistDir=<path> .");
+			LOG.debug("The '{}' property was not set; attempting to automatically determine distribution location.", DISTRIBUTION_DIRECTORY.getPropertyName());
+
+			Path projectRootPath;
+			Optional<Path> projectRoot = PROJECT_ROOT_DIRECTORY.get();
+			if (projectRoot.isPresent()) {
+				// running with maven
+				projectRootPath = projectRoot.get();
+			} else {
+				// running in the IDE; working directory is test module
+				Optional<Path> projectRootDirectory = findProjectRootDirectory(Paths.get("").toAbsolutePath());
+				// this distinction is required in case this class is used outside of Flink
+				if (projectRootDirectory.isPresent()) {
+					projectRootPath = projectRootDirectory.get();
+				} else {
+					throw new IllegalArgumentException(
+						"The 'distDir' property was not set and the flink-dist module could not be found automatically." +
+							" Please point the 'distDir' property to the directory containing distribution; you can set it when running maven via -DdistDir=<path> .");
+				}
+			}
+			Optional<Path> distribution = findDistribution(projectRootPath);
+			if (!distribution.isPresent()) {
+				throw new IllegalArgumentException(
+					"The 'distDir' property was not set and a distribution could not be found automatically." +
+						" Please point the 'distDir' property to the directory containing distribution; you can set it when running maven via -DdistDir=<path> .");
+			} else {
+				distributionDirectory = distribution;
+			}
 		}
 		Optional<Path> logBackupDirectory = DISTRIBUTION_LOG_BACKUP_DIRECTORY.get();
 		if (!logBackupDirectory.isPresent()) {
@@ -48,4 +79,46 @@ public final class LocalStandaloneFlinkResourceFactory implements FlinkResourceF
 		}
 		return new LocalStandaloneFlinkResource(distributionDirectory.get(), logBackupDirectory.orElse(null), setup);
 	}
+
+	private static Optional<Path> findProjectRootDirectory(Path currentDirectory) {
+		// move up the module structure until we find flink-dist; relies on all modules being prefixed with 'flink'
+		do {
+			if (Files.exists(currentDirectory.resolve("flink-dist"))) {
+				return Optional.of(currentDirectory);
+			}
+			currentDirectory = currentDirectory.getParent();
+		}  while (currentDirectory.getFileName().toString().startsWith("flink"));
+		return Optional.empty();
+	}
+
+	private static Optional<Path> findDistribution(Path projectRootDirectory) {
+		final Path distTargetDirectory = projectRootDirectory.resolve("flink-dist").resolve("target");
+		try {
+			Collection<Path> paths = FileUtils.listFilesInDirectory(
+				distTargetDirectory,
+				LocalStandaloneFlinkResourceFactory::isDistribution);
+			if (paths.size() == 0) {
+				// likely due to flink-dist not having been built
+				return Optional.empty();
+			}
+			if (paths.size() > 1) {
+				// target directory can contain distributions for multiple versions, or it's just a dirty environment
+				LOG.warn("Detected multiple distributions under flink-dist/target. It is recommended to explicitly" +
+					" select the distribution by setting the '{}}' property.", DISTRIBUTION_DIRECTORY.getPropertyName());
+			}
+			// jar should be in /lib; first getParent() returns /lib, second getParent() returns distribution directory
+			return Optional.of(paths.iterator().next().getParent().getParent());
+		} catch (IOException e) {
+			LOG.error("Error while searching for distribution.", e);
+			return Optional.empty();
+		}
+	}
+
+	private static boolean isDistribution(Path path) {
+		// check for `lib/flink-dist*'
+		// searching for the flink-dist jar is not sufficient since it also exists in the modules 'target' directory
+		return path.getFileName().toString().contains("flink-dist")
+			&& path.getParent().getFileName().toString().equals("lib");
+	}
 }
+


### PR DESCRIPTION
With this PR it should be possible to run the Java e2e tests in the IDE without having to manually set any property.

For the `moduleDir` property we just use the current working directory, which in IntelliJ is the module that the test resides in, which is exactly what we want.

For `distDir` we move up the module tree and check for the present of `flink-dist`, and then drill down into its `target` directory to find the actual distribution.