### PR TITLE
[FLINK-18281] [streaming-java][window-assigners] Add WindowStagger into TumblingEventTimeWindows

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
@@ -112,7 +112,7 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 	 * <p>Rather than that,if you are living in somewhere which is not using UTC±00:00 time,
 	 * such as China which is using UTC+08:00,and you want a time window with size of one day,
 	 * and window begins at every 00:00:00 of local time,you may use {@code of(Time.days(1),Time.hours(-8))}.
-	 * The parameter of globalOffset is {@code Time.hours(-8))} since UTC+08:00 is 8 hours earlier than UTC time.
+	 * The parameter of offset is {@code Time.hours(-8))} since UTC+08:00 is 8 hours earlier than UTC time.
 	 *
 	 * @param size The size of the generated windows.
 	 * @param offset The offset which window start would be shifted by.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
@@ -48,22 +48,30 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 
 	private final long size;
 
-	private final long offset;
+	private final long globalOffset;
 
-	protected TumblingEventTimeWindows(long size, long offset) {
+	private Long staggerOffset = null;
+
+	private final WindowStagger windowStagger;
+
+	protected TumblingEventTimeWindows(long size, long offset, WindowStagger windowStagger) {
 		if (Math.abs(offset) >= size) {
-			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy abs(offset) < size");
+			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy abs(globalOffset) < size");
 		}
 
 		this.size = size;
-		this.offset = offset;
+		this.globalOffset = offset;
+		this.windowStagger = windowStagger;
 	}
 
 	@Override
 	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
 		if (timestamp > Long.MIN_VALUE) {
+			if (staggerOffset == null) {
+				staggerOffset = windowStagger.getStaggerOffset(context.getCurrentProcessingTime(), size);
+			}
 			// Long.MIN_VALUE is currently assigned when no timestamp is present
-			long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, size);
+			long start = TimeWindow.getWindowStartWithOffset(timestamp, (globalOffset + staggerOffset) % size, size);
 			return Collections.singletonList(new TimeWindow(start, start + size));
 		} else {
 			throw new RuntimeException("Record has Long.MIN_VALUE timestamp (= no timestamp marker). " +
@@ -90,7 +98,7 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 	 * @return The time policy.
 	 */
 	public static TumblingEventTimeWindows of(Time size) {
-		return new TumblingEventTimeWindows(size.toMilliseconds(), 0);
+		return new TumblingEventTimeWindows(size.toMilliseconds(), 0, WindowStagger.ALIGNED);
 	}
 
 	/**
@@ -104,14 +112,31 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 	 * <p>Rather than that,if you are living in somewhere which is not using UTC±00:00 time,
 	 * such as China which is using UTC+08:00,and you want a time window with size of one day,
 	 * and window begins at every 00:00:00 of local time,you may use {@code of(Time.days(1),Time.hours(-8))}.
-	 * The parameter of offset is {@code Time.hours(-8))} since UTC+08:00 is 8 hours earlier than UTC time.
+	 * The parameter of globalOffset is {@code Time.hours(-8))} since UTC+08:00 is 8 hours earlier than UTC time.
 	 *
 	 * @param size The size of the generated windows.
 	 * @param offset The offset which window start would be shifted by.
 	 * @return The time policy.
 	 */
 	public static TumblingEventTimeWindows of(Time size, Time offset) {
-		return new TumblingEventTimeWindows(size.toMilliseconds(), offset.toMilliseconds());
+		return new TumblingEventTimeWindows(size.toMilliseconds(), offset.toMilliseconds(), WindowStagger.ALIGNED);
+	}
+
+
+	/**
+	 * Creates a new {@code TumblingEventTimeWindows} {@link WindowAssigner} that assigns
+	 * elements to time windows based on the element timestamp, offset and a staggering offset,
+	 * depending on the staggering policy.
+	 *
+	 * @param size The size of the generated windows.
+	 * @param offset The globalOffset which window start would be shifted by.
+	 * @param windowStagger The utility that produces staggering offset in runtime.
+	 *
+	 * @return The time policy.
+	 */
+	@PublicEvolving
+	public static TumblingEventTimeWindows of(Time size, Time offset, WindowStagger windowStagger) {
+		return new TumblingEventTimeWindows(size.toMilliseconds(), offset.toMilliseconds(), windowStagger);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
@@ -56,7 +56,7 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 
 	protected TumblingEventTimeWindows(long size, long offset, WindowStagger windowStagger) {
 		if (Math.abs(offset) >= size) {
-			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy abs(globalOffset) < size");
+			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy abs(offset) < size");
 		}
 
 		this.size = size;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingTimeWindows.java
@@ -33,7 +33,7 @@ public class TumblingTimeWindows extends TumblingEventTimeWindows {
 	private static final long serialVersionUID = 1L;
 
 	private TumblingTimeWindows(long size) {
-		super(size, 0);
+		super(size, 0, WindowStagger.ALIGNED);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
 import org.apache.flink.streaming.api.windowing.time.Time;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
@@ -21,7 +21,9 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -38,6 +40,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link TumblingEventTimeWindows}.
@@ -57,7 +60,20 @@ public class TumblingEventTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
-	public void testWindowAssignmentWithOffset() {
+	public void testWindowAssignmentWithStagger() {
+		WindowAssigner.WindowAssignerContext mockContext =
+			mock(WindowAssigner.WindowAssignerContext.class);
+
+		TumblingEventTimeWindows assigner = TumblingEventTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(0), WindowStagger.NATURAL);
+
+		when(mockContext.getCurrentProcessingTime()).thenReturn(150L);
+		assertThat(assigner.assignWindows("String", 150L, mockContext), contains(timeWindow(150, 5150)));
+		assertThat(assigner.assignWindows("String", 5099L, mockContext), contains(timeWindow(150, 5150)));
+		assertThat(assigner.assignWindows("String", 5300L, mockContext), contains(timeWindow(5150, 10150)));
+	}
+
+	@Test
+	public void testWindowAssignmentWithGlobalOffset() {
 		WindowAssigner.WindowAssignerContext mockContext =
 				mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -69,7 +85,7 @@ public class TumblingEventTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
-	public void testWindowAssignmentWithNegativeOffset() {
+	public void testWindowAssignmentWithNegativeGlobalOffset() {
 		WindowAssigner.WindowAssignerContext mockContext =
 			mock(WindowAssigner.WindowAssignerContext.class);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR is a follow-up of [FLINK-12855](https://issues.apache.org/jira/browse/FLINK-12855) and [PR 12297](https://github.com/apache/flink/pull/12297), which introduces WindowStagger in TumblingProcessingTimeWindows. 

In this PR, I added the staggering feature into TumblingEventTimeWindows.

## Brief changelog
  - *Added the staggering feature into TumblingEventTimeWindows*
  - *Added unit test*

## Verifying this change
This change added tests and can be verified as follows:
  - *Added test that validates that staggering feature work for tumbling event time window assigner*

## Does this pull request potentially affect one of the following parts:
   * Dependencies (does it add or upgrade a dependency): no
   * The public API, i.e., is any changed class annotated with @Public(Evolving): yes, TumblingEventTimeWindows(potentially all WindowAssigners)
   * The serializers: no
   * The runtime per-record code paths (performance sensitive): don't know, probably no ?
   * Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
   * The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
