### PR TITLE
[FLINK-18472][docs] Local Installation Getting Started Guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ Apache Flink is a framework and distributed processing engine for stateful compu
 
 If you’re interested in playing around with Flink, try one of our tutorials:
 
+* [Local Installation]({% link try-flink/local_installation.md %})
 * [Fraud Detection with the DataStream API]({% link try-flink/datastream_api.md %})
 * [Real Time Reporting with the Table API]({% link try-flink/table_api.md %})
 * [Intro to the Python Table API]({% link try-flink/python_table_api.md %})

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -34,6 +34,7 @@ Apache Flink 是一个在无界和有界数据流上进行状态计算的框架�
 
 如果您有兴趣使用 Flink, 可以试试我们的教程:
 
+* [Local Installation]({% link try-flink/local_installation.zh.md %})
 * [DataStream API 进行欺诈检测]({% link try-flink/datastream_api.zh.md %})
 * [Table API 构建实时报表]({% link try-flink/table_api.zh.md %})
 * [Python API 教程]({% link try-flink/python_table_api.zh.md %})

--- a/docs/try-flink/datastream_api.md
+++ b/docs/try-flink/datastream_api.md
@@ -2,7 +2,7 @@
 title: "Fraud Detection with the DataStream API"
 nav-title: 'Fraud Detection with the DataStream API'
 nav-parent_id: try-flink
-nav-pos: 1
+nav-pos: 2
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/try-flink/datastream_api.zh.md
+++ b/docs/try-flink/datastream_api.zh.md
@@ -2,7 +2,7 @@
 title: "基于 DataStream API 实现欺诈检测"
 nav-title: '基于 DataStream API 实现欺诈检测'
 nav-parent_id: try-flink
-nav-pos: 1
+nav-pos: 2
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/try-flink/flink-operations-playground.md
+++ b/docs/try-flink/flink-operations-playground.md
@@ -2,7 +2,7 @@
 title: "Flink Operations Playground"
 nav-title: 'Flink Operations Playground'
 nav-parent_id: try-flink
-nav-pos: 4
+nav-pos: 5
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/try-flink/flink-operations-playground.zh.md
+++ b/docs/try-flink/flink-operations-playground.zh.md
@@ -2,7 +2,7 @@
 title: "Flink 运维操场"
 nav-title: 'Flink 运维操场'
 nav-parent_id: try-flink
