### PR TITLE
[hotfix] Relocation hadoop runtime util

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -910,6 +910,10 @@ under the License.
 									<shadedPattern>org.apache.flink.hive.shaded.fs.hdfs</shadedPattern>
 								</relocation>
 								<relocation>
+									<pattern>org.apache.flink.runtime.util</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.util</shadedPattern>
+								</relocation>
+								<relocation>
 									<pattern>org.apache.flink.formats.parquet</pattern>
 									<shadedPattern>org.apache.flink.hive.shaded.formats.parquet</shadedPattern>
 								</relocation>


### PR DESCRIPTION

## What is the purpose of the change

Relocation hadoop runtime util for the flink-hadoop-fs dependency in flink-connector-hive.
To avoid duplicate classes in the class loader.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no