### PR TITLE
[FLINK-18448][pubsub] Update Google Cloud PubSub dependencies

### DIFF
--- a/docs/dev/connectors/pubsub.md
+++ b/docs/dev/connectors/pubsub.md
@@ -134,7 +134,7 @@ SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withProjectName("my-fake-project")
                                                 .withSubscriptionName("subscription")
                                                 .withHostAndPortForEmulator(hostAndPort)
-                                                .build()
+                                                .build();
 
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 env.addSource(pubsubSource)

--- a/docs/dev/connectors/pubsub.zh.md
+++ b/docs/dev/connectors/pubsub.zh.md
@@ -126,7 +126,7 @@ SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withProjectName("my-fake-project")
                                                 .withSubscriptionName("subscription")
                                                 .withHostAndPortForEmulator(hostAndPort)
-                                                .build()
+                                                .build();
 
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 env.addSource(pubsubSource)

--- a/flink-connectors/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-gcp-pubsub/pom.xml
@@ -40,8 +40,8 @@ under the License.
 			<dependency>
 				<!-- This is the way we get a consistent set of versions of the Google tools -->
 				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-bom</artifactId>
-				<version>0.80.0-alpha</version>
+				<artifactId>libraries-bom</artifactId>
+				<version>8.0.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -58,16 +58,20 @@ under the License.
 
 		<dependency>
 			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-core</artifactId>
+			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-pubsub</artifactId>
-			<!-- Version is pulled from google-cloud-bom -->
-			<exclusions>
-				<!-- Exclude an old version of guava that is being pulled
-                in by a transitive dependency of google-api-client -->
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava-jdk5</artifactId>
-				</exclusion>
-			</exclusions>
+			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.api.grpc</groupId>
+			<artifactId>grpc-google-cloud-pubsub-v1</artifactId>
+			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
 		</dependency>
 
 		<dependency>

--- a/flink-connectors/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-gcp-pubsub/pom.xml
@@ -35,13 +35,17 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<google-cloud-libraries-bom.version>8.1.0</google-cloud-libraries-bom.version>
+	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<!-- This is the way we get a consistent set of versions of the Google tools -->
 				<groupId>com.google.cloud</groupId>
 				<artifactId>libraries-bom</artifactId>
-				<version>8.0.0</version>
+				<version>${google-cloud-libraries-bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
@@ -56,7 +56,6 @@ class DefaultPubSubSubscriberFactory implements PubSubSubscriberFactory {
 
 		PullRequest pullRequest = PullRequest.newBuilder()
 								.setMaxMessages(maxMessagesPerPull)
-								.setReturnImmediately(false)
 								.setSubscription(projectSubscriptionName)
 								.build();
 		SubscriberGrpc.SubscriberBlockingStub stub = SubscriberGrpc.newBlockingStub(channel)

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
@@ -117,6 +117,10 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 				isRunning = false;
 			}
 		}
+	}
+
+	@Override
+	public void close() throws Exception {
 		subscriber.close();
 	}
 
