### PR TITLE
[hotfix] [docs] Fix typo ide setup

### DIFF
--- a/docs/flinkDev/ide_setup.md
+++ b/docs/flinkDev/ide_setup.md
@@ -121,7 +121,7 @@ Enable scalastyle in Intellij by selecting Settings -> Editor -> Inspections, th
 
 This section lists issues that developers have run into in the past when working with IntelliJ:
 
-- Compilation fails with `invalid flag: --add-expots=java.base/sun.net.util=ALL-UNNAMED`
+- Compilation fails with `invalid flag: --add-exports=java.base/sun.net.util=ALL-UNNAMED`
 
 This means that IntelliJ activated the `java11` profile despite an older JDK being used.
 Open the Maven tool window (View -> Tool Windows -> Maven), uncheck the `java11` profile and reimport the project.

--- a/docs/flinkDev/ide_setup.zh.md
+++ b/docs/flinkDev/ide_setup.zh.md
@@ -121,7 +121,7 @@ Enable scalastyle in Intellij by selecting Settings -> Editor -> Inspections, th
 
 This section lists issues that developers have run into in the past when working with IntelliJ:
 
-- Compilation fails with `invalid flag: --add-expots=java.base/sun.net.util=ALL-UNNAMED`
+- Compilation fails with `invalid flag: --add-exports=java.base/sun.net.util=ALL-UNNAMED`
 
 This means that IntelliJ activated the `java11` profile despite an older JDK being used.
 Open the Maven tool window (View -> Tool Windows -> Maven), uncheck the `java11` profile and reimport the project.


### PR DESCRIPTION
## What is the purpose of the change

Fix simple typo in the documentation for developers.

## Brief change log

Change `--add-expots=` into `--add-exports=`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  *no*
  - The serializers:  *no*
  - The runtime per-record code paths (performance sensitive):  *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  *no*
  - The S3 file system connector:  *no*

## Documentation

  - Does this pull request introduce a new feature?  *no*
