### PR TITLE
[FLINK-18416][table-common] Deprecate TableEnvironment#connect API

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -189,7 +189,7 @@ class TableEnvironment(object):
         :param table_source: The table source to register.
         :type table_source: pyflink.table.TableSource
 
-        .. note:: Deprecated in 1.10. Use :func:`connect` instead.
+        .. note:: Deprecated in 1.10. Use :func:`execute_sql` instead.
         """
         warnings.warn("Deprecated in 1.10. Use connect instead.", DeprecationWarning)
         self._j_tenv.registerTableSourceInternal(name, table_source._j_table_source)
@@ -214,7 +214,7 @@ class TableEnvironment(object):
         :param table_sink: The table sink to register.
         :type table_sink: pyflink.table.TableSink
 
-        .. note:: Deprecated in 1.10. Use :func:`connect` instead.
+        .. note:: Deprecated in 1.10. Use :func:`execute_sql` instead.
         """
         warnings.warn("Deprecated in 1.10. Use connect instead.", DeprecationWarning)
         self._j_tenv.registerTableSinkInternal(name, table_sink._j_table_sink)
@@ -798,6 +798,8 @@ class TableEnvironment(object):
         :return: A :class:`~pyflink.table.descriptors.ConnectTableDescriptor` used to build the
                  temporary table.
         :rtype: pyflink.table.descriptors.ConnectTableDescriptor
+
+        .. note:: Deprecated in 1.11. Use :func:`execute_sql` to register a table instead.
         """
         pass
 
@@ -1397,7 +1399,10 @@ class StreamTableEnvironment(TableEnvironment):
         :return: A :class:`~pyflink.table.descriptors.StreamTableDescriptor` used to build the
                  temporary table.
         :rtype: pyflink.table.descriptors.StreamTableDescriptor
+
+        .. note:: Deprecated in 1.11. Use :func:`execute_sql` to register a table instead.
         """
+        warnings.warn("Deprecated in 1.11. Use execute_sql instead.", DeprecationWarning)
         return StreamTableDescriptor(
             self._j_tenv.connect(connector_descriptor._j_connector_descriptor))
 
@@ -1531,7 +1536,10 @@ class BatchTableEnvironment(TableEnvironment):
                  to build the temporary table.
         :rtype: pyflink.table.descriptors.BatchTableDescriptor or
                 pyflink.table.descriptors.StreamTableDescriptor
