### PR TITLE
[FLINK-15467][task] Wait for invokable cancellation when stopping Task

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -34,6 +35,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
@@ -201,11 +203,12 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {
+		public CompletableFuture<Void> cancel() {
 			synchronized (lock) {
 				running = false;
 				lock.notifyAll();
 			}
+			return FutureUtils.completedVoidFuture();
 		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/time/Deadline.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/time/Deadline.java
@@ -93,4 +93,9 @@ public class Deadline {
 	public static Deadline fromNow(Duration duration) {
 		return new Deadline(Math.addExact(System.nanoTime(), duration.toNanos()));
 	}
+
+	@Override
+	public String toString() {
+		return timeNanos + " ns";
+	}
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
@@ -99,9 +99,6 @@ class BoundedStreamTask<IN, OUT, OP extends OneInputStreamOperator<IN, OUT> & Bo
 	}
 
 	@Override
-	protected void cancelTask() {}
-
-	@Override
 	protected void cleanup() throws Exception {
 		headOperator.close();
 		headOperator.dispose();

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -59,6 +60,7 @@ import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
@@ -384,8 +386,9 @@ public class WebFrontendITCase extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {
+		public CompletableFuture<Void> cancel() {
 			this.isRunning = false;
+			return FutureUtils.completedVoidFuture();
 		}
 
 		public static void reset() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 /**
@@ -294,9 +295,9 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public CompletableFuture<Void> cancel() throws Exception {
 		requestTermination();
-		super.cancel();
+		return super.cancel();
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
@@ -31,6 +32,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -104,9 +106,11 @@ public abstract class AbstractInvokable {
 	 *
 	 * @throws Exception
 	 *         thrown if any exception occurs during the execution of the user code
+	 * @return completion future
 	 */
-	public void cancel() throws Exception {
+	public CompletableFuture<Void> cancel() throws Exception {
 		// The default implementation does nothing.
+		return FutureUtils.completedVoidFuture();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableMaterialization;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -72,6 +73,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The base class for all batch tasks. Encapsulated common behavior and implements the main life-cycle
@@ -389,7 +391,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public CompletableFuture<Void> cancel() throws Exception {
 		this.running = false;
 
 		if (LOG.isDebugEnabled()) {
@@ -403,6 +405,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		} finally {
 			closeLocalStrategiesAndCaches();
 		}
+		return FutureUtils.completedVoidFuture();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -30,6 +30,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.MutableReader;
@@ -52,6 +53,8 @@ import org.apache.flink.util.MutableObjectIterator;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * DataSinkTask which is executed by a task manager. The task hands the data to an output format.
@@ -289,7 +292,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public CompletableFuture<Void> cancel() throws Exception {
 		this.taskCanceled = true;
 		OutputFormat<IT> format = this.format;
 		if (format != null) {
@@ -310,6 +313,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 		}
 		
 		LOG.debug(getLogString("Cancelling data sink operator"));
+		return FutureUtils.completedVoidFuture();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
@@ -53,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * DataSourceTask which is executed by a task manager. The task reads data and uses an 
@@ -252,9 +254,10 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 	}
 
 	@Override
-	public void cancel() throws Exception {
+	public CompletableFuture<Void> cancel() throws Exception {
 		this.taskCanceled = true;
 		LOG.debug(getLogString("Cancelling data source operator"));
+		return FutureUtils.completedVoidFuture();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.RecordReader;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
@@ -107,8 +108,9 @@ public class TestingAbstractInvokables {
 		}
 
 		@Override
-		public void cancel() {
+		public CompletableFuture<Void> cancel() {
 			gotCanceledFuture.complete(true);
+			return FutureUtils.completedVoidFuture();
 		}
 
 		public static void resetGotCanceledFuture() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -400,8 +401,9 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
 		}
 
 		@Override
-		public void cancel() throws Exception {
+		public CompletableFuture<Void> cancel() throws Exception {
 			running = false;
+			return FutureUtils.completedVoidFuture();
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -987,8 +988,9 @@ public class TaskTest extends TestLogger {
 		public void invoke() {}
 
 		@Override
-		public void cancel() {
+		public CompletableFuture<Void> cancel() {
 			fail("This should not be called");
+			return FutureUtils.completedVoidFuture();
 		}
 	}
 
@@ -1018,9 +1020,6 @@ public class TaskTest extends TestLogger {
 		public void invoke() {
 			throw new TestWrappedException(new IOException("test"));
 		}
-
-		@Override
-		public void cancel() {}
 	}
 
 	private static final class InvokableBlockingWithTrigger extends AbstractInvokable {
@@ -1128,11 +1127,12 @@ public class TaskTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() throws Exception {
+		public CompletableFuture<Void> cancel() throws Exception {
 			synchronized (this) {
 				triggerLatch.trigger();
 				wait();
 			}
+			return FutureUtils.completedVoidFuture();
 		}
 	}
 
@@ -1155,11 +1155,12 @@ public class TaskTest extends TestLogger {
 		}
 
 		@Override
-		public void cancel() {
+		public CompletableFuture<Void> cancel() {
 			synchronized (lock) {
 				// do nothing but a placeholder
 				triggerLatch.trigger();
 			}
+			return FutureUtils.completedVoidFuture();
 		}
 	}
 
@@ -1182,10 +1183,6 @@ public class TaskTest extends TestLogger {
 				} catch (InterruptedException ignored) {
 				}
 			}
-		}
-
-		@Override
-		public void cancel() {
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CancelableInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CancelableInvokable.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.runtime.testutils;
 
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * An {@link AbstractInvokable} that blocks at some point until cancelled.
@@ -36,8 +39,9 @@ public abstract class CancelableInvokable extends AbstractInvokable {
 	}
 
 	@Override
-	public void cancel() {
+	public CompletableFuture<Void> cancel() {
 		canceled = true;
+		return FutureUtils.completedVoidFuture();
 	}
 
 	protected void waitUntilCancelled() throws InterruptedException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -148,7 +148,7 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 	}
 
 	@Override
-	protected void cancelTask() {
+	protected CompletableFuture<Void> cancelTask() {
 		try {
 			if (headOperator != null) {
 				headOperator.cancel();
@@ -157,12 +157,13 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 		finally {
 			sourceFunctionRunner.interrupt();
 		}
+		return sourceFunctionRunner.getCompletionFuture();
 	}
 
 	@Override
-	protected void finishTask() throws Exception {
+	protected CompletableFuture<Void> finishTask() {
 		isFinished = true;
-		cancelTask();
+		return cancelTask();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -444,8 +444,8 @@ public class StreamTaskTest extends TestLogger {
 		protected void cleanup() {}
 
 		@Override
-		protected void cancelTask() throws Exception {
-			throw new Exception("test exception");
+		protected CompletableFuture<Void> cancelTask() {
+			throw new ExpectedTestException();
 		}
 
 		/**

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -379,9 +380,10 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		public void finishTask() throws Exception {
+		public CompletableFuture<Void> finishTask() throws Exception {
 			finishingLatch.await();
 			finishLatch.trigger();
+			return FutureUtils.completedVoidFuture();
 		}
 	}
 
@@ -406,9 +408,10 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		@Override
-		protected void cancelTask() throws Exception {
-			super.cancelTask();
+		protected CompletableFuture<Void> cancelTask() {
+			final CompletableFuture<Void> future = super.cancelTask();
 			finishLatch.trigger();
+			return future;
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Wait for the `LegacySourceFunctionThread` to finish when cancelling the task.
This prevents premature freeing of resources, particularly LibraryCache (see FLINK-15467 discussion).

Implemented by adding `Task. invokableCancelFuture` instead of just joining the source thread in `cancelTask`. This is because `cancelTask` can be called from TaskCanceller, while resources are freed by `Task.executingThread` or upon its death.

## Brief change log
 
There are three commits that should be squashed after reviewing:

 - Return future from `StreamTask.cancelTask` and finishTask - only change of signatures except for `SourceStreamTask`
 - Return completion future from `AbstractInvokable` cancel - only change of signatures except for `StreamTask`
 - Wait in `Task.cancelInvokable` for completion

## Verifying this change

- Added unit test: `TaskTest.testTaskTerminatesOnlyAfterInvokable`
- Manually tested on cluster

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
