### PR TITLE
[FLINK-18154][Runtime] Check Total Flink Memory plus JVM Metaspace is less than or equal to the configured Total Process Memory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/FlinkMemory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/FlinkMemory.java
@@ -24,6 +24,27 @@ import java.io.Serializable;
 
 /**
  * Memory components which constitute the Total Flink Memory.
+ *
+ * <p>The relationships of Flink JVM and rest memory components are shown below.
+ * <pre>
+ *               ┌ ─ ─  Total Flink Memory - ─ ─ ┐
+ *                 ┌───────────────────────────┐
+ *               | │       JVM Heap Memory     │ |
+ *                 └───────────────────────────┘
+ *               |┌ ─ ─ - - - Off-Heap  - - ─ ─ ┐|
+ *                │┌───────────────────────────┐│
+ *               │ │     JVM Direct Memory     │ │
+ *                │└───────────────────────────┘│
+ *               │ ┌───────────────────────────┐ │
+ *                ││   Rest Off-Heap Memory    ││
+ *               │ └───────────────────────────┘ │
+ *                └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+ *               └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+ * </pre>
+ *
+ * <p>The JVM and rest memory components can consist of further concrete Flink memory components depending on the process type.
+ * The Flink memory components can be derived from either its total size or a subset of configured required fine-grained components.
+ * Check the implementations for details about the concrete components.
  */
 public interface FlinkMemory extends Serializable {
 	MemorySize getJvmHeapMemorySize();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/FlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/FlinkMemoryUtils.java
@@ -22,8 +22,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 
 /**
- * Utility to derive Total Flink Memory from its required memory components and back.
- * @param <FM> the FLink memory components
+ * Utility to derive the {@link FlinkMemory} components.
+ *
+ * <p>The {@link FlinkMemory} represents memory components which constitute the Total Flink Memory.
+ * The Flink memory components can be derived from either its total size or a subset of configured required fine-grained components.
+ * See implementations for details about the concrete fine-grained components.
+ *
+ * @param <FM> the Flink memory components
  */
 public interface FlinkMemoryUtils<FM extends FlinkMemory> {
 	FM deriveFromRequiredFineGrainedOptions(Configuration config);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -30,6 +30,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * {@link FlinkMemoryUtils} for Job Manager.
+ *
+ * <p>The required fine-grained component is {@link JobManagerOptions#JVM_HEAP_MEMORY}.
  */
 public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFlinkMemory> {
 	private static final Logger LOG = LoggerFactory.getLogger(JobManagerFlinkMemoryUtils.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/taskmanager/TaskExecutorFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/taskmanager/TaskExecutorFlinkMemoryUtils.java
@@ -35,6 +35,9 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * {@link FlinkMemoryUtils} for Task Executor.
+ *
+ * <p>The required fine-grained components are {@link TaskManagerOptions#TASK_HEAP_MEMORY} and
+ * {@link TaskManagerOptions#MANAGED_MEMORY_SIZE}.
  */
 public class TaskExecutorFlinkMemoryUtils implements FlinkMemoryUtils<TaskExecutorFlinkMemory> {
 	private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorFlinkMemoryUtils.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -584,6 +584,17 @@ public class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<Tas
 		}
 	}
 
+	@Override
+	protected void configWithFineGrainedOptions(Configuration configuration, MemorySize totalFlinkMemorySize) {
+		MemorySize componentSize = new MemorySize(totalFlinkMemorySize.getBytes() / 6);
+		configuration.set(TaskManagerOptions.TASK_HEAP_MEMORY, componentSize);
+		configuration.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, componentSize);
+		configuration.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, componentSize);
+		configuration.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, componentSize);
+		configuration.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, componentSize);
+		// network is the 6th component, fixed implicitly
+	}
+
 	private static Configuration configWithExplicitTaskHeapAndManageMem() {
 		final Configuration conf = new Configuration();
 		conf.set(TaskManagerOptions.TASK_HEAP_MEMORY, TASK_HEAP_SIZE);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
@@ -199,6 +199,14 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 		}
 	}
 
+	@Override
+	protected void configWithFineGrainedOptions(Configuration configuration, MemorySize totalFlinkMemorySize) {
+		MemorySize heapSize = new MemorySize(totalFlinkMemorySize.getBytes() / 2);
+		MemorySize offHeapSize = totalFlinkMemorySize.subtract(heapSize);
+		configuration.set(JobManagerOptions.JVM_HEAP_MEMORY, heapSize);
+		configuration.set(JobManagerOptions.OFF_HEAP_MEMORY, offHeapSize);
+	}
+
 	private static Configuration configWithExplicitJvmHeap() {
 		Configuration conf = new Configuration();
 		conf.set(JobManagerOptions.JVM_HEAP_MEMORY, JVM_HEAP_SIZE);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtilsTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtilsTestBase.java
@@ -126,6 +126,35 @@ public abstract class ProcessMemoryUtilsTestBase<T extends ProcessMemorySpec> ex
 	}
 
 	@Test
+	public void testDerivedTotalProcessMemoryGreaterThanConfiguredFailureWithFineGrainedOptions() {
+		Configuration conf = getConfigurationWithJvmMetaspaceAndTotalFlinkMemory(100, 200);
+		// Total Flink memory + JVM Metaspace > Total Process Memory (no space for JVM overhead)
+		MemorySize totalFlinkMemorySize = MemorySize.ofMebiBytes(150);
+		configWithFineGrainedOptions(conf, totalFlinkMemorySize);
+		validateFail(conf);
+	}
+
+	@Test
+	public void testDerivedTotalProcessMemoryGreaterThanConfiguredFailureWithTotalFlinkMemory() {
+		Configuration conf = getConfigurationWithJvmMetaspaceAndTotalFlinkMemory(100, 200);
+		// Total Flink memory + JVM Metaspace > Total Process Memory (no space for JVM overhead)
+		MemorySize totalFlinkMemorySize = MemorySize.ofMebiBytes(150);
+		conf.set(options.getTotalFlinkMemoryOption(), totalFlinkMemorySize);
+		validateFail(conf);
+	}
+
+	private Configuration getConfigurationWithJvmMetaspaceAndTotalFlinkMemory(
+			long jvmMetaspaceSizeMb,
+			long totalProcessMemorySizeMb) {
+		MemorySize jvmMetaspaceSize = MemorySize.ofMebiBytes(jvmMetaspaceSizeMb);
+		MemorySize totalProcessMemorySize = MemorySize.ofMebiBytes(totalProcessMemorySizeMb);
+		Configuration conf = new Configuration();
+		conf.set(options.getJvmOptions().getJvmMetaspaceOption(), jvmMetaspaceSize);
+		conf.set(options.getTotalProcessMemoryOption(), totalProcessMemorySize);
+		return conf;
+	}
+
+	@Test
 	public void testConfigJvmMetaspaceSize() {
 		MemorySize jvmMetaspaceSize = MemorySize.parse("50m");
 
@@ -302,6 +331,8 @@ public abstract class ProcessMemoryUtilsTestBase<T extends ProcessMemorySpec> ex
 	protected abstract T processSpecFromConfig(Configuration config);
 
 	protected abstract Configuration getConfigurationWithLegacyHeapSizeMappedToNewConfigOption(Configuration config);
+
+	protected abstract void configWithFineGrainedOptions(Configuration configuration, MemorySize totalFlinkMemorySize);
 
 	protected ConfigOption<MemorySize> getNewOptionForLegacyHeapOption() {
 		return newOptionForLegacyHeapOption;


### PR DESCRIPTION
Check `totalProcessMemorySize >= totalFlinkAndJvmMetaspaceSize` in `ProcessMemoryUtils.deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory` to fail fast and log a descriptive error message.