### PR TITLE
[FLINK-18247][table-planner-blink] Fix unstable test: TableITCase.testCollectWithClose

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -20,8 +20,8 @@ package org.apache.flink.table.api
 
 import org.apache.flink.api.common.JobStatus
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
-import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.planner.utils.TestTableSourceSinks
 import org.apache.flink.types.Row
 import org.apache.flink.util.TestLogger
@@ -29,7 +29,7 @@ import org.apache.flink.util.TestLogger
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists
 
 import org.hamcrest.Matchers.containsString
-import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Assert.{assertEquals, assertNotEquals, assertTrue}
 import org.junit.rules.{ExpectedException, TemporaryFolder}
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -119,7 +119,16 @@ class TableITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     val it = tableResult.collect()
     it.close()
-    assertEquals(JobStatus.CANCELED, tableResult.getJobClient.get().getJobStatus().get())
+    val jobStatus = try {
+      Some(tableResult.getJobClient.get().getJobStatus.get())
+    } catch {
+      // ignore the exception,
+      // because the MiniCluster maybe already been shut down when getting job status
+      case _: Throwable => None
+    }
+    if (jobStatus.isDefined) {
+      assertNotEquals(JobStatus.RUNNING, jobStatus.get)
+    }
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

*The reason is after calling CloseableIterator#close to cancel job in TableITCase.testCollectWithClose method, the job status may be CANCELED, CANCELING or even the MiniCluster maybe already been shut down. An exception will be thrown when MiniCluster is down. This pr aims to fix the unstable case.*


## Brief change log

  - *Change the getting jobStatus logic and jobStatus checking logic in TableITCase.testCollectWithClose*



## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
