### PR TITLE
[FLINK-18407][runtime] Harden SlotPoolImpl#maybeRemapOrphanedAllocation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -614,7 +614,9 @@ public class SlotPoolImpl implements SlotPool {
 				// request id of the allocated slot can be null if the slot is returned by scheduler.
 				// the orphaned allocation will not be adopted in this case, which means it is not needed
 				// anymore by any pending requests. we should cancel it to avoid allocating unnecessary slots.
-				resourceManagerGateway.cancelSlotRequest(allocationIdOfRequest);
+				if (resourceManagerGateway != null) {
+					resourceManagerGateway.cancelSlotRequest(allocationIdOfRequest);
+				}
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -601,13 +601,15 @@ public class SlotPoolImpl implements SlotPool {
 		// if the request of that allocated slot is still pending, it should take over the orphaned allocation.
 		// this enables the request to fail fast if the remapped allocation fails.
 		if (!allocationIdOfRequest.equals(allocationIdOfSlot)) {
-			final SlotRequestId requestIdOfAllocatedSlot = pendingRequests.getKeyAByKeyB(allocationIdOfSlot);
-			if (requestIdOfAllocatedSlot != null) {
-				final PendingRequest requestOfAllocatedSlot = pendingRequests.getValueByKeyA(requestIdOfAllocatedSlot);
-				checkNotNull(requestOfAllocatedSlot).setAllocationId(allocationIdOfRequest);
+			final PendingRequest requestOfAllocatedSlot = pendingRequests.getValueByKeyB(allocationIdOfSlot);
+			if (requestOfAllocatedSlot != null) {
+				requestOfAllocatedSlot.setAllocationId(allocationIdOfRequest);
 
-				// this re-insertion of initiatedRequestId will not affect its original insertion order
-				pendingRequests.put(requestIdOfAllocatedSlot, allocationIdOfRequest, requestOfAllocatedSlot);
+				// this re-insertion of request will not affect its original insertion order
+				pendingRequests.put(
+					requestOfAllocatedSlot.getSlotRequestId(),
+					allocationIdOfRequest,
+					requestOfAllocatedSlot);
 			} else {
 				// request id of the allocated slot can be null if the slot is returned by scheduler.
 				// the orphaned allocation will not be adopted in this case, which means it is not needed


### PR DESCRIPTION
## What is the purpose of the change

Invokes resourceManagerGateway#cancelSlotRequest() only if resourceManagerGateway is not null.

## Brief change log

See commits.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
