### PR TITLE
[FLINK-17804][parquet] Follow Parquet spec when decoding DECIMAL

### DIFF
--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -185,6 +185,7 @@ under the License.
 							<goal>schema</goal>
 						</goals>
 						<configuration>
+							<enableDecimalLogicalType>true</enableDecimalLogicalType>
 							<testSourceDirectory>${project.basedir}/src/test/resources/avro</testSourceDirectory>
 							<testOutputDirectory>${project.basedir}/src/test/java/</testOutputDirectory>
 						</configuration>

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
@@ -78,9 +78,9 @@ public class ParquetRowDataWriterTest {
 			new FloatType(),
 			new DoubleType(),
 			new TimestampType(9),
-			new DecimalType(5, 0),
-			new DecimalType(15, 0),
-			new DecimalType(20, 0));
+			new DecimalType(9, 4),
+			new DecimalType(18, 4),
+			new DecimalType(30, 10));
 
 	@SuppressWarnings("unchecked")
 	private static final DataFormatConverters.DataFormatConverter<RowData, Row> CONVERTER =
@@ -121,9 +121,9 @@ public class ParquetRowDataWriterTest {
 					v.floatValue(),
 					v.doubleValue(),
 					toDateTime(v),
-					BigDecimal.valueOf(v),
-					BigDecimal.valueOf(v),
-					BigDecimal.valueOf(v)));
+					new BigDecimal("12345.6789").add(BigDecimal.valueOf(v)),
+					new BigDecimal("12345678901234.5678").add(BigDecimal.valueOf(v)),
+					new BigDecimal("12345678901234567890.1234567890").add(BigDecimal.valueOf(v))));
 		}
 
 		ParquetWriterFactory<RowData> factory = ParquetRowDataBuilder.createWriterFactory(

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetWriterUtil.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetWriterUtil.java
@@ -76,10 +76,18 @@ public class ParquetWriterUtil {
 						consumer.startField("f" + i, i);
 						switch (type.getPrimitiveTypeName()) {
 							case INT64:
-								consumer.addLong(((Number) field).longValue());
+								if (field instanceof BigDecimal) {
+									consumer.addLong(((BigDecimal) field).unscaledValue().longValueExact());
+								} else {
+									consumer.addLong(((Number) field).longValue());
+								}
 								break;
 							case INT32:
-								consumer.addInteger(((Number) field).intValue());
+								if (field instanceof BigDecimal) {
+									consumer.addInteger(((BigDecimal) field).unscaledValue().intValueExact());
+								} else {
+									consumer.addInteger(((Number) field).intValue());
+								}
 								break;
 							case BOOLEAN:
 								consumer.addBoolean((Boolean) field);

--- a/flink-formats/flink-parquet/src/test/resources/avro/decimal.avsc
+++ b/flink-formats/flink-parquet/src/test/resources/avro/decimal.avsc
@@ -1,0 +1,37 @@
+{
+  "name": "DecimalRecord",
+  "namespace": "org.apache.flink.formats.parquet.generated",
+  "type": "record",
+  "fields": [
+    {
+      "default": null,
+      "name": "decAsBytes",
+      "type": [
+        "null",
+        {
+          "type": "bytes",
+          "logicalType": "decimal",
+          "precision": 20,
+          "scale": 10
+        }
+      ]
+    },
+    {
+      "default": null,
+      "name": "decAsFixed",
+      "type": [
+        "null",
+        {
+          "type": "fixed",
+          "name": "decimal",
+          "logicalType": "decimal",
+          "size": 30,
+          "precision": 20,
+          "scale": 10
+        }
+      ]
+    }
+  ],
+  "schema_id": 1,
+  "type": "record"
+}


### PR DESCRIPTION
## What is the purpose of the change

Current implementation of the Parquet reader decodes DECIMAL types incorrectly. It doesn't follow the spec and will either throw
`NumberFormatException` or read incorrect values even on Parquet files produced by Flink itself.

This PR updates the `ParquetSchemaConverter` and `RowConverter` to handle all 4 encoding styles specified by the
[spec](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal):
- `int32`
- `int64`
- `fixed_len_byte_array`
- `binary`

## Brief change log

- Parquet reader will decode DECIMAL type according to the spec

## Verifying this change

This change added tests and can be verified as follows:
- Added tests that validate DECIMAL decoding with all backing types specified by Parquet spec
- Manually verified the change by reading Parquet files generated by Spark

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
