### PR TITLE
[FLINK-18435][metrics] Add support for intercepting reflection-based instantiations

### DIFF
--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
@@ -135,7 +135,15 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 				FACTORY),
 			TestParams.from("Jar in 'plugins'",
 				builder -> {},
+				REFLECTION),
+			TestParams.from("Jar in 'plugins'",
+				builder -> {},
 				FACTORY),
+			TestParams.from("Jar in 'lib' and 'plugins'",
+				builder -> {
+					builder.copyJar(PROMETHEUS_JAR_PREFIX, JarLocation.PLUGINS, JarLocation.LIB);
+				},
+				REFLECTION),
 			TestParams.from("Jar in 'lib' and 'plugins'",
 				builder -> {
 					builder.copyJar(PROMETHEUS_JAR_PREFIX, JarLocation.PLUGINS, JarLocation.LIB);

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InstantiateViaFactory.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InstantiateViaFactory.java
@@ -28,6 +28,9 @@ import java.lang.annotation.Target;
  * backwards-compatibility with existing reflection-based configurations.
  *
  * <p>When an annotated reporter is configured to be used via reflection the given factory will be used instead.
+ *
+ * <p>Attention: This annotation does not work if the reporter is loaded as a plugin. For these cases, annotate the
+ * factory with {@link InterceptInstantiationViaReflection} instead.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InterceptInstantiationViaReflection.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InterceptInstantiationViaReflection.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.reporter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for {@link MetricReporterFactory MetricReporterFactories} that want to maintain
+ * backwards-compatibility with existing reflection-based configurations.
+ *
+ * <p>When a reporter is configured to be used via reflection the annotated factory will be used instead.
+ *
+ * @see InstantiateViaFactory
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface InterceptInstantiationViaReflection {
+	String reporterClassName();
+}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.datadog;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
@@ -26,6 +27,7 @@ import java.util.Properties;
 /**
  * {@link MetricReporterFactory} for {@link DatadogHttpReporter}.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.datadog.DatadogHttpReporter")
 public class DatadogHttpReporterFactory implements MetricReporterFactory {
 
 	@Override

--- a/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporterFactory.java
+++ b/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporterFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.graphite;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
@@ -26,6 +27,7 @@ import java.util.Properties;
 /**
  * {@link MetricReporterFactory} for {@link GraphiteReporter}.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.graphite.GraphiteReporter")
 public class GraphiteReporterFactory implements MetricReporterFactory {
 
 	@Override

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterFactory.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.influxdb;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
@@ -26,6 +27,7 @@ import java.util.Properties;
 /**
  * {@link MetricReporterFactory} for {@link InfluxdbReporter}.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.influxdb.InfluxdbReporter")
 public class InfluxdbReporterFactory implements MetricReporterFactory {
 
 	@Override

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporterFactory.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporterFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.metrics.jmx;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
@@ -24,6 +25,7 @@ import java.util.Properties;
 /**
  * {@link MetricReporterFactory} for {@link JMXReporter}.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.jmx.JMXReporter")
 public class JMXReporterFactory implements MetricReporterFactory {
 
 	static final String ARG_PORT = "port";

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.metrics.prometheus;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
@@ -24,6 +25,7 @@ import java.util.Properties;
 /**
  * {@link MetricReporterFactory} for {@link PrometheusPushGatewayReporter}.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter")
 public class PrometheusPushGatewayReporterFactory implements MetricReporterFactory {
 
 	@Override

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.metrics.prometheus;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
@@ -24,6 +25,7 @@ import java.util.Properties;
 /**
  * {@link MetricReporterFactory} for {@link PrometheusReporter}.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusReporter")
 public class PrometheusReporterFactory implements MetricReporterFactory {
 
 	@Override

--- a/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporterFactory.java
+++ b/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporterFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.metrics.slf4j;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
@@ -25,6 +26,7 @@ import java.util.Properties;
 /**
  * {@link MetricReporterFactory} for {@link Slf4jReporter}.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.slf4j.Slf4jReporter")
 public class Slf4jReporterFactory implements MetricReporterFactory {
 
 	@Override

--- a/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporterFactory.java
+++ b/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporterFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.statsd;
 
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
@@ -26,6 +27,7 @@ import java.util.Properties;
 /**
  * A {@link MetricReporterFactory} implementation that creates a {@link StatsDReporter} instance.
  */
+@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.statsd.StatsDReporter")
 public class StatsDReporterFactory implements MetricReporterFactory {
 
 	@Override


### PR DESCRIPTION
Adds support for reporter factories to declare that they should be used for instantiating a specific reporter class.

With this change we maintain backwards compatibility with previous configurations that configure the reporter class name.
The existing `InstantiateViaFactory` approach does not work for plugins (but only for reporters in lib/), since we do not have access to the reporter class during the loading process.