### PR TITLE
[FLINK-17635][docs][table sql / api] Add documentation about view support

### DIFF
--- a/docs/dev/table/sql/create.md
+++ b/docs/dev/table/sql/create.md
@@ -31,6 +31,7 @@ Flink SQL supports the following CREATE statements for now:
 
 - CREATE TABLE
 - CREATE DATABASE
+- CREATE VIEW
 - CREATE FUNCTION
 
 ## Run a CREATE statement
@@ -348,6 +349,25 @@ If the database already exists, nothing happens.
 
 Database properties used to store extra information related to this database.
 The key and value of expression `key1=val1` should both be string literal.
+
+{% top %}
+
+## CREATE VIEW
+{% highlight sql %}
+CREATE [TEMPORARY] VIEW [IF NOT EXISTS] view_name
+  [{columnName [, columnName ]* }] [COMMENT view_comment]
+  AS query_expression
+{% endhighlight %}
+
+Create a view with the given query expression. If a view with the same name already exists in the catalog, an exception is thrown.
+
+**TEMPORARY**
+
+Create temporary view that has catalog and database namespaces and overrides views.
+
+**IF NOT EXISTS**
+
+If the view already exists, nothing happens.
 
 {% top %}
 

--- a/docs/dev/table/sql/create.md
+++ b/docs/dev/table/sql/create.md
@@ -354,7 +354,7 @@ The key and value of expression `key1=val1` should both be string literal.
 
 ## CREATE VIEW
 {% highlight sql %}
-CREATE [TEMPORARY] VIEW [IF NOT EXISTS] view_name
+CREATE [TEMPORARY] VIEW [IF NOT EXISTS] [catalog_name.][db_name.]view_name
   [{columnName [, columnName ]* }] [COMMENT view_comment]
   AS query_expression
 {% endhighlight %}

--- a/docs/dev/table/sql/create.zh.md
+++ b/docs/dev/table/sql/create.zh.md
@@ -347,7 +347,7 @@ CREATE DATABASE [IF NOT EXISTS] [catalog_name.]db_name
 
 ## CREATE VIEW
 {% highlight sql %}
-CREATE [TEMPORARY] VIEW [IF NOT EXISTS] view_name
+CREATE [TEMPORARY] VIEW [IF NOT EXISTS] [catalog_name.][db_name.]view_name
   [{columnName [, columnName ]* }] [COMMENT view_comment]
   AS query_expression
 {% endhighlight %}

