### PR TITLE
[FLINK-18370][Azure] Run tests nightly on Azure VMs

### DIFF
--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -76,6 +76,17 @@ stages:
     jobs:
       - template: jobs-template.yml
         parameters:
+          stage_name: cron_azure
+          test_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          e2e_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+          run_end_to_end: true
+          container: flink-build-container
+          jdk: jdk8
+      - template: jobs-template.yml
+        parameters:
           stage_name: cron_hadoop241
           test_pool_definition:
             name: Default


### PR DESCRIPTION
## What is the purpose of the change

There are some tests which happen a lot more frequently on the VMs provided by Azure (instead of the CI infrastructure hosted in Alibaba Cloud).

Since we have enough CI resources available (at night), we can add a run on the Azure machines to get more visibility into those failures, and to increase the stability of personal account CI runs.


This change has been validated here: https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=3790&view=results
