### PR TITLE
[FLINK-18265][connector] Hidden files should be ignored when the filesystem table searches for partitions

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
@@ -195,10 +195,7 @@ public class PartitionPathUtils {
 		if (statuses == null) {
 			return null;
 		}
-		return Arrays.stream(statuses).filter(fileStatus -> {
-			String name = fileStatus.getPath().getName();
-			return !name.startsWith("_") && !name.startsWith(".");
-		}).toArray(FileStatus[]::new);
+		return Arrays.stream(statuses).filter(fileStatus -> !isHiddenFile(fileStatus)).toArray(FileStatus[]::new);
 	}
 
 	/**
@@ -213,6 +210,10 @@ public class PartitionPathUtils {
 		FileStatus[] generatedParts = getFileStatusRecurse(path, partitionNumber, fs);
 		List<Tuple2<LinkedHashMap<String, String>, Path>> ret = new ArrayList<>();
 		for (FileStatus part : generatedParts) {
+			// ignore hidden file
+			if (isHiddenFile(part)) {
+				continue;
+			}
 			ret.add(new Tuple2<>(extractPartitionSpecFromPath(part.getPath()), part.getPath()));
 		}
 		return ret;
@@ -321,5 +322,10 @@ public class PartitionPathUtils {
 				listStatusRecursively(fs, stat, level + 1, expectLevel, results);
 			}
 		}
+	}
+
+	private static boolean isHiddenFile(FileStatus fileStatus) {
+		String name = fileStatus.getPath().getName();
+		return name.startsWith("_") || name.startsWith(".");
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.runtime
 
 import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.core.fs.Path
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.runtime.FileSystemITCaseBase._
@@ -28,8 +29,11 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TableEnvUtil.execInsertSqlAndWaitResult
 import org.apache.flink.types.Row
 
+import org.junit.Assert.assertTrue
 import org.junit.rules.TemporaryFolder
 import org.junit.{Rule, Test}
+
+import java.io.File
 
 import scala.collection.{JavaConverters, Seq}
 
@@ -184,6 +188,20 @@ trait FileSystemITCaseBase {
     check(
       "select x, y from partitionedTable",
       data
+    )
+  }
+
+  @Test
+  def testPartitionWithHiddenFile(): Unit = {
+    execInsertSqlAndWaitResult(tableEnv, "insert into partitionedTable " +
+      "partition(a='1', b='1') select x, y from originalT where a=1 and b=1")
+
+    // create hidden partition dir
+    assertTrue(new File(new Path(resultPath + "/a=1/.b=2").toUri).mkdir())
+
+    check(
+      "select x, y from partitionedTable",
+      data_partition_1_1
     )
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOutputFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOutputFormat.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
 import org.apache.flink.table.api.TableException;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
@@ -94,6 +95,8 @@ public class FileSystemOutputFormat<T> implements OutputFormat<T>, FinalizeOnMas
 			committer.commitUpToCheckpoint(CHECKPOINT_ID);
 		} catch (Exception e) {
 			throw new TableException("Exception in finalizeGlobal", e);
+		} finally {
+			new File(tmpPath.getPath()).delete();
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/FileSystemOutputFormatTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/FileSystemOutputFormatTest.java
@@ -42,6 +42,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Test for {@link FileSystemOutputFormat}.
@@ -128,6 +129,7 @@ public class FileSystemOutputFormatTest {
 		assertEquals(
 				"a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n",
 				content.values().iterator().next());
+		assertFalse(new File(tmpFile.toURI()).exists());
 	}
 
 	@Test
@@ -154,6 +156,7 @@ public class FileSystemOutputFormatTest {
 		assertEquals(
 				"a1,1\n" + "a2,2\n" + "a2,2\n" + "a3,3\n",
 				content.values().iterator().next());
+		assertFalse(new File(tmpFile.toURI()).exists());
 	}
 
 	@Test
@@ -173,6 +176,7 @@ public class FileSystemOutputFormatTest {
 		assertEquals(2, sortedContent.size());
 		assertEquals("a1,1\n" + "a2,2\n" + "a3,3\n", sortedContent.get("c=p1"));
 		assertEquals("a2,2\n", sortedContent.get("c=p2"));
+		assertFalse(new File(tmpFile.toURI()).exists());
 	}
 
 	@Test
@@ -198,6 +202,7 @@ public class FileSystemOutputFormatTest {
 		assertEquals(2, sortedContent.size());
 		assertEquals("a1,1\n" + "a2,2\n" + "a3,3\n", sortedContent.get("c=p1"));
 		assertEquals("a2,2\n", sortedContent.get("c=p2"));
+		assertFalse(new File(tmpFile.toURI()).exists());
 	}
 
 	private OneInputStreamOperatorTestHarness<Row, Object> createSink(


### PR DESCRIPTION

## What is the purpose of the change

*When there are some hidden files in the path of filesystem partitioned table, `TableException` will occur. This pr aims to fix this bug. Additional, this pr also fixes that the temp path does not deleted in FileSystemOutputFormat.*


## Brief change log

  - *Hidden files should be ignored when the filesystem table searches for partitions*
  - *temp path in FileSystemOutputFormat should be deleted*


## Verifying this change

FileSystemITCaseBase#testPartitionWithHiddenFile
FileSystemOutputFormatTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
