### PR TITLE
 [FLINK-17322][network] Fixes BroadcastRecordWriter overwriting memory segments on first finished BufferConsumer.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
@@ -50,6 +50,8 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 	 */
 	private boolean randomTriggered;
 
+	private BufferConsumer randomTriggeredConsumer;
+
 	BroadcastRecordWriter(
 			ResultPartitionWriter writer,
 			long timeout,
@@ -84,7 +86,7 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 		if (bufferBuilder != null) {
 			for (int index = 0; index < numberOfChannels; index++) {
 				if (index != targetChannelIndex) {
-					addBufferConsumer(bufferBuilder.createBufferConsumer(), index);
+					addBufferConsumer(randomTriggeredConsumer.copyWithReaderPosition(bufferBuilder.getCommittedBytes()), index);
 				}
 			}
 		}
@@ -130,7 +132,7 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 
 		BufferBuilder builder = super.requestNewBufferBuilder(targetChannel);
 		if (randomTriggered) {
-			addBufferConsumer(builder.createBufferConsumer(), targetChannel);
+			addBufferConsumer(randomTriggeredConsumer = builder.createBufferConsumer(), targetChannel);
 		} else {
 			try (BufferConsumer bufferConsumer = builder.createBufferConsumer()) {
 				for (int channel = 0; channel < numberOfChannels; channel++) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -349,4 +349,9 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 			}
 		}
 	}
