### PR TITLE
[FLINK-18083][hbase] Improve exception message of TIMESTAMP/TIME out of the HBase connector supported precision

### DIFF
--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/util/HBaseTypeUtils.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/util/HBaseTypeUtils.java
@@ -42,6 +42,11 @@ public class HBaseTypeUtils {
 
 	private static final byte[] EMPTY_BYTES = new byte[]{};
 
+	private static final int MIN_TIMESTAMP_PRECISION = 0;
+	private static final int MAX_TIMESTAMP_PRECISION = 3;
+	private static final int MIN_TIME_PRECISION = 0;
+	private static final int MAX_TIME_PRECISION = 3;
+
 	/**
 	 * Deserialize byte array to Java Object with the given type.
 	 */
@@ -184,16 +189,29 @@ public class HBaseTypeUtils {
 			case SMALLINT:
 			case INTEGER:
 			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 			case BIGINT:
 			case INTERVAL_DAY_TIME:
 			case FLOAT:
 			case DOUBLE:
 				return true;
+			case TIME_WITHOUT_TIME_ZONE:
+				final int timePrecision = getPrecision(type);
+				if (timePrecision < MIN_TIME_PRECISION || timePrecision > MAX_TIME_PRECISION) {
+					throw new UnsupportedOperationException(
+						String.format("The precision %s of TIME type is out of the range [%s, %s] supported by " +
+							"HBase connector", timePrecision, MIN_TIME_PRECISION, MAX_TIME_PRECISION));
+				}
+				return true;
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-				return getPrecision(type) <= 3;
+				final int timestampPrecision = getPrecision(type);
+				if (timestampPrecision < MIN_TIMESTAMP_PRECISION || timestampPrecision > MAX_TIMESTAMP_PRECISION) {
+					throw new UnsupportedOperationException(
+						String.format("The precision %s of TIMESTAMP type is out of the range [%s, %s] supported by " +
+							"HBase connector", timestampPrecision, MIN_TIMESTAMP_PRECISION, MAX_TIMESTAMP_PRECISION));
+				}
+				return true;
 			case TIMESTAMP_WITH_TIME_ZONE:
 			case ARRAY:
 			case MULTISET:

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDynamicTableFactoryTest.java
@@ -261,6 +261,64 @@ public class HBaseDynamicTableFactoryTest {
 		}
 	}
 
+	@Test
+	public void testTypeWithUnsupportedPrecision() {
+		Map<String, String> options = getAllOptions();
+		// test unsupported timestamp precision
+		TableSchema schema = TableSchema.builder()
+			.field(ROWKEY, STRING())
+			.field(FAMILY1, ROW(
+				FIELD(COL1, TIMESTAMP(6)),
+				FIELD(COL2, INT())))
+			.build();
+		try {
+			createTableSource(schema, options);
+			fail("Should fail");
+		} catch (Exception e) {
+			assertTrue(ExceptionUtils
+				.findThrowableWithMessage(e, "The precision 6 of TIMESTAMP type is out of the range [0, 3]" +
+					" supported by HBase connector")
+				.isPresent());
+		}
+
+		try {
+			createTableSink(schema, options);
+			fail("Should fail");
+		} catch (Exception e) {
+			assertTrue(ExceptionUtils
+				.findThrowableWithMessage(e, "The precision 6 of TIMESTAMP type is out of the range [0, 3]" +
+					" supported by HBase connector")
+				.isPresent());
+		}
+		// test unsupported time precision
+		schema = TableSchema.builder()
+			.field(ROWKEY, STRING())
+			.field(FAMILY1, ROW(
+				FIELD(COL1, TIME(6)),
+				FIELD(COL2, INT())))
+			.build();
+
+		try {
+			createTableSource(schema, options);
+			fail("Should fail");
+		} catch (Exception e) {
+			assertTrue(ExceptionUtils
+				.findThrowableWithMessage(e, "The precision 6 of TIME type is out of the range [0, 3]" +
+					" supported by HBase connector")
+				.isPresent());
+		}
+
+		try {
+			createTableSink(schema, options);
+			fail("Should fail");
+		} catch (Exception e) {
+			assertTrue(ExceptionUtils
+				.findThrowableWithMessage(e, "The precision 6 of TIME type is out of the range [0, 3]" +
+					" supported by HBase connector")
+				.isPresent());
+		}
+	}
+
 	private Map<String, String> getAllOptions() {
 		Map<String, String> options = new HashMap<>();
 		options.put("connector", "hbase-1.4");


### PR DESCRIPTION
## What is the purpose of the change

* This pull request Improve exception message of TIMESTAMP/TIME out of the HBase connector supported precision, HBase connector only supports precision range[0, 3].


## Brief change log

 * update file org/apache/flink/connector/hbase/util/HBaseTypeUtils.java
 * update file org/apache/flink/connector/hbase/util/HBaseSerde.java


## Verifying this change

 * Add unit tests in `HBaseTableFactoryTest.java`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
