### PR TITLE
[FLINK-15467][task] Join source thread in SourceStreamTask.cancelTask

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
@@ -201,7 +202,7 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {
+		public void cancel(Optional<Long> timeoutMs) {
 			synchronized (lock) {
 				running = false;
 				lock.notifyAll();

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
@@ -99,7 +99,7 @@ class BoundedStreamTask<IN, OUT, OP extends OneInputStreamOperator<IN, OUT> & Bo
 	}
 
 	@Override
-	protected void cancelTask() {}
+	protected void cancelTask(Optional<Long> timeoutMs) {}
 
 	@Override
 	protected void cleanup() throws Exception {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -59,6 +59,7 @@ import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
@@ -384,7 +385,7 @@ public class WebFrontendITCase extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {
+		public void cancel(Optional<Long> timeoutMs) {
 			this.isRunning = false;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 
 /**
@@ -294,9 +295,9 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public void cancel(Optional<Long> timeoutMs) throws Exception {
 		requestTermination();
-		super.cancel();
+		super.cancel(timeoutMs);
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -31,6 +31,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.Future;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -105,7 +106,7 @@ public abstract class AbstractInvokable {
 	 * @throws Exception
 	 *         thrown if any exception occurs during the execution of the user code
 	 */
-	public void cancel() throws Exception {
+	public void cancel(Optional<Long> timeoutMs) throws Exception {
 		// The default implementation does nothing.
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -72,6 +72,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The base class for all batch tasks. Encapsulated common behavior and implements the main life-cycle
@@ -389,7 +390,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public void cancel(Optional<Long> timeoutMs) throws Exception {
 		this.running = false;
 
 		if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -53,6 +53,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Optional;
+
 /**
  * DataSinkTask which is executed by a task manager. The task hands the data to an output format.
  * 
@@ -289,7 +291,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public void cancel(Optional<Long> timeoutMs) throws Exception {
 		this.taskCanceled = true;
 		OutputFormat<IT> format = this.format;
 		if (format != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 /**
  * DataSourceTask which is executed by a task manager. The task reads data and uses an 
@@ -252,7 +253,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public void cancel(Optional<Long> timeoutMs) throws Exception {
 		this.taskCanceled = true;
 		LOG.debug(getLogString("Cancelling data source operator"));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.types.IntValue;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -107,7 +108,7 @@ public class TestingAbstractInvokables {
 		}
 
 		@Override
-		public void cancel() {
+		public void cancel(Optional<Long> timeoutMs) {
 			gotCanceledFuture.complete(true);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
@@ -44,6 +44,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -378,7 +379,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 		
 		// cancel the task
 		Thread.sleep(500);
-		testTask.cancel();
+		testTask.cancel(Optional.empty());
 		taskRunner.interrupt();
 		
 		// wait for the canceling to complete

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -398,7 +399,7 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
 		}
 
 		@Override
-		public void cancel() throws Exception {
+		public void cancel(Optional<Long> timeoutMs) throws Exception {
 			running = false;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskCancelThread.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskCancelThread.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.util.ExceptionUtils;
 import org.junit.Assert;
 
+import java.util.Optional;
+
 public class TaskCancelThread extends Thread {
 	
 	private final DriverTestBase<?> cancelDriver;
@@ -60,7 +62,7 @@ public class TaskCancelThread extends Thread {
 				this.cancelDriver.cancel();
 			}
 			if (this.cancelTask != null) {
-				this.cancelTask.cancel();
+				this.cancelTask.cancel(Optional.empty());
 			}
 			
 			this.interruptedThread.interrupt();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -61,6 +61,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -987,7 +988,7 @@ public class TaskTest extends TestLogger {
 		public void invoke() {}
 
 		@Override
-		public void cancel() {
+		public void cancel(Optional<Long> timeoutMs) {
 			fail("This should not be called");
 		}
 	}
@@ -1020,7 +1021,7 @@ public class TaskTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {}
+		public void cancel(Optional<Long> timeoutMs) {}
 	}
 
 	private static final class InvokableBlockingWithTrigger extends AbstractInvokable {
@@ -1128,7 +1129,7 @@ public class TaskTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() throws Exception {
+		public void cancel(Optional<Long> timeoutMs) throws Exception {
 			synchronized (this) {
 				triggerLatch.trigger();
 				wait();
@@ -1155,7 +1156,7 @@ public class TaskTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {
+		public void cancel(Optional<Long> timeoutMs) {
 			synchronized (lock) {
 				// do nothing but a placeholder
 				triggerLatch.trigger();
@@ -1185,7 +1186,7 @@ public class TaskTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {
+		public void cancel(Optional<Long> timeoutMs) {
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CancelableInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CancelableInvokable.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.testutils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 
+import java.util.Optional;
+
 /**
  * An {@link AbstractInvokable} that blocks at some point until cancelled.
  *
@@ -36,7 +38,7 @@ public abstract class CancelableInvokable extends AbstractInvokable {
 	}
 
 	@Override
-	public void cancel() {
+	public void cancel(Optional<Long> timeoutMs) {
 		canceled = true;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -85,6 +85,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -329,7 +330,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 		testHarness.processElement(new StreamRecord<>("Wohoo", 0));
 		blockerCheckpointStreamFactory.getWaiterLatch().await();
-		task.cancel();
+		task.cancel(Optional.empty());
 		blockerCheckpointStreamFactory.getBlockerLatch().trigger();
 		testHarness.endInput();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -88,6 +88,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -325,7 +326,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	protected abstract void init() throws Exception;
 
-	protected void cancelTask() throws Exception {
+	protected void cancelTask(Optional<Long> timeoutMs) throws Exception {
 	}
 
 	protected void cleanup() throws Exception {
@@ -654,14 +655,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	@Override
-	public final void cancel() throws Exception {
+	public final void cancel(Optional<Long> timeoutMs) throws Exception {
 		isRunning = false;
 		canceled = true;
 
 		// the "cancel task" call must come first, but the cancelables must be
 		// closed no matter what
 		try {
-			cancelTask();
+			cancelTask(timeoutMs);
 		}
 		finally {
 			mailboxProcessor.allActionsCompleted();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.junit.Assert.assertEquals;
@@ -122,7 +123,7 @@ public class StreamSourceOperatorWatermarksTest {
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
 		Thread.sleep(200);
-		testHarness.getTask().cancel();
+		testHarness.getTask().cancel(Optional.empty());
 		try {
 			testHarness.waitForTaskCompletion();
 		} catch (Throwable t) {
@@ -226,7 +227,7 @@ public class StreamSourceOperatorWatermarksTest {
 				SourceStreamTask<T, ?, ?> sourceTask = new SourceStreamTask<>(env);
 				if (cancelImmediatelyAfterCreation) {
 					try {
-						sourceTask.cancel();
+						sourceTask.cancel(Optional.empty());
 					} catch (Exception e) {
 						throw new RuntimeException(e);
 					}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -55,6 +55,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -231,7 +232,7 @@ public class SourceStreamTaskTest {
 
 		testHarness.invoke();
 		CancelTestSource.getDataProcessing().await();
-		testHarness.getTask().cancel();
+		testHarness.getTask().cancel(Optional.empty());
 
 		try {
 			testHarness.waitForTaskCompletion();
@@ -305,7 +306,7 @@ public class SourceStreamTaskTest {
 		}
 
 		try {
-			testHarness.getTask().cancel();
+			testHarness.getTask().cancel(Optional.empty());
 		}
 		catch (ExpectedTestException e) {
 			checkState(throwInCancel);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 
+import java.util.Optional;
 import java.util.Queue;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -145,7 +146,7 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 
 	@Override
 	public void close() throws Exception {
-		streamTask.cancel();
+		streamTask.cancel(Optional.empty());
 
 		streamTask.afterInvoke();
 		streamTask.cleanUpInvoke();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -382,7 +382,7 @@ public class StreamTaskTest extends TestLogger {
 	}
 
 	/**
-	 * A task that locks for ever, fail in {@link #cancelTask()}. It can be only shut down cleanly
+	 * A task that locks for ever, fail in {@link StreamTask#cancelTask(Optional)}. It can be only shut down cleanly
 	 * if {@link StreamTask#getCancelables()} are closed properly.
 	 */
 	public static class CancelFailingTask extends StreamTask<String, AbstractStreamOperator<String>> {
@@ -428,7 +428,7 @@ public class StreamTaskTest extends TestLogger {
 		protected void cleanup() {}
 
 		@Override
-		protected void cancelTask() throws Exception {
+		protected void cancelTask(Optional<Long> timeoutMs) throws Exception {
 			throw new Exception("test exception");
 		}
 
@@ -755,7 +755,7 @@ public class StreamTaskTest extends TestLogger {
 			verify(managedOperatorStateHandle, never()).discardState();
 			verify(rawOperatorStateHandle, never()).discardState();
 
-			streamTask.cancel();
+			streamTask.cancel(Optional.empty());
 
 			completeAcknowledge.trigger();
 
@@ -813,7 +813,7 @@ public class StreamTaskTest extends TestLogger {
 
 		rawKeyedStateHandleFuture.awaitRun();
 
-		task.streamTask.cancel();
+		task.streamTask.cancel(Optional.empty());
 
 		final FutureUtils.ConjunctFuture<Void> discardFuture = FutureUtils.waitForAll(
 			Arrays.asList(
@@ -894,7 +894,7 @@ public class StreamTaskTest extends TestLogger {
 			// ensure that 'null' was acknowledged as subtask state
 			Assert.assertNull(checkpointResult.get(0));
 
-			task.streamTask.cancel();
+			task.streamTask.cancel(Optional.empty());
 			task.waitForTaskCompletion(true);
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -99,7 +100,7 @@ public class SynchronousCheckpointTest {
 		launchSynchronousSavepointAndWaitForSyncSavepointIdToBeSet();
 		assertTrue(streamTaskUnderTest.getSynchronousSavepointId().isPresent());
 
-		streamTaskUnderTest.cancel();
+		streamTaskUnderTest.cancel(Optional.empty());
 
 		waitUntilMainExecutionThreadIsFinished();
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskTest.NoOpStreamTask;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
@@ -389,7 +390,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 	 * A {@link StreamTask} that simply calls {@link CountDownLatch#countDown()} when
 	 * invoking {@link #triggerCheckpointAsync}.
 	 */
-	public static class CheckpointCountingTask extends NoOpStreamTask {
+	public static class CheckpointCountingTask extends NoOpStreamTask<Object, StreamOperator<Object>> {
 
 		private final transient OneShotLatch finishLatch;
 
@@ -406,8 +407,8 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected void cancelTask() throws Exception {
-			super.cancelTask();
+		protected void cancelTask(Optional<Long> timeoutMs) throws Exception {
+			super.cancelTask(timeoutMs);
 			finishLatch.trigger();
 		}
 


### PR DESCRIPTION
**This PR is WIP**

## What is the purpose of the change

Wait for the `LegacySourceFunctionThread` to finish when cancelling the task.
This prevents premature freeing of resources, particularly LibraryCache (see FLINK-15467 discussion).

## Brief change log

  - Join `sourceThread` in `SourceStreamTask.cancelTask`
  - Add wait timeout to have time for cleanup - this is quite invasive but independent change - so I extracted this to a separate commit


## Verifying this change

TBD. 
Unit test seems to be not enough; full test is non-trivial;

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
