### PR TITLE
[hotfix] Use hyphen instead of underscore when naming plugin's directory

### DIFF
--- a/flink-dist/src/main/assemblies/plugins.xml
+++ b/flink-dist/src/main/assemblies/plugins.xml
@@ -33,49 +33,49 @@
 
 		<file>
 			<source>../flink-metrics/flink-metrics-jmx/target/flink-metrics-jmx_${scala.binary.version}-${project.version}.jar</source>
-			<outputDirectory>plugins/metrics_jmx/</outputDirectory>
+			<outputDirectory>plugins/metrics-jmx/</outputDirectory>
 			<destName>flink-metrics-jmx-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-metrics/flink-metrics-graphite/target/flink-metrics-graphite-${project.version}.jar</source>
-			<outputDirectory>plugins/metrics_graphite/</outputDirectory>
+			<outputDirectory>plugins/metrics-graphite/</outputDirectory>
 			<destName>flink-metrics-graphite-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-metrics/flink-metrics-influxdb/target/flink-metrics-influxdb_${scala.binary.version}-${project.version}.jar</source>
-			<outputDirectory>plugins/metrics_influx/</outputDirectory>
+			<outputDirectory>plugins/metrics-influx/</outputDirectory>
 			<destName>flink-metrics-influxdb-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-metrics/flink-metrics-prometheus/target/flink-metrics-prometheus_${scala.binary.version}-${project.version}.jar</source>
-			<outputDirectory>plugins/metrics_prometheus/</outputDirectory>
+			<outputDirectory>plugins/metrics-prometheus/</outputDirectory>
 			<destName>flink-metrics-prometheus-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-metrics/flink-metrics-statsd/target/flink-metrics-statsd-${project.version}.jar</source>
-			<outputDirectory>plugins/metrics_statsd/</outputDirectory>
+			<outputDirectory>plugins/metrics-statsd/</outputDirectory>
 			<destName>flink-metrics-statsd-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-metrics/flink-metrics-datadog/target/flink-metrics-datadog-${project.version}.jar</source>
-			<outputDirectory>plugins/metrics_datadog/</outputDirectory>
+			<outputDirectory>plugins/metrics-datadog/</outputDirectory>
 			<destName>flink-metrics-datadog-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-metrics/flink-metrics-slf4j/target/flink-metrics-slf4j-${project.version}.jar</source>
-			<outputDirectory>plugins/metrics_slf4j/</outputDirectory>
+			<outputDirectory>plugins/metrics-slf4j/</outputDirectory>
 			<destName>flink-metrics-slf4j-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
@@ -83,21 +83,21 @@
 		<!-- External Resource -->
 		<file>
 			<source>../flink-external-resources/flink-external-resource-gpu/target/flink-external-resource-gpu-${project.version}.jar</source>
-			<outputDirectory>plugins/external_resource_gpu/</outputDirectory>
+			<outputDirectory>plugins/external-resource-gpu/</outputDirectory>
 			<destName>flink-external-resource-gpu-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-external-resources/flink-external-resource-gpu/src/main/resources/gpu-discovery-common.sh</source>
-			<outputDirectory>plugins/external_resource_gpu/</outputDirectory>
+			<outputDirectory>plugins/external-resource-gpu/</outputDirectory>
 			<destName>gpu-discovery-common.sh</destName>
 			<fileMode>0755</fileMode>
 		</file>
 
 		<file>
 			<source>../flink-external-resources/flink-external-resource-gpu/src/main/resources/nvidia-gpu-discovery.sh</source>
-			<outputDirectory>plugins/external_resource_gpu/</outputDirectory>
+			<outputDirectory>plugins/external-resource-gpu/</outputDirectory>
 			<destName>nvidia-gpu-discovery.sh</destName>
 			<fileMode>0755</fileMode>
 		</file>

--- a/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
+++ b/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
@@ -61,7 +61,7 @@ class GPUDriver implements ExternalResourceDriver {
 	static final ConfigOption<String> DISCOVERY_SCRIPT_PATH =
 		key("discovery-script.path")
 			.stringType()
-			.defaultValue(String.format("%s/external_resource_gpu/nvidia-gpu-discovery.sh", ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS));
+			.defaultValue(String.format("%s/external-resource-gpu/nvidia-gpu-discovery.sh", ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS));
 
 	@VisibleForTesting
 	static final ConfigOption<String> DISCOVERY_SCRIPT_ARG =


### PR DESCRIPTION

## What is the purpose of the change

Use hyphen instead of underscore when naming plugin's directory.

## Brief change log

Use hyphen instead of underscore when naming plugin's directory.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
