### PR TITLE
[FLINK-17998][hs] Support Flink history server archive size limitation

### DIFF
--- a/docs/_includes/generated/history_server_configuration.html
+++ b/docs/_includes/generated/history_server_configuration.html
@@ -27,6 +27,12 @@
             <td>Interval in milliseconds for refreshing the archived job directories.</td>
         </tr>
         <tr>
+            <td><h5>historyserver.archive.retained-jobs</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>The maximum number of jobs to retain in each archive directory defined by `historyserver.archive.fs.dir`. If set to `-1`(default), there is no limit to the number of archives. If set to `0` or less than `-1` HistoryServer will throw an <span markdown="span">`IllegalConfigurationException`</span>. </td>
+        </tr>
+        <tr>
             <td><h5>historyserver.web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -19,8 +19,10 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.code;
 
 /**
  * The set of configuration options relating to the HistoryServer.
@@ -98,6 +100,16 @@ public class HistoryServerOptions {
 			.defaultValue(false)
 			.withDescription("Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the" +
 				" global SSL flag security.ssl.enabled is set to true.");
+
+	public static final ConfigOption<Integer> HISTORY_SERVER_RETAINED_JOBS =
+		key("historyserver.archive.retained-jobs")
+			.intType()
+			.defaultValue(-1)
+			.withDescription(Description.builder()
+				.text(String.format("The maximum number of jobs to retain in each archive directory defined by `%s`. ", HISTORY_SERVER_ARCHIVE_DIRS.key()))
+				.text("If set to `-1`(default), there is no limit to the number of archives. ")
+				.text("If set to `0` or less than `-1` HistoryServer will throw an %s. ", code("IllegalConfigurationException"))
+				.build());
 
 	private HistoryServerOptions() {
 	}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HistoryServerOptions;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.plugin.PluginUtils;
@@ -200,7 +201,12 @@ public class HistoryServer {
 		}
 
 		long refreshIntervalMillis = config.getLong(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL);
-		archiveFetcher = new HistoryServerArchiveFetcher(refreshIntervalMillis, refreshDirs, webDir, jobArchiveEventListener, cleanupExpiredArchives);
+		int maxHistorySize = config.getInteger(HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS);
+		if (maxHistorySize == 0 || maxHistorySize < -1){
+			throw new IllegalConfigurationException("Cannot set %s to 0 or less than -1", HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS.key());
+		}
+		archiveFetcher = new HistoryServerArchiveFetcher(refreshIntervalMillis, refreshDirs, webDir, jobArchiveEventListener,
+			cleanupExpiredArchives, maxHistorySize);
 
 		this.shutdownHook = ShutdownHookUtil.addShutdownHook(
 			HistoryServer.this::stop,


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduces a new config option `historyserver.max.history.size` and with that the ability to limit the number of job archives kept in the history server, similarly to Spark’s `spark.history.retainedApplications`.*

* Upon refreshing the archive directories, if the number of job archives exceeds the configured limit, the least recently modified archive file is deleted and its content removed from the history server’s cache.
* To provide straightforward user experience, this config option is made independent of the value set to `historyserver.archive.clean-expired-jobs`.
* The default value of this config option is set to `50` similarly to the respective default value in Spark.*


## Brief change log

  - *The `HistoryServer` constructor loads the config option and passes it to the `HistoryServerArchiveFetcher`*
  - *The `HistoryServerArchiveFetcher`’s `JobArchiveFetcherTask` upon refreshing the archive directories cleans up the least recently modified archives from the filesystem and the cache*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that creates job archive files under the jobmanager’s directory with their `lastModified` attribute values 1 minute apart from each other before and after the history server starts, validating that the least recently modified files are removed upon refresh*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
