### PR TITLE
[FLINK-18261][parquet][orc] flink-orc and flink-parquet have invalid NOTICE file

### DIFF
--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -199,25 +199,6 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
-
-			<!-- build a jar-with-dependencies SQL Client uber jars -->
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-assembly</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -34,10 +34,6 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<properties>
-		<flink.format.parquet.version>1.10.0</flink.format.parquet.version>
-	</properties>
-
 	<dependencies>
 		<!-- Flink dependencies -->
 
@@ -209,25 +205,6 @@ under the License.
 						<configuration>
 							<skip>true</skip>
 						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<!-- build a jar-with-dependencies SQL Client uber jars -->
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-assembly</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-formats/flink-sql-orc/pom.xml
+++ b/flink-formats/flink-sql-orc/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-formats</artifactId>
+		<version>1.12-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-sql-orc_${scala.binary.version}</artifactId>
+	<name>flink-sql-orc</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-orc_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.flink:flink-orc_${scala.binary.version}</include>
+									<include>org.apache.orc:orc-core</include>
+									<include>org.apache.orc:orc-shims</include>
+									<include>org.apache.hive:hive-storage-api</include>
+									<include>io.airlift:aircompressor</include>
+									<include>commons-lang:commons-lang</include>
+									<include>com.google.protobuf:protobuf-java</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- skip dependency convergence due to Hadoop dependency -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>dependency-convergence</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-formats/flink-sql-orc/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-orc/src/main/resources/META-INF/NOTICE
@@ -1,4 +1,4 @@
-flink-orc
+flink-sql-orc
 Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-formats</artifactId>
+		<version>1.12-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-sql-parquet_${scala.binary.version}</artifactId>
+	<name>flink-sql-parquet</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-parquet_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.flink:flink-parquet_${scala.binary.version}</include>
+									<include>org.apache.parquet:parquet-hadoop</include>
+									<include>org.apache.parquet:parquet-format</include>
+									<include>org.apache.parquet:parquet-column</include>
+									<include>org.apache.parquet:parquet-common</include>
+									<include>org.apache.parquet:parquet-encoding</include>
+									<include>org.codehaus.jackson:jackson-core-asl</include>
+									<include>org.codehaus.jackson:jackson-mapper-asl</include>
+									<include>org.apache.commons:commons-compress</include>
+									<include>commons-pool:commons-pool</include>
+									<include>commons-codec:commons-codec</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- skip dependency convergence due to Hadoop dependency -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>dependency-convergence</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -1,4 +1,4 @@
-flink-parquet
+flink-sql-parquet
 Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
@@ -11,11 +11,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.parquet:parquet-common:1.10.0
 - org.apache.parquet:parquet-encoding:1.10.0
 - org.apache.parquet:parquet-format:2.4.0
-- org.apache.parquet:parquet-jackson:1.10.0
-- org.apache.parquet:parquet-avro:1.10.0
 - org.codehaus.jackson:jackson-mapper-asl:1.9.13
 - org.codehaus.jackson:jackson-core-asl:1.9.13
 - org.apache.commons:commons-compress:1.20
-- org.apache.avro:avro:1.8.2
 - commons-pool:commons-pool:1.6
 - commons-codec:commons-codec:1.10

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -65,4 +65,21 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<profiles>
+
+		<!-- Create SQL Client uber jars by default -->
+		<profile>
+			<id>sql-jars</id>
+			<activation>
+				<property>
+					<name>!skipSqlJars</name>
+				</property>
+			</activation>
+			<modules>
+				<module>flink-sql-orc</module>
+				<module>flink-sql-parquet</module>
+			</modules>
+		</profile>
+	</profiles>
+
 </project>

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -30,6 +30,9 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
+	<properties>
+		<flink.format.parquet.version>1.10.0</flink.format.parquet.version>
+	</properties>
 
 	<artifactId>flink-formats</artifactId>
 	<name>flink-formats</name>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@ under the License.
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
 		<japicmp.referenceVersion>1.10.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
-		<flink.format.parquet.version>1.10.0</flink.format.parquet.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@ under the License.
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
 		<japicmp.referenceVersion>1.10.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
+		<flink.format.parquet.version>1.10.0</flink.format.parquet.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What is the purpose of the change

flink-orc and flink-parquet provides a jar-with-dependencies.jar variant which ships binaries.
However, these binaries are not documented in META-INF/NOTICE.
There are two similar files in that directory (NOTICE from force-shading and NOTICE.txt from Commons Lang).

There is a NOTICE file that looks valid, but it is in META-INF/services.

This has been introduced in FLINK-17460.

And see FLINK-11026:

Instead of defining separate shade-plugin execution with a custom artifactSuffix this PR adds a dedicated flink-sql-** module which only contains the packaging logic. This is a similar approach that we've already been using for flink-sql-connector-elasticsearch6 .

The main motivation for this is licensing; for accurate notice files it is necessary to be able to supply each artifact with distinct NOTICE files.

This cannot be done within a single module in a reasonable way. We would have to un-package each created jar, add the appropriate license files, and re-pack them again. We'd end up with tightly-coupled plugin definitions (since the names have to match!) and an overall more complicated (and slower!) build.

## Brief change log

- Introduce flink-sql-orc to create orc bundled jar.
- Introduce flink-sql-parquet to create parquet bundled jar.
- add sqlJars profile to flink-formats to support skipping the creation of sql jars

## Verifying this change

- Manually check NOTICE file.
- Manually test bundled jar for sql filesystem connector.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no