### PR TITLE
[FLINK-18458] Do not use property java.version

### DIFF
--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -30,10 +30,10 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>@project.version@</flink.version>
-		<java.version>1.8</java.version>
+		<target.java.version>1.8</target.java.version>
 		<scala.binary.version>2.11</scala.binary.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.source>${target.java.version}</maven.compiler.source>
+		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<log4j.version>@log4j.version@</log4j.version>
 	</properties>
 
@@ -115,8 +115,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
+					<source>${target.java.version}</source>
+					<target>${target.java.version}</target>
 				</configuration>
 			</plugin>
 

--- a/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
@@ -31,10 +31,10 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>@project.version@</flink.version>
-		<java.version>1.8</java.version>
+		<target.java.version>1.8</target.java.version>
 		<scala.binary.version>2.11</scala.binary.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.source>${target.java.version}</maven.compiler.source>
+		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<log4j.version>@log4j.version@</log4j.version>
 	</properties>
 
@@ -115,8 +115,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
+					<source>${target.java.version}</source>
+					<target>${target.java.version}</target>
 				</configuration>
 			</plugin>
 

--- a/flink-walkthroughs/flink-walkthrough-table-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-table-java/src/main/resources/archetype-resources/pom.xml
@@ -31,10 +31,10 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>@project.version@</flink.version>
-		<java.version>1.8</java.version>
+		<target.java.version>1.8</target.java.version>
 		<scala.binary.version>2.11</scala.binary.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.source>${target.java.version}</maven.compiler.source>
+		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<log4j.version>@log4j.version@</log4j.version>
 	</properties>
 
@@ -135,8 +135,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
+					<source>${target.java.version}</source>
+					<target>${target.java.version}</target>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,14 +106,14 @@ under the License.
 		<flink.shaded.version>11.0</flink.shaded.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.5.21</akka.version>
-		<java.version>1.8</java.version>
+		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.15</slf4j.version>
 		<log4j.version>2.12.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 Intellij is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.source>${target.java.version}</maven.compiler.source>
+		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<scala.macros.version>2.1.0</scala.macros.version>
 		<!-- Default scala versions, must be overwritten by build profiles, so we set something
 		invalid here -->
@@ -1242,7 +1242,7 @@ under the License.
 				</property>
 			</activation>
 			<properties>
-				<java.version>1.8</java.version>
+				<target.java.version>1.8</target.java.version>
 			</properties>
 			<build>
 				<plugins>
@@ -1604,7 +1604,7 @@ under the License.
 									<version>[3.1.1,)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
-									<version>${java.version}</version>
+									<version>${target.java.version}</version>
 								</requireJavaVersion>
 							</rules>
 						</configuration>
@@ -1750,8 +1750,8 @@ under the License.
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<source>${java.version}</source>
-						<target>${java.version}</target>
+						<source>${target.java.version}</source>
+						<target>${target.java.version}</target>
 						<!-- The semantics of this option are reversed, see MCOMPILER-209. -->
 						<useIncrementalCompilation>false</useIncrementalCompilation>
 						<compilerArgs>
@@ -1932,7 +1932,7 @@ under the License.
 					<configuration>
 						<args>
 							<arg>-nobootcp</arg>
-							<arg>-target:jvm-${java.version}</arg>
+							<arg>-target:jvm-${target.java.version}</arg>
 						</args>
 						<jvmArgs>
 							<arg>-Xss2m</arg>


### PR DESCRIPTION
## What is the purpose of the change

In the pom.xml (in various places) the **user** property `java.version` is used containing the version of the jdk that is to be used.

There is however also a **system** property `java.version` which contains the actually used jdk version to build the software.

As a consequence some things become very confusing and brittle.

For example the profile activation in maven can be done using the `<jdk>` selector which looks at the system property java.version which is different from the user property java.version.

https://github.com/apache/maven/blob/master/maven-compat/src/main/java/org/apache/maven/profiles/activation/JdkPrefixProfileActivator.java#L36

Also the maven-enforcer-plugin is used with the clause
```
<requireJavaVersion>
   <version>${java.version}</version>
</requireJavaVersion>
```
Here also this rule effectively compares the system property with the user property with the same name to see if they match.

https://github.com/apache/maven-enforcer/blob/master/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireJavaVersion.java#L46
https://github.com/apache/commons-lang/blob/master/src/main/java/org/apache/commons/lang3/SystemUtils.java#L529

So although it works it also makes it impossible to debug which java.version is used by the various plugins as the value shown on the screen is always a different value.

The change is very simple: do no use java.version as the name for a user property.

## Brief change log

Rename any use of the user property `java.version` to `target.java.version` to indicate that this is the java runtime version for which we aim to build the software.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

The regular build should simply work as normal.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
