### PR TITLE
[FLINK-17977] Improve checkpoint triggering log message

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -657,7 +657,7 @@ public class CheckpointCoordinator {
 			}
 		}
 
-		LOG.info("Triggering checkpoint {} @ {} for job {}.", checkpointID, timestamp, job);
+		LOG.info("Triggering checkpoint {} (type={}) @ {} for job {}.", checkpointID, checkpoint.getProps().getCheckpointType(), timestamp, job);
 		return checkpoint;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Before this change, it was not possible to distinguish whether a checkpoint is a normal checkpoint or a savepoint.
After this change, the logs look as follows:

```
4873 [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph [] - testVertex (1/1) (c2e1f356aff7ba404f81493b9460ec53) switched from DEPLOYING to RUNNING.
4890 [Checkpoint Timer] INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator [] - Triggering checkpoint 1 (type=CHECKPOINT) @ 1591980437822 for job 7d38907b6c6d7d0612d0ca8403b5684d.
4909 [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.jobmaster.JobMaster [] - Triggering cancel-with-savepoint for job 7d38907b6c6d7d0612d0ca8403b5684d.
4935 [jobmanager-future-thread-4] INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator [] - Completed checkpoint 1 for job 7d38907b6c6d7d0612d0ca8403b5684d (0 bytes in 52 ms).
5006 [Checkpoint Timer] INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator [] - Triggering checkpoint 3 (type=SAVEPOINT) @ 1591980437878 for job 7d38907b6c6d7d0612d0ca8403b5684d.
```

## Brief change log

- extend log message


## Verifying this change

Passes on personal CI

