### PR TITLE
[FLINK-18283][API/Core,API/DataStream] Update outdated Javadoc for clear method of ProcessWindowFunction

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessAllWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessAllWindowFunction.java
@@ -50,7 +50,8 @@ public abstract class ProcessAllWindowFunction<IN, OUT, W extends Window> extend
 	public abstract void process(Context context, Iterable<IN> elements, Collector<OUT> out) throws Exception;
 
 	/**
-	 * Deletes any state in the {@code Context} when the Window is purged.
+	 * Deletes any state in the {@code Context} when the Window expires
+	 * (the watermark passes its {@code maxTimestamp} + {@code allowedLateness}).
 	 *
 	 * @param context The context to which the window is being evaluated
 	 * @throws Exception The function may throw exceptions to fail the program and trigger recovery.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessWindowFunction.java
@@ -52,7 +52,8 @@ public abstract class ProcessWindowFunction<IN, OUT, KEY, W extends Window> exte
 	public abstract void process(KEY key, Context context, Iterable<IN> elements, Collector<OUT> out) throws Exception;
 
 	/**
-	 * Deletes any state in the {@code Context} when the Window is purged.
+	 * Deletes any state in the {@code Context} when the Window expires
+	 * (the watermark passes its {@code maxTimestamp} + {@code allowedLateness}).
 	 *
 	 * @param context The context to which the window is being evaluated
 	 * @throws Exception The function may throw exceptions to fail the program and trigger recovery.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalWindowFunction.java
@@ -44,7 +44,8 @@ public interface InternalWindowFunction<IN, OUT, KEY, W extends Window> extends 
 	void process(KEY key, W window, InternalWindowContext context, IN input, Collector<OUT> out) throws Exception;
 
 	/**
-	 * Deletes any state in the {@code Context} when the Window is purged.
+	 * Deletes any state in the {@code Context} when the Window expires
+	 * (the watermark passes its {@code maxTimestamp} + {@code allowedLateness}).
 	 *
 	 * @param context The context to which the window is being evaluated
 	 * @throws Exception The function may throw exceptions to fail the program and trigger recovery.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessAllWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessAllWindowFunction.scala
@@ -48,7 +48,8 @@ abstract class ProcessAllWindowFunction[IN, OUT, W <: Window]
   def process(context: Context, elements: Iterable[IN], out: Collector[OUT])
 
   /**
-    * Deletes any state in the [[Context]] when the Window is purged.
+    * Deletes any state in the [[Context]] when the Window expires
+    * (the watermark passes its `maxTimestamp` + `allowedLateness`).
     *
     * @param context The context to which the window is being evaluated
     * @throws Exception The function may throw exceptions to fail the program and trigger recovery.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessWindowFunction.scala
@@ -51,7 +51,8 @@ abstract class ProcessWindowFunction[IN, OUT, KEY, W <: Window]
   def process(key: KEY, context: Context, elements: Iterable[IN], out: Collector[OUT])
 
   /**
-    * Deletes any state in the [[Context]] when the Window is purged.
+    * Deletes any state in the [[Context]] when the Window expires
+    * (the watermark passes its `maxTimestamp` + `allowedLateness`).
     *
     * @param context The context to which the window is being evaluated
     * @throws Exception The function may throw exceptions to fail the program and trigger recovery.


### PR DESCRIPTION
[FLINK-18283] [JavDocs] [API/Core,API/DataStream]
Update outdated Javadoc for *clear* method of ProcessWindowFunction

## What is the purpose of the change

- We want to edit the javadocs for ProcessWindowFunction's *clear* method so that it reflects the actual behavior.
- Please see [FLINK-18283](https://issues.apache.org/jira/browse/FLINK-18283) for detailed description of the issue.

## Brief change log
  - Change the javadoc for ProcessWindowFunction's *clear* method from
       > Deletes any state in the Context when the Window is purged

       to
       > Deletes any state in the Context when the Window expires (the watermark passes its maxTimestamp + allowedLateness).


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
- Manually verified in my IDE that the correct javadocs show up for [Java](https://user-images.githubusercontent.com/6713854/85186132-1b176c80-b24c-11ea-87d3-185fad39351d.png) and [Scala](https://user-images.githubusercontent.com/6713854/85186131-181c7c00-b24c-11ea-8861-d6d636722aaf.png).
- Ran the pipeline on Azure and all the builds passed (including e2e_ci_build)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
