### PR TITLE
[FLINK-18362][FLINK-13838][yarn] Add yarn.ship-archives to support LocalResourceType.ARCHIVE

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -135,6 +135,12 @@
             <td>When this is true Flink will ship the keytab file configured via security.kerberos.login.keytab as a localized YARN resource.</td>
         </tr>
         <tr>
+            <td><h5>yarn.ship-archives</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. They will be un-packed when localizing.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.ship-directories</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
@@ -100,7 +101,8 @@ public class UtilsTest extends TestLogger {
 			new Path(root.toURI()),
 			0,
 			System.currentTimeMillis(),
-			LocalResourceVisibility.APPLICATION).toString());
+			LocalResourceVisibility.APPLICATION,
+			LocalResourceType.FILE).toString());
 		env = Collections.unmodifiableMap(env);
 
 		File credentialFile = temporaryFolder.newFile("container_tokens");

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
+import org.apache.flink.yarn.testjob.YarnTestArchiveJob;
 import org.apache.flink.yarn.testjob.YarnTestCacheJob;
 import org.apache.flink.yarn.util.TestUtils;
 
@@ -39,7 +40,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,6 +65,9 @@ public class YARNITCase extends YarnTestBase {
 
 	private static final Duration yarnAppTerminateTimeout = Duration.ofSeconds(10);
 	private static final int sleepIntervalInMS = 100;
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@BeforeClass
 	public static void setup() {
@@ -101,8 +107,14 @@ public class YARNITCase extends YarnTestBase {
 
 		final Configuration flinkConfig = createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.DISABLED);
 		flinkConfig.set(YarnConfigOptions.PROVIDED_LIB_DIRS, Collections.singletonList(remoteLib.toString()));
-
 		runTest(() -> deployPerJob(flinkConfig, getTestingJobGraph(), false));
+	}
+
+	@Test
+	public void testPerJobWithArchive() throws Exception {
+		final Configuration flinkConfig = createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.DISABLED);
+		final JobGraph archiveJobGraph = YarnTestArchiveJob.getArchiveJobGraph(tmp.newFolder(), flinkConfig);
+		runTest(() -> deployPerJob(flinkConfig, archiveJobGraph, false));
 	}
 
 	private void deployPerJob(Configuration configuration, JobGraph jobGraph, boolean withDist) throws Exception {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -114,7 +114,7 @@ public class YARNITCase extends YarnTestBase {
 	public void testPerJobWithArchive() throws Exception {
 		final Configuration flinkConfig = createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.DISABLED);
 		final JobGraph archiveJobGraph = YarnTestArchiveJob.getArchiveJobGraph(tmp.newFolder(), flinkConfig);
-		runTest(() -> deployPerJob(flinkConfig, archiveJobGraph, false));
+		runTest(() -> deployPerJob(flinkConfig, archiveJobGraph, true));
 	}
 
 	private void deployPerJob(Configuration configuration, JobGraph jobGraph, boolean withDist) throws Exception {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/testjob/YarnTestArchiveJob.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/testjob/YarnTestArchiveJob.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.testjob;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Testing job for localizing resources of LocalResourceType.ARCHIVE in per job cluster mode.
+ */
+public class YarnTestArchiveJob {
+	private static final List<String> LIST = ImmutableList.of("test1", "test2");
+
+	private static final Map<String, String> srcFiles = new HashMap<String, String>() {{
+			put("local1.txt", "Local text Content1");
+			put("local2.txt", "Local text Content2");
+		}};
+
+	private static void archiveFilesInDirectory(File directory, String target) throws IOException {
+
+		for (Map.Entry<String, String> entry : srcFiles.entrySet()) {
+			Files.write(Paths.get(directory.getAbsolutePath() + File.separator + entry.getKey()),
+				entry.getValue().getBytes());
+		}
+
+		try (FileOutputStream fos = new FileOutputStream(target);
+				GzipCompressorOutputStream gos = new GzipCompressorOutputStream(new BufferedOutputStream(fos));
+				TarArchiveOutputStream taros = new TarArchiveOutputStream(gos)) {
+			taros.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+			for (File f : directory.listFiles()) {
+				taros.putArchiveEntry(new TarArchiveEntry(f,
+					directory.getName() + File.separator + f.getName()));
+				try (FileInputStream fis = new FileInputStream(f);
+						BufferedInputStream bis = new BufferedInputStream(fis)) {
+					IOUtils.copy(bis, taros);
+					taros.closeArchiveEntry();
+				}
+			}
+		}
+	}
+
+	public static JobGraph getArchiveJobGraph(File testDirectory, Configuration config) throws IOException {
+
+		final String archive = testDirectory.getAbsolutePath().concat(".tar.gz");
+		final String localizedPath = testDirectory.getName().concat(".tar.gz") + File.separator + testDirectory.getName();
+
+		archiveFilesInDirectory(testDirectory, archive);
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		env.addSource(new SourceFunctionWithArchive(LIST, localizedPath, TypeInformation.of(String.class)))
+			.setParallelism(1)
+			.addSink(new DiscardingSink<String>())
+			.setParallelism(1);
+		config.set(YarnConfigOptions.SHIP_ARCHIVES, Collections.singletonList(archive));
+
+		return env.getStreamGraph().getJobGraph();
+	}
+
+	private static class SourceFunctionWithArchive<T> extends RichSourceFunction<T> implements ResultTypeQueryable<T> {
+		private List<T> inputDataset;
+		private String resourcePath;
+		private TypeInformation returnType;
+
+		public void open(Configuration parameters) throws Exception {
+			for (Map.Entry<String, String> entry : srcFiles.entrySet()) {
+				String content = new String(Files.readAllBytes(Paths.get(resourcePath + File.separator + entry.getKey())));
+				checkArgument(entry.getValue().equals(content), "The content of the unpacked file should be identical to the original file's.");
+			}
+		}
+
+		SourceFunctionWithArchive(List<T> inputDataset, String resourcePath, TypeInformation returnType) {
+			this.inputDataset = inputDataset;
+			this.resourcePath = resourcePath;
+			this.returnType = returnType;
+		}
+
+		@Override
+		public void run(SourceContext<T> ctx) throws Exception {
+			for (T t : inputDataset) {
+				ctx.collect(t);
+			}
+		}
+
+		@Override
+		public void cancel() {}
+
+		@Override
+		public TypeInformation getProducedType() {
+			return this.returnType;
+		}
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -124,12 +124,13 @@ public final class Utils {
 			Path remoteRsrcPath,
 			long resourceSize,
 			long resourceModificationTime,
-			LocalResourceVisibility resourceVisibility) {
+			LocalResourceVisibility resourceVisibility,
+			LocalResourceType resourceType) {
 		LocalResource localResource = Records.newRecord(LocalResource.class);
 		localResource.setResource(ConverterUtils.getYarnUrlFromURI(remoteRsrcPath.toUri()));
 		localResource.setSize(resourceSize);
 		localResource.setTimestamp(resourceModificationTime);
-		localResource.setType(LocalResourceType.FILE);
+		localResource.setType(resourceType);
 		localResource.setVisibility(resourceVisibility);
 		return localResource;
 	}
@@ -140,13 +141,17 @@ public final class Utils {
 	 * @param remoteRsrcPath resource path to be registered
 	 * @return YARN resource
 	 */
-	private static LocalResource registerLocalResource(FileSystem fs, Path remoteRsrcPath) throws IOException {
+	private static LocalResource registerLocalResource(
+			FileSystem fs,
+			Path remoteRsrcPath,
+			LocalResourceType resourceType) throws IOException {
 		FileStatus jarStat = fs.getFileStatus(remoteRsrcPath);
 		return registerLocalResource(
 			remoteRsrcPath,
 			jarStat.getLen(),
 			jarStat.getModificationTime(),
-			LocalResourceVisibility.APPLICATION);
+			LocalResourceVisibility.APPLICATION,
+			resourceType);
 	}
 
 	public static void setTokensFor(ContainerLaunchContext amContainer, List<Path> paths, Configuration conf) throws IOException {
@@ -360,7 +365,7 @@ public final class Utils {
 			log.info("Adding keytab {} to the AM container local resource bucket", remoteKeytabPath);
 			Path keytabPath = new Path(remoteKeytabPath);
 			FileSystem fs = keytabPath.getFileSystem(yarnConfig);
-			keytabResource = registerLocalResource(fs, keytabPath);
+			keytabResource = registerLocalResource(fs, keytabPath, LocalResourceType.FILE);
 		}
 
 		//To support Yarn Secure Integration Test Scenario
@@ -371,14 +376,14 @@ public final class Utils {
 			log.info("TM:Adding remoteYarnConfPath {} to the container local resource bucket", remoteYarnConfPath);
 			Path yarnConfPath = new Path(remoteYarnConfPath);
 			FileSystem fs = yarnConfPath.getFileSystem(yarnConfig);
-			yarnConfResource = registerLocalResource(fs, yarnConfPath);
+			yarnConfResource = registerLocalResource(fs, yarnConfPath, LocalResourceType.FILE);
 		}
 
 		if (remoteKrb5Path != null) {
 			log.info("TM:Adding remoteKrb5Path {} to the container local resource bucket", remoteKrb5Path);
 			Path krb5ConfPath = new Path(remoteKrb5Path);
 			FileSystem fs = krb5ConfPath.getFileSystem(yarnConfig);
-			krb5ConfResource = registerLocalResource(fs, krb5ConfPath);
+			krb5ConfResource = registerLocalResource(fs, krb5ConfPath, LocalResourceType.FILE);
 			hasKrb5 = true;
 		}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,6 +140,21 @@ class YarnApplicationFileUploader implements AutoCloseable {
 		IOUtils.closeQuietly(fileSystem);
 	}
 
+	YarnLocalResourceDescriptor registerSingleLocalResource(
+		final String key,
+		final Path resourcePath,
+		final String relativeDstPath,
+		final boolean whetherToAddToRemotePaths,
+		final boolean whetherToAddToEnvShipResourceList) throws IOException {
+		return registerSingleLocalResource(
+			key,
+			resourcePath,
+			relativeDstPath,
+			whetherToAddToRemotePaths,
+			whetherToAddToEnvShipResourceList,
+			LocalResourceType.FILE);
+	}
+
 	/**
 	 * Register a single local/remote resource and adds it to <tt>localResources</tt>.
 	 * @param key the key to add the resource under
@@ -155,7 +171,8 @@ class YarnApplicationFileUploader implements AutoCloseable {
 			final Path resourcePath,
 			final String relativeDstPath,
 			final boolean whetherToAddToRemotePaths,
-			final boolean whetherToAddToEnvShipResourceList) throws IOException {
+			final boolean whetherToAddToEnvShipResourceList,
+			final LocalResourceType resourceType) throws IOException {
 
 		addToRemotePaths(whetherToAddToRemotePaths, resourcePath);
 
@@ -164,7 +181,7 @@ class YarnApplicationFileUploader implements AutoCloseable {
 			LOG.debug("Using remote file {} to register local resource", fileStatus.getPath());
 
 			final YarnLocalResourceDescriptor descriptor = YarnLocalResourceDescriptor
-				.fromFileStatus(key, fileStatus, LocalResourceVisibility.APPLICATION);
+				.fromFileStatus(key, fileStatus, LocalResourceVisibility.APPLICATION, resourceType);
 			addToEnvShipResourceList(whetherToAddToEnvShipResourceList, descriptor);
 			localResources.put(key, descriptor.toLocalResource());
 			return descriptor;
@@ -177,7 +194,9 @@ class YarnApplicationFileUploader implements AutoCloseable {
 			remoteFileInfo.f0,
 			localFile.length(),
 			remoteFileInfo.f1,
-			LocalResourceVisibility.APPLICATION);
+			LocalResourceVisibility.APPLICATION,
+			resourceType
+		);
 		addToEnvShipResourceList(whetherToAddToEnvShipResourceList, descriptor);
 		localResources.put(key, descriptor.toLocalResource());
 		return descriptor;
@@ -206,6 +225,13 @@ class YarnApplicationFileUploader implements AutoCloseable {
 		return Tuple2.of(dst, fss[0].getModificationTime());
 	}
 
+	List<String> registerMultipleLocalResources(
+		final Collection<Path> shipFiles,
+		final String localResourcesDirectory
+	) throws IOException {
+		return registerMultipleLocalResources(shipFiles, localResourcesDirectory, LocalResourceType.FILE);
+	}
+
 	/**
 	 * Recursively uploads (and registers) any (user and system) files in <tt>shipFiles</tt> except
 	 * for files matching "<tt>flink-dist*.jar</tt>" which should be uploaded separately. If it is
@@ -220,7 +246,9 @@ class YarnApplicationFileUploader implements AutoCloseable {
 	 */
 	List<String> registerMultipleLocalResources(
 			final Collection<Path> shipFiles,
-			final String localResourcesDirectory) throws IOException {
+			final String localResourcesDirectory,
+			LocalResourceType resourceType
+			) throws IOException {
 
 		final List<Path> localPaths = new ArrayList<>();
 		final List<Path> relativePaths = new ArrayList<>();
@@ -268,7 +296,9 @@ class YarnApplicationFileUploader implements AutoCloseable {
 						localPath,
 						relativePath.getParent().toString(),
 						true,
-						true);
+						true,
+						resourceType
+					);
 
 				if (!resourceDescriptor.alreadyRegisteredAsLocalResource()) {
 					if (key.endsWith("jar")) {
@@ -302,7 +332,9 @@ class YarnApplicationFileUploader implements AutoCloseable {
 				localJarPath,
 				"",
 				true,
-				false);
+				false,
+				LocalResourceType.FILE
+		);
 		return flinkDist;
 	}
 
@@ -313,26 +345,34 @@ class YarnApplicationFileUploader implements AutoCloseable {
 	 * @return list of class paths with the file name
 	 */
 	List<String> registerProvidedLocalResources() {
+		return registerLocalResources(providedSharedLibs, LocalResourceVisibility.PUBLIC, LocalResourceType.FILE);
+	}
+
+	List<String> registerLocalResources(
+			Map<String, FileStatus> resources,
+			LocalResourceVisibility resourceVisibility,
+			LocalResourceType resourceType) {
 		checkNotNull(localResources);
 
 		final ArrayList<String> classPaths = new ArrayList<>();
-		providedSharedLibs.forEach(
-				(fileName, fileStatus) -> {
-					final Path filePath = fileStatus.getPath();
-					LOG.debug("Using remote file {} to register local resource", filePath);
+		resources.forEach(
+			(fileName, fileStatus) -> {
+				final Path filePath = fileStatus.getPath();
+				LOG.debug("Using remote file {} to register local resource", filePath);
 
-					final YarnLocalResourceDescriptor descriptor = YarnLocalResourceDescriptor
-							.fromFileStatus(fileName, fileStatus, LocalResourceVisibility.PUBLIC);
-					localResources.put(fileName, descriptor.toLocalResource());
-					remotePaths.add(filePath);
-					envShipResourceList.add(descriptor);
+				final YarnLocalResourceDescriptor descriptor = YarnLocalResourceDescriptor
+					.fromFileStatus(fileName, fileStatus, resourceVisibility, resourceType);
+				localResources.put(fileName, descriptor.toLocalResource());
+				remotePaths.add(filePath);
+				envShipResourceList.add(descriptor);
 
-					if (!isFlinkDistJar(filePath.getName()) && !isPlugin(filePath)) {
-						classPaths.add(fileName);
-					} else if (isFlinkDistJar(filePath.getName())) {
-						flinkDist = descriptor;
-					}
-				});
+				if (!isFlinkDistJar(filePath.getName()) && !isPlugin(filePath)) {
+					classPaths.add(fileName);
+				} else if (isFlinkDistJar(filePath.getName())) {
+					flinkDist = descriptor;
+
+				}
+			});
 		return classPaths;
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -140,21 +140,6 @@ class YarnApplicationFileUploader implements AutoCloseable {
 		IOUtils.closeQuietly(fileSystem);
 	}
 
-	YarnLocalResourceDescriptor registerSingleLocalResource(
-		final String key,
-		final Path resourcePath,
-		final String relativeDstPath,
-		final boolean whetherToAddToRemotePaths,
-		final boolean whetherToAddToEnvShipResourceList) throws IOException {
-		return registerSingleLocalResource(
-			key,
-			resourcePath,
-			relativeDstPath,
-			whetherToAddToRemotePaths,
-			whetherToAddToEnvShipResourceList,
-			LocalResourceType.FILE);
-	}
-
 	/**
 	 * Register a single local/remote resource and adds it to <tt>localResources</tt>.
 	 * @param key the key to add the resource under
@@ -163,6 +148,7 @@ class YarnApplicationFileUploader implements AutoCloseable {
 	 *                              (this will be prefixed by the application-specific directory)
 	 * @param whetherToAddToRemotePaths whether to add the path of local resource to <tt>remotePaths</tt>
 	 * @param whetherToAddToEnvShipResourceList whether to add the local resource to <tt>envShipResourceList</tt>
+	 * @param resourceType type of the resource, which can be one of FILE, PATTERN, or ARCHIVE
 	 *
 	 * @return the uploaded resource descriptor
 	 */
@@ -225,13 +211,6 @@ class YarnApplicationFileUploader implements AutoCloseable {
 		return Tuple2.of(dst, fss[0].getModificationTime());
 	}
 
-	List<String> registerMultipleLocalResources(
-		final Collection<Path> shipFiles,
-		final String localResourcesDirectory
-	) throws IOException {
-		return registerMultipleLocalResources(shipFiles, localResourcesDirectory, LocalResourceType.FILE);
-	}
-
 	/**
 	 * Recursively uploads (and registers) any (user and system) files in <tt>shipFiles</tt> except
 	 * for files matching "<tt>flink-dist*.jar</tt>" which should be uploaded separately. If it is
@@ -241,13 +220,15 @@ class YarnApplicationFileUploader implements AutoCloseable {
 	 * 		local or remote files to register as Yarn local resources
 	 * @param localResourcesDirectory
 	 *		the directory the localResources are uploaded to
+	 * @param resourceType
+	 *      type of the resource, which can be one of FILE, PATTERN, or ARCHIVE
 	 *
 	 * @return list of class paths with the the proper resource keys from the registration
 	 */
 	List<String> registerMultipleLocalResources(
 			final Collection<Path> shipFiles,
 			final String localResourcesDirectory,
-			LocalResourceType resourceType
+			final LocalResourceType resourceType
 			) throws IOException {
 
 		final List<Path> localPaths = new ArrayList<>();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -885,7 +885,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			String flinkConfigKey = "flink-conf.yaml";
 			fileUploader.registerSingleLocalResource(
 				flinkConfigKey,
-				new Path(tmpConfigurationFile.toURI()),
+				new Path(tmpConfigurationFile.getAbsolutePath()),
 				"",
 				true,
 				true,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -29,6 +29,7 @@ import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
@@ -172,8 +173,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		this.userJarInclusion = getUserJarInclusionMode(flinkConfiguration);
 
 		getLocalFlinkDistPath(flinkConfiguration).ifPresent(this::setLocalJarPath);
-		decodeDirsToShipToCluster(flinkConfiguration).ifPresent(this::addShipFiles);
-		decodeArchivesToShipToCluster(flinkConfiguration).ifPresent(this::addShipArchives);
+		decodeFilesToShipToCluster(flinkConfiguration, YarnConfigOptions.SHIP_DIRECTORIES).ifPresent(this::addShipFiles);
+		decodeFilesToShipToCluster(flinkConfiguration, YarnConfigOptions.SHIP_ARCHIVES).ifPresent(this::addShipArchives);
 
 		this.yarnQueue = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_QUEUE);
 		this.customName = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_NAME);
@@ -184,17 +185,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		this.zookeeperNamespace = flinkConfiguration.getString(HighAvailabilityOptions.HA_CLUSTER_ID, null);
 	}
 
-	private Optional<List<File>> decodeDirsToShipToCluster(final Configuration configuration) {
+	private Optional<List<File>> decodeFilesToShipToCluster(final Configuration configuration, ConfigOption<List<String>> configOption) {
 		checkNotNull(configuration);
 
-		final List<File> files = ConfigUtils.decodeListFromConfig(configuration, YarnConfigOptions.SHIP_DIRECTORIES, File::new);
-		return files.isEmpty() ? Optional.empty() : Optional.of(files);
-	}
-
-	private Optional<List<File>> decodeArchivesToShipToCluster(final Configuration configuration) {
-		checkNotNull(configuration);
-
-		final List<File> files = ConfigUtils.decodeListFromConfig(configuration, YarnConfigOptions.SHIP_ARCHIVES, File::new);
+		final List<File> files = ConfigUtils.decodeListFromConfig(configuration, configOption, File::new);
 		return files.isEmpty() ? Optional.empty() : Optional.of(files);
 	}
 
@@ -263,7 +257,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * Adds the given files to the list of files to ship.
 	 *
 	 * <p>Note that any file matching "<tt>flink-dist*.jar</tt>" will be excluded from the upload by
-	 * {@link YarnApplicationFileUploader#registerMultipleLocalResources(Collection, String)}
+	 * {@link YarnApplicationFileUploader#registerMultipleLocalResources(Collection, String, LocalResourceType)}
 	 * since we upload the Flink uber jar ourselves and do not need to deploy it multiple times.
 	 *
 	 * @param shipFiles files to ship
@@ -797,7 +791,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		final List<String> systemClassPaths = fileUploader.registerProvidedLocalResources();
 		final List<String> uploadedDependencies = fileUploader.registerMultipleLocalResources(
 			systemShipFiles.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
-			Path.CUR_DIR);
+			Path.CUR_DIR,
+			LocalResourceType.FILE);
 		systemClassPaths.addAll(uploadedDependencies);
 
 		// upload and register ship-only files
@@ -806,21 +801,24 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			Set<File> shipOnlyFiles = new HashSet<>();
 			addPluginsFoldersToShipFiles(shipOnlyFiles);
 			fileUploader.registerMultipleLocalResources(
-					shipOnlyFiles.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
-					Path.CUR_DIR);
+				shipOnlyFiles.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
+				Path.CUR_DIR,
+				LocalResourceType.FILE);
 		}
 
 		if (!shipArchives.isEmpty()) {
 			fileUploader.registerMultipleLocalResources(
 				shipArchives.stream().map(e -> new Path(e.toURI())).collect(Collectors.toSet()),
-				Path.CUR_DIR, LocalResourceType.ARCHIVE);
+				Path.CUR_DIR,
+				LocalResourceType.ARCHIVE);
 		}
 
 		// Upload and register user jars
 		final List<String> userClassPaths = fileUploader.registerMultipleLocalResources(
 			userJarFiles,
 			userJarInclusion == YarnConfigOptions.UserJarInclusion.DISABLED ?
-				ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR : Path.CUR_DIR);
+				ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR : Path.CUR_DIR,
+				LocalResourceType.FILE);
 
 		if (userJarInclusion == YarnConfigOptions.UserJarInclusion.ORDER) {
 			systemClassPaths.addAll(userClassPaths);
@@ -864,7 +862,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					new Path(tmpJobGraphFile.toURI()),
 					"",
 					true,
-					false);
+					false,
+					LocalResourceType.FILE);
 				classPathBuilder.append(jobGraphFilename).append(File.pathSeparator);
 			} catch (Exception e) {
 				LOG.warn("Add job graph to local resource fail.");
@@ -889,7 +888,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				new Path(tmpConfigurationFile.toURI()),
 				"",
 				true,
-				true);
+				true,
+				LocalResourceType.FILE);
 			classPathBuilder.append("flink-conf.yaml").append(File.pathSeparator);
 		} finally {
 			if (tmpConfigurationFile != null && !tmpConfigurationFile.delete()) {
@@ -919,7 +919,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				yarnSitePath,
 				"",
 				false,
-				false).getPath();
+				false,
+				LocalResourceType.FILE).getPath();
 
 			String krb5Config = System.getProperty("java.security.krb5.conf");
 			if (krb5Config != null && krb5Config.length() != 0) {
@@ -931,7 +932,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					krb5ConfPath,
 					"",
 					false,
-					false).getPath();
+					false,
+					LocalResourceType.FILE).getPath();
 				hasKrb5 = true;
 			}
 		}
