### PR TITLE
[FLINK-18214][Runtime] Remove Job Cache size check against JVM Heap size

### DIFF
--- a/docs/ops/memory/mem_setup_master.md
+++ b/docs/ops/memory/mem_setup_master.md
@@ -62,14 +62,11 @@ As mentioned before in the [total memory description](mem_setup.html#configure-t
 for the Master is to specify explicitly the *JVM Heap* size ([`jobmanager.memory.heap.size`](../config.html#jobmanager-memory-heap-size)).
 It gives more control over the available *JVM Heap* which is used by:
 
-* Flink framework (e.g. *Job cache*)
+* Flink framework
 * User code executed during job submission (e.g. for certain batch sources) or in checkpoint completion callbacks
 
 The required size of *JVM Heap* is mostly driven by the number of running jobs, their structure, and requirements for
 the mentioned user code.
-
-The *Job cache* resides in the *JVM Heap*. It can be configured by
-[`jobstore.cache-size`](../config.html#jobstore-cache-size) which must be less than the configured or derived *JVM Heap* size.
 
 <span class="label label-info">Note</span> If you have configured the *JVM Heap* explicitly, it is recommended to set
 neither *total process memory* nor *total Flink memory*. Otherwise, it may easily lead to memory configuration conflicts.

--- a/docs/ops/memory/mem_setup_master.zh.md
+++ b/docs/ops/memory/mem_setup_master.zh.md
@@ -62,14 +62,11 @@ As mentioned before in the [total memory description](mem_setup.html#configure-t
 for the Master is to specify explicitly the *JVM Heap* size ([`jobmanager.memory.heap.size`](../config.html#jobmanager-memory-heap-size)).
 It gives more control over the available *JVM Heap* which is used by:
 
-* Flink framework (e.g. *Job cache*)
+* Flink framework
 * User code executed during job submission (e.g. for certain batch sources) or in checkpoint completion callbacks
 
 The required size of *JVM Heap* is mostly driven by the number of running jobs, their structure, and requirements for
 the mentioned user code.
-
-The *Job cache* resides in the *JVM Heap*. It can be configured by
-[`jobstore.cache-size`](../config.html#jobstore-cache-size) which must be less than the configured or derived *JVM Heap* size.
 
 <span class="label label-info">Note</span> If you have configured the *JVM Heap* explicitly, it is recommended to set
 neither *total process memory* nor *total Flink memory*. Otherwise, it may easily lead to memory configuration conflicts.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -56,7 +56,7 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 			}
 		}
 
-		return createJobManagerFlinkMemory(config, jvmHeapMemorySize, offHeapMemorySize);
+		return createJobManagerFlinkMemory(jvmHeapMemorySize, offHeapMemorySize);
 	}
 
 	@Override
@@ -69,15 +69,13 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 				offHeapMemorySize.toHumanReadableString());
 		}
 		MemorySize derivedJvmHeapMemorySize = totalFlinkMemorySize.subtract(offHeapMemorySize);
-		return createJobManagerFlinkMemory(config, derivedJvmHeapMemorySize, offHeapMemorySize);
+		return createJobManagerFlinkMemory(derivedJvmHeapMemorySize, offHeapMemorySize);
 	}
 
 	private static JobManagerFlinkMemory createJobManagerFlinkMemory(
-			Configuration config,
 			MemorySize jvmHeap,
 			MemorySize offHeapMemory) {
 		verifyJvmHeapSize(jvmHeap);
-		verifyJobStoreCacheSize(config, jvmHeap);
 		return new JobManagerFlinkMemory(jvmHeap, offHeapMemory);
 	}
 
@@ -87,20 +85,6 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 				"The configured or derived JVM heap memory size ({}) is less than its recommended minimum value ({})",
 				jvmHeapSize.toHumanReadableString(),
 				JobManagerOptions.MIN_JVM_HEAP_SIZE.toHumanReadableString());
-		}
-	}
-
-	private static void verifyJobStoreCacheSize(Configuration config, MemorySize jvmHeapSize) {
-		MemorySize jobStoreCacheHeapSize =
-			MemorySize.parse(config.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE) + "b");
-		if (jvmHeapSize.compareTo(jobStoreCacheHeapSize) < 0) {
-			LOG.warn(
-				"The configured or derived JVM heap memory size ({}: {}) is less than the configured or default size " +
-					"of the job store cache ({}: {})",
-				JobManagerOptions.JVM_HEAP_MEMORY.key(),
-				jvmHeapSize.toHumanReadableString(),
-				JobManagerOptions.JOB_STORE_CACHE_SIZE.key(),
-				jobStoreCacheHeapSize.toHumanReadableString());
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
@@ -84,27 +84,6 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 	}
 
 	@Test
