### PR TITLE
[FLINK-18514] Update groovy-all dependency to allow building under JDK 14

### DIFF
--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -179,7 +179,7 @@ under the License.
 					<dependency>
 						<groupId>org.codehaus.groovy</groupId>
 						<artifactId>groovy-all</artifactId>
-						<version>2.5.8</version>
+						<version>2.5.12</version>
 						<scope>runtime</scope>
 						<type>pom</type>
 					</dependency>


### PR DESCRIPTION
## What is the purpose of the change

I have JDK 14 installed on my laptop and when I try to build Flink it fails over an already fixed known problem in groovy which is used in flink-end-to-end-tests.
See also:
- https://github.com/gradle/gradle/issues/10248
- https://issues.apache.org/jira/browse/GROOVY-9211


## Brief change log

Simply update this groovy dependency to the latest version within the currently used major version.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

The build should simply work as-is.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
