### PR TITLE
[FLINK-18237][fs-connector] Exception when reading filesystem partitioned table with stream mode

### DIFF
--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamSinkITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamSinkITCase.java
@@ -18,20 +18,21 @@
 
 package org.apache.flink.formats.csv;
 
-import org.apache.flink.table.planner.runtime.stream.sql.StreamFileSystemITCaseBase;
+import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * ITCase to test csv format for {@link CsvFileSystemFormatFactory} in stream mode.
+ * ITCase to test csv format for {@link CsvFileSystemFormatFactory} for streaming sink.
  */
-public class CsvFilesystemStreamITCase extends StreamFileSystemITCaseBase {
-
+public class CsvFilesystemStreamSinkITCase extends FsStreamingSinkITCaseBase {
 	@Override
-	public String[] formatProperties() {
+	public String[] additionalProperties() {
 		List<String> ret = new ArrayList<>();
 		ret.add("'format'='csv'");
+		// for test purpose
+		ret.add("'sink.rolling-policy.file-size'='1b'");
 		return ret.toArray(new String[0]);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -19,24 +19,31 @@
 package org.apache.flink.table.filesystem;
 
 import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.io.CollectionInputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.FileSystemFormatFactory;
+import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
 import org.apache.flink.table.sources.FilterableTableSource;
-import org.apache.flink.table.sources.InputFormatTableSource;
 import org.apache.flink.table.sources.LimitableTableSource;
 import org.apache.flink.table.sources.PartitionableTableSource;
 import org.apache.flink.table.sources.ProjectableTableSource;
+import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.PartitionPathUtils;
+import org.apache.flink.table.utils.TableConnectorUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,7 +59,8 @@ import static org.apache.flink.table.filesystem.FileSystemTableFactory.createFor
 /**
  * File system table source.
  */
-public class FileSystemTableSource extends InputFormatTableSource<RowData> implements
+public class FileSystemTableSource implements
+		StreamTableSource<RowData>,
 		PartitionableTableSource,
 		ProjectableTableSource<RowData>,
 		LimitableTableSource<RowData>,
@@ -111,7 +119,22 @@ public class FileSystemTableSource extends InputFormatTableSource<RowData> imple
 	}
 
 	@Override
-	public InputFormat<RowData, ?> getInputFormat() {
+	public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
+		@SuppressWarnings("unchecked")
+		TypeInformation<RowData> typeInfo =
+				(TypeInformation<RowData>) TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(getProducedDataType());
+		DataStreamSource<RowData> source;
+		if (partitionKeys.isEmpty()) {
+			source = execEnv.createInput(getInputFormat(), typeInfo);
+		} else {
+			// Avoid using ContinuousFileMonitoringFunction
+			InputFormatSourceFunction<RowData> func = new InputFormatSourceFunction<>(getInputFormat(), typeInfo);
+			source = execEnv.addSource(func, explainSource(), typeInfo);
+		}
+		return source.name(explainSource());
+	}
+
+	private InputFormat<RowData, ?> getInputFormat() {
 		// When this table has no partition, just return a empty source.
 		if (!partitionKeys.isEmpty() && getOrFetchPartitions().isEmpty()) {
 			return new CollectionInputFormat<>(new ArrayList<>(), null);
@@ -301,7 +324,7 @@ public class FileSystemTableSource extends InputFormatTableSource<RowData> imple
 
 	@Override
 	public String explainSource() {
-		return super.explainSource() +
+		return TableConnectorUtils.generateRuntimeName(getClass(), getTableSchema().getFieldNames()) +
 				(readPartitions == null ? "" : ", readPartitions=" + readPartitions) +
 				(selectFields == null ? "" : ", selectFields=" + Arrays.toString(selectFields)) +
 				(limit == null ? "" : ", limit=" + limit) +

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -123,15 +123,15 @@ public class FileSystemTableSource implements
 		@SuppressWarnings("unchecked")
 		TypeInformation<RowData> typeInfo =
 				(TypeInformation<RowData>) TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(getProducedDataType());
-		DataStreamSource<RowData> source;
-		if (partitionKeys.isEmpty()) {
-			source = execEnv.createInput(getInputFormat(), typeInfo);
-		} else {
-			// Avoid using ContinuousFileMonitoringFunction
-			InputFormatSourceFunction<RowData> func = new InputFormatSourceFunction<>(getInputFormat(), typeInfo);
-			source = execEnv.addSource(func, explainSource(), typeInfo);
-		}
+		// Avoid using ContinuousFileMonitoringFunction
+		InputFormatSourceFunction<RowData> func = new InputFormatSourceFunction<>(getInputFormat(), typeInfo);
+		DataStreamSource<RowData> source = execEnv.addSource(func, explainSource(), typeInfo);
 		return source.name(explainSource());
+	}
+
+	@Override
+	public boolean isBounded() {
+		return true;
 	}
 
 	private InputFormat<RowData, ?> getInputFormat() {


### PR DESCRIPTION

## What is the purpose of the change

Fix "IllegalArgumentException when reading filesystem partitioned table with stream mode".
When reading filesystem partitioned table, will be many directories to read, but `ContinuousFileMonitoringFunction` not support multiple paths, we should not use it.

## Brief change log

`FileSystemTableSource` use `InputFormatSourceFunction` when reading filesystem partitioned table.

## Verifying this change

`CsvFilesystemStreamITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no