-	public void testLogFailureOfJobStoreCacheSizeVerification() {
-		MemorySize jvmHeapMemory = MemorySize.parse("150m");
-		MemorySize jobStoreCacheSize = MemorySize.parse("200m");
-
-		Configuration conf = new Configuration();
-		conf.set(JobManagerOptions.JVM_HEAP_MEMORY, jvmHeapMemory);
-		conf.set(JobManagerOptions.JOB_STORE_CACHE_SIZE, jobStoreCacheSize.getBytes());
-
-		JobManagerProcessUtils.processSpecFromConfig(conf);
-		MatcherAssert.assertThat(
-			testLoggerResource.getMessages(),
-			hasItem(containsString(String.format(
-				"The configured or derived JVM heap memory size (%s: %s) is less than the configured or default size " +
-					"of the job store cache (%s: %s)",
-				JobManagerOptions.JVM_HEAP_MEMORY.key(),
-				jvmHeapMemory.toHumanReadableString(),
-				JobManagerOptions.JOB_STORE_CACHE_SIZE.key(),
-				jobStoreCacheSize.toHumanReadableString()))));
-	}
-
-	@Test
 	public void testConfigOffHeapMemory() {
 		MemorySize offHeapMemory = MemorySize.parse("100m");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
@@ -63,8 +63,8 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 		Configuration conf = new Configuration();
 		conf.set(JobManagerOptions.JVM_HEAP_MEMORY, jvmHeapSize);
 
-		JobManagerProcessSpec JobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(conf);
-		assertThat(JobManagerProcessSpec.getJvmHeapMemorySize(), is(jvmHeapSize));
+		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(conf);
+		assertThat(jobManagerProcessSpec.getJvmHeapMemorySize(), is(jvmHeapSize));
 	}
 
 	@Test
@@ -171,9 +171,9 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 		log.info("Validating in configuration with explicit jvm heap.");
 		Configuration config = configWithExplicitJvmHeap();
 		config.addAll(customConfig);
-		JobManagerProcessSpec JobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
-		assertThat(JobManagerProcessSpec.getJvmHeapMemorySize(), is(JVM_HEAP_SIZE));
-		validateFunc.accept(JobManagerProcessSpec);
+		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
+		assertThat(jobManagerProcessSpec.getJvmHeapMemorySize(), is(JVM_HEAP_SIZE));
+		validateFunc.accept(jobManagerProcessSpec);
 	}
 
 	private void validateFailInConfigWithExplicitJvmHeap(Configuration customConfig) {
@@ -188,9 +188,9 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 		log.info("Validating in configuration with explicit total flink memory size.");
 		Configuration config = configWithExplicitTotalFlinkMem();
 		config.addAll(customConfig);
-		JobManagerProcessSpec JobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
-		assertThat(JobManagerProcessSpec.getTotalFlinkMemorySize(), is(TOTAL_FLINK_MEM_SIZE));
-		validateFunc.accept(JobManagerProcessSpec);
+		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
+		assertThat(jobManagerProcessSpec.getTotalFlinkMemorySize(), is(TOTAL_FLINK_MEM_SIZE));
+		validateFunc.accept(jobManagerProcessSpec);
 	}
 
 	private void validateFailInConfigWithExplicitTotalFlinkMem(Configuration customConfig) {
@@ -206,10 +206,10 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 		log.info("Validating in configuration with explicit total flink and jvm heap memory size.");
 		Configuration config = configWithExplicitTotalFlinkAndJvmHeapMem();
 		config.addAll(customConfig);
-		JobManagerProcessSpec JobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
-		assertThat(JobManagerProcessSpec.getTotalFlinkMemorySize(), is(TOTAL_FLINK_MEM_SIZE));
-		assertThat(JobManagerProcessSpec.getJvmHeapMemorySize(), is(JVM_HEAP_SIZE));
-		validateFunc.accept(JobManagerProcessSpec);
+		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
+		assertThat(jobManagerProcessSpec.getTotalFlinkMemorySize(), is(TOTAL_FLINK_MEM_SIZE));
+		assertThat(jobManagerProcessSpec.getJvmHeapMemorySize(), is(JVM_HEAP_SIZE));
+		validateFunc.accept(jobManagerProcessSpec);
 	}
 
 	private void validateFailInConfigWithExplicitTotalFlinkAndJvmHeapMem(Configuration customConfig) {
@@ -224,9 +224,9 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 		log.info("Validating in configuration with explicit total process memory size.");
 		Configuration config = configWithExplicitTotalProcessMem();
 		config.addAll(customConfig);
-		JobManagerProcessSpec JobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
-		assertThat(JobManagerProcessSpec.getTotalProcessMemorySize(), is(TOTAL_PROCESS_MEM_SIZE));
-		validateFunc.accept(JobManagerProcessSpec);
+		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(config);
+		assertThat(jobManagerProcessSpec.getTotalProcessMemorySize(), is(TOTAL_PROCESS_MEM_SIZE));
+		validateFunc.accept(jobManagerProcessSpec);
 	}
 
 	private void validateFailInConfigWithExplicitTotalProcessMem(Configuration customConfig) {


### PR DESCRIPTION
Checking that the job cache size is less than JVM heap for JM, may be inconclusive and confusing for users. The job cache size option does not strictly limit the real size and stays an advanced emergency mean. The job size calculation is approximate and the real cache size can be larger than its configured limit (`jobstore.cache-size`).

Therefore, this PR removes the related code from `JobManagerFlinkMemoryUtils`, tests and memory tuning guide.