### PR TITLE
[FLINK-18207][FLINK-18185][table] Fix datagen connector bugs

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/StatefulSequenceSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/StatefulSequenceSourceTest.java
@@ -79,7 +79,7 @@ public class StatefulSequenceSourceTest {
 			@Override
 			public void run() {
 				try {
-					source1.run(new BlockingSourceContext("1", latchToTrigger1, latchToWait1, outputCollector, 21));
+					source1.run(new BlockingSourceContext<>("1", latchToTrigger1, latchToWait1, outputCollector, 21));
 				}
 				catch (Throwable t) {
 					t.printStackTrace();
@@ -93,7 +93,7 @@ public class StatefulSequenceSourceTest {
 			@Override
 			public void run() {
 				try {
-					source2.run(new BlockingSourceContext("2", latchToTrigger2, latchToWait2, outputCollector, 32));
+					source2.run(new BlockingSourceContext<>("2", latchToTrigger2, latchToWait2, outputCollector, 32));
 				}
 				catch (Throwable t) {
 					t.printStackTrace();
@@ -139,7 +139,7 @@ public class StatefulSequenceSourceTest {
 			@Override
 			public void run() {
 				try {
-					source3.run(new BlockingSourceContext("3", latchToTrigger3, latchToWait3, outputCollector, 3));
+					source3.run(new BlockingSourceContext<>("3", latchToTrigger3, latchToWait3, outputCollector, 3));
 				}
 				catch (Throwable t) {
 					t.printStackTrace();
@@ -186,22 +186,22 @@ public class StatefulSequenceSourceTest {
 	/**
 	 * Test SourceContext.
 	 */
-	public static class BlockingSourceContext implements SourceFunction.SourceContext<Long> {
+	public static class BlockingSourceContext<T> implements SourceFunction.SourceContext<T> {
 
 		private final String name;
 
 		private final Object lock;
 		private final OneShotLatch latchToTrigger;
 		private final OneShotLatch latchToWait;
-		private final ConcurrentHashMap<String, List<Long>> collector;
+		private final ConcurrentHashMap<String, List<T>> collector;
 
 		private final int threshold;
 		private int counter = 0;
 
-		private final List<Long> localOutput;
+		private final List<T> localOutput;
 
 		public BlockingSourceContext(String name, OneShotLatch latchToTrigger, OneShotLatch latchToWait,
-									ConcurrentHashMap<String, List<Long>> output, int elemToFire) {
+									ConcurrentHashMap<String, List<T>> output, int elemToFire) {
 			this.name = name;
 			this.lock = new Object();
 			this.latchToTrigger = latchToTrigger;
@@ -210,19 +210,19 @@ public class StatefulSequenceSourceTest {
 			this.threshold = elemToFire;
 
 			this.localOutput = new ArrayList<>();
-			List<Long> prev = collector.put(name, localOutput);
+			List<T> prev = collector.put(name, localOutput);
 			if (prev != null) {
 				Assert.fail();
 			}
 		}
 
 		@Override
-		public void collectWithTimestamp(Long element, long timestamp) {
+		public void collectWithTimestamp(T element, long timestamp) {
 			collect(element);
 		}
 
 		@Override
-		public void collect(Long element) {
+		public void collect(T element) {
 			localOutput.add(element);
 			if (++counter == threshold) {
 				latchToTrigger.trigger();

--- a/flink-table/flink-table-api-java-bridge/pom.xml
+++ b/flink-table/flink-table-api-java-bridge/pom.xml
@@ -53,6 +53,8 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- test dependencies -->
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-java</artifactId>
@@ -79,6 +81,11 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.ConfigOptions.OptionBuilder;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
@@ -173,13 +174,17 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 	}
 
 	private DataGenerator createSequenceGenerator(String name, DataType type, ReadableConfig options) {
-		OptionBuilder startKey = key(FIELDS + "." + name + "." + START);
-		OptionBuilder endKey = key(FIELDS + "." + name + "." + END);
+		String startKeyStr = FIELDS + "." + name + "." + START;
+		String endKeyStr = FIELDS + "." + name + "." + END;
+		OptionBuilder startKey = key(startKeyStr);
+		OptionBuilder endKey = key(endKeyStr);
 
 		options.getOptional(startKey.stringType().noDefaultValue()).orElseThrow(
-				() -> new ValidationException("Could not find required property '" + startKey + "'."));
+				() -> new ValidationException(
+						"Could not find required property '" + startKeyStr + "' for sequence generator."));
 		options.getOptional(endKey.stringType().noDefaultValue()).orElseThrow(
-				() -> new ValidationException("Could not find required property '" + endKey + "'."));
+				() -> new ValidationException(
+						"Could not find required property '" + endKeyStr + "' for sequence generator."));
 
 		switch (type.getLogicalType().getTypeRoot()) {
 			case CHAR:
@@ -288,6 +293,13 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 				RuntimeContext runtimeContext) throws Exception {
 			for (int i = 0; i < fieldGenerators.length; i++) {
 				fieldGenerators[i].open(fieldNames[i], context, runtimeContext);
+			}
+		}
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			for (DataGenerator generator : fieldGenerators) {
+				generator.snapshotState(context);
 			}
 		}
 


### PR DESCRIPTION

## What is the purpose of the change

- RowGenerator in datagen factory should implement snapshotState, otherwise it is not exactly-once and loose data.
- If you create a "datagen" connector with a squence data type and do not provide "start" and "end" you'll see a validation error like below. Instead of logging the property an OptionBuilder is logged instead.

## Verifying this change

`DataGenTableSourceFactoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no