### PR TITLE
[FLINK-17327] Fix Kafka Producer Resource Leaks (backport to Flink 1.10)

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -84,6 +84,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -671,7 +672,8 @@ public class FlinkKafkaProducer011<IN>
 						break;
 					case AT_LEAST_ONCE:
 					case NONE:
-						currentTransaction.producer.close();
+						currentTransaction.producer.flush();
+						currentTransaction.producer.close(0, TimeUnit.SECONDS);
 						break;
 				}
 			}
@@ -955,7 +957,8 @@ public class FlinkKafkaProducer011<IN>
 
 	private void recycleTransactionalProducer(FlinkKafkaProducer<byte[], byte[]> producer) {
 		availableTransactionalIds.add(producer.getTransactionalId());
-		producer.close();
+		producer.flush();
+		producer.close(0, TimeUnit.SECONDS);
 	}
 
 	private FlinkKafkaProducer<byte[], byte[]> initTransactionalProducer(String transactionalId, boolean registerMetrics) {

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -36,7 +36,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<kafka.version>2.2.0</kafka.version>
+		<kafka.version>2.4.1</kafka.version>
 	</properties>
 
 	<dependencies>
@@ -68,7 +68,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Add Kafka 2.0.x as a dependency -->
+		<!-- Add Kafka 2.x as a dependency -->
 
 		<dependency>
 			<groupId>org.apache.kafka</groupId>

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -49,7 +49,6 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaDelegat
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.NetUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -72,6 +71,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -85,6 +85,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -841,7 +842,8 @@ public class FlinkKafkaProducer<IN>
 						break;
 					case AT_LEAST_ONCE:
 					case NONE:
-						currentTransaction.producer.close();
+						currentTransaction.producer.flush();
+						currentTransaction.producer.close(Duration.ofSeconds(0));
 						break;
 				}
 			}
@@ -852,12 +854,20 @@ public class FlinkKafkaProducer<IN>
 			// We may have to close producer of the current transaction in case some exception was thrown before
 			// the normal close routine finishes.
 			if (currentTransaction() != null) {
-				IOUtils.closeQuietly(currentTransaction().producer);
+				try {
+					currentTransaction().producer.close(Duration.ofSeconds(0));
+				} catch (Throwable t) {
+					LOG.warn("Error closing producer.", t);
+				}
 			}
 			// Make sure all the producers for pending transactions are closed.
-			pendingTransactions().forEach(transaction ->
-					IOUtils.closeQuietly(transaction.getValue().producer)
-			);
+			pendingTransactions().forEach(transaction -> {
+						try {
+							transaction.getValue().producer.close(Duration.ofSeconds(0));
+						} catch (Throwable t) {
+							LOG.warn("Error closing producer.", t);
+						}
+					});
 			// make sure we propagate pending errors
 			checkErroneous();
 		}
@@ -914,9 +924,10 @@ public class FlinkKafkaProducer<IN>
 	@Override
 	protected void recoverAndCommit(FlinkKafkaProducer.KafkaTransactionState transaction) {
 		if (transaction.isTransactional()) {
-			try (
-				FlinkKafkaInternalProducer<byte[], byte[]> producer =
-					initTransactionalProducer(transaction.transactionalId, false)) {
+			FlinkKafkaInternalProducer<byte[], byte[]> producer = null;
+			try {
+				producer =
+					initTransactionalProducer(transaction.transactionalId, false);
 				producer.resumeTransaction(transaction.producerId, transaction.epoch);
 				producer.commitTransaction();
 			} catch (InvalidTxnStateException | ProducerFencedException ex) {
@@ -925,6 +936,10 @@ public class FlinkKafkaProducer<IN>
 						"Presumably this transaction has been already committed before",
 					ex,
 					transaction);
+			} finally {
+				if (producer != null) {
+					producer.close(0, TimeUnit.SECONDS);
+				}
 			}
 		}
 	}
