### PR TITLE
[FLINK-18524][table-common] Fix type inference for Scala varargs

### DIFF
--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -207,6 +207,10 @@ Regular JVM method calling semantics apply. Therefore, it is possible to:
 - use object inheritance such as `eval(Object)` that takes both `LocalDateTime` and `Integer`,
 - and combinations of the above such as `eval(Object...)` that takes all kinds of arguments.
 
+If you intend to implement functions in Scala, please add the `scala.annotation.varargs` annotation in
+case of variable arguments. Furthermore, it is recommended to use boxed primitives (e.g. `java.lang.Integer`
+instead of `Int`) to support `NULL`.
+
 The following snippets shows an example of an overloaded function:
 
 <div class="codetabs" markdown="1">
@@ -240,6 +244,8 @@ public static class SumFunction extends ScalarFunction {
 <div data-lang="Scala" markdown="1">
 {% highlight scala %}
 import org.apache.flink.table.functions.ScalarFunction
+import java.lang.Integer
+import java.lang.Double
 import scala.annotation.varargs
 
 // function with overloaded evaluation methods
@@ -280,7 +286,7 @@ If more advanced type inference logic is required, an implementer can explicitly
 
 The automatic type inference inspects the function's class and evaluation methods to derive data types for the arguments and result of a function. `@DataTypeHint` and `@FunctionHint` annotations support the automatic extraction.
 
-For a full list of classes that can be implicitly mapped to a data type, see the [data type section]({% link dev/table/types.md %}#data-type-annotations).
+For a full list of classes that can be implicitly mapped to a data type, see the [data type extraction section]({% link dev/table/types.md %}#data-type-extraction).
 
 **`@DataTypeHint`**
 

--- a/docs/dev/table/types.md
+++ b/docs/dev/table/types.md
@@ -1348,15 +1348,21 @@ DataTypes.NULL()
 |`java.lang.Object` | X     | X      | *Default*                            |
 |*any class*        |       | (X)    | Any non-primitive type.              |
 
-Data Type Annotations
----------------------
+Data Type Extraction
+--------------------
 
 At many locations in the API, Flink tries to automatically extract data type from class information using
 reflection to avoid repetitive manual schema work. However, extracting a data type reflectively is not always
 successful because logical information might be missing. Therefore, it might be necessary to add additional
 information close to a class or field declaration for supporting the extraction logic.
 
-The following table lists classes that can be implicitly mapped to a data type without requiring further information:
+The following table lists classes that can be implicitly mapped to a data type without requiring further information.
+
+If you intend to implement classes in Scala, *it is recommended to use boxed types* (e.g. `java.lang.Integer`)
+instead of Scala's primitives. Scala's primitives (e.g. `Int` or `Double`) are compiled to JVM primitives (e.g.
+`int`/`double`) and result in `NOT NULL` semantics as shown in the table below. Furthermore, Scala primitives that
+are used in generics (e.g. `java.lang.Map[Int, Double]`) are erased during compilation and lead to class
+information similar to `java.lang.Map[java.lang.Object, java.lang.Object]`.
 
 | Class                       | Data Type                           |
 |:----------------------------|:------------------------------------|

--- a/docs/dev/table/types.zh.md
+++ b/docs/dev/table/types.zh.md
@@ -1245,7 +1245,13 @@ DataTypes.NULL()
 
 Flink API 经常尝试使用反射自动从类信息中提取数据类型，以避免重复的手动定义模式工作。然而以反射方式提取数据类型并不总是成功的，因为可能会丢失逻辑信息。因此，可能有必要在类或字段声明附近添加额外信息以支持提取逻辑。
 
-下表列出了可以隐式映射到数据类型而无需额外信息的类：
+下表列出了可以隐式映射到数据类型而无需额外信息的类。
+
+If you intend to implement classes in Scala, *it is recommended to use boxed types* (e.g. `java.lang.Integer`)
+instead of Scala's primitives. Scala's primitives (e.g. `Int` or `Double`) are compiled to JVM primitives (e.g.
+`int`/`double`) and result in `NOT NULL` semantics as shown in the table below. Furthermore, Scala primitives that
+are used in generics (e.g. `java.lang.Map[Int, Double]`) are erased during compilation and lead to class
+information similar to `java.lang.Map[java.lang.Object, java.lang.Object]`.
 
 | 类                          | 数据类型                            |
 |:----------------------------|:------------------------------------|

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionMappingExtractor.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,11 +158,13 @@ final class FunctionMappingExtractor {
 		}
 		for (Method method : methods) {
 			try {
+				final Method correctMethod = correctVarArgMethod(method);
+
 				final Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappingsPerMethod =
-					collectMethodMappings(method, global, globalResultOnly, resultExtraction, accessor);
+					collectMethodMappings(correctMethod, global, globalResultOnly, resultExtraction, accessor);
 
 				// check if the method can be called
-				verifyMappingForMethod(method, collectedMappingsPerMethod, verification);
+				verifyMappingForMethod(correctMethod, collectedMappingsPerMethod, verification);
 
 				// check if method strategies conflict with function strategies
 				collectedMappingsPerMethod.forEach((signature, result) -> putMapping(collectedMappings, signature, result));
@@ -172,6 +176,39 @@ final class FunctionMappingExtractor {
 			}
 		}
 		return collectedMappings;
+	}
+
+	/**
+	 * Special case for Scala which generates two methods when using var-args (a {@code Seq < String >}
+	 * and {@code String...}). This method searches for the Java-like variant.
+	 */
+	private static Method correctVarArgMethod(Method method) {
+		final int paramCount = method.getParameterCount();
+		final Class<?>[] paramClasses = method.getParameterTypes();
+		if (paramCount > 0 && paramClasses[paramCount - 1].getName().equals("scala.collection.Seq")) {
+			final Type[] paramTypes = method.getGenericParameterTypes();
+			final ParameterizedType seqType = (ParameterizedType) paramTypes[paramCount - 1];
+			final Type varArgType = seqType.getActualTypeArguments()[0];
+			return ExtractionUtils.collectMethods(method.getDeclaringClass(), method.getName())
+				.stream()
+				.filter(Method::isVarArgs)
+				.filter(candidate -> candidate.getParameterCount() == paramCount)
+				.filter(candidate -> {
+					final Type[] candidateParamTypes = candidate.getGenericParameterTypes();
+					for (int i = 0; i < paramCount - 1; i++) {
+						if (candidateParamTypes[i] != paramTypes[i]) {
+							return false;
+						}
+					}
+					final Class<?> candidateVarArgType = candidate.getParameterTypes()[paramCount - 1];
+					return candidateVarArgType.isArray() &&
+						// check for Object is needed in case of Scala primitives (e.g. Int)
+						(varArgType == Object.class || candidateVarArgType.getComponentType() == varArgType);
+				})
+				.findAny()
+				.orElse(method);
+		}
+		return method;
 	}
 
 	/**
@@ -368,7 +405,7 @@ final class FunctionMappingExtractor {
 				return FunctionArgumentTemplate.of(((CollectionDataType) type).getElementDataType());
 			}
 			// special case for varargs that have been misinterpreted as BYTES
-			else {
+			else if (type.equals(DataTypes.BYTES())) {
 				return FunctionArgumentTemplate.of(DataTypes.TINYINT().notNull().bridgedTo(byte.class));
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

Fixes the type inference for Scala varargs.

## Brief change log

See commit messages.

## Verifying this change

This change added tests and can be verified as follows: `TypeInferenceExtractorScalaTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