+
+        .. note:: Deprecated in 1.11. Use :func:`execute_sql` to register a table instead.
         """
+        warnings.warn("Deprecated in 1.11. Use execute_sql instead.", DeprecationWarning)
         gateway = get_gateway()
         blink_t_env_class = get_java_class(
             gateway.jvm.org.apache.flink.table.api.internal.TableEnvironmentImpl)

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/BatchTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/BatchTableEnvironment.java
@@ -442,8 +442,9 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * </pre>
 	 *
 	 * @param connectorDescriptor connector descriptor describing the external system
-	 * @deprecated this method might be refactored or dropped in the next versions,
-	 * please use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
+	 * @deprecated The SQL {@code CREATE TABLE} DDL is richer than this part of the API. This method
+	 * might be refactored in the next versions. Please use {@link #executeSql(String) executeSql(ddl)}
+	 * to register a table instead.
 	 */
 	@Override
 	@Deprecated

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/BatchTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/BatchTableEnvironment.java
@@ -442,8 +442,11 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * </pre>
 	 *
 	 * @param connectorDescriptor connector descriptor describing the external system
+	 * @deprecated this method might be refactored or dropped in the next versions,
+	 * please use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
 	 */
 	@Override
+	@Deprecated
 	BatchTableDescriptor connect(ConnectorDescriptor connectorDescriptor);
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -636,8 +636,11 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * </pre>
 	 *
 	 * @param connectorDescriptor connector descriptor describing the external system
+	 * @deprecated this method might be refactored or dropped in the next versions,
+	 * please use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
 	 */
 	@Override
+	@Deprecated
 	StreamTableDescriptor connect(ConnectorDescriptor connectorDescriptor);
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -636,8 +636,9 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * </pre>
 	 *
 	 * @param connectorDescriptor connector descriptor describing the external system
-	 * @deprecated this method might be refactored or dropped in the next versions,
-	 * please use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
+	 * @deprecated The SQL {@code CREATE TABLE} DDL is richer than this part of the API. This method
+	 * might be refactored in the next versions. Please use {@link #executeSql(String) executeSql(ddl)}
+	 * to register a table instead.
 	 */
 	@Override
 	@Deprecated

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -729,8 +729,9 @@ public interface TableEnvironment {
 	 *</pre>
 	 *
 	 * @param connectorDescriptor connector descriptor describing the external system
-	 * @deprecated this method might be refactored or dropped in the next versions,
-	 * please use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
+	 * @deprecated The SQL {@code CREATE TABLE} DDL is richer than this part of the API. This method
+	 * might be refactored in the next versions. Please use {@link #executeSql(String) executeSql(ddl)}
+	 * to register a table instead.
 	 */
 	@Deprecated
 	ConnectTableDescriptor connect(ConnectorDescriptor connectorDescriptor);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -556,7 +556,7 @@ public interface TableEnvironment {
 	 *
 	 * @param name        The name under which the {@link TableSource} is registered.
 	 * @param tableSource The {@link TableSource} to register.
-	 * @deprecated Use {@link #connect(ConnectorDescriptor)} instead.
+	 * @deprecated Use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
 	 */
 	@Deprecated
 	void registerTableSource(String name, TableSource<?> tableSource);
@@ -574,7 +574,7 @@ public interface TableEnvironment {
 	 * @param fieldNames The field names to register with the {@link TableSink}.
 	 * @param fieldTypes The field types to register with the {@link TableSink}.
 	 * @param tableSink The {@link TableSink} to register.
-	 * @deprecated Use {@link #connect(ConnectorDescriptor)} instead.
+	 * @deprecated Use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
 	 */
 	@Deprecated
 	void registerTableSink(String name, String[] fieldNames, TypeInformation<?>[] fieldTypes, TableSink<?> tableSink);
@@ -590,7 +590,7 @@ public interface TableEnvironment {
 	 *
 	 * @param name The name under which the {@link TableSink} is registered.
 	 * @param configuredSink The configured {@link TableSink} to register.
-	 * @deprecated Use {@link #connect(ConnectorDescriptor)} instead.
+	 * @deprecated Use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
 	 */
 	@Deprecated
 	void registerTableSink(String name, TableSink<?> configuredSink);
@@ -729,7 +729,10 @@ public interface TableEnvironment {
 	 *</pre>
 	 *
 	 * @param connectorDescriptor connector descriptor describing the external system
+	 * @deprecated this method might be refactored or dropped in the next versions,
+	 * please use {@link #executeSql(String) executeSql(ddl)} to register a table instead.
 	 */
+	@Deprecated
 	ConnectTableDescriptor connect(ConnectorDescriptor connectorDescriptor);
 
 	/**

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
@@ -303,34 +303,37 @@ trait BatchTableEnvironment extends TableEnvironment {
   override def execute(jobName: String): JobExecutionResult
 
   /**
-    * Creates a temporary table from a descriptor.
-    *
-    * Descriptors allow for declaring the communication to external systems in an
-    * implementation-agnostic way. The classpath is scanned for suitable table factories that match
-    * the desired configuration.
-    *
-    * The following example shows how to read from a connector using a JSON format and
-    * registering a temporary table as "MyTable":
-    *
-    * {{{
-    *
-    * tableEnv
-    *   .connect(
-    *     new ExternalSystemXYZ()
-    *       .version("0.11"))
-    *   .withFormat(
-    *     new Json()
-    *       .jsonSchema("{...}")
-    *       .failOnMissingField(false))
-    *   .withSchema(
-    *     new Schema()
-    *       .field("user-name", "VARCHAR").from("u_name")
-    *       .field("count", "DECIMAL")
-    *   .createTemporaryTable("MyTable")
-    * }}}
-    *
-    * @param connectorDescriptor connector descriptor describing the external system
-    */
+   * Creates a temporary table from a descriptor.
+   *
+   * Descriptors allow for declaring the communication to external systems in an
+   * implementation-agnostic way. The classpath is scanned for suitable table factories that match
+   * the desired configuration.
+   *
+   * The following example shows how to read from a connector using a JSON format and
+   * registering a temporary table as "MyTable":
+   *
+   * {{{
+   *
+   * tableEnv
+   *   .connect(
+   *     new ExternalSystemXYZ()
+   *       .version("0.11"))
+   *   .withFormat(
+   *     new Json()
+   *       .jsonSchema("{...}")
+   *       .failOnMissingField(false))
+   *   .withSchema(
+   *     new Schema()
+   *       .field("user-name", "VARCHAR").from("u_name")
+   *       .field("count", "DECIMAL")
+   *   .createTemporaryTable("MyTable")
+   * }}}
+   *
+   * @param connectorDescriptor connector descriptor describing the external system
+   * @deprecated this method might be refactored or dropped in the next versions,
+   *             please use [[executeSql]] to register a table instead.
+   */
+  @deprecated
   override def connect(connectorDescriptor: ConnectorDescriptor): BatchTableDescriptor
 }
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
@@ -330,8 +330,9 @@ trait BatchTableEnvironment extends TableEnvironment {
    * }}}
    *
    * @param connectorDescriptor connector descriptor describing the external system
-   * @deprecated The SQL `CREATE TABLE` DDL is richer than this part of the API. This method might be
-   *             refactored in the next versions. Please use [[executeSql]] to register a table instead.
+   * @deprecated The SQL `CREATE TABLE` DDL is richer than this part of the API.
+   *             This method might be refactored in the next versions.
+   *             Please use [[executeSql]] to register a table instead.
    */
   @deprecated
   override def connect(connectorDescriptor: ConnectorDescriptor): BatchTableDescriptor

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
@@ -330,8 +330,8 @@ trait BatchTableEnvironment extends TableEnvironment {
    * }}}
    *
    * @param connectorDescriptor connector descriptor describing the external system
-   * @deprecated this method might be refactored or dropped in the next versions,
-   *             please use [[executeSql]] to register a table instead.
+   * @deprecated The SQL `CREATE TABLE` DDL is richer than this part of the API. This method might be
+   *             refactored in the next versions. Please use [[executeSql]] to register a table instead.
    */
   @deprecated
   override def connect(connectorDescriptor: ConnectorDescriptor): BatchTableDescriptor

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -391,8 +391,9 @@ trait StreamTableEnvironment extends TableEnvironment {
    * }}}
    *
    * @param connectorDescriptor connector descriptor describing the external system
-   * @deprecated The SQL `CREATE TABLE` DDL is richer than this part of the API. This method might be
-   *             refactored in the next versions. Please use [[executeSql]] to register a table instead.
+   * @deprecated The SQL `CREATE TABLE` DDL is richer than this part of the API.
+   *             This method might be refactored in the next versions.
+   *             Please use [[executeSql]] to register a table instead.
    */
   @deprecated
   override def connect(connectorDescriptor: ConnectorDescriptor): StreamTableDescriptor

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -359,39 +359,42 @@ trait StreamTableEnvironment extends TableEnvironment {
   override def execute(jobName: String): JobExecutionResult
 
   /**
-    * Creates a table source and/or table sink from a descriptor.
-    *
-    * Descriptors allow for declaring the communication to external systems in an
-    * implementation-agnostic way. The classpath is scanned for suitable table factories that match
-    * the desired configuration.
-    *
-    * The following example shows how to read from a Kafka connector using a JSON format and
-    * registering a table source "MyTable" in append mode:
-    *
-    * {{{
-    *
-    * tableEnv
-    *   .connect(
-    *     new Kafka()
-    *       .version("0.11")
-    *       .topic("clicks")
-    *       .property("group.id", "click-group")
-    *       .startFromEarliest())
-    *   .withFormat(
-    *     new Json()
-    *       .jsonSchema("{...}")
-    *       .failOnMissingField(false))
-    *   .withSchema(
-    *     new Schema()
-    *       .field("user-name", "VARCHAR").from("u_name")
-    *       .field("count", "DECIMAL")
-    *       .field("proc-time", "TIMESTAMP").proctime())
-    *   .inAppendMode()
-    *   .createTemporaryTable("MyTable")
-    * }}}
-    *
-    * @param connectorDescriptor connector descriptor describing the external system
-    */
+   * Creates a table source and/or table sink from a descriptor.
+   *
+   * Descriptors allow for declaring the communication to external systems in an
+   * implementation-agnostic way. The classpath is scanned for suitable table factories that match
+   * the desired configuration.
+   *
+   * The following example shows how to read from a Kafka connector using a JSON format and
+   * registering a table source "MyTable" in append mode:
+   *
+   * {{{
+   *
+   * tableEnv
+   *   .connect(
+   *     new Kafka()
+   *       .version("0.11")
+   *       .topic("clicks")
+   *       .property("group.id", "click-group")
+   *       .startFromEarliest())
+   *   .withFormat(
+   *     new Json()
+   *       .jsonSchema("{...}")
+   *       .failOnMissingField(false))
+   *   .withSchema(
+   *     new Schema()
+   *       .field("user-name", "VARCHAR").from("u_name")
+   *       .field("count", "DECIMAL")
+   *       .field("proc-time", "TIMESTAMP").proctime())
+   *   .inAppendMode()
+   *   .createTemporaryTable("MyTable")
+   * }}}
+   *
+   * @param connectorDescriptor connector descriptor describing the external system
+   * @deprecated this method might be refactored or dropped in the next versions,
+   *             please use [[executeSql]] to register a table instead.
+   */
+  @deprecated
   override def connect(connectorDescriptor: ConnectorDescriptor): StreamTableDescriptor
 }
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -391,8 +391,8 @@ trait StreamTableEnvironment extends TableEnvironment {
    * }}}
    *
    * @param connectorDescriptor connector descriptor describing the external system
-   * @deprecated this method might be refactored or dropped in the next versions,
-   *             please use [[executeSql]] to register a table instead.
+   * @deprecated The SQL `CREATE TABLE` DDL is richer than this part of the API. This method might be
+   *             refactored in the next versions. Please use [[executeSql]] to register a table instead.
    */
   @deprecated
   override def connect(connectorDescriptor: ConnectorDescriptor): StreamTableDescriptor


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the past releases, the community focused on the new SQL DDL features and the `TableEnvironment#connect API` is not maintained for a long time. We have seen many (bug) issues around this APIs.

The `TableEnvironment#connect()` API might receive some refactoring in the next release. So we should deprecate the connect API in 1.11 and recommend users to use `executeSql(ddl)` instead. Thus, we can remove/refactor the existing `connect()` API in the next release even though it is API breaking.

## Brief change log

- deprecate all the existing `connect()` API and add deprecate Javadoc.


## Verifying this change

N/A.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)