### PR TITLE
[FLINK-18238][checkpoint] Emit CancelCheckpointMarker downstream on checkpointState in sync phase of checkpoint on task side

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -277,7 +277,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 	@Override
 	public void notifyCheckpointComplete(long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning) throws Exception {
 		if (isRunning.get()) {
-			LOG.debug("Notification of complete checkpoint {} for task {}", checkpointId, taskName);
+			LOG.debug("Notification of complete checkpoint for task {}", taskName);
 
 			for (StreamOperatorWrapper<?, ?> operatorWrapper : operatorChain.getAllOperators(true)) {
 				operatorWrapper.notifyCheckpointComplete(checkpointId);
@@ -293,7 +293,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 
 		Exception previousException = null;
 		if (isRunning.get()) {
-			LOG.debug("Notification of aborted checkpoint {} for task {}", checkpointId, taskName);
+			LOG.debug("Notification of aborted checkpoint for task {}", taskName);
 
 			boolean canceled = cancelAsyncCheckpointRunnable(checkpointId);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.MetricGroup;
@@ -28,7 +31,10 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriterImpl;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.writer.NonRecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
+import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -39,12 +45,16 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.TestCheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskTest.NoOpStreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
@@ -53,6 +63,8 @@ import org.apache.flink.util.ExceptionUtils;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -216,6 +228,67 @@ public class SubtaskCheckpointCoordinatorTest {
 		assertEquals(-1, stateManager.getReportedCheckpointId());
 		assertEquals(0, subtaskCheckpointCoordinator.getAbortedCheckpointSize());
 		assertEquals(0, subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize());
+	}
+
+	@Test
+	public void testDownstreamReceiveCancelCheckpointMarkerOnUpstreamAbortedInSyncPhase() throws Exception {
+		final OneInputStreamTaskTestHarness<String, String> testHarness =
+			new OneInputStreamTaskTestHarness<>(
+				OneInputStreamTask::new,
+				1, 1,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness.setupOutputForSingletonOperatorChain();
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(new MapOperator());
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		TestTaskStateManager stateManager = new TestTaskStateManager();
+		MockEnvironment mockEnvironment = MockEnvironment.builder().setTaskStateManager(stateManager).build();
+		SubtaskCheckpointCoordinatorImpl subtaskCheckpointCoordinator = (SubtaskCheckpointCoordinatorImpl) new MockSubtaskCheckpointCoordinatorBuilder()
+			.setEnvironment(mockEnvironment)
+			.setUnalignedCheckpointEnabled(true)
+			.build();
+
+		final TestPooledBufferProvider bufferProvider = new TestPooledBufferProvider(Integer.MAX_VALUE, 4096);
+		ArrayList<Object> recordOrEvents = new ArrayList<>();
+		StreamElementSerializer<String> stringStreamElementSerializer = new StreamElementSerializer<>(StringSerializer.INSTANCE);
+		RecordOrEventCollectingResultPartitionWriter<StreamElement> resultPartitionWriter = new RecordOrEventCollectingResultPartitionWriter<>(recordOrEvents, bufferProvider, stringStreamElementSerializer);
+		mockEnvironment.addOutputs(Collections.singletonList(resultPartitionWriter));
+
+		OneInputStreamTask<String, String> task = testHarness.getTask();
+		final OperatorChain<String, OneInputStreamOperator<String, String>> operatorChain = new OperatorChain<>(task, StreamTask.createRecordWriterDelegate(streamConfig, mockEnvironment));
+		long checkpointId = 42L;
+		// notify checkpoint aborted before execution.
+		subtaskCheckpointCoordinator.notifyCheckpointAborted(checkpointId, operatorChain, () -> true);
+		subtaskCheckpointCoordinator.getChannelStateWriter().start(checkpointId, CheckpointOptions.forCheckpointWithDefaultLocation());
+		subtaskCheckpointCoordinator.checkpointState(
+			new CheckpointMetaData(checkpointId, System.currentTimeMillis()),
+			CheckpointOptions.forCheckpointWithDefaultLocation(),
+			new CheckpointMetrics(),
+			operatorChain,
+			() -> true);
+
+		assertEquals(1, recordOrEvents.size());
+		Object recordOrEvent = recordOrEvents.get(0);
+		// ensure CancelCheckpointMarker is broadcast downstream.
+		assertTrue(recordOrEvent instanceof CancelCheckpointMarker);
+		assertEquals(checkpointId, ((CancelCheckpointMarker) recordOrEvent).getCheckpointId());
+	}
+
+	private static class MapOperator extends StreamMap<String, String> {
+		private static final long serialVersionUID = 1L;
+
+		public MapOperator() {
+			super((MapFunction<String, String>) value -> value);
+		}
+
+		@Override
+		public void notifyCheckpointAborted(long checkpointId) throws Exception {
+		}
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -247,8 +247,7 @@ public class SubtaskCheckpointCoordinatorTest {
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
 
-		TestTaskStateManager stateManager = new TestTaskStateManager();
-		MockEnvironment mockEnvironment = MockEnvironment.builder().setTaskStateManager(stateManager).build();
+		MockEnvironment mockEnvironment = MockEnvironment.builder().build();
 		SubtaskCheckpointCoordinator subtaskCheckpointCoordinator = new MockSubtaskCheckpointCoordinatorBuilder()
 			.setEnvironment(mockEnvironment)
 			.build();
@@ -256,15 +255,16 @@ public class SubtaskCheckpointCoordinatorTest {
 		TestPooledBufferProvider bufferProvider = new TestPooledBufferProvider(1, 4096);
 		ArrayList<Object> recordOrEvents = new ArrayList<>();
 		StreamElementSerializer<String> stringStreamElementSerializer = new StreamElementSerializer<>(StringSerializer.INSTANCE);
-		ResultPartitionWriter resultPartitionWriter = new RecordOrEventCollectingResultPartitionWriter<>(recordOrEvents, bufferProvider, stringStreamElementSerializer);
+		ResultPartitionWriter resultPartitionWriter = new RecordOrEventCollectingResultPartitionWriter<>(
+			recordOrEvents, bufferProvider, stringStreamElementSerializer);
 		mockEnvironment.addOutputs(Collections.singletonList(resultPartitionWriter));
 
 		OneInputStreamTask<String, String> task = testHarness.getTask();
-		OperatorChain<String, OneInputStreamOperator<String, String>> operatorChain = new OperatorChain<>(task, StreamTask.createRecordWriterDelegate(streamConfig, mockEnvironment));
+		OperatorChain<String, OneInputStreamOperator<String, String>> operatorChain = new OperatorChain<>(
+			task, StreamTask.createRecordWriterDelegate(streamConfig, mockEnvironment));
 		long checkpointId = 42L;
 		// notify checkpoint aborted before execution.
 		subtaskCheckpointCoordinator.notifyCheckpointAborted(checkpointId, operatorChain, () -> true);
-		subtaskCheckpointCoordinator.getChannelStateWriter().start(checkpointId, CheckpointOptions.forCheckpointWithDefaultLocation());
 		subtaskCheckpointCoordinator.checkpointState(
 			new CheckpointMetaData(checkpointId, System.currentTimeMillis()),
 			CheckpointOptions.forCheckpointWithDefaultLocation(),


### PR DESCRIPTION
## What is the purpose of the change

Emit `CancelCheckpointMarker` downstream on `checkpointState` in sync phase of checkpoint on task side to avoid downstream back-pressure.

## Brief change log
Emit `CancelCheckpointMarker` downstream on `checkpointState` in sync phase of checkpoint on task side.


## Verifying this change

This change added tests and can be verified as follows:

  - Added unit test `testDownstreamReceiveCancelCheckpointMarkerOnUpstreamAbortedInSyncPhase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
