### PR TITLE
[FLINK-18205] Mitigate the use of reflection in Utils and HadoopModule

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -150,7 +150,7 @@ public class HadoopModule implements SecurityModule {
 	}
 
 	@Override
-	public void uninstall() throws SecurityInstallException {
+	public void uninstall() {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -460,14 +459,7 @@ public final class Utils {
 			log.debug("Adding security tokens to TaskExecutor's container launch context.");
 
 			try (DataOutputBuffer dob = new DataOutputBuffer()) {
-				Method readTokenStorageFileMethod = Credentials.class.getMethod(
-					"readTokenStorageFile", File.class, org.apache.hadoop.conf.Configuration.class);
-
-				Credentials cred =
-					(Credentials) readTokenStorageFileMethod.invoke(
-						null,
-						new File(fileLocation),
-						HadoopUtils.getHadoopConfiguration(flinkConfig));
+				Credentials cred = Credentials.readTokenStorageFile(new File(fileLocation), HadoopUtils.getHadoopConfiguration(flinkConfig));
 
 				// Filter out AMRMToken before setting the tokens to the TaskManager container context.
 				Credentials taskManagerCred = new Credentials();


### PR DESCRIPTION

## What is the purpose of the change

Since Flink drops support for Hadoop 1 since FLINK-4895, it would be good to mitigate the use of reflection in HadoopModule and Utils. To be specific, we could make sure the following methods exist in Hadoop 2+:

- Credentials#getAllTokens
- Credentials#readTokenStorageFile
- UserGroupInformation#addCredentials

## Brief change log

Mitigate the use of reflection in Utils and HadoopModule


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
