### PR TITLE
[FLINK-18277][elasticsearch] Fix es6 sink identifier 

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSink.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSink.java
@@ -157,7 +157,7 @@ final class Elasticsearch6DynamicSink implements DynamicTableSink {
 
 	@Override
 	public String asSummaryString() {
-		return "Elasticsearch7";
+		return "Elasticsearch6";
 	}
 
 	/**


### PR DESCRIPTION
Fix typo from `Elasticsearch7` to `Elasticsearch6`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
