### PR TITLE
[FLINK-17982] Resolve TODOs in concepts documentation

### DIFF
--- a/docs/concepts/stateful-stream-processing.md
+++ b/docs/concepts/stateful-stream-processing.md
@@ -24,6 +24,11 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+* This will be replaced by the TOC
+{:toc}
+
+## What is State?
+
 While many operations in a dataflow simply look at one individual *event at a
 time* (for example an event parser), some operations remember information
 across multiple events (for example window operators). These operations are
@@ -53,13 +58,6 @@ that Flink takes care of redistributing state across parallel instances.
 When working with state, it might also be useful to read about [Flink's state
 backends]({% link ops/state/state_backends.md %}). Flink
 provides different state backends that specify how and where state is stored.
-
-* This will be replaced by the TOC
-{:toc}
-
-## What is State?
-
-`TODO: expand this section`
 
 {% top %}
 

--- a/docs/concepts/stateful-stream-processing.md
+++ b/docs/concepts/stateful-stream-processing.md
@@ -61,12 +61,6 @@ provides different state backends that specify how and where state is stored.
 
 {% top %}
 
-## State in Stream & Batch Processing
-
-`TODO: What is this section about? Do we even need it?`
-
-{% top %}
-
 ## Keyed State
 
 Keyed state is maintained in what can be thought of as an embedded key/value
@@ -250,8 +244,6 @@ See [Restart Strategies]({% link dev/task_failure_recovery.md
 
 ### State Backends
 
-`TODO: expand this section`
-
 The exact data structures in which the key/values indexes are stored depends on
 the chosen [state backend]({% link
 ops/state/state_backends.md %}). One state backend stores data in an in-memory
@@ -267,8 +259,6 @@ logic.
 {% top %}
 
 ### Savepoints
-
-`TODO: expand this section`
 
 All programs that use checkpointing can resume execution from a **savepoint**.
 Savepoints allow both updating your programs and your Flink cluster without
@@ -309,10 +299,6 @@ parallel streaming operations (`map()`, `flatMap()`, `filter()`, ...) actually
 give *exactly once* guarantees even in *at least once* mode.
 
 {% top %}
-
-## End-to-end Exactly-Once Programs
-
-`TODO: add`
 
 ## State and Fault Tolerance in Batch Programs
 

--- a/docs/concepts/timely-stream-processing.md
+++ b/docs/concepts/timely-stream-processing.md
@@ -34,7 +34,7 @@ concepts/stateful-stream-processing.md %}) in which time plays some role in the
 computation. Among other things, this is the case when you do time series
 analysis, when doing aggregations based on certain time periods (typically
 called windows), or when you do event processing where the time when an event
-occured is important.
+occurred is important.
 
 In the following sections we will highlight some of the topics that you should
 consider when working with timely Flink Applications.

--- a/docs/concepts/timely-stream-processing.md
+++ b/docs/concepts/timely-stream-processing.md
@@ -24,16 +24,24 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-`TODO: add introduction`
-
 * This will be replaced by the TOC
 {:toc}
+
+## Introduction
+
+Timely steam processing is an extension of [stateful stream processing]({% link
+concepts/stateful-stream-processing.md %}) in which time plays some role in the
+computation. Among other things, this is the case when you do time series
+analysis, when doing aggregations based on certain time periods (typically
+called windows), or when you do event processing where the time when an event
+occured is important.
+
+In the following sections we will highlight some of the topics that you should
+consider when working with timely Flink Applications.
 
 ## Latency & Completeness
 
 `TODO: add these two sections`
-
-### Latency vs. Completeness in Batch & Stream Processing
 
 {% top %}
 

--- a/docs/concepts/timely-stream-processing.md
+++ b/docs/concepts/timely-stream-processing.md
@@ -36,7 +36,7 @@ analysis, when doing aggregations based on certain time periods (typically
 called windows), or when you do event processing where the time when an event
 occurred is important.
 
-In the following sections we will highlight some of the topics that you should
+In the following sections, we will highlight some of the topics that you should
 consider when working with timely Flink Applications.
 
 ## Latency & Completeness


### PR DESCRIPTION
## Brief change log

 - move the introduction of "stateful stream processing" to be the "What is state?" section, because that's what it is
 - remove TODOs from documentation about expanding sections. We might still do them in the future but they are not strictly necessary now
 - add introduction to "timely stream processing"

## Open Questions

Should we remove the empty "Latency & Completeness" section? After the watermarks/event time section we talk about lateness already. If at all, it might make sense to have such a section there but I would also say that we can remove it for now.