### PR TITLE
[FLINK-18058][mesos][tests] Increase heartbeat interval/timeout

### DIFF
--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -338,7 +338,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				highAvailabilityServices = new TestingHighAvailabilityServices();
 				rmLeaderElectionService = new TestingLeaderElectionService();
 				highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
-				heartbeatServices = new HeartbeatServices(5L, 5L);
+				heartbeatServices = new HeartbeatServices(Integer.MAX_VALUE, Integer.MAX_VALUE);
 				slotManager = mock(SlotManager.class);
 				slotManagerStarted = new CompletableFuture<>();
 				jobLeaderIdService = new JobLeaderIdService(


### PR DESCRIPTION
The `MesosResourceManagerTest` uses mock TaskExecutorGateways that never respond to heartbeat requests. The test furthermore assumes that no heartbeat ever times out.

If a heartbeat times out, right before we send the slot report for one of the mock task executors, then we can run into the reported NPE.

This PR addresses the problem by increasing the heartbeat interval/timeout to Integer.MAX_VALUE.

Note that there are a variety of other issues in this test, like the excessive use of mocking, or directly calling methods of the ResourceManager.