### PR TITLE
[FLINK-18361] Support username and password options for new Elasticse…

### DIFF
--- a/docs/dev/table/connectors/elasticsearch.md
+++ b/docs/dev/table/connectors/elasticsearch.md
@@ -127,6 +127,20 @@ Connector Options
       <td>Delimiter for composite keys ("_" by default), e.g., "$" would result in IDs "KEY1$KEY2$KEY3"."</td>
     </tr>
     <tr>
+      <td><h5>username</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Username used to connect to Elasticsearch instance. Please notice that Elasticsearch doesn't pre-bundled security feature, but you can enable it by following the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-security.html">guideline</a> to secure an Elasticsearch cluster.</td>
+    </tr>
+    <tr>
+      <td><h5>password</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Password used to connect to Elasticsearch instance. If <code>username</code> is configured, this option must be configured with non-empty string as well.</td>
+    </tr>
+    <tr>
       <td><h5>failure-handler</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">fail</td>

--- a/docs/dev/table/connectors/elasticsearch.zh.md
+++ b/docs/dev/table/connectors/elasticsearch.zh.md
@@ -127,6 +127,20 @@ Connector Options
       <td>Delimiter for composite keys ("_" by default), e.g., "$" would result in IDs "KEY1$KEY2$KEY3"."</td>
     </tr>
     <tr>
