### PR TITLE
[FLINK-18137] Handle discarding of triggering checkpoint correctly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -540,7 +540,7 @@ public class CheckpointCoordinator {
 
 			FutureUtils.assertNoException(
 				CompletableFuture.allOf(masterStatesComplete, coordinatorCheckpointsComplete)
-					.whenCompleteAsync(
+					.handleAsync(
 						(ignored, throwable) -> {
 							final PendingCheckpoint checkpoint =
 								FutureUtils.getWithoutException(pendingCheckpointCompletableFuture);
@@ -575,6 +575,8 @@ public class CheckpointCoordinator {
 										onTriggerFailure(checkpoint, throwable);
 									}
 							}
+
+							return null;
 						},
 						timer));
 		} catch (Throwable throwable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -28,6 +28,8 @@ import org.apache.flink.util.function.SupplierWithException;
 
 import akka.dispatch.OnComplete;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1007,6 +1009,7 @@ public class FutureUtils {
 	 * @return the result of completable future,
 	 * or null if it's unfinished or finished exceptionally
 	 */
+	@Nullable
 	public static <T> T getWithoutException(CompletableFuture<T> future) {
 		if (future.isDone() && !future.isCompletedExceptionally()) {
 			try {


### PR DESCRIPTION
## What is the purpose of the change

Before discarding a triggering checkpoint could cause a NPE which would stop the
processing of subsequent checkpoint requests. This commit changes this behaviour
by checking this condition and instantiating a proper exception in case that a
triggering checkpoint is being discarded.

cc @rkhachatryan.

## Verifying this change

This change added tests and can be verified as follows:

- `CheckpointCoordinatorTriggeringCheckpointTest. discardingTriggeringCheckpointWillExecuteNextCheckpointRequest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
