### PR TITLE
[FLINK-18226][runtime] Fix ActiveResourceManager requesting extra workers on termination of existing workers.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -404,8 +404,9 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		final WorkerRegistration<WorkerType> workerTypeWorkerRegistration = taskExecutors.get(taskManagerResourceId);
 
 		if (workerTypeWorkerRegistration.getInstanceID().equals(taskManagerRegistrationId)) {
-			slotManager.registerTaskManager(workerTypeWorkerRegistration, slotReport);
-			onTaskManagerRegistration(workerTypeWorkerRegistration);
+			if (slotManager.registerTaskManager(workerTypeWorkerRegistration, slotReport)) {
+				onTaskManagerRegistration(workerTypeWorkerRegistration);
+			}
 			return CompletableFuture.completedFuture(Acknowledge.get());
 		} else {
 			return FutureUtils.completedExceptionally(new ResourceManagerException(String.format("Unknown TaskManager registration id %s.", taskManagerRegistrationId)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -405,10 +405,15 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		if (workerTypeWorkerRegistration.getInstanceID().equals(taskManagerRegistrationId)) {
 			slotManager.registerTaskManager(workerTypeWorkerRegistration, slotReport);
+			onTaskManagerRegistration(workerTypeWorkerRegistration);
 			return CompletableFuture.completedFuture(Acknowledge.get());
 		} else {
 			return FutureUtils.completedExceptionally(new ResourceManagerException(String.format("Unknown TaskManager registration id %s.", taskManagerRegistrationId)));
 		}
+	}
+
+	protected void onTaskManagerRegistration(WorkerRegistration<WorkerType> workerTypeWorkerRegistration) {
+		// noop
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -108,8 +108,9 @@ public interface SlotManager extends AutoCloseable {
 	 *
 	 * @param taskExecutorConnection for the new task manager
 	 * @param initialSlotReport for the new task manager
+	 * @return True if the task manager has not been registered before and is registered successfully; otherwise false
 	 */
-	void registerTaskManager(TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport);
+	boolean registerTaskManager(TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport);
 
 	/**
 	 * Unregisters the task manager identified by the given instance id and its associated slots

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -427,9 +427,10 @@ public class SlotManagerImpl implements SlotManager {
 	 *
 	 * @param taskExecutorConnection for the new task manager
 	 * @param initialSlotReport for the new task manager
+	 * @return True if the task manager has not been registered before and is registered successfully; otherwise false
 	 */
 	@Override
-	public void registerTaskManager(final TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport) {
+	public boolean registerTaskManager(final TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport) {
 		checkInit();
 
 		LOG.debug("Registering TaskManager {} under {} at the SlotManager.", taskExecutorConnection.getResourceID(), taskExecutorConnection.getInstanceID());
@@ -437,11 +438,12 @@ public class SlotManagerImpl implements SlotManager {
 		// we identify task managers by their instance id
 		if (taskManagerRegistrations.containsKey(taskExecutorConnection.getInstanceID())) {
 			reportSlotStatus(taskExecutorConnection.getInstanceID(), initialSlotReport);
+			return false;
 		} else {
 			if (isMaxSlotNumExceededAfterRegistration(initialSlotReport)) {
 				LOG.info("The total number of slots exceeds the max limitation {}, release the excess resource.", maxSlotNum);
 				resourceActions.releaseResource(taskExecutorConnection.getInstanceID(), new FlinkException("The total number of slots exceeds the max limitation."));
-				return;
+				return false;
 			}
 
 			// first register the TaskManager
@@ -466,6 +468,8 @@ public class SlotManagerImpl implements SlotManager {
 					slotStatus.getResourceProfile(),
 					taskExecutorConnection);
 			}
+
+			return true;
 		}
 
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -1193,7 +1193,7 @@ public class SlotManagerImpl implements SlotManager {
 	}
 
 	@VisibleForTesting
-	static ResourceProfile generateDefaultSlotResourceProfile(WorkerResourceSpec workerResourceSpec, int numSlotsPerWorker) {
+	public static ResourceProfile generateDefaultSlotResourceProfile(WorkerResourceSpec workerResourceSpec, int numSlotsPerWorker) {
 		return ResourceProfile.newBuilder()
 			.setCpuCores(workerResourceSpec.getCpuCores().divide(numSlotsPerWorker))
 			.setTaskHeapMemory(workerResourceSpec.getTaskHeapSize().divide(numSlotsPerWorker))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -119,8 +119,8 @@ public class TestingSlotManager implements SlotManager {
 	}
 
 	@Override
-	public void registerTaskManager(TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport) {
-
+	public boolean registerTaskManager(TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport) {
+		return true;
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -375,6 +375,8 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 					final ResourceID resourceId = new ResourceID(containerStatus.getContainerId().toString());
 					final YarnWorkerNode yarnWorkerNode = workerNodeMap.remove(resourceId);
 
+					notifyAllocatedWorkerStopped(resourceId);
+
 					if (yarnWorkerNode != null) {
 						// Container completed unexpectedly ~> start a new one
 						requestYarnContainerIfRequired();
@@ -397,7 +399,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 			// if we are waiting for no further containers, we can go to the
 			// regular heartbeat interval
-			if (getNumPendingWorkers() <= 0) {
+			if (getNumRequestedNotAllocatedWorkers() <= 0) {
 				resourceManagerClient.setHeartbeatInterval(yarnHeartbeatIntervalMillis);
 			}
 		});
@@ -410,7 +412,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	private void onContainersOfResourceAllocated(Resource resource, List<Container> containers) {
 		final List<WorkerResourceSpec> pendingWorkerResourceSpecs =
 			workerSpecContainerResourceAdapter.getWorkerSpecs(resource, matchingStrategy).stream()
-				.flatMap(spec -> Collections.nCopies(getNumPendingWorkersFor(spec), spec).stream())
+				.flatMap(spec -> Collections.nCopies(getNumRequestedNotAllocatedWorkersFor(spec), spec).stream())
 				.collect(Collectors.toList());
 
 		int numPending = pendingWorkerResourceSpecs.size();
@@ -429,9 +431,10 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			final WorkerResourceSpec workerResourceSpec = pendingWorkerSpecIterator.next();
 			final Container container = containerIterator.next();
 			final AMRMClient.ContainerRequest pendingRequest = pendingRequestsIterator.next();
+			final ResourceID resourceId = getContainerResourceId(container);
 
-			notifyNewWorkerAllocated(workerResourceSpec);
-			startTaskExecutorInContainer(container, workerResourceSpec);
+			notifyNewWorkerAllocated(workerResourceSpec, resourceId);
+			startTaskExecutorInContainer(container, workerResourceSpec, resourceId);
 			removeContainerRequest(pendingRequest, workerResourceSpec);
 
 			numAccepted++;
@@ -448,16 +451,17 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			numAccepted, numExcess, numPending, resource);
 	}
 
-	private void startTaskExecutorInContainer(Container container, WorkerResourceSpec workerResourceSpec) {
-		final String containerIdStr = container.getId().toString();
-		final ResourceID resourceId = new ResourceID(containerIdStr);
+	private static ResourceID getContainerResourceId(Container container) {
+		return new ResourceID(container.getId().toString());
+	}
 
+	private void startTaskExecutorInContainer(Container container, WorkerResourceSpec workerResourceSpec, ResourceID resourceId) {
 		workerNodeMap.put(resourceId, new YarnWorkerNode(container));
 
 		try {
 			// Context information used to start a TaskExecutor Java process
 			ContainerLaunchContext taskExecutorLaunchContext = createTaskExecutorLaunchContext(
-				containerIdStr,
+				resourceId.toString(),
 				container.getNodeId().getHost(),
 				TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(flinkConfig, workerResourceSpec));
 
@@ -476,6 +480,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		// release the failed container
 		workerNodeMap.remove(resourceId);
 		resourceManagerClient.releaseAssignedContainer(containerId);
+		notifyAllocatedWorkerStopped(resourceId);
 		// and ask for a new one
 		requestYarnContainerIfRequired();
 	}
@@ -608,7 +613,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	private void requestYarnContainerIfRequired() {
 		for (Map.Entry<WorkerResourceSpec, Integer> requiredWorkersPerResourceSpec : getRequiredResources().entrySet()) {
 			final WorkerResourceSpec workerResourceSpec = requiredWorkersPerResourceSpec.getKey();
-			while (requiredWorkersPerResourceSpec.getValue() > getNumPendingWorkersFor(workerResourceSpec)) {
+			while (requiredWorkersPerResourceSpec.getValue() > getNumRequestedNotRegisteredWorkersFor(workerResourceSpec)) {
 				final boolean requestContainerSuccess = requestYarnContainer(workerResourceSpec);
 				Preconditions.checkState(requestContainerSuccess,
 					"Cannot request container for worker resource spec {}.", workerResourceSpec);
@@ -624,7 +629,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 			// make sure we transmit the request fast and receive fast news of granted allocations
 			resourceManagerClient.setHeartbeatInterval(containerRequestHeartbeatIntervalMillis);
-			int numPendingWorkers = notifyNewWorkerRequested(workerResourceSpec);
+			int numPendingWorkers = notifyNewWorkerRequested(workerResourceSpec).getNumNotAllocated();
 
 			log.info("Requesting new TaskExecutor container with resource {}. Number pending workers of this resource is {}.",
 				workerResourceSpec,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -474,7 +474,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 		final ResourceID resourceId = new ResourceID(containerId.toString());
 		// release the failed container
-		YarnWorkerNode yarnWorkerNode = workerNodeMap.remove(resourceId);
+		workerNodeMap.remove(resourceId);
 		resourceManagerClient.releaseAssignedContainer(containerId);
 		// and ask for a new one
 		requestYarnContainerIfRequired();


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the problem that `ActiveResourceManager` may request unnecessary extra workers on termination of existing workers.

## Brief change log

The equation previously used by `ActiveResourceManager` for deciding whether and how many new workers to request on termination of existing workers is:
`workersToRequest = workersRequiredBySlotManager - workersRequestedByResourceManagerNotAllocated`

If there are workers allocated, being started but not yet registered, unnecessary new workers will be requested.

Now the equation is changed to: 
`workersToRequest = workersRequiredBySlotManager - workersRequestedByResourceManagerNotRegistered`

## Verifying this change

New test cases added in `KubernetesResourceManagerTest` and `YarnResourceManagerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable