### PR TITLE
[hotfix][k8s] remove redundant null value check for 'clusterId'

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -102,7 +102,7 @@ public class KubernetesSessionCli {
 			final FlinkKubeClient kubeClient = KubeClientFactory.fromConfiguration(configuration);
 
 			// Retrieve or create a session cluster.
-			if (clusterId != null && kubeClient.getRestService(clusterId).isPresent()) {
+			if (kubeClient.getRestService(clusterId).isPresent()) {
 				clusterClient = kubernetesClusterDescriptor.retrieve(clusterId).getClusterClient();
 			} else {
 				clusterClient = kubernetesClusterDescriptor


### PR DESCRIPTION
## What is the purpose of the change

remove redundant null value check for 'clusterId' in KubernetesSessionCli#run


## Brief change log

  - remove redundant null value check for 'clusterId'


## Verifying this change

- This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
