### PR TITLE
[FLINK-18250] Enrich OOM error messages with more details in ClusterEntrypoint

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.core.memory;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TaskManagerExceptionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,7 +147,7 @@ public final class MemorySegmentFactory {
 			// once we find a common way to handle OOM errors in netty threads.
 			// Here we enrich it to propagate better OOM message to the receiver
 			// if it happens in a netty thread.
-			Throwable enrichedOutOfMemoryError = ExceptionUtils.tryEnrichTaskManagerError(outOfMemoryError);
+			Throwable enrichedOutOfMemoryError = TaskManagerExceptionUtils.tryEnrichTaskManagerError(outOfMemoryError);
 			if (ExceptionUtils.isDirectOutOfMemoryError(outOfMemoryError)) {
 				LOG.error("Cannot allocate direct memory segment", enrichedOutOfMemoryError);
 			}

--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -120,7 +120,7 @@ public final class ExceptionUtils {
 	 * {@code null} if the argument was {@code null}
 	 */
 	@Nullable
-	static Throwable tryEnrichOutOfMemoryError(
+	public static Throwable tryEnrichOutOfMemoryError(
 			@Nullable Throwable exception,
 			String jvmMetaspaceOomNewErrorMessage,
 			String jvmDirectOomNewErrorMessage) {

--- a/flink-core/src/main/java/org/apache/flink/util/TaskManagerExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TaskManagerExceptionUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.configuration.TaskManagerOptions;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.ExceptionUtils.tryEnrichOutOfMemoryError;
+
+/**
+ * Exception utils to handle and enrich exceptions occurring in TaskManager.
+ */
+public class TaskManagerExceptionUtils {
+	private static final String TM_DIRECT_OOM_ERROR_MESSAGE = String.format(
+		"Direct buffer memory. The direct out-of-memory error has occurred. This can mean two things: either job(s) require(s) " +
+			"a larger size of JVM direct memory or there is a direct memory leak. The direct memory can be " +
+			"allocated by user code or some of its dependencies. In this case '%s' configuration option should be " +
+			"increased. Flink framework and its dependencies also consume the direct memory, mostly for network " +
+			"communication. The most of network memory is managed by Flink and should not result in out-of-memory " +
+			"error. In certain special cases, in particular for jobs with high parallelism, the framework may " +
+			"require more direct memory which is not managed by Flink. In this case '%s' configuration option " +
+			"should be increased. If the error persists then there is probably a direct memory leak in user code or " +
+			"some of its dependencies which has to be investigated and fixed. The task executor has to be shutdown...",
+		TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key(),
+		TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key());
+
+	private static final String TM_METASPACE_OOM_ERROR_MESSAGE = String.format(
+		"Metaspace. The metaspace out-of-memory error has occurred. This can mean two things: either the job requires " +
+			"a larger size of JVM metaspace to load classes or there is a class loading leak. In the first case " +
+			"'%s' configuration option should be increased. If the error persists (usually in cluster after " +
+			"several job (re-)submissions) then there is probably a class loading leak in user code or some of its dependencies " +
+			"which has to be investigated and fixed. The task executor has to be shutdown...",
+		TaskManagerOptions.JVM_METASPACE.key());
+
+	private TaskManagerExceptionUtils() {
+	}
+
+	/**
+	 * Tries to enrich the passed exception with additional information.
+	 *
+	 * <p>This method improves error message for direct and metaspace {@link OutOfMemoryError}.
+	 * It adds description of possible causes and ways of resolution.
+	 *
+	 * @param exception exception to enrich if not {@code null}
+	 * @return the enriched exception or the original if no additional information could be added;
+	 * {@code null} if the argument was {@code null}
+	 */
+	@Nullable
+	public static Throwable tryEnrichTaskManagerError(@Nullable Throwable exception) {
+		return tryEnrichOutOfMemoryError(exception, TM_METASPACE_OOM_ERROR_MESSAGE, TM_DIRECT_OOM_ERROR_MESSAGE);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/util/ExceptionUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/ExceptionUtilsTest.java
@@ -91,7 +91,7 @@ public class ExceptionUtilsTest extends TestLogger {
 
 	@Test
 	public void testTryEnrichTaskExecutorErrorCanHandleNullValue() {
-		assertThat(ExceptionUtils.tryEnrichTaskManagerError(null), is(nullValue()));
+		assertThat(ExceptionUtils.tryEnrichOutOfMemoryError(null, "", ""), is(nullValue()));
 	}
 
 	@Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntryPointExceptionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntryPointExceptionUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.configuration.JobManagerOptions;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.ExceptionUtils.tryEnrichOutOfMemoryError;
+
+/**
+ * Exception utils to handle and enrich exceptions occurring in TaskManager.
+ */
+class ClusterEntryPointExceptionUtils {
+	private static final String JM_DIRECT_OOM_ERROR_MESSAGE = String.format(
+		"Direct buffer memory. The direct out-of-memory error has occurred. This can mean two things: either Flink Master requires " +
+			"a larger size of JVM direct memory or there is a direct memory leak. The direct memory can be " +
+			"allocated by user code or some of its dependencies. Flink framework and its dependencies also consume " +
+			"the direct memory, mostly for network communication. In certain special cases, in particular for jobs with " +
+			"high parallelism, the framework may require more direct memory which is not managed by Flink. " +
+			"To increase the JVM Direct Memory limit, '%s' configuration option should be increased. " +
+			"If the error persists then there is probably a direct memory leak in user code or some of its dependencies " +
+			"which has to be investigated and fixed. The Flink Master has to be shutdown...",
+		JobManagerOptions.OFF_HEAP_MEMORY.key());
+
+	private static final String JM_METASPACE_OOM_ERROR_MESSAGE = String.format(
+		"Metaspace. The metaspace out-of-memory error has occurred. This can mean two things: either Flink Master requires " +
+			"a larger size of JVM metaspace to load classes or there is a class loading leak. In the first case " +
+			"'%s' configuration option should be increased. If the error persists (usually in cluster after " +
+			"several job (re-)submissions) then there is probably a class loading leak in user code or some of its dependencies " +
+			"which has to be investigated and fixed. The Flink Master has to be shutdown...",
+		JobManagerOptions.JVM_METASPACE.key());
+
+	private ClusterEntryPointExceptionUtils() {
+	}
+
+	/**
+	 * Tries to enrich the passed exception with additional information.
+	 *
+	 * <p>This method improves error message for direct and metaspace {@link OutOfMemoryError}.
+	 * It adds description of possible causes and ways of resolution.
+	 *
+	 * @param exception exception to enrich if not {@code null}
+	 * @return the enriched exception or the original if no additional information could be added;
+	 * {@code null} if the argument was {@code null}
+	 */
+	@Nullable
+	static Throwable tryEnrichClusterEntryPointError(@Nullable Throwable exception) {
+		return tryEnrichOutOfMemoryError(exception, JM_METASPACE_OOM_ERROR_MESSAGE, JM_DIRECT_OOM_ERROR_MESSAGE);
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -386,7 +386,8 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
 	@Override
 	public void onFatalError(Throwable exception) {
-		LOG.error("Fatal error occurred in the cluster entrypoint.", exception);
+		Throwable enrichedException = ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(exception);
+		LOG.error("Fatal error occurred in the cluster entrypoint.", enrichedException);
 
 		System.exit(RUNTIME_FAILURE_RETURN_CODE);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.util.TaskManagerExceptionUtils;
 import org.apache.flink.runtime.taskmanager.MemoryLogger;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -251,7 +252,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 	@Override
 	public void onFatalError(Throwable exception) {
-		Throwable enrichedException = ExceptionUtils.tryEnrichTaskManagerError(exception);
+		Throwable enrichedException = TaskManagerExceptionUtils.tryEnrichTaskManagerError(exception);
 		LOG.error("Fatal error occurred while executing the TaskManager. Shutting it down...", enrichedException);
 
 		// In case of the Metaspace OutOfMemoryError, we expect that the graceful shutdown is possible,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -75,6 +75,7 @@ import org.apache.flink.runtime.taskexecutor.BackPressureSampleableTask;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
+import org.apache.flink.util.TaskManagerExceptionUtils;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotPayload;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.types.Either;
@@ -754,7 +755,7 @@ public class Task implements Runnable, TaskSlotPayload, TaskActions, PartitionPr
 			// an exception was thrown as a side effect of cancelling
 			// ----------------------------------------------------------------
 
-			t = ExceptionUtils.tryEnrichTaskManagerError(t);
+			t = TaskManagerExceptionUtils.tryEnrichTaskManagerError(t);
 
 			try {
 				// check if the exception is unrecoverable


### PR DESCRIPTION
Similar to what we added for TM in #11408,
this PR adds more information and hints about out-of-memory failures in `ClusterEntrypoint`.
It also factors out TM/JM related exception handling out of general `ExceptionUtils`.