### PR TITLE
[hotfix] Fix typo in TableConfig.java/hive_catalog.md/hive_catalog.zh.md

### DIFF
--- a/docs/dev/table/hive/hive_catalog.md
+++ b/docs/dev/table/hive/hive_catalog.md
@@ -49,7 +49,7 @@ as those of an overall Flink-Hive integration.
 
 ## How to use HiveCatalog
 
-Once configured properly, `HiveCatalog` should just work out of box. Users can create Flink meta-objects with DDL, and shoud
+Once configured properly, `HiveCatalog` should just work out of box. Users can create Flink meta-objects with DDL, and should
 see them immediately afterwards.
 
 `HiveCatalog` can be used to handle two kinds of tables: Hive-compatible tables and generic tables. Hive-compatible tables

--- a/docs/dev/table/hive/hive_catalog.zh.md
+++ b/docs/dev/table/hive/hive_catalog.zh.md
@@ -49,7 +49,7 @@ as those of an overall Flink-Hive integration.
 
 ## How to use HiveCatalog
 
-Once configured properly, `HiveCatalog` should just work out of box. Users can create Flink meta-objects with DDL, and shoud
+Once configured properly, `HiveCatalog` should just work out of box. Users can create Flink meta-objects with DDL, and should
 see them immediately afterwards.
 
 `HiveCatalog` can be used to handle two kinds of tables: Hive-compatible tables and generic tables. Hive-compatible tables

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -282,7 +282,7 @@ public class TableConfig {
 			!(maxTime.toMilliseconds() == 0 && minTime.toMilliseconds() == 0)) {
 			throw new IllegalArgumentException(
 				"Difference between minTime: " + minTime.toString() + " and maxTime: " + maxTime.toString() +
-					"shoud be at least 5 minutes.");
+					" should be at least 5 minutes.");
 		}
 		minIdleStateRetentionTime = minTime.toMilliseconds();
 		maxIdleStateRetentionTime = maxTime.toMilliseconds();


### PR DESCRIPTION
## What is the purpose of the change

* This pull request Fix typo in TableConfig.java/hive_catalog.md/hive_catalog.zh.md.



## Brief change log

  - shoud -> should
 - "Difference between minTime: 0 ms and maxTime: 200 ms shoud be at least 5 minutes."
 ->"Difference between minTime: 0 ms and maxTime: 200 ms should be at least 5 minutes."

## Verifying this change

This change is a typo fixup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
