### PR TITLE
[hotfix][docs] Correct table identifier code example

### DIFF
--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -444,9 +444,9 @@ Identifiers follow SQL requirements which means that they can be escaped with a 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-TableEnvironment tEnv = ...;
-tEnv.useCatalog("custom_catalog");
-tEnv.useDatabase("custom_database");
+TableEnvironment tableEnv = ...;
+tableEnv.useCatalog("custom_catalog");
+tableEnv.useDatabase("custom_database");
 
 Table table = ...;
 
@@ -458,8 +458,8 @@ tableEnv.createTemporaryView("exampleView", table);
 // in the database named 'other_database' 
 tableEnv.createTemporaryView("other_database.exampleView", table);
 
-// register the view named 'example.View' in the catalog named 'custom_catalog'
-// in the database named 'custom_database' 
+// register the view named 'View' in the catalog named 'custom_catalog'
+// in the database named 'example' 
 tableEnv.createTemporaryView("`example.View`", table);
 
 // register the view named 'exampleView' in the catalog named 'other_catalog'


### PR DESCRIPTION
## What is the purpose of the change

*This PR corrects two minor errors in the code example under "Expanding Table Identifiers"*


## Brief change log

- The `TableEnvironment` is declared as `tEnv` then later on referenced as `tableEnv`. This PR refers to it as `tableEnv` consistently.
- I believe `example.View` would create a table `View` under database `example`. This PR corrects the comment on the relevant line of the code example.



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
