### PR TITLE
[FLINK-18262][python][e2e] Fix the unstable e2e tests of pyflink.

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -21,16 +21,16 @@ set -o pipefail
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_docker.sh
 
-FLINK_TARBALL_DIR=$TEST_DATA_DIR
-FLINK_TARBALL=flink.tar.gz
+FLINK_ZIP_DIR=$TEST_DATA_DIR
+FLINK_ZIP=flink.zip
 FLINK_DIRNAME=$(basename $FLINK_DIR)
 
 MAX_RETRY_SECONDS=120
 CLUSTER_SETUP_RETRIES=3
 IMAGE_BUILD_RETRIES=5
 
-echo "Flink Tarball directory $FLINK_TARBALL_DIR"
-echo "Flink tarball filename $FLINK_TARBALL"
+echo "Flink Zip directory $FLINK_ZIP_DIR"
+echo "Flink zip filename $FLINK_ZIP"
 echo "Flink distribution directory name $FLINK_DIRNAME"
 echo "End-to-end directory $END_TO_END_DIR"
 
@@ -42,7 +42,7 @@ function cluster_shutdown {
       debug_copy_and_show_logs
   fi
   docker-compose -f $END_TO_END_DIR/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml down
-  rm $FLINK_TARBALL_DIR/$FLINK_TARBALL
+  rm $FLINK_ZIP_DIR/$FLINK_ZIP
 }
 on_exit cluster_shutdown
 
@@ -110,13 +110,15 @@ function start_hadoop_cluster_and_prepare_flink() {
         exit 1
     fi
 
-    mkdir -p $FLINK_TARBALL_DIR
-    tar czf $FLINK_TARBALL_DIR/$FLINK_TARBALL -C $(dirname $FLINK_DIR) .
+    mkdir -p $FLINK_ZIP_DIR
+    current_dir=$(pwd)
+    cd $(dirname $FLINK_DIR) && zip -r $FLINK_ZIP_DIR/$FLINK_ZIP $(basename $FLINK_DIR)
+    cd $current_dir
 
-    docker cp $FLINK_TARBALL_DIR/$FLINK_TARBALL master:/home/hadoop-user/
+    docker cp $FLINK_ZIP_DIR/$FLINK_ZIP master:/home/hadoop-user/
 
     # now, at least the container is ready
-    docker exec master bash -c "tar xzf /home/hadoop-user/$FLINK_TARBALL --directory /home/hadoop-user/"
+    docker exec master bash -c "cd /home/hadoop-user/ && unzip $FLINK_ZIP"
 
     # minimal Flink config, bebe
     FLINK_CONFIG=$(cat << END


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the test hang problem of the pyflink e2e tests via replace the tar command with zip/unzip command in `common_yarn_docker.sh`.*

## Brief change log

  - *Replace the tar command with zip/unzip command in `common_yarn_docker.sh`.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
