### PR TITLE
[FLINK-18311] Fix StreamingKafkaITCase on Kafka 2.4.1

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
@@ -51,6 +51,18 @@ public interface KafkaResource extends ExternalResource {
 	void sendMessages(String topic, String ... messages) throws IOException;
 
 	/**
+	 * Sends the given keyed messages to the given topic. The messages themselves should contain
+	 * the specified {@code keySeparator}.
+	 *
+	 * @param topic topic name
+	 * @param keySeparator the separator used to parse key from value in the messages
+	 * @param messages messages to send
+	 * @throws IOException
+	 */
+	void sendKeyedMessages(
+			String topic, String keySeparator, String ... messages) throws IOException;
+
+	/**
 	 * Returns the kafka bootstrap server addresses.
 	 * @return kafka bootstrap server addresses
 	 */

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
@@ -251,7 +251,11 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 			"--broker-list",
 			KAFKA_ADDRESS,
 			"--topic",
-			topic)) {
+			topic,
+			"--property",
+			"parse.key=true",
+			"--property",
+			"key.separator=\t")) {
 
 			try (PrintStream printStream = new PrintStream(autoClosableProcess.getProcess().getOutputStream(), true, StandardCharsets.UTF_8.name())) {
 				for (final String message : messages) {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -113,7 +113,7 @@ public class StreamingKafkaITCase extends TestLogger {
 
 			LOG.info("Sending messages to Kafka topic [{}] ...", inputTopic);
 			// send some data to Kafka
-			kafka.sendMessages(inputTopic,
+			kafka.sendKeyedMessages(inputTopic, "\t",
 				"key\telephant,5,45218",
 				"key\tsquirrel,12,46213",
 				"key\tbee,3,51348",
@@ -142,7 +142,7 @@ public class StreamingKafkaITCase extends TestLogger {
 
 			// send some more messages to Kafka
 			LOG.info("Sending more messages to Kafka topic [{}] ...", inputTopic);
-			kafka.sendMessages(inputTopic,
+			kafka.sendKeyedMessages(inputTopic, "\t",
 				"key\telephant,13,64213",
 				"key\tgiraffe,9,65555",
 				"key\tbee,5,65647",

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -114,12 +114,12 @@ public class StreamingKafkaITCase extends TestLogger {
 			LOG.info("Sending messages to Kafka topic [{}] ...", inputTopic);
 			// send some data to Kafka
 			kafka.sendMessages(inputTopic,
-				"elephant,5,45218",
-				"squirrel,12,46213",
-				"bee,3,51348",
-				"squirrel,22,52444",
-				"bee,10,53412",
-				"elephant,9,54867");
+				"key\telephant,5,45218",
+				"key\tsquirrel,12,46213",
+				"key\tbee,3,51348",
+				"key\tsquirrel,22,52444",
+				"key\tbee,10,53412",
+				"key\telephant,9,54867");
 
 			LOG.info("Verifying messages from Kafka topic [{}] ...", outputTopic);
 			{
@@ -143,10 +143,10 @@ public class StreamingKafkaITCase extends TestLogger {
 			// send some more messages to Kafka
 			LOG.info("Sending more messages to Kafka topic [{}] ...", inputTopic);
 			kafka.sendMessages(inputTopic,
-				"elephant,13,64213",
-				"giraffe,9,65555",
-				"bee,5,65647",
-				"squirrel,18,66413");
+				"key\telephant,13,64213",
+				"key\tgiraffe,9,65555",
+				"key\tbee,5,65647",
+				"key\tsquirrel,18,66413");
 
 			// verify that our assumption that the new partition actually has written messages is correct
 			Assert.assertNotEquals(


### PR DESCRIPTION
## What is the purpose of the change / Brief change log

This was broken because the behaviour of the Kafka/ZooKeeper command
line tools on Kafka 2.4.1 is slightly different:

zookeeper_shell.sh does not print debug output to stderr as it did
before. We change queryBrokerStatus() to instead consume stdout and
check that we get valid information for the broker.

The output of kafka-topics.sh now has a space between "PartitionCount:"
and the partition count. Before we had "PartitionCount:2", now it's
"PartitionCount: 2". We fix this by making the regex more lenient.

This also splits the waiting on ZooKeeper/Kafka into two loops to better
see which one we're blocking on.

## Verifying this change

This can be verified by manually running `StreamingKafkaITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? *not applicable*
