### PR TITLE
[FLINK-18247][table-planner-blink] Fix unstable test: TableITCase.testCollectWithClose

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -119,15 +119,12 @@ class TableITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     val it = tableResult.collect()
     it.close()
-    val jobStatus = try {
-      Some(tableResult.getJobClient.get().getJobStatus.get())
+    try {
+      assertNotEquals(JobStatus.RUNNING, tableResult.getJobClient.get().getJobStatus.get())
     } catch {
       // ignore the exception,
       // because the MiniCluster maybe already been shut down when getting job status
       case _: Throwable => None
-    }
-    if (jobStatus.isDefined) {
-      assertNotEquals(JobStatus.RUNNING, jobStatus.get)
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -119,12 +119,15 @@ class TableITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     val it = tableResult.collect()
     it.close()
-    try {
-      assertNotEquals(JobStatus.RUNNING, tableResult.getJobClient.get().getJobStatus.get())
+    val jobStatus = try {
+      Some(tableResult.getJobClient.get().getJobStatus.get())
     } catch {
       // ignore the exception,
       // because the MiniCluster maybe already been shut down when getting job status
       case _: Throwable => None
+    }
+    if (jobStatus.isDefined) {
+      assertNotEquals(JobStatus.RUNNING, jobStatus.get)
     }
   }
 


### PR DESCRIPTION

## What is the purpose of the change

*The reason is after calling CloseableIterator#close to cancel job in TableITCase.testCollectWithClose method, the job status may be CANCELED, CANCELING or even the MiniCluster maybe already been shut down. An exception will be thrown when MiniCluster is down. This pr aims to fix the unstable case.*


## Brief change log

  - *Change the getting jobStatus logic and jobStatus checking logic in TableITCase.testCollectWithClose*



## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
