### PR TITLE
[FLINK-18130][hive][fs-connector] File name conflict for different jobs in filesystem/hive sink

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -77,6 +77,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_ROLLING_POLICY_FILE_SIZE;
 import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_ROLLING_POLICY_TIME_INTERVAL;
@@ -141,9 +142,10 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 					isCompressed);
 			String extension = Utilities.getFileExtension(jobConf, isCompressed,
 					(HiveOutputFormat<?, ?>) hiveOutputFormatClz.newInstance());
-			extension = extension == null ? "" : extension;
 			OutputFileConfig outputFileConfig = OutputFileConfig.builder()
-					.withPartSuffix(extension).build();
+					.withPartPrefix("part-" + UUID.randomUUID().toString())
+					.withPartSuffix(extension == null ? "" : extension)
+					.build();
 			if (isBounded) {
 				FileSystemOutputFormat.Builder<Row> builder = new FileSystemOutputFormat.Builder<>();
 				builder.setPartitionComputer(new HiveRowPartitionComputer(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -236,6 +236,43 @@ trait FileSystemITCaseBase {
         row(19, 3, "x19")
       ))
   }
+
+  @Test
+  def testInsertAppend(): Unit = {
+    tableEnv.sqlUpdate("insert into partitionedTable select x, y, a, b from originalT")
+    tableEnv.execute("test1")
+
+    tableEnv.sqlUpdate("insert into partitionedTable select x, y, a, b from originalT")
+    tableEnv.execute("test2")
+
+    check(
+      "select y, b, x from partitionedTable where a=3",
+      Seq(
+        row(17, 1, "x17"),
+        row(18, 2, "x18"),
+        row(19, 3, "x19"),
+        row(17, 1, "x17"),
+        row(18, 2, "x18"),
+        row(19, 3, "x19")
+      ))
+  }
+
+  @Test
+  def testInsertOverwrite(): Unit = {
+    tableEnv.sqlUpdate("insert overwrite partitionedTable select x, y, a, b from originalT")
+    tableEnv.execute("test1")
+
+    tableEnv.sqlUpdate("insert overwrite partitionedTable select x, y, a, b from originalT")
+    tableEnv.execute("test2")
+
+    check(
+      "select y, b, x from partitionedTable where a=3",
+      Seq(
+        row(17, 1, "x17"),
+        row(18, 2, "x18"),
+        row(19, 3, "x19")
+      ))
+  }
 }
 
 object FileSystemITCaseBase {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSink
 import org.apache.flink.types.Row
 
 import org.junit.Assert.assertEquals
-import org.junit.Before
+import org.junit.{Before, Test}
 
 import scala.collection.Seq
 
@@ -55,4 +55,8 @@ abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSys
       expectedResult.map(TestSinkUtil.rowToString(_)).sorted,
       sink.getAppendResults.sorted)
   }
+
+  // Streaming mode not support overwrite
+  @Test
+  override def testInsertOverwrite(): Unit = {}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionLoader.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionLoader.java
@@ -103,7 +103,7 @@ public class PartitionLoader implements Closeable {
 	}
 
 	/**
-	 * Moves files from srcDir to destDir. Delete files in destDir first when overwrite.
+	 * Moves files from srcDir to destDir.
 	 */
 	private void renameFiles(List<Path> srcDirs, Path destDir) throws Exception {
 		for (Path srcDir : srcDirs) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionLoader.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionLoader.java
@@ -113,12 +113,7 @@ public class PartitionLoader implements Closeable {
 					for (FileStatus srcFile : srcFiles) {
 						Path srcPath = srcFile.getPath();
 						Path destPath = new Path(destDir, srcPath.getName());
-						int count = 1;
-						while (!fs.rename(srcPath, destPath)) {
-							String name = srcPath.getName() + "_copy_" + count;
-							destPath = new Path(destDir, name);
-							count++;
-						}
+						fs.rename(srcPath, destPath);
 					}
 				}
 			}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTempFileManager.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTempFileManager.java
@@ -97,7 +97,7 @@ public class PartitionTempFileManager {
 	}
 
 	private String newFileName() {
-		return String.format("%s%s-%s-file-%d%s",
+		return String.format("%s-%s-%s-file-%d%s",
 				outputFileConfig.getPartPrefix(), checkpointName(checkpointId),
 				taskName(taskNumber), nameCounter++, outputFileConfig.getPartSuffix());
 	}


### PR DESCRIPTION

## What is the purpose of the change

The sink of different jobs (or the same SQL runs multiple times) will produce the same file name, the rename will fail, and different file systems will produce different results:
- HadoopFileSystem: ignore new data.
- LocalFileSystem: overwrite old data.

## Brief change log

We can add UUID to prefix, make sure there is no conflict between jobs.

## Verifying this change

- `HiveTableSinkITCase.testBatchAppend`
- `HiveTableSinkITCase.testStreamingAppend`
- `FileSystemITCaseBase.testInsertAppend`
- `FileSystemITCaseBase.testInsertOverwrite`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no