### PR TITLE
[FLINK-18399] [table-api-java] fix TableResult#print can not print the result of unbounded stream query

### DIFF
--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -134,8 +134,10 @@ class TableResult(object):
         """
         Print the result contents as tableau form to client console.
 
-        NOTE: please make sure the result data to print should be small.
-        Because all data will be collected to local first, and then print them to console.
+        This method guarantees end-to-end exactly-once record delivery
+        which requires the checkpointing mechanism to be enabled.
+        By default, checkpointing is disabled. To enable checkpointing,
+        call `StreamExecutionEnvironment#enableCheckpointing()` method.
 
         .. versionadded:: 1.11.0
         """

--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -134,10 +134,10 @@ class TableResult(object):
         """
         Print the result contents as tableau form to client console.
 
-        This method guarantees end-to-end exactly-once record delivery
+        For streaming mode, this method guarantees end-to-end exactly-once record delivery
         which requires the checkpointing mechanism to be enabled.
-        By default, checkpointing is disabled. To enable checkpointing,
-        call `StreamExecutionEnvironment#enableCheckpointing()` method.
+        By default, checkpointing is disabled. To enable checkpointing, set checkpointing properties
+        (see ExecutionCheckpointingOptions) through `TableConfig#getConfiguration()`.
 
         .. versionadded:: 1.11.0
         """

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -310,7 +310,7 @@ public class CliTableauResultViewTest {
 				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
 				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
 				"|   + |    true |         100 | -9223372036854775808 |           abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |" + System.lineSeparator() +
-				"|   - |  (NULL) |          -1 |                   -1 |  abcdefghijklmnop... |   -12345.06789 |                     (NULL) |" + System.lineSeparator() +
+				"|   - |  (NULL) |          -1 |                   -1 | abcdefghijklmnopq... |   -12345.06789 |                     (NULL) |" + System.lineSeparator() +
 				"|   + |  (NULL) |          -1 |                   -1 |         这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
 				"|   - |  (NULL) |          -1 |                   -1 |  これは日本語をテ... |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
 				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -132,12 +132,13 @@ public interface TableResult {
 	 *  }
 	 * }</pre>
 	 *
-	 * <p>This method guarantees end-to-end exactly-once record delivery
+	 * <p>For streaming mode, this method guarantees end-to-end exactly-once record delivery
 	 * which requires the checkpointing mechanism to be enabled.
-	 * By default, checkpointing is disabled. To enable checkpointing,
-	 * call `StreamExecutionEnvironment#enableCheckpointing()` method.
+	 * By default, checkpointing is disabled. To enable checkpointing, set checkpointing properties
+	 * (see ExecutionCheckpointingOptions) through {@link TableConfig#getConfiguration()}.
 	 *
-	 * <p>Only this method or {@link #print()} method can be called for a TableResult instance,
+	 * <p>In order to fetch result to local, you can call either {@link #collect()} and {@link #print()}.
+	 * But, they can't be called both on the same {@link TableResult} instance,
 	 * because the result can only be accessed once.
 	 */
 	CloseableIterator<Row> collect();
@@ -145,12 +146,13 @@ public interface TableResult {
 	/**
 	 * Print the result contents as tableau form to client console.
 	 *
-	 * <p>This method guarantees end-to-end exactly-once record delivery
+	 * <p>For streaming mode, this method guarantees end-to-end exactly-once record delivery
 	 * which requires the checkpointing mechanism to be enabled.
-	 * By default, checkpointing is disabled. To enable checkpointing,
-	 * call `StreamExecutionEnvironment#enableCheckpointing()` method.
+	 * By default, checkpointing is disabled. To enable checkpointing, set checkpointing properties
+	 * (see ExecutionCheckpointingOptions) through {@link TableConfig#getConfiguration()}.
 	 *
-	 * <p>only this method or {@link #collect()} ()} method can be called for a TableResult instance,
+	 * <p>In order to fetch result to local, you can call either {@link #collect()} and {@link #print()}.
+	 * But, they can't be called both on the same {@link TableResult} instance,
 	 * because the result can only be accessed once.
 	 */
 	void print();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -131,14 +131,27 @@ public interface TableResult {
 	 *      it... // collect same data
 	 *  }
 	 * }</pre>
+	 *
+	 * <p>This method guarantees end-to-end exactly-once record delivery
+	 * which requires the checkpointing mechanism to be enabled.
+	 * By default, checkpointing is disabled. To enable checkpointing,
+	 * call `StreamExecutionEnvironment#enableCheckpointing()` method.
+	 *
+	 * <p>Only this method or {@link #print()} method can be called for a TableResult instance,
+	 * because the result can only be accessed once.
 	 */
 	CloseableIterator<Row> collect();
 
 	/**
 	 * Print the result contents as tableau form to client console.
 	 *
-	 * <p><strong>NOTE:</strong> please make sure the result data to print should be small.
-	 * Because all data will be collected to local first, and then print them to console.
+	 * <p>This method guarantees end-to-end exactly-once record delivery
+	 * which requires the checkpointing mechanism to be enabled.
+	 * By default, checkpointing is disabled. To enable checkpointing,
+	 * call `StreamExecutionEnvironment#enableCheckpointing()` method.
+	 *
+	 * <p>only this method or {@link #collect()} ()} method can be called for a TableResult instance,
+	 * because the result can only be accessed once.
 	 */
 	void print();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -705,7 +705,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 					.tableSchema(operation.getTableSchema())
 					.data(resultProvider.getResultIterator())
 					.setPrintStyle(TableResultImpl.PrintStyle.tableau(
-							PrintUtils.MAX_COLUMN_WIDTH, PrintUtils.NULL_COLUMN, isStreamingMode))
+							PrintUtils.MAX_COLUMN_WIDTH, PrintUtils.NULL_COLUMN, true, isStreamingMode))
 					.build();
 		} catch (Exception e) {
 			throw new TableException("Failed to execute sql", e);
@@ -1091,7 +1091,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 						headers,
 						types).build())
 				.data(Arrays.stream(rows).map(Row::of).collect(Collectors.toList()))
