### PR TITLE
[FLINK-18175][conf] Log final memory configuration

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
@@ -21,13 +21,19 @@ package org.apache.flink.runtime.util.bash;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.jobmanager.JobManagerProcessSpec;
 import org.apache.flink.runtime.jobmanager.JobManagerProcessUtils;
 import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils;
+import org.apache.flink.runtime.util.config.memory.jobmanager.JobManagerFlinkMemory;
+import org.apache.flink.runtime.util.config.memory.taskmanager.TaskExecutorFlinkMemory;
 import org.apache.flink.util.FlinkException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,6 +45,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * Utility class for using java utilities in bash scripts.
  */
 public class BashJavaUtils {
+	private static final Logger LOG = LoggerFactory.getLogger(BashJavaUtils.class);
 
 	@VisibleForTesting
 	public static final String EXECUTION_PREFIX = "BASH_JAVA_UTILS_EXEC_RESULT:";
@@ -79,6 +86,9 @@ public class BashJavaUtils {
 			configuration,
 			TaskManagerOptions.TOTAL_FLINK_MEMORY);
 		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configurationWithFallback);
+
+		logTaskExecutorConfiguration(taskExecutorProcessSpec);
+
 		return Arrays.asList(
 			ProcessMemoryUtils.generateJvmParametersStr(taskExecutorProcessSpec),
 			TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec));
@@ -92,7 +102,40 @@ public class BashJavaUtils {
 		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 			configuration,
 			JobManagerOptions.JVM_HEAP_MEMORY);
+
+		logMasterConfiguration(jobManagerProcessSpec);
+
 		return Collections.singletonList(ProcessMemoryUtils.generateJvmParametersStr(jobManagerProcessSpec));