+      <td><h5>username</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Username used to connect to Elasticsearch instance. Please notice that Elasticsearch doesn't pre-bundled security feature, but you can enable it by following the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-security.html">guideline</a> to secure an Elasticsearch cluster.</td>
+    </tr>
+    <tr>
+      <td><h5>password</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Password used to connect to Elasticsearch instance. If <code>username</code> is configured, this option must be configured with non-empty string as well.</td>
+    </tr>
+    <tr>
       <td><h5>failure-handler</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">fail</td>

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
@@ -37,6 +37,8 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.BULK_FLUSH_BACKOFF_TYPE_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.BULK_FLUSH_INTERVAL_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.FAILURE_HANDLER_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 
 /**
  * Accessor methods to elasticsearch options.
@@ -96,6 +98,14 @@ class ElasticsearchConfiguration {
 		long interval = config.get(BULK_FLUSH_INTERVAL_OPTION).toMillis();
 		// convert 0 to -1, because Elasticsearch client use -1 to disable this configuration.
 		return interval == 0 ? -1 : interval;
+	}
+
+	public Optional<String> getUsername() {
+		return config.getOptional(USERNAME_OPTION);
+	}
+
+	public Optional<String> getPassword() {
+		return config.getOptional(PASSWORD_OPTION);
 	}
 
 	public boolean isBulkFlushBackoffEnabled() {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchOptions.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchOptions.java
@@ -59,6 +59,16 @@ public class ElasticsearchOptions {
 			.stringType()
 			.noDefaultValue()
 			.withDescription("Elasticsearch document type.");
+	public static final ConfigOption<String> PASSWORD_OPTION =
+		ConfigOptions.key("password")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Password used to connect to Elasticsearch instance.");
+	public static final ConfigOption<String> USERNAME_OPTION =
+		ConfigOptions.key("username")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Username used to connect to Elasticsearch instance.");
 	public static final ConfigOption<String> KEY_DELIMITER_OPTION =
 		ConfigOptions.key("document-id.key-delimiter")
 			.stringType()

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSink.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSink.java
@@ -30,8 +30,13 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.StringUtils;
 
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -138,7 +143,14 @@ final class Elasticsearch6DynamicSink implements DynamicTableSink {
 
 			// we must overwrite the default factory which is defined with a lambda because of a bug
 			// in shading lambda serialization shading see FLINK-18006
-			builder.setRestClientFactory(new DefaultRestClientFactory(config.getPathPrefix().orElse(null)));
+			if (config.getUsername().isPresent()
+				&& config.getPassword().isPresent()
+				&& !StringUtils.isNullOrWhitespaceOnly(config.getUsername().get())
+				&& !StringUtils.isNullOrWhitespaceOnly(config.getPassword().get())) {
+				builder.setRestClientFactory(new AuthRestClientFactory(config.getPathPrefix().orElse(null), config.getUsername().get(), config.getPassword().get()));
+			} else {
+				builder.setRestClientFactory(new DefaultRestClientFactory(config.getPathPrefix().orElse(null)));
+			}
 
 			final ElasticsearchSink<RowData> sink = builder.build();
 
@@ -194,6 +206,56 @@ final class Elasticsearch6DynamicSink implements DynamicTableSink {
 		@Override
 		public int hashCode() {
 			return Objects.hash(pathPrefix);
+		}
+	}
+
+	/**
+	 * Serializable {@link RestClientFactory} used by the sink which enable authentication.
+	 */
+	@VisibleForTesting
+	static class AuthRestClientFactory implements RestClientFactory {
+
+		private final String pathPrefix;
+		private final String username;
+		private final String password;
+		private transient CredentialsProvider credentialsProvider;
+
+		public AuthRestClientFactory(@Nullable String pathPrefix, String username, String password) {
+			this.pathPrefix = pathPrefix;
+			this.password = password;
+			this.username = username;
+		}
+
+		@Override
+		public void configureRestClientBuilder(RestClientBuilder restClientBuilder) {
+			if (pathPrefix != null) {
+				restClientBuilder.setPathPrefix(pathPrefix);
+			}
+			if (credentialsProvider == null) {
+				credentialsProvider = new BasicCredentialsProvider();
+				credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+			}
+			restClientBuilder.setHttpClientConfigCallback(httpAsyncClientBuilder ->
+				httpAsyncClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			AuthRestClientFactory that = (AuthRestClientFactory) o;
+			return Objects.equals(pathPrefix, that.pathPrefix) &&
+				Objects.equals(username, that.username) &&
+				Objects.equals(password, that.password);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(pathPrefix, username, password);
 		}
 	}
 

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.SerializationFormatFactory;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.util.StringUtils;
 
 import java.util.Set;
 import java.util.function.Supplier;
@@ -52,6 +53,8 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.HOSTS_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.INDEX_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.KEY_DELIMITER_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 
 /**
  * A {@link DynamicTableSinkFactory} for discovering {@link Elasticsearch6DynamicSink}.
@@ -75,7 +78,9 @@ public class Elasticsearch6DynamicSinkFactory implements DynamicTableSinkFactory
 		BULK_FLUSH_BACKOFF_DELAY_OPTION,
 		CONNECTION_MAX_RETRY_TIMEOUT_OPTION,
 		CONNECTION_PATH_PREFIX,
-		FORMAT_OPTION
+		FORMAT_OPTION,
+		PASSWORD_OPTION,
+		USERNAME_OPTION
 	).collect(Collectors.toSet());
 
 	@Override
@@ -133,6 +138,17 @@ public class Elasticsearch6DynamicSinkFactory implements DynamicTableSinkFactory
 				BULK_FLUSH_BACKOFF_MAX_RETRIES_OPTION.key(),
 				config.getBulkFlushBackoffRetries().get())
 		);
+		if (config.getUsername().isPresent() && !StringUtils.isNullOrWhitespaceOnly(config.getUsername().get())) {
+			validate(
+				config.getPassword().isPresent() && !StringUtils.isNullOrWhitespaceOnly(config.getPassword().get()),
+				() -> String.format(
+					"'%s' and '%s' must be set at the same time. Got: username '%s' and password '%s'",
+					USERNAME_OPTION.key(),
+					PASSWORD_OPTION.key(),
+					config.getUsername().get(),
+					config.getPassword().orElse("")
+				));
+		}
 	}
 
 	private static void validate(boolean condition, Supplier<String> message) {

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactoryTest.java
@@ -204,4 +204,25 @@ public class Elasticsearch6DynamicSinkFactoryTest {
 				.build()
 		);
 	}
+
+	@Test
+	public void validateWrongCredential() {
+		Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage(
+			"'username' and 'password' must be set at the same time. Got: username 'username' and password ''");
+		sinkFactory.createDynamicTableSink(
+			context()
+				.withSchema(TableSchema.builder()
+					.field("a", DataTypes.TIME())
+					.build())
+				.withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
+				.withOption(ElasticsearchOptions.HOSTS_OPTION.key(), "http://localhost:1234")
+				.withOption(ElasticsearchOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
+				.withOption(ElasticsearchOptions.USERNAME_OPTION.key(), "username")
+				.withOption(ElasticsearchOptions.PASSWORD_OPTION.key(), "")
+				.build()
+		);
+	}
 }

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSink.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSink.java
@@ -30,8 +30,13 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.StringUtils;
 
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -138,7 +143,14 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
 
 			// we must overwrite the default factory which is defined with a lambda because of a bug
 			// in shading lambda serialization shading see FLINK-18006
-			builder.setRestClientFactory(new DefaultRestClientFactory(config.getPathPrefix().orElse(null)));
+			if (config.getUsername().isPresent()
+				&& config.getPassword().isPresent()
+				&& !StringUtils.isNullOrWhitespaceOnly(config.getUsername().get())
+				&& !StringUtils.isNullOrWhitespaceOnly(config.getPassword().get())) {
+				builder.setRestClientFactory(new AuthRestClientFactory(config.getPathPrefix().orElse(null), config.getUsername().get(), config.getPassword().get()));
+			} else {
+				builder.setRestClientFactory(new DefaultRestClientFactory(config.getPathPrefix().orElse(null)));
+			}
 
 			final ElasticsearchSink<RowData> sink = builder.build();
 
@@ -194,6 +206,56 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
 		@Override
 		public int hashCode() {
 			return Objects.hash(pathPrefix);
+		}
+	}
+
+	/**
+	 * Serializable {@link RestClientFactory} used by the sink which enable authentication.
+	 */
+	@VisibleForTesting
+	static class AuthRestClientFactory implements RestClientFactory {
+
+		private final String pathPrefix;
+		private final String username;
+		private final String password;
+		private transient CredentialsProvider credentialsProvider;
+
+		public AuthRestClientFactory(@Nullable String pathPrefix, String username, String password) {
+			this.pathPrefix = pathPrefix;
+			this.password = password;
+			this.username = username;
+		}
+
+		@Override
+		public void configureRestClientBuilder(RestClientBuilder restClientBuilder) {
+			if (pathPrefix != null) {
+				restClientBuilder.setPathPrefix(pathPrefix);
+			}
+			if (credentialsProvider == null) {
+				credentialsProvider = new BasicCredentialsProvider();
+				credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+			}
+			restClientBuilder.setHttpClientConfigCallback(httpAsyncClientBuilder ->
+				httpAsyncClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			AuthRestClientFactory that = (AuthRestClientFactory) o;
+			return Objects.equals(pathPrefix, that.pathPrefix) &&
+				Objects.equals(username, that.username) &&
+				Objects.equals(password, that.password);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(pathPrefix, password, username);
 		}
 	}
 

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.SerializationFormatFactory;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.util.StringUtils;
 
 import java.util.Set;
 import java.util.function.Supplier;
@@ -51,6 +52,8 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.HOSTS_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.INDEX_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.KEY_DELIMITER_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 
 /**
  * A {@link DynamicTableSinkFactory} for discovering {@link Elasticsearch7DynamicSink}.
@@ -73,7 +76,9 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
 		BULK_FLUSH_BACKOFF_DELAY_OPTION,
 		CONNECTION_MAX_RETRY_TIMEOUT_OPTION,
 		CONNECTION_PATH_PREFIX,
-		FORMAT_OPTION
+		FORMAT_OPTION,
+		PASSWORD_OPTION,
+		USERNAME_OPTION
 	).collect(Collectors.toSet());
 
 	@Override
@@ -132,6 +137,17 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
 				BULK_FLUSH_BACKOFF_MAX_RETRIES_OPTION.key(),
 				config.getBulkFlushBackoffRetries().get())
 		);
+		if (config.getUsername().isPresent() && !StringUtils.isNullOrWhitespaceOnly(config.getUsername().get())) {
+			validate(
+				config.getPassword().isPresent() && !StringUtils.isNullOrWhitespaceOnly(config.getPassword().get()),
+				() -> String.format(
+					"'%s' and '%s' must be set at the same time. Got: username '%s' and password '%s'",
+					USERNAME_OPTION.key(),
+					PASSWORD_OPTION.key(),
+					config.getUsername().get(),
+					config.getPassword().orElse("")
+				));
+		}
 	}
 
 	private static void validate(boolean condition, Supplier<String> message) {

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactoryTest.java
@@ -197,4 +197,24 @@ public class Elasticsearch7DynamicSinkFactoryTest {
 				.build()
 		);
 	}
+
+	@Test
+	public void validateWrongCredential() {
+		Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage(
+			"'username' and 'password' must be set at the same time. Got: username 'username' and password ''");
+		sinkFactory.createDynamicTableSink(
+			context()
+				.withSchema(TableSchema.builder()
+					.field("a", DataTypes.TIME())
+					.build())
+				.withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
+				.withOption(ElasticsearchOptions.HOSTS_OPTION.key(), "http://localhost:1234")
+				.withOption(ElasticsearchOptions.USERNAME_OPTION.key(), "username")
+				.withOption(ElasticsearchOptions.PASSWORD_OPTION.key(), "")
+				.build()
+		);
+	}
 }

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkTest.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkTest.java
@@ -60,6 +60,8 @@ public class Elasticsearch7DynamicSinkTest {
 	private static final String SCHEMA = "https";
 	private static final String INDEX = "MyIndex";
 	private static final String DOC_TYPE = "MyType";
+	private static final String USERNAME = "username";
+	private static final String PASSWORD = "password";
 
 	@Test
 	public void testBuilder() {
@@ -111,6 +113,35 @@ public class Elasticsearch7DynamicSinkTest {
 		verify(provider.builderSpy).setBulkFlushMaxActions(1000);
 		verify(provider.builderSpy).setBulkFlushMaxSizeMb(2);
 		verify(provider.builderSpy).setRestClientFactory(new Elasticsearch7DynamicSink.DefaultRestClientFactory(null));
+		verify(provider.sinkSpy, never()).disableFlushOnCheckpoint();
+	}
+
+	@Test
+	public void testAuthConfig() {
+		final TableSchema schema = createTestSchema();
+		Configuration configuration = new Configuration();
+		configuration.setString(ElasticsearchOptions.INDEX_OPTION.key(), INDEX);
+		configuration.setString(ElasticsearchOptions.DOCUMENT_TYPE_OPTION.key(), DOC_TYPE);
+		configuration.setString(ElasticsearchOptions.HOSTS_OPTION.key(), SCHEMA + "://" + HOSTNAME + ":" + PORT);
+		configuration.setString(ElasticsearchOptions.USERNAME_OPTION.key(), USERNAME);
+		configuration.setString(ElasticsearchOptions.PASSWORD_OPTION.key(), PASSWORD);
+
+		BuilderProvider provider = new BuilderProvider();
+		final Elasticsearch7DynamicSink testSink = new Elasticsearch7DynamicSink(
+			new DummyEncodingFormat(),
+			new Elasticsearch7Configuration(configuration, this.getClass().getClassLoader()),
+			schema,
+			provider
+		);
+
+		testSink.getSinkRuntimeProvider(new MockSinkContext()).createSinkFunction();
+
+		verify(provider.builderSpy).setFailureHandler(new NoOpFailureHandler());
+		verify(provider.builderSpy).setBulkFlushBackoff(false);
+		verify(provider.builderSpy).setBulkFlushInterval(1000);
+		verify(provider.builderSpy).setBulkFlushMaxActions(1000);
+		verify(provider.builderSpy).setBulkFlushMaxSizeMb(2);
+		verify(provider.builderSpy).setRestClientFactory(new Elasticsearch7DynamicSink.AuthRestClientFactory(null, USERNAME, PASSWORD));
 		verify(provider.sinkSpy, never()).disableFlushOnCheckpoint();
 	}
 


### PR DESCRIPTION
…arch connector

Co-authored-by: zhisheng17 <zhisheng2018@gmail.com>

## What is the purpose of the change

 Support username and password options for new Elasticsearch connector.

Note that this PR tries to align the behavior with #11822 , so I add @zhisheng17 as co-auther.

## Brief change log

- Add `username` and `password` option to new ES DynamicTableSink.
- If both `username` and `password` configured, add a `UsernamePasswordCredentials` to `RestClientBuilder`.

## Verifying this change

This change added tests and can be verified as follows:

- Elasticsearch7DynamicSinkTest#testAuthConfig
- Elasticsearch7DynamicSinkFactoryTest#validateWrongCredential
- Elasticsearch6DynamicSinkTest#testAuthConfig
- Elasticsearch6DynamicSinkFactoryTest#validateWrongCredential

As the authentication logic we used is documented in [ES official doc](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_basic_authentication.html). I think Flink does not need to check it in an e2e test or integration test. However, I'll manually test it and record in this PR

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
