### PR TITLE
[FLINK-18209] Replace slave with worker in docker cluster test scripts

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -65,7 +65,7 @@ function start_hadoop_cluster() {
     done
 
     # perform health checks
-    containers_health_check "master" "slave1" "slave2" "kdc"
+    containers_health_check "master" "worker1" "worker2" "kdc"
 
     # try and see if NodeManagers are up, otherwise the Flink job will not have enough resources
     # to run

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml
@@ -45,28 +45,28 @@ services:
       KRB_REALM: EXAMPLE.COM
       DOMAIN_REALM: kdc.kerberos.com
 
-  slave1:
+  worker1:
     image: ${DOCKER_HADOOP_IMAGE_NAME:-flink/docker-hadoop-secure-cluster:latest}
     command: worker
     depends_on:
       - kdc
       - master
-    container_name: "slave1"
-    hostname: slave1.docker-hadoop-cluster-network
+    container_name: "worker1"
+    hostname: worker1.docker-hadoop-cluster-network
     networks:
       - docker-hadoop-cluster-network
     environment:
       KRB_REALM: EXAMPLE.COM
       DOMAIN_REALM: kdc.kerberos.com
 
-  slave2:
+  worker2:
     image: ${DOCKER_HADOOP_IMAGE_NAME:-flink/docker-hadoop-secure-cluster:latest}
     command: worker
     depends_on:
       - kdc
       - master
-    container_name: "slave2"
-    hostname: slave2.docker-hadoop-cluster-network
+    container_name: "worker2"
+    hostname: worker2.docker-hadoop-cluster-network
     networks:
       - docker-hadoop-cluster-network
     environment:


### PR DESCRIPTION
## Brief change log

We just replace `slave` by `worker` in the test script/docker-compose file. This does not affect users since it's only in tests

## Verifying this change

Covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: *no*
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? *not applicable*
