### PR TITLE
[FLINK-18455] Fix building Flink under Java > 11 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -935,7 +935,7 @@ under the License.
 		<profile>
 			<id>java11</id>
 			<activation>
-				<jdk>11</jdk>
+				<jdk>[11,)</jdk>
 			</activation>
 
 			<build>


### PR DESCRIPTION
## What is the purpose of the change

With Java JDK 12/13/14 installed the build would create invalid class files as it would not use the java11 profile (which changes a few compiler related settings).
The effect is that the class files would be "java 8" compatible classes that can only run with a "java 9+" runtime.
Running these under java 8 would result in exceptions like
```java.lang.NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;```

With this change this problem is fixed for this specific case:
When built with Java 11+ the classes can no longer run under JRE 8 thus avoid the above specific problem.

## Brief change log

  - *Make sure the java11 maven profile is active under all JDK versions 11 and newer*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

With jdk 14 installed the `mvn clean verify` passed for the most part on my machine.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: *no*
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? *not applicable*