-nav-pos: 4
+nav-pos: 5
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/try-flink/local_installation.md
+++ b/docs/try-flink/local_installation.md
@@ -1,0 +1,86 @@
+---
+title: "Local Installation"
+nav-title: 'Local Installation'
+nav-parent_id: try-flink
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+ 
+Follow these few steps to download the latest stable versions and get started.
+
+{% if site.version contains "SNAPSHOT" %}
+<p style="border-radius: 5px; padding: 5px" class="bg-danger">
+  <b>
+  NOTE: The Apache Flink community only pushlishes official builds for
+  released versions of Apache Flink.
+  </b><br>
+  Since you are currently looking at the latest SNAPSHOT
+  version of the documentation, all version references below will not work.
+  Please switch the documentation to the latest released version via the release picker which you
+  find on the left side below the menu.
+</p>
+{% endif %}
+
+## Step 1: Download
+
+To be able to run Flink, the only requirement is to have a working __Java 8 or 11__ installation.
+You can check the correct installation of Java by issuing the following command:
+
+{% highlight bash %}
+java -version
+{% endhighlight %}
+
+[Download](https://flink.apache.org/downloads.html) the {{ site.version }} release and un-tar it. 
+
+{% highlight bash %}
+$ tar -xzf flink-{{ site.version }}-bin-scala{{ site.scala_version_suffix }}.tgz
+$ cd flink-{{ site.version }}-bin-scala{{ site.scala_version_suffix }}
+{% endhighlight %}
+
+## Step 2: Start a Cluster
+
+Flink ships with a single bash script to start a local cluster.
+
+{% highlight bash %}
+$ ./bin/start-cluster.sh
+Starting cluster.
+Starting standalonesession daemon on host.
+Starting taskexecutor daemon on host.
+{% endhighlight %}
+
+## Step 3: Submit a Job
+
+Releases of Flink come with a number of example Jobs.
+You can quickly deploy one of these applications to the running cluster. 
+
+{% highlight bash %}
+$ ./bin/flink run examples/streaming/WordCount.jar
+{% endhighlight %}
+
+The output of the Job will be printed directly to standard out.
+Additionally, you can check Flink's [Web UI](http://localhost:8080) to monitor the status of the Cluster and running Job.
+
+## Step 4: Stop the Cluster
+
+When you are finished you can quickly stop the cluster and all running components.
+
+{% highlight bash %}
+$ ./bin/stop-cluster.sh
+{% endhighlight %}

--- a/docs/try-flink/local_installation.zh.md
+++ b/docs/try-flink/local_installation.zh.md
@@ -1,0 +1,81 @@
+---
+title: "Local Installation"
+nav-title: 'Local Installation'
+nav-parent_id: try-flink
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+ 
+Follow these few steps to download the latest stable versions and get started.
+
+{% if site.version contains "SNAPSHOT" %}
+<p style="border-radius: 5px; padding: 5px" class="bg-danger">
+  <b>
+  NOTE: You are currently looking at the SNAPSHOT version of the documentation.
+  We strongly recommend you use a <a href={{ site.stable_baseurl }}>stable release</a>.
+</p>
+{% endif %}
+
+## Step 1: Download
+
+To be able to run Flink, the only requirement is to have a working __Java 8 or 11__ installation.
+You can check the correct installation of Java by issuing the following command:
+
+{% highlight bash %}
+java -version
+{% endhighlight %}
+
+[Download](https://flink.apache.org/downloads.html) the {{ site.version }} release and un-tar it. 
+
+{% highlight bash %}
+$ tar -xzf flink-{{ site.version }}-bin-scala{{ site.scala_version_suffix }}.tgz
+$ cd flink-{{ site.version }}-bin-scala{{ site.scala_version_suffix }}
+{% endhighlight %}
+
+## Step 2: Start a Cluster
+
+Flink ships with a single bash script to start a local cluster.
+
+{% highlight bash %}
+$ ./bin/start-cluster.sh
+Starting cluster.
+Starting standalonesession daemon on host.
+Starting taskexecutor daemon on host.
+{% endhighlight %}
+
+## Step 3: Submit a Job
+
+Releases of Flink come with a number of example Jobs.
+You can quickly deploy one of these applications to the running cluster. 
+
+{% highlight bash %}
+$ ./bin/flink run examples/streaming/WordCount.jar
+{% endhighlight %}
+
+The output of the Job will be printed directly to standard out.
+Additionally, you can check Flink's [Web UI](http://localhost:8080) to monitor the status of the Cluster and running Job.
+
+## Step 4: Stop the Cluster
+
+When you are finished you can quickly stop the cluster and all running components.
+
+{% highlight bash %}
+$ ./bin/stop-cluster.sh
+{% endhighlight %}

--- a/docs/try-flink/python_table_api.md
+++ b/docs/try-flink/python_table_api.md
@@ -2,7 +2,7 @@
 title: "Python API Tutorial"
 nav-title: Python API
 nav-parent_id: try-flink
-nav-pos: 3
+nav-pos: 4
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/try-flink/python_table_api.zh.md
+++ b/docs/try-flink/python_table_api.zh.md
@@ -2,7 +2,7 @@
 title: "Python API 教程"
 nav-title: Python API
 nav-parent_id: try-flink
-nav-pos: 3
+nav-pos: 4
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/try-flink/table_api.md
+++ b/docs/try-flink/table_api.md
@@ -2,7 +2,7 @@
 title: "Real Time Reporting with the Table API"
 nav-title: 'Real Time Reporting with the Table API'
 nav-parent_id: try-flink
-nav-pos: 2
+nav-pos: 3
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/try-flink/table_api.zh.md
+++ b/docs/try-flink/table_api.zh.md
@@ -2,7 +2,7 @@
 title: "基于 Table API 实现实时报表"
 nav-title: '基于 Table API 实现实时报表'
 nav-parent_id: try-flink
-nav-pos: 2
+nav-pos: 3
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
## What is the purpose of the change

Add a local installation guide to "Try Flink"

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)

Rendered: 

<img width="786" alt="Screen Shot 2020-07-02 at 10 37 55 AM" src="https://user-images.githubusercontent.com/1891970/86379462-7dab3800-bc50-11ea-8d89-f95e687b9af8.png">

