### PR TITLE
[FLINK-18520][table] Fix unresolvable catalog table functions

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/FunctionCatalogOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/FunctionCatalogOperatorTable.java
@@ -154,7 +154,7 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 			FunctionIdentifier identifier,
 			FunctionDefinition definition) {
 
-		if (!verifyFunctionKind(category, definition)) {
+		if (!verifyFunctionKind(category, identifier, definition)) {
 			return Optional.empty();
 		}
 
@@ -197,6 +197,7 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 	@SuppressWarnings("RedundantIfStatement")
 	private boolean verifyFunctionKind(
 			@Nullable SqlFunctionCategory category,
+			FunctionIdentifier identifier,
 			FunctionDefinition definition) {
 
 		// for now, we don't allow other functions than user-defined ones
@@ -208,11 +209,17 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 		// it would be nice to give a more meaningful exception when a scalar function is used instead
 		// of a table function and vice versa, but we can do that only once FLIP-51 is implemented
 
-		if (definition.getKind() == FunctionKind.SCALAR &&
-				(category == SqlFunctionCategory.USER_DEFINED_FUNCTION || category == SqlFunctionCategory.SYSTEM)) {
+		if (definition.getKind() == FunctionKind.SCALAR) {
+			if (category != null && category.isTableFunction()) {
+				throw new ValidationException(
+					String.format(
+						"Function '%s' cannot be used as a table function.",
+						identifier.asSummaryString()
+					)
+				);
+			}
 			return true;
-		} else if (definition.getKind() == FunctionKind.TABLE &&
-				(category == SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION || category == SqlFunctionCategory.SYSTEM)) {
+		} else if (definition.getKind() == FunctionKind.TABLE) {
 			return true;
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

Improves the validation logic for scalar/table function usage. It made catalog functions unresolvable before.

## Brief change log

Remove checking for SQL function category.

## Verifying this change

This change is already covered by existing tests, such as `FunctionITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
