### PR TITLE
[hotfix] Correct the default path of nvidia-gpu-discovery

### DIFF
--- a/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
+++ b/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
@@ -61,7 +61,7 @@ class GPUDriver implements ExternalResourceDriver {
 	static final ConfigOption<String> DISCOVERY_SCRIPT_PATH =
 		key("discovery-script.path")
 			.stringType()
-			.defaultValue(String.format("%s/external-resource-gpu/nvidia-gpu-discovery.sh", ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS));
+			.defaultValue(String.format("%s/external_resource_gpu/nvidia-gpu-discovery.sh", ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS));
 
 	@VisibleForTesting
 	static final ConfigOption<String> DISCOVERY_SCRIPT_ARG =


### PR DESCRIPTION


## What is the purpose of the change

As we use "_" instead of "-" in the directory name in FLINK-18018, we also need to correct the default path of nvidia-gpu-discovery.sh.

## Brief change log

Correct the default path of nvidia-gpu-discovery

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
