### PR TITLE
[FLINK-18147][docs]Orc document display is disordered

### DIFF
--- a/docs/dev/connectors/streamfile_sink.md
+++ b/docs/dev/connectors/streamfile_sink.md
@@ -231,6 +231,7 @@ class Person {
 
 {% endhighlight %}
 </div>
+</div>
 
 Then a child implementation to convert the element of type `Person` and set them in the `VectorizedRowBatch` can be like: 
 

--- a/docs/dev/connectors/streamfile_sink.zh.md
+++ b/docs/dev/connectors/streamfile_sink.zh.md
@@ -216,6 +216,7 @@ class Person {
 
 {% endhighlight %}
 </div>
+</div>
 
 Then a child implementation to convert the element of type `Person` and set them in the `VectorizedRowBatch` can be like:
 


### PR DESCRIPTION
## What is the purpose of the change

*Official documents show that there is a problem. Missing div tag,`dev/connectors/streamfile_sink.md` and `dev/connectors/streamfile_sink.zh.md`.link: https://ci.apache.org/projects/flink/flink-docs-master/dev/connectors/streamfile_sink.html#tab_java_2*


## Brief change log

  - *Add div tag*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no** )
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
