### PR TITLE
 [hotfix][docs] Fix typo in System (Built-in) Functions page

### DIFF
--- a/docs/dev/table/functions/systemFunctions.md
+++ b/docs/dev/table/functions/systemFunctions.md
@@ -3736,7 +3736,7 @@ CONVERT_TZ(string1, string2, string3)
       </td>
       <td>
         <p>Converts a datetime <i>string1</i> (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time zone <i>string2</i> to time zone <i>string3</i>. The format of time zone should be either an abbreviation such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-8:00".</p>
-        <p>E.g., <code>CONVERT('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles')</code> returns '1969-12-31 16:00:00'.</p>
+        <p>E.g., <code>CONVERT_TZ('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles')</code> returns '1969-12-31 16:00:00'.</p>
         <p>Only supported in blink planner.</p>
       </td>
     </tr>

--- a/docs/dev/table/functions/systemFunctions.zh.md
+++ b/docs/dev/table/functions/systemFunctions.zh.md
@@ -3735,7 +3735,7 @@ CONVERT_TZ(string1, string2, string3)
       </td>
       <td>
         <p>Converts a datetime <i>string1</i> (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time zone <i>string2</i> to time zone <i>string3</i>. The format of time zone should be either an abbreviation such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-8:00".</p>
-        <p>E.g., <code>CONVERT('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles')</code> returns '1969-12-31 16:00:00'.</p>
+        <p>E.g., <code>CONVERT_TZ('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles')</code> returns '1969-12-31 16:00:00'.</p>
         <p>Only supported in blink planner.</p>
       </td>
     </tr>


### PR DESCRIPTION
## Brief change log
Correct typo in Temporal Functions , the description is `CONVERT` but actually the function name  is `CONVERT_TZ `, and `CONVERT` will raise an exception.