### PR TITLE
[FLINK-18142][hive] Wrong state names in HiveContinuousMonitoringFunction

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
@@ -171,13 +171,13 @@ public class HiveContinuousMonitoringFunction
 	public void initializeState(FunctionInitializationContext context) throws Exception {
 		this.currReadTimeState = context.getOperatorStateStore().getListState(
 			new ListStateDescriptor<>(
-				"partition-monitoring-state",
+				"current-read-time-state",
 				LongSerializer.INSTANCE
 			)
 		);
 		this.distinctPartsState = context.getOperatorStateStore().getListState(
 			new ListStateDescriptor<>(
-				"partition-monitoring-state",
+				"distinct-partitions-state",
 				new ListSerializer<>(new ListSerializer<>(StringSerializer.INSTANCE))
 			)
 		);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -464,6 +464,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 		final String dbName = "source_db";
 		final String tblName = "stream_test";
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.enableCheckpointing(100);
 		StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
 		tEnv.registerCatalog(catalogName, hiveCatalog);
 		tEnv.useCatalog(catalogName);


### PR DESCRIPTION

## What is the purpose of the change

Should have different name between currReadTimeState and distinctPartsState.
Otherwise will checkpoint failure.

## Verifying this change

`HiveTableSourceITCase.testStreamPartitionRead`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no