### PR TITLE
[FLINK-18242][state-backend-rocksdb] Separate RocksDBOptionsFactory from OptionsFactory

### DIFF
--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -641,7 +641,7 @@ class RocksDBStateBackend(StateBackend):
         j_options_factory_clz = load_java_class(options_factory_class_name)
         if not get_java_class(JOptionsFactory).isAssignableFrom(j_options_factory_clz):
             raise ValueError("The input class not implements OptionsFactory.")
-        self._j_rocks_db_state_backend.setOptions(j_options_factory_clz.newInstance())
+        self._j_rocks_db_state_backend.setRocksDBOptions(j_options_factory_clz.newInstance())
 
     def get_options(self):
         """
@@ -650,7 +650,7 @@ class RocksDBStateBackend(StateBackend):
 
         :return: The fully-qualified class name of the options factory in Java.
         """
-        j_options_factory = self._j_rocks_db_state_backend.getOptions()
+        j_options_factory = self._j_rocks_db_state_backend.getRocksDBOptions()
         if j_options_factory is not None:
             return j_options_factory.getClass().getName()
         else:

--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -637,10 +637,10 @@ class RocksDBStateBackend(StateBackend):
                                            The options factory must have a default constructor.
         """
         gateway = get_gateway()
-        JOptionsFactory = gateway.jvm.org.apache.flink.contrib.streaming.state.OptionsFactory
+        JOptionsFactory = gateway.jvm.org.apache.flink.contrib.streaming.state.RocksDBOptionsFactory
         j_options_factory_clz = load_java_class(options_factory_class_name)
         if not get_java_class(JOptionsFactory).isAssignableFrom(j_options_factory_clz):
-            raise ValueError("The input class not implements OptionsFactory.")
+            raise ValueError("The input class not implements RocksDBOptionsFactory.")
         self._j_rocks_db_state_backend.setRocksDBOptions(j_options_factory_clz.newInstance())
 
     def get_options(self):

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/OptionsFactoryAdapter.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/OptionsFactoryAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+
+import java.util.ArrayList;
+
+/**
+ * A conversion from {@link RocksDBOptionsFactory} to {@link OptionsFactory}.
+ */
+public class OptionsFactoryAdapter implements OptionsFactory {
+
+	private static final long serialVersionUID = 1L;
+
+	private final RocksDBOptionsFactory rocksDBOptionsFactory;
+
+	OptionsFactoryAdapter(RocksDBOptionsFactory rocksDBOptionsFactory) {
+		this.rocksDBOptionsFactory = rocksDBOptionsFactory;
+	}
+
+	@Override
+	public DBOptions createDBOptions(DBOptions currentOptions) {
+		return rocksDBOptionsFactory.createDBOptions(currentOptions, new ArrayList<>());
+	}
+
+	@Override
+	public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+		return rocksDBOptionsFactory.createColumnOptions(currentOptions, new ArrayList<>());
+	}
+
+	@VisibleForTesting
+	RocksDBOptionsFactory getRocksDBOptionsFactory() {
+		return rocksDBOptionsFactory;
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactory.java
@@ -21,7 +21,6 @@ package org.apache.flink.contrib.streaming.state;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -32,7 +31,7 @@ import java.util.Collection;
  * <p>A typical pattern to use this OptionsFactory is as follows:
  *
  * <pre>{@code
- * rocksDbBackend.setOptions(new RocksDBOptionsFactory() {
+ * rocksDbBackend.setRocksDBOptions(new RocksDBOptionsFactory() {
  *
  *		public DBOptions createDBOptions(DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
  *			return currentOptions.setMaxOpenFiles(1024);
@@ -49,8 +48,7 @@ import java.util.Collection;
  * });
  * }</pre>
  */
-@SuppressWarnings("deprecation")
-public interface RocksDBOptionsFactory extends OptionsFactory, java.io.Serializable {
+public interface RocksDBOptionsFactory extends java.io.Serializable {
 
 	/**
 	 * This method should set the additional options on top of the current options object.
@@ -91,27 +89,5 @@ public interface RocksDBOptionsFactory extends OptionsFactory, java.io.Serializa
 	 */
 	default RocksDBNativeMetricOptions createNativeMetricsOptions(RocksDBNativeMetricOptions nativeMetricOptions) {
 		return nativeMetricOptions;
-	}
-
-	// ------------------------------------------------------------------------
-	//  for compatibility
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Do not override these methods, they are only to maintain interface compatibility with
-	 * prior versions. They will be removed in one of the next versions.
-	 */
-	@Override
-	default DBOptions createDBOptions(DBOptions currentOptions) {
-		return createDBOptions(currentOptions, new ArrayList<>());
-	}
-
-	/**
-	 * Do not override these methods, they are only to maintain interface compatibility with
-	 * prior versions. They will be removed in one of the next versions.
-	 */
-	@Override
-	default ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
-		return createColumnOptions(currentOptions, new ArrayList<>());
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactoryAdapter.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactoryAdapter.java
@@ -67,9 +67,9 @@ final class RocksDBOptionsFactoryAdapter implements ConfigurableRocksDBOptionsFa
 	}
 
 	@Nullable
-	public static OptionsFactory unwrapIfAdapter(RocksDBOptionsFactory factory) {
+	static OptionsFactory unwrapIfAdapter(RocksDBOptionsFactory factory) {
 		return factory instanceof RocksDBOptionsFactoryAdapter
 				? ((RocksDBOptionsFactoryAdapter) factory).optionsFactory
-				: factory;
+				: new OptionsFactoryAdapter(factory);
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -811,9 +811,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 */
 	@Deprecated
 	public void setOptions(OptionsFactory optionsFactory) {
-		this.rocksDbOptionsFactory = optionsFactory instanceof RocksDBOptionsFactory
-				? (RocksDBOptionsFactory) optionsFactory
-				: new RocksDBOptionsFactoryAdapter(optionsFactory);
+		this.rocksDbOptionsFactory = new RocksDBOptionsFactoryAdapter(optionsFactory);
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -822,7 +822,11 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 */
 	@Deprecated
 	public OptionsFactory getOptions() {
-		return RocksDBOptionsFactoryAdapter.unwrapIfAdapter(rocksDbOptionsFactory);
+		if (rocksDbOptionsFactory == null) {
+			return null;
+		} else {
+			return RocksDBOptionsFactoryAdapter.unwrapIfAdapter(rocksDbOptionsFactory);
+		}
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -552,7 +552,14 @@ public class RocksDBStateBackendConfigTest {
 		rocksDbBackend = rocksDbBackend.configure(config, getClass().getClassLoader());
 
 		assertTrue(rocksDbBackend.getRocksDBOptions() instanceof TestOptionsFactory);
-		assertTrue(rocksDbBackend.getOptions() instanceof TestOptionsFactory);
+		OptionsFactory optionsFactory = rocksDbBackend.getOptions();
+		if (optionsFactory instanceof OptionsFactoryAdapter) {
+			RocksDBOptionsFactory rocksDBOptionsFactory =
+				((OptionsFactoryAdapter) optionsFactory).getRocksDBOptionsFactory();
+			assertTrue(rocksDBOptionsFactory instanceof TestOptionsFactory);
+		} else {
+			assertTrue(optionsFactory instanceof TestOptionsFactory);
+		}
 
 		try (RocksDBResourceContainer optionsContainer = rocksDbBackend.createOptionsAndResourceContainer()) {
 			DBOptions dbOptions = optionsContainer.getDbOptions();
@@ -640,7 +647,7 @@ public class RocksDBStateBackendConfigTest {
 
 		assertEquals(original.isIncrementalCheckpointsEnabled(), copy.isIncrementalCheckpointsEnabled());
 		assertArrayEquals(original.getDbStoragePaths(), copy.getDbStoragePaths());
-		assertEquals(original.getOptions(), copy.getOptions());
+		assertEquals(original.getRocksDBOptions(), copy.getRocksDBOptions());
 		assertEquals(original.getPredefinedOptions(), copy.getPredefinedOptions());
 
 		FsStateBackend copyCheckpointBackend = (FsStateBackend) copy.getCheckpointBackend();


### PR DESCRIPTION
## What is the purpose of the change

Completely separate `RocksDBOptionsFactory` from `OptionsFactory` to prevent silent failure of setting RocksDB options by extending `DefaultConfigurableOptionsFactory` but implementing old `createDBOptions(DBOptions currentOptions)` method (as described by FLINK-18242).

The changes here would require a re-compilation of user codes if `RocksDBOptionsFactory` is used, as well as some code change if the customized `OptionsFactory` is extending `DefaultConfigurableOptionsFactory`.

## Brief change log

Separate `RocksDBOptionsFactory` from `OptionsFactory` and introduce a new `OptionsFactoryAdapter` to keep backward compatibility of `RocksDBStateBackend#setOptions`.


## Verifying this change

This change is already covered by existing tests, such as `RocksDBOptionsFactoryCompatibilityTest` and `RocksDBStateBackendConfigTest`, etc.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
     - `RocksDBOptionsFactory` is actually user-facing interface and changes here require a release note.
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