@@ -950,7 +952,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					new Path(keytab),
 					"",
 					false,
-					false).getPath();
+					false,
+					LocalResourceType.FILE).getPath();
 			} else {
 				// // Assume Keytab is pre-installed in the container.
 				localizedKeytabPath = flinkConfiguration.getString(YarnConfigOptions.LOCALIZED_KEYTAB_PATH);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 
 import java.util.Objects;
@@ -38,27 +39,41 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 class YarnLocalResourceDescriptor {
 
 	private static final String STRING_FORMAT = "YarnLocalResourceDescriptor{" +
-		"key=%s, path=%s, size=%d, modificationTime=%d, visibility=%s}";
+		"key=%s, path=%s, size=%d, modificationTime=%d, visibility=%s, type=%s}";
 	private static final Pattern LOCAL_RESOURCE_DESC_FORMAT = Pattern.compile("YarnLocalResourceDescriptor\\{" +
-		"key=(\\S+), path=(\\S+), size=([\\d]+), modificationTime=([\\d]+), visibility=(\\S+)}");
+		"key=(\\S+), path=(\\S+), size=([\\d]+), modificationTime=([\\d]+), visibility=(\\S+), type=(\\S+)}");
 
 	private final String resourceKey;
 	private final Path path;
 	private final long size;
 	private final long modificationTime;
 	private final LocalResourceVisibility visibility;
+	private final LocalResourceType resourceType;
 
 	YarnLocalResourceDescriptor(
 			String resourceKey,
 			Path path,
 			long resourceSize,
 			long modificationTime,
-			LocalResourceVisibility visibility) {
+			LocalResourceVisibility visibility,
+			LocalResourceType resourceType
+			) {
 		this.resourceKey = checkNotNull(resourceKey);
 		this.path = checkNotNull(path);
 		this.size = resourceSize;
 		this.modificationTime = modificationTime;
 		this.visibility = checkNotNull(visibility);
+		this.resourceType = resourceType;
+	}
+
+	YarnLocalResourceDescriptor(
+		String resourceKey,
+		Path path,
+		long resourceSize,
+		long modificationTime,
+		LocalResourceVisibility visibility
+	) {
+		this(resourceKey, path, resourceSize, modificationTime, visibility, LocalResourceType.FILE);
 	}
 
 	boolean alreadyRegisteredAsLocalResource() {
@@ -85,6 +100,10 @@ class YarnLocalResourceDescriptor {
 		return visibility;
 	}
 
+	LocalResourceType getResourceType() {
+		return resourceType;
+	}
+
 	static YarnLocalResourceDescriptor fromString(String desc) throws Exception {
 		Matcher m = LOCAL_RESOURCE_DESC_FORMAT.matcher(desc);
 		boolean mat = m.find();
@@ -94,7 +113,9 @@ class YarnLocalResourceDescriptor {
 				new Path(m.group(2)),
 				Long.parseLong(m.group(3)),
 				Long.parseLong(m.group(4)),
-				LocalResourceVisibility.valueOf(m.group(5)));
+				LocalResourceVisibility.valueOf(m.group(5)),
+				LocalResourceType.valueOf(m.group(6))
+			);
 		} else {
 			throw new FlinkException("Error to parse YarnLocalResourceDescriptor from " + desc);
 		}
@@ -103,7 +124,8 @@ class YarnLocalResourceDescriptor {
 	static YarnLocalResourceDescriptor fromFileStatus(
 			final String key,
 			final FileStatus fileStatus,
-			final LocalResourceVisibility visibility) {
+			final LocalResourceVisibility visibility,
+			final LocalResourceType resourceType) {
 		checkNotNull(key);
 		checkNotNull(fileStatus);
 		checkNotNull(visibility);
@@ -112,12 +134,14 @@ class YarnLocalResourceDescriptor {
 				fileStatus.getPath(),
 				fileStatus.getLen(),
 				fileStatus.getModificationTime(),
-				visibility);
+				visibility,
+				resourceType
+			);
 	}
 
 	@Override
 	public String toString() {
-		return String.format(STRING_FORMAT, resourceKey, path.toString(), size, modificationTime, visibility);
+		return String.format(STRING_FORMAT, resourceKey, path.toString(), size, modificationTime, visibility, resourceType);
 	}
 
 	@Override
@@ -127,6 +151,7 @@ class YarnLocalResourceDescriptor {
 		result = 31 * result + Objects.hashCode(size);
 		result = 31 * result + Objects.hashCode(modificationTime);
 		result = 31 * result + Objects.hashCode(visibility.toString());
+		result = 31 * result + Objects.hashCode(resourceType.toString());
 		return result;
 	}
 
@@ -140,7 +165,8 @@ class YarnLocalResourceDescriptor {
 				Objects.equals(path, that.path) &&
 				Objects.equals(size, that.size) &&
 				Objects.equals(modificationTime, that.modificationTime) &&
-				Objects.equals(visibility, that.visibility);
+				Objects.equals(visibility, that.visibility) &&
+				Objects.equals(resourceType, that.resourceType);
 		}
 		return false;
 	}
