### PR TITLE
[FLINK-18072][hbase] Fix HBaseLookupFunction can not work with new internal data structure RowData

### DIFF
--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseDynamicTableSource.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseDynamicTableSource.java
@@ -77,7 +77,7 @@ public class HBaseDynamicTableSource implements ScanTableSource, LookupTableSour
 				.isPresent(),
 			"Currently, HBase table only supports lookup by rowkey field.");
 
-		return TableFunctionProvider.of(new HBaseLookupFunction(conf, tableName, hbaseSchema));
+		return TableFunctionProvider.of(new HBaseRowDataLookupFunction(conf, tableName, hbaseSchema, nullStringLiteral));
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
@@ -20,13 +20,12 @@ package org.apache.flink.connector.hbase.source;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
-import org.apache.flink.connector.hbase.util.HBaseReadWriteHelper;
+import org.apache.flink.connector.hbase.util.HBaseSerde;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.TableFunction;
-import org.apache.flink.types.Row;
 import org.apache.flink.util.StringUtils;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,6 +35,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Result;
 import org.slf4j.Logger;
@@ -44,29 +44,33 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /**
- * The HBaseLookupFunction is a standard user-defined table function, it can be used in tableAPI
- * and also useful for temporal table join plan in SQL. It looks up the result as {@link Row}.
+ * The HBaseRowDataLookupFunction is a standard user-defined table function, it can be used in tableAPI
+ * and also useful for temporal table join plan in SQL. It looks up the result as {@link RowData}.
  */
 @Internal
-public class HBaseLookupFunction extends TableFunction<Row> {
-	private static final Logger LOG = LoggerFactory.getLogger(HBaseLookupFunction.class);
+public class HBaseRowDataLookupFunction extends TableFunction<RowData> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HBaseRowDataLookupFunction.class);
 	private static final long serialVersionUID = 1L;
 
 	private final String hTableName;
 	private final byte[] serializedConfig;
 	private final HBaseTableSchema hbaseTableSchema;
+	private final String nullStringLiteral;
 
-	private transient HBaseReadWriteHelper readHelper;
 	private transient Connection hConnection;
 	private transient HTable table;
+	private transient HBaseSerde serde;
 
