### PR TITLE
[FLINK-18358] Fix comparing double in TableEnvironmentITCase

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
@@ -231,6 +231,7 @@ class TableEnvironmentITCase(
 
     val resultFile = _tempFolder.newFile().getAbsolutePath
     result.toDataSet[(Long, Double)]
+      .map(ds => (ds._1.toString, "%.5f".format(ds._2)))
       .writeAsCsv(resultFile, writeMode=FileSystem.WriteMode.OVERWRITE)
 
     tEnv.execute("job name")


### PR DESCRIPTION
## What is the purpose of the change
This PR limits the number of compared fractional digits in a double result type.

## Verifying this change

I run the test ~400 times without errors.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
