### PR TITLE
[FLINK-18429][DataStream API] Make CheckpointListener.notifyCheckpointAborted(checkpointId) a default method.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointListener.java
@@ -18,14 +18,14 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Public;
 
 /**
  * This interface must be implemented by functions/operations that want to receive
  * a commit notification once a checkpoint has been completely acknowledged by all
  * participants.
  */
-@PublicEvolving
+@Public
 public interface CheckpointListener {
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointListener.java
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.runtime.state;
 
+package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 
@@ -30,12 +30,13 @@ public interface CheckpointListener {
 
 	/**
 	 * This method is called as a notification once a distributed checkpoint has been completed.
-	 * 
-	 * Note that any exception during this method will not cause the checkpoint to
+	 *
+	 * <p>Note that any exception during this method will not cause the checkpoint to
 	 * fail any more.
-	 * 
+	 *
 	 * @param checkpointId The ID of the checkpoint that has been completed.
-	 * @throws Exception
+	 * @throws Exception This method can propagate exceptions, which leads to a failure/recovery for
+	 *                   the task. Not that this will NOT lead to the checkpoint being revoked.
 	 */
 	void notifyCheckpointComplete(long checkpointId) throws Exception;
 
@@ -43,7 +44,8 @@ public interface CheckpointListener {
 	 * This method is called as a notification once a distributed checkpoint has been aborted.
 	 *
 	 * @param checkpointId The ID of the checkpoint that has been aborted.
-	 * @throws Exception
+	 * @throws Exception This method can propagate exceptions, which leads to a failure/recovery for
+	 *                   the task.
 	 */
-	default void notifyCheckpointAborted(long checkpointId) throws Exception {};
+	default void notifyCheckpointAborted(long checkpointId) throws Exception {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointListener.java
@@ -45,5 +45,5 @@ public interface CheckpointListener {
 	 * @param checkpointId The ID of the checkpoint that has been aborted.
 	 * @throws Exception
 	 */
-	void notifyCheckpointAborted(long checkpointId) throws Exception;
+	default void notifyCheckpointAborted(long checkpointId) throws Exception {};
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.api.checkpoint;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.api.common.state.OperatorStateStore;
@@ -140,7 +140,7 @@ import org.apache.flink.runtime.state.FunctionSnapshotContext;
  * @see ListCheckpointed
  * @see RuntimeContext
  */
-@PublicEvolving
+@Public
 public interface CheckpointedFunction {
 
 	/**


### PR DESCRIPTION
## Purpose / Brief change log

This PR prevents breaking existing user programs by making the newly added method `CheckpointListener.notifyCheckpointAborted(checkpointId)` a default method.

In addition, this PR upgrades the stability of `CheckpointListener` and `CheckpointedFunction` to `@Public` to reflect that we should not break them and make sure this is caught by our tooling.

## Original Confusion about (Not) Having a Default Method

*(Copying the description from the JIRA issue here)*

There was confusion about this originally, going back to a comment by myself suggesting this should not be a default method, incorrectly thinking of it as an internal interface: https://github.com/apache/flink/pull/8693#issuecomment-542834147

See clarification email on the mailing list:

```
About the "notifyCheckpointAborted()":

When I wrote that comment, I was (apparently wrongly) assuming we were talking about
an internal interface here, because the "abort" signal was originally only intended to cancel
the async part of state backend checkpoints.

I just realized that this is exposed to users - and I am actually with Thomas on this one. 
he "CheckpointListener" is a very public interface that many users implement. The fact that
it is tagged "@PublicEvolving" is somehow not aligned with reality. So adding the method
here will in reality break lots and lots of user programs.

I think also in practice it is much less relevant for user applications to react to aborted checkpoints.
Since the notifications there can not be relied upon (if there is a task failure concurrently) users
 always have to follow the "newer checkpoint subsumes older checkpoint" contract, so the abort
method is probably rarely relevant.
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
