### PR TITLE
[FLINK-18406] Add Nullable annotation to DualKeyLinkedMap

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -71,6 +71,7 @@ class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
+	@Nullable
 	V getValueByKeyB(B bKey) {
 		final A aKey = bMap.get(bKey);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -82,6 +82,7 @@ class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
+	@Nullable
 	A getKeyAByKeyB(B bKey) {
 		return bMap.get(bKey);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -87,6 +87,7 @@ class DualKeyLinkedMap<A, B, V> {
 		return bMap.get(bKey);
 	}
 
+	@Nullable
 	B getKeyBByKeyA(A aKey) {
 		final Tuple2<B, V> value = aMap.get(aKey);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -98,6 +98,7 @@ class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
+	@Nullable
 	V put(A aKey, B bKey, V value) {
 		final V oldValue = getValueByKeyA(aKey);
 
@@ -131,6 +132,7 @@ class DualKeyLinkedMap<A, B, V> {
 		return bMap.containsKey(bKey);
 	}
 
+	@Nullable
 	V removeKeyA(A aKey) {
 		Tuple2<B, V> aValue = aMap.remove(aKey);
 
@@ -142,6 +144,7 @@ class DualKeyLinkedMap<A, B, V> {
 		}
 	}
 
+	@Nullable
 	V removeKeyB(B bKey) {
 		A aKey = bMap.remove(bKey);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyLinkedMap.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 
+import javax.annotation.Nullable;
+
 import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.HashMap;
@@ -58,6 +60,7 @@ class DualKeyLinkedMap<A, B, V> {
 		return aMap.size();
 	}
 
+	@Nullable
 	V getValueByKeyA(A aKey) {
 		final Tuple2<B, V> value = aMap.get(aKey);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -1089,10 +1089,6 @@ public class SlotPoolImpl implements SlotPool {
 			return allocatedSlotsById.getValueByKeyA(allocationID);
 		}
 
-		AllocatedSlot get(final SlotRequestId slotRequestId) {
-			return allocatedSlotsById.getValueByKeyB(slotRequestId);
-		}
-
 		/**
 		 * Check whether we have allocated this slot.
 		 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -600,7 +600,7 @@ public class SlotPoolImpl implements SlotPool {
 			final SlotRequestId requestIdOfAllocatedSlot = pendingRequests.getKeyAByKeyB(allocationIdOfSlot);
 			if (requestIdOfAllocatedSlot != null) {
 				final PendingRequest requestOfAllocatedSlot = pendingRequests.getValueByKeyA(requestIdOfAllocatedSlot);
-				requestOfAllocatedSlot.setAllocationId(allocationIdOfRequest);
+				checkNotNull(requestOfAllocatedSlot).setAllocationId(allocationIdOfRequest);
 
 				// this re-insertion of initiatedRequestId will not affect its original insertion order
 				pendingRequests.put(requestIdOfAllocatedSlot, allocationIdOfRequest, requestOfAllocatedSlot);
@@ -1084,6 +1084,7 @@ public class SlotPoolImpl implements SlotPool {
 		 * @param allocationID The allocation id
 		 * @return The allocated slot, null if we can't find a match
 		 */
+		@Nullable
 		AllocatedSlot get(final AllocationID allocationID) {
 			return allocatedSlotsById.getValueByKeyA(allocationID);
 		}


### PR DESCRIPTION
## What is the purpose of the change

Add `Nullable` annotation to `DualKeyLinkedMap` and fixes call sites.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
