### PR TITLE
[FLINK-16572][e2e][pubsub] Acknowledge message in previous test 

### DIFF
--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -82,7 +82,12 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils-junit</artifactId>
+			<scope>test</scope>
+        </dependency>
+    </dependencies>
 
 	<!-- ONLY run the tests when explicitly told to do so  -->
 	<properties>

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.connectors.gcp.pubsub.emulator;
 
+import org.apache.flink.util.TestLogger;
+
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
@@ -36,7 +38,7 @@ import static org.apache.flink.streaming.connectors.gcp.pubsub.emulator.GCloudEm
 /**
  * The base class from which unit tests should inherit if they need to use the Google cloud emulators.
  */
-public class GCloudUnitTestBase implements Serializable {
+public class GCloudUnitTestBase extends TestLogger implements Serializable {
 	@BeforeClass
 	public static void launchGCloudEmulator() throws Exception {
 		// Separated out into separate class so the entire test class to be serializable


### PR DESCRIPTION
## What is the purpose of the change

Further trying to fix the Pubsub test instability. Adding the logs hasn't really helped, but I noticed that the test running before the unstable test was incorrect.


## Brief change log

- Improve logging (Test logger)
- ack messages
- make the test more robust by making it fail on timeout.
