### PR TITLE
[FLINK-18157][runtime] Jobstore size check compares against offHeapMemory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -88,16 +88,16 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 		}
 	}
 
-	private static void verifyJobStoreCacheSize(Configuration config, MemorySize jvmHeapSize) {
+	private static void verifyJobStoreCacheSize(Configuration config, MemorySize offHeapMemorySize) {
 		MemorySize jobStoreCacheHeapSize =
 			MemorySize.parse(config.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE) + "b");
-		if (jvmHeapSize.compareTo(jobStoreCacheHeapSize) < 1) {
+		if (offHeapMemorySize.compareTo(jobStoreCacheHeapSize) < 1) {
 			LOG.warn(
-				"The configured or derived JVM heap memory size ({}: {}) is less than the configured or default size " +
+				"The configured or derived JVM off-Heap memory size ({}: {}) is less than the configured or default size " +
 					"of the job store cache ({}: {})",
+				JobManagerOptions.OFF_HEAP_MEMORY.key(),
+				offHeapMemorySize.toHumanReadableString(),
 				JobManagerOptions.JOB_STORE_CACHE_SIZE.key(),
-				jvmHeapSize.toHumanReadableString(),
-				JobManagerOptions.JVM_HEAP_MEMORY.key(),
 				jobStoreCacheHeapSize.toHumanReadableString());
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -75,12 +75,12 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 			MemorySize jvmHeap,
 			MemorySize offHeapMemory) {
 		verifyJvmHeapSize(jvmHeap);
-		verifyJobStoreCacheSize(config, offHeapMemory);
+		verifyJobStoreCacheSize(config, jvmHeap);
 		return new JobManagerFlinkMemory(jvmHeap, offHeapMemory);
 	}
 
 	private static void verifyJvmHeapSize(MemorySize jvmHeapSize) {
-		if (jvmHeapSize.compareTo(JobManagerOptions.MIN_JVM_HEAP_SIZE) < 1) {
+		if (jvmHeapSize.compareTo(JobManagerOptions.MIN_JVM_HEAP_SIZE) < 0) {
 			LOG.warn(
 				"The configured or derived JVM heap memory size ({}) is less than its recommended minimum value ({})",
 				jvmHeapSize.toHumanReadableString(),
@@ -88,15 +88,15 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 		}
 	}
 
-	private static void verifyJobStoreCacheSize(Configuration config, MemorySize offHeapMemorySize) {
+	private static void verifyJobStoreCacheSize(Configuration config, MemorySize jvmHeapSize) {
 		MemorySize jobStoreCacheHeapSize =
 			MemorySize.parse(config.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE) + "b");
-		if (offHeapMemorySize.compareTo(jobStoreCacheHeapSize) < 1) {
+		if (jvmHeapSize.compareTo(jobStoreCacheHeapSize) < 0) {
 			LOG.warn(
-				"The configured or derived JVM off-Heap memory size ({}: {}) is less than the configured or default size " +
+				"The configured or derived JVM heap memory size ({}: {}) is less than the configured or default size " +
 					"of the job store cache ({}: {})",
-				JobManagerOptions.OFF_HEAP_MEMORY.key(),
-				offHeapMemorySize.toHumanReadableString(),
+				JobManagerOptions.JVM_HEAP_MEMORY.key(),
+				jvmHeapSize.toHumanReadableString(),
 				JobManagerOptions.JOB_STORE_CACHE_SIZE.key(),
 				jobStoreCacheHeapSize.toHumanReadableString());
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -84,7 +84,7 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 			LOG.warn(
 				"The configured or derived JVM heap memory size ({}) is less than its recommended minimum value ({})",
 				jvmHeapSize.toHumanReadableString(),
-				JobManagerOptions.MIN_JVM_HEAP_SIZE);
+				JobManagerOptions.MIN_JVM_HEAP_SIZE.toHumanReadableString());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
@@ -68,7 +68,7 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 	}
 
 	@Test
-	public void testLogVerifyJvmHeapSizeAndJobStoreCacheSize() {
+	public void testLogFailureOfJvmHeapSizeMinSizeVerification() {
 		MemorySize jvmHeapMemory = MemorySize.parse("50m");
 
 		Configuration conf = new Configuration();
@@ -77,22 +77,27 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 		JobManagerProcessUtils.processSpecFromConfig(conf);
 		MatcherAssert.assertThat(
 			testLoggerResource.getMessages(),
-			hasItem(containsString(String.format("The configured or derived JVM heap memory size (%s) is less than its recommended minimum value (%s)",
+			hasItem(containsString(String.format(
+				"The configured or derived JVM heap memory size (%s) is less than its recommended minimum value (%s)",
 				jvmHeapMemory.toHumanReadableString(),
 				JobManagerOptions.MIN_JVM_HEAP_SIZE.toHumanReadableString()))));
+	}
 
-		jvmHeapMemory = MemorySize.parse("150m");
+	@Test
+	public void testLogFailureOfJobStoreCacheSizeVerification() {
+		MemorySize jvmHeapMemory = MemorySize.parse("150m");
+		MemorySize jobStoreCacheSize = MemorySize.parse("200m");
 
+		Configuration conf = new Configuration();
 		conf.set(JobManagerOptions.JVM_HEAP_MEMORY, jvmHeapMemory);
-		conf.set(JobManagerOptions.JOB_STORE_CACHE_SIZE, 200L * 1024L * 1024L);
+		conf.set(JobManagerOptions.JOB_STORE_CACHE_SIZE, jobStoreCacheSize.getBytes());
 
 		JobManagerProcessUtils.processSpecFromConfig(conf);
-		MemorySize jobStoreCacheSize =
-			MemorySize.parse(conf.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE) + "b");
 		MatcherAssert.assertThat(
 			testLoggerResource.getMessages(),
-			hasItem(containsString(String.format("The configured or derived JVM heap memory size (%s: %s) is less than the configured or default size " +
-				"of the job store cache (%s: %s)",
+			hasItem(containsString(String.format(
+				"The configured or derived JVM heap memory size (%s: %s) is less than the configured or default size " +
+					"of the job store cache (%s: %s)",
 				JobManagerOptions.JVM_HEAP_MEMORY.key(),
 				jvmHeapMemory.toHumanReadableString(),
 				JobManagerOptions.JOB_STORE_CACHE_SIZE.key(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
@@ -70,6 +70,20 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 	}
 
 	@Test
+	public void testConfigJvmHeapAndOffHeapMemory() {
+		MemorySize jvmHeapMemory = MemorySize.parse("50m");
+		MemorySize offHeapMemory = MemorySize.parse("40m");
+
+		Configuration conf = new Configuration();
+		conf.set(JobManagerOptions.JVM_HEAP_MEMORY, jvmHeapMemory);
+		conf.set(JobManagerOptions.OFF_HEAP_MEMORY, offHeapMemory);
+
+		JobManagerProcessSpec JobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(conf);
+		assertThat(JobManagerProcessSpec.getJvmHeapMemorySize(), is(jvmHeapMemory));
+		assertThat(JobManagerProcessSpec.getJvmDirectMemorySize(), is(offHeapMemory));
+	}
+
+	@Test
 	public void testFlinkInternalMemorySizeAddUpFailure() {
 		MemorySize totalFlinkMemory = MemorySize.parse("199m");
 		MemorySize jvmHeap = MemorySize.parse("100m");


### PR DESCRIPTION
## What is the purpose of the change

*Setting `jobmanager.memory.off-heap.size` to 0 results in this confusing error:`The configured or derived JVM heap memory size (jobstore.cache-size: 0 bytes) is less than the configured or default size of the job store cache (jobmanager.memory.heap.size: 50.000mb (52428800 bytes))`.  This log is confused for users, and should correct the content of this warn log. Method `verifyJobStoreCacheSize` in `JobManagerFlinkMemoryUtils` should correct validation result of jobstore cache size with jvm heap size.*

## Brief change log

  - *Correct warn log of method `verifyJobStoreCacheSize` in `JobManagerFlinkMemoryUtils`.*

## Verifying this change

  - *Add test method `testLogVerifyJvmHeapSizeAndJobStoreCacheSize` in `JobManagerProcessUtilsTest` to verfiy for JVM-Heap memory configuration and the case that JVM-Heap memory is less than default jobstore cache size.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
