### PR TITLE
[FLINK-18413][streaming] CollectResultIterator should throw exception if user does not enable checkpointing in streaming mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
@@ -49,14 +49,14 @@ public final class DataStreamUtils {
 			stream.getExecutionEnvironment().getConfig());
 		String accumulatorName = "dataStreamCollect_" + UUID.randomUUID().toString();
 
+		StreamExecutionEnvironment env = stream.getExecutionEnvironment();
+
 		CollectSinkOperatorFactory<OUT> factory = new CollectSinkOperatorFactory<>(serializer, accumulatorName);
 		CollectSinkOperator<OUT> operator = (CollectSinkOperator<OUT>) factory.getOperator();
 		CollectResultIterator<OUT> iterator = new CollectResultIterator<>(
-			operator.getOperatorIdFuture(), serializer, accumulatorName);
+			true, env.getCheckpointConfig(), operator.getOperatorIdFuture(), serializer, accumulatorName);
 		CollectStreamSink<OUT> sink = new CollectStreamSink<>(stream, factory);
 		sink.name("Data stream collect sink");
-
-		StreamExecutionEnvironment env = stream.getExecutionEnvironment();
 		env.addOperator(sink.getTransformation());
 
 		try {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/BatchSelectTableSink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/BatchSelectTableSink.java
@@ -32,7 +32,7 @@ import org.apache.flink.types.Row;
 public class BatchSelectTableSink extends SelectTableSinkBase implements StreamTableSink<Row> {
 
 	public BatchSelectTableSink(TableSchema tableSchema) {
-		super(tableSchema);
+		super(tableSchema, false);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.collect.CollectResultIterator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory;
@@ -33,6 +34,7 @@ import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
 
@@ -42,22 +44,14 @@ import java.util.UUID;
 public class SelectTableSinkBase implements SelectTableSink {
 
 	private final TableSchema tableSchema;
-	private final CollectSinkOperatorFactory<Row> factory;
-	private final CollectResultIterator<Row> iterator;
+	private final boolean isStreamingMode;
 
-	@SuppressWarnings("unchecked")
-	public SelectTableSinkBase(TableSchema tableSchema) {
+	private CollectResultIterator<Row> iterator;
+
+	public SelectTableSinkBase(TableSchema tableSchema, boolean isStreamingMode) {
 		this.tableSchema = SelectTableSinkSchemaConverter.convertTimeAttributeToRegularTimestamp(
 			SelectTableSinkSchemaConverter.changeDefaultConversionClass(tableSchema));
-
-		TypeSerializer<Row> typeSerializer = (TypeSerializer<Row>) TypeInfoDataTypeConverter
-			.fromDataTypeToTypeInfo(this.tableSchema.toRowDataType())
-			.createSerializer(new ExecutionConfig());
-		String accumulatorName = "tableResultCollect_" + UUID.randomUUID();
-
-		this.factory = new CollectSinkOperatorFactory<>(typeSerializer, accumulatorName);
-		CollectSinkOperator<Row> operator = (CollectSinkOperator<Row>) factory.getOperator();
-		this.iterator = new CollectResultIterator<>(operator.getOperatorIdFuture(), typeSerializer, accumulatorName);
+		this.isStreamingMode = isStreamingMode;
 	}
 
 	@Override
@@ -70,19 +64,41 @@ public class SelectTableSinkBase implements SelectTableSink {
 		return tableSchema;
 	}
 
+	@SuppressWarnings("unchecked")
 	protected DataStreamSink<?> consumeDataStream(DataStream<Row> dataStream) {
+		TypeSerializer<Row> typeSerializer = (TypeSerializer<Row>) TypeInfoDataTypeConverter
+			.fromDataTypeToTypeInfo(this.tableSchema.toRowDataType())
+			.createSerializer(new ExecutionConfig());
+		String accumulatorName = "tableResultCollect_" + UUID.randomUUID();
+
+		CollectSinkOperatorFactory<Row> factory = new CollectSinkOperatorFactory<>(typeSerializer, accumulatorName);
+		CollectSinkOperator<Row> operator = (CollectSinkOperator<Row>) factory.getOperator();
+		StreamExecutionEnvironment env = dataStream.getExecutionEnvironment();
+		iterator = new CollectResultIterator<>(
+			isStreamingMode,
+			env.getCheckpointConfig(),
+			operator.getOperatorIdFuture(),
+			typeSerializer,
+			accumulatorName);
+
 		CollectStreamSink<Row> sink = new CollectStreamSink<>(dataStream, factory);
-		dataStream.getExecutionEnvironment().addOperator(sink.getTransformation());
+		env.addOperator(sink.getTransformation());
 		return sink.name("Select table sink");
 	}
 
 	@Override
 	public void setJobClient(JobClient jobClient) {
+		checkIteratorCreated();
 		iterator.setJobClient(jobClient);
 	}
 
 	@Override
 	public CloseableIterator<Row> getResultIterator() {
+		checkIteratorCreated();
 		return iterator;
+	}
+
+	private void checkIteratorCreated() {
+		Preconditions.checkNotNull(iterator, "CollectResultIterator must be created before configuration or use");
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/StreamSelectTableSink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/StreamSelectTableSink.java
@@ -35,7 +35,7 @@ import org.apache.flink.types.Row;
 public class StreamSelectTableSink extends SelectTableSinkBase implements AppendStreamTableSink<Row> {
 
 	public StreamSelectTableSink(TableSchema tableSchema) {
-		super(tableSchema);
+		super(tableSchema, true);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -75,25 +75,22 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     tableEnvName match {
       case "TableEnvironment" =>
         tEnv = TableEnvironmentImpl.create(settings)
-        if (isStreaming) {
-          tEnv.getConfig.getConfiguration.set(
-            ExecutionCheckpointingOptions.CHECKPOINTING_MODE,
-            CheckpointingMode.EXACTLY_ONCE)
-          tEnv.getConfig.getConfiguration.set(
-            ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL,
-            Duration.ofMillis(CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME)
-          )
-        }
       case "StreamTableEnvironment" =>
-        val execEnv = StreamExecutionEnvironment.getExecutionEnvironment
-        tEnv = StreamTableEnvironment.create(execEnv, settings)
-        if (isStreaming) {
-          execEnv.enableCheckpointing(
-            CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME,
-            CheckpointingMode.EXACTLY_ONCE)
-        }
+        tEnv = StreamTableEnvironment.create(
+          StreamExecutionEnvironment.getExecutionEnvironment, settings)
       case _ => throw new UnsupportedOperationException("unsupported tableEnvName: " + tableEnvName)
     }
+
+    if (isStreaming) {
+      tEnv.getConfig.getConfiguration.set(
+        ExecutionCheckpointingOptions.CHECKPOINTING_MODE,
+        CheckpointingMode.EXACTLY_ONCE)
+      tEnv.getConfig.getConfiguration.set(
+        ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL,
+        Duration.ofMillis(CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME)
+      )
+    }
+
     TestTableSourceSinks.createPersonCsvTemporaryTable(tEnv, "MyTable")
   }
 


### PR DESCRIPTION
## What is the purpose of the change

Currently CollectResultIterator will only output results after a checkpoint in streaming mode. It will be strange for users who does not enable checkpointing to stuck forever when using the iterator without further notice.

As 1.11 is about to release, we shall at least throw an exception notifying the user to enable checkpointing. We'll support iterators with at least once semantics or exactly once semantics without fault tolerance in the future.

## Brief change log

 - CollectResultIterator now throws exception if user does not enable checkpointing in streaming mode

## Verifying this change

This change is already covered by existing tests, such as `TableEnvironmentITCase`.
This change can also be verified by newly added tests in `TableEnvironmentTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable