### PR TITLE
[hotfix] Fix the typo when describing checkpointed data size

### DIFF
--- a/docs/monitoring/checkpoint_monitoring.md
+++ b/docs/monitoring/checkpoint_monitoring.md
@@ -61,7 +61,7 @@ The checkpoint history keeps statistics about recently triggered checkpoints, in
 - **Trigger Time**: The time when the checkpoint was triggered at the JobManager.
 - **Latest Acknowledgement**: The time when the latest acknowledged for any subtask was received at the JobManager (or n/a if no acknowledgement received yet).
 - **End to End Duration**: The duration from the trigger timestamp until the latest acknowledgement (or n/a if no acknowledgement received yet). This end to end duration for a complete checkpoint is determined by the last subtask that acknowledges the checkpoint. This time is usually larger than single subtasks need to actually checkpoint the state.
-- **Checkpointed Data Size**: The checkpointed data size over all acknowledged subtasks. This value would be the delta delta checkpointed data if incremetnal checkpoint is on.
+- **Checkpointed Data Size**: The checkpointed data size over all acknowledged subtasks. This value would be the delta checkpointed data if incremetnal checkpoint is on.
 - **Buffered During Alignment**: The number of bytes buffered during alignment over all acknowledged subtasks. This is only > 0 if a stream alignment takes place during checkpointing. If the checkpointing mode is `AT_LEAST_ONCE` this will always be zero as at least once mode does not require stream alignment.
 
 #### History Size Configuration

--- a/docs/monitoring/checkpoint_monitoring.zh.md
+++ b/docs/monitoring/checkpoint_monitoring.zh.md
@@ -61,7 +61,7 @@ The checkpoint history keeps statistics about recently triggered checkpoints, in
 - **Trigger Time**: The time when the checkpoint was triggered at the JobManager.
 - **Latest Acknowledgement**: The time when the latest acknowledged for any subtask was received at the JobManager (or n/a if no acknowledgement received yet).
 - **End to End Duration**: The duration from the trigger timestamp until the latest acknowledgement (or n/a if no acknowledgement received yet). This end to end duration for a complete checkpoint is determined by the last subtask that acknowledges the checkpoint. This time is usually larger than single subtasks need to actually checkpoint the state.
-- **Checkpointed Data Size**: The state size over all acknowledged subtasks.
+- **Checkpointed Data Size**: The state size over all acknowledged subtasks. This value would be the delta checkpointed data if incremetnal checkpoint is on.
 - **Buffered During Alignment**: The number of bytes buffered during alignment over all acknowledged subtasks. This is only > 0 if a stream alignment takes place during checkpointing. If the checkpointing mode is `AT_LEAST_ONCE` this will always be zero as at least once mode does not require stream alignment.
 
 #### History Size Configuration


### PR DESCRIPTION

## What is the purpose of the change

Fix the typo when describing checkpointed data size



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