-	public HBaseLookupFunction(
+	public HBaseRowDataLookupFunction(
 			Configuration configuration,
 			String hTableName,
-			HBaseTableSchema hbaseTableSchema) {
+			HBaseTableSchema hbaseTableSchema,
+			String nullStringLiteral) {
 		this.serializedConfig = HBaseConfigurationUtil.serializeConfiguration(configuration);
 		this.hTableName = hTableName;
 		this.hbaseTableSchema = hbaseTableSchema;
+		this.nullStringLiteral = nullStringLiteral;
 	}
 
 	/**
@@ -75,19 +79,17 @@ public class HBaseLookupFunction extends TableFunction<Row> {
 	 */
 	public void eval(Object rowKey) throws IOException {
 		// fetch result
-		Result result = table.get(readHelper.createGet(rowKey));
-		if (!result.isEmpty()) {
-			// parse and collect
-			collect(readHelper.parseToRow(result, rowKey));
+		Get get = serde.createGet(rowKey);
+		if (get != null) {
+			Result result = table.get(get);
+			if (!result.isEmpty()) {
+				// parse and collect
+				collect(serde.convertToRow(result));
+			}
 		}
 	}
 
-	@Override
-	public TypeInformation<Row> getResultType() {
-		return hbaseTableSchema.convertsToTableSchema().toRowType();
-	}
-
-	private org.apache.hadoop.conf.Configuration prepareRuntimeConfiguration() {
+	private Configuration prepareRuntimeConfiguration() {
 		// create default configuration from current runtime env (`hbase-site.xml` in classpath) first,
 		// and overwrite configuration using serialized configuration from client-side env (`hbase-site.xml` in classpath).
 		// user params from client-side have the highest priority
@@ -107,7 +109,7 @@ public class HBaseLookupFunction extends TableFunction<Row> {
 	@Override
 	public void open(FunctionContext context) {
 		LOG.info("start open ...");
-		org.apache.hadoop.conf.Configuration config = prepareRuntimeConfiguration();
+		Configuration config = prepareRuntimeConfiguration();
 		try {
 			hConnection = ConnectionFactory.createConnection(config);
 			table = (HTable) hConnection.getTable(TableName.valueOf(hTableName));
@@ -118,7 +120,7 @@ public class HBaseLookupFunction extends TableFunction<Row> {
 			LOG.error("Exception while creating connection to HBase.", ioe);
 			throw new RuntimeException("Cannot create connection to HBase.", ioe);
 		}
-		this.readHelper = new HBaseReadWriteHelper(hbaseTableSchema);
+		this.serde = new HBaseSerde(hbaseTableSchema, nullStringLiteral);
 		LOG.info("end open.");
 	}
 

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDynamicTableFactoryTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.connector.hbase.options.HBaseOptions;
 import org.apache.flink.connector.hbase.options.HBaseWriteOptions;
 import org.apache.flink.connector.hbase.sink.HBaseDynamicTableSink;
 import org.apache.flink.connector.hbase.source.HBaseDynamicTableSource;
-import org.apache.flink.connector.hbase.source.HBaseLookupFunction;
+import org.apache.flink.connector.hbase.source.HBaseRowDataLookupFunction;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTableImpl;
@@ -111,8 +111,8 @@ public class HBaseDynamicTableFactoryTest {
 		assertTrue(lookupProvider instanceof TableFunctionProvider);
 
 		TableFunction tableFunction = ((TableFunctionProvider) lookupProvider).createTableFunction();
-		assertTrue(tableFunction instanceof HBaseLookupFunction);
-		assertEquals("testHBastTable", ((HBaseLookupFunction) tableFunction).getHTableName());
+		assertTrue(tableFunction instanceof HBaseRowDataLookupFunction);
+		assertEquals("testHBastTable", ((HBaseRowDataLookupFunction) tableFunction).getHTableName());
 
 		HBaseTableSchema hbaseSchema = hbaseSource.getHBaseTableSchema();
 		assertEquals(2, hbaseSchema.getRowKeyIndex());

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/util/HBaseTestBase.java
@@ -28,8 +28,16 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.dateToInternal;
+import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.timeToInternal;
+import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.timestampToInternal;
 
 /**
  * Abstract IT case class for HBase.
@@ -40,7 +48,8 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 	protected static final String TEST_TABLE_2 = "testTable2";
 	protected static final String TEST_TABLE_3 = "testTable3";
 
-	protected static final String ROWKEY = "rk";
+	protected static final String ROW_KEY = "rowkey";
+
 	protected static final String FAMILY1 = "family1";
 	protected static final String F1COL1 = "col1";
 
@@ -54,11 +63,16 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 	protected static final String F3COL3 = "col3";
 
 	protected static final String FAMILY4 = "family4";
+	protected static final String F4COL1 = "col1";
+	protected static final String F4COL2 = "col2";
+	protected static final String F4COL3 = "col3";
+	protected static final String F4COL4 = "col4";
 
 	private static final byte[][] FAMILIES = new byte[][]{
 		Bytes.toBytes(FAMILY1),
 		Bytes.toBytes(FAMILY2),
-		Bytes.toBytes(FAMILY3)
+		Bytes.toBytes(FAMILY3),
+		Bytes.toBytes(FAMILY4)
 	};
 
 	private static final byte[][] SPLIT_KEYS = new byte[][]{Bytes.toBytes(4)};
@@ -107,14 +121,30 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 		HTable table = openTable(tableName);
 		List<Put> puts = new ArrayList<>();
 		// add some data
-		puts.add(putRow(1, 10, "Hello-1", 100L, 1.01, false, "Welt-1"));
-		puts.add(putRow(2, 20, "Hello-2", 200L, 2.02, true, "Welt-2"));
-		puts.add(putRow(3, 30, "Hello-3", 300L, 3.03, false, "Welt-3"));
-		puts.add(putRow(4, 40, null, 400L, 4.04, true, "Welt-4"));
-		puts.add(putRow(5, 50, "Hello-5", 500L, 5.05, false, "Welt-5"));
-		puts.add(putRow(6, 60, "Hello-6", 600L, 6.06, true, "Welt-6"));
-		puts.add(putRow(7, 70, "Hello-7", 700L, 7.07, false, "Welt-7"));
-		puts.add(putRow(8, 80, null, 800L, 8.08, true, "Welt-8"));
+		puts.add(putRow(1, 10, "Hello-1", 100L, 1.01, false, "Welt-1",
+			Timestamp.valueOf("2019-08-18 19:00:00"), Date.valueOf("2019-08-18"),
+			Time.valueOf("19:00:00"), new BigDecimal(12345678.0001)));
+		puts.add(putRow(2, 20, "Hello-2", 200L, 2.02, true, "Welt-2",
+			Timestamp.valueOf("2019-08-18 19:01:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:01:00"),
+			new BigDecimal(12345678.0002)));
+		puts.add(putRow(3, 30, "Hello-3", 300L, 3.03, false, "Welt-3",
+			Timestamp.valueOf("2019-08-18 19:02:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:02:00"),
+			new BigDecimal(12345678.0003)));
+		puts.add(putRow(4, 40, null, 400L, 4.04, true, "Welt-4",
+			Timestamp.valueOf("2019-08-18 19:03:00"), Date.valueOf("2019-08-18"), Time.valueOf("19:03:00"),
+			new BigDecimal(12345678.0004)));
+		puts.add(putRow(5, 50, "Hello-5", 500L, 5.05, false, "Welt-5",
+			Timestamp.valueOf("2019-08-19 19:10:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:10:00"),
+			new BigDecimal(12345678.0005)));
+		puts.add(putRow(6, 60, "Hello-6", 600L, 6.06, true, "Welt-6",
+			Timestamp.valueOf("2019-08-19 19:20:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:20:00"),
+			new BigDecimal(12345678.0006)));
+		puts.add(putRow(7, 70, "Hello-7", 700L, 7.07, false, "Welt-7",
+			Timestamp.valueOf("2019-08-19 19:30:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:30:00"),
+			new BigDecimal(12345678.0007)));
+		puts.add(putRow(8, 80, null, 800L, 8.08, true, "Welt-8",
+			Timestamp.valueOf("2019-08-19 19:40:00"), Date.valueOf("2019-08-19"), Time.valueOf("19:40:00"),
+			new BigDecimal(12345678.0008)));
 
 		// append rows to table
 		table.put(puts);
@@ -139,7 +169,18 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 		createTable(tableName, families, SPLIT_KEYS);
 	}
 
-	private static Put putRow(int rowKey, int f1c1, String f2c1, long f2c2, double f3c1, boolean f3c2, String f3c3) {
+	private static Put putRow(
+			int rowKey,
+			int f1c1,
+			String f2c1,
+			long f2c2,
+			double f3c1,
+			boolean f3c2,
+			String f3c3,
+			Timestamp f4c1,
+			Date f4c2,
+			Time f4c3,
+			BigDecimal f4c4) {
 		Put put = new Put(Bytes.toBytes(rowKey));
 		// family 1
 		put.addColumn(Bytes.toBytes(FAMILY1), Bytes.toBytes(F1COL1), Bytes.toBytes(f1c1));
@@ -153,6 +194,11 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 		put.addColumn(Bytes.toBytes(FAMILY3), Bytes.toBytes(F3COL2), Bytes.toBytes(f3c2));
 		put.addColumn(Bytes.toBytes(FAMILY3), Bytes.toBytes(F3COL3), Bytes.toBytes(f3c3));
 
+		// family 4
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL1), Bytes.toBytes(timestampToInternal(f4c1)));
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(dateToInternal(f4c2)));
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL3), Bytes.toBytes(timeToInternal(f4c3)));
+		put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL4), Bytes.toBytes(f4c4));
 		return put;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

* This PR fix HBase lookup function can not work properly with the new internal Data structure `RowData` .
* This PR only for branch:`release-1.11`, because branch master codebase and branch 1.11 codebase has been different.

## Brief change log

  - Import org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java to lookup RowData
  - Clean up some test code


## Verifying this change

This change is covered by ITCase `HBaseConnectorITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
