### PR TITLE
[FLINK-18484][core] - Add length difference information to arity exception

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
@@ -110,7 +110,8 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		int len = fieldSerializers.length;
 
 		if (from.getArity() != len) {
-			throw new RuntimeException("Row arity of from does not match serializers.");
+			throw new RuntimeException("Row arity of from (" + from.getArity() +
+				") does not match this serializers field length (" + len + ").");
 		}
 
 		Row result = new Row(from.getKind(), len);
@@ -138,7 +139,7 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
 		if (from.getArity() != len || reuse.getArity() != len) {
 			throw new RuntimeException(
-				"Row arity of reuse or from is incompatible with this RowSerializer.");
+				"Row arity of reuse (" + reuse.getArity() + ") or from (" + from.getArity() + ") is incompatible with this serializers field length (" + len + ").");
 		}
 
 		reuse.setKind(from.getKind());
@@ -177,7 +178,7 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		final int len = fieldSerializers.length;
 
 		if (record.getArity() != len) {
-			throw new RuntimeException("Row arity of from does not match serializers.");
+			throw new RuntimeException("Row arity of record (" + record.getArity() + ") does not match this serializers field length (" + len + ").");
 		}
 
 		// write bitmask
@@ -221,7 +222,7 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		final int len = fieldSerializers.length;
 
 		if (reuse.getArity() != len) {
-			throw new RuntimeException("Row arity of from does not match serializers.");
+			throw new RuntimeException("Row arity of reuse (" + reuse.getArity() + ") does not match this serializers field length (" + len + ").");
 		}
 
 		// read bitmask


### PR DESCRIPTION

## What is the purpose of the change

* Include length difference details when RowSerializer throws RuntimeException due to this difference

## Brief change log

* Exception message updated 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
