### PR TITLE
[FLINK-18425][table] Convert object arrays to primitive arrays in GenericArrayData

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
@@ -244,39 +244,82 @@ public final class GenericArrayData implements ArrayData {
 	// Conversion Utilities
 	// ------------------------------------------------------------------------------------------
 
+	private boolean anyNull() {
+		for (Object element : (Object[]) array) {
+			if (element == null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void checkNoNull() {
+		if (anyNull()) {
+			throw new RuntimeException("Primitive array must not contain a null value.");
+		}
+	}
+
 	@Override
 	public boolean[] toBooleanArray() {
-		return (boolean[]) array;
+		if (isPrimitiveArray) {
+			return (boolean[]) array;
+		}
+		checkNoNull();
+		return ArrayUtils.toPrimitive((Boolean[]) array);
 	}
 
 	@Override
 	public byte[] toByteArray() {
-		return (byte[]) array;
+		if (isPrimitiveArray) {
+			return (byte[]) array;
+		}
+		checkNoNull();
+		return ArrayUtils.toPrimitive((Byte[]) array);
 	}
 
 	@Override
 	public short[] toShortArray() {
-		return (short[]) array;
+		if (isPrimitiveArray) {
+			return (short[]) array;
+		}
+		checkNoNull();
+		return ArrayUtils.toPrimitive((Short[]) array);
 	}
 
 	@Override
 	public int[] toIntArray() {
-		return (int[]) array;
+		if (isPrimitiveArray) {
+			return (int[]) array;
+		}
+		checkNoNull();
+		return ArrayUtils.toPrimitive((Integer[]) array);
 	}
 
 	@Override
 	public long[] toLongArray() {
-		return (long[]) array;
+		if (isPrimitiveArray) {
+			return (long[]) array;
+		}
+		checkNoNull();
+		return ArrayUtils.toPrimitive((Long[]) array);
 	}
 
 	@Override
 	public float[] toFloatArray() {
-		return (float[]) array;
+		if (isPrimitiveArray) {
+			return (float[]) array;
+		}
+		checkNoNull();
+		return ArrayUtils.toPrimitive((Float[]) array);
 	}
 
 	@Override
 	public double[] toDoubleArray() {
-		return (double[]) array;
+		if (isPrimitiveArray) {
+			return (double[]) array;
+		}
+		checkNoNull();
+		return ArrayUtils.toPrimitive((Double[]) array);
 	}
 }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
@@ -434,7 +434,7 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
 
 	private void checkNoNull() {
 		if (anyNull()) {
-			throw new RuntimeException("Array can not have null value!");
+			throw new RuntimeException("Primitive array must not contain a null value.");
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -198,9 +198,19 @@ public class DataStructureConvertersTest {
 				.convertedTo(Long.class, 123L),
 
 			TestSpec
-				.forDataType(ARRAY(BOOLEAN()))
+				.forDataType(ARRAY(BOOLEAN().notNull()))
 				.convertedTo(boolean[].class, new boolean[]{true, false, true, true})
 				.convertedTo(ArrayData.class, new GenericArrayData(new boolean[]{true, false, true, true})),
+
+			TestSpec
+				.forDataType(ARRAY(BOOLEAN()))
+				.convertedTo(Boolean[].class, new Boolean[]{true, null, true, true})
+				.convertedTo(ArrayData.class, new GenericArrayData(new Boolean[]{true, null, true, true})),
+
+			TestSpec
+				.forDataType(ARRAY(INT().notNull()))
+				.convertedTo(int[].class, new int[]{1, 2, 3, 4})
+				.convertedTo(Integer[].class, new Integer[]{1, 2, 3, 4}),
 
 			// arrays of TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DOUBLE are skipped for simplicity
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes GenericArrayData primitive array conversions.

## Brief change log

Fixes GenericArrayData primitive array conversions.

## Verifying this change

This change added tests and can be verified as follows: `DataStructureConvertersTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
