### PR TITLE
[FLINK-18162][connector/common] Serialize the splits in the AddSplitsEvent

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
@@ -73,8 +74,10 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
 		CoordinatorExecutorThreadFactory coordinatorThreadFactory =
 				new CoordinatorExecutorThreadFactory(coordinatorThreadName);
 		ExecutorService coordinatorExecutor = Executors.newSingleThreadExecutor(coordinatorThreadFactory);
+		SimpleVersionedSerializer<SplitT> splitSerializer = source.getSplitSerializer();
 		SourceCoordinatorContext<SplitT> sourceCoordinatorContext =
-				new SourceCoordinatorContext<>(coordinatorExecutor, coordinatorThreadFactory, numWorkerThreads, context);
+				new SourceCoordinatorContext<>(coordinatorExecutor, coordinatorThreadFactory, numWorkerThreads,
+						context, splitSerializer);
 		return new SourceCoordinator<>(operatorName, coordinatorExecutor, source, sourceCoordinatorContext);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/AddSplitEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/AddSplitEvent.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.runtime.source.event;
 
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,15 +33,23 @@ import java.util.List;
 public class AddSplitEvent<SplitT> implements OperatorEvent {
 
 	private static final long serialVersionUID = 1L;
+	private final int serializerVersion;
+	private final ArrayList<byte[]> splits;
 
-	private final List<SplitT> splits;
-
-	public AddSplitEvent(List<SplitT> splits) {
-		this.splits = splits;
+	public AddSplitEvent(List<SplitT> splits, SimpleVersionedSerializer<SplitT> splitSerializer) throws IOException {
+		this.splits = new ArrayList<>(splits.size());
+		this.serializerVersion = splitSerializer.getVersion();
+		for (SplitT split : splits) {
+			this.splits.add(splitSerializer.serialize(split));
+		}
 	}
 
-	public List<SplitT> splits() {
-		return splits;
+	public List<SplitT> splits(SimpleVersionedSerializer<SplitT> splitSerializer) throws IOException {
+		List<SplitT> result = new ArrayList<>(splits.size());
+		for (byte[] serializedSplit : splits) {
+			result.add(splitSerializer.deserialize(serializerVersion, serializedSplit));
+		}
+		return result;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -71,16 +72,16 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 	}
 
 	@Test
-	public void testAssignSplitsFromCoordinatorExecutor() throws ExecutionException, InterruptedException {
+	public void testAssignSplitsFromCoordinatorExecutor() throws Exception {
 		testAssignSplits(true);
 	}
 
 	@Test
-	public void testAssignSplitsFromOtherThread() throws ExecutionException, InterruptedException {
+	public void testAssignSplitsFromOtherThread() throws Exception {
 		testAssignSplits(false);
 	}
 
-	private void testAssignSplits(boolean fromCoordinatorExecutor) throws ExecutionException, InterruptedException {
+	private void testAssignSplits(boolean fromCoordinatorExecutor) throws Exception {
 		// Register the readers.
 		registerReaders();
 
@@ -104,7 +105,7 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 		assertEquals(1, eventsToSubtask0.size());
 		OperatorEvent event = eventsToSubtask0.get(0);
 		assertTrue(event instanceof AddSplitEvent);
-		verifyAssignment(Arrays.asList("0"), ((AddSplitEvent) event).splits());
+		verifyAssignment(Arrays.asList("0"), ((AddSplitEvent) event).splits(new MockSourceSplitSerializer()));
 	}
 
 	@Test
@@ -153,6 +154,7 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 					coordinatorThreadFactory,
 					1,
 					operatorCoordinatorContext,
+					new MockSourceSplitSerializer(),
 					restoredTracker);
 			restoredContext.restoreState(new MockSourceSplitSerializer(), in);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -32,10 +32,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.getSplitsAssignment;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyAssignment;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumerator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
@@ -28,6 +29,7 @@ import org.apache.flink.runtime.source.event.SourceEventWrapper;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -165,8 +167,14 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 
 			List<OperatorEvent> eventsToReader0 = operatorCoordinatorContext.getEventsToOperator().get(0);
 			assertEquals(2, eventsToReader0.size());
-			verifyAssignment(Arrays.asList("0", "3"), ((AddSplitEvent<MockSourceSplit>) eventsToReader0.get(0)).splits());
-			verifyAssignment(Arrays.asList("6"), ((AddSplitEvent<MockSourceSplit>) eventsToReader0.get(1)).splits());
+			try {
+				verifyAssignment(Arrays.asList("0", "3"),
+						((AddSplitEvent<MockSourceSplit>) eventsToReader0.get(0)).splits(new MockSourceSplitSerializer()));
+				verifyAssignment(Arrays.asList("6"),
+						((AddSplitEvent<MockSourceSplit>) eventsToReader0.get(1)).splits(new MockSourceSplitSerializer()));
+			} catch (IOException e) {
+				fail("Failed to deserialize splits.");
+			}
 		});
 
 		// Fail reader 0.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumerator;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
@@ -63,6 +64,7 @@ public abstract class SourceCoordinatorTestBase {
 				coordinatorThreadFactory,
 				1,
 				operatorCoordinatorContext,
+				new MockSourceSplitSerializer(),
 				splitSplitAssignmentTracker);
 		sourceCoordinator = getNewSourceCoordinator();
 		enumerator = (MockSplitEnumerator) sourceCoordinator.getEnumerator();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -103,7 +103,8 @@ public class SourceOperatorTest {
 		operator.initializeState(getStateContext());
 		operator.open();
 		MockSourceSplit newSplit = new MockSourceSplit((2));
-		operator.handleOperatorEvent(new AddSplitEvent<>(Collections.singletonList(newSplit)));
+		operator.handleOperatorEvent(new AddSplitEvent<>(
+				Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
 		// The source reader should have been assigned two splits.
 		assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), mockSourceReader.getAssignedSplits());
 	}
@@ -124,7 +125,8 @@ public class SourceOperatorTest {
 		operator.initializeState(stateContext);
 		operator.open();
 		MockSourceSplit newSplit = new MockSourceSplit((2));
-		operator.handleOperatorEvent(new AddSplitEvent<>(Collections.singletonList(newSplit)));
+		operator.handleOperatorEvent(new AddSplitEvent<>(
+				Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
 		operator.snapshotState(new StateSnapshotContextSynchronousImpl(100L, 100L));
 
 		// Verify the splits in state.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -152,7 +153,8 @@ public class SourceOperatorStreamTaskTest {
 			// Prepare the source split and assign it to the source reader.
 			MockSourceSplit split = new MockSourceSplit(0, 0);
 			// Assign the split to the source reader.
-			AddSplitEvent<MockSourceSplit> addSplitEvent = new AddSplitEvent<>(Collections.singletonList(split));
+			AddSplitEvent<MockSourceSplit> addSplitEvent =
+					new AddSplitEvent<>(Collections.singletonList(split), new MockSourceSplitSerializer());
 			testHarness
 					.getStreamTask()
 					.dispatchOperatorEvent(OPERATOR_ID, new SerializedValue<>(addSplitEvent));


### PR DESCRIPTION
## What is the purpose of the change
The `AddSplitsEvent` contains a list of `SourceSplit` to be sent from the source coordinator to the source reader.  Currently the `AddSplitsEvent` is a serializable but the `SourceSplit` is not serializable as we expect the users to provide a split serializer. In order to make sure the `AddSplitsEvent` is serializable, we need to use the user provided split serializer to save the serialized splits in the `AddSplitsEvent` instead of having the split objects.

## Brief change log
90d421fc94e29c0af0fa563661b9dd8f2a388b1b changes the `AddSplitsEvent` to save the serialized splits instead of the original instance.

## Verifying this change
Existing unit tests covers the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
