### PR TITLE
[FLINK-18298][table] Rename TableResult headers of SHOW statements

### DIFF
--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -52,7 +52,7 @@ class TableResult(object):
         """
         Get the schema of result.
 
-        The schema of DDL, USE, SHOW, EXPLAIN:
+        The schema of DDL, USE, EXPLAIN:
         ::
 
             +-------------+-------------+----------+
@@ -60,6 +60,20 @@ class TableResult(object):
             +-------------+-------------+----------+
             | result      | STRING      |          |
             +-------------+-------------+----------+
+
+        The schema of SHOW:
+        ::
+
+            +---------------+-------------+----------+
+            |  column name  | column type | comments |
+            +---------------+-------------+----------+
+            | <object name> | STRING      |          |
+            +---------------+-------------+----------+
+            The column name of `SHOW CATALOGS` is "catalog name",
+            the column name of `SHOW DATABASES` is "database name",
+            the column name of `SHOW TABLES` is "table name",
+            the column name of `SHOW VIEWS` is "view name",
+            the column name of `SHOW FUNCTIONS` is "function name".
 
         The schema of DESCRIBE:
         ::
@@ -106,8 +120,8 @@ class TableResult(object):
         """
         Return the ResultKind which represents the result type.
 
-         For DDL operation and USE operation, the result kind is always SUCCESS.
-         For other operations, the result kind is always SUCCESS_WITH_CONTENT.
+        For DDL operation and USE operation, the result kind is always SUCCESS.
+        For other operations, the result kind is always SUCCESS_WITH_CONTENT.
 
         :return: The result kind.
         :rtype: pyflink.table.ResultKind

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -41,13 +41,27 @@ public interface TableResult {
 	/**
 	 * Get the schema of result.
 	 *
-	 * <p>The schema of DDL, USE, SHOW, EXPLAIN:
+	 * <p>The schema of DDL, USE, EXPLAIN:
 	 * <pre>
 	 * +-------------+-------------+----------+
 	 * | column name | column type | comments |
 	 * +-------------+-------------+----------+
 	 * | result      | STRING      |          |
 	 * +-------------+-------------+----------+
+	 * </pre>
+	 *
+	 * <p>The schema of SHOW:
+	 * <pre>
+	 * +---------------+-------------+----------+
+	 * |  column name  | column type | comments |
+	 * +---------------+-------------+----------+
+	 * | &lt;object name&gt; | STRING      |          |
+	 * +---------------+-------------+----------+
+	 * The column name of `SHOW CATALOGS` is "catalog name",
+	 * the column name of `SHOW DATABASES` is "database name",
+	 * the column name of `SHOW TABLES` is "table name",
+	 * the column name of `SHOW VIEWS` is "view name",
+	 * the column name of `SHOW FUNCTIONS` is "function name".
 	 * </pre>
 	 *
 	 * <p>The schema of DESCRIBE:

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -1009,15 +1009,15 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName());
 			return TableResultImpl.TABLE_RESULT_OK;
 		} else if (operation instanceof ShowCatalogsOperation) {
-			return buildShowResult(listCatalogs());
+			return buildShowResult("catalog name", listCatalogs());
 		} else if (operation instanceof ShowDatabasesOperation) {
-			return buildShowResult(listDatabases());
+			return buildShowResult("database name", listDatabases());
 		} else if (operation instanceof ShowTablesOperation) {
-			return buildShowResult(listTables());
+			return buildShowResult("table name", listTables());
 		} else if (operation instanceof ShowFunctionsOperation) {
-			return buildShowResult(listFunctions());
+			return buildShowResult("function name", listFunctions());
 		} else if (operation instanceof ShowViewsOperation) {
-			return buildShowResult(listViews());
+			return buildShowResult("view name", listViews());
 		} else if (operation instanceof ExplainOperation) {
 			String explanation = planner.explain(Collections.singletonList(((ExplainOperation) operation).getChild()));
 			return TableResultImpl.builder()
@@ -1044,9 +1044,9 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 		}
 	}
 
-	private TableResult buildShowResult(String[] objects) {
+	private TableResult buildShowResult(String columnName, String[] objects) {
 		return buildResult(
-			new String[]{"result"},
+			new String[]{columnName},
 			new DataType[]{DataTypes.STRING()},
 			Arrays.stream(objects).map((c) -> new String[]{c}).toArray(String[][]::new));
 	}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -337,6 +337,9 @@ class TableEnvironmentTest {
     tableEnv.registerCatalog("my_catalog", new GenericInMemoryCatalog("my_catalog"))
     val tableResult = tableEnv.executeSql("SHOW CATALOGS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("catalog name", DataTypes.STRING()).build(),
+      tableResult.getTableSchema)
     checkData(
       util.Arrays.asList(Row.of("default_catalog"), Row.of("my_catalog")).iterator(),
       tableResult.collect())
@@ -348,6 +351,9 @@ class TableEnvironmentTest {
     assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
     val tableResult2 = tableEnv.executeSql("SHOW DATABASES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("database name", DataTypes.STRING()).build(),
+      tableResult2.getTableSchema)
     checkData(
       util.Arrays.asList(Row.of("default_database"), Row.of("db1")).iterator(),
       tableResult2.collect())
@@ -371,6 +377,9 @@ class TableEnvironmentTest {
 
     val tableResult2 = tableEnv.executeSql("SHOW TABLES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("table name", DataTypes.STRING()).build(),
+      tableResult2.getTableSchema)
     checkData(
       util.Arrays.asList(Row.of("tbl1")).iterator(),
       tableResult2.collect())
@@ -380,6 +389,9 @@ class TableEnvironmentTest {
   def testExecuteSqlWithShowFunctions(): Unit = {
     val tableResult = tableEnv.executeSql("SHOW FUNCTIONS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("function name", DataTypes.STRING()).build(),
+      tableResult.getTableSchema)
     checkData(
       tableEnv.listFunctions().map(Row.of(_)).toList.asJava.iterator(),
       tableResult.collect())
@@ -780,6 +792,9 @@ class TableEnvironmentTest {
 
     val tableResult3 = tableEnv.executeSql("SHOW VIEWS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult3.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("view name", DataTypes.STRING()).build(),
+      tableResult3.getTableSchema)
     checkData(
       util.Arrays.asList(Row.of("view1")).iterator(),
       tableResult3.collect())

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -740,13 +740,13 @@ abstract class TableEnvImpl(
         catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName)
         TableResultImpl.TABLE_RESULT_OK
       case _: ShowCatalogsOperation =>
-        buildShowResult(listCatalogs())
+        buildShowResult("catalog name", listCatalogs())
       case _: ShowDatabasesOperation =>
-        buildShowResult(listDatabases())
+        buildShowResult("database name", listDatabases())
       case _: ShowTablesOperation =>
-        buildShowResult(listTables())
+        buildShowResult("table name", listTables())
       case _: ShowFunctionsOperation =>
-        buildShowResult(listFunctions())
+        buildShowResult("function name", listFunctions())
       case createViewOperation: CreateViewOperation =>
         if (createViewOperation.isTemporary) {
           catalogManager.createTemporaryTable(
@@ -772,7 +772,7 @@ abstract class TableEnvImpl(
         }
         TableResultImpl.TABLE_RESULT_OK
       case _: ShowViewsOperation =>
-        buildShowResult(listViews())
+        buildShowResult("view name", listViews())
       case explainOperation: ExplainOperation =>
         val explanation = explainInternal(JCollections.singletonList(explainOperation.getChild))
         TableResultImpl.builder.
@@ -798,12 +798,12 @@ abstract class TableEnvImpl(
     }
   }
 
-  private def buildShowResult(objects: Array[String]): TableResult = {
+  private def buildShowResult(columnName: String, objects: Array[String]): TableResult = {
     val rows = Array.ofDim[Object](objects.length, 1)
     objects.zipWithIndex.foreach {
       case (obj, i) => rows(i)(0) = obj
     }
-    buildResult(Array("result"), Array(DataTypes.STRING), rows)
+    buildResult(Array(columnName), Array(DataTypes.STRING), rows)
   }
 
   private def buildDescribeResult(schema: TableSchema): TableResult = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
@@ -216,6 +216,9 @@ class BatchTableEnvironmentTest extends TableTestBase {
     testUtil.tableEnv.registerCatalog("my_catalog", new GenericInMemoryCatalog("my_catalog"))
     val tableResult = testUtil.tableEnv.executeSql("SHOW CATALOGS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("catalog name", DataTypes.STRING()).build(),
+      tableResult.getTableSchema)
     checkData(
       util.Arrays.asList(Row.of("default_catalog"), Row.of("my_catalog")).iterator(),
       tableResult.collect())
@@ -229,6 +232,9 @@ class BatchTableEnvironmentTest extends TableTestBase {
     testUtil.tableEnv.registerCatalog("my_catalog", new GenericInMemoryCatalog("my_catalog"))
     val tableResult2 = testUtil.tableEnv.executeSql("SHOW DATABASES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("database name", DataTypes.STRING()).build(),
+      tableResult2.getTableSchema)
     checkData(
       util.Arrays.asList(Row.of("default_database"), Row.of("db1")).iterator(),
       tableResult2.collect())
@@ -253,6 +259,9 @@ class BatchTableEnvironmentTest extends TableTestBase {
 
     val tableResult2 = testUtil.tableEnv.executeSql("SHOW TABLES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("table name", DataTypes.STRING()).build(),
+      tableResult2.getTableSchema)
     checkData(
       util.Arrays.asList(Row.of("tbl1")).iterator(),
       tableResult2.collect())
@@ -263,6 +272,9 @@ class BatchTableEnvironmentTest extends TableTestBase {
     val util = batchTestUtil()
     val tableResult = util.tableEnv.executeSql("SHOW FUNCTIONS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("function name", DataTypes.STRING()).build(),
+      tableResult.getTableSchema)
     checkData(
       util.tableEnv.listFunctions().map(Row.of(_)).toList.asJava.iterator(),
       tableResult.collect())
@@ -324,6 +336,9 @@ class BatchTableEnvironmentTest extends TableTestBase {
 
     val tableResult4 = util.tableEnv.executeSql("SHOW VIEWS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult4.getResultKind)
+    assertEquals(
+      TableSchema.builder().field("view name", DataTypes.STRING()).build(),
+      tableResult4.getTableSchema)
     checkData(
       util.tableEnv.listViews().map(Row.of(_)).toList.asJava.iterator(),
       tableResult4.collect())


### PR DESCRIPTION
## What is the purpose of the change

*Rename TableResult headers of SHOW statements, the new headers look like: 

command | header
-- | --
SHOW CATALOG | catalog name
SHOW DATABASE | database name
SHOW TABLES | table name
SHOW VIEW | view name
SHOW FUNCTIONS | function name
*


## Brief change log

  - *Rename TableResult headers of SHOW statements*
  - *update the javadoc of TableResult#getTableSchema method*


## Verifying this change


This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended TableEnvironmentTest and BatchTableEnvironmentTest to verify the change*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
