### PR TITLE
[FLINK-18268][docs] Correct Table API in Temporal table docs

### DIFF
--- a/docs/dev/table/connectors/hbase.md
+++ b/docs/dev/table/connectors/hbase.md
@@ -274,7 +274,7 @@ double toDouble(byte[] bytes)
       <td>Not supported</td>
     </tr>
     <tr>
-      <td><code>MAP / MULTISET<code></td>
+      <td><code>MAP / MULTISET</code></td>
       <td>Not supported</td>
     </tr>
     <tr>

--- a/docs/dev/table/connectors/hbase.md
+++ b/docs/dev/table/connectors/hbase.md
@@ -62,7 +62,7 @@ CREATE TABLE hTable (
 ) WITH (
  'connector' = 'hbase-1.4',
  'table-name' = 'mytable',
- 'zookeeper.quorum' = 'localhost:2121'
+ 'zookeeper.quorum' = 'localhost:2181'
 )
 {% endhighlight %}
 </div>

--- a/docs/dev/table/connectors/hbase.zh.md
+++ b/docs/dev/table/connectors/hbase.zh.md
@@ -274,7 +274,7 @@ double toDouble(byte[] bytes)
       <td>Not supported</td>
     </tr>
     <tr>
-      <td><code>MAP / MULTISET<code></td>
+      <td><code>MAP / MULTISET</code></td>
       <td>Not supported</td>
     </tr>
     <tr>

--- a/docs/dev/table/connectors/hbase.zh.md
+++ b/docs/dev/table/connectors/hbase.zh.md
@@ -62,7 +62,7 @@ CREATE TABLE hTable (
 ) WITH (
  'connector' = 'hbase-1.4',
  'table-name' = 'mytable',
- 'zookeeper.quorum' = 'localhost:2121'
+ 'zookeeper.quorum' = 'localhost:2181'
 )
 {% endhighlight %}
 </div>

--- a/docs/dev/table/streaming/temporal_tables.md
+++ b/docs/dev/table/streaming/temporal_tables.md
@@ -265,6 +265,7 @@ StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
 // or TableEnvironment tEnv = TableEnvironment.create(settings);
 
 // Define an HBase table with DDL, then we can use it as a temporal table in sql
