### PR TITLE
[hotfix] [table-api-java] Add missing @PublicEvolving annotations to classes in flink-table-api-java.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 /**
  * ExplainDetail defines the types of details for explain result.
  */
+@PublicEvolving
 public enum ExplainDetail {
 	/**
 	 * The cost information on physical rel node estimated by optimizer.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ResultKind.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ResultKind.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 /**
  * ResultKind defines the types of the result.
  */
+@PublicEvolving
 public enum ResultKind {
 	/**
 	 * The statement (e.g. DDL, USE) executes successfully,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.api.config;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.description.Description;
@@ -33,6 +34,7 @@ import static org.apache.flink.configuration.description.TextElement.text;
  *
  * <p>NOTE: All option keys in this class must start with "table.exec".
  */
+@PublicEvolving
 public class ExecutionConfigOptions {
 
 	// ------------------------------------------------------------------------

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.api.config;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 
@@ -30,6 +31,7 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  *
  * <p>NOTE: All option keys in this class must start with "table.optimizer".
  */
+@PublicEvolving
 public class OptimizerConfigOptions {
 
 	// ------------------------------------------------------------------------

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.api.config;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.api.SqlDialect;
@@ -30,6 +31,7 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  *
  * <p>NOTE: All option keys in this class must start with "table".
  */
+@PublicEvolving
 public class TableConfigOptions {
 	private TableConfigOptions() {}
 


### PR DESCRIPTION


## What is the purpose of the change

*Add missing @PublicEvolving annotations to classes in flink-table-api-java, the classes include: ExecutionConfigOptions, OptimizerConfigOptions, TableConfigOptions, ExplainDetail, ResultKind*


## Brief change log

  - *Add missing @PublicEvolving annotations to classes in flink-table-api-java*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
