### PR TITLE
[FLINK-18063][checkpointing] Fix the race condition for aborting current checkpoint in CheckpointBarrierUnaligner

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
@@ -96,7 +96,7 @@ class AlternatingCheckpointBarrierHandler extends CheckpointBarrierHandler {
 
 	@Override
 	public long getAlignmentDurationNanos() {
-		return alignedHandler.getAlignmentDurationNanos();
+		return activeHandler.getAlignmentDurationNanos();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -93,6 +93,14 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 	}
 
 	@Override
+	public void abortPendingCheckpoint(long checkpointId, CheckpointException exception) throws IOException {
+		if (checkpointId > currentCheckpointId && isCheckpointPending()) {
+			releaseBlocksAndResetBarriers();
+			notifyAbort(currentCheckpointId, exception);
+		}
+	}
+
+	@Override
 	public void releaseBlocksAndResetBarriers() {
 		LOG.debug("{}: End of stream alignment, feeding buffered data back.", taskName);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -60,7 +60,9 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 	 * @param channelIndex The channel index to check.
 	 * @return True if the channel is blocked, false if not.
 	 */
-	public abstract boolean isBlocked(int channelIndex);
+	public boolean isBlocked(int channelIndex) {
+		return false;
+	}
 
 	@Override
 	public void close() throws IOException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -52,7 +52,8 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 		this.toNotifyOnCheckpoint = checkNotNull(toNotifyOnCheckpoint);
 	}
 
-	public abstract void releaseBlocksAndResetBarriers();
+	public void releaseBlocksAndResetBarriers() {
+	}
 
 	/**
 	 * Checks whether the channel with the given index is blocked.
@@ -138,4 +139,7 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 	}
 
 	protected abstract boolean isCheckpointPending();
+
+	protected void abortPendingCheckpoint(long checkpointId, CheckpointException exception) throws IOException {
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -76,7 +76,9 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 
 	public abstract long getLatestCheckpointId();
 
-	public abstract long getAlignmentDurationNanos();
+	public long getAlignmentDurationNanos() {
+		return 0;
+	}
 
 	public long getCheckpointStartDelayNanos() {
 		return latestCheckpointStartDelayNanos;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
@@ -217,10 +217,6 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 		return pendingCheckpoints.isEmpty() ? -1 : pendingCheckpoints.peekLast().checkpointId();
 	}
 
-	public long getAlignmentDurationNanos() {
-		return 0;
-	}
-
 	public boolean isCheckpointPending() {
 		return !pendingCheckpoints.isEmpty();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
@@ -75,11 +75,6 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 		this.pendingCheckpoints = new ArrayDeque<>();
 	}
 
-	@Override
-	public void releaseBlocksAndResetBarriers() {
-	}
-
-	@Override
 	public void processBarrier(CheckpointBarrier receivedBarrier, int channelIndex) throws Exception {
 		final long barrierId = receivedBarrier.getId();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
@@ -80,11 +80,6 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 	}
 
 	@Override
-	public boolean isBlocked(int channelIndex) {
-		return false;
-	}
-
-	@Override
 	public void processBarrier(CheckpointBarrier receivedBarrier, int channelIndex) throws Exception {
 		final long barrierId = receivedBarrier.getId();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
@@ -117,17 +117,6 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 		threadSafeUnaligner = new ThreadSafeUnaligner(totalNumChannels,	checkNotNull(channelStateWriter), this);
 	}
 
-	@Override
-	public void releaseBlocksAndResetBarriers() {
-		if (isCheckpointPending()) {
-			// make sure no additional data is persisted
-			Arrays.fill(hasInflightBuffers, false);
-			// the next barrier that comes must assume it is the first
-			numBarrierConsumed = 0;
-		}
-		threadSafeUnaligner.resetReceivedBarriers(currentConsumedCheckpointId);
-	}
-
 	/**
 	 * We still need to trigger checkpoint via {@link ThreadSafeUnaligner#notifyBarrierReceived(CheckpointBarrier, InputChannelInfo)}
 	 * while reading the first barrier from one channel, because this might happen
@@ -155,41 +144,46 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 	}
 
 	@Override
+	public void abortPendingCheckpoint(long checkpointId, CheckpointException exception) throws IOException {
+		threadSafeUnaligner.tryAbortPendingCheckpoint(checkpointId, exception);
+
+		if (checkpointId > currentConsumedCheckpointId) {
+			resetPendingCheckpoint(checkpointId);
+		}
+	}
+
+	@Override
 	public void processCancellationBarrier(CancelCheckpointMarker cancelBarrier) throws Exception {
-		long cancelledId = cancelBarrier.getCheckpointId();
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("{}: Checkpoint {} canceled, aborting alignment.", taskName, cancelledId);
-		}
-
-		if (currentConsumedCheckpointId >= cancelledId && !isCheckpointPending()) {
-			return;
-		}
-
-		if (isCheckpointPending()) {
-			LOG.warn("{}: Received cancellation barrier for checkpoint {} before completing current checkpoint {}. " +
-					"Skipping current checkpoint.",
-				taskName,
+		final long cancelledId = cancelBarrier.getCheckpointId();
+		boolean shouldAbort = threadSafeUnaligner.setCancelledCheckpointId(cancelledId);
+		if (shouldAbort) {
+			notifyAbort(
 				cancelledId,
-				currentConsumedCheckpointId);
+				new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER));
 		}
 
-		releaseBlocksAndResetBarriers();
-		currentConsumedCheckpointId = cancelledId;
-		threadSafeUnaligner.setCurrentReceivedCheckpointId(currentConsumedCheckpointId);
-		notifyAbortOnCancellationBarrier(cancelledId);
+		if (cancelledId >= currentConsumedCheckpointId) {
+			resetPendingCheckpoint(cancelledId);
+			currentConsumedCheckpointId = cancelledId;
+		}
 	}
 
 	@Override
 	public void processEndOfPartition() throws Exception {
 		threadSafeUnaligner.onChannelClosed();
+		resetPendingCheckpoint(-1L);
+	}
 
+	private void resetPendingCheckpoint(long checkpointId) {
 		if (isCheckpointPending()) {
-			// let the task know we skip a checkpoint
-			notifyAbort(
-				currentConsumedCheckpointId,
-				new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED_INPUT_END_OF_STREAM));
-			// no chance to complete this checkpoint
-			releaseBlocksAndResetBarriers();
+			LOG.warn("{}: Received barrier or EndOfPartition(-1) {} before completing current checkpoint {}. " +
+					"Skipping current checkpoint.",
+				taskName,
+				checkpointId,
+				currentConsumedCheckpointId);
+
+			Arrays.fill(hasInflightBuffers, false);
+			numBarrierConsumed = 0;
 		}
 	}
 
@@ -360,15 +354,6 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 			channelStateWriter.start(barrierId, barrier.getCheckpointOptions());
 		}
 
-		synchronized void resetReceivedBarriers(long checkpointId) {
-			if (checkpointId >= currentReceivedCheckpointId && numBarriersReceived > 0) {
-				// avoid more data being serialized after abortion
-				Arrays.fill(storeNewBuffers, false);
-				// the next barrier that comes must assume it is the first
-				numBarriersReceived = 0;
-			}
-		}
-
 		synchronized CompletableFuture<Void> getAllBarriersReceivedFuture(long checkpointId) {
 			if (checkpointId < currentReceivedCheckpointId) {
 				return FutureUtils.completedVoidFuture();
@@ -379,12 +364,40 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 			return allBarriersReceivedFuture;
 		}
 
-		synchronized void onChannelClosed() {
+		synchronized void onChannelClosed() throws IOException {
 			numOpenChannels--;
+
+			if (resetPendingCheckpoint()) {
+				handler.notifyAbort(
+					currentReceivedCheckpointId,
+					new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED_INPUT_END_OF_STREAM));
+			}
 		}
 
-		synchronized void setCurrentReceivedCheckpointId(long currentReceivedCheckpointId) {
-			this.currentReceivedCheckpointId = Math.max(currentReceivedCheckpointId, this.currentReceivedCheckpointId);
+		synchronized boolean setCancelledCheckpointId(long cancelledId) {
+			if (currentReceivedCheckpointId > cancelledId || (currentReceivedCheckpointId == cancelledId && numBarriersReceived == 0)) {
+				return false;
+			}
+
+			resetPendingCheckpoint();
+			currentReceivedCheckpointId = cancelledId;
+			return true;
+		}
+
+		synchronized void tryAbortPendingCheckpoint(long checkpointId, CheckpointException exception) throws IOException {
+			if (checkpointId > currentReceivedCheckpointId && resetPendingCheckpoint()) {
+				handler.notifyAbort(currentReceivedCheckpointId, exception);
+			}
+		}
+
+		private boolean resetPendingCheckpoint() {
+			if (numBarriersReceived == 0) {
+				return false;
+			}
+
+			Arrays.fill(storeNewBuffers, false);
+			numBarriersReceived = 0;
+			return true;
 		}
 
 		@VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
@@ -347,10 +347,6 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 			allBarriersReceivedFuture.cancel(false);
 		}
 
-		boolean isCheckpointPending() {
-			return numBarriersReceived > 0;
-		}
-
 		private synchronized void handleNewCheckpoint(CheckpointBarrier barrier) throws IOException {
 			long barrierId = barrier.getId();
 			if (!allBarriersReceivedFuture.isDone() && isCheckpointPending()) {
@@ -409,8 +405,14 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 			return numOpenChannels;
 		}
 
+		@VisibleForTesting
 		synchronized long getCurrentCheckpointId() {
 			return currentReceivedCheckpointId;
+		}
+
+		@VisibleForTesting
+		boolean isCheckpointPending() {
+			return numBarriersReceived > 0;
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
@@ -129,14 +129,6 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 	}
 
 	/**
-	 * For unaligned checkpoint, it never blocks processing from the task aspect.
-	 */
-	@Override
-	public boolean isBlocked(int channelIndex) {
-		return false;
-	}
-
-	/**
 	 * We still need to trigger checkpoint via {@link ThreadSafeUnaligner#notifyBarrierReceived(CheckpointBarrier, InputChannelInfo)}
 	 * while reading the first barrier from one channel, because this might happen
 	 * earlier than the previous async trigger via mailbox by netty thread.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
@@ -199,11 +199,6 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 	}
 
 	@Override
-	public long getAlignmentDurationNanos() {
-		return 0;
-	}
-
-	@Override
 	public String toString() {
 		return String.format("%s: last checkpoint: %d", taskName, currentConsumedCheckpointId);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -185,7 +185,8 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 	 *
 	 * @return The ID of the pending of completed checkpoint.
 	 */
-	public long getLatestCheckpointId() {
+	@VisibleForTesting
+	long getLatestCheckpointId() {
 		return barrierHandler.getLatestCheckpointId();
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerCancellationTest.java
@@ -70,7 +70,7 @@ public class CheckpointBarrierUnalignerCancellationTest {
 				new Object[]{true, false, Arrays.asList(checkpoint(20), checkpoint(10)), 1, 0},
 				new Object[]{true, true, Arrays.asList(checkpoint(10), cancel(10)), 1, 0},
 				new Object[]{true, true, Arrays.asList(checkpoint(10), cancel(20)), 1, 0},
-				new Object[]{true, true, Arrays.asList(checkpoint(20), cancel(10)), 1, 0},
+				new Object[]{true, false, Arrays.asList(checkpoint(20), cancel(10)), 1, 0},
 		};
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

 There are three aborting scenarios which might encounter race condition:
    
    1. CheckpointBarrierUnaligner#processCancellationBarrier
    2. CheckpointBarrierUnaligner#processEndOfPartition
    3. AlternatingCheckpointBarrierHandler#processBarrier
    
They only consider the pending checkpoint triggered by #processBarrier from task thread to abort it. Actually the checkpoint might also be triggered by #notifyBarrierReceived from netty thread in race condition, so we should also handle properly to abort it.

## Brief change log

- Fix the process of `AlternatingCheckpointBarrierHandler#processBarrier`
- Fix the process of `CheckpointBarrierUnaligner#processEndOfPartition` to abort checkpoint properly
- Fix the process of `CheckpointBarrierUnaligner#processCancellationBarrier` to abort checkpoint properly

## Verifying this change

- Added new unit test `CheckpointBarrierUnalignerTest#testProcessCancellationBarrierAfterNotifyBarrierReceived`
- Added new unit test `CheckpointBarrierUnalignerTest#testProcessCancellationBarrierAfterProcessBarrier`
- Added new unit test `CheckpointBarrierUnalignerTest#testProcessCancellationBarrierBeforeProcessAndReceiveBarrier`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
