### PR TITLE
[FLINK-18160][scripts] Do not log about HADOOP_CONF_DIR if HADOOP_CLA…

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -332,20 +332,20 @@ if [ -z "$HADOOP_CONF_DIR" ]; then
     if [ -n "$HADOOP_HOME" ]; then
         # HADOOP_HOME is set. Check if its a Hadoop 1.x or 2.x HADOOP_HOME path
         if [ -d "$HADOOP_HOME/conf" ]; then
-            # its a Hadoop 1.x
+            # It's Hadoop 1.x
             HADOOP_CONF_DIR="$HADOOP_HOME/conf"
         fi
         if [ -d "$HADOOP_HOME/etc/hadoop" ]; then
-            # Its Hadoop 2.2+
+            # It's Hadoop 2.2+
             HADOOP_CONF_DIR="$HADOOP_HOME/etc/hadoop"
         fi
     fi
 fi
 
-# try and set HADOOP_CONF_DIR to some common default if it's not set
-if [ -z "$HADOOP_CONF_DIR" ]; then
+# if neither HADOOP_CONF_DIR nor HADOOP_CLASSPATH are set, use some common default (if available)
+if [ -z "$HADOOP_CONF_DIR" ] && [ -z "$HADOOP_CLASSPATH" ]; then
     if [ -d "/etc/hadoop/conf" ]; then
-        echo "Setting HADOOP_CONF_DIR=/etc/hadoop/conf because no HADOOP_CONF_DIR was set."
+        echo "Setting HADOOP_CONF_DIR=/etc/hadoop/conf because no HADOOP_CONF_DIR or HADOOP_CLASSPATH was set."
         HADOOP_CONF_DIR="/etc/hadoop/conf"
     fi
 fi


### PR DESCRIPTION
## What is the purpose of the change

When running Flink on YARN with the HADOOP_CLASSPATH set, "hadoop classpath" also returns the configuration directory, so HADOOP_CONF_DIR is not needed anymore.

## Brief change log

- some minor cleanups
- change conditions and log message.


## Verifying this change

Print the `INTERNAL_HADOOP_CLASSPATHS`, pass HADOOP_CONF_DIR, HADOOP_CLASSPATH and add the `/etc/hadoop/conf` directory to test the updated condition.