@@ -150,6 +176,6 @@ class YarnLocalResourceDescriptor {
 	 * @return YARN resource
 	 */
 	public LocalResource toLocalResource() {
-		return Utils.registerLocalResource(path, size, modificationTime, visibility);
+		return Utils.registerLocalResource(path, size, modificationTime, visibility, resourceType);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
@@ -56,24 +56,13 @@ class YarnLocalResourceDescriptor {
 			long resourceSize,
 			long modificationTime,
 			LocalResourceVisibility visibility,
-			LocalResourceType resourceType
-			) {
+			LocalResourceType resourceType) {
 		this.resourceKey = checkNotNull(resourceKey);
 		this.path = checkNotNull(path);
 		this.size = resourceSize;
 		this.modificationTime = modificationTime;
 		this.visibility = checkNotNull(visibility);
 		this.resourceType = resourceType;
-	}
-
-	YarnLocalResourceDescriptor(
-		String resourceKey,
-		Path path,
-		long resourceSize,
-		long modificationTime,
-		LocalResourceVisibility visibility
-	) {
-		this(resourceKey, path, resourceSize, modificationTime, visibility, LocalResourceType.FILE);
 	}
 
 	boolean alreadyRegisteredAsLocalResource() {
@@ -114,8 +103,7 @@ class YarnLocalResourceDescriptor {
 				Long.parseLong(m.group(3)),
 				Long.parseLong(m.group(4)),
 				LocalResourceVisibility.valueOf(m.group(5)),
-				LocalResourceType.valueOf(m.group(6))
-			);
+				LocalResourceType.valueOf(m.group(6)));
 		} else {
 			throw new FlinkException("Error to parse YarnLocalResourceDescriptor from " + desc);
 		}
@@ -135,8 +123,7 @@ class YarnLocalResourceDescriptor {
 				fileStatus.getLen(),
 				fileStatus.getModificationTime(),
 				visibility,
-				resourceType
-			);
+				resourceType);
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -203,6 +203,14 @@ public class YarnConfigOptions {
 				.noDefaultValue()
 				.withDescription("A semicolon-separated list of directories to be shipped to the YARN cluster.");
 
+	public static final ConfigOption<List<String>> SHIP_ARCHIVES =
+			key("yarn.ship-archives")
+				.stringType()
+				.asList()
+				.noDefaultValue()
+				.withDescription("A semicolon-separated list of archives to be shipped to the YARN cluster." +
+						" They will be un-packed when localizing.");
+
 	public static final ConfigOption<String> FLINK_DIST_JAR =
 			key("yarn.flink-dist-jar")
 				.stringType()

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -58,4 +58,5 @@ public class UtilsTest extends TestLogger {
 			assertThat(files.count(), equalTo(0L));
 		}
 	}
