### PR TITLE
[FLINK-18143][python] Fix Python meter metric incorrect value problem

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/metric/FlinkMetricContainer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/metric/FlinkMetricContainer.java
@@ -135,7 +135,7 @@ public final class FlinkMetricContainer {
 				}
 
 				Long update = metricResult.getAttempted();
-				meter.markEvent(update);
+				meter.markEvent(update - meter.getCount());
 			} else {
 				Counter counter = flinkCounterCache.get(flinkMetricIdentifier);
 				if (null == counter) {


### PR DESCRIPTION


## What is the purpose of the change

This pull request fixes Python meter metric incorrect value problem.


## Brief change log

  - Report the diff value instead of the total ones for meter.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
