### PR TITLE
[FLINK-17000][table] Ensure that every logical type can be represented as TypeInformation

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
@@ -58,7 +58,7 @@ public class AvroFormatFactoryTest extends TestLogger {
 	@Test
 	public void testSeDeSchema() {
 		final AvroRowDataDeserializationSchema expectedDeser =
-				new AvroRowDataDeserializationSchema(ROW_TYPE, new RowDataTypeInfo(ROW_TYPE));
+				new AvroRowDataDeserializationSchema(ROW_TYPE, WrapperTypeInfo.of(ROW_TYPE));
 
 		final Map<String, String> options = getAllOptions();
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.formats.avro.generated.JodaTimeRecord;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -96,7 +96,7 @@ public class AvroRowDataDeSerializationSchemaTest {
 			FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))),
 			FIELD("map2array", MAP(STRING(), ARRAY(INT()))));
 		final RowType rowType = (RowType) dataType.getLogicalType();
-		final TypeInformation<RowData> typeInfo = new RowDataTypeInfo(rowType);
+		final TypeInformation<RowData> typeInfo = WrapperTypeInfo.of(rowType);
 
 		final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
 		final GenericRecord record = new GenericData.Record(schema);
@@ -180,7 +180,7 @@ public class AvroRowDataDeSerializationSchemaTest {
 				FIELD("type_date", DATE()),
 				FIELD("type_time_millis", TIME(3)));
 		final RowType rowType = (RowType) dataType.getLogicalType();
-		final TypeInformation<RowData> typeInfo = new RowDataTypeInfo(rowType);
+		final TypeInformation<RowData> typeInfo = WrapperTypeInfo.of(rowType);
 		AvroRowDataSerializationSchema serializationSchema = new AvroRowDataSerializationSchema(rowType);
 		serializationSchema.open(null);
 		AvroRowDataDeserializationSchema deserializationSchema =

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
@@ -65,7 +65,7 @@ public class CsvFormatFactoryTest extends TestLogger {
 	@Test
 	public void testSeDeSchema() {
 		final CsvRowDataDeserializationSchema expectedDeser =
-				new CsvRowDataDeserializationSchema.Builder(ROW_TYPE, new RowDataTypeInfo(ROW_TYPE))
+				new CsvRowDataDeserializationSchema.Builder(ROW_TYPE, WrapperTypeInfo.of(ROW_TYPE))
 						.setFieldDelimiter(';')
 						.setQuoteCharacter('\'')
 						.setAllowComments(true)

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
@@ -276,7 +276,7 @@ public class CsvRowDataSerDeSchemaTest {
 
 		// deserialization
 		CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =
-			new CsvRowDataDeserializationSchema.Builder(rowType, new RowDataTypeInfo(rowType));
+			new CsvRowDataDeserializationSchema.Builder(rowType, WrapperTypeInfo.of(rowType));
 		deserializationConfig.accept(deserSchemaBuilder);
 		RowData deserializedRow = deserialize(deserSchemaBuilder, expectedCsv);
 
@@ -304,7 +304,7 @@ public class CsvRowDataSerDeSchemaTest {
 
 		// deserialization
 		CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =
-			new CsvRowDataDeserializationSchema.Builder(rowType, new RowDataTypeInfo(rowType));
+			new CsvRowDataDeserializationSchema.Builder(rowType, WrapperTypeInfo.of(rowType));
 		deserializationConfig.accept(deserSchemaBuilder);
 		RowData deserializedRow = deserialize(deserSchemaBuilder, csv);
 		Row actualRow = (Row) DataFormatConverters.getConverterForDataType(dataType)
@@ -323,7 +323,7 @@ public class CsvRowDataSerDeSchemaTest {
 			FIELD("f2", STRING()));
 		RowType rowType = (RowType) dataType.getLogicalType();
 		CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =
-			new CsvRowDataDeserializationSchema.Builder(rowType, new RowDataTypeInfo(rowType))
+			new CsvRowDataDeserializationSchema.Builder(rowType, WrapperTypeInfo.of(rowType))
 				.setIgnoreParseErrors(allowParsingErrors)
 				.setAllowComments(allowComments);
 		RowData deserializedRow = deserialize(deserSchemaBuilder, string);

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
@@ -118,7 +118,7 @@ public class JsonFormatFactoryTest extends TestLogger {
 		final JsonRowDataDeserializationSchema expectedDeser =
 				new JsonRowDataDeserializationSchema(
 						ROW_TYPE,
-						new RowDataTypeInfo(ROW_TYPE),
+						WrapperTypeInfo.of(ROW_TYPE),
 						false,
 						true,
 						TimestampFormat.ISO_8601);

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -18,9 +18,10 @@
 
 package org.apache.flink.formats.json;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
@@ -140,7 +141,7 @@ public class JsonRowDataSerDeSchemaTest {
 			FIELD("map", MAP(STRING(), BIGINT())),
 			FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))));
 		RowType schema = (RowType) dataType.getLogicalType();
-		RowDataTypeInfo resultTypeInfo = new RowDataTypeInfo(schema);
+		TypeInformation<RowData> resultTypeInfo = WrapperTypeInfo.of(schema);
 
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
 			schema, resultTypeInfo, false, false, TimestampFormat.ISO_8601);
@@ -211,7 +212,7 @@ public class JsonRowDataSerDeSchemaTest {
 		RowType rowType = (RowType) dataType.getLogicalType();
 
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
-			rowType, new RowDataTypeInfo(rowType), false, false,  TimestampFormat.ISO_8601);
+			rowType, WrapperTypeInfo.of(rowType), false, false,  TimestampFormat.ISO_8601);
 
 		Row expected = new Row(7);
 		expected.setField(0, bool);
