### PR TITLE
[FLINK-18189][runtime] Incorrect size check for sum of heap/non-heap memory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -41,9 +41,8 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 		MemorySize derivedTotalFlinkMemorySize = jvmHeapMemorySize.add(offHeapMemorySize);
 
 		if (config.contains(JobManagerOptions.TOTAL_FLINK_MEMORY)) {
-			// derive network memory from total flink memory, and check against network min/max
 			MemorySize totalFlinkMemorySize = ProcessMemoryUtils.getMemorySizeFromConfig(config, JobManagerOptions.TOTAL_FLINK_MEMORY);
-			if (derivedTotalFlinkMemorySize.getBytes() != totalFlinkMemorySize.getBytes()) {
+			if (derivedTotalFlinkMemorySize.getBytes() > totalFlinkMemorySize.getBytes()) {
 				throw new IllegalConfigurationException(String.format(
 					"Sum of the configured JVM Heap Memory (%s) and the configured or default Off-heap Memory (%s) " +
 						"exceeds the configured Total Flink Memory (%s). Please, make the configuration consistent " +


### PR DESCRIPTION
## What is the purpose of the change

*Log of method `deriveFromRequiredFineGrainedOptions` in `JobManagerFlinkMemoryUtils` isn't consistent with the condtion which is `derivedTotalFlinkMemorySize.getBytes() != totalFlinkMemorySize.getBytes()`. This condition should be `derivedTotalFlinkMemorySize.getBytes() > totalFlinkMemorySize.getBytes()`.*

## Brief change log

  - *Modify the log condition of `deriveFromRequiredFineGrainedOptions` to `derivedTotalFlinkMemorySize.getBytes() > totalFlinkMemorySize.getBytes()`.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