--- a/docs/dev/table/sql/create.zh.md
+++ b/docs/dev/table/sql/create.zh.md
@@ -31,6 +31,7 @@ CREATE 语句用于向当前或指定的 [Catalog]({{ site.baseurl }}/zh/dev/tab
 
 - CREATE TABLE
 - CREATE DATABASE
+- CREATE VIEW
 - CREATE FUNCTION
 
 ## 执行 CREATE 语句
@@ -341,6 +342,25 @@ CREATE DATABASE [IF NOT EXISTS] [catalog_name.]db_name
 
 数据库属性一般用于存储关于这个数据库额外的信息。
 表达式 `key1=val1` 中的键和值都需要是字符串文本常量。
+
+{% top %}
+
+## CREATE VIEW
+{% highlight sql %}
+CREATE [TEMPORARY] VIEW [IF NOT EXISTS] view_name
+  [{columnName [, columnName ]* }] [COMMENT view_comment]
+  AS query_expression
+{% endhighlight %}
+
+根据给定的 query 语句创建一个视图。若数据库中已经存在同名视图会抛出异常.
+
+**TEMPORARY**
+
+创建一个有 catalog 和数据库命名空间的临时视图，并覆盖原有的视图。
+
+**IF NOT EXISTS**
+
+若该视图已经存在，则不会进行任何操作。
 
 {% top %}
 

--- a/docs/dev/table/sql/drop.md
+++ b/docs/dev/table/sql/drop.md
@@ -161,7 +161,7 @@ Drop temporary view that has catalog and database namespaces.
 If the view does not exist, nothing happens.
 
 **MAINTAIN DEPENDENCIES**
-Flink does not maintain dependencies of view by CASCADE/RESTRICT keyword, the current lenient approach is producing postpone error message when user tries to use the view under the scenarios like the underlying table of view has been dropped.
+Flink does not maintain dependencies of view by CASCADE/RESTRICT keyword, the current way is producing postpone error message when user tries to use the view under the scenarios like the underlying table of view has been dropped.
 
 ## DROP FUNCTION
 

--- a/docs/dev/table/sql/drop.md
+++ b/docs/dev/table/sql/drop.md
@@ -161,7 +161,7 @@ Drop temporary view that has catalog and database namespaces.
 If the view does not exist, nothing happens.
 
 **MAINTAIN DEPENDENCIES**
-Flink does not maintain dependencies of view by CASCADE/RESTRICT keyword, the current way is producing postpone error message when user tries to use the view under the scenarios like the underlying table of view has been dropped.
+Flink does not maintain dependencies of view by CASCADE/RESTRICT keywords, the current way is producing postpone error message when user tries to use the view under the scenarios like the underlying table of view has been dropped.
 
 ## DROP FUNCTION
 

--- a/docs/dev/table/sql/drop.md
+++ b/docs/dev/table/sql/drop.md
@@ -31,6 +31,7 @@ Flink SQL supports the following DROP statements for now:
 
 - DROP TABLE
 - DROP DATABASE
+- DROP VIEW
 - DROP FUNCTION
 
 ## Run a DROP statement
@@ -142,6 +143,22 @@ Dropping a non-empty database triggers an exception. Enabled by default.
 **CASCADE**
 
 Dropping a non-empty database also drops all associated tables and functions.
+
+## DROP VIEW
+
+{% highlight sql %}
+DROP [TEMPORARY] VIEW  [ IF EXISTS ] view_name
+{% endhighlight %}
+
+Drop a view that has catalog and database namespaces. If the view to drop does not exist, an exception is thrown.
+
+**IF EXISTS**
+
+If the view does not exist, nothing happens.
+
+**TEMPORARY**
+
+Drop temporary view that has catalog and database namespaces.
 
 ## DROP FUNCTION
 

--- a/docs/dev/table/sql/drop.md
+++ b/docs/dev/table/sql/drop.md
@@ -147,18 +147,18 @@ Dropping a non-empty database also drops all associated tables and functions.
 ## DROP VIEW
 
 {% highlight sql %}
-DROP [TEMPORARY] VIEW  [ IF EXISTS ] view_name
+DROP [TEMPORARY] VIEW  [IF EXISTS] [catalog_name.][db_name.]view_name
 {% endhighlight %}
 
 Drop a view that has catalog and database namespaces. If the view to drop does not exist, an exception is thrown.
 
-**IF EXISTS**
-
-If the view does not exist, nothing happens.
-
 **TEMPORARY**
 
 Drop temporary view that has catalog and database namespaces.
+
+**IF EXISTS**
+
+If the view does not exist, nothing happens.
 
 ## DROP FUNCTION
 

--- a/docs/dev/table/sql/drop.md
+++ b/docs/dev/table/sql/drop.md
@@ -160,6 +160,9 @@ Drop temporary view that has catalog and database namespaces.
 
 If the view does not exist, nothing happens.
 
+**MAINTAIN DEPENDENCIES**
+Flink does not maintain dependencies of view by CASCADE/RESTRICT keyword, the current lenient approach is producing postpone error message when user tries to use the view under the scenarios like the underlying table of view has been dropped.
+
 ## DROP FUNCTION
 
 {% highlight sql%}

--- a/docs/dev/table/sql/drop.zh.md
+++ b/docs/dev/table/sql/drop.zh.md
@@ -147,18 +147,18 @@ DROP DATABASE [IF EXISTS] [catalog_name.]db_name [ (RESTRICT | CASCADE) ]
 ## DROP VIEW
 
 {% highlight sql %}
-DROP [TEMPORARY] VIEW  [ IF EXISTS ] view_name
+DROP [TEMPORARY] VIEW  [IF EXISTS] [catalog_name.][db_name.]view_name
 {% endhighlight %}
 
 删除一个有 catalog 和数据库命名空间的视图。若需要删除的视图不存在，则会产生异常。
 
-**IF EXISTS**
-
-若视图不存在，则不会进行任何操作。
-
 **TEMPORARY**
 
 删除一个有 catalog 和数据库命名空间的临时视图。
+
+**IF EXISTS**
+
+若视图不存在，则不会进行任何操作。
 
 ## DROP FUNCTION
 

--- a/docs/dev/table/sql/drop.zh.md
+++ b/docs/dev/table/sql/drop.zh.md
@@ -161,7 +161,7 @@ DROP [TEMPORARY] VIEW  [IF EXISTS] [catalog_name.][db_name.]view_name
 若视图不存在，则不会进行任何操作。
 
 **依赖管理**
-Flink 没有使用 CASCADE / RESTRICT 关键字来维护视图的依赖关系，当前的简单方案是用户使用视图时再提示错误信息，比如在视图的底层表已经被删除等场景。
+Flink 没有使用 CASCADE / RESTRICT 关键字来维护视图的依赖关系，当前的方案是在用户使用视图时再提示错误信息，比如在视图的底层表已经被删除等场景。
 
 ## DROP FUNCTION
 

--- a/docs/dev/table/sql/drop.zh.md
+++ b/docs/dev/table/sql/drop.zh.md
@@ -31,6 +31,7 @@ Flink SQL 目前支持以下 DROP 语句：
 
 - DROP TABLE
 - DROP DATABASE
+- DROP VIEW
 - DROP FUNCTION
 
 ## 执行 DROP 语句
@@ -142,6 +143,22 @@ DROP DATABASE [IF EXISTS] [catalog_name.]db_name [ (RESTRICT | CASCADE) ]
 **CASCADE**
 
 删除一个非空数据库时，把相关联的表与函数一并删除。
+
+## DROP VIEW
+
+{% highlight sql %}
+DROP [TEMPORARY] VIEW  [ IF EXISTS ] view_name
+{% endhighlight %}
+
+删除一个有 catalog 和数据库命名空间的视图。若需要删除的视图不存在，则会产生异常。
+
+**IF EXISTS**
+
+若视图不存在，则不会进行任何操作。
+
+**TEMPORARY**
+
+删除一个有 catalog 和数据库命名空间的临时视图。
 
 ## DROP FUNCTION
 

--- a/docs/dev/table/sql/drop.zh.md
+++ b/docs/dev/table/sql/drop.zh.md
@@ -160,6 +160,9 @@ DROP [TEMPORARY] VIEW  [IF EXISTS] [catalog_name.][db_name.]view_name
 
 若视图不存在，则不会进行任何操作。
 
+**依赖管理**
+Flink 没有使用 CASCADE / RESTRICT 关键字来维护视图的依赖关系，当前的简单方案是用户使用视图时再提示错误信息，比如在视图的底层表已经被删除等场景。
+
 ## DROP FUNCTION
 
 {% highlight sql%}

--- a/docs/dev/table/sql/index.md
+++ b/docs/dev/table/sql/index.md
@@ -29,8 +29,8 @@ This page describes the SQL language supported in Flink, including Data Definiti
 This page lists all the supported statements supported in Flink SQL for now:
 
 - [SELECT (Queries)](queries.html)
-- [CREATE TABLE, DATABASE, FUNCTION](create.html)
-- [DROP TABLE, DATABASE, FUNCTION](drop.html)
+- [CREATE TABLE, DATABASE, VIEW, FUNCTION](create.html)
+- [DROP TABLE, DATABASE, VIEW, FUNCTION](drop.html)
 - [ALTER TABLE, DATABASE, FUNCTION](alter.html)
 - [INSERT](insert.html)
 

--- a/docs/dev/table/sql/index.zh.md
+++ b/docs/dev/table/sql/index.zh.md
@@ -29,8 +29,8 @@ under the License.
 本页面列出了目前 Flink SQL 所支持的所有语句：
 
 - [SELECT (查询)](queries.html)
-- [CREATE TABLE, DATABASE, FUNCTION](create.html)
-- [DROP TABLE, DATABASE, FUNCTION](drop.html)
+- [CREATE TABLE, DATABASE, VIEW, FUNCTION](create.html)
+- [DROP TABLE, DATABASE, VIEW, FUNCTION](drop.html)
 - [ALTER TABLE, DATABASE, FUNCTION](alter.html)
 - [INSERT](insert.html)
 

--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -285,7 +285,7 @@ String literals must be enclosed in single quotes (e.g., `SELECT 'Hello World'`)
 
 ## Operations
 
-### Show and Use
+### Show, Describe, and Use
 
 <div markdown="1">
 <table class="table table-bordered">
@@ -314,8 +314,28 @@ SHOW DATABASES;
 {% highlight sql %}
 SHOW TABLES;
 {% endhighlight %}
+        <p>Show all views in the current database in the current catalog</p>
+{% highlight sql %}
+SHOW VIEWS;
+{% endhighlight %}
       </td>
     </tr>
+    <tr>
+      <td>
+        <strong>Describe</strong><br>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+      </td>
+      <td>
+			<p>Describe the given table.</p>
+{% highlight sql %}
+DESCRIBE myTable;
+{% endhighlight %}
+            <p>Describe the given view.</p>
+{% highlight sql %}
+DESCRIBE myView;
+{% endhighlight %}
+      </td>
+    </tr>    
     <tr>
       <td>
         <strong>Use</strong><br>

--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -326,11 +326,11 @@ SHOW VIEWS;
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
       <td>
-			<p>Describe the given table.</p>
+			<p>Describe the schema of the given table.</p>
 {% highlight sql %}
 DESCRIBE myTable;
 {% endhighlight %}
-            <p>Describe the given view.</p>
+            <p>Describe the schema of the given view.</p>
 {% highlight sql %}
 DESCRIBE myView;
 {% endhighlight %}

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -326,11 +326,11 @@ SHOW VIEWS;
         <span class="label label-primary">批处理</span> <span class="label label-primary">流处理</span>
       </td>
       <td>
-			<p>描述给定表的元数据.</p>
+			<p>描述给定表的模式.</p>
 {% highlight sql %}
 DESCRIBE myTable;
 {% endhighlight %}
-            <p>描述给定视图的元数据.</p>
+            <p>描述给定视图的模式.</p>
 {% highlight sql %}
 DESCRIBE myView;
 {% endhighlight %}

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -285,7 +285,7 @@ Flink SQL 对于标识符（表、属性、函数名）有类似于 Java 的词�
 
 ## 操作符
 
-### Show 与 Use
+### Show, Describe 与 Use
 
 <div markdown="1">
 <table class="table table-bordered">
@@ -314,8 +314,28 @@ SHOW DATABASES;
 {% highlight sql %}
 SHOW TABLES;
 {% endhighlight %}
+        <p>显示当前数据库、Catalog中的所有视图</p>
+{% highlight sql %}
+SHOW VIEWS;
+{% endhighlight %}
       </td>
     </tr>
+    <tr>
+      <td>
+        <strong>Describe</strong><br>
+        <span class="label label-primary">批处理</span> <span class="label label-primary">流处理</span>
+      </td>
+      <td>
+			<p>描述给定表的元数据.</p>
+{% highlight sql %}
+DESCRIBE myTable;
+{% endhighlight %}
+            <p>描述给定视图的元数据.</p>
+{% highlight sql %}
+DESCRIBE myView;
+{% endhighlight %}
+      </td>
+    </tr>    
     <tr>
       <td>
         <strong>Use</strong><br>

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -326,11 +326,11 @@ SHOW VIEWS;
         <span class="label label-primary">批处理</span> <span class="label label-primary">流处理</span>
       </td>
       <td>
-			<p>描述给定表的模式.</p>
+			<p>描述给定表的 Schema</p>
 {% highlight sql %}
 DESCRIBE myTable;
 {% endhighlight %}
-            <p>描述给定视图的模式.</p>
+            <p>描述给定视图的 Schema</p>
 {% highlight sql %}
 DESCRIBE myView;
 {% endhighlight %}


### PR DESCRIPTION
## What is the purpose of the change

* We support Create/Drop/DESCRIBE view in 1.11. this pull request Add documentation about view support.


## Brief change log

  - *Add Create/Drop/DESCRIBE view section in SQL documentation*
  - *Translate corresponding Chinese documentation*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
