### PR TITLE
[FLINK-18519][REST] Propagate exception to client when application fails to execute.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
@@ -29,13 +29,16 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
-import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -78,7 +81,7 @@ public class DetachedApplicationRunner implements ApplicationRunner {
 			ClientUtils.executeProgram(executorServiceLoader, configuration, program, enforceSingleJobExecution, true);
 		} catch (ProgramInvocationException e) {
 			LOG.warn("Could not execute application: ", e);
-			throw new FlinkRuntimeException("Could not execute application.", e);
+			throw new CompletionException(new RestHandlerException("Could not execute application.", HttpResponseStatus.BAD_REQUEST, e));
 		}
 
 		return applicationJobIds;

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -37,6 +37,7 @@ under the License.
 	<properties>
 		<test.parameterProgram.name>parameter-program</test.parameterProgram.name>
 		<test.ParameterProgramNoManifest.name>parameter-program-without-manifest</test.ParameterProgramNoManifest.name>
+		<test.ParameterProgramWithEagerSink.name>parameter-program-with-eager-sink</test.ParameterProgramWithEagerSink.name>
 	</properties>
 
 	<dependencies>
@@ -196,6 +197,25 @@ under the License.
 					</execution>
 					<execution>
 						<!-- Used for JarHandler tests -->
+						<id>test-parameter-program-jar-with-eager-sink</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>org/apache/flink/runtime/webmonitor/handlers/utils/EagerSinkProgram.java</include>
+							</includes>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.runtime.webmonitor.handlers.utils.EagerSinkProgram</mainClass>
+								</manifest>
+							</archive>
+							<finalName>${test.ParameterProgramWithEagerSink.name}</finalName>
+						</configuration>
+					</execution>
+					<execution>
+						<!-- Used for JarHandler tests -->
 						<id>test-parameter-program-jar-without-manifest</id>
 						<phase>process-test-classes</phase>
 						<goals>
@@ -279,6 +299,7 @@ under the License.
 						<targetDir>${project.build.directory}</targetDir>
 						<parameterJarName>${test.parameterProgram.name}</parameterJarName>
 						<parameterJarWithoutManifestName>${test.ParameterProgramNoManifest.name}</parameterJarWithoutManifestName>
+						<parameterJarWithEagerSinkName>${test.ParameterProgramWithEagerSink.name}</parameterJarWithEagerSinkName>
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.client.deployment.application.ApplicationRunner;
 import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
 import org.apache.flink.client.program.PackagedProgram;
-import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
@@ -33,6 +32,8 @@ import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.utils.JarHandlerUtils.JarHandlerContext;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.annotation.Nonnull;
 
@@ -99,7 +100,8 @@ public class JarRunHandler extends
 				.supplyAsync(() -> applicationRunner.run(gateway, program, effectiveConfiguration), executor)
 				.thenApply(jobIds -> {
 					if (jobIds.isEmpty()) {
-						throw new CompletionException(new ProgramInvocationException("No jobs submitted."));
+						throw new CompletionException(
+								new RestHandlerException("No jobs included in application.", HttpResponseStatus.BAD_REQUEST));
 					}
 					return new JarRunResponseBody(jobIds.get(0));
 				});

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests for {@link JarDeleteHandler}.
@@ -105,7 +106,9 @@ public class JarDeleteHandlerTest extends TestLogger {
 			final RestHandlerException restHandlerException = (RestHandlerException) throwable;
 			assertThat(restHandlerException.getMessage(), containsString("File doesnotexist.jar does not exist in"));
 			assertThat(restHandlerException.getHttpResponseStatus(), equalTo(HttpResponseStatus.BAD_REQUEST));
+			return;
 		}
+		fail("The test should have failed by now.");
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -259,7 +259,7 @@ public abstract class JarHandlerParameterTest
 			? Arrays.asList(PROG_ARGS) : null;
 	}
 
-	private static <REQB extends JarRequestBody, M extends JarMessageParameters>
+	protected static <REQB extends JarRequestBody, M extends JarMessageParameters>
 	HandlerRequest<REQB, M> createRequest(
 		REQB requestBody, M parameters, M unresolvedMessageParameters, Path jar)
 		throws HandlerRequestException {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -23,30 +23,45 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.client.deployment.application.DetachedApplicationRunner;
 import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
 import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.testutils.ParameterProgram;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the parameter handling of the {@link JarRunHandler}.
@@ -57,6 +72,8 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 
 	private static JarRunHandler handler;
 
+	private static Path jarWithEagerSink;
+
 	@BeforeClass
 	public static void setup() throws Exception {
 		init();
@@ -64,6 +81,12 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 		final Time timeout = Time.seconds(10);
 		final Map<String, String> responseHeaders = Collections.emptyMap();
 		final Executor executor = TestingUtils.defaultExecutor();
+
+		final Path jarLocation = Paths.get(System.getProperty("targetDir"));
+		final String parameterProgramWithEagerSink = "parameter-program-with-eager-sink.jar";
+		jarWithEagerSink = Files.copy(
+				jarLocation.resolve(parameterProgramWithEagerSink),
+				jarDir.resolve("program-with-eager-sink.jar"));
 
 		handler = new JarRunHandler(
 			gatewayRetriever,
@@ -154,6 +177,32 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 	@Override
 	JarRunRequestBody getJarRequestBodyWithJobId(JobID jobId) {
 		return new JarRunRequestBody(null, null, null, null, jobId, null, null);
+	}
+
+	@Test
+	public void testRestHandlerExceptionThrownWithEagerSinks() throws Exception {
+		final HandlerRequest<JarRunRequestBody, JarRunMessageParameters> request = createRequest(
+				getDefaultJarRequestBody(),
+				getUnresolvedJarMessageParameters(),
+				getUnresolvedJarMessageParameters(),
+				jarWithEagerSink
+		);
+
+		try {
+			handler.handleRequest(request, restfulGateway).get();
+		} catch (final ExecutionException e) {
+			final Throwable throwable =	 ExceptionUtils.stripCompletionException(e.getCause());
+			assertThat(throwable, instanceOf(RestHandlerException.class));
+
+			final RestHandlerException restHandlerException = (RestHandlerException) throwable;
+			assertThat(restHandlerException.getHttpResponseStatus(), equalTo(HttpResponseStatus.BAD_REQUEST));
+
+			final Throwable invocationException = restHandlerException.getCause();
+			assertThat(invocationException, instanceOf(ProgramInvocationException.class));
+			assertThat(invocationException.getMessage(), containsString("Job was submitted in detached mode."));
+			return;
+		}
+		fail("The test should have failed.");
 	}
 
 	@Override

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/utils/EagerSinkProgram.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/utils/EagerSinkProgram.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.handlers.utils;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+
+/**
+ * Javadoc.
+ */
+public class EagerSinkProgram {
+	public static void main(String[] args) throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.fromElements("hello", "world").print();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, when submitting an application through the REST API, if the application fails to execute, the exception is logged but not sent back to the client. With this change, the exception will be propagated back to the client so that it is easier to debug.

## Brief change log

The `JarRunHandler` and the `DetachedApplicationRunner` now wrap the original exception into a `RestHandlerException`.

## Verifying this change

This change is verified by the `JarRunHandlerParameterTest.testRestHandlerExceptionThrownWithEagerSinks()` and can also be verified manually by launching a flink cluster locally by using the `bin/start-cluster.sh` script and submitting the `batch/WordCount` example through the Web-UI. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
