### PR TITLE
[FLINK-18238][checkpoint] Emit CancelCheckpointMarker downstream on checkpointState in sync phase of checkpoint on task side

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -235,9 +235,11 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 			return;
 		}
 
-		// Step (0): Record the last triggered checkpointId.
+		// Step (0): Record the last triggered checkpointId and abort the sync phase of checkpoint if necessary.
 		lastCheckpointId = metadata.getCheckpointId();
 		if (checkAndClearAbortedStatus(metadata.getCheckpointId())) {
+			// broadcast cancel checkpoint marker to avoid downstream back-pressure due to checkpoint barrier align.
+			operatorChain.broadcastEvent(new CancelCheckpointMarker(metadata.getCheckpointId()));
 			LOG.info("Checkpoint {} has been notified as aborted, would not trigger any checkpoint.", metadata.getCheckpointId());
 			return;
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR targets for release-1.11 branch.

Emit `CancelCheckpointMarker` downstream on `checkpointState` in sync phase of checkpoint on task side to avoid downstream back-pressure.

## Brief change log
Emit `CancelCheckpointMarker` downstream on `checkpointState` in sync phase of checkpoint on task side.


## Verifying this change

This change added tests and can be verified as follows:

  - Added unit test `testDownstreamReceiveCancelCheckpointMarkerOnUpstreamAbortedInSyncPhase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