+
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -218,7 +219,7 @@ public class YarnFileStageTest extends TestLogger {
 
 			final List<String> classpath = uploader.registerMultipleLocalResources(
 				Collections.singletonList(srcPath),
-				localResourceDirectory);
+				localResourceDirectory, LocalResourceType.FILE);
 
 			final Path basePath = new Path(localResourceDirectory, srcPath.getName());
 			final Path nestedPath = new Path(basePath, "nested");
@@ -283,7 +284,8 @@ public class YarnFileStageTest extends TestLogger {
 
 			final List<String> classpath = uploader.registerMultipleLocalResources(
 				Collections.singletonList(new Path(srcDir.getAbsolutePath(), localFile)),
-				localResourceDirectory);
+				localResourceDirectory,
+				LocalResourceType.FILE);
 
 			assertThat(classpath, containsInAnyOrder(new Path(localResourceDirectory, localFile).toString()));
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -219,7 +219,8 @@ public class YarnFileStageTest extends TestLogger {
 
 			final List<String> classpath = uploader.registerMultipleLocalResources(
 				Collections.singletonList(srcPath),
-				localResourceDirectory, LocalResourceType.FILE);
+				localResourceDirectory,
+				LocalResourceType.FILE);
 
 			final Path basePath = new Path(localResourceDirectory, srcPath.getName());
 			final Path nestedPath = new Path(basePath, "nested");

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -41,7 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-					import java.io.File;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
@@ -48,8 +48,7 @@ public class YarnLocalResourceDescriptionTest extends TestLogger {
 			size,
 			ts,
 			LocalResourceVisibility.PUBLIC,
-			LocalResourceType.FILE
-		);
+			LocalResourceType.FILE);
 
 		final String desc = localResourceDesc.toString();
 		YarnLocalResourceDescriptor newLocalResourceDesc = YarnLocalResourceDescriptor.fromString(desc);
