### PR TITLE
[FLINK-17327] Fix Kafka Producer Resource Leaks

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -83,6 +83,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -675,7 +676,8 @@ public class FlinkKafkaProducer011<IN>
 						break;
 					case AT_LEAST_ONCE:
 					case NONE:
-						currentTransaction.producer.close();
+						currentTransaction.producer.flush();
+						currentTransaction.producer.close(0, TimeUnit.SECONDS);
 						break;
 				}
 			}
@@ -959,7 +961,8 @@ public class FlinkKafkaProducer011<IN>
 
 	private void recycleTransactionalProducer(FlinkKafkaProducer<byte[], byte[]> producer) {
 		availableTransactionalIds.add(producer.getTransactionalId());
-		producer.close();
+		producer.flush();
+		producer.close(0, TimeUnit.SECONDS);
 	}
 
 	private FlinkKafkaProducer<byte[], byte[]> initTransactionalProducer(String transactionalId, boolean registerMetrics) {

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -36,7 +36,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<kafka.version>2.2.2</kafka.version>
+		<kafka.version>2.4.1</kafka.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
@@ -147,16 +147,7 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 
 	@Override
 	public void close() {
-		synchronized (producerClosingLock) {
-			kafkaProducer.close();
-			if (LOG.isDebugEnabled()) {
-				LOG.debug(
-						"Closed internal KafkaProducer {}. Stacktrace: {}",
-						System.identityHashCode(this),
-						Joiner.on("\n").join(Thread.currentThread().getStackTrace()));
-			}
-			closed = true;
-		}
+		throw new UnsupportedOperationException("Close without timeout is now allowed because it can leave lingering Kafka threads.");
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
@@ -218,18 +218,18 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 				producerId,
 				epoch);
 
-			Object transactionManager = getValue(kafkaProducer, "transactionManager");
+			Object transactionManager = getField(kafkaProducer, "transactionManager");
 			synchronized (transactionManager) {
-				Object nextSequence = getValue(transactionManager, "nextSequence");
+				Object nextSequence = getField(transactionManager, "nextSequence");
 
 				invoke(transactionManager,
 					"transitionTo",
 					getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.INITIALIZING"));
 				invoke(nextSequence, "clear");
 
-				Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
-				setValue(producerIdAndEpoch, "producerId", producerId);
-				setValue(producerIdAndEpoch, "epoch", epoch);
+				Object producerIdAndEpoch = getField(transactionManager, "producerIdAndEpoch");
+				setField(producerIdAndEpoch, "producerId", producerId);
+				setField(producerIdAndEpoch, "epoch", epoch);
 
 				invoke(transactionManager,
 					"transitionTo",
@@ -238,7 +238,7 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 				invoke(transactionManager,
 					"transitionTo",
 					getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.IN_TRANSACTION"));
-				setValue(transactionManager, "transactionStarted", true);
+				setField(transactionManager, "transactionStarted", true);
 			}
 		}
 	}
@@ -248,20 +248,20 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 	}
 
 	public long getProducerId() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
-		Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
-		return (long) getValue(producerIdAndEpoch, "producerId");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
+		Object producerIdAndEpoch = getField(transactionManager, "producerIdAndEpoch");
+		return (long) getField(producerIdAndEpoch, "producerId");
 	}
 
 	public short getEpoch() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
-		Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
-		return (short) getValue(producerIdAndEpoch, "epoch");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
+		Object producerIdAndEpoch = getField(transactionManager, "producerIdAndEpoch");
+		return (short) getField(producerIdAndEpoch, "epoch");
 	}
 
 	@VisibleForTesting
 	public int getTransactionCoordinatorId() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
 		Node node = (Node) invoke(transactionManager, "coordinator", FindCoordinatorRequest.CoordinatorType.TRANSACTION);
 		return node.id();
 	}
@@ -281,21 +281,21 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 	private void flushNewPartitions() {
 		LOG.info("Flushing new partitions");
 		TransactionalRequestResult result = enqueueNewPartitions();
-		Object sender = getValue(kafkaProducer, "sender");
+		Object sender = getField(kafkaProducer, "sender");
 		invoke(sender, "wakeup");
 		result.await();
 	}
 
 	private TransactionalRequestResult enqueueNewPartitions() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
 		synchronized (transactionManager) {
-			Object newPartitionsInTransaction = getValue(transactionManager, "newPartitionsInTransaction");
+			Object newPartitionsInTransaction = getField(transactionManager, "newPartitionsInTransaction");
 			Object newPartitionsInTransactionIsEmpty = invoke(newPartitionsInTransaction, "isEmpty");
 			TransactionalRequestResult result;
 			if (newPartitionsInTransactionIsEmpty instanceof Boolean && !((Boolean) newPartitionsInTransactionIsEmpty)) {
 				Object txnRequestHandler = invoke(transactionManager, "addPartitionsToTransactionHandler");
 				invoke(transactionManager, "enqueueRequest", new Class[]{txnRequestHandler.getClass().getSuperclass()}, new Object[]{txnRequestHandler});
-				result = (TransactionalRequestResult) getValue(txnRequestHandler, txnRequestHandler.getClass().getSuperclass(), "result");
+				result = (TransactionalRequestResult) getField(txnRequestHandler, txnRequestHandler.getClass().getSuperclass(), "result");
 			} else {
 				result = new TransactionalRequestResult();
 				result.done();
@@ -337,11 +337,19 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 		}
 	}
 
