### PR TITLE
[FLINK-18057][tests] Fix unstable test SingleInputGateTest#testConcurrentReadStateAndProcessAndClose

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -84,6 +84,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -236,9 +237,12 @@ public class SingleInputGateTest extends InputGateTestBase {
 			};
 
 			submitTasksAndWaitForResults(executor, new Callable[] {closeTask, readRecoveredStateTask, processStateTask});
-			assertEquals(totalBuffers, environment.getNetworkBufferPool().getNumberOfAvailableMemorySegments());
 		} finally {
 			executor.shutdown();
+			// wait until the internal channel state recover task finishes
+			executor.awaitTermination(60, TimeUnit.SECONDS);
+			assertEquals(totalBuffers, environment.getNetworkBufferPool().getNumberOfAvailableMemorySegments());
+
 			environment.close();
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

Fix unstable test SingleInputGateTest#testConcurrentReadStateAndProcessAndClose

## Brief change log

  - Fix unstable test SingleInputGateTest#testConcurrentReadStateAndProcessAndClose


## Verifying this change

This change is a trivial work.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
