### PR TITLE
[FLINK-17666][table-planner-blink] Insert into partitioned table can …

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
@@ -47,7 +47,7 @@ public class SqlShowCatalogs extends SqlCall {
 
 	@Override
 	public List<SqlNode> getOperandList() {
-		return Collections.EMPTY_LIST;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -111,7 +111,7 @@ class FlinkPlannerImpl(
   private def validate(sqlNode: SqlNode, validator: FlinkCalciteSqlValidator): SqlNode = {
     try {
       sqlNode.accept(new PreValidateReWriter(
-        validator.getCatalogReader.unwrap(classOf[CalciteCatalogReader]), typeFactory))
+        validator, typeFactory))
       // do extended validation.
       sqlNode match {
         case node: ExtendedSqlNode =>


### PR DESCRIPTION
…fail with select *

## What is the purpose of the change

Before this patch, Blink planner throws for query `insert into target_table partition ... select * from src_table`.


## Brief change log

  - Fix the blink planner
  - Add ITCase for blink-planner and Hive connector

## Verifying this change

Added ITCases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