@@ -223,13 +227,12 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 	 * @param <OUT> The type of objects which will be read
 	 */
 	public static class PubSubSourceBuilder<OUT> implements ProjectNameBuilder<OUT>, SubscriptionNameBuilder<OUT> {
-		private PubSubDeserializationSchema<OUT> deserializationSchema;
+		private final PubSubDeserializationSchema<OUT> deserializationSchema;
 		private String projectName;
 		private String subscriptionName;
 
 		private PubSubSubscriberFactory pubSubSubscriberFactory;
 		private Credentials credentials;
-		private int maxMessageToAcknowledge = 10000;
 		private int messagePerSecondRateLimit = 100000;
 
 		private PubSubSourceBuilder(DeserializationSchema<OUT> deserializationSchema) {

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeOnCheckpoint.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeOnCheckpoint.java
@@ -65,7 +65,7 @@ public class AcknowledgeOnCheckpoint<ACKID extends Serializable> implements Chec
 	}
 
 	@Override
-	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+	public void notifyCheckpointComplete(long checkpointId) {
 		//get all acknowledgeIds of this and earlier checkpoints
 		List<ACKID> idsToAcknowledge = acknowledgeIdsPerCheckpoint
 			.stream()
@@ -87,7 +87,7 @@ public class AcknowledgeOnCheckpoint<ACKID extends Serializable> implements Chec
 	}
 
 	@Override
-	public List<AcknowledgeIdsForCheckpoint<ACKID>> snapshotState(long checkpointId, long timestamp) throws Exception {
+	public List<AcknowledgeIdsForCheckpoint<ACKID>> snapshotState(long checkpointId, long timestamp) {
 		acknowledgeIdsPerCheckpoint.add(new AcknowledgeIdsForCheckpoint<>(checkpointId, acknowledgeIdsForPendingCheckpoint));
 		acknowledgeIdsForPendingCheckpoint = new ArrayList<>();
 
@@ -95,7 +95,7 @@ public class AcknowledgeOnCheckpoint<ACKID extends Serializable> implements Chec
 	}
 
 	@Override
-	public void restoreState(List<AcknowledgeIdsForCheckpoint<ACKID>> state) throws Exception {
+	public void restoreState(List<AcknowledgeIdsForCheckpoint<ACKID>> state) {
 		outstandingAcknowledgements = new AtomicInteger(numberOfAcknowledgementIds(state));
 		acknowledgeIdsPerCheckpoint = state;
 	}

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/EmulatorCredentials.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/EmulatorCredentials.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.gcp.pubsub.emulator;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.OAuth2Credentials;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static java.lang.Long.MAX_VALUE;
+
+/**
+ * A placeholder for credentials to signify that requests sent to the server should not be
+ * authenticated. This is typically useful when using local service emulators.
+ * NOTE: The Google provided NoCredentials and NoCredentialsProvider do not behave as expected
+ *       See https://github.com/googleapis/gax-java/issues/1148
+ */
+public final class EmulatorCredentials extends OAuth2Credentials {
+	private static final EmulatorCredentials INSTANCE = new EmulatorCredentials();
+
+	private EmulatorCredentials() {
+	}
+
+	private Object readResolve() {
+		return INSTANCE;
+	}
+
+	public static EmulatorCredentials getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return this == obj;
+	}
+
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
+	}
+
+	@Override
+	public AccessToken refreshAccessToken() {
+		return new AccessToken("Dummy credentials for emulator", Date.from(Instant.ofEpochMilli(MAX_VALUE)));
+	}
+}

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/EmulatorCredentialsProvider.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/EmulatorCredentialsProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.gcp.pubsub.emulator;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+
+/**
+ * A CredentialsProvider that simply provides the right credentials that are to be used for connecting to an emulator.
+ * NOTE: The Google provided NoCredentials and NoCredentialsProvider do not behave as expected.
+ *       See https://github.com/googleapis/gax-java/issues/1148
+ */
+public final class EmulatorCredentialsProvider implements CredentialsProvider {
+	@Override
+	public Credentials getCredentials() {
+		return EmulatorCredentials.getInstance();
+	}
+
+	public static EmulatorCredentialsProvider create() {
+		return new EmulatorCredentialsProvider();
+	}
+}

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubSubSubscriberFactoryForEmulator.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubSubSubscriberFactoryForEmulator.java
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.gcp.pubsub;
+package org.apache.flink.streaming.connectors.gcp.pubsub.emulator;
 
+import org.apache.flink.streaming.connectors.gcp.pubsub.BlockingGrpcPubSubSubscriber;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriber;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriberFactory;
 
@@ -57,7 +58,6 @@ public class PubSubSubscriberFactoryForEmulator implements PubSubSubscriberFacto
 
 		PullRequest pullRequest = PullRequest.newBuilder()
 											.setMaxMessages(maxMessagesPerPull)
-											.setReturnImmediately(false)
 											.setSubscription(projectSubscriptionName)
 											.build();
 		SubscriberGrpc.SubscriberBlockingStub stub = SubscriberGrpc.newBlockingStub(managedChannel);

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
@@ -32,7 +32,6 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.ReceivedMessage;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -134,7 +133,7 @@ public class PubSubConsumingTest {
 		PubSubSource<String> pubSubSource = PubSubSource.newBuilder()
 			.withDeserializationSchema(new SimpleStringSchema() {
 				@Override
-				public void deserialize(byte[] message, Collector<String> out) throws IOException {
+				public void deserialize(byte[] message, Collector<String> out) {
 					String[] records = super.deserialize(message).split(",");
 					for (String record : records) {
 						out.collect(record);
@@ -234,7 +233,7 @@ public class PubSubConsumingTest {
 		}
 
 		@Override
-		public void close() throws Exception {
+		public void close() {
 
 		}
 

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSourceTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSourceTest.java
@@ -36,16 +36,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeOnCheckpointTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeOnCheckpointTest.java
@@ -40,7 +40,7 @@ public class AcknowledgeOnCheckpointTest {
 	private final Acknowledger<String> mockedAcknowledger = mock(Acknowledger.class);
 
 	@Test
-	public void testRestoreStateAndSnapshot() throws Exception {
+	public void testRestoreStateAndSnapshot() {
 		List<AcknowledgeIdsForCheckpoint<String>> input = new ArrayList<>();
 		input.add(new AcknowledgeIdsForCheckpoint<>(0, asList("idsFor0", "moreIdsFor0")));
 		input.add(new AcknowledgeIdsForCheckpoint<>(1, asList("idsFor1", "moreIdsFor1")));
@@ -60,7 +60,7 @@ public class AcknowledgeOnCheckpointTest {
 	}
 
 	@Test
-	public void testAddAcknowledgeIdOnEmptyState() throws Exception {
+	public void testAddAcknowledgeIdOnEmptyState() {
 		AcknowledgeOnCheckpoint<String> acknowledgeOnCheckpoint = new AcknowledgeOnCheckpoint<>(mockedAcknowledger);
 
 		acknowledgeOnCheckpoint.addAcknowledgeId("ackId");
@@ -74,7 +74,7 @@ public class AcknowledgeOnCheckpointTest {
 	}
 
 	@Test
-	public void testAddAcknowledgeIdOnExistingState() throws Exception {
+	public void testAddAcknowledgeIdOnExistingState() {
 		List<AcknowledgeIdsForCheckpoint<String>> input = new ArrayList<>();
 		input.add(new AcknowledgeIdsForCheckpoint<>(0, asList("idsFor0", "moreIdsFor0")));
 		input.add(new AcknowledgeIdsForCheckpoint<>(1, asList("idsFor1", "moreIdsFor1")));
@@ -96,7 +96,7 @@ public class AcknowledgeOnCheckpointTest {
 	}
 
 	@Test
-	public void testAddMultipleAcknowledgeIds() throws Exception {
+	public void testAddMultipleAcknowledgeIds() {
 		AcknowledgeOnCheckpoint<String> acknowledgeOnCheckpoint = new AcknowledgeOnCheckpoint<>(mockedAcknowledger);
 
 		acknowledgeOnCheckpoint.addAcknowledgeId("ackId");
@@ -111,7 +111,7 @@ public class AcknowledgeOnCheckpointTest {
 	}
 
 	@Test
-	public void testAcknowledgeIdsForCheckpoint() throws Exception {
+	public void testAcknowledgeIdsForCheckpoint() {
 		List<AcknowledgeIdsForCheckpoint<String>> input = new ArrayList<>();
 		input.add(new AcknowledgeIdsForCheckpoint<>(0, asList("idsFor0", "moreIdsFor0")));
 		input.add(new AcknowledgeIdsForCheckpoint<>(1, asList("idsFor1", "moreIdsFor1")));
@@ -134,7 +134,7 @@ public class AcknowledgeOnCheckpointTest {
 	}
 
 	@Test
-	public void testNumberOfOutstandingAcknowledgementsOnEmptyState() throws Exception {
+	public void testNumberOfOutstandingAcknowledgementsOnEmptyState() {
 		AcknowledgeOnCheckpoint<String> acknowledgeOnCheckpoint = new AcknowledgeOnCheckpoint<>(mockedAcknowledger);
 		assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements(), is(0));
 	}

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -35,6 +35,23 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<dependencyManagement>
+		<dependencies>
+		<!-- NOTE: Without this building the software will fail with                    -->
+		<!--    Failed to resolve dependencies for one or more projects in the reactor. -->
+		<!--    Reason: The artifact has no valid ranges                                -->
+		<!--    [ERROR]   io.grpc:grpc-api:jar:1.28.1                                   -->
+			<dependency>
+				<!-- This is the way we get a consistent set of versions of the Google tools -->
+				<groupId>com.google.cloud</groupId>
+				<artifactId>libraries-bom</artifactId>
+				<version>8.0.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 
 		<!--All dependencies are   <scope>test</scope> -->
@@ -63,7 +80,7 @@ under the License.
 		<dependency>
 			<groupId>com.spotify</groupId>
 			<artifactId>docker-client</artifactId>
-			<version>8.11.7</version>
+			<version>8.16.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -82,12 +99,13 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils-junit</artifactId>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
 			<scope>test</scope>
-        </dependency>
-    </dependencies>
+		</dependency>
+	</dependencies>
 
 	<!-- ONLY run the tests when explicitly told to do so  -->
 	<properties>

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -35,23 +35,6 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<dependencyManagement>
-		<dependencies>
-		<!-- NOTE: Without this building the software will fail with                    -->
-		<!--    Failed to resolve dependencies for one or more projects in the reactor. -->
-		<!--    Reason: The artifact has no valid ranges                                -->
-		<!--    [ERROR]   io.grpc:grpc-api:jar:1.28.1                                   -->
-			<dependency>
-				<!-- This is the way we get a consistent set of versions of the Google tools -->
-				<groupId>com.google.cloud</groupId>
-				<artifactId>libraries-bom</artifactId>
-				<version>8.0.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 
 		<!--All dependencies are   <scope>test</scope> -->

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedFullTopologyTest.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedFullTopologyTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.gcp.pubsub;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.EmulatorCredentials;
+import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.GCloudUnitTestBase;
+import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.PubSubSubscriberFactoryForEmulator;
+import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.PubsubHelper;
+
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.ReceivedMessage;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.streaming.connectors.gcp.pubsub.SimpleStringSchemaWithStopMarkerDetection.STOP_MARKER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This is a test using the emulator for a full topology that uses PubSub as both input and output.
+ */
+public class EmulatedFullTopologyTest extends GCloudUnitTestBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(EmulatedFullTopologyTest.class);
+
+	private static final String PROJECT_NAME             = "Project";
+	private static final String INPUT_TOPIC_NAME         = "InputTopic";
+	private static final String INPUT_SUBSCRIPTION_NAME  = "InputSubscription";
+	private static final String OUTPUT_TOPIC_NAME        = "OutputTopic";
+	private static final String OUTPUT_SUBSCRIPTION_NAME = "OutputSubscription";
+
+	private static PubsubHelper pubsubHelper;
+
+	// ======================================================================================================
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		pubsubHelper = getPubsubHelper();
+		assertNotNull("Missing pubsubHelper.", pubsubHelper);
+		pubsubHelper.createTopic(PROJECT_NAME, INPUT_TOPIC_NAME);
+		pubsubHelper.createSubscription(PROJECT_NAME, INPUT_SUBSCRIPTION_NAME, PROJECT_NAME, INPUT_TOPIC_NAME);
+		pubsubHelper.createTopic(PROJECT_NAME, OUTPUT_TOPIC_NAME);
+		pubsubHelper.createSubscription(PROJECT_NAME, OUTPUT_SUBSCRIPTION_NAME, PROJECT_NAME, OUTPUT_TOPIC_NAME);
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		assertNotNull("Missing pubsubHelper.", pubsubHelper);
+		pubsubHelper.deleteSubscription(PROJECT_NAME, INPUT_SUBSCRIPTION_NAME);
+		pubsubHelper.deleteTopic(PROJECT_NAME, INPUT_TOPIC_NAME);
+		pubsubHelper.deleteSubscription(PROJECT_NAME, OUTPUT_SUBSCRIPTION_NAME);
+		pubsubHelper.deleteTopic(PROJECT_NAME, OUTPUT_TOPIC_NAME);
+	}
+
+	// ======================================================================================================
+
+	// IMPORTANT: This test makes use of things that happen in the emulated PubSub that
+	//            are GUARANTEED to be different in the real Google hosted PubSub.
+	//            So running these tests against the real thing will have a very high probability of failing.
+	// The assumptions:
+	// 1) The ordering of the messages is maintained.
+	//    We are inserting a STOP_MARKER _after_ the set of test measurements and we assume this STOP event will
+	//    arrive after the actual test data so we can stop the processing. In the real PubSub this is NOT true.
+	// 2) Exactly once: We assume that every message we put in comes out exactly once.
+	//    In the real PubSub there are a lot of situations (mostly failure/retry) where this is not true.
+	@Test
+	public void testFullTopology() throws Exception {
+		// ===============================================================================
+		// Step 0: The test data
+		List<String> input = new ArrayList<>(Arrays.asList("One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"));
+
+		List<String> messagesToSend = new ArrayList<>(input);
+
+		// Now add some stream termination messages.
+		// NOTE: Messages are pulled from PubSub in batches by the source.
+		//       So we need enough STOP_MARKERs to ensure ALL parallel tasks get at least one STOP_MARKER
+		//       If not then at least one task will not terminate and the test will not end.
+		//       We pull 3 at a time, have 4 parallel: We need at least 12 STOP_MARKERS
+		IntStream.rangeClosed(1, 20).forEach(i -> messagesToSend.add(STOP_MARKER));
+
+		// IMPORTANT NOTE: This way of testing uses an effect of the PubSub emulator that is absolutely
+		// guaranteed NOT to work in the real PubSub: The ordering of the messages is maintained in the topic.
+		// So here we can assume that if we add a stop message LAST we can terminate the test stream when we see it.
+
+		// ===============================================================================
+		// Step 1: We put test data into the topic
+		// Publish the test messages into the input topic
+		Publisher publisher = pubsubHelper.createPublisher(PROJECT_NAME, INPUT_TOPIC_NAME);
+		for (String s : messagesToSend) {
+			publisher
+				.publish(
+					PubsubMessage
+						.newBuilder()
+						.setData(ByteString.copyFromUtf8(s))
+						.build()
+				).get();
+		}
+		publisher.shutdown();
+
+		// ===============================================================================
+		// Step 2: Now we run our topology
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.enableCheckpointing(100);
+		env.setParallelism(4);
+		env.setRestartStrategy(RestartStrategies.noRestart());
+
+		// Silly topology
+		env
+			// Read the records from PubSub
+			.addSource(
+				// We create a PubSubSource which is the same as the normal source but with a self termination feature.
+				PubSubSource
+					.newBuilder()
+					.withDeserializationSchema(new SimpleStringSchemaWithStopMarkerDetection())
+
+					// First we set the exact same settings as we would normally use.
+					.withProjectName(PROJECT_NAME)
+					.withSubscriptionName(INPUT_SUBSCRIPTION_NAME)
+
+					// We use the credentials for the emulator
+					.withCredentials(EmulatorCredentials.getInstance())
+
+					// Connect to the emulator
+					.withPubSubSubscriberFactory(
+						new PubSubSubscriberFactoryForEmulator(
+							getPubSubHostPort(),
+							PROJECT_NAME,
+							INPUT_SUBSCRIPTION_NAME,
+							1,
+							Duration.ofSeconds(1),
+							3))
+
+					// Make sure we stop the source after a timeout to cleanly end the test.
+					.build())
+
+			// The actual application: Reverse the strings
+			.map((MapFunction<String, String>) StringUtils::reverse)
+
+			// And write them back to pubsub.
+			.addSink(PubSubSink
+				.newBuilder()
+				.withSerializationSchema(new SimpleStringSchema())
+
+				// First we set the exact same settings as we would normally use.
+				.withProjectName(PROJECT_NAME)
+				.withTopicName(OUTPUT_TOPIC_NAME)
+
+				// We use the credentials for the emulator
+				.withCredentials(EmulatorCredentials.getInstance())
+
+				// Connect to the emulator
+				.withHostAndPortForEmulator(getPubSubHostPort())
+				.build());
+
+		env.execute("Running unit test");
+
+		// ===============================================================================
+		// Now we should have all the resulting data in the output topic.
+		// Step 3: Get the result from the output topic and verify if everything is there
+		List<ReceivedMessage> receivedMessages = pubsubHelper.pullMessages(PROJECT_NAME, OUTPUT_SUBSCRIPTION_NAME, 100);
+
+		assertEquals("Wrong number of elements", input.size(), receivedMessages.size());
+
+		// Check output strings
+		List<String> output = new ArrayList<>();
+
+		// Extract the actual Strings from the ReceivedMessages
+		receivedMessages.forEach(msg -> output.add(msg.getMessage().getData().toStringUtf8()));
+
+		for (String test : input) {
+			String reversedTest = org.apache.commons.lang3.StringUtils.reverse(test);
+			LOG.info("Checking if \"{}\" --> \"{}\" exists", test, reversedTest);
+			assertTrue("Missing " + test, output.contains(reversedTest));
+		}
+		// ===============================================================================
+	}
+}

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedPubSubSinkTest.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedPubSubSinkTest.java
@@ -23,10 +23,10 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.EmulatorCredentials;
 import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.GCloudUnitTestBase;
 import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.PubsubHelper;
 
-import com.google.cloud.NoCredentials;
 import com.google.pubsub.v1.ReceivedMessage;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
@@ -66,8 +66,9 @@ public class EmulatedPubSubSinkTest extends GCloudUnitTestBase {
 	@Test
 	public void testFlinkSink() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(4);
 
-		List<String> input = Arrays.asList("One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eigth", "Nine", "Ten");
+		List<String> input = Arrays.asList("One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten");
 
 		// Create test stream
 		DataStream<String> theData = env
@@ -83,7 +84,7 @@ public class EmulatedPubSubSinkTest extends GCloudUnitTestBase {
 								.withTopicName(TOPIC_NAME)
 							   // Specific for emulator
 							.withHostAndPortForEmulator(getPubSubHostPort())
-							.withCredentials(NoCredentials.getInstance())
+							.withCredentials(EmulatorCredentials.getInstance())
 							.build())
 			.name("PubSub sink");
 
@@ -122,14 +123,14 @@ public class EmulatedPubSubSinkTest extends GCloudUnitTestBase {
 								.withTopicName(TOPIC_NAME)
 								// Specific for emulator
 								.withHostAndPortForEmulator("unknown-host-to-force-sink-crash:1234")
-								.withCredentials(NoCredentials.getInstance())
+								.withCredentials(EmulatorCredentials.getInstance())
 								.build()).name("PubSub sink");
 
 		// Run
 		env.execute();
 	}
 
-	private class SingleInputSourceFunction implements SourceFunction<String> {
+	private static class SingleInputSourceFunction implements SourceFunction<String> {
 
 		@Override
 		public void run(SourceContext<String> ctx) throws Exception {

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedPubSubSourceTest.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedPubSubSourceTest.java
@@ -18,16 +18,14 @@
 package org.apache.flink.streaming.connectors.gcp.pubsub;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubDeserializationSchema;
+import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.EmulatorCredentials;
 import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.GCloudUnitTestBase;
+import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.PubSubSubscriberFactoryForEmulator;
 import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.PubsubHelper;
 
-import com.google.cloud.NoCredentials;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
@@ -35,13 +33,14 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
 
+import static org.apache.flink.streaming.connectors.gcp.pubsub.SimpleStringSchemaWithStopMarkerDetection.STOP_MARKER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -68,13 +67,32 @@ public class EmulatedPubSubSourceTest extends GCloudUnitTestBase {
 		pubsubHelper.deleteTopic(PROJECT_NAME, TOPIC_NAME);
 	}
 
+	// IMPORTANT: This test makes use of things that happen in the emulated PubSub that
+	//            are GUARANTEED to be different in the real Google hosted PubSub.
+	//            So running these tests against the real thing will have a very high probability of failing.
+	// The assumptions:
+	// 1) The ordering of the messages is maintained.
+	//    We are inserting a STOP_MARKER _after_ the set of test measurements and we assume this STOP event will
+	//    arrive after the actual test data so we can stop the processing. In the real PubSub this is NOT true.
+	// 2) Exactly once: We assume that every message we put in comes out exactly once.
+	//    In the real PubSub there are a lot of situations (mostly failure/retry) where this is not true.
 	@Test
 	public void testFlinkSource() throws Exception {
 		// Create some messages and put them into pubsub
 		List<String> input = Arrays.asList("One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten");
 
 		List<String> messagesToSend = new ArrayList<>(input);
-		messagesToSend.add("End");
+
+		// Now add some stream termination messages.
+		// NOTE: Messages are pulled from PubSub in batches by the source.
+		//       So we need enough STOP_MARKERs to ensure ALL parallel tasks get at least one STOP_MARKER
+		//       If not then at least one task will not terminate and the test will not end.
+		//       We pull 3 at a time, have 4 parallel: We need at least 12 STOP_MARKERS
+		IntStream.rangeClosed(1, 20).forEach(i -> messagesToSend.add(STOP_MARKER));
+
+		// IMPORTANT NOTE: This way of testing uses an effect of the PubSub emulator that is absolutely
+		// guaranteed NOT to work in the real PubSub: The ordering of the messages is maintained in the topic.
+		// So here we can assume that if we add a stop message LAST we can terminate the test stream when we see it.
 
 		// Publish the messages into PubSub
 		Publisher publisher = pubsubHelper.createPublisher(PROJECT_NAME, TOPIC_NAME);
@@ -91,24 +109,31 @@ public class EmulatedPubSubSourceTest extends GCloudUnitTestBase {
 		});
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.enableCheckpointing(1000);
-		env.setParallelism(1);
+		env.enableCheckpointing(100);
+		env.setParallelism(4);
 		env.setRestartStrategy(RestartStrategies.noRestart());
 
 		DataStream<String> fromPubSub = env
 			.addSource(PubSubSource.newBuilder()
-								.withDeserializationSchema(new BoundedStringDeserializer(10))
+								.withDeserializationSchema(new SimpleStringSchemaWithStopMarkerDetection())
 								.withProjectName(PROJECT_NAME)
 								.withSubscriptionName(SUBSCRIPTION_NAME)
-								.withCredentials(NoCredentials.getInstance())
-								.withPubSubSubscriberFactory(new PubSubSubscriberFactoryForEmulator(getPubSubHostPort(), PROJECT_NAME, SUBSCRIPTION_NAME, 10, Duration.ofSeconds(15), 100))
+								.withCredentials(EmulatorCredentials.getInstance())
+								.withPubSubSubscriberFactory(
+									new PubSubSubscriberFactoryForEmulator(
+										getPubSubHostPort(),
+										PROJECT_NAME,
+										SUBSCRIPTION_NAME,
+										10,
+										Duration.ofSeconds(1),
+										3))
 								.build())
 			.name("PubSub source");
 
 		List<String> output = new ArrayList<>();
-		fromPubSub.writeUsingOutputFormat(new LocalCollectionOutputFormat<>(output));
-
-		env.execute();
+		DataStreamUtils
+			.collect(fromPubSub)
+			.forEachRemaining(output::add);
 
 		assertEquals("Wrong number of elements", input.size(), output.size());
 		for (String test : input) {
@@ -116,29 +141,4 @@ public class EmulatedPubSubSourceTest extends GCloudUnitTestBase {
 		}
 	}
 
-	private static class BoundedStringDeserializer implements PubSubDeserializationSchema<String> {
-		private final int maxMessage;
-		private int counter;
-
-		private BoundedStringDeserializer(int maxMessages) {
-			this.maxMessage = maxMessages;
-			this.counter = 0;
-		}
-
-		@Override
-		public boolean isEndOfStream(String message) {
-			counter++;
-			return counter > maxMessage;
-		}
-
-		@Override
-		public String deserialize(PubsubMessage message) throws Exception {
-			return message.getData().toString(StandardCharsets.UTF_8);
-		}
-
-		@Override
-		public TypeInformation<String> getProducedType() {
-			return Types.STRING;
-		}
-	}
 }

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/SimpleStringSchemaWithStopMarkerDetection.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/SimpleStringSchemaWithStopMarkerDetection.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.gcp.pubsub;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+
+/**
+ * <p>For testing PubSub we need to have messages that can indicate the end of the stream
+ * to cleanly terminate the test run.</p>
+ *
+ * <p>IMPORTANT NOTE: This way of testing uses an effect of the PubSub emulator that is absolutely
+ * guaranteed NOT to work in the real PubSub: The ordering of the messages is maintained in the topic.
+ * So here we can assume that if we add a stop message LAST we can terminate the test stream when we see it.</p>
+ */
+public class SimpleStringSchemaWithStopMarkerDetection extends SimpleStringSchema {
+	public static final String STOP_MARKER = "<><><>STOP STOP STOP<><><>";
+
+	@Override
+	public boolean isEndOfStream(String s) {
+		return (STOP_MARKER.equals(s));
+	}
+}

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudUnitTestBase.java
@@ -64,7 +64,7 @@ public class GCloudUnitTestBase extends TestLogger implements Serializable {
 			//noinspection deprecation
 			channel = ManagedChannelBuilder
 				.forTarget(getPubSubHostPort())
-				.usePlaintext(true)
+				.usePlaintext()
 				.build();
 			channelProvider = FixedTransportChannelProvider
 				.create(GrpcTransportChannel.create(channel));

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
@@ -32,6 +32,23 @@ under the License.
 	<name>flink-examples-streaming-gcp-pubsub</name>
 	<packaging>jar</packaging>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- NOTE: Without this building the software will fail with                    -->
+			<!--    Failed to resolve dependencies for one or more projects in the reactor. -->
+			<!--    Reason: The artifact has no valid ranges                                -->
+			<!--    [ERROR]   io.grpc:grpc-api:jar:1.28.1                                   -->
+			<dependency>
+				<!-- This is the way we get a consistent set of versions of the Google tools -->
+				<groupId>com.google.cloud</groupId>
+				<artifactId>libraries-bom</artifactId>
+				<version>8.0.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
@@ -32,23 +32,6 @@ under the License.
 	<name>flink-examples-streaming-gcp-pubsub</name>
 	<packaging>jar</packaging>
 
-	<dependencyManagement>
-		<dependencies>
-			<!-- NOTE: Without this building the software will fail with                    -->
-			<!--    Failed to resolve dependencies for one or more projects in the reactor. -->
-			<!--    Reason: The artifact has no valid ranges                                -->
-			<!--    [ERROR]   io.grpc:grpc-api:jar:1.28.1                                   -->
-			<dependency>
-				<!-- This is the way we get a consistent set of versions of the Google tools -->
-				<groupId>com.google.cloud</groupId>
-				<artifactId>libraries-bom</artifactId>
-				<version>8.0.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/src/main/java/org/apache/flink/streaming/examples/gcp/pubsub/PubSubPublisher.java
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/src/main/java/org/apache/flink/streaming/examples/gcp/pubsub/PubSubPublisher.java
@@ -19,8 +19,8 @@ package org.apache.flink.streaming.examples.gcp.pubsub;
 
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.protobuf.ByteString;
-import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
 
 import java.math.BigInteger;
 
@@ -44,7 +44,7 @@ class PubSubPublisher {
 	void publish(int amountOfMessages) {
 		Publisher publisher = null;
 		try {
-			publisher = Publisher.newBuilder(ProjectTopicName.of(projectName, topicName)).build();
+			publisher = Publisher.newBuilder(TopicName.of(projectName, topicName)).build();
 			for (int i = 0; i < amountOfMessages; i++) {
 				ByteString messageData = ByteString.copyFrom(BigInteger.valueOf(i).toByteArray());
 				PubsubMessage message = PubsubMessage.newBuilder().setData(messageData).build();


### PR DESCRIPTION
## What is the purpose of the change

The PubSub connector was created with the Google Cloud libraries of some time ago.
Because over time Google has changed their API in a not backward compatible way this change simply updates the Google PubSub dependencies and fixes the API incompatibilities.

## Brief change log

- Use the updated dependencies from Google
- Fix problematic API changes
  - .usePlaintext(true)
  - NoCredentials.getInstance()
- Limit the retries in case of testing. 
  - Apparently now in the Google code a retry system is present that does way too many retries for testing scenarios.

## Verifying this change

This change is already covered by existing tests, such as the tests in the **flink-connector-gcp-pubsub** and  **flink-connector-gcp-pubsub-emulator-tests** maven modules.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **YES**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