@@ -940,10 +955,15 @@ public class FlinkKafkaProducer<IN>
 	@Override
 	protected void recoverAndAbort(FlinkKafkaProducer.KafkaTransactionState transaction) {
 		if (transaction.isTransactional()) {
-			try (
-				FlinkKafkaInternalProducer<byte[], byte[]> producer =
-					initTransactionalProducer(transaction.transactionalId, false)) {
+			FlinkKafkaInternalProducer<byte[], byte[]> producer = null;
+			try {
+				producer =
+						initTransactionalProducer(transaction.transactionalId, false);
 				producer.initTransactions();
+			} finally {
+				if (producer != null) {
+					producer.close(0, TimeUnit.SECONDS);
+				}
 			}
 		}
 	}
@@ -1110,10 +1130,16 @@ public class FlinkKafkaProducer<IN>
 				final Properties myConfig = new Properties();
 				myConfig.putAll(producerConfig);
 				initTransactionalProducerConfig(myConfig, transactionalId);
-				try (FlinkKafkaInternalProducer<byte[], byte[]> kafkaProducer =
-						new FlinkKafkaInternalProducer<>(myConfig)) {
+				FlinkKafkaInternalProducer<byte[], byte[]> kafkaProducer = null;
+				try {
+					kafkaProducer =
+							new FlinkKafkaInternalProducer<>(myConfig);
 					// it suffices to call initTransactions - this will abort any lingering transactions
 					kafkaProducer.initTransactions();
+				} finally {
+					if (kafkaProducer != null) {
+						kafkaProducer.close(Duration.ofSeconds(0));
+					}
 				}
 			}
 		});
@@ -1146,7 +1172,8 @@ public class FlinkKafkaProducer<IN>
 
 	private void recycleTransactionalProducer(FlinkKafkaInternalProducer<byte[], byte[]> producer) {
 		availableTransactionalIds.add(producer.getTransactionalId());
-		producer.close();
+		producer.flush();
+		producer.close(Duration.ofSeconds(0));
 	}
 
 	private FlinkKafkaInternalProducer<byte[], byte[]> initTransactionalProducer(String transactionalId, boolean registerMetrics) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.shaded.guava18.com.google.common.base.Joiner;
+
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -145,25 +147,34 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 
 	@Override
 	public void close() {
-		closed = true;
-		synchronized (producerClosingLock) {
-			kafkaProducer.close();
-		}
+		throw new UnsupportedOperationException("Close without timeout is now allowed because it can leave lingering Kafka threads.");
 	}
 
 	@Override
 	public void close(long timeout, TimeUnit unit) {
-		closed = true;
 		synchronized (producerClosingLock) {
 			kafkaProducer.close(timeout, unit);
+			if (LOG.isDebugEnabled()) {
+				LOG.debug(
+						"Closed internal KafkaProducer {}. Stacktrace: {}",
+						System.identityHashCode(this),
+						Joiner.on("\n").join(Thread.currentThread().getStackTrace()));
+			}
+			closed = true;
 		}
 	}
 
 	@Override
 	public void close(Duration duration) {
-		closed = true;
 		synchronized (producerClosingLock) {
 			kafkaProducer.close(duration);
+			if (LOG.isDebugEnabled()) {
+				LOG.debug(
+						"Closed internal KafkaProducer {}. Stacktrace: {}",
+						System.identityHashCode(this),
+						Joiner.on("\n").join(Thread.currentThread().getStackTrace()));
+			}
+			closed = true;
 		}
 	}
 
@@ -248,7 +259,7 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 
 	private void ensureNotClosed() {
 		if (closed) {
-			throw new IllegalStateException("The producer has already been closed");
+			throw new IllegalStateException(String.format("The producer %s has already been closed", System.identityHashCode(this)));
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
@@ -266,6 +266,13 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 		result.await();
 	}
 
+	/**
+	 * Enqueues new transactions at the transaction manager and returns a {@link
+	 * TransactionalRequestResult} that allows waiting on them.
+	 *
+	 * <p>If there are no new transactions we return a {@link TransactionalRequestResult} that is
+	 * already done.
+	 */
 	private TransactionalRequestResult enqueueNewPartitions() {
 		Object transactionManager = getField(kafkaProducer, "transactionManager");
 		synchronized (transactionManager) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaInternalProducer.java
@@ -198,18 +198,18 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 				producerId,
 				epoch);
 
-			Object transactionManager = getValue(kafkaProducer, "transactionManager");
+			Object transactionManager = getField(kafkaProducer, "transactionManager");
 			synchronized (transactionManager) {
-				Object nextSequence = getValue(transactionManager, "nextSequence");
+				Object nextSequence = getField(transactionManager, "nextSequence");
 
 				invoke(transactionManager,
 					"transitionTo",
 					getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.INITIALIZING"));
 				invoke(nextSequence, "clear");
 
-				Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
-				setValue(producerIdAndEpoch, "producerId", producerId);
-				setValue(producerIdAndEpoch, "epoch", epoch);
+				Object producerIdAndEpoch = getField(transactionManager, "producerIdAndEpoch");
+				setField(producerIdAndEpoch, "producerId", producerId);
+				setField(producerIdAndEpoch, "epoch", epoch);
 
 				invoke(transactionManager,
 					"transitionTo",
@@ -218,7 +218,7 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 				invoke(transactionManager,
 					"transitionTo",
 					getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.IN_TRANSACTION"));
-				setValue(transactionManager, "transactionStarted", true);
+				setField(transactionManager, "transactionStarted", true);
 			}
 		}
 	}
@@ -228,20 +228,20 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 	}
 
 	public long getProducerId() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
-		Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
-		return (long) getValue(producerIdAndEpoch, "producerId");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
+		Object producerIdAndEpoch = getField(transactionManager, "producerIdAndEpoch");
+		return (long) getField(producerIdAndEpoch, "producerId");
 	}
 
 	public short getEpoch() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