+	}
+
+	private static void logMasterConfiguration(JobManagerProcessSpec spec) {
+		JobManagerFlinkMemory flinkMemory = spec.getFlinkMemory();
+		LOG.info("Final Master Memory configuration:");
+		LOG.info("  Total Process Memory: {}", spec.getTotalProcessMemorySize().toHumanReadableString());
+		LOG.info("    Total Flink Memory: {}", flinkMemory.getTotalFlinkMemorySize().toHumanReadableString());
+		LOG.info("      Heap:             {}", flinkMemory.getJvmHeapMemorySize().toHumanReadableString());
+		LOG.info("      Off-heap:         {}", flinkMemory.getJvmDirectMemorySize().toHumanReadableString());
+		LOG.info("    JVM Metaspace:      {}", spec.getJvmMetaspaceSize().toHumanReadableString());
+		LOG.info("    JVM Overhead:       {}", spec.getJvmOverheadSize().toHumanReadableString());
+	}
+
+	private static void logTaskExecutorConfiguration(TaskExecutorProcessSpec spec) {
+		TaskExecutorFlinkMemory flinkMemory = spec.getFlinkMemory();
+		MemorySize totalOffHeapMemory = flinkMemory.getManaged().add(flinkMemory.getJvmDirectMemorySize());
+		LOG.info("Final TaskExecutor Memory configuration:");
+		LOG.info("  Total Process Memory:      {}", spec.getTotalProcessMemorySize().toHumanReadableString());
+		LOG.info("    Total Flink Memory:      {}", flinkMemory.getTotalFlinkMemorySize().toHumanReadableString());
+		LOG.info("      Total Heap Memory:     {}", flinkMemory.getJvmHeapMemorySize().toHumanReadableString());
+		LOG.info("        Framework:           {}", flinkMemory.getFrameworkHeap().toHumanReadableString());
+		LOG.info("        Task:                {}", flinkMemory.getTaskHeap().toHumanReadableString());
+		LOG.info("      Total Off-heap Memory: {}", totalOffHeapMemory.toHumanReadableString());
+		LOG.info("        Managed:             {}", flinkMemory.getManaged().toHumanReadableString());
+		LOG.info("        Total Direct Memory: {}", flinkMemory.getJvmDirectMemorySize().toHumanReadableString());
+		LOG.info("          Framework:         {}", flinkMemory.getFrameworkOffHeap().toHumanReadableString());
+		LOG.info("          Task:              {}", flinkMemory.getTaskOffHeap().toHumanReadableString());
+		LOG.info("          Network:           {}", flinkMemory.getNetwork().toHumanReadableString());
+		LOG.info("    JVM Metaspace:           {}", spec.getJvmMetaspaceSize().toHumanReadableString());
+		LOG.info("    JVM Overhead:            {}", spec.getJvmOverheadSize().toHumanReadableString());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
@@ -113,7 +113,7 @@ public class BashJavaUtils {
 		LOG.info("Final Master Memory configuration:");
 		LOG.info("  Total Process Memory: {}", spec.getTotalProcessMemorySize().toHumanReadableString());
 		LOG.info("    Total Flink Memory: {}", flinkMemory.getTotalFlinkMemorySize().toHumanReadableString());
-		LOG.info("      Heap:             {}", flinkMemory.getJvmHeapMemorySize().toHumanReadableString());
+		LOG.info("      JVM Heap:         {}", flinkMemory.getJvmHeapMemorySize().toHumanReadableString());
 		LOG.info("      Off-heap:         {}", flinkMemory.getJvmDirectMemorySize().toHumanReadableString());
 		LOG.info("    JVM Metaspace:      {}", spec.getJvmMetaspaceSize().toHumanReadableString());
 		LOG.info("    JVM Overhead:       {}", spec.getJvmOverheadSize().toHumanReadableString());
@@ -123,19 +123,19 @@ public class BashJavaUtils {
 		TaskExecutorFlinkMemory flinkMemory = spec.getFlinkMemory();
 		MemorySize totalOffHeapMemory = flinkMemory.getManaged().add(flinkMemory.getJvmDirectMemorySize());
 		LOG.info("Final TaskExecutor Memory configuration:");
-		LOG.info("  Total Process Memory:      {}", spec.getTotalProcessMemorySize().toHumanReadableString());
-		LOG.info("    Total Flink Memory:      {}", flinkMemory.getTotalFlinkMemorySize().toHumanReadableString());
-		LOG.info("      Total Heap Memory:     {}", flinkMemory.getJvmHeapMemorySize().toHumanReadableString());
-		LOG.info("        Framework:           {}", flinkMemory.getFrameworkHeap().toHumanReadableString());
-		LOG.info("        Task:                {}", flinkMemory.getTaskHeap().toHumanReadableString());
-		LOG.info("      Total Off-heap Memory: {}", totalOffHeapMemory.toHumanReadableString());
-		LOG.info("        Managed:             {}", flinkMemory.getManaged().toHumanReadableString());
-		LOG.info("        Total Direct Memory: {}", flinkMemory.getJvmDirectMemorySize().toHumanReadableString());
-		LOG.info("          Framework:         {}", flinkMemory.getFrameworkOffHeap().toHumanReadableString());
-		LOG.info("          Task:              {}", flinkMemory.getTaskOffHeap().toHumanReadableString());
-		LOG.info("          Network:           {}", flinkMemory.getNetwork().toHumanReadableString());
-		LOG.info("    JVM Metaspace:           {}", spec.getJvmMetaspaceSize().toHumanReadableString());
-		LOG.info("    JVM Overhead:            {}", spec.getJvmOverheadSize().toHumanReadableString());
+		LOG.info("  Total Process Memory:          {}", spec.getTotalProcessMemorySize().toHumanReadableString());
+		LOG.info("    Total Flink Memory:          {}", flinkMemory.getTotalFlinkMemorySize().toHumanReadableString());
+		LOG.info("      Total JVM Heap Memory:     {}", flinkMemory.getJvmHeapMemorySize().toHumanReadableString());
+		LOG.info("        Framework:               {}", flinkMemory.getFrameworkHeap().toHumanReadableString());
+		LOG.info("        Task:                    {}", flinkMemory.getTaskHeap().toHumanReadableString());
+		LOG.info("      Total Off-heap Memory:     {}", totalOffHeapMemory.toHumanReadableString());
+		LOG.info("        Managed:                 {}", flinkMemory.getManaged().toHumanReadableString());
+		LOG.info("        Total JVM Direct Memory: {}", flinkMemory.getJvmDirectMemorySize().toHumanReadableString());
+		LOG.info("          Framework:             {}", flinkMemory.getFrameworkOffHeap().toHumanReadableString());
+		LOG.info("          Task:                  {}", flinkMemory.getTaskOffHeap().toHumanReadableString());
+		LOG.info("          Network:               {}", flinkMemory.getNetwork().toHumanReadableString());
+		LOG.info("    JVM Metaspace:               {}", spec.getJvmMetaspaceSize().toHumanReadableString());
+		LOG.info("    JVM Overhead:                {}", spec.getJvmOverheadSize().toHumanReadableString());
 	}
 
 	/**


### PR DESCRIPTION
Adds some logging for the final memory configuration.

Examples of the logging output:

master:
```
Final Master Memory configuration:
  Total Process Memory: 1024.000mb (1073741824 bytes)
    Total Flink Memory: 576.000mb (603979776 bytes)
      Heap:             448.000mb (469762048 bytes)
      Off-heap:         128.000mb (134217728 bytes)
    JVM Metaspace:      256.000mb (268435456 bytes)
    JVM Overhead:       192.000mb (201326592 bytes)
```

taskexecutor:
```
Final TaskExecutor Memory configuration:
  Total Process Memory:      1024.000mb (1073741824 bytes)
    Total Flink Memory:      576.000mb (603979776 bytes)
      Total Heap Memory:     153.600mb (161061270 bytes)
        Framework:           128.000mb (134217728 bytes)
        Task:                25.600mb (26843542 bytes)
      Total Off-heap Memory: 422.400mb (442918506 bytes)
        Managed:             230.400mb (241591914 bytes)
        Total Direct Memory: 192.000mb (201326592 bytes)
          Framework:         128.000mb (134217728 bytes)
          Task:              0 bytes
          Network:           64.000mb (67108864 bytes)
    JVM Metaspace:           256.000mb (268435456 bytes)
    JVM Overhead:            192.000mb (201326592 bytes)
```