### PR TITLE
[FLINK-18376][Table SQL/Runtime]Fix java.lang.ArrayIndexOutOfBoundsException in RetractableTopNFunction

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -406,9 +406,11 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 					curRank = rankOfLastRecord;
 				} else {
 					int index = Long.valueOf(rankEnd - curRank - 1).intValue();
-					List<RowData> inputs = dataState.get(key);
-					RowData toAdd = inputs.get(index);
-					collectInsert(out, toAdd);
+					if (index >= 0) {
+						List<RowData> inputs = dataState.get(key);
+						RowData toAdd = inputs.get(index);
+						collectInsert(out, toAdd);
+					}
 					break;
 				}
 			} else {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix java.lang.ArrayIndexOutOfBoundsException -1 bug in RetractableTopNFunction*.

For example, when use ROW_NUMBER() function, the sql like this :
create view results as select *, ROW_NUMBER() OVER (PARTITION BY name ORDER BY cnt DESC) as row_num from test;

I will output the data when row_num < 4. Now the user_id is "dema", the SortedMap is :
9 , 1
8, 2
7, 1
6,1
cnt is 7 , it has one record. when the cnt = 7 becomes retract, curRank is 3 . But now curRank(3) + count(1) is 4 , rankEnd - curRank - 1 is -1 , so ArrayIndexOutOfBoundsException:-1 will be thrown.



## Brief change log
Add a judement of index , when index >= 0 , send the record.
if index == -1 , It indicates the record of the current retract didn't effect the row num when curRank == rankEnd,
so it didn't need to send the record.


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
