### PR TITLE
[FLINK-18468][tests] Harden TaskExecutorITCase.testJobReExecutionAfterTaskExecutorTermination()

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -103,11 +103,11 @@ public class TaskExecutorITCase extends TestLogger {
 
 		miniCluster.startTaskExecutor();
 
+		final JobGraph newJobGraph = createJobGraph(PARALLELISM);
 		BlockingOperator.unblock();
+		miniCluster.submitJob(newJobGraph).get();
 
-		miniCluster.submitJob(jobGraph).get();
-
-		miniCluster.requestJobResult(jobGraph.getJobID()).get();
+		miniCluster.requestJobResult(newJobGraph.getJobID()).get();
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This commit hardens the TaskExecutorITCase.testJobReExecutionAfterTaskExecutorTermination() by
resubmitting the job under a new JobID. A JobID identifies a run of a job and should not be
reused.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
