### PR TITLE
[FLINK-17544][jdbc]fix close() method bug and add test cases for JdbcOutputFormat

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
@@ -209,8 +209,6 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 		if (!closed) {
 			closed = true;
 
-			checkFlushException();
-
 			if (this.scheduledFuture != null) {
 				scheduledFuture.cancel(false);
 				this.scheduler.shutdown();
@@ -220,7 +218,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 				try {
 					flush();
 				} catch (Exception e) {
-					throw new RuntimeException("Writing records to JDBC failed.", e);
+					LOG.warn("Writing records to JDBC failed.", e);
 				}
 			}
 
@@ -233,6 +231,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 			}
 		}
 		super.close();
+		checkFlushException();
 	}
 
 	public static Builder builder() {
@@ -348,5 +347,4 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 	static JdbcStatementBuilder<Row> createRowJdbcStatementBuilder(int[] types) {
 		return (st, record) -> setRecordToStatement(st, types, record);
 	}
-
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
@@ -83,7 +83,9 @@ class TableJdbcUpsertOutputFormat extends JdbcBatchingOutputFormat<Tuple2<Boolea
 			super.close();
 		} finally {
 			try {
-				deleteExecutor.closeStatements();
+				if (deleteExecutor != null){
+					deleteExecutor.closeStatements();
+				}
 			} catch (SQLException e) {
 				LOG.warn("unable to close delete statement runner", e);
 			}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcFullTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcFullTest.java
@@ -117,7 +117,7 @@ public class JdbcFullTest extends JdbcDataTestBase {
 		// use scheduledThreadPool
 		JdbcExecutionOptions jdbcExecutionOptions = JdbcExecutionOptions.builder()
 			.withBatchIntervalMs(1000_000L)
-			.withBatchSize(1)
+			.withBatchSize(2)
 			.withMaxRetries(1)
 			.build();
 		ExecutionConfig executionConfig = new ExecutionConfig();

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
@@ -66,7 +66,6 @@ public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
 
 	@Test
 	public void testUpsertFormatCloseBeforeOpen() throws Exception{
-		// FLINK-17544: There should be no NPE thrown from this method
 		JdbcOptions options = JdbcOptions.builder()
 			.setDBUrl(getDbMetadata().getUrl())
 			.setTableName(OUTPUT_TABLE)
@@ -75,6 +74,7 @@ public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
 			.withTableName(options.getTableName()).withDialect(options.getDialect())
 			.withFieldNames(fieldNames).withKeyFields(keyFields).build();
 		format = new TableJdbcUpsertOutputFormat(new SimpleJdbcConnectionProvider(options), dmlOptions, JdbcExecutionOptions.defaults());
+		// FLINK-17544: There should be no NPE thrown from this method
 		format.close();
 	}
 

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
@@ -66,6 +66,7 @@ public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
 
 	@Test
 	public void testUpsertFormatCloseBeforeOpen() throws Exception{
+		// FLINK-17544: There should be no NPE thrown from this method
 		JdbcOptions options = JdbcOptions.builder()
 			.setDBUrl(getDbMetadata().getUrl())
 			.setTableName(OUTPUT_TABLE)

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
@@ -65,6 +65,19 @@ public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
 	}
 
 	@Test
+	public void testUpsertFormatCloseBeforeOpen() throws Exception{
+		JdbcOptions options = JdbcOptions.builder()
+			.setDBUrl(getDbMetadata().getUrl())
+			.setTableName(OUTPUT_TABLE)
+			.build();
+		JdbcDmlOptions dmlOptions = JdbcDmlOptions.builder()
+			.withTableName(options.getTableName()).withDialect(options.getDialect())
+			.withFieldNames(fieldNames).withKeyFields(keyFields).build();
+		format = new TableJdbcUpsertOutputFormat(new SimpleJdbcConnectionProvider(options), dmlOptions, JdbcExecutionOptions.defaults());
+		format.close();
+	}
+
+	@Test
 	public void testJdbcOutputFormat() throws Exception {
 		JdbcOptions options = JdbcOptions.builder()
 				.setDBUrl(getDbMetadata().getUrl())


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*According to the description of FLINK-17544, TableJdbcUpsertOutputFormat will throw NPE if someone invokes close() method of formatter before open() or with open() at the same time. Meanwhile we find that JdbcOutputFormat will cause reasource leak if scheduler throws exception. Therefore, we fix these bugs and add tests to verify our work.*

## Brief change log

  - *check value of  deleteExecutor whether is null before close*
  - *rearrange close method of JdbcBatchingOutput*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validate whether TableJdbcUpsertOutputFormat can quit safely if we invoke TableJdbcUpsertOutputFormat.close() before open()*
  - *Added test that validate whether JdbcTableOutputFormat can quit safely if flush() method throws exception*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
