### PR TITLE
[hotfix] Add nohive classifier to orc-core in flink-sql-connector-hive:1.2.2 NOTICE file

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-1.2.2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hive-1.2.2/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.airlift:aircompressor:0.8
 - org.apache.hive:hive-exec:1.2.2
 - org.apache.hive:hive-metastore:1.2.2
-- org.apache.orc:orc-core:1.4.3
+- org.apache.orc:orc-core:nohive:1.4.3
 - org.apache.thrift:libfb303:0.9.2
 
 The bundled Apache Hive dependencies bundle the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)


### PR DESCRIPTION
Added missing classifier