+
+	@VisibleForTesting
+	ResultPartitionWriter getTargetPartition() {
+		return targetPartition;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -123,6 +123,10 @@ public class BufferBuilder {
 		return getMaxCapacity() - positionMarker.getCached();
 	}
 
+	public int getCommittedBytes() {
+		return positionMarker.getCached();
+	}
+
 	public int getMaxCapacity() {
 		return memorySegment.size();
 	}
@@ -167,7 +171,7 @@ public class BufferBuilder {
 	 *
 	 * <p>Remember to commit the {@link SettablePositionMarker} to make the changes visible.
 	 */
-	private static class SettablePositionMarker implements PositionMarker {
+	static class SettablePositionMarker implements PositionMarker {
 		private volatile int position = 0;
 
 		/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -41,6 +41,8 @@ public class BufferBuilder {
 
 	private final SettablePositionMarker positionMarker = new SettablePositionMarker();
 
+	private boolean bufferConsumerCreated = false;
+
 	public BufferBuilder(MemorySegment memorySegment, BufferRecycler recycler) {
 		this.memorySegment = checkNotNull(memorySegment);
 		this.recycler = checkNotNull(recycler);
@@ -53,6 +55,8 @@ public class BufferBuilder {
 	 * @return created matching instance of {@link BufferConsumer} to this {@link BufferBuilder}.
 	 */
 	public BufferConsumer createBufferConsumer() {
+		checkState(!bufferConsumerCreated, "Two BufferConsumer shouldn't exist for one BufferBuilder");
+		bufferConsumerCreated = true;
 		return new BufferConsumer(
 			memorySegment,
 			recycler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -686,11 +686,11 @@ public class RecordWriterTest {
 		}
 	}
 
-	private static class KeepingPartitionWriter extends MockResultPartitionWriter {
+	static class KeepingPartitionWriter extends MockResultPartitionWriter {
 		private final BufferProvider bufferProvider;
 		private Map<Integer, List<BufferConsumer>> produced = new HashMap<>();
 
-		private KeepingPartitionWriter(BufferProvider bufferProvider) {
+		KeepingPartitionWriter(BufferProvider bufferProvider) {
 			this.bufferProvider = bufferProvider;
 		}
 
@@ -710,6 +710,10 @@ public class RecordWriterTest {
 			produced.putIfAbsent(targetChannel, new ArrayList<>());
 			produced.get(targetChannel).add(bufferConsumer);
 			return true;
+		}
+
+		public List<BufferConsumer> getAddedBufferConsumers(int subpartitionIndex) {
+			return produced.get(subpartitionIndex);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -519,8 +519,9 @@ public class RecordWriterTest {
 			new NoOpResultPartitionConsumableNotifier());
 		final RecordWriter recordWriter = createRecordWriter(partitionWrapper);
 		BufferBuilder builder = recordWriter.requestNewBufferBuilder(0);
-		final Buffer buffer = BufferBuilderTestUtils.buildSingleBuffer(builder);
-		builder.finish();
+		BufferBuilderTestUtils.fillBufferBuilder(builder, 1).finish();
+		ResultSubpartitionView readView = resultPartition.getSubpartition(0).createReadView(new NoOpBufferAvailablityListener());
+		Buffer buffer = readView.getNextBuffer().buffer();
 
 		// idle time is zero when there is buffer available.
 		assertEquals(0, recordWriter.getIdleTimeMsPerSecond().getCount());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -119,21 +119,11 @@ public class BufferBuilderAndConsumerTest {
 		assertContent(bufferConsumer, 42);
 	}
 
-	@Test
+	@Test(expected = IllegalStateException.class)
 	public void creatingBufferConsumerTwice() {
 		BufferBuilder bufferBuilder = createBufferBuilder();
-		BufferConsumer bufferConsumer1 = bufferBuilder.createBufferConsumer();
-
-		assertEquals(0, bufferConsumer1.getCurrentReaderPosition());
-		assertContent(bufferConsumer1);
-
-		ByteBuffer bytesToWrite = toByteBuffer(0, 1);
-		bufferBuilder.appendAndCommit(bytesToWrite);
-		BufferConsumer bufferConsumer2 = bufferBuilder.createBufferConsumer();
-		bufferBuilder.appendAndCommit(toByteBuffer(2));
-
-		assertEquals(bytesToWrite.position(), bufferConsumer2.getCurrentReaderPosition());
-		assertContent(bufferConsumer2, 2);
+		bufferBuilder.createBufferConsumer();
+		bufferBuilder.createBufferConsumer();
 	}
 
 	@Test

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/LatencyMarkerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/LatencyMarkerITCase.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.test.checkpointing.utils.MigrationTestUtils.AccumulatorCountingSink;
+import org.apache.flink.util.Collector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Tests latency marker.
+ */
+public class LatencyMarkerITCase {
+	/**
+	 * FLINK-17780: Tests that streams are not corrupted/records lost when using latency markers with broadcast.
+	 */
+	@Test
+	public void testBroadcast() throws Exception {
+		int inputCount = 100000;
+		int parallelism = 4;
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(parallelism);
+		env.getConfig().setLatencyTrackingInterval(2000);
+		env.setRestartStrategy(RestartStrategies.noRestart());
+
+		List<Integer> broadcastData = IntStream.range(0, inputCount).boxed().collect(Collectors.toList());
+		DataStream<Integer> broadcastDataStream = env.fromCollection(broadcastData)
+			.setParallelism(1);
+
+		// broadcast the configurations and create the broadcast state
+
+		DataStream<String> streamWithoutData = env.fromCollection(Collections.emptyList(), TypeInformation.of(String.class));
+
+		MapStateDescriptor<String, Integer> stateDescriptor = new MapStateDescriptor<>("BroadcastState", BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+
+		SingleOutputStreamOperator<Integer> processor = streamWithoutData
+			.connect(broadcastDataStream.broadcast(stateDescriptor))
+			.process(new BroadcastProcessFunction<String, Integer, Integer>() {
+				int expected = 0;
+
+				public void processElement(String value, ReadOnlyContext ctx, Collector<Integer> out) {
+				}
+
+				public void processBroadcastElement(Integer value, Context ctx, Collector<Integer> out) {
+					if (value != expected++) {
+						throw new AssertionError(String.format("Value was supposed to be: '%s', but was: '%s'", expected - 1, value));
+					}
+					out.collect(value);
+				}
+			});
+
+		processor.addSink(new AccumulatorCountingSink<>())
+			.setParallelism(1);
+
+		JobExecutionResult executionResult = env.execute();
+
+		Integer count = executionResult.getAccumulatorResult(AccumulatorCountingSink.NUM_ELEMENTS_ACCUMULATOR);
+		Assert.assertEquals(inputCount * parallelism, count.intValue());
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

(Unchanged backport of https://github.com/apache/flink/pull/12353/)

## What is the purpose of the change

`BroadcastRecordWriter#randomEmit` initialized buffer consumers for other non-target channels incorrectly leading to separate buffer reference counting and subsequently released buffers too early.

## Brief change log

- Fixes `BroadcastRecordWriter#randomEmit`.

## Verifying this change

This change added tests and can be verified as follows:
 - Added unit test in `BroadcastRecordWriterTest`
 - Added integration tests for latency markers and broadcast

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
