### PR TITLE
[FLINK-15416][task][network] Retry connection to the upstream

### DIFF
--- a/docs/_includes/generated/all_taskmanager_network_section.html
+++ b/docs/_includes/generated/all_taskmanager_network_section.html
@@ -57,6 +57,12 @@
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.retries</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -75,6 +75,12 @@
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.retries</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -248,6 +248,14 @@ public class NettyShuffleEnvironmentOptions {
 			.withDescription("The Netty client connection timeout.");
 
 	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+	public static final ConfigOption<Integer> NETWORK_RETRIES =
+		key("taskmanager.network.retries")
+			.defaultValue(0)
+			.withDeprecatedKeys("taskmanager.network.retries")
+			.withDescription("The number of retry attempts for network communication." +
+				" Currently it's only used for establishing input/output channel connections");
+
+	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
 	public static final ConfigOption<Integer> SEND_RECEIVE_BUFFER_SIZE =
 		key("taskmanager.network.netty.sendReceiveBufferSize")
 			.defaultValue(0) // default: 0 => Netty's default

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -116,6 +116,10 @@ public class NettyConfig {
 		return config.getInteger(NettyShuffleEnvironmentOptions.CLIENT_CONNECT_TIMEOUT_SECONDS);
 	}
 
+	public int getNetworkRetries() {
+		return config.getInteger(NettyShuffleEnvironmentOptions.NETWORK_RETRIES);
+	}
+
 	public int getSendAndReceiveBufferSize() {
 		return config.getInteger(NettyShuffleEnvironmentOptions.SEND_RECEIVE_BUFFER_SIZE);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -49,7 +49,7 @@ public class NettyConnectionManager implements ConnectionManager {
 		this.client = new NettyClient(nettyConfig);
 		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
 
-		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client);
+		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client, nettyConfig.getNetworkRetries());
 
 		this.nettyProtocol = new NettyProtocol(checkNotNull(partitionProvider), checkNotNull(taskEventPublisher));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
@@ -21,17 +21,21 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.NetworkClientHandler;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
-import org.apache.flink.runtime.io.network.netty.exception.LocalTransportException;
 import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFutureListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Factory for {@link NettyPartitionRequestClient} instances.
@@ -40,13 +44,21 @@ import java.util.concurrent.ConcurrentMap;
  * instances.
  */
 class PartitionRequestClientFactory {
+	private static final Logger LOG = LoggerFactory.getLogger(PartitionRequestClientFactory.class);
 
 	private final NettyClient nettyClient;
 
-	private final ConcurrentMap<ConnectionID, Object> clients = new ConcurrentHashMap<ConnectionID, Object>();
+	private final int retryNumber;
+
+	private final ConcurrentMap<ConnectionID, CompletableFuture<NettyPartitionRequestClient>> clients = new ConcurrentHashMap<>();
 
 	PartitionRequestClientFactory(NettyClient nettyClient) {
+		this(nettyClient, 0);
+	}
+
+	PartitionRequestClientFactory(NettyClient nettyClient, int retryNumber) {
 		this.nettyClient = nettyClient;
+		this.retryNumber = retryNumber;
 	}
 
 	/**
@@ -54,69 +66,70 @@ class PartitionRequestClientFactory {
 	 * creates a {@link NettyPartitionRequestClient} instance for this connection.
 	 */
 	NettyPartitionRequestClient createPartitionRequestClient(ConnectionID connectionId) throws IOException, InterruptedException {
-		Object entry;
-		NettyPartitionRequestClient client = null;
-
-		while (client == null) {
-			entry = clients.get(connectionId);
-
-			if (entry != null) {
-				// Existing channel or connecting channel
-				if (entry instanceof NettyPartitionRequestClient) {
-					client = (NettyPartitionRequestClient) entry;
-				}
-				else {
-					ConnectingChannel future = (ConnectingChannel) entry;
-					client = future.waitForChannel();
-
-					clients.replace(connectionId, future, client);
-				}
-			}
-			else {
-				// No channel yet. Create one, but watch out for a race.
-				// We create a "connecting future" and atomically add it to the map.
-				// Only the thread that really added it establishes the channel.
-				// The others need to wait on that original establisher's future.
-				ConnectingChannel connectingChannel = new ConnectingChannel(connectionId, this);
-				Object old = clients.putIfAbsent(connectionId, connectingChannel);
-
-				if (old == null) {
-					nettyClient.connect(connectionId.getAddress()).addListener(connectingChannel);
-
-					client = connectingChannel.waitForChannel();
-
-					clients.replace(connectionId, connectingChannel, client);
-				}
-				else if (old instanceof ConnectingChannel) {
-					client = ((ConnectingChannel) old).waitForChannel();
-
-					clients.replace(connectionId, old, client);
-				}
-				else {
-					client = (NettyPartitionRequestClient) old;
-				}
+		while (true) {
+			AtomicBoolean isTheFirstOne = new AtomicBoolean(false);
+			CompletableFuture<NettyPartitionRequestClient> clientFuture = clients.computeIfAbsent(connectionId, unused -> {
+				isTheFirstOne.set(true);
+				return new CompletableFuture<>();
+			});
+			if (isTheFirstOne.get()) {
+				clientFuture.complete(connectWithRetries(connectionId));
 			}
 
+			final NettyPartitionRequestClient client;
+			try {
+				client = clientFuture.get();
+			} catch (ExecutionException e) {
+				throw new IOException(e);
+			}
 			// Make sure to increment the reference count before handing a client
 			// out to ensure correct bookkeeping for channel closing.
-			if (!client.incrementReferenceCounter()) {
+			if (client.incrementReferenceCounter()) {
+				return client;
+			} else {
 				destroyPartitionRequestClient(connectionId, client);
-				client = null;
 			}
 		}
-
-		return client;
 	}
 
-	public void closeOpenChannelConnections(ConnectionID connectionId) {
-		Object entry = clients.get(connectionId);
-
-		if (entry instanceof ConnectingChannel) {
-			ConnectingChannel channel = (ConnectingChannel) entry;
-
-			if (channel.dispose()) {
-				clients.remove(connectionId, channel);
+	private NettyPartitionRequestClient connectWithRetries(ConnectionID connectionId) {
+		int tried = 0;
+		while (true) {
+			try {
+				return connect(connectionId);
+			} catch (RemoteTransportException e) {
+				tried++;
+				LOG.error("Failed {} times to connect to {}", tried, connectionId.getAddress(), e);
+				if (tried > retryNumber) {
+					throw new CompletionException(e);
+				}
 			}
+		}
+	}
+
+	private NettyPartitionRequestClient connect(ConnectionID connectionId) throws RemoteTransportException {
+		try {
+			Channel channel = nettyClient.connect(connectionId.getAddress()).await().channel();
+			NetworkClientHandler clientHandler = channel.pipeline().get(NetworkClientHandler.class);
+			return new NettyPartitionRequestClient(channel, clientHandler, connectionId, this);
+		} catch (Exception e) {
+			throw new RemoteTransportException(
+				"Connecting to remote task manager '" + connectionId.getAddress() +
+					"' has failed. This might indicate that the remote task " +
+					"manager has been lost.",
+				connectionId.getAddress(), e);
+		}
+	}
+
+	void closeOpenChannelConnections(ConnectionID connectionId) {
+		CompletableFuture<NettyPartitionRequestClient> entry = clients.get(connectionId);
+
+		if (entry != null && !entry.isDone()) {
+			entry.thenAccept(client -> {
+				if (client.disposeIfNotUsed()) {
+					clients.remove(connectionId, entry);
+				}
+			});
 		}
 	}
 
@@ -128,104 +141,14 @@ class PartitionRequestClientFactory {
 	 * Removes the client for the given {@link ConnectionID}.
 	 */
 	void destroyPartitionRequestClient(ConnectionID connectionId, PartitionRequestClient client) {
-		clients.remove(connectionId, client);
+		final CompletableFuture<NettyPartitionRequestClient> future = clients.get(connectionId);
+		if (future != null && future.isDone()) {
+			future.thenAccept(futureClient -> {
+				if (client.equals(futureClient)) {
+					clients.remove(connectionId, future);
+				}
+			});
+		}
 	}
 
-	private static final class ConnectingChannel implements ChannelFutureListener {
-
-		private final Object connectLock = new Object();
-
-		private final ConnectionID connectionId;
-
-		private final PartitionRequestClientFactory clientFactory;
-
-		private boolean disposeRequestClient = false;
-
-		public ConnectingChannel(ConnectionID connectionId, PartitionRequestClientFactory clientFactory) {
-			this.connectionId = connectionId;
-			this.clientFactory = clientFactory;
-		}
-
-		private boolean dispose() {
-			boolean result;
-			synchronized (connectLock) {
-				if (partitionRequestClient != null) {
-					result = partitionRequestClient.disposeIfNotUsed();
-				}
-				else {
-					disposeRequestClient = true;
-					result = true;
-				}
-
-				connectLock.notifyAll();
-			}
-
-			return result;
-		}
-
-		private void handInChannel(Channel channel) {
-			synchronized (connectLock) {
-				try {
-					NetworkClientHandler clientHandler = channel.pipeline().get(NetworkClientHandler.class);
-					partitionRequestClient = new NettyPartitionRequestClient(
-						channel, clientHandler, connectionId, clientFactory);
-
-					if (disposeRequestClient) {
-						partitionRequestClient.disposeIfNotUsed();
-					}
-
-					connectLock.notifyAll();
-				}
-				catch (Throwable t) {
-					notifyOfError(t);
-				}
-			}
-		}
-
-		private volatile NettyPartitionRequestClient partitionRequestClient;
-
-		private volatile Throwable error;
-
-		private NettyPartitionRequestClient waitForChannel() throws IOException, InterruptedException {
-			synchronized (connectLock) {
-				while (error == null && partitionRequestClient == null) {
-					connectLock.wait(2000);
-				}
-			}
-
-			if (error != null) {
-				throw new IOException("Connecting the channel failed: " + error.getMessage(), error);
-			}
-
-			return partitionRequestClient;
-		}
-
-		private void notifyOfError(Throwable error) {
-			synchronized (connectLock) {
-				this.error = error;
-				connectLock.notifyAll();
-			}
-		}
-
-		@Override
-		public void operationComplete(ChannelFuture future) throws Exception {
-			if (future.isSuccess()) {
-				handInChannel(future.channel());
-			}
-			else if (future.cause() != null) {
-				notifyOfError(new RemoteTransportException(
-						"Connecting to remote task manager + '" + connectionId.getAddress() +
-								"' has failed. This might indicate that the remote task " +
-								"manager has been lost.",
-						connectionId.getAddress(), future.cause()));
-			}
-			else {
-				notifyOfError(new LocalTransportException(
-					String.format(
-						"Connecting to remote task manager '%s' has been cancelled.",
-						connectionId.getAddress()),
-					null));
-			}
-		}
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.flink.util.NetUtils;
 
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;


### PR DESCRIPTION
## What is the purpose of the change

This PR implements retries for connection to the upstream.

It contains changes from #11541 and fixes the issue of blocking the whole `ConcurrentHashMap` by computing the value in `Future`.
It further simplifies the code and fixes some minor issues.

**Merging**
I think the three first commits should be squashed together.

## Brief change log

Original PR:
1. Add task manager netty client retry mechenism
2. use computeIfAbsent for exclusively building a new channel

Fix:
3. Don't block the whole NettyPartitionRequestClientFactory while connecting

Optional changes:
4. Remove NettyPartitionRequestClientFactory.ConnectingChannel
5. Simplify loop in NettyPartitionRequestClientFactory.createPartitionRequestClient
6. Fix logging NettyPartitionRequestClientFactory
7. Remove ignored test

## Verifying this change
Added unit tests in `PartitionRequestClientFactoryTest`: `testNettyClientConnectRetry`, `testNettyClientConnectRetryMultipleThread`, `testNettyClientConnectRetryFailure`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
