### PR TITLE
[FLINK-18315][table-planner-blink] Insert into partitioned table can …

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
@@ -688,6 +688,17 @@ public class TableEnvHiveConnectorITCase {
 		tableEnv.executeSql("drop table if exists dest");
 	}
 
+	@Test
+	public void testInsertPartitionWithValuesSource() {
+		TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
+		tableEnv.executeSql("create table dest (x int) partitioned by (p1 int,p2 string)");
+		TableEnvUtil.execInsertSqlAndWaitResult(tableEnv,
+				"insert into dest partition (p1=1) values(1, 'a')");
+		List<Row> results = Lists.newArrayList(tableEnv.sqlQuery("select * from dest").execute().collect());
+		assertEquals("[1,1,a]", results.toString());
+		tableEnv.executeSql("drop table if exists dest");
+	}
+
 	private TableEnvironment getTableEnvWithHiveCatalog() {
 		TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
 		tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
@@ -94,6 +94,25 @@ LegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testStaticWithValues">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink PARTITION (b=1, c=1) VALUES (5)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
++- LogicalProject(a=[5:BIGINT], b=[1:BIGINT], c=[1:BIGINT])
+   +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
++- Calc(select=[5:BIGINT AS a, 1:BIGINT AS b, 1:BIGINT AS c])
+   +- Values(tuples=[[{ 0 }]], values=[ZERO])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testWrongFields">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
@@ -79,10 +79,6 @@ class PartitionableSinkTest extends TableTestBase {
 
   @Test
   def testStaticWithValues(): Unit = {
-    thrown.expect(classOf[ValidationException])
-    thrown.expectMessage(
-      "INSERT INTO <table> PARTITION statement only support SELECT clause for now," +
-          " 'VALUES ROW(5)' is not supported yet")
     util.verifyPlanInsert("INSERT INTO sink PARTITION (b=1, c=1) VALUES (5)")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -182,6 +182,16 @@ class PartitionableSinkITCase extends BatchTestBase {
   }
 
   @Test
+  def testInsertWithStaticPartitionAndValuesSource(): Unit = {
+    registerTableSink(partitionColumns = Array("b", "c"))
+    execInsertSqlAndWaitResult("insert into sinkTable partition(b=1)\n"
+      + "(values (1, 'Hello world, how are you?'), (4, '你好，陌生人，我是'), (2, 'Hello'))")
+    assertEquals(List("1,1,Hello world, how are you?"), RESULT1.toList)
+    assertEquals(List("4,1,你好，陌生人，我是"), RESULT2.toList)
+    assertEquals(List("2,1,Hello"), RESULT3.toList)
+  }
+
+  @Test
   def testStaticPartitionNotInPartitionFields(): Unit = {
     expectedEx.expect(classOf[ValidationException])
     registerTableSink(tableName = "sinkTable2", rowType = type4,


### PR DESCRIPTION
…fail with values

## What is the purpose of the change

Before this patch, `insert into partiton ... values` could not work correctly.

## Brief change log

  - Fix the blink planner
  - Add a ITCase for Hive connector


## Verifying this change

Added ITCases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
