### PR TITLE
[FLINK-18478] Use AvroFactory.extractAvroSpecificSchema in AvroDeserializationSchema

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.typeutils.AvroFactory;
 import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
@@ -144,7 +145,7 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
 		if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
 			SpecificData specificData = new SpecificData(cl);
 			this.datumReader = new SpecificDatumReader<>(specificData);
-			this.reader = specificData.getSchema(recordClazz);
+			this.reader = AvroFactory.extractAvroSpecificSchema(recordClazz, specificData);
 		} else {
 			this.reader = new Schema.Parser().parse(schemaString);
 			GenericData genericData = new GenericData(cl);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroFactory.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type to be serialized.
  */
 @Internal
-final class AvroFactory<T> {
+public final class AvroFactory<T> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AvroFactory.class);
 
@@ -138,7 +138,7 @@ final class AvroFactory<T> {
 	 * Extracts an Avro {@link Schema} from a {@link SpecificRecord}. We do this either via {@link
 	 * SpecificData} or by instantiating a record and extracting the schema from the instance.
 	 */
-	static <T> Schema extractAvroSpecificSchema(
+	public static <T> Schema extractAvroSpecificSchema(
 			Class<T> type,
 			SpecificData specificData) {
 		Optional<Schema> newSchemaOptional = tryExtractAvroSchemaViaInstance(type);


### PR DESCRIPTION
## What is the purpose of the change

 This makes `AvroFactory` and the used method public where they were package private before.

This fixes the problem that `AvroDeserializationSchema` was not working with types generated from avrohugger. It could also just be seen as refactoring/code cleanup.

I don't like making the `AvroFactory` public, ideally all the code would be in one package and we could keep things package private. Any thoughts on this?

## Brief change log

- make `AvroFactory` `public`, it was package private before
- use `AvroFactory.extractAvroSpecificSchema` in `AvroDeserializationSchema`


## Verifying this change

This is covered by existing tests. I'm not adding an actual Scala test with avrohugger. The fact that it now works with avrohugger is more a side effect of the fact that we now use the correct way to get a schema.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

Only internal changes.  