### PR TITLE
[FLINK-18188][Runtime] Derive JM Off-Heap memory from configured Total Flink Memory minus JVM Heap

### DIFF
--- a/docs/ops/memory/mem_setup_master.md
+++ b/docs/ops/memory/mem_setup_master.md
@@ -89,6 +89,11 @@ There can be the following possible sources of *Off-heap* memory consumption:
 * Flink framework dependencies (e.g. Akka network communication)
 * User code executed during job submission (e.g. for certain batch sources) or in checkpoint completion callbacks
 
+<span class="label label-info">Note</span> If you have configured the [Total Flink Memory](mem_setup.html#configure-total-memory)
+and the [JVM Heap](#configure-jvm-heap) explicitly but you have not configured the *Off-heap* memory, the size of the *Off-heap* memory
+will be derived as the [Total Flink Memory](mem_setup.html#configure-total-memory) minus the [JVM Heap](#configure-jvm-heap).
+The default value of the *Off-heap* memory option will be ignored.
+
 ## Local Execution
 
 If you run Flink locally (e.g. from your IDE) without creating a cluster, then the Master memory configuration options are ignored.

--- a/docs/ops/memory/mem_setup_master.zh.md
+++ b/docs/ops/memory/mem_setup_master.zh.md
@@ -89,6 +89,10 @@ There can be the following possible sources of *Off-heap* memory consumption:
 * Flink framework dependencies (e.g. Akka network communication)
 * User code executed during job submission (e.g. for certain batch sources) or in checkpoint completion callbacks
 
+<span class="label label-info">Note</span> If you have configured the [Total Flink Memory](mem_setup.html#configure-total-memory)
+and the [JVM Heap](#configure-jvm-heap) explicitly but you have not configured the *Off-heap* memory, the size of the *Off-heap* memory
+will be derived as the [Total Flink Memory](mem_setup.html#configure-total-memory) minus the [JVM Heap](#configure-jvm-heap).
+The default value of the *Off-heap* memory option will be ignored.
 ## Local Execution
 
 If you run Flink locally (e.g. from your IDE) without creating a cluster, then the Master memory configuration options are ignored.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -38,23 +38,61 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 	public JobManagerFlinkMemory deriveFromRequiredFineGrainedOptions(Configuration config) {
 		MemorySize jvmHeapMemorySize = ProcessMemoryUtils.getMemorySizeFromConfig(config, JobManagerOptions.JVM_HEAP_MEMORY);
 		MemorySize offHeapMemorySize = ProcessMemoryUtils.getMemorySizeFromConfig(config, JobManagerOptions.OFF_HEAP_MEMORY);
-		MemorySize derivedTotalFlinkMemorySize = jvmHeapMemorySize.add(offHeapMemorySize);
 
 		if (config.contains(JobManagerOptions.TOTAL_FLINK_MEMORY)) {
 			// derive network memory from total flink memory, and check against network min/max
 			MemorySize totalFlinkMemorySize = ProcessMemoryUtils.getMemorySizeFromConfig(config, JobManagerOptions.TOTAL_FLINK_MEMORY);
-			if (derivedTotalFlinkMemorySize.getBytes() != totalFlinkMemorySize.getBytes()) {
-				throw new IllegalConfigurationException(String.format(
-					"Sum of the configured JVM Heap Memory (%s) and the configured or default Off-heap Memory (%s) " +
-						"exceeds the configured Total Flink Memory (%s). Please, make the configuration consistent " +
-						"or configure only one option: either JVM Heap or Total Flink Memory.",
-					jvmHeapMemorySize.toHumanReadableString(),
-					offHeapMemorySize.toHumanReadableString(),
-					totalFlinkMemorySize.toHumanReadableString()));
+			if (config.contains(JobManagerOptions.OFF_HEAP_MEMORY)) {
+				// off-heap memory is explicitly set by user
+				sanityCheckTotalFlinkMemory(totalFlinkMemorySize, jvmHeapMemorySize, totalFlinkMemorySize);
+			} else {
+				// off-heap memory is not explicitly set by user, derive it from Total Flink Memory and JVM Heap
+				offHeapMemorySize = deriveOffHeapMemory(jvmHeapMemorySize, totalFlinkMemorySize, offHeapMemorySize);
 			}
 		}
 
 		return createJobManagerFlinkMemory(config, jvmHeapMemorySize, offHeapMemorySize);
+	}
+
+	private static void sanityCheckTotalFlinkMemory(
+			MemorySize totalFlinkMemorySize,
+			MemorySize jvmHeapMemorySize,
+			MemorySize offHeapMemorySize) {
+		MemorySize derivedTotalFlinkMemorySize = jvmHeapMemorySize.add(offHeapMemorySize);
+		if (derivedTotalFlinkMemorySize.getBytes() != totalFlinkMemorySize.getBytes()) {
+			throw new IllegalConfigurationException(String.format(
+				"Sum of the configured JVM Heap Memory (%s) and the configured Off-heap Memory (%s) " +
+					"does not match the configured Total Flink Memory (%s). Please, make the configuration consistent " +
+					"or configure only one option: either JVM Heap or Total Flink Memory.",
+				jvmHeapMemorySize.toHumanReadableString(),
+				offHeapMemorySize.toHumanReadableString(),
+				totalFlinkMemorySize.toHumanReadableString()));
+		}
+	}
+
+	private static MemorySize deriveOffHeapMemory(
+			MemorySize jvmHeapMemorySize,
+			MemorySize totalFlinkMemorySize,
+			MemorySize defaultOffHeapMemorySize) {
+		if (totalFlinkMemorySize.getBytes() < jvmHeapMemorySize.getBytes()) {
+			throw new IllegalConfigurationException(String.format(
+				"The configured JVM Heap Memory (%s) exceeds the configured Total Flink Memory (%s). " +
+					"Please, make the configuration consistent or configure only one option: either JVM Heap " +
+					"or Total Flink Memory.",
+				jvmHeapMemorySize.toHumanReadableString(),
+				totalFlinkMemorySize.toHumanReadableString()));
+		}
+		MemorySize offHeapMemorySize = totalFlinkMemorySize.subtract(jvmHeapMemorySize);
+		if (offHeapMemorySize.getBytes() != defaultOffHeapMemorySize.getBytes()) {
+			LOG.info(
+				"The Off-Heap Memory size ({}) is derived the configured Total Flink Memory size ({}) minus " +
+					"the configured JVM Heap Memory size ({}). The default Off-Heap Memory size ({}) is ignored.",
+				offHeapMemorySize.toHumanReadableString(),
+				totalFlinkMemorySize.toHumanReadableString(),
+				jvmHeapMemorySize.toHumanReadableString(),
+				defaultOffHeapMemorySize.toHumanReadableString());
+		}
+		return offHeapMemorySize;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

For the following JM memory configuration:
- jvm.heap = 128m (set)
- default off-heap = 128m (not set)
- total.flink.mem = 512m (set)
we currently fail if `jvm.heap + off-heap <> total.flink.mem`
(Normally: total.flink.mem = jvm.heap + off-heap).

The PR extends off-heap (if not set) to (total.flink.mem - jvm.heap) instead.
This is also logged as info message and documented for JM off-heap.

## Verifying this change

Unit tests.

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
