### PR TITLE
[FLINK-18507][python] Move get_config implementation to TableEnvironment

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1006,15 +1006,17 @@ class TableEnvironment(object):
         """
         self._j_tenv.useDatabase(database_name)
 
-    @abstractmethod
-    def get_config(self):
+    def get_config(self) -> TableConfig:
         """
         Returns the table config to define the runtime behavior of the Table API.
 
         :return: Current table config.
-        :rtype: pyflink.table.TableConfig
         """
-        pass
+        if not hasattr(self, "table_config"):
+            table_config = TableConfig()
+            table_config._j_table_config = self._j_tenv.getConfig()
+            setattr(self, "table_config", table_config)
+        return getattr(self, "table_config")
 
     @abstractmethod
     def connect(self, connector_descriptor):
@@ -1617,17 +1619,6 @@ class StreamTableEnvironment(TableEnvironment):
         else:
             return self._j_tenv.getPlanner().getExecutionEnvironment()
 
-    def get_config(self):
-        """
-        Returns the table config to define the runtime behavior of the Table API.
-
-        :return: Current table config.
-        :rtype: pyflink.table.TableConfig
-        """
-        table_config = TableConfig()
-        table_config._j_table_config = self._j_tenv.getConfig()
-        return table_config
-
     def connect(self, connector_descriptor):
         """
         Creates a temporary table from a descriptor.
@@ -1751,17 +1742,6 @@ class BatchTableEnvironment(TableEnvironment):
             return self._j_tenv.getPlanner().getExecEnv()
         else:
             return self._j_tenv.execEnv()
-
-    def get_config(self):
-        """
-        Returns the table config to define the runtime behavior of the Table API.
-
-        :return: Current table config.
-        :rtype: pyflink.table.TableConfig
-        """
-        table_config = TableConfig()
-        table_config._j_table_config = self._j_tenv.getConfig()
-        return table_config
 
     def connect(self, connector_descriptor):
         """


### PR DESCRIPTION
## What is the purpose of the change

*This pull request moves get_config implementation to TableEnvironment to eliminate the code duplication.*

## Brief change log

  - *Move get_config implementation to TableEnvironment*

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
