### PR TITLE
[hotfix][docs] Mark 1.10 as outdated

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -61,7 +61,7 @@ pythondocs_baseurl: //ci.apache.org/projects/flink/flink-docs-release-1.10
 is_stable: true
 
 # Flag to indicate whether an outdated warning should be shown.
-show_outdated_warning: false
+show_outdated_warning: true
 
 previous_docs:
   1.9: http://ci.apache.org/projects/flink/flink-docs-release-1.9


### PR DESCRIPTION
This is a trivial documentation change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