-				.setPrintStyle(TableResultImpl.PrintStyle.tableau(Integer.MAX_VALUE, "", false))
+				.setPrintStyle(TableResultImpl.PrintStyle.tableau(Integer.MAX_VALUE, "", false, false))
 				.build();
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -216,7 +216,7 @@ public class PrintUtils {
 			} else {
 				passedWidth += 1;
 			}
-			if (passedWidth >= targetWidth) {
+			if (passedWidth > targetWidth) {
 				break;
 			}
 		}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -55,7 +55,7 @@ public class PrintUtils {
 	public static final int MAX_COLUMN_WIDTH = 30;
 	public static final String NULL_COLUMN = "(NULL)";
 	private static final String COLUMN_TRUNCATED_FLAG = "...";
-	private static final String ROW_KIND_COLUMN = "row_kind";
+	private static final String ROW_KIND_COLUMN = "op";
 
 	private PrintUtils() {
 	}
@@ -88,14 +88,14 @@ public class PrintUtils {
 	 *
 	 * <p>For example: (printRowKind is true)
 	 * <pre>
-	 * +----------+-------------+---------+-------------+
-	 * | row_kind | boolean_col | int_col | varchar_col |
-	 * +----------+-------------+---------+-------------+
-	 * |       +I |        true |       1 |         abc |
-	 * |       -U |       false |       2 |         def |
-	 * |       +U |       false |       3 |         def |
-	 * |       -D |      (NULL) |  (NULL) |      (NULL) |
-	 * +----------+-------------+---------+-------------+
+	 * +----+-------------+---------+-------------+
+	 * | op | boolean_col | int_col | varchar_col |
+	 * +----+-------------+---------+-------------+
+	 * | +I |        true |       1 |         abc |
+	 * | -U |       false |       2 |         def |
+	 * | +U |       false |       3 |         def |
+	 * | -D |      (NULL) |  (NULL) |      (NULL) |
+	 * +----+-------------+---------+-------------+
 	 * 4 rows in result
 	 * </pre>
 	 *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -19,20 +19,31 @@
 package org.apache.flink.table.utils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 
+import javax.annotation.Nullable;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -45,6 +56,7 @@ public class PrintUtils {
 	public static final int MAX_COLUMN_WIDTH = 30;
 	public static final String NULL_COLUMN = "(NULL)";
 	private static final String COLUMN_TRUNCATED_FLAG = "...";
+	private static final String ROW_KIND_COLUMN = "row_kind";
 
 	private PrintUtils() {
 	}
@@ -66,7 +78,7 @@ public class PrintUtils {
 			TableSchema tableSchema,
 			Iterator<Row> it,
 			PrintWriter printWriter) {
-		printAsTableauForm(tableSchema, it, printWriter, MAX_COLUMN_WIDTH, NULL_COLUMN, false);
+		printAsTableauForm(tableSchema, it, printWriter, MAX_COLUMN_WIDTH, NULL_COLUMN, false, false);
 	}
 
 	/**
@@ -89,26 +101,81 @@ public class PrintUtils {
 			PrintWriter printWriter,
 			int maxColumnWidth,
 			String nullColumn,
+			boolean deriveColumnWidthByType,
 			boolean printRowKind) {
-		List<String[]> rows = new ArrayList<>();
-
-		// fill field names first
-		final List<TableColumn> columns;
-		if (printRowKind) {
-			columns = Stream.concat(
-					Stream.of(TableColumn.of("row_kind", DataTypes.STRING())),
-					tableSchema.getTableColumns().stream()
-			).collect(Collectors.toList());
+		final long numRows;
+		if (deriveColumnWidthByType) {
+			numRows = printWithTypeColumnWidth(tableSchema, it, printWriter, maxColumnWidth, nullColumn, printRowKind);
 		} else {
-			columns = tableSchema.getTableColumns();
+			numRows = printWithContentColumnWidth(
+					tableSchema, it, printWriter, maxColumnWidth, nullColumn, printRowKind);
 		}
 
-		rows.add(columns.stream().map(TableColumn::getName).toArray(String[]::new));
+		final String rowTerm;
+		if (numRows > 1) {
+			rowTerm = "rows";
+		} else {
+			rowTerm = "row";
+		}
+		printWriter.println(numRows + " " + rowTerm + " in set");
+		printWriter.flush();
+	}
+
+	private static long printWithTypeColumnWidth(
+			TableSchema tableSchema,
+			Iterator<Row> it,
+			PrintWriter printWriter,
+			int maxColumnWidth,
+			String nullColumn,
+			boolean printRowKind) {
+		Preconditions.checkArgument(maxColumnWidth < Integer.MAX_VALUE,
+				"maxColumnWidth should be less than Integer.MAX_VALUE");
+		final int[] colWidths = columnWidthsByType(
+				tableSchema.getTableColumns(),
+				maxColumnWidth,
+				nullColumn,
+				getRowKindColumn(printRowKind));
+		final String borderline = PrintUtils.genBorderLine(colWidths);
+		// print border line
+		printWriter.println(borderline);
+
+		String[] fullColumnNames = getFullColumnNames(tableSchema, printRowKind);
+		// print filed names
+		PrintUtils.printSingleRow(colWidths, fullColumnNames, printWriter);
+		// print border line
+		printWriter.println(borderline);
+		printWriter.flush();
+
+		long numRows = 0;
+		while (it.hasNext()) {
+			String[] cols = rowToString(it.next(), nullColumn, printRowKind);
+			// print content
+			printSingleRow(colWidths, cols, printWriter);
+			numRows++;
+		}
+
+		if (numRows > 0) {
+			// print border line
+			printWriter.println(borderline);
+		}
+		return numRows;
+	}
+
+	private static long printWithContentColumnWidth(
+			TableSchema tableSchema,
+			Iterator<Row> it,
+			PrintWriter printWriter,
+			int maxColumnWidth,
+			String nullColumn,
+			boolean printRowKind) {
+		String[] fullColumnNames = getFullColumnNames(tableSchema, printRowKind);
+		List<String[]> rows = new ArrayList<>();
+		rows.add(fullColumnNames);
 		while (it.hasNext()) {
 			rows.add(rowToString(it.next(), nullColumn, printRowKind));
 		}
 
-		int[] colWidths = columnWidthsByContent(columns, rows, maxColumnWidth);
+		int[] colWidths = columnWidthsByContent(fullColumnNames, rows, maxColumnWidth);
 		String borderline = genBorderLine(colWidths);
 
 		// print field names
@@ -121,16 +188,20 @@ public class PrintUtils {
 			rows.subList(1, rows.size()).forEach(row -> printSingleRow(colWidths, row, printWriter));
 			printWriter.println(borderline);
 		}
+		return rows.size() - 1;
+	}
 
-		int numRows = rows.size() - 1;
-		final String rowTerm;
-		if (numRows > 1) {
-			rowTerm = "rows";
-		} else {
-			rowTerm = "row";
+	private static String getRowKindColumn(boolean printRowKind) {
+		return printRowKind ? ROW_KIND_COLUMN : null;
+	}
+
+	private static String[] getFullColumnNames(TableSchema tableSchema, boolean printRowKind) {
+		final List<TableColumn> columns = tableSchema.getTableColumns();
+		String[] columnNames = columns.stream().map(TableColumn::getName).toArray(String[]::new);
+		if (printRowKind) {
+			columnNames = Stream.concat(Stream.of(ROW_KIND_COLUMN), Arrays.stream(columnNames)).toArray(String[]::new);
 		}
-		printWriter.println((rows.size() - 1) + " " + rowTerm + " in set");
-		printWriter.flush();
+		return columnNames;
 	}
 
 	public static String[] rowToString(Row row) {
@@ -154,12 +225,22 @@ public class PrintUtils {
 		return fields.toArray(new String[0]);
 	}
 
+	public static String genBorderLine(int[] colWidths) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("+");
+		for (int width : colWidths) {
+			sb.append(EncodingUtils.repeat('-', width + 1));
+			sb.append("-+");
+		}
+		return sb.toString();
+	}
+
 	private static int[] columnWidthsByContent(
-			List<TableColumn> columns,
+			String[] columnNames,
 			List<String[]> rows,
 			int maxColumnWidth) {
 		// fill width with field names first
-		int[] colWidths = columns.stream().mapToInt(col -> col.getName().length()).toArray();
+		int[] colWidths = Stream.of(columnNames).mapToInt(String::length).toArray();
 
 		// fill column width with real data
 		for (String[] row : rows) {
@@ -176,14 +257,101 @@ public class PrintUtils {
 		return colWidths;
 	}
 
-	public static String genBorderLine(int[] colWidths) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("+");
-		for (int width : colWidths) {
-			sb.append(EncodingUtils.repeat('-', width + 1));
-			sb.append("-+");
+	/**
+	 * Try to infer column width based on column types. In streaming case, we will have an
+	 * endless result set, thus couldn't determine column widths based on column values.
+	 */
+	public static int[] columnWidthsByType(
+			List<TableColumn> columns,
+			int maxColumnWidth,
+			String nullColumn,
+			@Nullable String rowKindColumn) {
+		// fill width with field names first
+		int[] colWidths = columns.stream()
+				.mapToInt(col -> col.getName().length())
+				.toArray();
+
+		// determine proper column width based on types
+		for (int i = 0; i < columns.size(); ++i) {
+			LogicalType type = columns.get(i).getType().getLogicalType();
+			int len;
+			switch (type.getTypeRoot()) {
+				case TINYINT:
+					len = TinyIntType.PRECISION + 1; // extra for negative value
+					break;
+				case SMALLINT:
+					len = SmallIntType.PRECISION + 1; // extra for negative value
+					break;
+				case INTEGER:
+					len = IntType.PRECISION + 1; // extra for negative value
+					break;
+				case BIGINT:
+					len = BigIntType.PRECISION + 1; // extra for negative value
+					break;
+				case DECIMAL:
+					len = ((DecimalType) type).getPrecision() + 2; // extra for negative value and decimal point
+					break;
+				case BOOLEAN:
+					len = 5; // "true" or "false"
+					break;
+				case DATE:
+					len = 10; // e.g. 9999-12-31
+					break;
+				case TIME_WITHOUT_TIME_ZONE:
+					int precision = ((TimeType) type).getPrecision();
+					len = precision == 0 ? 8 : precision + 9; // 23:59:59[.999999999]
+					break;
+				case TIMESTAMP_WITHOUT_TIME_ZONE:
+					precision = ((TimestampType) type).getPrecision();
+					len = timestampTypeColumnWidth(precision);
+					break;
+				case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+					precision = ((LocalZonedTimestampType) type).getPrecision();
+					len = timestampTypeColumnWidth(precision);
+					break;
+				default:
+					len = maxColumnWidth;
+			}
+
+			// adjust column width with potential null values
+			colWidths[i] = Math.max(colWidths[i], Math.max(len, nullColumn.length()));
 		}
-		return sb.toString();
+
+		// add an extra column for row kind if necessary
+		if (rowKindColumn != null) {
+			int[] ret = new int[columns.size() + 1];
+			ret[0] = rowKindColumn.length();
+			System.arraycopy(colWidths, 0, ret, 1, columns.size());
+			return ret;
+		} else {
+			return colWidths;
+		}
+	}
+
+	/**
+	 * Here we consider two popular class for timestamp: LocalDateTime and java.sql.Timestamp.
+	 *
+	 * <p>According to LocalDateTime's comment, the string output will be one of the following
+	 * ISO-8601 formats:
+	 *  <li>{@code uuuu-MM-dd'T'HH:mm:ss}</li>
+	 *  <li>{@code uuuu-MM-dd'T'HH:mm:ss.SSS}</li>
+	 *  <li>{@code uuuu-MM-dd'T'HH:mm:ss.SSSSSS}</li>
+	 *  <li>{@code uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS}</li>
+	 *
+	 * <p>And for java.sql.Timestamp, the number of digits after point will be precision except
+	 * when precision is 0. In that case, the format would be 'uuuu-MM-dd HH:mm:ss.0'
+	 */
+	private static int timestampTypeColumnWidth(int precision) {
+		int base = 19; // length of uuuu-MM-dd HH:mm:ss
+		if (precision == 0) {
+			return base + 2; // consider java.sql.Timestamp
+		} else if (precision <= 3) {
+			return base + 4;
+		} else if (precision <= 6) {
+			return base + 7;
+		} else {
+			return base + 10;
+		}
 	}
 
 	public static void printSingleRow(int[] colWidths, String[] cols, PrintWriter printWriter) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -130,9 +130,8 @@ public class PrintUtils {
 					nullColumn,
 					printRowKind ? ROW_KIND_COLUMN : null);
 		} else {
-			//
-			List<Row> rows = new ArrayList<>();
-			List<String[]> content = new ArrayList<>();
+			final List<Row> rows = new ArrayList<>();
+			final List<String[]> content = new ArrayList<>();
 			content.add(columnNames);
 			while (it.hasNext()) {
 				Row row = it.next();
@@ -146,7 +145,7 @@ public class PrintUtils {
 		final String borderline = PrintUtils.genBorderLine(colWidths);
 		// print border line
 		printWriter.println(borderline);
-		// print filed names
+		// print field names
 		PrintUtils.printSingleRow(colWidths, columnNames, printWriter);
 		// print border line
 		printWriter.println(borderline);
@@ -212,7 +211,7 @@ public class PrintUtils {
 			List<String[]> rows,
 			int maxColumnWidth) {
 		// fill width with field names first
-		int[] colWidths = Stream.of(columnNames).mapToInt(String::length).toArray();
+		final int[] colWidths = Stream.of(columnNames).mapToInt(String::length).toArray();
 
 		// fill column width with real data
 		for (String[] row : rows) {
@@ -230,8 +229,9 @@ public class PrintUtils {
 	}
 
 	/**
-	 * Try to infer column width based on column types. In streaming case, we will have an
-	 * endless result set, thus couldn't determine column widths based on column values.
+	 * Try to derive column width based on column types.
+	 * If result set is not small enough to be stored in java heap memory,
+	 * we can't determine column widths based on column values.
 	 */
 	public static int[] columnWidthsByType(
 			List<TableColumn> columns,
@@ -239,7 +239,7 @@ public class PrintUtils {
 			String nullColumn,
 			@Nullable String rowKindColumn) {
 		// fill width with field names first
-		int[] colWidths = columns.stream()
+		final int[] colWidths = columns.stream()
 				.mapToInt(col -> col.getName().length())
 				.toArray();
 
@@ -291,7 +291,7 @@ public class PrintUtils {
 
 		// add an extra column for row kind if necessary
 		if (rowKindColumn != null) {
-			int[] ret = new int[columns.size() + 1];
+			final int[] ret = new int[columns.size() + 1];
 			ret[0] = rowKindColumn.length();
 			System.arraycopy(colWidths, 0, ret, 1, columns.size());
 			return ret;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
@@ -120,6 +120,9 @@ public class PrintUtilsTest {
 		// note: the expected result may look irregular because every CJK(Chinese/Japanese/Korean) character's
 		// width < 2 in IDE by default, every CJK character usually's width is 2, you can open this source file
 		// by vim or just cat the file to check the regular result.
+		// The last row of `varchar` value will pad with two ' ' before the column.
+		// Because the length of `これは日本語をテストするた` plus the length of `...` is 29,
+		// no more Japanese character can be added to the line.
 		assertEquals(
 				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
 				"| boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |\n" +
@@ -129,7 +132,7 @@ public class PrintUtilsTest {
 				"|    true |  2147483647 |               (NULL) |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
 				"|   false | -2147483648 |  9223372036854775807 |                         (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |\n" +
 				"|    true |         100 | -9223372036854775808 |                     abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |\n" +
-				"|  (NULL) |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                     (NULL) |\n" +
+				"|  (NULL) |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                     (NULL) |\n" +
 				"|  (NULL) |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
 				"|  (NULL) |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
 				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
@@ -150,6 +153,9 @@ public class PrintUtilsTest {
 		// note: the expected result may look irregular because every CJK(Chinese/Japanese/Korean) character's
 		// width < 2 in IDE by default, every CJK character usually's width is 2, you can open this source file
 		// by vim or just cat the file to check the regular result.
+		// The last row of `varchar` value will pad with two ' ' before the column.
+		// Because the length of `これは日本語をテストするた` plus the length of `...` is 29,
+		// no more Japanese character can be added to the line.
 		assertEquals(
 				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
 				"| row_kind | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |\n" +
@@ -159,7 +165,7 @@ public class PrintUtilsTest {
 				"|       -D |    true |  2147483647 |                      |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
 				"|       +I |   false | -2147483648 |  9223372036854775807 |                                |    12345.06789 |    2020-03-01 18:39:14.123 |\n" +
 				"|       +I |    true |         100 | -9223372036854775808 |                     abcdefg111 |                | 2020-03-01 18:39:14.123456 |\n" +
-				"|       -U |         |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                            |\n" +
+				"|       -U |         |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                            |\n" +
 				"|       +U |         |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
 				"|       -D |         |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
 				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
@@ -230,7 +236,7 @@ public class PrintUtilsTest {
 				null,
 				-1,
 				-1,
-				"abcdefghijklmnopqrstuvwxyz",
+				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
 				BigDecimal.valueOf(-12345.06789),
 				null)
 		);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
@@ -104,9 +104,9 @@ public class PrintUtilsTest {
 				true);
 
 		assertEquals(
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
-				"| row_kind | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
 				"0 row in set" + System.lineSeparator(),
 				outContent.toString());
 	}
@@ -178,18 +178,18 @@ public class PrintUtilsTest {
 		// Because the length of `これは日本語をテストするた` plus the length of `...` is 29,
 		// no more Japanese character can be added to the line.
 		assertEquals(
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
-				"| row_kind | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
-				"|       +I |         |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
-				"|       +I |   false |             |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
-				"|       -D |    true |  2147483647 |                      |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
-				"|       +I |   false | -2147483648 |  9223372036854775807 |                                |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
-				"|       +I |    true |         100 | -9223372036854775808 |                     abcdefg111 |                | 2020-03-01 18:39:14.123456 |" + System.lineSeparator() +
-				"|       -U |         |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                            |" + System.lineSeparator() +
-				"|       +U |         |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
-				"|       -D |         |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| +I |         |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"| +I |   false |             |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"| -D |    true |  2147483647 |                      |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"| +I |   false | -2147483648 |  9223372036854775807 |                                |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
+				"| +I |    true |         100 | -9223372036854775808 |                     abcdefg111 |                | 2020-03-01 18:39:14.123456 |" + System.lineSeparator() +
+				"| -U |         |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                            |" + System.lineSeparator() +
+				"| +U |         |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"| -D |         |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
 				"8 rows in set" + System.lineSeparator(),
 				outContent.toString());
 	}
@@ -206,13 +206,13 @@ public class PrintUtilsTest {
 				true);
 
 		assertEquals(
-				"+----------+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
-				"| row_kind | boolean |        int | bigint | varchar | decimal(10, 5) |              timestamp |" + System.lineSeparator() +
-				"+----------+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
-				"|       +I |         |          1 |      2 |     abc |           1.23 |  2020-03-01 18:39:14.0 |" + System.lineSeparator() +
-				"|       +I |   false |            |      0 |         |              1 |  2020-03-01 18:39:14.1 |" + System.lineSeparator() +
-				"|       -D |    true | 2147483647 |        | abcdefg |     1234567890 | 2020-03-01 18:39:14.12 |" + System.lineSeparator() +
-				"+----------+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
+				"+----+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
+				"| op | boolean |        int | bigint | varchar | decimal(10, 5) |              timestamp |" + System.lineSeparator() +
+				"+----+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
+				"| +I |         |          1 |      2 |     abc |           1.23 |  2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"| +I |   false |            |      0 |         |              1 |  2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"| -D |    true | 2147483647 |        | abcdefg |     1234567890 | 2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"+----+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
 				"3 rows in set" + System.lineSeparator(),
 				outContent.toString());
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
@@ -85,9 +85,9 @@ public class PrintUtilsTest {
 				new PrintWriter(outContent));
 
 		assertEquals(
-				"+---------+-----+--------+---------+----------------+-----------+\n" +
-				"| boolean | int | bigint | varchar | decimal(10, 5) | timestamp |\n" +
-				"+---------+-----+--------+---------+----------------+-----------+\n" +
+				"+---------+-----+--------+---------+----------------+-----------+" + System.lineSeparator() +
+				"| boolean | int | bigint | varchar | decimal(10, 5) | timestamp |" + System.lineSeparator() +
+				"+---------+-----+--------+---------+----------------+-----------+" + System.lineSeparator() +
 				"0 row in set" + System.lineSeparator(),
 				outContent.toString());
 	}
@@ -100,12 +100,32 @@ public class PrintUtilsTest {
 				new PrintWriter(outContent),
 				PrintUtils.MAX_COLUMN_WIDTH,
 				"",
+				true, // derive column width by type
 				true);
 
 		assertEquals(
-				"+----------+---------+-----+--------+---------+----------------+-----------+\n" +
-				"| row_kind | boolean | int | bigint | varchar | decimal(10, 5) | timestamp |\n" +
-				"+----------+---------+-----+--------+---------+----------------+-----------+\n" +
+				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| row_kind | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"0 row in set" + System.lineSeparator(),
+				outContent.toString());
+	}
+
+	@Test
+	public void testPrintWithEmptyResultAndDriverColumnWidthByContent() {
+		PrintUtils.printAsTableauForm(
+				getSchema(),
+				Collections.<Row>emptyList().iterator(),
+				new PrintWriter(outContent),
+				PrintUtils.MAX_COLUMN_WIDTH,
+				"",
+				false, // derive column width by content
+				false);
+
+		assertEquals(
+				"+---------+-----+--------+---------+----------------+-----------+" + System.lineSeparator() +
+				"| boolean | int | bigint | varchar | decimal(10, 5) | timestamp |" + System.lineSeparator() +
+				"+---------+-----+--------+---------+----------------+-----------+" + System.lineSeparator() +
 				"0 row in set" + System.lineSeparator(),
 				outContent.toString());
 	}
@@ -124,18 +144,18 @@ public class PrintUtilsTest {
 		// Because the length of `これは日本語をテストするた` plus the length of `...` is 29,
 		// no more Japanese character can be added to the line.
 		assertEquals(
-				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
-				"| boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |\n" +
-				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
-				"|  (NULL) |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |\n" +
-				"|   false |      (NULL) |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |\n" +
-				"|    true |  2147483647 |               (NULL) |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
-				"|   false | -2147483648 |  9223372036854775807 |                         (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |\n" +
-				"|    true |         100 | -9223372036854775808 |                     abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |\n" +
-				"|  (NULL) |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                     (NULL) |\n" +
-				"|  (NULL) |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"|  (NULL) |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
+				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"|  (NULL) |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"|   false |      (NULL) |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"|    true |  2147483647 |               (NULL) |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"|   false | -2147483648 |  9223372036854775807 |                         (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
+				"|    true |         100 | -9223372036854775808 |                     abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |" + System.lineSeparator() +
+				"|  (NULL) |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                     (NULL) |" + System.lineSeparator() +
+				"|  (NULL) |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"|  (NULL) |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
 				"8 rows in set" + System.lineSeparator(),
 				outContent.toString());
 	}
@@ -148,6 +168,7 @@ public class PrintUtilsTest {
 				new PrintWriter(outContent),
 				PrintUtils.MAX_COLUMN_WIDTH,
 				"",
+				true, // derive column width by type
 				true);
 
 		// note: the expected result may look irregular because every CJK(Chinese/Japanese/Korean) character's
@@ -157,19 +178,42 @@ public class PrintUtilsTest {
 		// Because the length of `これは日本語をテストするた` plus the length of `...` is 29,
 		// no more Japanese character can be added to the line.
 		assertEquals(
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
-				"| row_kind | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |\n" +
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
-				"|       +I |         |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |\n" +
-				"|       +I |   false |             |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |\n" +
-				"|       -D |    true |  2147483647 |                      |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
-				"|       +I |   false | -2147483648 |  9223372036854775807 |                                |    12345.06789 |    2020-03-01 18:39:14.123 |\n" +
-				"|       +I |    true |         100 | -9223372036854775808 |                     abcdefg111 |                | 2020-03-01 18:39:14.123456 |\n" +
-				"|       -U |         |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                            |\n" +
-				"|       +U |         |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"|       -D |         |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
+				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| row_kind | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"|       +I |         |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"|       +I |   false |             |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"|       -D |    true |  2147483647 |                      |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"|       +I |   false | -2147483648 |  9223372036854775807 |                                |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
+				"|       +I |    true |         100 | -9223372036854775808 |                     abcdefg111 |                | 2020-03-01 18:39:14.123456 |" + System.lineSeparator() +
+				"|       -U |         |          -1 |                   -1 | abcdefghijklmnopqrstuvwxyza... |   -12345.06789 |                            |" + System.lineSeparator() +
+				"|       +U |         |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"|       -D |         |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"+----------+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
 				"8 rows in set" + System.lineSeparator(),
+				outContent.toString());
+	}
+
+	@Test
+	public void testPrintWithMultipleRowsAndDriverColumnWidthByContent() {
+		PrintUtils.printAsTableauForm(
+				getSchema(),
+				getData().subList(0, 3).iterator(),
+				new PrintWriter(outContent),
+				PrintUtils.MAX_COLUMN_WIDTH,
+				"",
+				false, // derive column width by content
+				true);
+
+		assertEquals(
+				"+----------+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
+				"| row_kind | boolean |        int | bigint | varchar | decimal(10, 5) |              timestamp |" + System.lineSeparator() +
+				"+----------+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
+				"|       +I |         |          1 |      2 |     abc |           1.23 |  2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"|       +I |   false |            |      0 |         |              1 |  2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"|       -D |    true | 2147483647 |        | abcdefg |     1234567890 | 2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"+----------+---------+------------+--------+---------+----------------+------------------------+" + System.lineSeparator() +
+				"3 rows in set" + System.lineSeparator(),
 				outContent.toString());
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
@@ -112,7 +112,7 @@ public class PrintUtilsTest {
 	}
 
 	@Test
-	public void testPrintWithEmptyResultAndDriverColumnWidthByContent() {
+	public void testPrintWithEmptyResultAndDeriveColumnWidthByContent() {
 		PrintUtils.printAsTableauForm(
 				getSchema(),
 				Collections.<Row>emptyList().iterator(),
@@ -195,7 +195,7 @@ public class PrintUtilsTest {
 	}
 
 	@Test
-	public void testPrintWithMultipleRowsAndDriverColumnWidthByContent() {
+	public void testPrintWithMultipleRowsAndDeriveColumnWidthByContent() {
 		PrintUtils.printAsTableauForm(
 				getSchema(),
 				getData().subList(0, 3).iterator(),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -44,10 +44,12 @@ import org.apache.flink.table.types.{AbstractDataType, DataType}
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.table.utils.PrintUtils
 import org.apache.flink.types.Row
+
 import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools.FrameworkConfig
 import org.apache.commons.lang3.StringUtils
+
 import _root_.java.lang.{Iterable => JIterable, Long => JLong}
 import _root_.java.util.function.{Function => JFunction, Supplier => JSupplier}
 import _root_.java.util.{Optional, Collections => JCollections, HashMap => JHashMap, List => JList, Map => JMap}
@@ -598,7 +600,7 @@ abstract class TableEnvImpl(
         .tableSchema(tableSchema)
         .data(selectResultProvider.getResultIterator)
         .setPrintStyle(
-          PrintStyle.tableau(PrintUtils.MAX_COLUMN_WIDTH, PrintUtils.NULL_COLUMN, false))
+          PrintStyle.tableau(PrintUtils.MAX_COLUMN_WIDTH, PrintUtils.NULL_COLUMN, true, false))
         .build
     } catch {
       case e: Exception =>


### PR DESCRIPTION
## What is the purpose of the change

*In current implementation of PrintUtils, all result will be collected to local memory to compute column width first. this can works fine with batch query and bounded stream query. but for unbounded stream query, the result will be endless, so the result will be never printed. To solve this, we can use fix-length strategy, and print a row immediately once the row is accessed. This pr aims to fix the bug.*


## Brief change log

  - *[hotfix] correct the logic of `truncateString` method in PrintUtils*
  - *Correct the logic of PrintUtils for unbounded stream query case*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended PrintUtilsTest and CliTableauResultViewTest  to verify the fixes*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
