### PR TITLE
[FLINK-15687][runtime][test] Fix test instability due to concurrent access to JobTable.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -165,13 +165,6 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 			}).build();
 
 		final DefaultJobTable jobTable = DefaultJobTable.create();
-		TaskSubmissionTestEnvironment.registerJobMasterConnection(
-			jobTable,
-			jobId,
-			rpc,
-			jobMasterGateway,
-			new NoOpTaskManagerActions(),
-			timeout);
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setJobTable(jobTable)
@@ -195,6 +188,15 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 		try {
 			taskExecutor.start();
 			taskExecutor.waitUntilStarted();
+
+			TaskSubmissionTestEnvironment.registerJobMasterConnection(
+				jobTable,
+				jobId,
+				rpc,
+				jobMasterGateway,
+				new NoOpTaskManagerActions(),
+				timeout,
+				taskExecutor.getMainThreadExecutableForTesting());
 
 			final TaskExecutorGateway taskExecutorGateway = taskExecutor.getSelfGateway(TaskExecutorGateway.class);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the test instabilities due to concurrent access to JobTable.

## Brief change log

Added an argument `MainThreadExecutable` for `TaskSubmissionTestEnvironment#registerJobMasterConnection` to guarantee it's always executed in the RPC main thread.

## Verifying this change

Manually verified by printing all the access thread names in `DefaultJobTable`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (nono)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
