### PR TITLE
[FLINK-18359][Connectors/ElasticSearch] Improve error-log strategy for Elasticsearch sink for large data documentId conflict when using create mode for `insert ignore` semantics

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -39,8 +39,6 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -70,8 +68,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends RichSinkFunction<T> implements CheckpointedFunction {
 
 	private static final long serialVersionUID = -1007596293618451942L;
-
-	private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSinkBase.class);
 
 	// ------------------------------------------------------------------------
 	//  Internal bulk processor configuration
@@ -408,8 +404,6 @@ public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends 
 						itemResponse = response.getItems()[i];
 						failure = callBridge.extractFailureCauseFromBulkItemResponse(itemResponse);
 						if (failure != null) {
-							LOG.error("Failed Elasticsearch item request: {}", itemResponse.getFailureMessage(), failure);
-
 							restStatus = itemResponse.getFailure().getStatus();
 							actionRequest = request.requests().get(i);
 							if (restStatus == null) {
@@ -441,8 +435,6 @@ public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends 
 
 		@Override
 		public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
-			LOG.error("Failed Elasticsearch bulk request: {}", failure.getMessage(), failure);
-
 			try {
 				for (DocWriteRequest writeRequest : request.requests()) {
 					if (writeRequest instanceof ActionRequest) {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
@@ -22,6 +22,8 @@ import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureH
 import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
 
 import org.elasticsearch.action.ActionRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An {@link ActionRequestFailureHandler} that simply fails the sink on any failures.
@@ -31,8 +33,11 @@ public class NoOpFailureHandler implements ActionRequestFailureHandler {
 
 	private static final long serialVersionUID = 737941343410827885L;
 
+	private static final Logger LOG = LoggerFactory.getLogger(NoOpFailureHandler.class);
+
 	@Override
 	public void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
+		LOG.error("Failed Elasticsearch item request: {}", failure.getMessage(), failure);
 		// simply fail the sink
 		throw failure;
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
@@ -25,6 +25,8 @@ import org.apache.flink.util.ExceptionUtils;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An {@link ActionRequestFailureHandler} that re-adds requests that failed due to temporary
@@ -36,8 +38,11 @@ public class RetryRejectedExecutionFailureHandler implements ActionRequestFailur
 
 	private static final long serialVersionUID = -7423562912824511906L;
 
+	private static final Logger LOG = LoggerFactory.getLogger(RetryRejectedExecutionFailureHandler.class);
+
 	@Override
 	public void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
+		LOG.error("Failed Elasticsearch item request: {}", failure.getMessage(), failure);
 		if (ExceptionUtils.findThrowable(failure, EsRejectedExecutionException.class).isPresent()) {
 			indexer.add(action);
 		} else {


### PR DESCRIPTION
## What is the purpose of the change

The story is: when a flink job for ingesting large number of records from data sources, processing and indexing with Elasticsearch sink failed, we may restart it from a specific data set which contains lots of data which already sink into ES.

At this case, a `INSERT IGNORE` semantics is necessary, and we use `public IndexRequest create(boolean create)` with `true` args and ignore the 409 restStatusCode at a customized ActionRequestFailureHandler to make it work.

But, the `BulkProcessorListener` always log a error event before it calls the `failureHandler` in its `afterBulk` method, and will produce tons of error log for document id conflict, which we already know and handle them in customized ActionRequestFailureHandler.

Therefore, it seems that the error log action at the ActionRequestFailureHandler (either the default IgnoringFailureHandler or a custom handler) is more flexible.

## Brief change log

- Deleted 2 `LOG.error()` in `ElasticsearchSinkBase`
- Placed `LOG.error()` into 2 implement classes of `ActionRequestFailureHandler`: `NoOpFailureHandler` and `RetryRejectedExecutionFailureHandler`, so that user can customize their log actions

## Verifying this change

- Implement a custom `ActionRequestFailureHandler` without logging  409 restStatusCode (or other status that handled at failure handler and no need for logging)
- Build the ElasticSearchSink via Builder and use above custom failure handler, and then exceptions can be handled and logged properly (user can decide log it or not).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (every record in ES sink that fails to index)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not documented
