### PR TITLE
[FLINK-18336][checkpointing] CheckpointFailureManager fixes (WIP)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -77,6 +77,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
+import static java.util.Arrays.asList;
 import static java.util.Optional.of;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -540,7 +541,7 @@ public class CheckpointCoordinator {
 							timer);
 
 			FutureUtils.assertNoException(
-				CompletableFuture.allOf(masterStatesComplete, coordinatorCheckpointsComplete)
+				FutureUtils.waitForAll(asList(masterStatesComplete, coordinatorCheckpointsComplete))
 					.handleAsync(
 						(ignored, throwable) -> {
 							final PendingCheckpoint checkpoint =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -77,6 +77,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
+import static java.util.Optional.of;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -1613,7 +1614,7 @@ public class CheckpointCoordinator {
 						exception, pendingCheckpoint.getCheckpointId(), executionAttemptID);
 				} else {
 					failureManager.handleJobLevelCheckpointException(
-						exception, pendingCheckpoint.getCheckpointId());
+						exception, of(pendingCheckpoint.getCheckpointId()));
 				}
 			} finally {
 				sendAbortedMessages(pendingCheckpoint.getCheckpointId(), pendingCheckpoint.getCheckpointTimestamp());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -84,7 +84,7 @@ public class CheckpointFailureManager {
 	private void handleException(CheckpointException exception, long checkpointId, BiConsumer<FailJobCallback, Exception> onFailure) {
 		if (isCheckpointFailure(exception) &&
 				countedCheckpointIds.add(checkpointId) &&
-				continuousFailureCounter.incrementAndGet() > tolerableCpFailureNumber) {
+				continuousFailureCounter.incrementAndGet() == tolerableCpFailureNumber + 1) {
 			clearCount();
 			onFailure.accept(failureCallback, new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold."));
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_EXPIRED;
 import static org.junit.Assert.assertEquals;
 
@@ -34,12 +36,12 @@ public class CheckpointFailureManagerTest extends TestLogger {
 	public void testOnlySucceededCheckpointIdRemoved(){
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 1L); // remember
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 2L); // remember
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), of(1L)); // remember
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), of(2L)); // remember
 		failureManager.handleCheckpointSuccess(2L); // reset counter and forget 2L only
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 1L); // ignore (seen)
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 3L); // remember but don't fail (counter <= 2)
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 4L); // remember but don't fail (counter <= 2)
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), of(1L)); // ignore (seen)
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), of(3L)); // remember but don't fail (counter <= 2)
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), of(4L)); // remember but don't fail (counter <= 2)
 		assertEquals(0, callback.getInvokeCounter());
 	}
 
@@ -48,16 +50,16 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 1);
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), of(1L));
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
+			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), of(2L));
 
 		//ignore this
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), 3);
+			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), of(3L));
 
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 4);
+			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), of(4L));
 		assertEquals(1, callback.getInvokeCounter());
 	}
 
@@ -66,19 +68,19 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.EXCEPTION), 1);
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.EXCEPTION), of(1L));
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
+			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), of(2L));
 
 		//ignore this
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), 3);
+			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), of(3L));
 
 		//reset
 		failureManager.handleCheckpointSuccess(4);
 
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CHECKPOINT_EXPIRED), 5);
+			new CheckpointException(CHECKPOINT_EXPIRED), of(5L));
 		assertEquals(0, callback.getInvokeCounter());
 	}
 
@@ -87,7 +89,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(0, callback);
 		for (CheckpointFailureReason reason : CheckpointFailureReason.values()) {
-			failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
+			failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), empty());
 		}
 
 		assertEquals(1, callback.getInvokeCounter());
@@ -98,17 +100,17 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		TestFailJobCallback callback = new TestFailJobCallback();
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
-		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 1);
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), of(1L));
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
+			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), of(2L));
 
 		//ignore this
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), 3);
+			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION), of(3L));
 
 		//ignore repeatedly report from one checkpoint
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
+			new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), of(2L));
 		assertEquals(0, callback.getInvokeCounter());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -76,7 +76,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
 			failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
 		}
 
-		assertEquals(2, callback.getInvokeCounter());
+		assertEquals(1, callback.getInvokeCounter());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -22,12 +22,26 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_EXPIRED;
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the checkpoint failure manager.
  */
 public class CheckpointFailureManagerTest extends TestLogger {
+
+	@Test
+	public void testOnlySucceededCheckpointIdRemoved(){
+		TestFailJobCallback callback = new TestFailJobCallback();
+		CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 1L); // remember
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 2L); // remember
+		failureManager.handleCheckpointSuccess(2L); // reset counter and forget 2L only
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 1L); // ignore (seen)
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 3L); // remember but don't fail (counter <= 2)
+		failureManager.handleJobLevelCheckpointException(new CheckpointException(CHECKPOINT_EXPIRED), 4L); // remember but don't fail (counter <= 2)
+		assertEquals(0, callback.getInvokeCounter());
+	}
 
 	@Test
 	public void testContinuousFailure() {
@@ -64,7 +78,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
 		failureManager.handleCheckpointSuccess(4);
 
 		failureManager.handleJobLevelCheckpointException(
-			new CheckpointException(CheckpointFailureReason.CHECKPOINT_EXPIRED), 5);
+			new CheckpointException(CHECKPOINT_EXPIRED), 5);
 		assertEquals(0, callback.getInvokeCounter());
 	}
 


### PR DESCRIPTION
This is a followup PR after #12670.
**WIP**

## What is the purpose of the change

 - Fail job only once
 - Remove only succeeded checkpoint id from CheckpointFailureManager.ids
 - Fail checkpoint future ASAP


## Brief change log

  - TBD


## Verifying this change

TDB

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
