### PR TITLE
[FLINK-18488][python] Added additional params to CsvTableSource constructor

### DIFF
--- a/flink-python/pyflink/table/sources.py
+++ b/flink-python/pyflink/table/sources.py
@@ -69,7 +69,6 @@ class CsvTableSource(TableSource):
         ignore_comments=None,
         lenient=None,
     ):
-        # type: (str, list[str], list[DataType]) -> None
         gateway = get_gateway()
 
         builder = gateway.jvm.CsvTableSource.builder()

--- a/flink-python/pyflink/table/sources.py
+++ b/flink-python/pyflink/table/sources.py
@@ -17,8 +17,7 @@
 ################################################################################
 
 from pyflink.java_gateway import get_gateway
-from pyflink.table.types import DataType, _to_java_type
-from pyflink.util import utils
+from pyflink.table.types import _to_java_type
 
 __all__ = ['TableSource', 'CsvTableSource']
 
@@ -36,6 +35,11 @@ class CsvTableSource(TableSource):
     """
     A :class:`TableSource` for simple CSV files with a
     (logically) unlimited number of fields.
+
+    Example:
+    ::
+
+        >>> CsvTableSource("/csv/file/path", ["a", "b"], [DataTypes.INT(), DataTypes.STRING()])
 
     :param source_path: The path to the CSV file.
     :type source_path: str
@@ -55,6 +59,8 @@ class CsvTableSource(TableSource):
     :type ignore_comments: str, optional
     :param lenient: Flag to skip records with parse error instead to fail, false by default.
     :type lenient: bool, optional
+    :param empty_column_as_null: Treat empty column as null, false by default.
+    :type empty_column_as_null: bool, optional
     """
 
     def __init__(
@@ -68,6 +74,7 @@ class CsvTableSource(TableSource):
         ignore_first_line=None,
         ignore_comments=None,
         lenient=None,
+        empty_column_as_null=None,
     ):
         gateway = get_gateway()
 
@@ -106,5 +113,8 @@ class CsvTableSource(TableSource):
 
         if lenient:
             builder.ignoreParseErrors()
+
+        if empty_column_as_null:
+            builder.emptyColumnAsNull()
 
         super(CsvTableSource, self).__init__(builder.build())

--- a/flink-python/pyflink/table/sources.py
+++ b/flink-python/pyflink/table/sources.py
@@ -84,6 +84,18 @@ class CsvTableSource(TableSource):
             builder.lineDelimiter(line_delim)
 
         if quote_character is not None:
+            # Java API has a Character type for this field. At time of writing,
+            # Py4J will convert the Python str to Java Character by taking only
+            # the first character.  This results in either:
+            #   - Silently truncating a Python str with more than one character
+            #     with no further type error from either Py4J or Java
+            #     CsvTableSource
+            #   - java.lang.StringIndexOutOfBoundsException from Py4J for an
+            #     empty Python str.  That error can be made more friendly here.
+            if len(quote_character) != 1:
+                raise ValueError(
+                    "Expected a single CSV quote character but got '{}'".format(quote_character)
+                )
             builder.quoteCharacter(quote_character)
 
         if ignore_first_line:


### PR DESCRIPTION
## What is the purpose of the change

CsvTableSource exists in the Python API, however the Python constructor is missing the optional params available in the overloaded constructors from the Java/Scala APIs.  Here's links to the docs:

  - https://ci.apache.org/projects/flink/flink-docs-master/api/python/pyflink.table.html#pyflink.table.CsvTableSource
  - https://ci.apache.org/projects/flink/flink-docs-master/api/java/org/apache/flink/table/sources/CsvTableSource.html

In particular, the current Python constructor is missing the following params that are available in the Java constructor:

  - fieldDelim. The field delimiter.
  - lineDelim. The row delimiter.
  - quoteCharacter. An optional quote character for String values.
  - ignoreFirstLine. Flag to ignore the first line.
  - ignoreComments. An optional prefix to indicate comments.
  - lenient. Flag to skip records with parse error instead to fail.

## Brief change log

  - *Added additional parameters to CsvTableSource in Python API*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (pyflink)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