@@ -236,7 +237,7 @@ public class JsonRowDataSerDeSchemaTest {
 		).getLogicalType();
 
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
-			rowType, new RowDataTypeInfo(rowType), false, false,  TimestampFormat.ISO_8601);
+			rowType, WrapperTypeInfo.of(rowType), false, false,  TimestampFormat.ISO_8601);
 		JsonRowDataSerializationSchema serializationSchema = new JsonRowDataSerializationSchema(rowType, TimestampFormat.ISO_8601);
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -290,7 +291,7 @@ public class JsonRowDataSerDeSchemaTest {
 		).getLogicalType();
 
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
-			rowType, new RowDataTypeInfo(rowType), false, true, TimestampFormat.ISO_8601);
+			rowType, WrapperTypeInfo.of(rowType), false, true, TimestampFormat.ISO_8601);
 		JsonRowDataSerializationSchema serializationSchema = new JsonRowDataSerializationSchema(rowType, TimestampFormat.ISO_8601);
 
 		for (int i = 0; i < jsons.length; i++) {
@@ -315,7 +316,7 @@ public class JsonRowDataSerDeSchemaTest {
 
 		// pass on missing field
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
-			schema, new RowDataTypeInfo(schema), false, false, TimestampFormat.ISO_8601);
+			schema, WrapperTypeInfo.of(schema), false, false, TimestampFormat.ISO_8601);
 
 		Row expected = new Row(1);
 		Row actual = convertToExternal(deserializationSchema.deserialize(serializedJson), dataType);
@@ -323,7 +324,7 @@ public class JsonRowDataSerDeSchemaTest {
 
 		// fail on missing field
 		deserializationSchema = deserializationSchema = new JsonRowDataDeserializationSchema(
-			schema, new RowDataTypeInfo(schema), true, false, TimestampFormat.ISO_8601);
+			schema, WrapperTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
 
 		thrown.expect(IOException.class);
 		thrown.expectMessage("Failed to deserialize JSON '{\"id\":123123123}'");
@@ -331,7 +332,7 @@ public class JsonRowDataSerDeSchemaTest {
 
 		// ignore on parse error
 		deserializationSchema = new JsonRowDataDeserializationSchema(
-			schema, new RowDataTypeInfo(schema), false, true, TimestampFormat.ISO_8601);
+			schema, WrapperTypeInfo.of(schema), false, true, TimestampFormat.ISO_8601);
 		actual = convertToExternal(deserializationSchema.deserialize(serializedJson), dataType);
 		assertEquals(expected, actual);
 
@@ -340,7 +341,7 @@ public class JsonRowDataSerDeSchemaTest {
 		// failOnMissingField and ignoreParseErrors both enabled
 		//noinspection ConstantConditions
 		new JsonRowDataDeserializationSchema(
-			schema, new RowDataTypeInfo(schema), true, true, TimestampFormat.ISO_8601);
+			schema, WrapperTypeInfo.of(schema), true, true, TimestampFormat.ISO_8601);
 	}
 
 	@Test