-		Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
-		return (short) getValue(producerIdAndEpoch, "epoch");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
+		Object producerIdAndEpoch = getField(transactionManager, "producerIdAndEpoch");
+		return (short) getField(producerIdAndEpoch, "epoch");
 	}
 
 	@VisibleForTesting
 	public int getTransactionCoordinatorId() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
 		Node node = (Node) invoke(transactionManager, "coordinator", FindCoordinatorRequest.CoordinatorType.TRANSACTION);
 		return node.id();
 	}
@@ -261,21 +261,21 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 	private void flushNewPartitions() {
 		LOG.info("Flushing new partitions");
 		TransactionalRequestResult result = enqueueNewPartitions();
-		Object sender = getValue(kafkaProducer, "sender");
+		Object sender = getField(kafkaProducer, "sender");
 		invoke(sender, "wakeup");
 		result.await();
 	}
 
 	private TransactionalRequestResult enqueueNewPartitions() {
-		Object transactionManager = getValue(kafkaProducer, "transactionManager");
+		Object transactionManager = getField(kafkaProducer, "transactionManager");
 		synchronized (transactionManager) {
-			Object newPartitionsInTransaction = getValue(transactionManager, "newPartitionsInTransaction");
+			Object newPartitionsInTransaction = getField(transactionManager, "newPartitionsInTransaction");
 			Object newPartitionsInTransactionIsEmpty = invoke(newPartitionsInTransaction, "isEmpty");
 			TransactionalRequestResult result;
 			if (newPartitionsInTransactionIsEmpty instanceof Boolean && !((Boolean) newPartitionsInTransactionIsEmpty)) {
 				Object txnRequestHandler = invoke(transactionManager, "addPartitionsToTransactionHandler");
 				invoke(transactionManager, "enqueueRequest", new Class[]{txnRequestHandler.getClass().getSuperclass()}, new Object[]{txnRequestHandler});
-				result = (TransactionalRequestResult) getValue(txnRequestHandler, txnRequestHandler.getClass().getSuperclass(), "result");
+				result = (TransactionalRequestResult) getField(txnRequestHandler, txnRequestHandler.getClass().getSuperclass(), "result");
 			} else {
 				result = new TransactionalRequestResult();
 				result.done();
@@ -317,11 +317,19 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 		}
 	}
 
-	protected static Object getValue(Object object, String fieldName) {
-		return getValue(object, object.getClass(), fieldName);
+	/**
+	 * Gets and returns the field {@code fieldName} from the given Object {@code object} using
+	 * reflection.
+	 */
+	protected static Object getField(Object object, String fieldName) {
+		return getField(object, object.getClass(), fieldName);
 	}
 
-	private static Object getValue(Object object, Class<?> clazz, String fieldName) {
+	/**
+	 * Gets and returns the field {@code fieldName} from the given Object {@code object} using
+	 * reflection.
+	 */
+	private static Object getField(Object object, Class<?> clazz, String fieldName) {
 		try {
 			Field field = clazz.getDeclaredField(fieldName);
 			field.setAccessible(true);
@@ -331,7 +339,11 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
 		}
 	}
 
-	protected static void setValue(Object object, String fieldName, Object value) {
+	/**
+	 * Sets the field {@code fieldName} on the given Object {@code object} to {@code value} using
+	 * reflection.
+	 */
+	protected static void setField(Object object, String fieldName, Object value) {
 		try {
 			Field field = object.getClass().getDeclaredField(fieldName);
 			field.setAccessible(true);

--- a/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:2.2.0
+- org.apache.kafka:kafka-clients:2.4.1

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -23,7 +23,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
 - org.javassist:javassist:3.24.0-GA
-- org.lz4:lz4-java:1.5.0
+- org.lz4:lz4-java:1.6.0
 - org.objenesis:objenesis:2.1
 - org.xerial.snappy:snappy-java:1.1.4
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
@@ -51,6 +51,18 @@ public interface KafkaResource extends ExternalResource {
 	void sendMessages(String topic, String ... messages) throws IOException;
 
 	/**
+	 * Sends the given keyed messages to the given topic. The messages themselves should contain
+	 * the specified {@code keySeparator}.
+	 *
+	 * @param topic topic name
+	 * @param keySeparator the separator used to parse key from value in the messages
+	 * @param messages messages to send
+	 * @throws IOException
+	 */
+	void sendKeyedMessages(
+			String topic, String keySeparator, String ... messages) throws IOException;
+
+	/**
 	 * Returns the kafka bootstrap server addresses.
 	 * @return kafka bootstrap server addresses
 	 */

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaResource.java
@@ -63,15 +63,16 @@ public interface KafkaResource extends ExternalResource {
 	InetSocketAddress getZookeeperAddress();
 
 	/**
-	 * Reads up to {@code maxNumMessages} from the given topic.
+	 * Reads {@code expectedNumMessages} from the given topic. If we can't read the expected number
+	 * of messages we throw an exception.
 	 *
-	 * @param maxNumMessages maximum number of messages that should be read
+	 * @param expectedNumMessages expected number of messages that should be read
 	 * @param groupId group id to identify consumer
 	 * @param topic topic name
 	 * @return read messages
 	 * @throws IOException
 	 */
-	List<String> readMessage(int maxNumMessages, String groupId, String topic) throws IOException;
+	List<String> readMessage(int expectedNumMessages, String groupId, String topic) throws IOException;
 
 	/**
 	 * Modifies the number of partitions for the given topic.

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
@@ -278,7 +278,7 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 			.setStdoutProcessor(messages::add)
 			.runNonBlocking()) {
 
-			final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(30));
+			final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(120));
 			while (deadline.hasTimeLeft() && messages.size() < expectedNumMessages) {
 				try {
 					LOG.info("Waiting for messages. Received {}/{}.", messages.size(),

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
@@ -139,9 +139,18 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 			kafkaDir.resolve(Paths.get("config", "server.properties")).toString()
 		);
 
-		while (!isZookeeperRunning(kafkaDir) || !isKafkaRunning(kafkaDir)) {
+		while (!isZookeeperRunning(kafkaDir)) {
 			try {
-				LOG.info("Waiting for kafka & zookeeper to start.");
+				LOG.info("Waiting for ZooKeeper to start.");
+				Thread.sleep(500L);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				break;
+			}
+		}
+		while (!isKafkaRunning(kafkaDir)) {
+			try {
+				LOG.info("Waiting for Kafka to start.");
 				Thread.sleep(500L);
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -199,7 +208,9 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 	private static boolean isKafkaRunning(final Path kafkaDir) throws IOException {
 		try {
 			final AtomicBoolean atomicBrokerStarted = new AtomicBoolean(false);
-			queryBrokerStatus(kafkaDir, line -> atomicBrokerStarted.compareAndSet(false, !line.contains("Node does not exist")));
+			queryBrokerStatus(kafkaDir, line -> {
+				atomicBrokerStarted.compareAndSet(false, line.contains("\"port\":"));
+			});
 			return atomicBrokerStarted.get();
 		} catch (final IOException ioe) {
 			// we get an exception if zookeeper isn't running
@@ -214,7 +225,7 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 				ZOOKEEPER_ADDRESS,
 				"get",
 				"/brokers/ids/0")
-			.setStderrProcessor(stderrProcessor)
+			.setStdoutProcessor(stderrProcessor)
 			.runBlocking();
 	}
 
@@ -312,7 +323,7 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 
 	@Override
 	public int getNumPartitions(String topic) throws IOException {
-		final Pattern partitionCountPattern = Pattern.compile(".*PartitionCount:([0-9]+).*");
+		final Pattern partitionCountPattern = Pattern.compile(".*PartitionCount:\\s*([0-9]+).*");
 		final AtomicReference<Integer> partitionCountFound = new AtomicReference<>(-1);
 		AutoClosableProcess
 			.create(kafkaDir.resolve(Paths.get("bin", "kafka-topics.sh")).toString(),

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -64,6 +65,8 @@ public class StreamingKafkaITCase extends TestLogger {
 
 	private final Path kafkaExampleJar;
 
+	private final String kafkaVersion;
+
 	@Rule
 	public final KafkaResource kafka;
 
@@ -73,6 +76,7 @@ public class StreamingKafkaITCase extends TestLogger {
 	public StreamingKafkaITCase(final String kafkaExampleJarPattern, final String kafkaVersion) {
 		this.kafkaExampleJar = TestUtils.getResourceJar(kafkaExampleJarPattern);
 		this.kafka = KafkaResource.get(kafkaVersion);
+		this.kafkaVersion = kafkaVersion;
 	}
 
 	@Test
@@ -84,8 +88,8 @@ public class StreamingKafkaITCase extends TestLogger {
 
 		try (final ClusterController clusterController = flink.startCluster(1)) {
 
-			final String inputTopic = "test-input";
-			final String outputTopic = "test-output";
+			final String inputTopic = "test-input-" + kafkaVersion + "-" + UUID.randomUUID().toString();
+			final String outputTopic = "test-output" + kafkaVersion + "-" + UUID.randomUUID().toString();
 
 			// create the required topics
 			kafka.createTopic(1, 1, inputTopic);

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -111,13 +111,13 @@ public class StreamingKafkaITCase extends TestLogger {
 
 			LOG.info("Sending messages to Kafka topic [{}] ...", inputTopic);
 			// send some data to Kafka
-			kafka.sendMessages(inputTopic,
-				"elephant,5,45218",
-				"squirrel,12,46213",
-				"bee,3,51348",
-				"squirrel,22,52444",
-				"bee,10,53412",
-				"elephant,9,54867");
+			kafka.sendKeyedMessages(inputTopic, "\t",
+				"key\telephant,5,45218",
+				"key\tsquirrel,12,46213",
+				"key\tbee,3,51348",
+				"key\tsquirrel,22,52444",
+				"key\tbee,10,53412",
+				"key\telephant,9,54867");
 
 			LOG.info("Verifying messages from Kafka topic [{}] ...", outputTopic);
 			{
@@ -140,11 +140,11 @@ public class StreamingKafkaITCase extends TestLogger {
 
 			// send some more messages to Kafka
 			LOG.info("Sending more messages to Kafka topic [{}] ...", inputTopic);
-			kafka.sendMessages(inputTopic,
-				"elephant,13,64213",
-				"giraffe,9,65555",
-				"bee,5,65647",
-				"squirrel,18,66413");
+			kafka.sendKeyedMessages(inputTopic, "\t",
+				"key\telephant,13,64213",
+				"key\tgiraffe,9,65555",
+				"key\tbee,5,65647",
+				"key\tsquirrel,18,66413");
 
 			// verify that our assumption that the new partition actually has written messages is correct
 			Assert.assertNotEquals(

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -58,7 +58,7 @@ public class StreamingKafkaITCase extends TestLogger {
 		return Arrays.asList(new Object[][]{
 			{"flink-streaming-kafka010-test.*", "0.10.2.0"},
 			{"flink-streaming-kafka011-test.*", "0.11.0.2"},
-			{"flink-streaming-kafka-test.*", "2.2.0"}
+			{"flink-streaming-kafka-test.*", "2.4.1"}
 		});
 	}
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -338,6 +338,7 @@ function check_logs_for_errors {
       | grep -v "Error while loading kafka-version.properties :null" \
       | grep -v "Failed Elasticsearch item request" \
       | grep -v "[Terror] modules" \
+      | grep -v "Error sending fetch request" \
       | grep -ic "error" || true)
   if [[ ${error_count} -gt 0 ]]; then
     echo "Found error in log files:"

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -258,7 +258,7 @@ under the License.
 		<dependency>
 			<groupId>org.lz4</groupId>
 			<artifactId>lz4-java</artifactId>
-			<version>1.5.0</version>
+			<version>1.6.0</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
This is a backport of #12589 for Flink 1.10.x. Porting was simple, there were (almost) no incompatibilities in the code. The big question is whether to do a version bump from Kafka 2.2.x to 2.4.1 in a Flink 1.10.x release. I do think that this is a very critical bug to fix, though.

The review and PR form for #12589 should hold for this PR.