### PR TITLE
[FLINK-18181][fs-connector] StreamingFileCommitter should not use fs modification time for proc committer

### DIFF
--- a/docs/dev/table/connectors/filesystem.md
+++ b/docs/dev/table/connectors/filesystem.md
@@ -146,6 +146,8 @@ After writing a partition, it is often necessary to notify downstream applicatio
 - Trigger: The timing of the commit of the partition can be determined by the watermark with the time extracted from the partition, or by processing time.
 - Policy: How to commit a partition, built-in policies support for the commit of success files and metastore, you can also implement your own policies, such as triggering hive's analysis to generate statistics, or merging small files, etc.
 
+**NOTE:** Partition Commit only works in dynamic partition inserting.
+
 #### Partition commit trigger
 
 To define when to commit a partition, providing partition commit trigger:

--- a/docs/dev/table/connectors/filesystem.zh.md
+++ b/docs/dev/table/connectors/filesystem.zh.md
@@ -146,6 +146,8 @@ After writing a partition, it is often necessary to notify downstream applicatio
 - Trigger: The timing of the commit of the partition can be determined by the watermark with the time extracted from the partition, or by processing time.
 - Policy: How to commit a partition, built-in policies support for the commit of success files and metastore, you can also implement your own policies, such as triggering hive's analysis to generate statistics, or merging small files, etc.
 
+**NOTE:** Partition Commit only works in dynamic partition inserting.
+
 #### Partition commit trigger
 
 To define when to commit a partition, providing partition commit trigger:

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -127,6 +127,7 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 			StorageDescriptor sd = table.getSd();
 			HiveTableMetaStoreFactory msFactory = new HiveTableMetaStoreFactory(
 					jobConf, hiveVersion, dbName, tableName);
+			HadoopFileSystemFactory fsFactory = new HadoopFileSystemFactory(jobConf);
 
 			Class hiveOutputFormatClz = hiveShim.getHiveOutputFormatClass(
 					Class.forName(sd.getOutputFormat()));
@@ -158,7 +159,7 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 						partitionColumns));
 				builder.setDynamicGrouped(dynamicGrouping);
 				builder.setPartitionColumns(partitionColumns);
-				builder.setFileSystemFactory(new HadoopFileSystemFactory(jobConf));
+				builder.setFileSystemFactory(fsFactory);
 				builder.setFormatFactory(new HiveOutputFormatFactory(recordWriterFactory));
 				builder.setMetaStoreFactory(
 						msFactory);
@@ -213,7 +214,8 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 						overwrite,
 						dataStream,
 						builder,
-						msFactory);
+						msFactory,
+						fsFactory);
 			}
 		} catch (TException e) {
 			throw new CatalogException("Failed to query Hive metaStore", e);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.ValidationException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -99,7 +100,7 @@ public interface PartitionCommitPolicy {
 			String policyKind,
 			String customClass,
 			String successFileName,
-			FileSystem fileSystem) {
+			Supplier<FileSystem> fsSupplier) {
 		if (policyKind == null) {
 			return Collections.emptyList();
 		}
@@ -109,7 +110,7 @@ public interface PartitionCommitPolicy {
 				case METASTORE:
 					return new MetastoreCommitPolicy();
 				case SUCCESS_FILE:
-					return new SuccessFileCommitPolicy(successFileName, fileSystem);
+					return new SuccessFileCommitPolicy(successFileName, fsSupplier.get());
 				case CUSTOM:
 					try {
 						return (PartitionCommitPolicy) cl.loadClass(customClass).newInstance();


### PR DESCRIPTION

## What is the purpose of the change

The filesystem path modification time is the last modification time of all files in directory. 
If there is new data in partition all the time, it will never end.
We should use earlier time for committer.

## Brief change log

- Refactor `ProcTimeCommitTigger` to save the time when the partition just entered. And use this time to commit instead of filesystem path modification time.
- Use `FileSystemFactory` for better integration of external DFS.

## Verifying this change

Manually testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no