+// Column 'currency' is the rowKey in HBase table
 tEnv.executeSql(
     "CREATE TABLE LatestRates (" +
     "   currency STRING," +
@@ -285,6 +286,7 @@ val tEnv = StreamTableEnvironment.create(env, settings)
 // or val tEnv = TableEnvironment.create(settings)
 
 // Define an HBase table with DDL, then we can use it as a temporal table in sql
+// Column 'currency' is the rowKey in HBase table
 tEnv.executeSql(
     s"""
        |CREATE TABLE LatestRates (

--- a/docs/dev/table/streaming/temporal_tables.md
+++ b/docs/dev/table/streaming/temporal_tables.md
@@ -260,7 +260,7 @@ See also the page about [joins for continuous queries](joins.html) for more info
 {% highlight java %}
 // Get the stream and table environments.
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
 StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
 // or TableEnvironment tEnv = TableEnvironment.create(settings);
 
@@ -281,7 +281,7 @@ tEnv.executeSql(
 {% highlight scala %}
 // Get the stream and table environments.
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+val settings = EnvironmentSettings.newInstance().build()
 val tEnv = StreamTableEnvironment.create(env, settings)
 // or val tEnv = TableEnvironment.create(settings)
 

--- a/docs/dev/table/streaming/temporal_tables.md
+++ b/docs/dev/table/streaming/temporal_tables.md
@@ -260,32 +260,43 @@ See also the page about [joins for continuous queries](joins.html) for more info
 {% highlight java %}
 // Get the stream and table environments.
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
+// or TableEnvironment tEnv = TableEnvironment.create(settings);
 
-// Create an HBaseTableSource as a temporal table which implements LookableTableSource
-// In the real setup, you should replace this with your own table.
-HBaseTableSource rates = new HBaseTableSource(conf, "Rates");
-rates.setRowKey("currency", String.class);   // currency as the primary key
-rates.addColumn("fam1", "rate", Double.class);
-
-// register the temporal table into environment, then we can query it in sql
-tEnv.registerTableSource("Rates", rates);
+// Define an HBase table with DDL, then we can use it as a temporal table in sql
+tEnv.executeSql(
+    "CREATE TABLE LatestRates (" +
+    "   currency STRING," +
+    "   fam1 ROW<rate DOUBLE>" +
+    ") WITH (" +
+    "   'connector' = 'hbase-1.4'," +
+    "   'table-name' = 'Rates'," +
+    "   'zookeeper.quorum' = 'localhost:2181'" +
+    ")");
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // Get the stream and table environments.
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val tEnv = TableEnvironment.getTableEnvironment(env)
+val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+val tEnv = StreamTableEnvironment.create(env, settings)
+// or val tEnv = TableEnvironment.create(settings)
 
-// Create an HBaseTableSource as a temporal table which implements LookableTableSource
-// In the real setup, you should replace this with your own table.
-val rates = new HBaseTableSource(conf, "Rates")
-rates.setRowKey("currency", String.class)   // currency as the primary key
-rates.addColumn("fam1", "rate", Double.class)
+// Define an HBase table with DDL, then we can use it as a temporal table in sql
+tEnv.executeSql(
+    s"""
+       |CREATE TABLE LatestRates (
+       |    currency STRING,
+       |    fam1 ROW<rate DOUBLE>
+       |) WITH (
+       |    'connector' = 'hbase-1.4',
+       |    'table-name' = 'Rates',
+       |    'zookeeper.quorum' = 'localhost:2181'
+       |)
+       |""".stripMargin)
 
-// register the temporal table into environment, then we can query it in sql
-tEnv.registerTableSource("Rates", rates)
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/streaming/temporal_tables.zh.md
+++ b/docs/dev/table/streaming/temporal_tables.zh.md
@@ -261,7 +261,7 @@ Yen           1
 {% highlight java %}
 // 获取 stream 和 table 环境
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
 StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
 // or TableEnvironment tEnv = TableEnvironment.create(settings);
 
@@ -282,7 +282,7 @@ tEnv.executeSql(
 {% highlight scala %}
 // 获取 stream 和 table 环境
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+val settings = EnvironmentSettings.newInstance().build()
 val tEnv = StreamTableEnvironment.create(env, settings)
 // or val tEnv = TableEnvironment.create(settings)
 

--- a/docs/dev/table/streaming/temporal_tables.zh.md
+++ b/docs/dev/table/streaming/temporal_tables.zh.md
@@ -265,7 +265,8 @@ EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner
 StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
 // or TableEnvironment tEnv = TableEnvironment.create(settings);
 
-// 用 DDL 定义一张 HBase 表，然后我们可以在 SQL 中将其当作一张时态表使用。
+// 用 DDL 定义一张 HBase 表，然后我们可以在 SQL 中将其当作一张时态表使用
+// 'currency' 列是 HBase 表中的 rowKey
 tEnv.executeSql(
     "CREATE TABLE LatestRates (" +
     "   currency STRING," +
@@ -285,7 +286,8 @@ val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMo
 val tEnv = StreamTableEnvironment.create(env, settings)
 // or val tEnv = TableEnvironment.create(settings)
 
-// 用 DDL 定义一张 HBase 表，然后我们可以在 SQL 中将其当作一张时态表使用。
+// 用 DDL 定义一张 HBase 表，然后我们可以在 SQL 中将其当作一张时态表使用
+// 'currency' 列是 HBase 表中的 rowKey
 tEnv.executeSql(
     s"""
        |CREATE TABLE LatestRates (

--- a/docs/dev/table/streaming/temporal_tables.zh.md
+++ b/docs/dev/table/streaming/temporal_tables.zh.md
@@ -261,32 +261,42 @@ Yen           1
 {% highlight java %}
 // 获取 stream 和 table 环境
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
+// or TableEnvironment tEnv = TableEnvironment.create(settings);
 
-// 创建一个实现 LookableTableSource 的 HBaseTableSource 作为时态表
-// 在实际设置中，应使用自己的表替换它
-HBaseTableSource rates = new HBaseTableSource(conf, "Rates");
-rates.setRowKey("currency", String.class);   // currency 作为主键
-rates.addColumn("fam1", "rate", Double.class);
-
-// 注册这个临时表到环境中，然后我们可以用 sql 查询它
-tEnv.registerTableSource("Rates", rates);
+// 用 DDL 定义一张 HBase 表，然后我们可以在 SQL 中将其当作一张时态表使用。
+tEnv.executeSql(
+    "CREATE TABLE LatestRates (" +
+    "   currency STRING," +
+    "   fam1 ROW<rate DOUBLE>" +
+    ") WITH (" +
+    "   'connector' = 'hbase-1.4'," +
+    "   'table-name' = 'Rates'," +
+    "   'zookeeper.quorum' = 'localhost:2181'" +
+    ")");
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // 获取 stream 和 table 环境
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val tEnv = TableEnvironment.getTableEnvironment(env)
+val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+val tEnv = StreamTableEnvironment.create(env, settings)
+// or val tEnv = TableEnvironment.create(settings)
 
-// 创建一个实现 LookableTableSource 的 HBaseTableSource 作为时态表
-// 在实际设置中，应使用自己的表替换它
-val rates = new HBaseTableSource(conf, "Rates")
-rates.setRowKey("currency", String.class)   // currency 作为主键
-rates.addColumn("fam1", "rate", Double.class)
-
-// 注册这个临时表到环境中，然后我们可以用 sql 查询它
-tEnv.registerTableSource("Rates", rates)
+// 用 DDL 定义一张 HBase 表，然后我们可以在 SQL 中将其当作一张时态表使用。
+tEnv.executeSql(
+    s"""
+       |CREATE TABLE LatestRates (
+       |    currency STRING,
+       |    fam1 ROW<rate DOUBLE>
+       |) WITH (
+       |    'connector' = 'hbase-1.4',
+       |    'table-name' = 'Rates',
+       |    'zookeeper.quorum' = 'localhost:2181'
+       |)
+       |""".stripMargin)
 {% endhighlight %}
 </div>
 </div>


### PR DESCRIPTION
 ## What is the purpose of the change

* This pull request Using DDL define a temporal table to replace out-of-date TableEnvironment API. 


## Brief change log
  - update  temporal_tables.md、temporal_tables.zh.md
  - [minor] update hbase server's port from 2121 to 2181 in hbase connector docs 


## Verifying this change

Verify in local environment which servers in http://localhost:4000

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