-	protected static Object getValue(Object object, String fieldName) {
-		return getValue(object, object.getClass(), fieldName);
+	/**
+	 * Gets and returns the field {@code fieldName} from the given Object {@code object} using
+	 * reflection.
+	 */
+	protected static Object getField(Object object, String fieldName) {
+		return getField(object, object.getClass(), fieldName);
 	}
 
-	private static Object getValue(Object object, Class<?> clazz, String fieldName) {
+	/**
+	 * Gets and returns the field {@code fieldName} from the given Object {@code object} using
+	 * reflection.
+	 */
+	private static Object getField(Object object, Class<?> clazz, String fieldName) {
 		try {
 			Field field = clazz.getDeclaredField(fieldName);
 			field.setAccessible(true);
@@ -351,7 +359,11 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 		}
 	}
 
-	protected static void setValue(Object object, String fieldName, Object value) {
+	/**
+	 * Sets the field {@code fieldName} on the given Object {@code object} to {@code value} using
+	 * reflection.
+	 */
+	protected static void setField(Object object, String fieldName, Object value) {
 		try {
 			Field field = object.getClass().getDeclaredField(fieldName);
 			field.setAccessible(true);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
@@ -286,6 +286,13 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 		result.await();
 	}
 
+	/**
+	 * Enqueues new transactions at the transaction manager and returns a {@link
+	 * TransactionalRequestResult} that allows waiting on them.
+	 *
+	 * <p>If there are no new transactions we return a {@link TransactionalRequestResult} that is
+	 * already done.
+	 */
 	private TransactionalRequestResult enqueueNewPartitions() {
 		Object transactionManager = getField(kafkaProducer, "transactionManager");
 		synchronized (transactionManager) {

--- a/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:2.2.2
+- org.apache.kafka:kafka-clients:2.4.1

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -23,7 +23,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
 - org.javassist:javassist:3.24.0-GA
-- org.lz4:lz4-java:1.5.0
+- org.lz4:lz4-java:1.6.0
 - org.objenesis:objenesis:2.1
 - org.xerial.snappy:snappy-java:1.1.4
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -81,7 +81,7 @@ public class SQLClientKafkaITCase extends TestLogger {
 		return Arrays.asList(new Object[][]{
 				{"0.10.2.0", "0.10", ".*kafka-0.10.jar"},
 				{"0.11.0.2", "0.11", ".*kafka-0.11.jar"},
-				{"2.2.0", "universal", ".*kafka.jar"}
+				{"2.4.1", "universal", ".*kafka.jar"}
 		});
 	}
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -60,7 +60,7 @@ public class StreamingKafkaITCase extends TestLogger {
 		return Arrays.asList(new Object[][]{
 			{"flink-streaming-kafka010-test.*", "0.10.2.0"},
 			{"flink-streaming-kafka011-test.*", "0.11.0.2"},
-			{"flink-streaming-kafka-test.*", "2.2.2"}
+			{"flink-streaming-kafka-test.*", "2.4.1"}
 		});
 	}
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -363,6 +363,7 @@ function check_logs_for_errors {
       | grep -v "[Terror] modules" \
       | grep -v "HeapDumpOnOutOfMemoryError" \
       | grep -v "error_prone_annotations" \
+      | grep -v "Error sending fetch request" \
       | grep -ic "error" || true)
   if [[ ${error_count} -gt 0 ]]; then
     echo "Found error in log files; printing first 500 lines; see full logs for details:"

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -263,7 +263,7 @@ under the License.
 		<dependency>
 			<groupId>org.lz4</groupId>
 			<artifactId>lz4-java</artifactId>
-			<version>1.5.0</version>
+			<version>1.6.0</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
## What is the purpose of the change

This fixes thread leaks that will lead to Flink Task Managers being killed because of the watchdog.

A summary of the bug:
 - our code calls close() on the KafkaProducer (Kafka code), which is equivalent to calling close with a timeout of Long.MAX_VALUE
 - this means threads will leak when a failure happens, for example because of Broker downtime
 - the Flink Task Watchdog will kill the Task Manager because of these threads after a timeout
The fix is to always call close() with a reasonable timeout.

The fix also requires a Kafka version bump because of KAFKA-6635/KAFKA-7763, which mean that resources still leak even when closing with a timeout. Additionally, we need to close with exactly zero as timeout, because otherwise in-flight transactions will be aborted.

## Brief change log

- always call close with zero timeout
- bump Kafka version, this requires some changes to how we use reflection on the Kafka Producer because the internals changed

I add code that forbids calling `close()` with zero timeout by throwing an exception. Alternatively, I could change that to call `close(0)` under the hood, i.e. always enforce calling with zero timeout from the "inside".

## Verifying this change

This is covered by existing threads. I didn't add a test that verifies that we fix the original bug because we would essentially be testing Kafka internals. If I have to I might be able to whip something up.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, Kafka
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

Doesn't introduce a new feature.
