### PR TITLE
[hotfix][docs] Fix Python example in event_time doc

### DIFF
--- a/docs/dev/event_time.md
+++ b/docs/dev/event_time.md
@@ -77,11 +77,11 @@ stream
 {% highlight python %}
 env = StreamExecutionEnvironment.get_execution_environment()
 
-env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
+env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
 
 # alternatively:
 # env.set_stream_time_characteristic(TimeCharacteristic.IngestionTime)
-# env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+# env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/event_time.zh.md
+++ b/docs/dev/event_time.zh.md
@@ -67,11 +67,11 @@ stream
 {% highlight python %}
 env = StreamExecutionEnvironment.get_execution_environment()
 
-env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
+env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
 
 # alternatively:
 # env.set_stream_time_characteristic(TimeCharacteristic.IngestionTime)
-# env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+# env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
 {% endhighlight %}
 </div>
 </div>


### PR DESCRIPTION
## What is the purpose of the change

the Python example in event_time doc uses unexpected `ProcessingTime`

## Brief change log

* Fix documentation

## Verifying this change

Docs only change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no