### PR TITLE
[FLINK-18246][python][e2e] Disable PyFlink e2e tests when running on jdk11 to avoid the UnsupportedClassVersionError.

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -215,10 +215,7 @@ run_test "Dependency shading of table modules test" "$END_TO_END_DIR/test-script
 
 run_test "Shaded Hadoop S3A with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_with_provider"
 
-# These tests are known to fail on JDK11. See FLINK-13719
-if [[ ${PROFILE} != *"jdk11"* ]]; then
-	run_test "PyFlink end-to-end test" "$END_TO_END_DIR/test-scripts/test_pyflink.sh" "skip_check_exceptions"
-fi
+run_test "PyFlink end-to-end test" "$END_TO_END_DIR/test-scripts/test_pyflink.sh" "skip_check_exceptions"
 
 ################################################################################
 # Sticky Scheduling

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -215,7 +215,10 @@ run_test "Dependency shading of table modules test" "$END_TO_END_DIR/test-script
 
 run_test "Shaded Hadoop S3A with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_with_provider"
 
-run_test "PyFlink end-to-end test" "$END_TO_END_DIR/test-scripts/test_pyflink.sh" "skip_check_exceptions"
+# These tests are known to fail on JDK11. See FLINK-13719
+if [[ ${PROFILE} != *"jdk11"* ]]; then
+	run_test "PyFlink end-to-end test" "$END_TO_END_DIR/test-scripts/test_pyflink.sh" "skip_check_exceptions"
+fi
 
 ################################################################################
 # Sticky Scheduling

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -20,7 +20,6 @@
 set -Eeuo pipefail
 CURRENT_DIR=`cd "$(dirname "$0")" && pwd -P`
 source "${CURRENT_DIR}"/common.sh
-source "${CURRENT_DIR}"/common_yarn_docker.sh
 
 cp -r "${FLINK_DIR}/conf" "${TEST_DATA_DIR}/conf"
 
@@ -164,6 +163,8 @@ stop_cluster
 
 # These tests are known to fail on JDK11. See FLINK-13719
 if [[ ${PROFILE} != *"jdk11"* ]]; then
+    cd "${CURRENT_DIR}/../"
+    source "${CURRENT_DIR}"/common_yarn_docker.sh
     # test submitting on yarn
     start_hadoop_cluster_and_prepare_flink
 

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -162,45 +162,48 @@ wait_job_terminal_state "$JOB_ID" "FINISHED"
 
 stop_cluster
 
-# test submitting on yarn
-start_hadoop_cluster_and_prepare_flink
+# These tests are known to fail on JDK11. See FLINK-13719
+if [[ ${PROFILE} != *"jdk11"* ]]; then
+    # test submitting on yarn
+    start_hadoop_cluster_and_prepare_flink
 
-# copy test files
-docker cp "${FLINK_PYTHON_DIR}/dev/lint-python.sh" master:/tmp/
-docker cp "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar" master:/tmp/
-docker cp "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" master:/tmp/
-docker cp "${REQUIREMENTS_PATH}" master:/tmp/
-docker cp "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" master:/tmp/
-PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache-flink-*.tar.gz)
-docker cp "${FLINK_PYTHON_DIR}/dist/${PYFLINK_PACKAGE_FILE}" master:/tmp/
+    # copy test files
+    docker cp "${FLINK_PYTHON_DIR}/dev/lint-python.sh" master:/tmp/
+    docker cp "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar" master:/tmp/
+    docker cp "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" master:/tmp/
+    docker cp "${REQUIREMENTS_PATH}" master:/tmp/
+    docker cp "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" master:/tmp/
+    PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache-flink-*.tar.gz)
+    docker cp "${FLINK_PYTHON_DIR}/dist/${PYFLINK_PACKAGE_FILE}" master:/tmp/
 
-# prepare environment
-docker exec master bash -c "
-/tmp/lint-python.sh -s miniconda
-source /tmp/.conda/bin/activate
-pip install /tmp/${PYFLINK_PACKAGE_FILE}
-conda install -y -q zip=3.0
-rm -rf /tmp/.conda/pkgs
-cd /tmp
-zip -q -r /tmp/venv.zip .conda
-echo \"taskmanager.memory.task.off-heap.size: 100m\" >> \"/home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml\"
-"
+    # prepare environment
+    docker exec master bash -c "
+    /tmp/lint-python.sh -s miniconda
+    source /tmp/.conda/bin/activate
+    pip install /tmp/${PYFLINK_PACKAGE_FILE}
+    conda install -y -q zip=3.0
+    rm -rf /tmp/.conda/pkgs
+    cd /tmp
+    zip -q -r /tmp/venv.zip .conda
+    echo \"taskmanager.memory.task.off-heap.size: 100m\" >> \"/home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml\"
+    "
 
-docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
-    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
-    /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
-    -pyfs /tmp/add_one.py \
-    -pyreq /tmp/requirements.txt \
-    -pyarch /tmp/venv.zip \
-    -pyexec venv.zip/.conda/bin/python \
-    /tmp/PythonUdfSqlJobExample.jar"
+    docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+        export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+        /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
+        -pyfs /tmp/add_one.py \
+        -pyreq /tmp/requirements.txt \
+        -pyarch /tmp/venv.zip \
+        -pyexec venv.zip/.conda/bin/python \
+        /tmp/PythonUdfSqlJobExample.jar"
 
-docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
-    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
-    /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
-    -pyfs /tmp/add_one.py \
-    -pyreq /tmp/requirements.txt \
-    -pyarch /tmp/venv.zip \
-    -pyexec venv.zip/.conda/bin/python \
-    -py /tmp/python_job.py \
-    pipeline.jars file:/tmp/PythonUdfSqlJobExample.jar"
+    docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+        export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+        /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
+        -pyfs /tmp/add_one.py \
+        -pyreq /tmp/requirements.txt \
+        -pyarch /tmp/venv.zip \
+        -pyexec venv.zip/.conda/bin/python \
+        -py /tmp/python_job.py \
+        pipeline.jars file:/tmp/PythonUdfSqlJobExample.jar"
+fi


### PR DESCRIPTION
## What is the purpose of the change

*This pull request disables PyFlink e2e tests when running on jdk11 to avoid the UnsupportedClassVersionError.*


## Brief change log

  - *Disable PyFlink e2e tests when running on jdk11.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
