### PR TITLE
[FLINK-17824][tests] Fix resume_savepoint e2e test by slowing down th…

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -79,7 +79,7 @@ run_resume_savepoint_test() {
     --state_backend $STATE_BACKEND_TYPE \
     --state_backend.checkpoint_directory $CHECKPOINT_DIR \
     --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
-    --sequence_generator_source.sleep_time 15 \
+    --sequence_generator_source.sleep_time 30 \
     --sequence_generator_source.sleep_after_elements 1 \
     | grep "Job has been submitted with JobID" | sed 's/.* //g')
 


### PR DESCRIPTION
## What is the purpose of the change

Fix `test_resume_savepoint.sh` e2e test by slowing down the Source.
This prevents it from generating too much data to consume by the downstream which can lead to test timeouts  (see FLINK-17824 for more information).

## Brief change log
 - increase `sequence_generator_source.sleep_time` from 15 to 30

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
