### PR TITLE
[FLINK-18420][tests] Disable failed test SQLClientHBaseITCase in java 11

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.tests.util.flink.FlinkResource;
 import org.apache.flink.tests.util.flink.FlinkResourceSetup;
 import org.apache.flink.tests.util.flink.LocalStandaloneFlinkResourceFactory;
 import org.apache.flink.tests.util.flink.SQLJobSubmission;
+import org.apache.flink.testutils.junit.FailsOnJava11;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -61,7 +62,7 @@ import static org.junit.Assert.assertThat;
 /**
  * End-to-end test for the HBase connectors.
  */
-@Category(value = {TravisGroup1.class, PreCommit.class})
+@Category(value = {TravisGroup1.class, PreCommit.class, FailsOnJava11.class})
 public class SQLClientHBaseITCase extends TestLogger {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SQLClientHBaseITCase.class);


### PR DESCRIPTION
## What is the purpose of the change

* This pull request disable SQLClientHBaseITCase in java 11. We only support HBase 1.4.3 which is not supported JDK11, skip the java 11 test for  e2e test.


## Brief change log

  - update file SQLClientHBaseITCase.java


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
