### PR TITLE
[FLINK-18149][k8s] Do not add DeploymentOptionsInternal#CONF_DIR to config map

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.kubeclient.decorators;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
@@ -148,6 +149,7 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
 
 		// remove kubernetes.config.file
 		propertiesMap.remove(KubernetesConfigOptions.KUBE_CONFIG_FILE.key());
+		propertiesMap.remove(DeploymentOptionsInternal.CONF_DIR.key());
 		return propertiesMap;
 	}
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -56,7 +56,9 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
 
 	@Override
 	public String getConfigDirectory() {
-		final String configDir = flinkConfig.get(DeploymentOptionsInternal.CONF_DIR);
+		final String configDir = flinkConfig.getOptional(DeploymentOptionsInternal.CONF_DIR).orElse(
+			flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR));
+
 		checkNotNull(configDir);
 		return configDir;
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.kubernetes;
 
+import org.apache.flink.configuration.Configuration;
+
 import org.apache.flink.shaded.guava18.com.google.common.io.Files;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,5 +35,16 @@ public class KubernetesTestUtils {
 
 	public static void createTemporyFile(String data, File directory, String fileName) throws IOException {
 		Files.write(data, new File(directory, fileName), StandardCharsets.UTF_8);
+	}
+
+	public static Configuration loadConfigurationFromString(String content) {
+		final Configuration configuration = new Configuration();
+		for (String line : content.split(System.lineSeparator())) {
+			final String[] splits = line.split(":");
+			if (splits.length >= 2) {
+				configuration.setString(splits[0].trim(), StringUtils.substringAfter(line, ":").trim());
+			}
+		}
+		return configuration;
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecoratorTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.kubernetes.kubeclient.decorators;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.kubernetes.KubernetesTestUtils;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
@@ -42,9 +44,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILENAME;
+import static org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator.getFlinkConfConfigMapName;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 /**
  * General tests for the {@link FlinkConfMountDecorator}.
@@ -88,15 +93,20 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 
 		assertEquals(Constants.API_VERSION, resultConfigMap.getApiVersion());
 
-		assertEquals(flinkConfMountDecorator.getFlinkConfConfigMapName(CLUSTER_ID),
+		assertEquals(getFlinkConfConfigMapName(CLUSTER_ID),
 				resultConfigMap.getMetadata().getName());
 		assertEquals(getCommonLabels(), resultConfigMap.getMetadata().getLabels());
 
 		Map<String, String> resultDatas = resultConfigMap.getData();
 		assertEquals("some data", resultDatas.get("logback.xml"));
 		assertEquals("some data", resultDatas.get("log4j.properties"));
-		assertTrue(resultDatas.get(FLINK_CONF_FILENAME).contains(KubernetesConfigOptions.FLINK_CONF_DIR.key() +
-				": " + FLINK_CONF_DIR_IN_POD));
+
+		final Configuration resultFlinkConfig = KubernetesTestUtils.loadConfigurationFromString(
+			resultDatas.get(FLINK_CONF_FILENAME));
+		assertThat(resultFlinkConfig.get(KubernetesConfigOptions.FLINK_CONF_DIR), is(FLINK_CONF_DIR_IN_POD));
+		// The following config options should not be added to config map
+		assertThat(resultFlinkConfig.get(KubernetesConfigOptions.KUBE_CONFIG_FILE), is(nullValue()));
+		assertThat(resultFlinkConfig.get(DeploymentOptionsInternal.CONF_DIR), is(nullValue()));
 	}
 
 	@Test
@@ -112,7 +122,7 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 			new VolumeBuilder()
 				.withName(Constants.FLINK_CONF_VOLUME)
 				.withNewConfigMap()
-					.withName(flinkConfMountDecorator.getFlinkConfConfigMapName(CLUSTER_ID))
+					.withName(getFlinkConfConfigMapName(CLUSTER_ID))
 					.withItems(expectedKeyToPaths)
 					.endConfigMap()
 				.build());
@@ -145,7 +155,7 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 			new VolumeBuilder()
 				.withName(Constants.FLINK_CONF_VOLUME)
 				.withNewConfigMap()
-				.withName(flinkConfMountDecorator.getFlinkConfConfigMapName(CLUSTER_ID))
+				.withName(getFlinkConfConfigMapName(CLUSTER_ID))
 				.withItems(expectedKeyToPaths)
 				.endConfigMap()
 				.build());
@@ -171,7 +181,7 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 			new VolumeBuilder()
 				.withName(Constants.FLINK_CONF_VOLUME)
 				.withNewConfigMap()
-				.withName(flinkConfMountDecorator.getFlinkConfConfigMapName(CLUSTER_ID))
+				.withName(getFlinkConfConfigMapName(CLUSTER_ID))
 				.withItems(expectedKeyToPaths)
 				.endConfigMap()
 				.build());
@@ -202,7 +212,7 @@ public class FlinkConfMountDecoratorTest extends KubernetesJobManagerTestBase {
 			new VolumeBuilder()
 				.withName(Constants.FLINK_CONF_VOLUME)
 				.withNewConfigMap()
-				.withName(flinkConfMountDecorator.getFlinkConfConfigMapName(CLUSTER_ID))
+				.withName(getFlinkConfConfigMapName(CLUSTER_ID))
 				.withItems(expectedKeyToPaths)
 				.endConfigMap()
 				.build());

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.kubernetes.kubeclient.parameters;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.StringUtils;
@@ -31,6 +32,8 @@ import java.util.Map;
 import java.util.Random;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * General tests for the {@link AbstractKubernetesParameters}.
@@ -60,6 +63,19 @@ public class AbstractKubernetesParametersTest extends TestLogger {
 			IllegalArgumentException.class,
 			testingKubernetesParameters::getClusterId
 		);
+	}
+
+	@Test
+	public void getConfigDirectory() {
+		final String confDir = "/path/of/flink-conf";
+		flinkConfig.set(DeploymentOptionsInternal.CONF_DIR, confDir);
+		assertThat(testingKubernetesParameters.getConfigDirectory(), is(confDir));
+	}
+
+	@Test
+	public void getConfigDirectoryFallbackToPodConfDir() {
+		final String confDirInPod = flinkConfig.get(KubernetesConfigOptions.FLINK_CONF_DIR);
+		assertThat(testingKubernetesParameters.getConfigDirectory(), is(confDirInPod));
 	}
 
 	private class TestingKubernetesParameters extends AbstractKubernetesParameters {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In FLINK-17935, we use `flinkConfig.get(DeploymentOptionsInternal.CONF_DIR)` to replace `CliFrontend.getConfigurationDirectoryFromEnv`. It will cause problem in native K8s integration. The root cause we set the `DeploymentOptionsInternal.CONF_DIR` in flink-conf.yaml to a client local path. However, it does not exist in JobManager pod.

So `DeploymentOptionsInternal#CONF_DIR` should not be added to config map and used by JobManager pod. Instead, `KubernetesConfigOptions#FLINK_CONF_DIR` will be used.


## Brief change log

* 4efe13e3f5df26d736b9fc63dd3df92ca86f1883 Do not add DeploymentOptionsInternal#CONF_DIR to config map


## Verifying this change

* New added and updated tests, `FlinkConfMountDecoratorTest#testConfigMap` `AbstractKubernetesParametersTest#getConfigDirectory` `AbstractKubernetesParametersTest#getConfigDirectoryFallbackToPodConfDir`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
