### PR TITLE
[javadocs] Fixed typo in Output.java

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Output.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Output.java
@@ -45,7 +45,7 @@ public interface Output<T> extends Collector<T> {
 	void emitWatermark(Watermark mark);
 
 	/**
-	 * Emits a record the side output identified by the given {@link OutputTag}.
+	 * Emits a record to the side output identified by the given {@link OutputTag}.
 	 *
 	 * @param record The record to collect.
 	 */


### PR DESCRIPTION
"Emits a record the side output identified...." -> "Emits a record to the side output identified..."