@@ -351,7 +352,7 @@ public class JsonRowDataSerDeSchemaTest {
 		).getLogicalType();
 
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
-			rowType, new RowDataTypeInfo(rowType), false, false, TimestampFormat.SQL);
+			rowType, WrapperTypeInfo.of(rowType), false, false, TimestampFormat.SQL);
 		JsonRowDataSerializationSchema serializationSchema = new JsonRowDataSerializationSchema(rowType, TimestampFormat.SQL);
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -378,7 +379,7 @@ public class JsonRowDataSerDeSchemaTest {
 	private void testIgnoreParseErrors(TestSpec spec) throws Exception {
 		// the parsing field should be null and no exception is thrown
 		JsonRowDataDeserializationSchema ignoreErrorsSchema = new JsonRowDataDeserializationSchema(
-			spec.rowType,  new RowDataTypeInfo(spec.rowType), false, true,
+			spec.rowType, WrapperTypeInfo.of(spec.rowType), false, true,
 			TimestampFormat.ISO_8601);
 		Row expected;
 		if (spec.expected != null) {
@@ -396,7 +397,7 @@ public class JsonRowDataSerDeSchemaTest {
 	private void testParseErrors(TestSpec spec) throws Exception {
 		// expect exception if parse error is not ignored
 		JsonRowDataDeserializationSchema failingSchema = new JsonRowDataDeserializationSchema(
-			spec.rowType,  new RowDataTypeInfo(spec.rowType), false, false,
+			spec.rowType, WrapperTypeInfo.of(spec.rowType), false, false,
 			spec.timestampFormat);
 
 		thrown.expectMessage(spec.errorMessage);

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchemaTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.formats.json.canal;
 
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
 
@@ -65,7 +65,7 @@ public class CanalJsonDeserializationSchemaTest {
 		List<String> lines = readLines("canal-data.txt");
 		CanalJsonDeserializationSchema deserializationSchema = new CanalJsonDeserializationSchema(
 			SCHEMA,
-			new RowDataTypeInfo(SCHEMA),
+			WrapperTypeInfo.of(SCHEMA),
 			false,
 			TimestampFormat.ISO_8601);
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
@@ -65,7 +65,7 @@ public class CanalJsonFormatFactoryTest extends TestLogger {
 	public void testSeDeSchema() {
 		final CanalJsonDeserializationSchema expectedDeser = new CanalJsonDeserializationSchema(
 			ROW_TYPE,
-			new RowDataTypeInfo(ROW_TYPE),
+			WrapperTypeInfo.of(ROW_TYPE),
 			true,
 			TimestampFormat.ISO_8601);
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchemaTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.formats.json.debezium;
 
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
 
@@ -74,7 +74,7 @@ public class DebeziumJsonDeserializationSchemaTest {
 		List<String> lines = readLines(resourceFile);
 		DebeziumJsonDeserializationSchema deserializationSchema = new DebeziumJsonDeserializationSchema(
 			SCHEMA,
-			new RowDataTypeInfo(SCHEMA),
+			WrapperTypeInfo.of(SCHEMA),
 			schemaInclude,
 			false,
 			TimestampFormat.ISO_8601);

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
@@ -65,7 +65,7 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
 	public void testSeDeSchema() {
 		final DebeziumJsonDeserializationSchema expectedDeser = new DebeziumJsonDeserializationSchema(
 			ROW_TYPE,
-			new RowDataTypeInfo(ROW_TYPE),
+			WrapperTypeInfo.of(ROW_TYPE),
 			true,
 			true,
 			TimestampFormat.ISO_8601);

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
@@ -39,6 +39,8 @@ import org.apache.flink.table.types.inference.TypeInferenceUtil
 import org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{hasRoot, isCompositeType}
 import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot, RowType}
+import org.apache.flink.table.types.utils.DataTypeUtils
+import org.apache.flink.table.types.utils.DataTypeUtils.{validateInputDataType, validateOutputDataType}
 import org.apache.flink.util.Preconditions
 
 /**
@@ -260,13 +262,7 @@ class BridgingSqlFunctionCallGen(call: RexCall) extends CallGenerator {
     }
     // the data type class can only partially verify the conversion class,
     // now is the time for the final check
-    enrichedDataTypes.foreach(dataType => {
-      if (!dataType.getLogicalType.supportsOutputConversion(dataType.getConversionClass)) {
-        throw new CodeGenException(
-          s"Data type '$dataType' does not support an output conversion " +
-            s"to class '${dataType.getConversionClass}'.")
-      }
-    })
+    enrichedDataTypes.foreach(validateOutputDataType)
   }
 
   private def verifyFunctionAwareOutputType(
@@ -301,11 +297,7 @@ class BridgingSqlFunctionCallGen(call: RexCall) extends CallGenerator {
     }
     // the data type class can only partially verify the conversion class,
     // now is the time for the final check
-    if (!enrichedType.supportsInputConversion(enrichedDataType.getConversionClass)) {
-      throw new CodeGenException(
-        s"Data type '$enrichedDataType' does not support an input conversion " +
-          s"to class '${enrichedDataType.getConversionClass}'.")
-    }
+    validateInputDataType(enrichedDataType)
   }
 
   private def verifyFunctionAwareImplementation(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -54,7 +54,6 @@ import org.apache.flink.table.planner.factories.TestValuesRuntimeFunctions.Keyed
 import org.apache.flink.table.planner.factories.TestValuesRuntimeFunctions.RetractingSinkFunction;
 import org.apache.flink.table.planner.factories.TestValuesRuntimeFunctions.TestValuesLookupFunction;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
-import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
@@ -597,7 +596,6 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 
 		@Override
 		public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
-			assert context.createTypeInformation(schema.toPhysicalRowDataType()) instanceof RowDataTypeInfo;
 			DataStructureConverter converter = context.createDataStructureConverter(schema.toPhysicalRowDataType());
 			if (isInsertOnly) {
 				checkArgument(expectedNum == -1,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/connector/sink/SinkRuntimeProviderContext.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/connector/sink/SinkRuntimeProviderContext.java
@@ -22,11 +22,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.inference.TypeTransformations;
-import org.apache.flink.table.types.utils.DataTypeUtils;
 
-import static org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo;
+import static org.apache.flink.table.types.utils.DataTypeUtils.validateOutputDataType;
 
 /**
  * Implementation of {@link DynamicTableSink.Context}.
@@ -47,14 +46,13 @@ public final class SinkRuntimeProviderContext implements DynamicTableSink.Contex
 
 	@Override
 	public TypeInformation<?> createTypeInformation(DataType consumedDataType) {
-		final DataType internalDataType = DataTypeUtils.transform(
-			consumedDataType,
-			TypeTransformations.TO_INTERNAL_CLASS);
-		return fromDataTypeToTypeInfo(internalDataType);
+		validateOutputDataType(consumedDataType);
+		return WrapperTypeInfo.of(consumedDataType.getLogicalType());
 	}
 
 	@Override
 	public DynamicTableSink.DataStructureConverter createDataStructureConverter(DataType consumedDataType) {
+		validateOutputDataType(consumedDataType);
 		return new DataStructureConverterWrapper(DataStructureConverters.getConverter(consumedDataType));
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/connector/source/LookupRuntimeProviderContext.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/connector/source/LookupRuntimeProviderContext.java
@@ -23,11 +23,10 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.connector.source.DynamicTableSource.DataStructureConverter;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.inference.TypeTransformations;
-import org.apache.flink.table.types.utils.DataTypeUtils;
 
-import static org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo;
+import static org.apache.flink.table.types.utils.DataTypeUtils.validateInputDataType;
 
 /**
  * Implementation of {@link LookupTableSource.Context}.
@@ -48,14 +47,13 @@ public final class LookupRuntimeProviderContext implements LookupTableSource.Loo
 
 	@Override
 	public TypeInformation<?> createTypeInformation(DataType producedDataType) {
-		final DataType internalDataType = DataTypeUtils.transform(
-			producedDataType,
-			TypeTransformations.TO_INTERNAL_CLASS);
-		return fromDataTypeToTypeInfo(internalDataType);
+		validateInputDataType(producedDataType);
+		return WrapperTypeInfo.of(producedDataType.getLogicalType());
 	}
 
 	@Override
 	public DataStructureConverter createDataStructureConverter(DataType producedDataType) {
+		validateInputDataType(producedDataType);
 		return new DataStructureConverterWrapper(DataStructureConverters.getConverter(producedDataType));
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/connector/source/ScanRuntimeProviderContext.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/connector/source/ScanRuntimeProviderContext.java
@@ -23,11 +23,10 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.connector.source.DynamicTableSource.DataStructureConverter;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.runtime.typeutils.WrapperTypeInfo;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.inference.TypeTransformations;
-import org.apache.flink.table.types.utils.DataTypeUtils;
 
-import static org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo;
+import static org.apache.flink.table.types.utils.DataTypeUtils.validateInputDataType;
 
 /**
  * Implementation of {@link ScanTableSource.Context}.
@@ -39,14 +38,13 @@ public final class ScanRuntimeProviderContext implements ScanTableSource.ScanCon
 
 	@Override
 	public TypeInformation<?> createTypeInformation(DataType producedDataType) {
-		final DataType internalDataType = DataTypeUtils.transform(
-			producedDataType,
-			TypeTransformations.TO_INTERNAL_CLASS);
-		return fromDataTypeToTypeInfo(internalDataType);
+		validateInputDataType(producedDataType);
+		return WrapperTypeInfo.of(producedDataType.getLogicalType());
 	}
 
 	@Override
 	public DataStructureConverter createDataStructureConverter(DataType producedDataType) {
+		validateInputDataType(producedDataType);
 		return new DataStructureConverterWrapper(DataStructureConverters.getConverter(producedDataType));
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
@@ -61,7 +61,11 @@ public class InternalSerializers {
 
 	/**
 	 * Creates a {@link TypeSerializer} for internal data structures of the given {@link LogicalType}.
+	 *
+	 * @deprecated Use {@link #create(LogicalType)} instead. All types of the new type system have been
+	 *             fully resolved before.
 	 */
+	@Deprecated
 	public static TypeSerializer create(LogicalType type, ExecutionConfig config) {
 		// ordered by type root definition
 		switch (type.getTypeRoot()) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/TypeInfoDataTypeConverter.java
@@ -79,6 +79,9 @@ import static org.apache.flink.table.runtime.types.PlannerTypeUtils.isPrimitive;
  * 1.See {@link TableFunctionDefinition#getResultType()}.
  * 2.See {@link AggregateFunctionDefinition#getAccumulatorTypeInfo()}.
  * 3.See {@link MapViewTypeInfo#getKeyType()}.
+ *
+ * @deprecated Use {@link WrapperTypeInfo#of(LogicalType)} instead if {@link TypeInformation} is really
+ *             required. In many cases, {@link InternalSerializers#create(LogicalType)} should be sufficient.
  */
 @Deprecated
 public class TypeInfoDataTypeConverter {
@@ -191,6 +194,6 @@ public class TypeInfoDataTypeConverter {
 	}
 
 	private static <T> WrapperTypeInfo<T> createWrapperTypeInfo(RawType<T> rawType) {
-		return new WrapperTypeInfo<>(rawType.getOriginatingClass(), rawType.getTypeSerializer());
+		return new WrapperTypeInfo<>(rawType, rawType.getOriginatingClass(), rawType.getTypeSerializer());
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataTypeInfo.java
@@ -40,8 +40,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * TypeInformation for {@link RowData}.
+ *
+ * @deprecated Use {@link WrapperTypeInfo#of(LogicalType)} to represent all kinds of {@link LogicalType}
+ *             as instances of {@link TypeInformation}.
  */
 @Internal
+@Deprecated
 public class RowDataTypeInfo extends TupleTypeInfoBase<RowData> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/WrapperTypeInfoTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/WrapperTypeInfoTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.table.types.logical.IntType;
 
 import java.time.DayOfWeek;
 
@@ -34,12 +35,15 @@ public class WrapperTypeInfoTest extends TypeInformationTestBase<WrapperTypeInfo
 	protected WrapperTypeInfo<?>[] getTestData() {
 		return new WrapperTypeInfo<?>[] {
 				new WrapperTypeInfo<>(
+					new IntType(),
 					Object.class,
 					new KryoSerializer<>(Object.class, new ExecutionConfig())),
 				new WrapperTypeInfo<>(
+					new IntType(),
 					DayOfWeek.class,
 					new KryoSerializer<>(DayOfWeek.class, new ExecutionConfig())),
 				new WrapperTypeInfo<>(
+					new IntType(),
 					Integer.class,
 					IntSerializer.INSTANCE)
 		};


### PR DESCRIPTION
## What is the purpose of the change

The `TypeInformation` class is a legacy class that is actually not necessary in the Blink planner. However, some Flink components require a type information. Therefore, this PR introduces a `WrapperTypeInfo` that can replace most (if not all)  TypeInformation classes in `runtime.typeutils`.

## Brief change log

Only expose `WrapperTypeInfo` for sources and sinks.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
