### PR TITLE
[FLINK-17761][connector/common] Add a constructor taking capacity as a parameter for `FutureCompletingBlockingQueue`

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
@@ -36,9 +36,19 @@ import java.util.concurrent.TimeUnit;
  * @param <T> the type of the elements in the queue.
  */
 public class FutureCompletingBlockingQueue<T> extends LinkedBlockingQueue<T> {
+
 	private final FutureNotifier futureNotifier;
+	/**
+	 *  The default capacity  for {@link LinkedBlockingQueue}.
+	 */
+	private final static Integer DEFAULT_CAPACITY = 10000;
 
 	public FutureCompletingBlockingQueue(FutureNotifier futureNotifier) {
+		this(futureNotifier, DEFAULT_CAPACITY);
+	}
+
+	public FutureCompletingBlockingQueue(FutureNotifier futureNotifier, int capacity) {
+		super(capacity);
 		this.futureNotifier = futureNotifier;
 	}
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
@@ -39,9 +39,9 @@ public class FutureCompletingBlockingQueue<T> extends LinkedBlockingQueue<T> {
 
 	private final FutureNotifier futureNotifier;
 	/**
-	 *  The default capacity  for {@link LinkedBlockingQueue}.
+	 * The default capacity for {@link LinkedBlockingQueue}.
 	 */
-	private final static Integer DEFAULT_CAPACITY = 10000;
+	private static final Integer DEFAULT_CAPACITY = 10000;
 
 	public FutureCompletingBlockingQueue(FutureNotifier futureNotifier) {
 		this(futureNotifier, DEFAULT_CAPACITY);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
@@ -1,22 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.base.source.reader.synchronization;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * The unit test for {@link FutureCompletingBlockingQueue}
  */
 public class FutureCompletingBlockingQueueTest {
 
+
 	private static final Integer DEFAULT_CAPACITY = 10000;
+	private static final Integer SPECIFIED_CAPACITY = 20000;
 
 	@Test
 	public void testFutureCompletingBlockingQueueConstructor(){
 		FutureNotifier notifier = new FutureNotifier();
 		FutureCompletingBlockingQueue<Object> defaultCapacityFutureCompletingBlockingQueue = new FutureCompletingBlockingQueue<>(notifier);
-		FutureCompletingBlockingQueue<Object> specifiedCapacityFutureCompletingBlockingQueue = new FutureCompletingBlockingQueue<>(notifier, DEFAULT_CAPACITY);
+		FutureCompletingBlockingQueue<Object> specifiedCapacityFutureCompletingBlockingQueue = new FutureCompletingBlockingQueue<>(notifier, SPECIFIED_CAPACITY);
+		// The capacity of the queue needs to be equal to 10000
 		assertEquals(defaultCapacityFutureCompletingBlockingQueue.remainingCapacity(),(int)DEFAULT_CAPACITY);
-		assertEquals(specifiedCapacityFutureCompletingBlockingQueue.remainingCapacity(),(int)DEFAULT_CAPACITY);
+		// The capacity of the queue needs to be equal to SPECIFIED_CAPACITY
+		assertEquals(specifiedCapacityFutureCompletingBlockingQueue.remainingCapacity(),(int)SPECIFIED_CAPACITY);
 	}
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * The unit test for {@link FutureCompletingBlockingQueue}
+ * The unit test for {@link FutureCompletingBlockingQueue}.
  */
 public class FutureCompletingBlockingQueueTest {
 
@@ -32,13 +32,13 @@ public class FutureCompletingBlockingQueueTest {
 	private static final Integer SPECIFIED_CAPACITY = 20000;
 
 	@Test
-	public void testFutureCompletingBlockingQueueConstructor(){
+	public void testFutureCompletingBlockingQueueConstructor() {
 		FutureNotifier notifier = new FutureNotifier();
 		FutureCompletingBlockingQueue<Object> defaultCapacityFutureCompletingBlockingQueue = new FutureCompletingBlockingQueue<>(notifier);
 		FutureCompletingBlockingQueue<Object> specifiedCapacityFutureCompletingBlockingQueue = new FutureCompletingBlockingQueue<>(notifier, SPECIFIED_CAPACITY);
 		// The capacity of the queue needs to be equal to 10000
-		assertEquals(defaultCapacityFutureCompletingBlockingQueue.remainingCapacity(),(int)DEFAULT_CAPACITY);
+		assertEquals(defaultCapacityFutureCompletingBlockingQueue.remainingCapacity(), (int) DEFAULT_CAPACITY);
 		// The capacity of the queue needs to be equal to SPECIFIED_CAPACITY
-		assertEquals(specifiedCapacityFutureCompletingBlockingQueue.remainingCapacity(),(int)SPECIFIED_CAPACITY);
+		assertEquals(specifiedCapacityFutureCompletingBlockingQueue.remainingCapacity(), (int) SPECIFIED_CAPACITY);
 	}
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
@@ -1,0 +1,22 @@
+package org.apache.flink.connector.base.source.reader.synchronization;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * The unit test for {@link FutureCompletingBlockingQueue}
+ */
+public class FutureCompletingBlockingQueueTest {
+
+	private static final Integer DEFAULT_CAPACITY = 10000;
+
+	@Test
+	public void testFutureCompletingBlockingQueueConstructor(){
+		FutureNotifier notifier = new FutureNotifier();
+		FutureCompletingBlockingQueue<Object> defaultCapacityFutureCompletingBlockingQueue = new FutureCompletingBlockingQueue<>(notifier);
+		FutureCompletingBlockingQueue<Object> specifiedCapacityFutureCompletingBlockingQueue = new FutureCompletingBlockingQueue<>(notifier, DEFAULT_CAPACITY);
+		assertEquals(defaultCapacityFutureCompletingBlockingQueue.remainingCapacity(),(int)DEFAULT_CAPACITY);
+		assertEquals(specifiedCapacityFutureCompletingBlockingQueue.remainingCapacity(),(int)DEFAULT_CAPACITY);
+	}
+}


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Add a constructor taking capacity as a parameter for `FutureCompletingBlockingQueue`

## Brief change log
Add a constructor taking capacity as a parameter for `FutureCompletingBlockingQueue`
`private final static Integer DEFAULT_CAPACITY = 10000;

public FutureCompletingBlockingQueue(FutureNotifier futureNotifier) {
   this(futureNotifier, DEFAULT_CAPACITY);
}

public FutureCompletingBlockingQueue(FutureNotifier futureNotifier, int capacity) {
   super(capacity);
   this.futureNotifier = futureNotifier;
}`

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (no), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
