### PR TITLE
[FLINK-18347][connector] kinesis connector throw Error java.lang.NoSuchFieldError: NO_INTS

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -37,6 +37,7 @@ under the License.
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
+		<jackson.dataformat-cbor.version>2.6.7</jackson.dataformat-cbor.version>
 	</properties>
 
 	<packaging>jar</packaging>
@@ -154,6 +155,11 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-cbor</artifactId>
+			<version>${jackson.dataformat-cbor.version}</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1617,7 +1617,7 @@ under the License.
 							<rules>
 								<bannedDependencies>
 									<excludes>
-										<exclude>com.fasterxml.jackson*:*:(,2.10.0]</exclude>
+										<exclude>com.fasterxml.jackson.databind*:*:(,2.10.0]</exclude>
 									</excludes>
 								</bannedDependencies>
 							</rules>


### PR DESCRIPTION
## What is the purpose of the change

*`java.lang.NoSuchFieldError: NO_INTS` is caused by conflicting versions of the jackson libraries. flink-connector-kinesis uses the 1.11.754 version of `aws-java-sdk-kinesis` and `aws-java-sdk-core`. The version of `aws-java-sdk-core` uses the 2.6.7 version of `jackson-dataformat-cbor`, which repository refers to [AWS SDK For Java Core 1.11.754](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.11.754). Flink generally uses the 2.10.1 version of jackson and the version of jackson-dataformat-cbor couldn't correctly parse the CBOR data format.*

## Brief change log

  - *Modify the version of `jackson-dataformat-cbor` dependency in flink-connector-kinesis to use 2.6.7.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
