### PR TITLE
[hotfix] Fix the table document errors

### DIFF
--- a/docs/dev/table/streaming/dynamic_tables.md
+++ b/docs/dev/table/streaming/dynamic_tables.md
@@ -153,7 +153,7 @@ GROUP BY user;
 - **Computing Updates:** Some queries require to recompute and update a large fraction of the emitted result rows even if only a single input record is added or updated. Clearly, such queries are not well suited to be executed as continuous queries. An example is the following query which computes for each user a `RANK` based on the time of the last click. As soon as the `clicks` table receives a new row, the `lastAction` of the user is updated and a new rank must be computed. However since two rows cannot have the same rank, all lower ranked rows need to be updated as well.
 
 {% highlight sql %}
-SELECT user, RANK() OVER (ORDER BY lastLogin)
+SELECT user, RANK() OVER (ORDER BY lastAction)
 FROM (
   SELECT user, MAX(cTime) AS lastAction FROM clicks GROUP BY user
 );

--- a/docs/dev/table/streaming/dynamic_tables.zh.md
+++ b/docs/dev/table/streaming/dynamic_tables.zh.md
@@ -155,7 +155,7 @@ GROUP BY user;
 - **计算更新：** 有些查询需要重新计算和更新大量已输出的结果行，即使只添加或更新一条输入记录。显然，这样的查询不适合作为连续查询执行。下面的查询就是一个例子，它根据最后一次单击的时间为每个用户计算一个 `RANK`。一旦 `click` 表接收到一个新行，用户的 `lastAction` 就会更新，并必须计算一个新的排名。然而，由于两行不能具有相同的排名，所以所有较低排名的行也需要更新。
 
 {% highlight sql %}
-SELECT user, RANK() OVER (ORDER BY lastLogin)
+SELECT user, RANK() OVER (ORDER BY lastAction)
 FROM (
   SELECT user, MAX(cTime) AS lastAction FROM clicks GROUP BY user
 );

--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -270,7 +270,7 @@ In either case the event time timestamp field will hold the value of the `DataSt
 DataStream<Tuple2<String, String>> stream = inputStream.assignTimestampsAndWatermarks(...);
 
 // declare an additional logical field as an event time attribute
-Table table = tEnv.fromDataStream(stream, $("user_name"), $("data"), $("user_action_time").rowtime()");
+Table table = tEnv.fromDataStream(stream, $("user_name"), $("data"), $("user_action_time").rowtime());
 
 
 // Option 2:

--- a/docs/dev/table/streaming/time_attributes.zh.md
+++ b/docs/dev/table/streaming/time_attributes.zh.md
@@ -272,7 +272,7 @@ GROUP BY TUMBLE(user_action_time, INTERVAL '10' MINUTE);
 DataStream<Tuple2<String, String>> stream = inputStream.assignTimestampsAndWatermarks(...);
 
 // 声明一个额外的逻辑字段作为事件时间属性
-Table table = tEnv.fromDataStream(stream, $("user_name"), $("data"), $("user_action_time").rowtime()");
+Table table = tEnv.fromDataStream(stream, $("user_name"), $("data"), $("user_action_time").rowtime());
 
 
 // Option 2:


### PR DESCRIPTION
## What is the purpose of the change

This pr fixes some errors in the documentation of table, including the wrong examples and additional quotation marks. 


## Brief change log

- f8f8164b7fdb730cc7f3215059e1037bd96fe949 fixes the example and removes the redundant quotation marks.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector:**no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**