### PR TITLE
[FLINK-18310][metrics] Properly handle interval parsing errors

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -40,12 +40,14 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -95,6 +97,11 @@ public class MetricRegistryImpl implements MetricRegistry {
 	 * Creates a new MetricRegistry and starts the configured reporter.
 	 */
 	public MetricRegistryImpl(MetricRegistryConfiguration config, Collection<ReporterSetup> reporterConfigurations) {
+		this(config, reporterConfigurations, Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("Flink-MetricRegistry")));
+	}
+
+	@VisibleForTesting
+	MetricRegistryImpl(MetricRegistryConfiguration config, Collection<ReporterSetup> reporterConfigurations, ScheduledExecutorService scheduledExecutor) {
 		this.maximumFramesize = config.getQueryServiceMessageSizeLimit();
 		this.scopeFormats = config.getScopeFormats();
 		this.globalDelimiter = config.getDelimiter();
@@ -104,7 +111,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 		// second, instantiate any custom configured reporters
 		this.reporters = new ArrayList<>(4);
 
-		this.executor = Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("Flink-MetricRegistry"));
+		this.executor = scheduledExecutor;
 
 		this.queryService = null;
 		this.metricQueryServiceRpcService = null;
@@ -119,14 +126,11 @@ public class MetricRegistryImpl implements MetricRegistry {
 
 				try {
 					Optional<String> configuredPeriod = reporterSetup.getIntervalSettings();
-					TimeUnit timeunit = TimeUnit.SECONDS;
-					long period = MetricOptions.REPORTER_INTERVAL.defaultValue().getSeconds();
+					Duration period = MetricOptions.REPORTER_INTERVAL.defaultValue();
 
 					if (configuredPeriod.isPresent()) {
 						try {
-							String[] interval = configuredPeriod.get().split(" ");
-							period = Long.parseLong(interval[0]);
-							timeunit = TimeUnit.valueOf(interval[1]);
+							period = TimeUtils.parseDuration(configuredPeriod.get());
 						}
 						catch (Exception e) {
 							LOG.error("Cannot parse report interval from config: " + configuredPeriod +
@@ -139,10 +143,10 @@ public class MetricRegistryImpl implements MetricRegistry {
 					final String className = reporterInstance.getClass().getName();
 
 					if (reporterInstance instanceof Scheduled) {
-						LOG.info("Periodically reporting metrics in intervals of {} {} for reporter {} of type {}.", period, timeunit.name(), namedReporter, className);
+						LOG.info("Periodically reporting metrics in intervals of {} for reporter {} of type {}.", TimeUtils.formatWithHighestUnit(period), namedReporter, className);
 
 						executor.scheduleWithFixedDelay(
-								new MetricRegistryImpl.ReporterTask((Scheduled) reporterInstance), period, period, timeunit);
+								new MetricRegistryImpl.ReporterTask((Scheduled) reporterInstance), period.toMillis(), period.toMillis(), TimeUnit.MILLISECONDS);
 					} else {
 						LOG.info("Reporting metrics for reporter {} of type {}.", namedReporter, className);
 					}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.metrics.dump.MetricDumpSerialization;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.metrics.groups.MetricGroupTest;
@@ -42,13 +43,17 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceGateway;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -159,6 +164,28 @@ public class MetricRegistryImplTest extends TestLogger {
 		Assert.assertTrue("No report was triggered.", TestReporter3.reportCount > 0);
 
 		registry.shutdown().get();
+	}
+
+	@Test
+	public void testReporterIntervalParsingErrorFallsBackToDefaultValue() throws Exception {
+		MetricConfig config = new MetricConfig();
+		// in a prior implementation the time amount was applied even if the time unit was invalid
+		// in this case this would imply using 1 SECOND as the interval (seconds is the default)
+		config.setProperty(ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, "1 UNICORN");
+
+		final ManuallyTriggeredScheduledExecutorService manuallyTriggeredScheduledExecutorService = new ManuallyTriggeredScheduledExecutorService();
+
+		MetricRegistryImpl registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Collections.singletonList(ReporterSetup.forReporter("test", config, new TestReporter3())),
+			manuallyTriggeredScheduledExecutorService);
+		try {
+			Collection<ScheduledFuture<?>> scheduledTasks = manuallyTriggeredScheduledExecutorService.getScheduledTasks();
+			ScheduledFuture<?> reportTask = Iterators.getOnlyElement(scheduledTasks.iterator());
+			Assert.assertEquals(MetricOptions.REPORTER_INTERVAL.defaultValue().getSeconds(), reportTask.getDelay(TimeUnit.SECONDS));
+		} finally {
+			registry.shutdown().get();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Changes the reporter interval parsing to use the `TimeUtils` instead, which should make it more consistent with other time-based options . This also makes the parsing of both components an atomic operation.