@@ -59,7 +58,6 @@ public class YarnLocalResourceDescriptionTest extends TestLogger {
 		assertThat(newLocalResourceDesc.getModificationTime(), is(ts));
 		assertThat(newLocalResourceDesc.getVisibility(), is(LocalResourceVisibility.PUBLIC));
 		assertThat(newLocalResourceDesc.getResourceType(), is(LocalResourceType.FILE));
-
 	}
 
 	@Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.junit.Test;
 
@@ -46,7 +47,9 @@ public class YarnLocalResourceDescriptionTest extends TestLogger {
 			path,
 			size,
 			ts,
-			LocalResourceVisibility.PUBLIC);
+			LocalResourceVisibility.PUBLIC,
+			LocalResourceType.FILE
+		);
 
 		final String desc = localResourceDesc.toString();
 		YarnLocalResourceDescriptor newLocalResourceDesc = YarnLocalResourceDescriptor.fromString(desc);
@@ -55,6 +58,8 @@ public class YarnLocalResourceDescriptionTest extends TestLogger {
 		assertThat(newLocalResourceDesc.getSize(), is(size));
 		assertThat(newLocalResourceDesc.getModificationTime(), is(ts));
 		assertThat(newLocalResourceDesc.getVisibility(), is(LocalResourceVisibility.PUBLIC));
+		assertThat(newLocalResourceDesc.getResourceType(), is(LocalResourceType.FILE));
+
 	}
 
 	@Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.ContainerState;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
