### PR TITLE
[FLINK-18440][table-planner-blink] Allow ROW/RANGE with RANK, DENSE_RANK or ROW_NUMBER functions on window stream 

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/SqlRankFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/SqlRankFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.Optionality;
+
+/**
+ * Operator which aggregates sets of values into a result.
+ */
+public class SqlRankFunction extends SqlAggFunction {
+	//~ Constructors -----------------------------------------------------------
+
+	@Deprecated
+	public SqlRankFunction(boolean requiresOrder, SqlKind kind) {
+		this(kind, ReturnTypes.INTEGER, requiresOrder);
+	}
+
+	public SqlRankFunction(SqlKind kind, SqlReturnTypeInference returnTypes,
+						   boolean requiresOrder) {
+		super(kind.name(), null, kind, returnTypes, null,
+			OperandTypes.NILADIC, SqlFunctionCategory.NUMERIC, requiresOrder,
+			true, Optionality.FORBIDDEN);
+	}
+
+	//~ Methods ----------------------------------------------------------------
+
+	@Override public boolean allowsFraming() {
+		return true;
+	}
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -296,6 +296,26 @@ Calc(select=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testRowNumOverWindow">
+    <Resource name="sql">
+      <![CDATA[select name, age, row_num from src_view where row_num <= 3]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], age=[$1], row_num=[$2])
++- LogicalFilter(condition=[<=($2, 3)])
+   +- LogicalProject(name=[$0], age=[$1], row_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[name], orderBy=[age DESC], select=[name, age, w0$o0])
++- Exchange(distribution=[hash[name]])
+   +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[name, age])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTopN">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
@@ -650,7 +650,7 @@ class RankTest extends TableTestBase {
         |)
       """.stripMargin)
     util.tableEnv.executeSql("create view src_view as select *, " +
-      "ROW_NUMBER_WINDOW() OVER (PARTITION BY name ORDER BY age DESC) as row_num from src")
+      "ROW_NUMBER() OVER (PARTITION BY name ORDER BY age DESC) as row_num from src")
     util.verifyPlan("select name, age, row_num from src_view where row_num <= 3")
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
@@ -638,5 +638,21 @@ class RankTest extends TableTestBase {
     util.verifyPlan(sql, ExplainDetail.CHANGELOG_MODE)
   }
 
+  @Test
+  def testRowNumOverWindow(): Unit = {
+    util.addTable(
+      """
+        |CREATE TABLE src (
+        |  name STRING,
+        |  age BIGINT
+        |) WITH (
+        |  'connector' = 'values'
+        |)
+      """.stripMargin)
+    util.tableEnv.executeSql("create view src_view as select *, " +
+      "ROW_NUMBER_WINDOW() OVER (PARTITION BY name ORDER BY age DESC) as row_num from src")
+    util.verifyPlan("select name, age, row_num from src_view where row_num <= 3")
+  }
+
   // TODO add tests about multi-sinks and udf
 }


### PR DESCRIPTION
<!--
## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This PR makes Flink sql allow ROW/RANGE with RANK, DENSE_RANK or ROW_NUMBER functions 

## Brief change log
Use `SqlRankFunction` in `flink-table-planner-blink` module which `allowsFraming()` return `true` to overwrite this one in `calcite` module which not allow framing.

## Verifying this change

Unit test can be used to test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
