### PR TITLE
[FLINK-18470] Ensure rocksdb is loaded in RocksKeyGroupsRocksSingleStateIteratorTest

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
@@ -25,11 +25,13 @@ import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.util.IOUtils;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 
@@ -50,6 +52,11 @@ public class RocksKeyGroupsRocksSingleStateIteratorTest {
 
 	@Rule
 	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Before
+	public void before() throws Exception {
+		NativeLibraryLoader.getInstance().loadLibrary(tempFolder.newFolder().getAbsolutePath());
+	}
 
 	@Test
 	public void testEmptyMergeIterator() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Make the test pass reliably in local environment.

## Brief change log

* Load the rocks db library before running the tests.


## Verifying this change

Run the affected tests locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
