### PR TITLE
[FLINK-18360][runtime/web-frontend/HS] fix no jobs/overview.json file created for HS when no archived jobs present

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -190,6 +190,7 @@ class HistoryServerArchiveFetcher {
 			webJobDir.mkdir();
 			this.webOverviewDir = new File(webDir, "overviews");
 			webOverviewDir.mkdir();
+			updateJobOverview(webOverviewDir, webDir);
 		}
 
 		@Override

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -310,7 +310,9 @@ class HistoryServerArchiveFetcher {
 				if (!archivesBeyondSizeLimit.isEmpty() && processBeyondLimitArchiveDeletion) {
 					events.addAll(cleanupJobsBeyondSizeLimit(archivesBeyondSizeLimit));
 				}
-				updateJobOverview(webOverviewDir, webDir);
+				if (!events.isEmpty()) {
+					updateJobOverview(webOverviewDir, webDir);
+				}
 				events.forEach(jobArchiveEventListener::accept);
 				LOG.debug("Finished archive fetching.");
 			} catch (Exception e) {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -309,9 +309,7 @@ class HistoryServerArchiveFetcher {
 				if (!archivesBeyondSizeLimit.isEmpty() && processBeyondLimitArchiveDeletion) {
 					events.addAll(cleanupJobsBeyondSizeLimit(archivesBeyondSizeLimit));
 				}
-				if (!events.isEmpty()) {
-					updateJobOverview(webOverviewDir, webDir);
-				}
+				updateJobOverview(webOverviewDir, webDir);
 				events.forEach(jobArchiveEventListener::accept);
 				LOG.debug("Finished archive fetching.");
 			} catch (Exception e) {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -267,6 +267,11 @@ public class HistoryServerTest extends TestLogger {
 		runArchiveExpirationTest(true);
 	}
 
+	@Test
+	public void testRemainExpiredJob() throws Exception {
+		runArchiveExpirationTest(false);
+	}
+
 	private void runArchiveExpirationTest(boolean cleanupExpiredJobs) throws Exception {
 		int numExpiredJobs = cleanupExpiredJobs ? 1 : 0;
 		int numJobs = 3;

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -240,13 +240,31 @@ public class HistoryServerTest extends TestLogger {
 	}
 
 	@Test
-	public void testCleanExpiredJob() throws Exception {
-		runArchiveExpirationTest(true);
+	public void testHistoryServerNoArchivedJobs() throws Exception {
+
+		CountDownLatch numExpectedArchivedJobs = new CountDownLatch(0);
+		Configuration historyServerConfig = createTestConfiguration(false);
+
+		HistoryServer hs = new HistoryServer(historyServerConfig, (event) -> {
+		});
+
+		try {
+			hs.start();
+			String baseUrl = "http://localhost:" + hs.getWebPort();
+			assertTrue(numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS));
+			//check that /jobs/overview is correctly populated with zero items
+			Assert.assertEquals(0, getJobsOverview(baseUrl).getJobs().size());
+
+			// checks whether the dashboard configuration contains all expected fields
+			getDashboardConfiguration(baseUrl);
+		} finally {
+			hs.stop();
+		}
 	}
 
 	@Test
-	public void testRemainExpiredJob() throws Exception {
-		runArchiveExpirationTest(false);
+	public void testCleanExpiredJob() throws Exception {
+		runArchiveExpirationTest(true);
 	}
 
 	private void runArchiveExpirationTest(boolean cleanupExpiredJobs) throws Exception {


### PR DESCRIPTION
fix no jobs/overview.json file created for HS when no archived jobs are in the archive directory

## What is the purpose of the change

This pull requests fixes creation of the `${historyserver.web.tmpdir}/jobs/overview.json` file creation for history server. This file was not created if the directory defined using the directive `${historyserver.archive.fs.dir}` contained no completed/archived jobs. When the file was not created, History Server showed nothing in the Completed Jobs tab.

## Brief change log

Histrory server show correctly Completed Jobs table when there are no archived jobs


## Verifying this change
This change added tests and can be verified as follows:

  -  Added integration test for no job in the `${historyserver.archive.fs.dir}`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
