### PR TITLE
[FLINK-18072][hbase] HBaseLookupFunction can not work with new internal data structure RowData

### DIFF
--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseDynamicTableSource.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseDynamicTableSource.java
@@ -77,7 +77,7 @@ public class HBaseDynamicTableSource implements ScanTableSource, LookupTableSour
 				.isPresent(),
 			"Currently, HBase table only supports lookup by rowkey field.");
 
-		return TableFunctionProvider.of(new HBaseLookupFunction(conf, tableName, hbaseSchema));
+		return TableFunctionProvider.of(new HBaseRowDataLookupFunction(conf, tableName, hbaseSchema, nullStringLiteral));
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Result;
 import org.slf4j.Logger;
@@ -77,10 +78,13 @@ public class HBaseRowDataLookupFunction extends TableFunction<RowData> {
 	 */
 	public void eval(Object rowKey) throws IOException {
 		// fetch result
-		Result result = table.get(serde.createGet(rowKey));
-		if (!result.isEmpty()) {
-			// parse and collect
-			collect(serde.convertToRow(result));
+		Get get = serde.createGet(rowKey);
+		if (get != null) {
+			Result result = table.get(get);
+			if (!result.isEmpty()) {
+				// parse and collect
+				collect(serde.convertToRow(result));
+			}
 		}
 	}
 

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
@@ -21,7 +21,6 @@ package org.apache.flink.connector.hbase.source;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
-import org.apache.flink.connector.hbase.util.HBaseReadWriteHelper;
 import org.apache.flink.connector.hbase.util.HBaseSerde;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.table.data.RowData;
@@ -57,7 +56,6 @@ public class HBaseRowDataLookupFunction extends TableFunction<RowData> {
 	private final HBaseTableSchema hbaseTableSchema;
 	private final String nullStringLiteral;
 
-	private transient HBaseReadWriteHelper readHelper;
 	private transient Connection hConnection;
 	private transient HTable table;
 	private transient HBaseSerde serde;
@@ -79,7 +77,7 @@ public class HBaseRowDataLookupFunction extends TableFunction<RowData> {
 	 */
 	public void eval(Object rowKey) throws IOException {
 		// fetch result
-		Result result = table.get(readHelper.createGet(rowKey));
+		Result result = table.get(serde.createGet(rowKey));
 		if (!result.isEmpty()) {
 			// parse and collect
 			collect(serde.convertToRow(result));
@@ -117,7 +115,6 @@ public class HBaseRowDataLookupFunction extends TableFunction<RowData> {
 			LOG.error("Exception while creating connection to HBase.", ioe);
 			throw new RuntimeException("Cannot create connection to HBase.", ioe);
 		}
-		this.readHelper = new HBaseReadWriteHelper(hbaseTableSchema);
 		this.serde = new HBaseSerde(hbaseTableSchema, nullStringLiteral);
 		LOG.info("end open.");
 	}

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 
 import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
@@ -188,6 +189,30 @@ public class HBaseSerde {
 			}
 		}
 		return scan;
+	}
+
+	/**
+	 * Returns an instance of Get that retrieves the matches records from the HBase table.
+	 *
+	 * @return The appropriate instance of Get for this use case.
+	 */
+	public Get createGet(Object rowKey) {
+		checkArgument(keyEncoder != null, "row key is not set.");
+		GenericRowData rowData = new GenericRowData(1);
+		rowData.setField(0, rowKey);
+		byte[] rowkey = keyEncoder.encode(rowData, 0);
+		if (rowkey.length == 0) {
+			// drop dirty records, rowkey shouldn't be zero length
+			return null;
+		}
+		Get get = new Get(rowkey);
+		for (int f = 0; f < families.length; f++) {
+			byte[] family = families[f];
+			for (byte[] qualifier : qualifiers[f]) {
+				get.addColumn(family, qualifier);
+			}
+		}
+		return get;
 	}
 
 	/**

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
@@ -72,7 +72,7 @@ public class HBaseSerde {
 	private final @Nullable FieldDecoder keyDecoder;
 	private final FieldEncoder[][] qualifierEncoders;
 	private final FieldDecoder[][] qualifierDecoders;
-	private final transient GenericRowData rowWithRowKey;
+	private final GenericRowData rowWithRowKey;
 
 	public HBaseSerde(HBaseTableSchema hbaseSchema, final String nullStringLiteral) {
 		this.families = hbaseSchema.getFamilyKeys();

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
@@ -76,13 +76,6 @@ import scala.Option;
 
 import static org.apache.flink.connector.hbase.util.PlannerType.OLD_PLANNER;
 import static org.apache.flink.table.api.Expressions.$;
-import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
-import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
-import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_TABLE_NAME;
-import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_TYPE_VALUE_HBASE;
-import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_VERSION_VALUE_143;
-import static org.apache.flink.table.descriptors.HBaseValidator.CONNECTOR_ZK_QUORUM;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
 import static org.junit.Assert.assertEquals;
 

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDynamicTableFactoryTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.connector.hbase.options.HBaseOptions;
 import org.apache.flink.connector.hbase.options.HBaseWriteOptions;
 import org.apache.flink.connector.hbase.sink.HBaseDynamicTableSink;
 import org.apache.flink.connector.hbase.source.HBaseDynamicTableSource;
-import org.apache.flink.connector.hbase.source.HBaseLookupFunction;
+import org.apache.flink.connector.hbase.source.HBaseRowDataLookupFunction;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTableImpl;
@@ -111,8 +111,8 @@ public class HBaseDynamicTableFactoryTest {
 		assertTrue(lookupProvider instanceof TableFunctionProvider);
 
 		TableFunction tableFunction = ((TableFunctionProvider) lookupProvider).createTableFunction();
-		assertTrue(tableFunction instanceof HBaseLookupFunction);
-		assertEquals("testHBastTable", ((HBaseLookupFunction) tableFunction).getHTableName());
+		assertTrue(tableFunction instanceof HBaseRowDataLookupFunction);
+		assertEquals("testHBastTable", ((HBaseRowDataLookupFunction) tableFunction).getHTableName());
 
 		HBaseTableSchema hbaseSchema = hbaseSource.getHBaseTableSchema();
 		assertEquals(2, hbaseSchema.getRowKeyIndex());

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/util/HBaseTestBase.java
@@ -28,8 +28,16 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.dateToInternal;
+import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.timeToInternal;
+import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.timestampToInternal;
 
 /**
  * Abstract IT case class for HBase.
@@ -40,7 +48,8 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 	protected static final String TEST_TABLE_2 = "testTable2";
 	protected static final String TEST_TABLE_3 = "testTable3";
 
-	protected static final String ROWKEY = "rk";
+	protected static final String ROW_KEY = "rowkey";
+
 	protected static final String FAMILY1 = "family1";
 	protected static final String F1COL1 = "col1";
 
@@ -54,11 +63,16 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 	protected static final String F3COL3 = "col3";
 
 	protected static final String FAMILY4 = "family4";
+	protected static final String F4COL1 = "col1";
+	protected static final String F4COL2 = "col2";
+	protected static final String F4COL3 = "col3";
+	protected static final String F4COL4 = "col4";
 
 	private static final byte[][] FAMILIES = new byte[][]{
 		Bytes.toBytes(FAMILY1),
 		Bytes.toBytes(FAMILY2),
-		Bytes.toBytes(FAMILY3)
+		Bytes.toBytes(FAMILY3),
+		Bytes.toBytes(FAMILY4)
 	};
 
 	private static final byte[][] SPLIT_KEYS = new byte[][]{Bytes.toBytes(4)};
@@ -107,14 +121,30 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 		HTable table = openTable(tableName);
 		List<Put> puts = new ArrayList<>();
 		// add some data
-		puts.add(putRow(1, 10, "Hello-1", 100L, 1.01, false, "Welt-1"));
-		puts.add(putRow(2, 20, "Hello-2", 200L, 2.02, true, "Welt-2"));
-		puts.add(putRow(3, 30, "Hello-3", 300L, 3.03, false, "Welt-3"));
-		puts.add(putRow(4, 40, null, 400L, 4.04, true, "Welt-4"));
-		puts.add(putRow(5, 50, "Hello-5", 500L, 5.05, false, "Welt-5"));
-		puts.add(putRow(6, 60, "Hello-6", 600L, 6.06, true, "Welt-6"));
-		puts.add(putRow(7, 70, "Hello-7", 700L, 7.07, false, "Welt-7"));
-		puts.add(putRow(8, 80, null, 800L, 8.08, true, "Welt-8"));
+		puts.add(putRow(1, 10, "Hello-1", 100L, 1.01, false, "Welt-1",
+			Timestamp.valueOf("2019-08-18 19:00:00"), Date.valueOf("2019-08-18"),
+			Time.valueOf("19:00:00"), new BigDecimal(12345678.0001)));
+		puts.add(putRow(2, 20, "Hello-2", 200L, 2.02, true, "Welt-2",
+			Timestamp.valueOf("2019-08-18 19:01:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:01:00"),
+			new BigDecimal(12345678.0002)));
+		puts.add(putRow(3, 30, "Hello-3", 300L, 3.03, false, "Welt-3",
+			Timestamp.valueOf("2019-08-18 19:02:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:02:00"),
+			new BigDecimal(12345678.0003)));
+		puts.add(putRow(4, 40, null, 400L, 4.04, true, "Welt-4",
+			Timestamp.valueOf("2019-08-18 19:03:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:03:00"),
+			new BigDecimal(12345678.0004)));
+		puts.add(putRow(5, 50, "Hello-5", 500L, 5.05, false, "Welt-5",
+			Timestamp.valueOf("2019-08-19 19:10:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:10:00"),
+			new BigDecimal(12345678.0005)));
+		puts.add(putRow(6, 60, "Hello-6", 600L, 6.06, true, "Welt-6",
+			Timestamp.valueOf("2019-08-19 19:20:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:20:00"),
+			new BigDecimal(12345678.0006)));
+		puts.add(putRow(7, 70, "Hello-7", 700L, 7.07, false, "Welt-7",
+			Timestamp.valueOf("2019-08-19 19:30:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:30:00"),
+			new BigDecimal(12345678.0007)));
+		puts.add(putRow(8, 80, null, 800L, 8.08, true, "Welt-8",
+			Timestamp.valueOf("2019-08-19 19:40:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:40:00"),
+			new BigDecimal(12345678.0008)));
 
 		// append rows to table
 		table.put(puts);
@@ -139,7 +169,18 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 		createTable(tableName, families, SPLIT_KEYS);
 	}
 
-	private static Put putRow(int rowKey, int f1c1, String f2c1, long f2c2, double f3c1, boolean f3c2, String f3c3) {
+	private static Put putRow(
+			int rowKey,
+			int f1c1,
+			String f2c1,
+			long f2c2,
+			double f3c1,
+			boolean f3c2,
+			String f3c3,
+			Timestamp f4c1,
+			Date f4c2,
+			Time f4c3,
+			BigDecimal f4c4) {
 		Put put = new Put(Bytes.toBytes(rowKey));
 		// family 1
 		put.addColumn(Bytes.toBytes(FAMILY1), Bytes.toBytes(F1COL1), Bytes.toBytes(f1c1));
@@ -153,6 +194,11 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 		put.addColumn(Bytes.toBytes(FAMILY3), Bytes.toBytes(F3COL2), Bytes.toBytes(f3c2));
 		put.addColumn(Bytes.toBytes(FAMILY3), Bytes.toBytes(F3COL3), Bytes.toBytes(f3c3));
 
+		// family 4
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL1), Bytes.toBytes(timestampToInternal(f4c1)));
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(dateToInternal(f4c2)));
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL3), Bytes.toBytes(timeToInternal(f4c3)));
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL4), Bytes.toBytes(f4c4));
 		return put;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

* This PR fix HBase lookup function can not work properly with the new internal Data structure `RowData`.


## Brief change log

  - Import org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java to lookup RowData
  - Clean up some test code


## Verifying this change

This change is covered by ITCase `HBaseConnectorITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
