### PR TITLE
[FLINK-18038] [statebackend] Logging user-provided state backends after they are configured

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -197,15 +197,11 @@ public class StateBackendLoader {
 
 		// (1) the application defined state backend has precedence
 		if (fromApplication != null) {
-			if (logger != null) {
-				logger.info("Using application-defined state backend: {}", fromApplication);
-			}
-
 			// see if this is supposed to pick up additional configuration parameters
 			if (fromApplication instanceof ConfigurableStateBackend) {
 				// needs to pick up configuration
 				if (logger != null) {
-					logger.info("Configuring application-defined state backend with job/cluster config");
+					logger.info("Using job/cluster config to configure application-defined state backend: {}", fromApplication);
 				}
 
 				backend = ((ConfigurableStateBackend) fromApplication).configure(config, classLoader);
@@ -213,6 +209,10 @@ public class StateBackendLoader {
 			else {
 				// keep as is!
 				backend = fromApplication;
+			}
+
+			if (logger != null) {
+				logger.info("Using application-defined state backend: {}", backend);
 			}
 		}
 		else {


### PR DESCRIPTION

## What is the purpose of the change

Currently, for user-provided configurable state backends, we log them before we configure them. This is confusing when looking at the logs because there is no way to tell whether or not your state backend was configured correctly with the values provided in your flink-conf.yaml


## Brief change log

  - Moving the part where we log the statebackend that the job is using to after it is configured



## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
