### PR TITLE
[FLINK-18434] Fix getter methods of AbstractJdbcCatalog

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -226,12 +226,12 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
 
 	@Override
 	public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws PartitionNotExistException, CatalogException {
-		throw new UnsupportedOperationException();
+		throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
 	}
 
 	@Override
 	public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
-		throw new UnsupportedOperationException();
+		return false;
 	}
 
 	@Override
@@ -258,12 +258,12 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
 
 	@Override
 	public CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException {
-		throw new UnsupportedOperationException();
+		throw new FunctionNotExistException(getName(), functionPath);
 	}
 
 	@Override
 	public boolean functionExists(ObjectPath functionPath) throws CatalogException {
-		throw new UnsupportedOperationException();
+		return false;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -53,6 +53,13 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 	}
 
 	@Test
+	public void testSelectField() {
+		List<Row> results = Lists.newArrayList(
+			tEnv.sqlQuery(String.format("select id from %s", TABLE1)).execute().collect());
+		assertEquals("[1]", results.toString());
+	}
+
+	@Test
 	public void testWithoutSchema() {
 		List<Row> results = Lists.newArrayList(
 			tEnv.sqlQuery(String.format("select * from %s", TABLE1)).execute().collect());


### PR DESCRIPTION
## What is the purpose of the change

The `AbstractJdbcCatalog` does not implement getter methods correctly causing planner to fail. This PR fixes the methods.


## Brief change log
Throw `*NotExistExceptions` instead of `UnsupportedOperationException` in methods of `AbstractJdbcCatalog`.
Return false for `*Exists` functions.


## Verifying this change

Added test `org.apache.flink.connector.jdbc.catalog.PostgresCatalogITCase#testSelectField`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
