### PR TITLE
[FLINK-17976][docs][k8s/docker] Improvements about custom docker images

### DIFF
--- a/docs/ops/deployment/docker.md
+++ b/docs/ops/deployment/docker.md
@@ -268,12 +268,10 @@ There are several ways in which you can further customize the Flink image:
 
 * install custom software (e.g. python)
 * enable (symlink) optional libraries or plugins from `/opt/flink/opt` into `/opt/flink/lib` or `/opt/flink/plugins`
-* add other libraries to `/opt/flink/lib` (e.g. [hadoop](#extend-with-maven))
+* add other libraries to `/opt/flink/lib` (e.g. Hadoop)
 * add other plugins to `/opt/flink/plugins`
 
-All files in the `/opt/flink/lib/` folder are added to the classpath used to start Flink. It is suitable for libraries such as Hadoop or file systems not available as plugins.
-
-Files in the `/opt/flink/plugins/` are loaded at runtime by Flink through separate classloaders to avoid conflicts with classes loaded and used by Flink. Only jar files which are prepared as [plugins]({{ site.baseurl }}/ops/plugins.html) can be added here.
+See also: [How to provide dependencies in the classpath]({% link index.md %}#how-to-provide-dependencies-in-the-classpath).
 
 You can customize the Flink image in several ways:
 
@@ -337,48 +335,6 @@ as described in [how to run the Flink image](#how-to-run-flink-image).
     # e.g. to distribute the custom image to your cluster
     docker push custom_flink_image
     ```
-
-    <a name="extend-with-maven"></a>
-    If you need to **extend the Flink image with a Maven dependency (and its transitive dependencies)**,
-you can use a Maven *pom.xml* file such as:
-
-   *pom.xml*:
-
-    ```xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-      <modelVersion>4.0.0</modelVersion>
-
-      <groupId>org.apache.flink</groupId>
-      <artifactId>docker-dependencies</artifactId>
-      <version>1.0-SNAPSHOT</version>
-
-      <dependencies>
-            <!-- Put your dependency here, for example a Hadoop GCS connector -->
-      </dependencies>
-
-      <build>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-dependency-plugin</artifactId>
-              <version>3.1.2</version>
-              <executions>
-                <execution>
-                  <id>copy-dependencies</id>
-                  <phase>package</phase>
-                  <goals><goal>copy-dependencies</goal></goals>
-                  <configuration><outputDirectory>jars</outputDirectory></configuration>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-      </build>
-    </project>
-    ```
-  
-    Running `mvn package` will create a `jars/` folder containing all the jar files, which you can add to your Docker image.
 
 {% top %}
 

--- a/docs/ops/deployment/index.md
+++ b/docs/ops/deployment/index.md
@@ -263,7 +263,7 @@ To provide a dependency, there are the following options:
 ### Download Maven dependencies locally
 
 If you need to extend the Flink with a Maven dependency (and its transitive dependencies),
-you can use a [Apache Maven](https://maven.apache.org) *pom.xml* file such as to download all required files into a local folder:
+you can use an [Apache Maven](https://maven.apache.org) *pom.xml* file to download all required files into a local folder:
 
 *pom.xml*:
 
@@ -302,4 +302,3 @@ you can use a [Apache Maven](https://maven.apache.org) *pom.xml* file such as to
 
 Running `mvn package` in the same directory will create a `jars/` folder containing all the jar files, 
 which you can add to the desired folder, Docker image etc.
-

--- a/docs/ops/deployment/index.md
+++ b/docs/ops/deployment/index.md
@@ -119,7 +119,7 @@ Apache Flink ships with first class support for a number of common deployment ta
       </div>
       <div class="panel-body">
         Run Flink locally for basic testing and experimentation
-        <br><a href="{{ site.baseurl }}/ops/deployment/local.html">Learn more</a>
+        <br><a href="{% link ops/deployment/local.md %}">Learn more</a>
       </div>
     </div>
   </div>
@@ -130,7 +130,7 @@ Apache Flink ships with first class support for a number of common deployment ta
       </div>
       <div class="panel-body">
         A simple solution for running Flink on bare metal or VM's 
-        <br><a href="{{ site.baseurl }}/ops/deployment/cluster_setup.html">Learn more</a>
+        <br><a href="{% link ops/deployment/cluster_setup.md %}">Learn more</a>
       </div>
     </div>
   </div>
@@ -141,7 +141,7 @@ Apache Flink ships with first class support for a number of common deployment ta
       </div>
       <div class="panel-body">
         Deploy Flink on-top of Apache Hadoop's resource manager 
-        <br><a href="{{ site.baseurl }}/ops/deployment/yarn_setup.html">Learn more</a>
+        <br><a href="{% link ops/deployment/yarn_setup.md %}">Learn more</a>
       </div>
     </div>
   </div>
@@ -154,7 +154,7 @@ Apache Flink ships with first class support for a number of common deployment ta
       </div>
       <div class="panel-body">
         A generic resource manager for running distriubted systems
-        <br><a href="{{ site.baseurl }}/ops/deployment/mesos.html">Learn more</a>
+        <br><a href="{% link ops/deployment/mesos.md %}">Learn more</a>
       </div>
     </div>
   </div>
@@ -165,7 +165,7 @@ Apache Flink ships with first class support for a number of common deployment ta
       </div>
       <div class="panel-body">
         A popular solution for running Flink within a containerized environment
-        <br><a href="{{ site.baseurl }}/ops/deployment/docker.html">Learn more</a>
+        <br><a href="{% link ops/deployment/docker.md %}">Learn more</a>
       </div>
     </div>
   </div>
@@ -176,7 +176,7 @@ Apache Flink ships with first class support for a number of common deployment ta
       </div>
       <div class="panel-body">
         An automated system for deploying containerized applications
-        <br><a href="{{ site.baseurl }}/ops/deployment/kubernetes.html">Learn more</a>
+        <br><a href="{% link ops/deployment/kubernetes.md %}">Learn more</a>
       </div>
     </div>
   </div>
@@ -247,3 +247,60 @@ Supported Environments:
 <span class="label label-primary">Azure</span>
 <span class="label label-primary">Google Cloud</span>
 <span class="label label-primary">On-Premise</span>
+
+## Deployment Best Practices
+
+### How to provide dependencies in the classpath
+
+Flink provides several approaches for providing dependencies (such as `*.jar` files or static data) to Flink or user-provided
+applications. These approaches differ based on the deployment mode and target, but also have commonalities, which are described here.
+
+To provide a dependency, there are the following options:
+- files in the **`lib/` folder** are added to the classpath used to start Flink. It is suitable for libraries such as Hadoop or file systems not available as plugins. Beware that classes added here can potentially interfere with Flink, for example if Flink you are adding a different version of a library already provided by Flink.
+
+- **`plugins/<name>/`** are loaded at runtime by Flink through separate classloaders to avoid conflicts with classes loaded and used by Flink. Only jar files which are prepared as [plugins]({% link ops/plugins.md %}) can be added here.
+
+### Download Maven dependencies locally
+
+If you need to extend the Flink with a Maven dependency (and its transitive dependencies),
+you can use a [Apache Maven](https://maven.apache.org) *pom.xml* file such as to download all required files into a local folder:
+
+*pom.xml*:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>docker-dependencies</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+        <!-- Put your dependency here, for example a Hadoop GCS connector -->
+  </dependencies>
+
+  <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.2</version>
+          <executions>
+            <execution>
+              <id>copy-dependencies</id>
+              <phase>package</phase>
+              <goals><goal>copy-dependencies</goal></goals>
+              <configuration><outputDirectory>jars</outputDirectory></configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+  </build>
+</project>
+```
+
+Running `mvn package` in the same directory will create a `jars/` folder containing all the jar files, 
+which you can add to the desired folder, Docker image etc.
+
+

--- a/docs/ops/deployment/index.md
+++ b/docs/ops/deployment/index.md
@@ -256,7 +256,7 @@ Flink provides several approaches for providing dependencies (such as `*.jar` fi
 applications. These approaches differ based on the deployment mode and target, but also have commonalities, which are described here.
 
 To provide a dependency, there are the following options:
-- files in the **`lib/` folder** are added to the classpath used to start Flink. It is suitable for libraries such as Hadoop or file systems not available as plugins. Beware that classes added here can potentially interfere with Flink, for example if Flink you are adding a different version of a library already provided by Flink.
+- files in the **`lib/` folder** are added to the classpath used to start Flink. It is suitable for libraries such as Hadoop or file systems not available as plugins. Beware that classes added here can potentially interfere with Flink, for example if you are adding a different version of a library already provided by Flink.
 
 - **`plugins/<name>/`** are loaded at runtime by Flink through separate classloaders to avoid conflicts with classes loaded and used by Flink. Only jar files which are prepared as [plugins]({% link ops/plugins.md %}) can be added here.
 
@@ -302,5 +302,4 @@ you can use a [Apache Maven](https://maven.apache.org) *pom.xml* file such as to
 
 Running `mvn package` in the same directory will create a `jars/` folder containing all the jar files, 
 which you can add to the desired folder, Docker image etc.
-
 

--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -103,7 +103,7 @@ $ ./bin/flink run -d -t kubernetes-session -Dkubernetes.cluster-id=<ClusterId> e
 ### Accessing Job Manager UI
 
 There are several ways to expose a Service onto an external (outside of your cluster) IP address.
-This can be configured using `kubernetes.service.exposed.type`.
+This can be configured using [`kubernetes.rest-service.exposed.type`]({% link ops/config.md %}#kubernetes-rest-service-exposed-type).
 
 - `ClusterIP`: Exposes the service on a cluster-internal IP.
 The Service is only reachable within the cluster. If you want to access the Job Manager ui or submit job to the existing session, you need to start a local proxy.
@@ -116,7 +116,7 @@ $ kubectl port-forward service/<ServiceName> 8081
 - `NodePort`: Exposes the service on each Node’s IP at a static port (the `NodePort`). `<NodeIP>:<NodePort>` could be used to contact the Job Manager Service. `NodeIP` could be easily replaced with Kubernetes ApiServer address.
 You could find it in your kube config file.
 
-- `LoadBalancer`: **Default value**, exposes the service externally using a cloud provider’s load balancer.
+- `LoadBalancer`: exposes the service externally using a cloud provider’s load balancer.
 Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.
 You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`.
 

--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -116,9 +116,11 @@ $ kubectl port-forward service/<ServiceName> 8081
 - `NodePort`: Exposes the service on each Node’s IP at a static port (the `NodePort`). `<NodeIP>:<NodePort>` could be used to contact the Job Manager Service. `NodeIP` could be easily replaced with Kubernetes ApiServer address.
 You could find it in your kube config file.
 
-- `LoadBalancer`: Default value, exposes the service externally using a cloud provider’s load balancer.
+- `LoadBalancer`: **Default value**, exposes the service externally using a cloud provider’s load balancer.
 Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.
 You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`.
+
+  <span class="label label-warning">Warning!</span> Your JobManager (which can run arbitary jar files) might be exposed to the public internet, without authentication.
 
 - `ExternalName`: Map a service to a DNS name, not supported in current version.
 

--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -116,7 +116,7 @@ $ kubectl port-forward service/<ServiceName> 8081
 - `NodePort`: Exposes the service on each Node’s IP at a static port (the `NodePort`). `<NodeIP>:<NodePort>` could be used to contact the Job Manager Service. `NodeIP` could be easily replaced with Kubernetes ApiServer address.
 You could find it in your kube config file.
 
-- `LoadBalancer`: exposes the service externally using a cloud provider’s load balancer.
+- `LoadBalancer`: Exposes the service externally using a cloud provider’s load balancer.
 Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.
 You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`.
 


### PR DESCRIPTION
## What is the purpose of the change

While testing the native Kubernetes integration (in particular when trying to access Google's GCS file system), I had issues building a custom docker image for that purpose.
This PR tries to give users some clarification and tools for the task.