@@ -159,7 +160,8 @@ public class YarnResourceManagerTest extends TestLogger {
 			new Path("/tmp/flink.jar"),
 			0,
 			System.currentTimeMillis(),
-			LocalResourceVisibility.APPLICATION).toString());
+			LocalResourceVisibility.APPLICATION,
+			LocalResourceType.FILE).toString());
 		env.put(ApplicationConstants.Environment.PWD.key(), home.getAbsolutePath());
 
 		BootstrapTools.writeConfiguration(flinkConfig, new File(home.getAbsolutePath(), FLINK_CONF_FILENAME));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR makes Flink support shipping archives for Yarn deployment. It is very useful when deploying flink clusters or jobs on with compressed packages on yarn.

Flink supports to transfer jars needed when deploying a job on Yarn cluster through distributed cache([yarn.ship-directories](https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html#yarn-ship-directories)). Even though YARN support 3 types of LocalResource, [FILE, ARCHIVE and PATTERN](https://hadoop.apache.org/docs/r2.7.7/api/index.html?org/apache/hadoop/yarn/api/records/LocalResourceType.html). Currently Flink only supports FILE type. In some cases, ARCHIVE type is also needed. For example, when a Flink cluster has to use JDK8 or higher version on a yarn cluster which cannot support them, Flink cluster is needed to deploy with appropriate JDK package, and unpack it before run JobManager and TaskManagers. The problem will be gone if the compressed jdk8 package(i.e. jdk8.tar.gz) can be shipped as ARCHIVE type because yarn will unpack it.
 
## Brief change log
  -  Add yarn.ship-archives to support LocalResourceType.ARCHIVE

## Verifying this change

This change is covered by existing tests modified, such as *`YarnLocalResourceDescriptionTest`, `YarnResourceManagerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) yes(yarn)
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) docs
