### PR TITLE
[FLINK-18187] Backport PubSub e2e test instabilities fix to 1.11

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -34,3 +34,9 @@ ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUT
 DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
 USE OR PERFORMANCE OF THIS SOFTWARE.
+
+The Apache Flink project contains or reuses code that is licensed under the Apache 2.0 license from the following projects:
+- Google Cloud Client Library for Java (https://github.com/googleapis/google-cloud-java) Copyright 2017 Google LLC
+
+  See: flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
+

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -93,9 +93,9 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.4</version>
 				<configuration>
 					<skipTests>${skipTests}</skipTests>
+					<forkCount>1</forkCount> <!-- Enforce single test execution -->
 				</configuration>
 				<executions>
 					<execution>

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/CheckPubSubEmulatorTest.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/CheckPubSubEmulatorTest.java
@@ -50,10 +50,11 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 	private static final String TOPIC_NAME = "Topic";
 	private static final String SUBSCRIPTION_NAME = "Subscription";
 
-	private static PubsubHelper pubsubHelper = getPubsubHelper();
+	private static PubsubHelper pubsubHelper;
 
 	@BeforeClass
 	public static void setUp() throws Exception {
+		pubsubHelper = getPubsubHelper();
 		pubsubHelper.createTopic(PROJECT_NAME, TOPIC_NAME);
 		pubsubHelper.createSubscription(PROJECT_NAME, SUBSCRIPTION_NAME, PROJECT_NAME, TOPIC_NAME);
 	}
@@ -101,7 +102,7 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 
 		LOG.info("Waiting a while to receive the message...");
 
-		waitUntill(() -> receivedMessages.size() > 0);
+		waitUntil(() -> receivedMessages.size() > 0);
 
 		assertEquals(1, receivedMessages.size());
 		assertEquals("Hello World", receivedMessages.get(0).getData().toStringUtf8());
@@ -109,7 +110,7 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 		try {
 			subscriber.stopAsync().awaitTerminated(100, MILLISECONDS);
 		} catch (TimeoutException tme) {
-			// Yeah, whatever. Don't care about clean shutdown here.
+			LOG.info("Timeout during shutdown", tme);
 		}
 		publisher.shutdown();
 	}
@@ -117,14 +118,12 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 	/*
 	 * Returns when predicate returns true or if 10 seconds have passed
 	 */
-	private void waitUntill(Supplier<Boolean> predicate) {
+	private void waitUntil(Supplier<Boolean> predicate) throws InterruptedException {
 		int retries = 0;
 
 		while (!predicate.get() && retries < 100) {
 			retries++;
-			try {
-				Thread.sleep(10);
-			} catch (InterruptedException e) { }
+			Thread.sleep(10);
 		}
 	}
 

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/CheckPubSubEmulatorTest.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/CheckPubSubEmulatorTest.java
@@ -33,10 +33,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -76,6 +75,7 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 			.get();
 
 		List<ReceivedMessage> receivedMessages = pubsubHelper.pullMessages(PROJECT_NAME, SUBSCRIPTION_NAME, 1);
+
 		assertEquals(1, receivedMessages.size());
 		assertEquals("Hello World PULL", receivedMessages.get(0).getMessage().getData().toStringUtf8());
 
@@ -89,8 +89,12 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 			subscribeToSubscription(
 				PROJECT_NAME,
 				SUBSCRIPTION_NAME,
-				(message, consumer) -> receivedMessages.add(message)
+				(message, consumer) -> {
+					receivedMessages.add(message);
+					consumer.ack();
+				}
 			);
+		subscriber.awaitRunning(5, MINUTES);
 
 		Publisher publisher = pubsubHelper.createPublisher(PROJECT_NAME, TOPIC_NAME);
 		publisher
@@ -107,11 +111,9 @@ public class CheckPubSubEmulatorTest extends GCloudUnitTestBase {
 		assertEquals(1, receivedMessages.size());
 		assertEquals("Hello World", receivedMessages.get(0).getData().toStringUtf8());
 
-		try {
-			subscriber.stopAsync().awaitTerminated(100, MILLISECONDS);
-		} catch (TimeoutException tme) {
-			LOG.info("Timeout during shutdown", tme);
-		}
+		LOG.info("Received message. Shutting down ...");
+
+		subscriber.stopAsync().awaitTerminated(5, MINUTES);
 		publisher.shutdown();
 	}
 

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
@@ -27,6 +27,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.flink.streaming.connectors.gcp.pubsub.emulator.GCloudEmulatorManager.getDockerIpAddress;
@@ -44,6 +45,9 @@ public class GCloudUnitTestBase implements Serializable {
 
 	@AfterClass
 	public static void terminateGCloudEmulator() throws DockerException, InterruptedException {
+		channel.shutdownNow();
+		channel.awaitTermination(1, TimeUnit.MINUTES);
+		channel = null;
 		GCloudEmulatorManager.terminateDocker();
 	}
 

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
@@ -153,7 +153,10 @@ public class PubsubHelper {
 		}
 	}
 
+	//
 	// Mostly copied from the example on https://cloud.google.com/pubsub/docs/pull
+	// Licensed under the Apache 2.0 License to "Google LLC" from https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/src/main/java/com/google/cloud/examples/pubsub/snippets/SubscriberSnippets.java.
+	//
 	public List<ReceivedMessage> pullMessages(String projectId, String subscriptionId, int maxNumberOfMessages) throws Exception {
 		SubscriberStubSettings subscriberStubSettings =
 			SubscriberStubSettings.newBuilder()

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/resources/log4j2-test.properties
@@ -16,9 +16,8 @@
 # limitations under the License.
 ################################################################################
 
-# Set root logger level to OFF to not flood build logs
-# set manually to INFO for debugging purposes
-rootLogger.level = OFF
+# Set logging level to INFO: Tests are executed as a Bash e2e test.
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/flink-end-to-end-tests/test-scripts/test_streaming_gcp_pubsub.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_gcp_pubsub.sh
@@ -17,6 +17,8 @@
 # limitations under the License.
 ################################################################################
 
+# This test is a Java end to end test, but it requires Docker. Therefore, we run it from bash.
+
 cd "${END_TO_END_DIR}/flink-connector-gcp-pubsub-emulator-tests"
 
 run_mvn test -DskipTests=false


### PR DESCRIPTION
## What is the purpose of the change

The instabilities in the PubSub e2e have been fixed successfully as part of FLINK-16572 (but only for the master branch). This PR backports the respective commits to `release-1.11`.

