### PR TITLE
 [FLINK-17425][blink-planner] supportsFilterPushDown rule in DynamicSource.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.resolver.ExpressionResolver;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.expressions.converter.ExpressionConverter;
+import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
+import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import scala.Tuple2;
+
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
+
+/**
+ * Planner rule that tries to push a filter into a [[LogicalTableScan]].
+ */
+public class PushFilterIntoTableSourceScanRule extends RelOptRule {
+	public static final PushFilterIntoTableSourceScanRule INSTANCE = new PushFilterIntoTableSourceScanRule();
+
+	public PushFilterIntoTableSourceScanRule() {
+		super(operand(Filter.class,
+			operand(LogicalTableScan.class, none())),
+			"PushFilterIntoTableSourceScanRule");
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		TableConfig config = call.getPlanner().getContext().unwrap(FlinkContext.class).getTableConfig();
+		if (!config.getConfiguration().getBoolean(
+			OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED)) {
+			return false;
+		}
+
+		Filter filter = call.rel(0);
+		if (filter.getCondition() == null) {
+			return false;
+		}
+
+		LogicalTableScan scan = call.rel(1);
+		TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
+		if (tableSourceTable != null && tableSourceTable.tableSource() instanceof SupportsFilterPushDown && tableSourceTable.extraDigests().length == 0) {
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public void onMatch(RelOptRuleCall call) {
+		Filter filter = call.rel(0);
+		LogicalTableScan scan = call.rel(1);
+		TableSourceTable table = scan.getTable().unwrap(TableSourceTable.class);
+		pushFilterIntoScan(call, filter, scan, table);
+
+	}
+
+	private void pushFilterIntoScan(
+		RelOptRuleCall call,
+		Filter filter,
+		LogicalTableScan scan,
+		FlinkPreparingTableBase relOptTable) {
+
+		RelBuilder relBuilder = call.builder();
+		FlinkContext context = call.getPlanner().getContext().unwrap(FlinkContext.class);
+		int maxCnfNodeCount = FlinkRelOptUtil.getMaxCnfNodeCount(scan);
+		Tuple2<Expression[], RexNode[]> tuple2 =
+			RexNodeExtractor.extractConjunctiveConditions(
+				filter.getCondition(),
+				maxCnfNodeCount,
+				filter.getInput().getRowType().getFieldNames(),
+				relBuilder.getRexBuilder(),
+				context.getFunctionCatalog(),
+				context.getCatalogManager(),
+				TimeZone.getTimeZone(scan.getCluster().getPlanner().getContext()
+					.unwrap(FlinkContext.class).getTableConfig().getLocalTimeZone()));
+		Expression[] predicates = tuple2._1;
+		RexNode[] unconvertedRexNodes = tuple2._2;
+		if (predicates.length == 0) {
+			// no condition can be translated to expression
+			return;
+		}
+
+		List<Expression> remainingPredicates = new LinkedList<>();
+		remainingPredicates.addAll(Arrays.asList(predicates));
+		//record size before applyFilters for update statistics
+		int originPredicatesSize = remainingPredicates.size();
+
+		//Update DynamicTableSource
+		TableSourceTable oldTableSourceTable = relOptTable.unwrap(TableSourceTable.class);
+		DynamicTableSource newTableSource = oldTableSourceTable.tableSource().copy();
+		ExpressionResolver resolver = ExpressionResolver.resolverFor(
+			context.getTableConfig(),
+			name -> Optional.empty(),
+			context.getFunctionCatalog().asLookup(str -> {
+				throw new TableException("We should not need to lookup any expressions at this point");
+			}),
+			context.getCatalogManager().getDataTypeFactory())
+			.build();
+		SupportsFilterPushDown.Result result = ((SupportsFilterPushDown) newTableSource).applyFilters(resolver.resolve(remainingPredicates));
+
+		//Update statistics
+		FlinkStatistic oldStatistic = oldTableSourceTable.getStatistic();
+		FlinkStatistic newStatistic = null;
+		//record size after applyFilters for update statistics
+		int updatedPredicatesSize = result.getRemainingFilters().size();
+		if (originPredicatesSize == updatedPredicatesSize) {
+			// Keep all Statistics if no predicates can be pushed down
+			newStatistic = oldStatistic;
+		} else if (oldStatistic == FlinkStatistic.UNKNOWN()) {
+			newStatistic = oldStatistic;
+		} else {
+			// Remove tableStats after predicates pushed down
+			newStatistic = FlinkStatistic.builder().statistic(oldStatistic).tableStats(null).build();
+		}
+
+		//Update extraDigests
+		String[] oldExtraDigests = oldTableSourceTable.extraDigests();
+		String[] newExtraDigests = null;
+		if (!result.getAcceptedFilters().isEmpty()) {
+			String extraDigests = "filter=["
+				+ result.getAcceptedFilters().stream().reduce((l, r) -> new CallExpression(AND, Arrays.asList(l, r), DataTypes.BOOLEAN())).get().toString()
+				+ "]";
+			newExtraDigests = Stream.concat(Arrays.stream(oldExtraDigests), Arrays.stream(new String[]{extraDigests})).toArray(String[]::new);
+		} else {
+			newExtraDigests = oldExtraDigests;
+		}
+			//set the newStatistic newTableSource and extraDigests
+		TableSourceTable newTableSourceTable = new TableSourceTable(
+			oldTableSourceTable.getRelOptSchema(),
+			oldTableSourceTable.tableIdentifier(),
+			oldTableSourceTable.getRowType(),
+			newStatistic,
+			newTableSource,
+			oldTableSourceTable.isStreamingMode(),
+			oldTableSourceTable.catalogTable(),
+			oldTableSourceTable.dynamicOptions(),
+			newExtraDigests
+		);
+		TableScan newScan = new LogicalTableScan(scan.getCluster(), scan.getTraitSet(), scan.getHints(), newTableSourceTable);
+
+		// check whether framework still need to do a filter
+		if (result.getRemainingFilters().isEmpty() && unconvertedRexNodes.length == 0) {
+			call.transformTo(newScan);
+		} else {
+			relBuilder.push(scan);
+			ExpressionConverter converter = new ExpressionConverter(relBuilder);
+			List<RexNode> remainingConditions = result.getRemainingFilters().stream().map(e -> e.accept(converter)).collect(Collectors.toList());
+			remainingConditions.addAll(Arrays.asList(unconvertedRexNodes));
+			RexNode remainingCondition = remainingConditions.stream().reduce((l, r) -> relBuilder.and(l, r)).get();
+			Filter newFilter = filter.copy(filter.getTraitSet(), newScan, remainingCondition);
+			call.transformTo(newFilter);
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -165,6 +165,7 @@ object FlinkBatchRuleSets {
     */
   val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
     // push a filter down into the table scan
+    PushFilterIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE
@@ -247,6 +248,7 @@ object FlinkBatchRuleSets {
     // scan optimization
     PushProjectIntoTableSourceScanRule.INSTANCE,
     PushProjectIntoLegacyTableSourceScanRule.INSTANCE,
+    PushFilterIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE,
 
     // reorder sort and projection

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -166,6 +166,7 @@ object FlinkStreamRuleSets {
     */
   val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
     // push a filter down into the table scan
+    PushFilterIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE
@@ -232,6 +233,7 @@ object FlinkStreamRuleSets {
     // scan optimization
     PushProjectIntoTableSourceScanRule.INSTANCE,
     PushProjectIntoLegacyTableSourceScanRule.INSTANCE,
+    PushFilterIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE,
 
     // reorder sort and projection

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
@@ -200,7 +200,6 @@ class CatalogSourceTable[T](
   private def validateTableSource(tableSource: DynamicTableSource): Unit = {
     // throw exception if unsupported ability interface is implemented
     val unsupportedAbilities = List(
-      classOf[SupportsFilterPushDown],
       classOf[SupportsLimitPushDown],
       classOf[SupportsPartitionPushDown],
       classOf[SupportsComputedColumnPushDown],

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.planner.calcite.CalciteConfig;
+import org.apache.flink.table.planner.plan.optimize.program.BatchOptimizeContext;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgramBuilder;
+import org.apache.flink.table.planner.plan.optimize.program.HEP_RULES_EXECUTION_TYPE;
+import org.apache.flink.table.planner.utils.TableConfigUtils;
+
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
+import org.apache.calcite.tools.RuleSets;
+
+/**
+ * Test for [[PushFilterIntoTableSourceScanRule]].
+ */
+public class PushFilterIntoTableSourceScanRuleTest extends PushFilterIntoLegacyTableSourceScanRuleTest {
+
+	@Override
+	public void setup() {
+		util().buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE());
+		CalciteConfig calciteConfig = TableConfigUtils.getCalciteConfig(util().tableEnv().getConfig());
+		calciteConfig.getBatchProgram().get().addLast(
+			"rules",
+			FlinkHepRuleSetProgramBuilder.<BatchOptimizeContext>newBuilder()
+				.setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION())
+				.setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+				.add(RuleSets.ofList(PushFilterIntoTableSourceScanRule.INSTANCE,
+					FilterProjectTransposeRule.INSTANCE))
+				.build()
+		);
+		// name: STRING, id: LONG, amount: INT, price: DOUBLE
+		String ddl1 =
+			"CREATE TABLE MyTable (\n" +
+				"  name STRING,\n" +
+				"  id bigint,\n" +
+				"  amount int,\n" +
+				"  price double\n" +
+				") WITH (\n" +
+				" 'connector' = 'values',\n" +
+				" 'filterable-fields' = 'amount',\n" +
+				" 'bounded' = 'true'\n" +
+				")";
+		util().tableEnv().executeSql(ddl1);
+
+		String ddl2 =
+			"CREATE TABLE VirtualTable (\n" +
+				"  name STRING,\n" +
+				"  id bigint,\n" +
+				"  amount int,\n" +
+				"  virtualField as amount + 1,\n" +
+				"  price double\n" +
+				") WITH (\n" +
+				" 'connector' = 'values',\n" +
+				" 'filterable-fields' = 'amount',\n" +
+				" 'bounded' = 'true'\n" +
+				")";
+
+		util().tableEnv().executeSql(ddl2);
+	}
+
+	@Override
+	public void testLowerUpperPushdown() {
+		String ddl3 =
+			"CREATE TABLE MTable (\n" +
+				"  a STRING,\n" +
+				"  b STRING\n" +
+				") WITH (\n" +
+				" 'connector' = 'values',\n" +
+				" 'filterable-fields' = 'a;b',\n" +
+				" 'bounded' = 'true'\n" +
+				")";
+		util().tableEnv().executeSql(ddl3);
+		util().verifyPlan("SELECT * FROM MTable WHERE LOWER(a) = 'foo' AND UPPER(b) = 'bar'");
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -16,7 +16,7 @@
 org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 org.apache.flink.table.planner.runtime.batch.sql.TestPartitionableSinkFactory
 org.apache.flink.table.planner.utils.TestPartitionableSourceFactory
-org.apache.flink.table.planner.utils.TestFilterableTableSourceFactory
+org.apache.flink.table.planner.utils.TestLegacyFilterableTableSourceFactory
 org.apache.flink.table.planner.utils.TestLegacyProjectableTableSourceFactory
 org.apache.flink.table.planner.utils.TestOptionsTableFactory
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testCannotPushDown">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE price > 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDownWithVirtualColumn">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalFilter(condition=[>($4, 10)])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+   +- LogicalFilter(condition=[>($3, 10)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDown3">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE amount > 2 OR amount < 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDown3WithVirtualColumn">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM VirtualTable WHERE amount > 2 OR amount < 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+   +- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushDown">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE amount > 2]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($2, 2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushDownWithVirtualColumn">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM VirtualTable WHERE amount > 2]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalFilter(condition=[>($2, 2)])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testFullyPushDown">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE amount > 2 AND amount < 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[AND(>($2, 2), <($2, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testFullyPushDownWithVirtualColumn">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM VirtualTable WHERE amount > 2 AND amount < 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalFilter(condition=[AND(>($2, 2), <($2, 10))])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testLowerUpperPushdown">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MTable WHERE LOWER(a) = 'foo' AND UPPER(b) = 'bar']]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[AND(=(LOWER($0), _UTF-16LE'foo'), =(UPPER($1), _UTF-16LE'bar'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, MTable, filter=[and(equals(lower(a), 'foo'), equals(upper(b), 'bar'))]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testPartialPushDown">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE amount > 2 AND price > 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[AND(>($2, 2), >($3, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testPartialPushDown2">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE amount > 2 OR price > 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[OR(>($2, 2), >($3, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[OR(>($2, 2), >($3, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testUnconvertedExpression">
+		<Resource name="sql">
+			<![CDATA[
+SELECT * FROM MyTable WHERE
+    amount > 2 AND id < 100 AND CAST(amount AS BIGINT) > 10
+      ]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[AND(>($2, 2), <($1, 100), >(CAST($2):BIGINT, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[AND(<($1, 100), >(CAST($2):BIGINT, 10))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testPartialPushDown2WithVirtualColumn">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM VirtualTable WHERE amount > 2 OR price > 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalFilter(condition=[OR(>($2, 2), >($4, 10))])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+   +- LogicalFilter(condition=[OR(>($2, 2), >($3, 10))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testWithUdf">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE amount > 2 AND myUdf(amount) < 32]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[AND(>($2, 2), <(myUdf($2), 32))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[<(org$apache$flink$table$planner$expressions$utils$Func1$$879c8537562dbe74f3349fa0e6502755($2), 32)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testPartialPushDownWithVirtualColumn">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM VirtualTable WHERE amount > 2 AND price > 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalFilter(condition=[AND(>($2, 2), >($4, 10))])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+   +- LogicalFilter(condition=[>($3, 10)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]])
+]]>
+		</Resource>
+	</TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LegacyTableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LegacyTableSourceTest.scala
@@ -48,9 +48,9 @@ class LegacyTableSourceTest extends TableTestBase {
       Seq.empty[Row])
     )
 
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       util.tableEnv,
-      TestFilterableTableSource.defaultSchema,
+      TestLegacyFilterableTableSource.defaultSchema,
       "FilterableTable",
       isBounded = true)
     TestPartitionableSourceFactory.createTemporaryTable(util.tableEnv, "PartitionableTable", true)
@@ -194,7 +194,7 @@ class LegacyTableSourceTest extends TableTestBase {
     row.setField(2, DateTimeTestUtil.localTime("14:23:02"))
     row.setField(3, DateTimeTestUtil.localDateTime("2017-01-24 12:45:01.234"))
 
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       util.tableEnv,
       schema,
       "FilterableTable1",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
@@ -23,7 +23,7 @@ import org.apache.calcite.tools.RuleSets
 import org.apache.flink.table.api.{DataTypes, TableSchema}
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
-import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TestFilterableTableSource}
+import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TestLegacyFilterableTableSource}
 import org.apache.flink.types.Row
 import org.junit.{Before, Test}
 
@@ -31,7 +31,7 @@ import org.junit.{Before, Test}
   * Test for [[PushFilterIntoLegacyTableSourceScanRule]].
   */
 class PushFilterIntoLegacyTableSourceScanRuleTest extends TableTestBase {
-  private val util = batchTestUtil()
+  protected val util = batchTestUtil()
 
   @Before
   def setup(): Unit = {
@@ -48,9 +48,9 @@ class PushFilterIntoLegacyTableSourceScanRuleTest extends TableTestBase {
     )
 
     // name: STRING, id: LONG, amount: INT, price: DOUBLE
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       util.tableEnv,
-      TestFilterableTableSource.defaultSchema,
+      TestLegacyFilterableTableSource.defaultSchema,
       "MyTable",
       isBounded = true)
     val ddl =
@@ -156,7 +156,7 @@ class PushFilterIntoLegacyTableSourceScanRuleTest extends TableTestBase {
       .build()
 
     val data = List(Row.of("foo", "bar"))
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       util.tableEnv,
       schema,
       "MTable",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.scala
@@ -38,9 +38,9 @@ class LegacyTableSourceTest extends TableTestBase {
 
   @Before
   def setup(): Unit = {
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       util.tableEnv,
-      TestFilterableTableSource.defaultSchema,
+      TestLegacyFilterableTableSource.defaultSchema,
       "FilterableTable")
 
     TestPartitionableSourceFactory.createTemporaryTable(util.tableEnv, "PartitionableTable", false)
@@ -414,7 +414,7 @@ class LegacyTableSourceTest extends TableTestBase {
     row.setField(2, DateTimeTestUtil.localTime("14:23:02"))
     row.setField(3, DateTimeTestUtil.localDateTime("2017-01-24 12:45:01.234"))
 
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       util.tableEnv,
       schema,
       "FilterableTable1",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -21,9 +21,8 @@ package org.apache.flink.table.planner.plan.stream.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.expressions.utils.Func0
-import org.apache.flink.table.planner.factories.TestValuesTableFactory.{MockedFilterPushDownTableSource, MockedLookupTableSource}
+import org.apache.flink.table.planner.factories.TestValuesTableFactory.MockedLookupTableSource
 import org.apache.flink.table.planner.utils.TableTestBase
-
 import org.junit.Test
 
 class TableScanTest extends TableTestBase {
@@ -371,24 +370,6 @@ class TableScanTest extends TableTestBase {
       """.stripMargin)
     thrown.expect(classOf[TableException])
     thrown.expectMessage("Cannot generate a valid execution plan for the given query")
-    util.verifyPlan("SELECT * FROM src", ExplainDetail.CHANGELOG_MODE)
-  }
-
-  @Test
-  def testUnsupportedAbilityInterface(): Unit = {
-    util.addTable(
-      s"""
-         |CREATE TABLE src (
-         |  ts TIMESTAMP(3),
-         |  a INT,
-         |  b DOUBLE
-         |) WITH (
-         |  'connector' = 'values',
-         |  'table-source-class' = '${classOf[MockedFilterPushDownTableSource].getName}'
-         |)
-      """.stripMargin)
-    thrown.expect(classOf[UnsupportedOperationException])
-    thrown.expectMessage("DynamicTableSource with SupportsFilterPushDown ability is not supported")
     util.verifyPlan("SELECT * FROM src", ExplainDetail.CHANGELOG_MODE)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LegacyTableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LegacyTableSourceITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchAbstractTestBase.TEMPORARY_FOLDER
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
-import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestLegacyProjectableTableSource, TestTableSourceSinks}
+import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestLegacyFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestLegacyProjectableTableSource, TestTableSourceSinks}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.types.Row
 
@@ -147,9 +147,9 @@ class LegacyTableSourceITCase extends BatchTestBase {
 
   @Test
   def testTableSourceWithFilterable(): Unit = {
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       tEnv,
-      TestFilterableTableSource.defaultSchema,
+      TestLegacyFilterableTableSource.defaultSchema,
       "FilterableTable",
       isBounded = true)
     checkResult(
@@ -164,9 +164,9 @@ class LegacyTableSourceITCase extends BatchTestBase {
 
   @Test
   def testTableSourceWithFunctionFilterable(): Unit = {
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       tEnv,
-      TestFilterableTableSource.defaultSchema,
+      TestLegacyFilterableTableSource.defaultSchema,
       "FilterableTable",
       isBounded = true,
       filterableFields = List("amount", "name"))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -49,8 +49,7 @@ class TableSourceITCase extends BatchTestBase {
         |""".stripMargin)
 
     val filterableTableDataId = TestValuesTableFactory.registerData(
-      TestFilterableTableSource.defaultRows)
-    // TODO: [FLINK-17425] support filter pushdown for TestValuesTableSource
+      TestLegacyFilterableTableSource.defaultRows)
     tEnv.executeSql(
       s"""
          |CREATE TABLE FilterableTable (
@@ -61,6 +60,7 @@ class TableSourceITCase extends BatchTestBase {
          |) WITH (
          |  'connector' = 'values',
          |  'data-id' = '$filterableTableDataId',
+         |  'filterable-fields' = 'amount',
          |  'bounded' = 'true'
          |)
          |""".stripMargin)
@@ -152,22 +152,22 @@ class TableSourceITCase extends BatchTestBase {
   @Test
   def testTableSourceWithFilterable(): Unit = {
     checkResult(
-      "SELECT id, name FROM FilterableTable WHERE amount > 4 AND price < 9",
+      "SELECT id, amount, name FROM FilterableTable WHERE amount > 4 AND price < 9",
       Seq(
-        row(5, "Record_5"),
-        row(6, "Record_6"),
-        row(7, "Record_7"),
-        row(8, "Record_8"))
+        row(5, 5, "Record_5"),
+        row(6, 6, "Record_6"),
+        row(7, 7, "Record_7"),
+        row(8, 8, "Record_8"))
     )
   }
 
   @Test
   def testTableSourceWithFunctionFilterable(): Unit = {
     checkResult(
-      "SELECT id, name FROM FilterableTable " +
+      "SELECT id, amount, name FROM FilterableTable " +
         "WHERE amount > 4 AND price < 9 AND upper(name) = 'RECORD_5'",
       Seq(
-        row(5, "Record_5"))
+        row(5, 5, "Record_5"))
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LegacyTableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LegacyTableSourceITCase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestData, TestingAppendSink}
-import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestLegacyProjectableTableSource, TestStreamTableSource, TestTableSourceSinks}
+import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestLegacyFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestLegacyProjectableTableSource, TestStreamTableSource, TestTableSourceSinks}
 import org.apache.flink.types.Row
 
 import org.junit.Assert._
@@ -307,9 +307,9 @@ class LegacyTableSourceITCase extends StreamingTestBase {
 
   @Test
   def testTableSourceWithFilterable(): Unit = {
-    TestFilterableTableSource.createTemporaryTable(
+    TestLegacyFilterableTableSource.createTemporaryTable(
       tEnv,
-      TestFilterableTableSource.defaultSchema,
+      TestLegacyFilterableTableSource.defaultSchema,
       "MyTable")
 
     val sqlQuery = "SELECT id, name FROM MyTable WHERE amount > 4 AND price < 9"

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
@@ -49,8 +49,7 @@ class TableSourceITCase extends StreamingTestBase {
          |""".stripMargin)
 
     val filterableTableDataId = TestValuesTableFactory.registerData(
-      TestFilterableTableSource.defaultRows)
-    // TODO: [FLINK-17425] support filter pushdown for TestValuesTableSource
+      TestLegacyFilterableTableSource.defaultRows)
     tEnv.executeSql(
       s"""
          |CREATE TABLE FilterableTable (
@@ -60,6 +59,7 @@ class TableSourceITCase extends StreamingTestBase {
          |  price DOUBLE
          |) WITH (
          |  'connector' = 'values',
+         |  'filterable-fields' = 'amount',
          |  'data-id' = '$filterableTableDataId'
          |)
          |""".stripMargin)
@@ -161,26 +161,26 @@ class TableSourceITCase extends StreamingTestBase {
 
   @Test
   def testTableSourceWithFilterable(): Unit = {
-    val query = "SELECT id, name FROM FilterableTable WHERE amount > 4 AND price < 9"
+    val query = "SELECT id, amount, name FROM FilterableTable WHERE amount > 4 AND price < 9"
     val result = tEnv.sqlQuery(query).toAppendStream[Row]
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
 
-    val expected = Seq("5,Record_5", "6,Record_6", "7,Record_7", "8,Record_8")
+    val expected = Seq("5,5,Record_5", "6,6,Record_6", "7,7,Record_7", "8,8,Record_8")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 
   @Test
   def testTableSourceWithFunctionFilterable(): Unit = {
-    val query = "SELECT id, name FROM FilterableTable " +
+    val query = "SELECT id, amount, name FROM FilterableTable " +
       "WHERE amount > 4 AND price < 9 AND upper(name) = 'RECORD_5'"
     val result = tEnv.sqlQuery(query).toAppendStream[Row]
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
 
-    val expected = Seq("5,Record_5")
+    val expected = Seq("5,5,Record_5")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
@@ -494,7 +494,7 @@ class TestLegacyProjectableTableSourceFactory extends StreamTableSourceFactory[R
   * @param filterPredicates The predicates that should be used to filter.
   * @param filterPushedDown Whether predicates have been pushed down yet.
   */
-class TestFilterableTableSource(
+class TestLegacyFilterableTableSource(
     override val isBounded: Boolean,
     schema: TableSchema,
     data: Seq[Row],
@@ -533,7 +533,7 @@ class TestFilterableTableSource(
       }
     }
 
-    new TestFilterableTableSource(
+    new TestLegacyFilterableTableSource(
       isBounded,
       schema,
       data,
@@ -631,7 +631,7 @@ class TestFilterableTableSource(
   override def getTableSchema: TableSchema = schema
 }
 
-object TestFilterableTableSource {
+object TestLegacyFilterableTableSource {
   val defaultFilterableFields = Set("amount")
 
   val defaultSchema: TableSchema = TableSchema.builder()
@@ -678,8 +678,8 @@ object TestFilterableTableSource {
   }
 }
 
-/** Table source factory to find and create [[TestFilterableTableSource]]. */
-class TestFilterableTableSourceFactory extends StreamTableSourceFactory[Row] {
+/** Table source factory to find and create [[TestLegacyFilterableTableSource]]. */
+class TestLegacyFilterableTableSourceFactory extends StreamTableSourceFactory[Row] {
   override def createStreamTableSource(properties: JMap[String, String])
     : StreamTableSource[Row] = {
     val descriptorProps = new DescriptorProperties()
@@ -690,16 +690,16 @@ class TestFilterableTableSourceFactory extends StreamTableSourceFactory[Row] {
     val rows = if (serializedRows != null) {
       EncodingUtils.decodeStringToObject(serializedRows, classOf[List[Row]])
     } else {
-      TestFilterableTableSource.defaultRows
+      TestLegacyFilterableTableSource.defaultRows
     }
     val serializedFilterableFields =
       descriptorProps.getOptionalString("filterable-fields").orElse(null)
     val filterableFields = if (serializedFilterableFields != null) {
       EncodingUtils.decodeStringToObject(serializedFilterableFields, classOf[List[String]]).toSet
     } else {
-      TestFilterableTableSource.defaultFilterableFields
+      TestLegacyFilterableTableSource.defaultFilterableFields
     }
-    new TestFilterableTableSource(isBounded, schema, rows, filterableFields)
+    new TestLegacyFilterableTableSource(isBounded, schema, rows, filterableFields)
   }
 
   override def requiredContext(): JMap[String, String] = {


### PR DESCRIPTION
## What is the purpose of the change
- make the DynamicSource supports FilterPushDown Rule

## Verifying this change
This change added tests and can be verified as follows:

- Added PushFilterIntoTableSourceScanRuleTest to verify the plan
- Extended TableSourceITCase (batch and stream )to verify the result filter projection

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (JavaDocs)
