### PR TITLE
[hotfix][docs] Fix typo in sql queries

### DIFF
--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -916,7 +916,7 @@ StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironm
 StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 
 // ingest a DataStream from an external source
-DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
+DataStream<Tuple4<String, String, String, Long>> ds = env.addSource(...);
 // register the DataStream as table "ShopSales"
 tableEnv.createTemporaryView("ShopSales", ds, $("product_id"), $("category"), $("product_name"), $("sales"));
 
@@ -971,7 +971,7 @@ StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironm
 StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 
 // ingest a DataStream from an external source
-DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
+DataStream<Tuple4<String, String, String, Long>> ds = env.addSource(...);
 // register the DataStream as table "ShopSales"
 tableEnv.createTemporaryView("ShopSales", ds, $("product_id"), $("category"), $("product_name"), $("sales"));
 
@@ -1051,7 +1051,7 @@ StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironm
 StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 
 // ingest a DataStream from an external source
-DataStream<Tuple3<String, String, String, Integer>> ds = env.addSource(...);
+DataStream<Tuple4<String, String, String, Integer>> ds = env.addSource(...);
 // register the DataStream as table "Orders"
 tableEnv.createTemporaryView("Orders", ds, $("order_id"), $("user"), $("product"), $("number"), $("proctime").proctime());
 

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -914,7 +914,7 @@ StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironm
 StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 
 // 接收来自外部数据源的 DataStream
-DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
+DataStream<Tuple4<String, String, String, Long>> ds = env.addSource(...);
 // 把 DataStream 注册为表，表名是 “ShopSales”
 tableEnv.createTemporaryView("ShopSales", ds, "product_id, category, product_name, sales");
 
@@ -969,7 +969,7 @@ StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironm
 StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 
 // 从外部数据源读取 DataStream
-DataStream<Tuple3<String, String, String, Long>> ds = env.addSource(...);
+DataStream<Tuple4<String, String, String, Long>> ds = env.addSource(...);
 // 把 DataStream 注册为表，表名是 “ShopSales”
 tableEnv.createTemporaryView("ShopSales", ds, $("product_id"), $("category"), $("product_name"), $("sales"));
 
@@ -1048,7 +1048,7 @@ StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironm
 StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 
 // 从外部数据源读取 DataStream
-DataStream<Tuple3<String, String, String, Integer>> ds = env.addSource(...);
+DataStream<Tuple4<String, String, String, Integer>> ds = env.addSource(...);
 // 注册名为 “Orders” 的 DataStream
 tableEnv.createTemporaryView("Orders", ds, $("order_id"), $("user"), $("product"), $("number"), $("proctime").proctime());
 


### PR DESCRIPTION
## Brief change log
Correct six typos in code example under "Table API & SQL / SQL / Queries"
In the example the generic type of DataStream define Tuple3<String, String, String, Long>,
actual need DataStream<Tuple4<String, String, String, Long>>.

