### PR TITLE
[FLINK-18110][fs-connector] StreamingFileSink notifies for buckets detected to be inactive on restoring

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -187,6 +187,10 @@ public class Buckets<IN, BucketID> {
 
 	private void updateActiveBucketId(final BucketID bucketId, final Bucket<IN, BucketID> restoredBucket) throws IOException {
 		if (!restoredBucket.isActive()) {
+			if (bucketLifeCycleListener != null) {
+				bucketLifeCycleListener.bucketInactive(restoredBucket);
+			}
+
 			return;
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -187,10 +187,7 @@ public class Buckets<IN, BucketID> {
 
 	private void updateActiveBucketId(final BucketID bucketId, final Bucket<IN, BucketID> restoredBucket) throws IOException {
 		if (!restoredBucket.isActive()) {
-			if (bucketLifeCycleListener != null) {
-				bucketLifeCycleListener.bucketInactive(restoredBucket);
-			}
-
+			notifyBucketInactive(restoredBucket);
 			return;
 		}
 
@@ -216,10 +213,7 @@ public class Buckets<IN, BucketID> {
 				// We've dealt with all the pending files and the writer for this bucket is not currently open.
 				// Therefore this bucket is currently inactive and we can remove it from our state.
 				activeBucketIt.remove();
-
-				if (bucketLifeCycleListener != null) {
-					bucketLifeCycleListener.bucketInactive(bucket);
-				}
+				notifyBucketInactive(bucket);
 			}
 		}
 	}
@@ -308,10 +302,7 @@ public class Buckets<IN, BucketID> {
 					rollingPolicy,
 					outputFileConfig);
 			activeBuckets.put(bucketId, bucket);
-
-			if (bucketLifeCycleListener != null) {
-				bucketLifeCycleListener.bucketCreated(bucket);
-			}
+			notifyBucketCreate(bucket);
 		}
 		return bucket;
 	}
@@ -334,6 +325,18 @@ public class Buckets<IN, BucketID> {
 			return basePath;
 		}
 		return new Path(basePath, child);
+	}
+
+	private void notifyBucketCreate(Bucket<IN, BucketID> bucket) {
+		if (bucketLifeCycleListener != null) {
+			bucketLifeCycleListener.bucketCreated(bucket);
+		}
+	}
+
+	private void notifyBucketInactive(Bucket<IN, BucketID> bucket) {
+		if (bucketLifeCycleListener != null) {
+			bucketLifeCycleListener.bucketInactive(bucket);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This PR fixed the issue that the `BucketLifeCycleListener` in `StreamingFileSink` misses the notification for buckets detected inactive on restoring. On restoring, the buckets with only pending files will get all the pending files committed and will not be recorded. At this time, `StreamingFileSink` should notify that the buckets get inactive.

## Brief change log
  - 18db5ae4db2c5284bf0530c60e05f02be3a40d19 adds the missed notification.

## Verifying this change

This change added tests and can be verified as follows:
  - Added test that validates that the notification is sent on restoring if buckets get inactive.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**