### PR TITLE
[FLINK-18487][table] Datagen and Blackhole factory omits unrecognized properties silently

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BlackHoleTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BlackHoleTableSinkFactory.java
@@ -29,6 +29,8 @@ import org.apache.flink.types.RowKind;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.table.factories.FactoryUtil.createTableFactoryHelper;
+
 /**
  * Black hole table sink factory swallowing all input records. It is designed for:
  * - high performance testing.
@@ -57,6 +59,7 @@ public class BlackHoleTableSinkFactory implements DynamicTableSinkFactory {
 
 	@Override
 	public DynamicTableSink createDynamicTableSink(Context context) {
+		createTableFactoryHelper(this, context).validate();
 		return new BlackHoleSink();
 	}
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
@@ -51,7 +51,6 @@ import java.util.Set;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
-import static org.apache.flink.table.factories.FactoryUtil.createTableFactoryHelper;
 
 /**
  * Factory for creating configured instances of {@link DataGenTableSource} in a stream environment.
@@ -61,6 +60,7 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 
 	public static final String IDENTIFIER = "datagen";
 	public static final Long ROWS_PER_SECOND_DEFAULT_VALUE = 10000L;
+	public static final int RANDOM_STRING_LENGTH_DEFAULT = 100;
 
 	public static final ConfigOption<Long> ROWS_PER_SECOND = key("rows-per-second")
 			.longType()
@@ -97,8 +97,6 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 
 	@Override
 	public DynamicTableSource createDynamicTableSource(Context context) {
-		createTableFactoryHelper(this, context).validateExcept(FIELDS);
-
 		Configuration options = new Configuration();
 		context.getCatalogTable().getOptions().forEach(options::setString);
 
@@ -119,7 +117,7 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 			optionalOptions.addAll(container.options);
 		}
 
-		FactoryUtil.validateFactoryOptions(new HashSet<>(), optionalOptions, options);
+		FactoryUtil.validateFactoryOptions(requiredOptions(), optionalOptions, options);
 
 		Set<String> consumedOptionKeys = new HashSet<>();
 		consumedOptionKeys.add(CONNECTOR.key());
@@ -153,7 +151,7 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 			case VARCHAR: {
 				ConfigOption<Integer> lenOption = key(FIELDS + "." + name + "." + LENGTH)
 						.intType()
-						.defaultValue(100);
+						.defaultValue(RANDOM_STRING_LENGTH_DEFAULT);
 				return DataGeneratorContainer.of(getRandomStringGenerator(config.get(lenOption)), lenOption);
 			}
 			case TINYINT: {

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -190,8 +190,8 @@ public class DataGenTableSourceFactoryTest {
 					descriptor.asMap());
 		} catch (ValidationException e) {
 			Throwable cause = e.getCause();
-			Assert.assertTrue(cause instanceof ValidationException);
-			Assert.assertTrue(cause.getMessage().contains(
+			Assert.assertTrue(cause.toString(), cause instanceof ValidationException);
+			Assert.assertTrue(cause.getMessage(), cause.getMessage().contains(
 					"Could not find required property 'fields.f0.start' for sequence generator."));
 			return;
 		}
@@ -211,9 +211,93 @@ public class DataGenTableSourceFactoryTest {
 					descriptor.asMap());
 		} catch (ValidationException e) {
 			Throwable cause = e.getCause();
-			Assert.assertTrue(cause instanceof ValidationException);
-			Assert.assertTrue(cause.getMessage().contains(
+			Assert.assertTrue(cause.toString(), cause instanceof ValidationException);
+			Assert.assertTrue(cause.getMessage(), cause.getMessage().contains(
 					"Could not find required property 'fields.f0.end' for sequence generator."));
+			return;
+		}
+		Assert.fail("Should fail by ValidationException.");
+	}
+
+	@Test
+	public void testWrongKey() {
+		try {
+			DescriptorProperties descriptor = new DescriptorProperties();
+			descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+			descriptor.putLong("wrong-rows-per-second", 1);
+
+			createSource(
+					TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+					descriptor.asMap());
+		} catch (ValidationException e) {
+			Throwable cause = e.getCause();
+			Assert.assertTrue(cause.toString(), cause instanceof ValidationException);
+			Assert.assertTrue(cause.getMessage(), cause.getMessage().contains(
+					"Unsupported options:\n\nwrong-rows-per-second"));
+			return;
+		}
+		Assert.fail("Should fail by ValidationException.");
+	}
+
+	@Test
+	public void testWrongStartInRandom() {
+		try {
+			DescriptorProperties descriptor = new DescriptorProperties();
+			descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+			descriptor.putString(FIELDS + ".f0." + KIND, RANDOM);
+			descriptor.putLong(FIELDS + ".f0." + START, 0);
+
+			createSource(
+					TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+					descriptor.asMap());
+		} catch (ValidationException e) {
+			Throwable cause = e.getCause();
+			Assert.assertTrue(cause.toString(), cause instanceof ValidationException);
+			Assert.assertTrue(cause.getMessage(), cause.getMessage().contains(
+					"Unsupported options:\n\nfields.f0.start"));
+			return;
+		}
+		Assert.fail("Should fail by ValidationException.");
+	}
+
+	@Test
+	public void testWrongLenInRandomLong() {
+		try {
+			DescriptorProperties descriptor = new DescriptorProperties();
+			descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+			descriptor.putString(FIELDS + ".f0." + KIND, RANDOM);
+			descriptor.putInt(FIELDS + ".f0." + LENGTH, 100);
+
+			createSource(
+					TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+					descriptor.asMap());
+		} catch (ValidationException e) {
+			Throwable cause = e.getCause();
+			Assert.assertTrue(cause.toString(), cause instanceof ValidationException);
+			Assert.assertTrue(cause.getMessage(), cause.getMessage().contains(
+					"Unsupported options:\n\nfields.f0.length"));
+			return;
+		}
+		Assert.fail("Should fail by ValidationException.");
+	}
+
+	@Test
+	public void testWrongTypes() {
+		try {
+			DescriptorProperties descriptor = new DescriptorProperties();
+			descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+			descriptor.putString(FIELDS + ".f0." + KIND, SEQUENCE);
+			descriptor.putString(FIELDS + ".f0." + START, "Wrong");
+			descriptor.putString(FIELDS + ".f0." + END, "Wrong");
+
+			createSource(
+					TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+					descriptor.asMap());
+		} catch (ValidationException e) {
+			Throwable cause = e.getCause();
+			Assert.assertTrue(cause.toString(), cause instanceof IllegalArgumentException);
+			Assert.assertTrue(cause.getMessage(), cause.getMessage().contains(
+					"Could not parse value 'Wrong' for key 'fields.f0.start'"));
 			return;
 		}
 		Assert.fail("Should fail by ValidationException.");


### PR DESCRIPTION
## What is the purpose of the change

For the following DDL, we just omits the unrecognized property 'records-per-second'.
```
CREATE TABLE MyDataGen (
  int_field int,
  double_field double,
  string_field varchar
) WITH (
  'connector' = 'datagen',
  'records-per-second' = '1'  -- should be rows-per-second
)
```
We should throw Exceptions to tell users that they used a wrong property.

## Brief change log

- Refactory `FactoryUtil`: provides `validateFactoryOptions` and `validateUnconsumedKeys`.
- `DataGenTableSourceFactory`: Dynamic generation config options, validate them, and check unconsumed keys.
- `BlackHoleTableSinkFactory`: Using helper.validate.

## Verifying this change

- `DataGeneratorSourceTest`
- `BlackHoleSinkFactoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? (no