### PR TITLE
[FLINK-18218][python][e2e] Add yarn perjob, java dependency management e2e tests for pyflink.

### DIFF
--- a/flink-end-to-end-tests/flink-python-test/python/python_job.py
+++ b/flink-end-to-end-tests/flink-python-test/python/python_job.py
@@ -38,6 +38,11 @@ def word_count():
     env = ExecutionEnvironment.get_execution_environment()
     t_env = BatchTableEnvironment.create(env, t_config)
 
+    # used to test pipeline.jars and pipleline.classpaths
+    config_key = sys.argv[1]
+    config_value = sys.argv[2]
+    t_env.get_config().get_configuration().set_string(config_key, config_value)
+
     # register Results table in table environment
     tmp_dir = tempfile.gettempdir()
     result_path = tmp_dir + '/result'
@@ -55,7 +60,8 @@ def word_count():
     sink_ddl = """
         create table Results(
             word VARCHAR,
-            `count` BIGINT
+            `count` BIGINT,
+            `count_java` BIGINT
         ) with (
             'connector.type' = 'filesystem',
             'format.type' = 'csv',
@@ -65,12 +71,13 @@ def word_count():
     t_env.sql_update(sink_ddl)
 
     t_env.sql_update("create temporary system function add_one as 'add_one.add_one' language python")
+    t_env.register_java_function("add_one_java", "org.apache.flink.python.tests.TestScalarUdf")
 
     elements = [(word, 0) for word in content.split(" ")]
     t_env.from_elements(elements, ["word", "count"]) \
-        .select("word, add_one(count) as count") \
+        .select("word, add_one(count) as count, add_one_java(count) as count_java") \
         .group_by("word") \
-        .select("word, count(count) as count") \
+        .select("word, count(count) as count, count(count_java) as count_java") \
         .insert_into("Results")
 
     t_env.execute("word_count")

--- a/flink-end-to-end-tests/flink-python-test/python/python_job.py
+++ b/flink-end-to-end-tests/flink-python-test/python/python_job.py
@@ -71,7 +71,7 @@ def word_count():
     t_env.sql_update(sink_ddl)
 
     t_env.sql_update("create temporary system function add_one as 'add_one.add_one' language python")
-    t_env.register_java_function("add_one_java", "org.apache.flink.python.tests.TestScalarUdf")
+    t_env.register_java_function("add_one_java", "org.apache.flink.python.tests.util.AddOne")
 
     elements = [(word, 0) for word in content.split(" ")]
     t_env.from_elements(elements, ["word", "count"]) \

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/TestScalarUdf.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/TestScalarUdf.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.tests;
+
+import org.apache.flink.table.functions.ScalarFunction;
+
+/**
+ * Scala UDF for testing.
+ */
+public class TestScalarUdf extends ScalarFunction {
+	public long eval(long input) {
+		return input + 1;
+	}
+}

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/util/AddOne.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/util/AddOne.java
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.python.tests;
+package org.apache.flink.python.tests.util;
 
 import org.apache.flink.table.functions.ScalarFunction;
 
 /**
  * Scala UDF for testing.
  */
-public class TestScalarUdf extends ScalarFunction {
+public class AddOne extends ScalarFunction {
 	public long eval(long input) {
 		return input + 1;
 	}

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -18,8 +18,11 @@
 ################################################################################
 
 set -Eeuo pipefail
+set -x
 CURRENT_DIR=`cd "$(dirname "$0")" && pwd -P`
+cd "${CURRENT_DIR}/../"
 source "${CURRENT_DIR}"/common.sh
+source "${CURRENT_DIR}"/common_yarn_docker.sh
 
 cp -r "${FLINK_DIR}/conf" "${TEST_DATA_DIR}/conf"
 
@@ -65,13 +68,23 @@ REQUIREMENTS_PATH="${TEST_DATA_DIR}/requirements.txt"
 
 echo "scipy==1.4.1" > "${REQUIREMENTS_PATH}"
 
-echo "Test submitting python job:\n"
+echo "Test submitting python job with 'pipeline.jars':\n"
 PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
     -pyreq "${REQUIREMENTS_PATH}" \
     -pyarch "${TEST_DATA_DIR}/venv.zip" \
     -pyexec "venv.zip/.conda/bin/python" \
-    -py "${FLINK_PYTHON_TEST_DIR}/python/python_job.py"
+    -py "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" \
+    pipeline.jars "file://${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
+
+echo "Test submitting python job with 'pipeline.classpaths':\n"
+PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
+    -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
+    -pyreq "${REQUIREMENTS_PATH}" \
+    -pyarch "${TEST_DATA_DIR}/venv.zip" \
+    -pyexec "venv.zip/.conda/bin/python" \
+    -py "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" \
+    pipeline.classpaths "file://${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
 echo "Test blink stream python udf sql job:\n"
 PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
@@ -150,3 +163,48 @@ JOB_ID=$($FLINK_DIR/bin/sql-client.sh embedded \
 wait_job_terminal_state "$JOB_ID" "FINISHED"
 
 stop_cluster
+
+# test submitting on yarn
+start_hadoop_cluster_and_prepare_flink
+
+# copy test files
+docker cp "${FLINK_PYTHON_DIR}/dev/lint-python.sh" master:/tmp/
+docker cp "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar" master:/tmp/
+docker cp "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" master:/tmp/
+docker cp "${REQUIREMENTS_PATH}" master:/tmp/
+docker cp "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" master:/tmp/
+PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache-flink-*.tar.gz)
+docker cp "${FLINK_PYTHON_DIR}/dist/${PYFLINK_PACKAGE_FILE}" master:/tmp/
+
+# prepare environment
+docker exec master bash -c "
+/tmp/lint-python.sh -s miniconda
+source /tmp/.conda/bin/activate
+pip install /tmp/${PYFLINK_PACKAGE_FILE}
+conda install -y -q zip=3.0
+rm -rf /tmp/.conda/pkgs
+cd /tmp
+zip -q -r /tmp/venv.zip .conda
+echo \"taskmanager.memory.task.off-heap.size: 100m\" >> \"/home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml\"
+"
+
+docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+    /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
+    -pyfs /tmp/add_one.py \
+    -pyreq /tmp/requirements.txt \
+    -pyarch /tmp/venv.zip \
+    -pyexec venv.zip/.conda/bin/python \
+    /tmp/PythonUdfSqlJobExample.jar"
+
+docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+    /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
+    -pyfs /tmp/add_one.py \
+    -pyreq /tmp/requirements.txt \
+    -pyarch /tmp/venv.zip \
+    -pyexec venv.zip/.conda/bin/python \
+    -py /tmp/python_job.py \
+    pipeline.jars file:/tmp/PythonUdfSqlJobExample.jar"
+
+cluster_shutdown

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -206,5 +206,3 @@ docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
     -pyexec venv.zip/.conda/bin/python \
     -py /tmp/python_job.py \
     pipeline.jars file:/tmp/PythonUdfSqlJobExample.jar"
-
-cluster_shutdown

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -18,9 +18,7 @@
 ################################################################################
 
 set -Eeuo pipefail
-set -x
 CURRENT_DIR=`cd "$(dirname "$0")" && pwd -P`
-cd "${CURRENT_DIR}/../"
 source "${CURRENT_DIR}"/common.sh
 source "${CURRENT_DIR}"/common_yarn_docker.sh
 

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -28,10 +28,10 @@ function download() {
     local DOWNLOAD_STATUS=
     if hash "wget" 2>/dev/null; then
         # because of the difference of all versions of wget, so we turn of the option --show-progress
-        wget "$1" -O "$2" -q
+        wget "$1" -O "$2" -q -T20 -t3
         DOWNLOAD_STATUS="$?"
     else
-        curl "$1" -o "$2" --progress-bar
+        curl "$1" -o "$2" --progress-bar --connect-timeout 20 --retry 3
         DOWNLOAD_STATUS="$?"
     fi
     if [ $DOWNLOAD_STATUS -ne 0 ]; then


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds yarn perjob, java dependency management e2e tests for pyflink.*


## Brief change log

  - *Add yarn perjob, java dependency management e2e tests for pyflink.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
