### PR TITLE
[FLINK-18558][streaming] Introduce collect iterator with at least once semantics and exactly once semantics without fault tolerance

### DIFF
--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -146,9 +146,9 @@ A SELECT statement or a VALUES statement can be executed to collect the content 
 We can also print the select result to client console through the `TableResult.print()` method. The result data in `TableResult` can be accessed only once. Thus, `collect()` and `print()` must not be called after each other.
 
 `TableResult.collect()` and `TableResult.print()` have slightly different behaviors under different checkpointing settings (to enable checkpointing for a streaming job, see <a href="{{ site.baseurl }}/ops/config.html#checkpointing">checkpointing config</a>).
-* If the user is running a batch job, or does not enable checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` have neither exactly-once nor at-least-once guarantee. Query results are immediately accessible by the clients once they're produced, but the function calls will throw an exception when the job fails and restarts.
-* If the user enables exactly-once checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end exactly-once record delivery. A result will be accessible by clients only after its corresponding checkpoint completes.
-* If the user enables at-least-once checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end at-least-once record delivery. Query results are immediately accessible by the clients once they're produced, but it is possible for the same result to be delivered multiple times.
+* For batch jobs or streaming jobs without checkpointing, `TableResult.collect()` and `TableResult.print()` have neither exactly-once nor at-least-once guarantee. Query results are immediately accessible by the clients once they're produced, but exceptions will be thrown when the job fails and restarts.
+* For streaming jobs with exactly-once checkpointing, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end exactly-once record delivery. A result will be accessible by clients only after its corresponding checkpoint completes.
+* For streaming jobs with at-least-once checkpointing, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end at-least-once record delivery. Query results are immediately accessible by the clients once they're produced, but it is possible for the same result to be delivered multiple times.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -145,21 +145,16 @@ A SELECT statement or a VALUES statement can be executed to collect the content 
 `TableResult.collect()` method returns a closeable row iterator. The select job will not be finished unless all result data has been collected. We should actively close the job to avoid resource leak through the `CloseableIterator#close()` method. 
 We can also print the select result to client console through the `TableResult.print()` method. The result data in `TableResult` can be accessed only once. Thus, `collect()` and `print()` must not be called after each other.
 
-For streaming job, `TableResult.collect()` method or `TableResult.print` method guarantee end-to-end exactly-once record delivery. This requires the checkpointing mechanism to be enabled. By default, checkpointing is disabled. To enable checkpointing, we can set checkpointing properties (see the <a href="{{ site.baseurl }}/ops/config.html#checkpointing">checkpointing config</a> for details) through `TableConfig`.
-So a result record can be accessed by client only after its corresponding checkpoint completes.
-
-**Notes:** For streaming mode, only append-only query is supported now. 
+`TableResult.collect()` and `TableResult.print()` have slightly different behaviors under different checkpointing settings (to enable checkpointing for a streaming job, see <a href="{{ site.baseurl }}/ops/config.html#checkpointing">checkpointing config</a>).
+* If the user is running a batch job, or does not enable checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` have neither exactly-once nor at-least-once guarantee. Query results are immediately accessible by the clients once they're produced, but the function calls will throw an exception when the job fails and restarts;
+* If the user enables exactly-once checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end exactly-once record delivery. A result will be accessible by clients only after its corresponding checkpoint completes;
+* If the user enables at-least-once checkpointing for a streaming job,`TableResult.collect()` and `TableResult.print()` guarantee an end-to-end at-least-once record delivery. Query results are immediately accessible by the clients once they're produced, but it is possible for the same result to be delivered multiple times.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
-// enable checkpointing
-tableEnv.getConfig().getConfiguration().set(
-  ExecutionCheckpointingOptions.CHECKPOINTING_MODE, CheckpointingMode.EXACTLY_ONCE);
-tableEnv.getConfig().getConfiguration().set(
-  ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(10));
 
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
 

--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -146,9 +146,9 @@ A SELECT statement or a VALUES statement can be executed to collect the content 
 We can also print the select result to client console through the `TableResult.print()` method. The result data in `TableResult` can be accessed only once. Thus, `collect()` and `print()` must not be called after each other.
 
 `TableResult.collect()` and `TableResult.print()` have slightly different behaviors under different checkpointing settings (to enable checkpointing for a streaming job, see <a href="{{ site.baseurl }}/ops/config.html#checkpointing">checkpointing config</a>).
-* If the user is running a batch job, or does not enable checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` have neither exactly-once nor at-least-once guarantee. Query results are immediately accessible by the clients once they're produced, but the function calls will throw an exception when the job fails and restarts;
-* If the user enables exactly-once checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end exactly-once record delivery. A result will be accessible by clients only after its corresponding checkpoint completes;
-* If the user enables at-least-once checkpointing for a streaming job,`TableResult.collect()` and `TableResult.print()` guarantee an end-to-end at-least-once record delivery. Query results are immediately accessible by the clients once they're produced, but it is possible for the same result to be delivered multiple times.
+* If the user is running a batch job, or does not enable checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` have neither exactly-once nor at-least-once guarantee. Query results are immediately accessible by the clients once they're produced, but the function calls will throw an exception when the job fails and restarts.
+* If the user enables exactly-once checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end exactly-once record delivery. A result will be accessible by clients only after its corresponding checkpoint completes.
+* If the user enables at-least-once checkpointing for a streaming job, `TableResult.collect()` and `TableResult.print()` guarantee an end-to-end at-least-once record delivery. Query results are immediately accessible by the clients once they're produced, but it is possible for the same result to be delivered multiple times.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -145,9 +145,9 @@ SELECT 语句或者 VALUES 语句可以通过 `TableEnvironment.executeSql()` �
 我们还可以通过 `TableResult.print()` 方法将查询结果打印到本地控制台。`TableResult` 中的结果数据只能被访问一次，因此一个 `TableResult` 实例中，`collect()` 方法和 `print()` 方法不能被同时使用。
 
 `TableResult.collect()` 与 `TableResult.print()` 的行为在不同的 checkpointing 模式下略有不同（流作业开启 checkpointing 的方法可参考 <a href="{{ site.baseurl }}/zh/ops/config.html#checkpointing">checkpointing 配置</a>）。
-* 若用户正在运行批作业，或正在运行流作业但没有配置任何 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 既不保证精确一次的数据交付、也不保证至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但作业失败并重启时将会报错。
-* 若用户正在运行流作业并配置了精准一次的 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 保证端到端精确一次的数据交付。一条结果数据只有在其对应的 checkpointing 完成后才能在客户端被访问。
-* 若用户正在运行流作业并配置了至少一次的 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 保证端到端至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但同一条结果可能被多次传递给客户端。
+* 对于批作业或没有配置任何 checkpointing 的流作业，`TableResult.collect()` 与 `TableResult.print()` 既不保证精确一次的数据交付、也不保证至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但作业失败并重启时将会报错。
+* 对于配置了精准一次 checkpointing 的流作业，`TableResult.collect()` 与 `TableResult.print()` 保证端到端精确一次的数据交付。一条结果数据只有在其对应的 checkpointing 完成后才能在客户端被访问。
+* 对于配置了至少一次 checkpointing 的流作业，`TableResult.collect()` 与 `TableResult.print()` 保证端到端至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但同一条结果可能被多次传递给客户端。
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -145,8 +145,8 @@ SELECT 语句或者 VALUES 语句可以通过 `TableEnvironment.executeSql()` �
 我们还可以通过 `TableResult.print()` 方法将查询结果打印到本地控制台。`TableResult` 中的结果数据只能被访问一次，因此一个 `TableResult` 实例中，`collect()` 方法和 `print()` 方法不能被同时使用。
 
 `TableResult.collect()` 与 `TableResult.print()` 的行为在不同的 checkpointing 模式下略有不同（流作业开启 checkpointing 的方法可参考 <a href="{{ site.baseurl }}/zh/ops/config.html#checkpointing">checkpointing 配置</a>）。
-* 若用户正在运行批作业，或正在运行流作业但没有配置任何 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 既不保证精确一次的数据交付、也不保证至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但作业失败并重启时将会报错；
-* 若用户正在运行流作业并配置了精准一次的 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 保证端到端精确一次的数据交付。一条结果数据只有在其对应的 checkpointing 完成后才能在客户端被访问；
+* 若用户正在运行批作业，或正在运行流作业但没有配置任何 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 既不保证精确一次的数据交付、也不保证至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但作业失败并重启时将会报错。
+* 若用户正在运行流作业并配置了精准一次的 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 保证端到端精确一次的数据交付。一条结果数据只有在其对应的 checkpointing 完成后才能在客户端被访问。
 * 若用户正在运行流作业并配置了至少一次的 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 保证端到端至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但同一条结果可能被多次传递给客户端。
 
 <div class="codetabs" markdown="1">

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -144,21 +144,16 @@ SELECT 语句或者 VALUES 语句可以通过 `TableEnvironment.executeSql()` �
 `TableResult.collect()` 方法返回一个可以关闭的行迭代器。除非所有的数据都被收集到本地，否则一个查询作业永远不会结束。所以我们应该通过 `CloseableIterator#close()` 方法主动地关闭作业以防止资源泄露。
 我们还可以通过 `TableResult.print()` 方法将查询结果打印到本地控制台。`TableResult` 中的结果数据只能被访问一次，因此一个 `TableResult` 实例中，`collect()` 方法和 `print()` 方法不能被同时使用。
 
-对于流模式，`TableResult.collect()` 方法或者 `TableResult.print` 方法保证端到端精确一次的数据交付。这就要求开启 checkpointing。默认情况下 checkpointing 是禁止的，我们可以通过 `TableConfig` 设置 checkpointing 相关属性（请参考 <a href="{{ site.baseurl }}/zh/ops/config.html#checkpointing">checkpointing 配置</a>）来开启 checkpointing。
-因此一条结果数据只有在其对应的 checkpointing 完成后才能在客户端被访问。
-
-**注意：** 对于流模式，当前仅支持追加模式的查询语句，并且应该开启 checkpoint。因为一条结果只有在其对应的 checkpoint 完成之后才能被客户端访问到。
+`TableResult.collect()` 与 `TableResult.print()` 的行为在不同的 checkpointing 模式下略有不同（流作业开启 checkpointing 的方法可参考 <a href="{{ site.baseurl }}/zh/ops/config.html#checkpointing">checkpointing 配置</a>）。
+* 若用户正在运行批作业，或正在运行流作业但没有配置任何 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 既不保证精确一次的数据交付、也不保证至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但作业失败并重启时将会报错；
+* 若用户正在运行流作业并配置了精准一次的 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 保证端到端精确一次的数据交付。一条结果数据只有在其对应的 checkpointing 完成后才能在客户端被访问；
+* 若用户正在运行流作业并配置了至少一次的 checkpointing，`TableResult.collect()` 与 `TableResult.print()` 保证端到端至少一次的数据交付。查询结果在产生后可被客户端即刻访问，但同一条结果可能被多次传递给客户端。
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
-// enable checkpointing
-tableEnv.getConfig().getConfiguration().set(
-  ExecutionCheckpointingOptions.CHECKPOINTING_MODE, CheckpointingMode.EXACTLY_ONCE);
-tableEnv.getConfig().getConfiguration().set(
-  ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(10));
 
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
 

--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -138,15 +138,15 @@ class TableResult(object):
 
             - For batch jobs or streaming jobs without checkpointing,
               this method has neither exactly-once nor at-least-once guarantee.
-        	  Query results are immediately accessible by the clients once they're produced,
-        	  but exceptions will be thrown when the job fails and restarts.
-        	- For streaming jobs with exactly-once checkpointing,
-        	  this method guarantees an end-to-end exactly-once record delivery.
-        	  A result will be accessible by clients only after its corresponding checkpoint completes.
-        	- For streaming jobs with at-least-once checkpointing,
-        	  this method guarantees an end-to-end at-least-once record delivery.
-        	  Query results are immediately accessible by the clients once they're produced,
-        	  but it is possible for the same result to be delivered multiple times.
+              Query results are immediately accessible by the clients once they're produced,
+              but exceptions will be thrown when the job fails and restarts.
+            - For streaming jobs with exactly-once checkpointing,
+              this method guarantees an end-to-end exactly-once record delivery.
+              A result will be accessible by clients only after its corresponding checkpoint completes.
+            - For streaming jobs with at-least-once checkpointing,
+              this method guarantees an end-to-end at-least-once record delivery.
+              Query results are immediately accessible by the clients once they're produced,
+              but it is possible for the same result to be delivered multiple times.
 
         .. versionadded:: 1.11.0
         """

--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -142,7 +142,8 @@ class TableResult(object):
               but exceptions will be thrown when the job fails and restarts.
             - For streaming jobs with exactly-once checkpointing,
               this method guarantees an end-to-end exactly-once record delivery.
-              A result will be accessible by clients only after its corresponding checkpoint completes.
+              A result will be accessible by clients only after its corresponding checkpoint
+              completes.
             - For streaming jobs with at-least-once checkpointing,
               this method guarantees an end-to-end at-least-once record delivery.
               Query results are immediately accessible by the clients once they're produced,

--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -134,10 +134,19 @@ class TableResult(object):
         """
         Print the result contents as tableau form to client console.
 
-        For streaming mode, this method guarantees end-to-end exactly-once record delivery
-        which requires the checkpointing mechanism to be enabled.
-        By default, checkpointing is disabled. To enable checkpointing, set checkpointing properties
-        (see ExecutionCheckpointingOptions) through `TableConfig#getConfiguration()`.
+        This method has slightly different behaviors under different checkpointing settings.
+
+            - For batch jobs or streaming jobs without checkpointing,
+              this method has neither exactly-once nor at-least-once guarantee.
+        	  Query results are immediately accessible by the clients once they're produced,
+        	  but exceptions will be thrown when the job fails and restarts.
+        	- For streaming jobs with exactly-once checkpointing,
+        	  this method guarantees an end-to-end exactly-once record delivery.
+        	  A result will be accessible by clients only after its corresponding checkpoint completes.
+        	- For streaming jobs with at-least-once checkpointing,
+        	  this method guarantees an end-to-end at-least-once record delivery.
+        	  Query results are immediately accessible by the clients once they're produced,
+        	  but it is possible for the same result to be delivered multiple times.
 
         .. versionadded:: 1.11.0
         """

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
@@ -49,14 +49,13 @@ public final class DataStreamUtils {
 			stream.getExecutionEnvironment().getConfig());
 		String accumulatorName = "dataStreamCollect_" + UUID.randomUUID().toString();
 
+		StreamExecutionEnvironment env = stream.getExecutionEnvironment();
 		CollectSinkOperatorFactory<OUT> factory = new CollectSinkOperatorFactory<>(serializer, accumulatorName);
 		CollectSinkOperator<OUT> operator = (CollectSinkOperator<OUT>) factory.getOperator();
 		CollectResultIterator<OUT> iterator = new CollectResultIterator<>(
-			operator.getOperatorIdFuture(), serializer, accumulatorName);
+			operator.getOperatorIdFuture(), serializer, accumulatorName, env.getCheckpointConfig());
 		CollectStreamSink<OUT> sink = new CollectStreamSink<>(stream, factory);
 		sink.name("Data stream collect sink");
-
-		StreamExecutionEnvironment env = stream.getExecutionEnvironment();
 		env.addOperator(sink.getTransformation());
 
 		try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
@@ -82,17 +82,11 @@ public abstract class AbstractCollectResultBuffer<T> {
 		String responseVersion = response.getVersion();
 		long responseLastCheckpointedOffset = response.getLastCheckpointedOffset();
 
-		if (INIT_VERSION.equals(version)) {
-			// first response, just update version and do nothing
-			version = responseVersion;
-			return;
-		}
-
-		if (!version.equals(responseVersion)) {
+		if (!INIT_VERSION.equals(version) && !version.equals(responseVersion)) {
 			// version not matched, sink has restarted
 			sinkRestarted(responseLastCheckpointedOffset);
-			version = responseVersion;
 		}
+		version = responseVersion;
 
 		addResults(response, responseOffset);
 		maintainVisibility(userVisibleTail, responseLastCheckpointedOffset);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A buffer which encapsulates the logic of dealing with the response from the {@link CollectSinkFunction}.
+ */
+public abstract class AbstractCollectResultBuffer<T> {
+
+	private static final String INIT_VERSION = "";
+
+	private final TypeSerializer<T> serializer;
+	private final LinkedList<T> buffer;
+
+	// for detailed explanation of the following 2 variables, see Java doc of CollectSinkFunction
+	// `version` is to check if the sink restarts
+	private String version;
+	// `offset` is the offset of the next result we want to fetch
+	private long offset;
+
+	// userVisibleHead <= user visible results offset < userVisibleTail
+	private long userVisibleHead;
+	private long userVisibleTail;
+
+	public AbstractCollectResultBuffer(TypeSerializer<T> serializer) {
+		this.serializer = serializer;
+		this.buffer = new LinkedList<>();
+
+		this.version = INIT_VERSION;
+		this.offset = 0;
+
+		this.userVisibleHead = 0;
+		this.userVisibleTail = 0;
+	}
+
+	public T next() {
+		if (userVisibleHead == userVisibleTail) {
+			return null;
+		}
+		T ret = buffer.removeFirst();
+		userVisibleHead++;
+
+		sanityCheck();
+		return ret;
+	}
+
+	public long getOffset() {
+		return offset;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void dealWithResponse(CollectCoordinationResponse response, long responseOffset) throws IOException {
+		String responseVersion = response.getVersion();
+		long responseLastCheckpointedOffset = response.getLastCheckpointedOffset();
+
+		if (INIT_VERSION.equals(version)) {
+			version = responseVersion;
+			return;
+		}
+
+		if (!version.equals(responseVersion)) {
+			sinkRestarted(responseLastCheckpointedOffset);
+			version = responseVersion;
+		}
+
+		addResults(response, responseOffset);
+		maintainVisibility(userVisibleTail, responseLastCheckpointedOffset);
+
+		sanityCheck();
+	}
+
+	public void complete() {
+		makeResultsVisible(offset);
+	}
+
+	protected abstract void sinkRestarted(long lastCheckpointedOffset);
+
+	protected abstract void maintainVisibility(long currentVisiblePos, long lastCheckpointedOffset);
+
+	protected void makeResultsVisible(long visiblePos) {
+		userVisibleTail = visiblePos;
+	}
+
+	protected void revert(long checkpointedOffset) {
+		while (offset > checkpointedOffset) {
+			buffer.removeLast();
+			offset--;
+		}
+	}
+
+	protected void reset() {
+		buffer.clear();
+		userVisibleHead = 0;
+		userVisibleTail = 0;
+		offset = 0;
+	}
+
+	private void addResults(CollectCoordinationResponse response, long responseOffset) throws IOException {
+		List<T> results = response.getResults(serializer);
+		if (!results.isEmpty()) {
+			// response contains some data, add them to buffer
+			int addStart = (int) (offset - responseOffset);
+			List<T> addedResults = results.subList(addStart, results.size());
+			buffer.addAll(addedResults);
+			offset += addedResults.size();
+		}
+	}
+
+	private void sanityCheck() {
+		Preconditions.checkState(
+			userVisibleHead <= userVisibleTail,
+			"userVisibleHead should not be larger than userVisibleTail. This is a bug.");
+		Preconditions.checkState(
+			userVisibleTail <= offset,
+			"userVisibleTail should not be larger than offset. This is a bug.");
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
@@ -56,6 +56,9 @@ public abstract class AbstractCollectResultBuffer<T> {
 		this.userVisibleTail = 0;
 	}
 
+	/**
+	 * Get next user visible result, returns null if currently there is no more.
+	 */
 	public T next() {
 		if (userVisibleHead == userVisibleTail) {
 			return null;
@@ -80,11 +83,13 @@ public abstract class AbstractCollectResultBuffer<T> {
 		long responseLastCheckpointedOffset = response.getLastCheckpointedOffset();
 
 		if (INIT_VERSION.equals(version)) {
+			// first response, just update version and do nothing
 			version = responseVersion;
 			return;
 		}
 
 		if (!version.equals(responseVersion)) {
+			// version not matched, sink has restarted
 			sinkRestarted(responseLastCheckpointedOffset);
 			version = responseVersion;
 		}
@@ -107,6 +112,9 @@ public abstract class AbstractCollectResultBuffer<T> {
 		userVisibleTail = visiblePos;
 	}
 
+	/**
+	 * Revert the buffer back to the result whose offset is `checkpointedOffset`.
+	 */
 	protected void revert(long checkpointedOffset) {
 		while (offset > checkpointedOffset) {
 			buffer.removeLast();
@@ -114,6 +122,9 @@ public abstract class AbstractCollectResultBuffer<T> {
 		}
 	}
 
+	/**
+	 * Clear the whole buffer and discard all results.
+	 */
 	protected void reset() {
 		buffer.clear();
 		userVisibleHead = 0;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CheckpointedCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CheckpointedCollectResultBuffer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.io.IOException;
+
+/**
+ * A buffer which encapsulates the logic of dealing with the response from the {@link CollectSinkFunction}.
+ * It will consider the checkpoint related fields in the response.
+ * See Java doc of {@link CollectSinkFunction} for explanation of this communication protocol.
+ */
+public class CheckpointedCollectResultBuffer<T> extends AbstractCollectResultBuffer<T> {
+
+	public CheckpointedCollectResultBuffer(TypeSerializer<T> serializer) {
+		super(serializer);
+	}
+
+	@Override
+	protected void sinkRestarted(long lastCheckpointedOffset) {
+		// sink restarted, we revert back to where the sink tells us
+		revert(lastCheckpointedOffset);
+	}
+
+	@Override
+	protected void maintainVisibility(long currentVisiblePos, long lastCheckpointedOffset) {
+		if (currentVisiblePos < lastCheckpointedOffset) {
+			// lastCheckpointedOffset increases, this means that more results have been
+			// checkpointed, and we can give these results to the user
+			makeResultsVisible(lastCheckpointedOffset);
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CheckpointedCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CheckpointedCollectResultBuffer.java
@@ -20,8 +20,6 @@ package org.apache.flink.streaming.api.operators.collect;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-import java.io.IOException;
-
 /**
  * A buffer which encapsulates the logic of dealing with the response from the {@link CollectSinkFunction}.
  * It will consider the checkpoint related fields in the response.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
@@ -32,6 +32,16 @@ import java.util.concurrent.CompletableFuture;
 /**
  * An iterator which iterates through the results of a query job.
  *
+ * <p>The behavior of the iterator is slightly different under different checkpointing mode.
+ * <ul>
+ *     <li>If the user does not specify any checkpointing,
+ *     results are immediately delivered but exceptions will be thrown when the job restarts.
+ *     <li>If the user specifies exactly-once checkpointing,
+ *     results are guaranteed to be exactly-once but they're only visible after the corresponding checkpoint completes.
+ *     <li>If the user specifies at-least-once checkpointing,
+ *     results are immediately delivered but the same result may be delivered multiple times.
+ * </ul>
+ *
  * <p>NOTE: After using this iterator, the close method MUST be called in order to release job related resources.
  */
 public class CollectResultIterator<T> implements CloseableIterator<T> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
@@ -100,14 +100,14 @@ public class CollectResultIterator<T> implements CloseableIterator<T> {
 	private AbstractCollectResultBuffer<T> createBuffer(
 			TypeSerializer<T> serializer,
 			CheckpointConfig checkpointConfig) {
-		if (checkpointConfig.getCheckpointingMode() == CheckpointingMode.EXACTLY_ONCE) {
-			if (checkpointConfig.isCheckpointingEnabled()) {
+		if (checkpointConfig.isCheckpointingEnabled()) {
+			if (checkpointConfig.getCheckpointingMode() == CheckpointingMode.EXACTLY_ONCE) {
 				return new CheckpointedCollectResultBuffer<>(serializer);
 			} else {
-				return new UncheckpointedCollectResultBuffer<>(serializer, false);
+				return new UncheckpointedCollectResultBuffer<>(serializer, true);
 			}
 		} else {
-			return new UncheckpointedCollectResultBuffer<>(serializer, true);
+			return new UncheckpointedCollectResultBuffer<>(serializer, false);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/UncheckpointedCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/UncheckpointedCollectResultBuffer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.io.IOException;
+
+/**
+ * A buffer which encapsulates the logic of dealing with the response from the {@link CollectSinkFunction}.
+ * It ignores the checkpoint related fields in the response.
+ * See Java doc of {@link CollectSinkFunction} for explanation of this communication protocol.
+ */
+public class UncheckpointedCollectResultBuffer<T> extends AbstractCollectResultBuffer<T> {
+
+	private final boolean failureTolerance;
+
+	public UncheckpointedCollectResultBuffer(TypeSerializer<T> serializer, boolean failureTolerance) {
+		super(serializer);
+		this.failureTolerance = failureTolerance;
+	}
+
+	@Override
+	protected void sinkRestarted(long lastCheckpointedOffset) {
+		if (!failureTolerance) {
+			// sink restarted but we do not tolerate failure
+			throw new RuntimeException("Job restarted");
+		}
+		reset();
+	}
+
+	@Override
+	protected void maintainVisibility(long currentVisiblePos, long lastCheckpointedOffset) {
+		// the results are instantly visible by users
+		makeResultsVisible(getOffset());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/UncheckpointedCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/UncheckpointedCollectResultBuffer.java
@@ -20,8 +20,6 @@ package org.apache.flink.streaming.api.operators.collect;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-import java.io.IOException;
-
 /**
  * A buffer which encapsulates the logic of dealing with the response from the {@link CollectSinkFunction}.
  * It ignores the checkpoint related fields in the response.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultBufferTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link AbstractCollectResultBuffer} and its subclasses.
+ */
+public class CollectResultBufferTest {
+
+	private static final TypeSerializer<Integer> serializer = IntSerializer.INSTANCE;
+
+	@Test
+	public void testUncheckpointedValidResponse() throws Exception {
+		String version = "version";
+		AbstractCollectResultBuffer<Integer> buffer = new UncheckpointedCollectResultBuffer<>(serializer, false);
+
+		// first response to sync version, no data
+		CollectCoordinationResponse response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+
+		List<Integer> expected = Arrays.asList(1, 2, 3);
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(expected));
+		buffer.dealWithResponse(response, 0);
+		// for uncheckpointed buffer, results can be instantly seen by user
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+
+		expected = Arrays.asList(4, 5);
+		// 3 is a retransmitted value, it should be skipped
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(Arrays.asList(3, 4, 5)));
+		buffer.dealWithResponse(response, 2);
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+		Assert.assertNull(buffer.next());
+	}
+
+	@Test
+	public void testUncheckpointedFaultTolerance() throws Exception {
+		String version = "version";
+		AbstractCollectResultBuffer<Integer> buffer = new UncheckpointedCollectResultBuffer<>(serializer, true);
+
+		// first response to sync version, no data
+		CollectCoordinationResponse response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+
+		List<Integer> expected = Arrays.asList(1, 2, 3);
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(expected));
+		buffer.dealWithResponse(response, 0);
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+
+		// version changed, job restarted
+		version = "another";
+		response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+
+		// retransmit same data
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(expected));
+		buffer.dealWithResponse(response, 0);
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testUncheckpointedNotFaultTolerance() throws Exception {
+		String version = "version";
+		AbstractCollectResultBuffer<Integer> buffer = new UncheckpointedCollectResultBuffer<>(serializer, false);
+
+		// first response to sync version, no data
+		CollectCoordinationResponse response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+
+		List<Integer> expected = Arrays.asList(1, 2, 3);
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(expected));
+		buffer.dealWithResponse(response, 0);
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+
+		// version changed, job restarted
+		version = "another";
+		response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+	}
+
+	@Test
+	public void testCheckpointedValidResponse() throws Exception {
+		String version = "version";
+		AbstractCollectResultBuffer<Integer> buffer = new CheckpointedCollectResultBuffer<>(serializer);
+
+		// first response to sync version, no data
+		CollectCoordinationResponse response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+
+		List<Integer> expected = Arrays.asList(1, 2, 3);
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(expected));
+		buffer.dealWithResponse(response, 0);
+		// for checkpointed buffer, results can only be seen after a checkpoint
+		Assert.assertNull(buffer.next());
+
+		response = new CollectCoordinationResponse(version, 3, createSerializedResults(Arrays.asList(4, 5, 6)));
+		buffer.dealWithResponse(response, 3);
+		// results before checkpoint can be seen now
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+
+		expected = Arrays.asList(4, 5, 6);
+		// 6 is a retransmitted value, it should be skipped
+		response = new CollectCoordinationResponse(version, 6, createSerializedResults(Arrays.asList(6, 7)));
+		buffer.dealWithResponse(response, 5);
+		// results before checkpoint can be seen now
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+
+		buffer.complete();
+		Assert.assertEquals((Integer) 7, buffer.next());
+		Assert.assertNull(buffer.next());
+	}
+
+	@Test
+	public void testCheckpointedRestart() throws Exception {
+		String version = "version";
+		AbstractCollectResultBuffer<Integer> buffer = new CheckpointedCollectResultBuffer<>(serializer);
+
+		// first response to sync version, no data
+		CollectCoordinationResponse response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(Arrays.asList(1, 2, 3)));
+		buffer.dealWithResponse(response, 0);
+		// for checkpointed buffer, results can only be seen after a checkpoint
+		Assert.assertNull(buffer.next());
+
+		// version changed, job restarted
+		version = "another";
+		response = new CollectCoordinationResponse(version, 0, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+
+		List<Integer> expected = Arrays.asList(4, 5, 6);
+		// transmit some different data, they should overwrite previous ones
+		response = new CollectCoordinationResponse(version, 0, createSerializedResults(expected));
+		buffer.dealWithResponse(response, 0);
+		// checkpoint still not done
+		Assert.assertNull(buffer.next());
+
+		// checkpoint completed
+		response = new CollectCoordinationResponse(version, 3, Collections.emptyList());
+		buffer.dealWithResponse(response, 0);
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+		Assert.assertNull(buffer.next());
+	}
+
+	private List<byte[]> createSerializedResults(List<Integer> values) throws Exception {
+		List<byte[]> serializedResults = new ArrayList<>();
+		for (int value : values) {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			DataOutputView wrapper = new DataOutputViewStreamWrapper(baos);
+			serializer.serialize(value, wrapper);
+			serializedResults.add(baos.toByteArray());
+		}
+		return serializedResults;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultBufferTest.java
@@ -187,6 +187,24 @@ public class CollectResultBufferTest {
 		Assert.assertNull(buffer.next());
 	}
 
+	@Test
+	public void testImmediateAccumulatorResult() throws Exception {
+		String version = "version";
+		AbstractCollectResultBuffer<Integer> buffer = new UncheckpointedCollectResultBuffer<>(serializer, false);
+
+		// job finished before the first request,
+		// so the first and only response is from the accumulator and contains results
+		List<Integer> expected = Arrays.asList(1, 2, 3);
+		CollectCoordinationResponse response = new CollectCoordinationResponse(version, 0, createSerializedResults(expected));
+		buffer.dealWithResponse(response, 0);
+		buffer.complete();
+
+		for (Integer expectedValue : expected) {
+			Assert.assertEquals(expectedValue, buffer.next());
+		}
+		Assert.assertNull(buffer.next());
+	}
+
 	private List<byte[]> createSerializedResults(List<Integer> values) throws Exception {
 		List<byte[]> serializedResults = new ArrayList<>();
 		for (int value : values) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultIteratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultIteratorTest.java
@@ -25,8 +25,10 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.streaming.api.operators.collect.utils.TestCoordinationRequestHandler;
+import org.apache.flink.streaming.api.operators.collect.utils.AbstractTestCoordinationRequestHandler;
+import org.apache.flink.streaming.api.operators.collect.utils.TestCheckpointedCoordinationRequestHandler;
 import org.apache.flink.streaming.api.operators.collect.utils.TestJobClient;
+import org.apache.flink.streaming.api.operators.collect.utils.TestUncheckpointedCoordinationRequestHandler;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.TestLogger;
 
@@ -35,8 +37,11 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -51,6 +56,37 @@ public class CollectResultIteratorTest extends TestLogger {
 	private static final String ACCUMULATOR_NAME = "accumulatorName";
 
 	@Test
+	public void testUncheckpointedIterator() throws Exception {
+		Random random = new Random();
+
+		// run this random test multiple times
+		for (int testCount = 200; testCount > 0; testCount--) {
+			List<Integer> expected = new ArrayList<>();
+			for (int i = 0; i < 200; i++) {
+				expected.add(i);
+			}
+
+			CollectResultIterator<Integer> iterator = createIteratorAndJobClient(
+				new UncheckpointedCollectResultBuffer<>(serializer, true),
+				new TestUncheckpointedCoordinationRequestHandler<>(
+					random.nextInt(3), expected, serializer, ACCUMULATOR_NAME)).f0;
+
+			List<Integer> actual = new ArrayList<>();
+			while (iterator.hasNext()) {
+				actual.add(iterator.next());
+			}
+
+			// this is an at least once iterator, so we expect each value to at least appear
+			Set<Integer> actualSet = new HashSet<>(actual);
+			for (int expectedValue : expected) {
+				Assert.assertTrue(actualSet.contains(expectedValue));
+			}
+
+			iterator.close();
+		}
+	}
+
+	@Test
 	public void testCheckpointedIterator() throws Exception {
 		// run this random test multiple times
 		for (int testCount = 200; testCount > 0; testCount--) {
@@ -60,7 +96,8 @@ public class CollectResultIteratorTest extends TestLogger {
 			}
 
 			CollectResultIterator<Integer> iterator = createIteratorAndJobClient(
-				new TestCoordinationRequestHandler<>(expected, serializer, ACCUMULATOR_NAME)).f0;
+				new CheckpointedCollectResultBuffer<>(serializer),
+				new TestCheckpointedCoordinationRequestHandler<>(expected, serializer, ACCUMULATOR_NAME)).f0;
 
 			List<Integer> actual = new ArrayList<>();
 			while (iterator.hasNext()) {
@@ -84,7 +121,8 @@ public class CollectResultIteratorTest extends TestLogger {
 		}
 
 		Tuple2<CollectResultIterator<Integer>, JobClient> tuple2 = createIteratorAndJobClient(
-			new TestCoordinationRequestHandler<>(expected, serializer, ACCUMULATOR_NAME));
+			new CheckpointedCollectResultBuffer<>(serializer),
+			new TestCheckpointedCoordinationRequestHandler<>(expected, serializer, ACCUMULATOR_NAME));
 		CollectResultIterator<Integer> iterator = tuple2.f0;
 		JobClient jobClient = tuple2.f1;
 
@@ -99,10 +137,11 @@ public class CollectResultIteratorTest extends TestLogger {
 	}
 
 	private Tuple2<CollectResultIterator<Integer>, JobClient> createIteratorAndJobClient(
-			TestCoordinationRequestHandler<Integer> handler) {
+			AbstractCollectResultBuffer<Integer> buffer,
+			AbstractTestCoordinationRequestHandler<Integer> handler) {
 		CollectResultIterator<Integer> iterator = new CollectResultIterator<>(
+			buffer,
 			CompletableFuture.completedFuture(TEST_OPERATOR_ID),
-			serializer,
 			ACCUMULATOR_NAME,
 			0);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionRandomITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionRandomITCase.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.operators.collect.utils.CollectSinkFunctionTestWrapper;
+import org.apache.flink.streaming.api.operators.collect.utils.TestJobClient;
+import org.apache.flink.util.OptionalFailure;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.RunnableWithException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.streaming.api.operators.collect.utils.CollectSinkFunctionTestWrapper.ACCUMULATOR_NAME;
+
+/**
+ * Random IT cases for {@link CollectSinkFunction}.
+ * It will perform random insert, random checkpoint and random restart.
+ */
+public class CollectSinkFunctionRandomITCase extends TestLogger {
+
+	private static final int MAX_RESULTS_PER_BATCH = 3;
+	private static final JobID TEST_JOB_ID = new JobID();
+	private static final OperatorID TEST_OPERATOR_ID = new OperatorID();
+
+	private static final TypeSerializer<Integer> serializer = IntSerializer.INSTANCE;
+
+	private CollectSinkFunctionTestWrapper<Integer> functionWrapper;
+	private boolean jobFinished;
+
+	@Test
+	public void testCheckpointedFunction() throws Exception {
+		// run multiple times for this random test
+		for (int testCount = 30; testCount > 0; testCount--) {
+			functionWrapper = new CollectSinkFunctionTestWrapper<>(serializer, MAX_RESULTS_PER_BATCH * 4);
+			jobFinished = false;
+
+			List<Integer> expected = new ArrayList<>();
+			for (int i = 0; i < 50; i++) {
+				expected.add(i);
+			}
+			Thread feeder = new ThreadWithException(new CheckpointedDataFeeder(expected));
+
+			List<Integer> actual = runFunctionRandomTest(feeder);
+			assertResultsEqualAfterSort(expected, actual);
+
+			functionWrapper.closeWrapper();
+		}
+	}
+
+	private List<Integer> runFunctionRandomTest(Thread feeder) throws Exception {
+		CollectClient collectClient = new CollectClient();
+		Thread client = new ThreadWithException(collectClient);
+
+		Thread.UncaughtExceptionHandler exceptionHandler = (t, e) -> {
+			feeder.interrupt();
+			client.interrupt();
+			e.printStackTrace();
+		};
+		feeder.setUncaughtExceptionHandler(exceptionHandler);
+		client.setUncaughtExceptionHandler(exceptionHandler);
+
+		feeder.start();
+		client.start();
+		feeder.join();
+		client.join();
+
+		return collectClient.results;
+	}
+
+	private void assertResultsEqualAfterSort(List<Integer> expected, List<Integer> actual) {
+		Collections.sort(expected);
+		Collections.sort(actual);
+		Assert.assertThat(actual, CoreMatchers.is(expected));
+	}
+
+	/**
+	 * A {@link RunnableWithException} feeding data to the function. It will fail when half of the data is fed.
+	 */
+	private class UncheckpointedDataFeeder implements RunnableWithException {
+
+		private LinkedList<Integer> data;
+		private final List<Integer> originalData;
+		private boolean failedBefore;
+
+		private UncheckpointedDataFeeder(List<Integer> data) {
+			this.data = new LinkedList<>(data);
+			this.originalData = new ArrayList<>(data);
+			this.failedBefore = false;
+		}
+
+		@Override
+		public void run() throws Exception {
+			Random random = new Random();
+			functionWrapper.openFunction();
+
+			while (data.size() > 0) {
+				// feed some data to the function
+				int size = Math.min(data.size(), random.nextInt(MAX_RESULTS_PER_BATCH * 3) + 1);
+				for (int i = 0; i < size; i++) {
+					functionWrapper.invoke(data.removeFirst());
+				}
+
+				if (!failedBefore && data.size() < originalData.size() / 2) {
+					if (random.nextBoolean()) {
+						// with 50% chance we fail half-way
+						// we shuffle the data to simulate jobs whose result order is undetermined
+						data = new LinkedList<>(originalData);
+						Collections.shuffle(data);
+
+						functionWrapper.closeFunctionAbnormally();
+						functionWrapper.openFunction();
+					}
+
+					failedBefore = true;
+				}
+
+				if (random.nextBoolean()) {
+					Thread.sleep(random.nextInt(10));
+				}
+			}
+
+			functionWrapper.closeFunctionNormally();
+			jobFinished = true;
+		}
+	}
+
+	/**
+	 * A {@link RunnableWithException} feeding data to the function. It will randomly do checkpoint or fail.
+	 */
+	private class CheckpointedDataFeeder implements RunnableWithException {
+
+		private LinkedList<Integer> data;
+		private List<Integer> checkpointedData;
+		private long checkpointId;
+		private long lastSuccessCheckpointId;
+		private final List<CheckpointCountdown> checkpointCountdowns;
+
+		private CheckpointedDataFeeder(List<Integer> data) {
+			this.data = new LinkedList<>(data);
+			this.checkpointedData = new ArrayList<>(data);
+			this.checkpointId = 0;
+			this.lastSuccessCheckpointId = 0;
+			this.checkpointCountdowns = new ArrayList<>();
+		}
+
+		@Override
+		public void run() throws Exception {
+			Random random = new Random();
+			functionWrapper.openFunctionWithState();
+
+			while (data.size() > 0) {
+				// countdown each on-going checkpoint
+				ListIterator<CheckpointCountdown> iterator = checkpointCountdowns.listIterator();
+				while (iterator.hasNext()) {
+					CheckpointCountdown countdown = iterator.next();
+					if (countdown.id < lastSuccessCheckpointId) {
+						// this checkpoint is stale, throw it away
+						iterator.remove();
+					} else if (countdown.tick()) {
+						// complete a checkpoint
+						checkpointedData = countdown.data;
+						functionWrapper.checkpointComplete(countdown.id);
+						lastSuccessCheckpointId = countdown.id;
+						iterator.remove();
+					}
+				}
+
+				int r = random.nextInt(10);
+				if (r < 6) {
+					// with 60% chance we add some data
+					int size = Math.min(data.size(), random.nextInt(MAX_RESULTS_PER_BATCH * 3) + 1);
+					for (int i = 0; i < size; i++) {
+						functionWrapper.invoke(data.removeFirst());
+					}
+				} else if (r < 9) {
+					// with 30% chance we make a checkpoint
+					checkpointId++;
+
+					if (random.nextBoolean()) {
+						// with 50% chance this checkpoint will succeed in the future
+						checkpointCountdowns.add(
+							new CheckpointCountdown(checkpointId, data, random.nextInt(3) + 1));
+					}
+
+					functionWrapper.checkpointFunction(checkpointId);
+				} else {
+					// with 10% chance we fail
+					checkpointCountdowns.clear();
+
+					// we shuffle data to simulate jobs whose result order is undetermined
+					Collections.shuffle(checkpointedData);
+					data = new LinkedList<>(checkpointedData);
+
+					functionWrapper.closeFunctionAbnormally();
+					functionWrapper.openFunctionWithState();
+				}
+
+				if (random.nextBoolean()) {
+					Thread.sleep(random.nextInt(10));
+				}
+			}
+
+			functionWrapper.closeFunctionNormally();
+			jobFinished = true;
+		}
+	}
+
+	/**
+	 * Countdown for a checkpoint which will succeed in the future.
+	 */
+	private static class CheckpointCountdown {
+
+		private final long id;
+		private final List<Integer> data;
+		private int countdown;
+
+		private CheckpointCountdown(long id, List<Integer> data, int countdown) {
+			this.id = id;
+			this.data = new ArrayList<>(data);
+			this.countdown = countdown;
+		}
+
+		private boolean tick() {
+			if (countdown > 0) {
+				countdown--;
+				return countdown == 0;
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * A {@link RunnableWithException} collecting results with the collecting iterator.
+	 */
+	private class CollectClient implements RunnableWithException {
+
+		private final List<Integer> results;
+		private final CollectResultIterator<Integer> iterator;
+
+		private CollectClient() {
+			this.results = new ArrayList<>();
+
+			this.iterator = new CollectResultIterator<>(
+				CompletableFuture.completedFuture(TEST_OPERATOR_ID),
+				serializer,
+				ACCUMULATOR_NAME,
+				0
+			);
+
+			TestJobClient.JobInfoProvider infoProvider = new TestJobClient.JobInfoProvider() {
+
+				@Override
+				public boolean isJobFinished() {
+					return jobFinished;
+				}
+
+				@Override
+				public Map<String, OptionalFailure<Object>> getAccumulatorResults() {
+					Map<String, OptionalFailure<Object>> accumulatorResults = new HashMap<>();
+					accumulatorResults.put(
+						ACCUMULATOR_NAME,
+						OptionalFailure.of(functionWrapper.getAccumulatorLocalValue()));
+					return accumulatorResults;
+				}
+			};
+
+			TestJobClient jobClient = new TestJobClient(
+				TEST_JOB_ID,
+				TEST_OPERATOR_ID,
+				functionWrapper.getCoordinator(),
+				infoProvider);
+
+			iterator.setJobClient(jobClient);
+		}
+
+		@Override
+		public void run() throws Exception {
+			Random random = new Random();
+
+			while (iterator.hasNext()) {
+				results.add(iterator.next());
+				if (random.nextBoolean()) {
+					try {
+						Thread.sleep(5);
+					} catch (InterruptedException e) {
+						// ignore
+					}
+				}
+			}
+
+			iterator.close();
+		}
+	}
+
+	/**
+	 * A subclass of thread which wraps a {@link RunnableWithException} for the ease of tests.
+	 */
+	private static class ThreadWithException extends Thread {
+
+		private final RunnableWithException runnable;
+
+		private ThreadWithException(RunnableWithException runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			try {
+				runnable.run();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionRandomITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionRandomITCase.java
@@ -59,6 +59,26 @@ public class CollectSinkFunctionRandomITCase extends TestLogger {
 	private boolean jobFinished;
 
 	@Test
+	public void testUncheckpointedFunction() throws Exception {
+		// run multiple times for this random test
+		for (int testCount = 30; testCount > 0; testCount--) {
+			functionWrapper = new CollectSinkFunctionTestWrapper<>(serializer, MAX_RESULTS_PER_BATCH * 4);
+			jobFinished = false;
+
+			List<Integer> expected = new ArrayList<>();
+			for (int i = 0; i < 50; i++) {
+				expected.add(i);
+			}
+			Thread feeder = new ThreadWithException(new UncheckpointedDataFeeder(expected));
+
+			List<Integer> actual = runFunctionRandomTest(feeder);
+			assertResultsEqualAfterSort(expected, actual);
+
+			functionWrapper.closeWrapper();
+		}
+	}
+
+	@Test
 	public void testCheckpointedFunction() throws Exception {
 		// run multiple times for this random test
 		for (int testCount = 30; testCount > 0; testCount--) {
@@ -272,8 +292,8 @@ public class CollectSinkFunctionRandomITCase extends TestLogger {
 			this.results = new ArrayList<>();
 
 			this.iterator = new CollectResultIterator<>(
+				new CheckpointedCollectResultBuffer<>(serializer),
 				CompletableFuture.completedFuture(TEST_OPERATOR_ID),
-				serializer,
 				ACCUMULATOR_NAME,
 				0
 			);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
@@ -17,408 +17,239 @@
 
 package org.apache.flink.streaming.api.operators.collect;
 
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
-import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.operators.testutils.MockEnvironment;
-import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
-import org.apache.flink.streaming.api.operators.collect.utils.MockFunctionInitializationContext;
-import org.apache.flink.streaming.api.operators.collect.utils.MockFunctionSnapshotContext;
-import org.apache.flink.streaming.api.operators.collect.utils.MockOperatorEventGateway;
-import org.apache.flink.streaming.api.operators.collect.utils.TestJobClient;
-import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
-import org.apache.flink.util.OptionalFailure;
+import org.apache.flink.streaming.api.operators.collect.utils.CollectSinkFunctionTestWrapper;
+import org.apache.flink.streaming.api.operators.collect.utils.CollectTestUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link CollectSinkFunction}.
  */
 public class CollectSinkFunctionTest extends TestLogger {
 
-	private static final int MAX_RESULTS_PER_BATCH = 3;
-	private static final int MAX_BYTES_PER_BATCH = 12; // sizeof(int) * MAX_RESULTS_PER_BATCH
-	private static final String ACCUMULATOR_NAME = "tableCollectAccumulator";
-	private static final int FUTURE_TIMEOUT_MILLIS = 10000;
-	private static final int SOCKET_TIMEOUT_MILLIS = 1000;
-	private static final int MAX_RETIRES = 100;
-
-	private static final JobID TEST_JOB_ID = new JobID();
-	private static final OperatorID TEST_OPERATOR_ID = new OperatorID();
-
 	private static final TypeSerializer<Integer> serializer = IntSerializer.INSTANCE;
 
-	private CollectSinkFunction<Integer> function;
-	private CollectSinkOperatorCoordinator coordinator;
-	private MockFunctionInitializationContext functionInitializationContext;
-	private boolean jobFinished;
-
-	private IOManager ioManager;
-	private StreamingRuntimeContext runtimeContext;
-	private MockOperatorEventGateway gateway;
+	private CollectSinkFunctionTestWrapper<Integer> functionWrapper;
 
 	@Before
 	public void before() throws Exception {
-		ioManager = new IOManagerAsync();
-		MockEnvironment environment = new MockEnvironmentBuilder()
-			.setTaskName("mockTask")
-			.setManagedMemorySize(4 * MemoryManager.DEFAULT_PAGE_SIZE)
-			.setIOManager(ioManager)
-			.build();
-		runtimeContext = new MockStreamingRuntimeContext(false, 1, 0, environment);
-
-		gateway = new MockOperatorEventGateway();
-		coordinator = new CollectSinkOperatorCoordinator(SOCKET_TIMEOUT_MILLIS);
-		coordinator.start();
-
-		// only used in checkpointed tests
-		functionInitializationContext = new MockFunctionInitializationContext();
-
-		jobFinished = false;
+		// max bytes per batch = 3 * sizeof(int)
+		functionWrapper = new CollectSinkFunctionTestWrapper<>(serializer, 12);
 	}
 
 	@After
 	public void after() throws Exception {
-		coordinator.close();
-		ioManager.close();
+		functionWrapper.closeWrapper();
 	}
 
 	@Test
-	public void testUncheckpointedProtocol() throws Exception {
-		openFunction();
+	public void testIncreasingToken() throws Exception {
+		functionWrapper.openFunction();
 		for (int i = 0; i < 6; i++) {
-			// CollectSinkFunction never use context when invoked
-			function.invoke(i, null);
+			functionWrapper.invoke(i);
 		}
+		String version = initializeVersion();
 
-		CollectCoordinationResponse response = sendRequestAndGetValidResponse("", 0);
-		Assert.assertEquals(0, response.getLastCheckpointedOffset());
-		String version = response.getVersion();
-
-		response = sendRequestAndGetValidResponse(version, 0);
+		CollectCoordinationResponse response;
+		response = functionWrapper.sendRequestAndGetResponse(version, 0);
 		assertResponseEquals(response, version, 0, Arrays.asList(0, 1, 2));
+		response = functionWrapper.sendRequestAndGetResponse(version, 4);
+		assertResponseEquals(response, version, 0, Arrays.asList(4, 5));
+		response = functionWrapper.sendRequestAndGetResponse(version, 6);
+		assertResponseEquals(response, version, 0, Collections.emptyList());
 
-		response = sendRequestAndGetValidResponse(version, 4);
+		functionWrapper.closeFunctionNormally();
+	}
+
+	@Test
+	public void testDuplicatedToken()  throws Exception {
+		functionWrapper.openFunction();
+		for (int i = 0; i < 6; i++) {
+			functionWrapper.invoke(i);
+		}
+		String version = initializeVersion();
+
+		CollectCoordinationResponse response;
+		response = functionWrapper.sendRequestAndGetResponse(version, 0);
+		assertResponseEquals(response, version, 0, Arrays.asList(0, 1, 2));
+		response = functionWrapper.sendRequestAndGetResponse(version, 4);
+		assertResponseEquals(response, version, 0, Arrays.asList(4, 5));
+		response = functionWrapper.sendRequestAndGetResponse(version, 4);
 		assertResponseEquals(response, version, 0, Arrays.asList(4, 5));
 
-		response = sendRequestAndGetValidResponse(version, 6);
-		assertResponseEquals(response, version, 0, Collections.emptyList());
-
-		for (int i = 6; i < 10; i++) {
-			function.invoke(i, null);
-		}
-
-		// invalid request
-		response = sendRequestAndGetValidResponse(version, 5);
-		assertResponseEquals(response, version, 0, Collections.emptyList());
-
-		response = sendRequestAndGetValidResponse(version, 6);
-		assertResponseEquals(response, version, 0, Arrays.asList(6, 7, 8));
-
-		response = sendRequestAndGetValidResponse(version, 6);
-		assertResponseEquals(response, version, 0, Arrays.asList(6, 7, 8));
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		assertResponseEquals(response, version, 0, Collections.emptyList());
-
-		for (int i = 10; i < 16; i++) {
-			function.invoke(i, null);
-		}
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		assertResponseEquals(response, version, 0, Arrays.asList(12, 13, 14));
-
-		finishJob();
-
-		assertAccumulatorResult(12, version, 0, Arrays.asList(12, 13, 14, 15));
+		functionWrapper.closeFunctionNormally();
 	}
 
 	@Test
-	public void testCheckpointProtocol() throws Exception {
-		openFunctionWithState();
-		for (int i = 0; i < 2; i++) {
-			// CollectSinkFunction never use context when invoked
-			function.invoke(i, null);
+	public void testInvalidToken() throws Exception {
+		functionWrapper.openFunction();
+		for (int i = 0; i < 6; i++) {
+			functionWrapper.invoke(i);
 		}
+		String version = initializeVersion();
+		functionWrapper.sendRequestAndGetResponse(version, 4);
 
-		CollectCoordinationResponse response = sendRequestAndGetValidResponse("", 0);
-		Assert.assertEquals(0, response.getLastCheckpointedOffset());
-		String version = response.getVersion();
+		// invalid token
+		CollectCoordinationResponse response = functionWrapper.sendRequestAndGetResponse(version, 3);
+		assertResponseEquals(response, version, 0, Collections.emptyList());
 
-		response = sendRequestAndGetValidResponse(version, 0);
+		functionWrapper.closeFunctionNormally();
+	}
+
+	@Test
+	public void testInvalidVersion() throws Exception {
+		functionWrapper.openFunction();
+		for (int i = 0; i < 6; i++) {
+			functionWrapper.invoke(i);
+		}
+		String version = initializeVersion();
+
+		// invalid version
+		CollectCoordinationResponse response = functionWrapper.sendRequestAndGetResponse("invalid version", 0);
+		assertResponseEquals(response, version, 0, Collections.emptyList());
+
+		functionWrapper.closeFunctionNormally();
+	}
+
+	@Test
+	public void testCheckpoint() throws Exception {
+		functionWrapper.openFunctionWithState();
+		for (int i = 0; i < 2; i++) {
+			functionWrapper.invoke(i);
+		}
+		String version = initializeVersion();
+
+		CollectCoordinationResponse response = functionWrapper.sendRequestAndGetResponse(version, 0);
 		assertResponseEquals(response, version, 0, Arrays.asList(0, 1));
 
 		for (int i = 2; i < 6; i++) {
-			function.invoke(i, null);
+			functionWrapper.invoke(i);
 		}
 
-		response = sendRequestAndGetValidResponse(version, 3);
+		response = functionWrapper.sendRequestAndGetResponse(version, 3);
 		assertResponseEquals(response, version, 0, Arrays.asList(3, 4, 5));
 
-		checkpointFunction(1);
+		functionWrapper.checkpointFunction(1);
 
 		// checkpoint hasn't finished yet
-		response = sendRequestAndGetValidResponse(version, 4);
+		response = functionWrapper.sendRequestAndGetResponse(version, 4);
 		assertResponseEquals(response, version, 0, Arrays.asList(4, 5));
 
-		checkpointComplete(1);
+		functionWrapper.checkpointComplete(1);
 
 		// checkpoint finished
-		response = sendRequestAndGetValidResponse(version, 4);
+		response = functionWrapper.sendRequestAndGetResponse(version, 4);
 		assertResponseEquals(response, version, 3, Arrays.asList(4, 5));
 
+		functionWrapper.closeFunctionNormally();
+	}
+
+	@Test
+	public void testRestart() throws Exception {
+		functionWrapper.openFunctionWithState();
+		for (int i = 0; i < 3; i++) {
+			functionWrapper.invoke(i);
+		}
+		String version = initializeVersion();
+
+		functionWrapper.sendRequestAndGetResponse(version, 1);
+		functionWrapper.checkpointFunction(1);
+		functionWrapper.checkpointComplete(1);
+
+		CollectCoordinationResponse response = functionWrapper.sendRequestAndGetResponse(version, 1);
+		assertResponseEquals(response, version, 1, Arrays.asList(1, 2));
+
+		// these records are not checkpointed
+		for (int i = 3; i < 6; i++) {
+			functionWrapper.invoke(i);
+		}
+		response = functionWrapper.sendRequestAndGetResponse(version, 2);
+		assertResponseEquals(response, version, 1, Arrays.asList(2, 3, 4));
+
+		functionWrapper.closeFunctionAbnormally();
+		functionWrapper.openFunctionWithState();
+		version = initializeVersion();
+
+		response = functionWrapper.sendRequestAndGetResponse(version, 1);
+		assertResponseEquals(response, version, 1, Arrays.asList(1, 2));
+
 		for (int i = 6; i < 9; i++) {
-			function.invoke(i, null);
+			functionWrapper.invoke(i);
 		}
+		response = functionWrapper.sendRequestAndGetResponse(version, 2);
+		assertResponseEquals(response, version, 1, Arrays.asList(2, 6, 7));
 
-		response = sendRequestAndGetValidResponse(version, 6);
-		assertResponseEquals(response, version, 3, Arrays.asList(6, 7, 8));
-
-		closeFuntionAbnormally();
-
-		openFunctionWithState();
-
-		for (int i = 9; i < 12; i++) {
-			function.invoke(i, null);
-		}
-
-		response = sendRequestAndGetValidResponse(version, 4);
-		Assert.assertEquals(3, response.getLastCheckpointedOffset());
-		version = response.getVersion();
-
-		response = sendRequestAndGetValidResponse(version, 4);
-		assertResponseEquals(response, version, 3, Arrays.asList(4, 5, 9));
-
-		response = sendRequestAndGetValidResponse(version, 6);
-		assertResponseEquals(response, version, 3, Arrays.asList(9, 10, 11));
-
-		checkpointFunction(2);
-		checkpointComplete(2);
-
-		function.invoke(12, null);
-
-		response = sendRequestAndGetValidResponse(version, 7);
-		assertResponseEquals(response, version, 6, Arrays.asList(10, 11, 12));
-
-		closeFuntionAbnormally();
-
-		openFunctionWithState();
-
-		response = sendRequestAndGetValidResponse(version, 7);
-		Assert.assertEquals(6, response.getLastCheckpointedOffset());
-		version = response.getVersion();
-
-		response = sendRequestAndGetValidResponse(version, 7);
-		assertResponseEquals(response, version, 6, Arrays.asList(10, 11));
-
-		response = sendRequest(version, 9);
-		assertResponseEquals(response, version, 6, Collections.emptyList());
-
-		for (int i = 13; i < 17; i++) {
-			function.invoke(i, null);
-		}
-
-		response = sendRequestAndGetValidResponse(version, 9);
-		assertResponseEquals(response, version, 6, Arrays.asList(13, 14, 15));
-
-		checkpointFunction(3);
-		checkpointComplete(3);
-
-		closeFuntionAbnormally();
-
-		openFunctionWithState();
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		Assert.assertEquals(9, response.getLastCheckpointedOffset());
-		version = response.getVersion();
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		assertResponseEquals(response, version, 9, Collections.singletonList(16));
-
-		for (int i = 17; i < 20; i++) {
-			function.invoke(i, null);
-		}
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		assertResponseEquals(response, version, 9, Arrays.asList(16, 17, 18));
-
-		// this checkpoint will not complete
-		checkpointFunction(4);
-
-		closeFuntionAbnormally();
-
-		openFunctionWithState();
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		Assert.assertEquals(9, response.getLastCheckpointedOffset());
-		version = response.getVersion();
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		assertResponseEquals(response, version, 9, Collections.singletonList(16));
-
-		for (int i = 20; i < 23; i++) {
-			function.invoke(i, null);
-		}
-
-		response = sendRequestAndGetValidResponse(version, 12);
-		assertResponseEquals(response, version, 9, Arrays.asList(16, 20, 21));
-
-		finishJob();
-
-		assertAccumulatorResult(12, version, 9, Arrays.asList(16, 20, 21, 22));
+		functionWrapper.closeFunctionNormally();
 	}
 
 	@Test
-	public void testUncheckpointedFunction() throws Exception {
-		// run multiple times for this random test
-		for (int testCount = 30; testCount > 0; testCount--) {
-			List<Integer> expected = new ArrayList<>();
-			for (int i = 0; i < 50; i++) {
-				expected.add(i);
-			}
-			UncheckpointedDataFeeder feeder = new UncheckpointedDataFeeder(expected);
-
-			List<Integer> actual = runFunctionRandomTest(feeder);
-			assertResultsEqualAfterSort(expected, actual);
-
-			after();
-			before();
-		}
+	public void testAccumulatorResultWithoutCheckpoint() throws Exception {
+		testAccumulatorResultWithoutCheckpoint(2, Arrays.asList(2, 3, 4, 5));
 	}
 
 	@Test
-	public void testCheckpointedFunction() throws Exception {
-		// run multiple times for this random test
-		for (int testCount = 30; testCount > 0; testCount--) {
-			List<Integer> expected = new ArrayList<>();
-			for (int i = 0; i < 50; i++) {
-				expected.add(i);
-			}
-			CheckpointedDataFeeder feeder = new CheckpointedDataFeeder(expected);
+	public void testEmptyAccumulatorResult() throws Exception {
+		testAccumulatorResultWithoutCheckpoint(6, Collections.emptyList());
+	}
 
-			List<Integer> actual = runFunctionRandomTest(feeder);
-			assertResultsEqualAfterSort(expected, actual);
-
-			after();
-			before();
+	private void testAccumulatorResultWithoutCheckpoint(int offset, List<Integer> expected) throws Exception {
+		functionWrapper.openFunction();
+		for (int i = 0; i < 6; i++) {
+			functionWrapper.invoke(i);
 		}
+		String version = initializeVersion();
+		functionWrapper.sendRequestAndGetResponse(version, offset);
+
+		functionWrapper.closeFunctionNormally();
+		CollectTestUtils.assertAccumulatorResult(
+			functionWrapper.getAccumulatorResults(),
+			offset,
+			version,
+			0,
+			expected,
+			serializer);
 	}
 
-	private List<Integer> runFunctionRandomTest(Thread feeder) throws Exception {
-		CollectClient client = new CollectClient();
-
-		Thread.UncaughtExceptionHandler exceptionHandler = (t, e) -> {
-			feeder.interrupt();
-			client.interrupt();
-			e.printStackTrace();
-		};
-		feeder.setUncaughtExceptionHandler(exceptionHandler);
-		client.setUncaughtExceptionHandler(exceptionHandler);
-
-		feeder.start();
-		client.start();
-		feeder.join();
-		client.join();
-
-		return client.results;
-	}
-
-	private void openFunction() throws Exception {
-		function = new CollectSinkFunction<>(serializer, MAX_BYTES_PER_BATCH, ACCUMULATOR_NAME);
-		function.setRuntimeContext(runtimeContext);
-		function.setOperatorEventGateway(gateway);
-		function.open(new Configuration());
-		coordinator.handleEventFromOperator(0, gateway.getNextEvent());
-	}
-
-	private void openFunctionWithState() throws Exception {
-		functionInitializationContext.getOperatorStateStore().revertToLastSuccessCheckpoint();
-		function = new CollectSinkFunction<>(serializer, MAX_BYTES_PER_BATCH, ACCUMULATOR_NAME);
-		function.setRuntimeContext(runtimeContext);
-		function.setOperatorEventGateway(gateway);
-		function.initializeState(functionInitializationContext);
-		function.open(new Configuration());
-		coordinator.handleEventFromOperator(0, gateway.getNextEvent());
-	}
-
-	private void checkpointFunction(long checkpointId) throws Exception {
-		function.snapshotState(new MockFunctionSnapshotContext(checkpointId));
-		functionInitializationContext.getOperatorStateStore().checkpointBegin(checkpointId);
-	}
-
-	private void checkpointComplete(long checkpointId) throws Exception {
-		function.notifyCheckpointComplete(checkpointId);
-		functionInitializationContext.getOperatorStateStore().checkpointSuccess(checkpointId);
-	}
-
-	private void closeFuntionAbnormally() throws Exception {
-		// this is an exceptional shutdown
-		function.close();
-		coordinator.subtaskFailed(0, null);
-	}
-
-	private void finishJob() throws Exception {
-		// this is a normal shutdown
-		function.accumulateFinalResults();
-		function.close();
-
-		jobFinished = true;
-	}
-
-	private CollectCoordinationResponse sendRequest(String version, long offset) throws Exception {
-		CollectCoordinationRequest request = new CollectCoordinationRequest(version, offset);
-		// we add a timeout to not block the tests
-		return ((CollectCoordinationResponse) coordinator
-			.handleCoordinationRequest(request).get(FUTURE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-	}
-
-	private CollectCoordinationResponse sendRequestAndGetValidResponse(String version, long offset) throws Exception {
-		CollectCoordinationResponse response;
-		for (int i = 0; i < MAX_RETIRES; i++) {
-			response = sendRequest(version, offset);
-			if (response.getLastCheckpointedOffset() >= 0) {
-				return response;
-			}
+	@Test
+	public void testAccumulatorResultWithCheckpoint() throws Exception {
+		functionWrapper.openFunctionWithState();
+		for (int i = 0; i < 6; i++) {
+			functionWrapper.invoke(i);
 		}
-		throw new RuntimeException("Too many retries in sendRequestAndGetValidResponse");
+		String version = initializeVersion();
+		functionWrapper.sendRequestAndGetResponse(version, 3);
+
+		functionWrapper.checkpointFunction(1);
+		functionWrapper.checkpointComplete(1);
+
+		for (int i = 6; i < 9; i++) {
+			functionWrapper.invoke(i);
+		}
+		functionWrapper.sendRequestAndGetResponse(version, 5);
+
+		functionWrapper.closeFunctionNormally();
+		CollectTestUtils.assertAccumulatorResult(
+			functionWrapper.getAccumulatorResults(),
+			5,
+			version,
+			3,
+			Arrays.asList(5, 6, 7, 8),
+			serializer);
 	}
 
-	@SuppressWarnings("unchecked")
-	private Tuple2<Long, CollectCoordinationResponse> getAccumualtorResults() throws Exception {
-		Accumulator accumulator = runtimeContext.getAccumulator(ACCUMULATOR_NAME);
-		ArrayList<byte[]> accLocalValue = ((SerializedListAccumulator) accumulator).getLocalValue();
-		List<byte[]> serializedResults =
-			SerializedListAccumulator.deserializeList(accLocalValue, BytePrimitiveArraySerializer.INSTANCE);
-		Assert.assertEquals(1, serializedResults.size());
-		byte[] serializedResult = serializedResults.get(0);
-		return CollectSinkFunction.deserializeAccumulatorResult(serializedResult);
+	private String initializeVersion() throws Exception {
+		CollectCoordinationResponse response = functionWrapper.sendRequestAndGetResponse("", 0);
+		return response.getVersion();
 	}
 
 	private void assertResponseEquals(
@@ -426,262 +257,6 @@ public class CollectSinkFunctionTest extends TestLogger {
 			String version,
 			long lastCheckpointedOffset,
 			List<Integer> expected) throws IOException {
-		Assert.assertEquals(version, response.getVersion());
-		Assert.assertEquals(lastCheckpointedOffset, response.getLastCheckpointedOffset());
-		List<Integer> results = response.getResults(serializer);
-		assertResultsEqual(expected, results);
-	}
-
-	private void assertResultsEqual(List<Integer> expected, List<Integer> actual) {
-		Assert.assertArrayEquals(expected.toArray(new Integer[0]), actual.toArray(new Integer[0]));
-	}
-
-	private void assertResultsEqualAfterSort(List<Integer> expected, List<Integer> actual) {
-		Collections.sort(expected);
-		Collections.sort(actual);
-		assertResultsEqual(expected, actual);
-	}
-
-	private void assertAccumulatorResult(
-			long expectedOffset,
-			String expectedVersion,
-			long expectedLastCheckpointedOffset,
-			List<Integer> expectedResults) throws Exception {
-		Tuple2<Long, CollectCoordinationResponse> accResults = getAccumualtorResults();
-		long offset = accResults.f0;
-		CollectCoordinationResponse response = accResults.f1;
-		List<Integer> actualResults = response.getResults(serializer);
-
-		Assert.assertEquals(expectedOffset, offset);
-		Assert.assertEquals(expectedVersion, response.getVersion());
-		Assert.assertEquals(expectedLastCheckpointedOffset, response.getLastCheckpointedOffset());
-		assertResultsEqual(expectedResults, actualResults);
-	}
-
-	/**
-	 * A thread feeding data to the function. It will fail when half of the data is fed.
-	 */
-	private class UncheckpointedDataFeeder extends Thread {
-
-		private LinkedList<Integer> data;
-		private List<Integer> checkpointedData;
-		private boolean failedBefore;
-
-		private UncheckpointedDataFeeder(List<Integer> data) {
-			this.data = new LinkedList<>(data);
-			this.checkpointedData = new ArrayList<>(data);
-			this.failedBefore = false;
-		}
-
-		@Override
-		public void run() {
-			Random random = new Random();
-
-			try {
-				openFunction();
-
-				while (data.size() > 0) {
-					int size = Math.min(data.size(), random.nextInt(MAX_RESULTS_PER_BATCH * 3) + 1);
-					for (int i = 0; i < size; i++) {
-						function.invoke(data.removeFirst(), null);
-					}
-
-					if (!failedBefore && data.size() < checkpointedData.size() / 2) {
-						if (random.nextBoolean()) {
-							// with 50% chance we fail half-way
-							Collections.shuffle(checkpointedData);
-							data = new LinkedList<>(checkpointedData);
-
-							closeFuntionAbnormally();
-							openFunction();
-						}
-
-						failedBefore = true;
-					}
-
-					if (random.nextBoolean()) {
-						Thread.sleep(random.nextInt(10));
-					}
-				}
-
-				finishJob();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-	}
-
-	/**
-	 * A thread feeding data to the function. It will randomly do checkpoint or fail.
-	 */
-	private class CheckpointedDataFeeder extends Thread {
-
-		private LinkedList<Integer> data;
-		private List<Integer> checkpointedData;
-		private long checkpointId;
-		private long lastSuccessCheckpointId;
-		private List<CheckpointCountdown> checkpointCountdowns;
-
-		private CheckpointedDataFeeder(List<Integer> data) {
-			this.data = new LinkedList<>(data);
-			this.checkpointedData = new ArrayList<>(data);
-			this.checkpointId = 0;
-			this.lastSuccessCheckpointId = 0;
-			this.checkpointCountdowns = new ArrayList<>();
-		}
-
-		@Override
-		public void run() {
-			Random random = new Random();
-
-			try {
-				openFunctionWithState();
-
-				while (data.size() > 0) {
-					ListIterator<CheckpointCountdown> iterator = checkpointCountdowns.listIterator();
-					while (iterator.hasNext()) {
-						CheckpointCountdown countdown = iterator.next();
-						if (countdown.id < lastSuccessCheckpointId) {
-							iterator.remove();
-						} else if (countdown.tick()) {
-							// complete a checkpoint
-							checkpointedData = countdown.data;
-							checkpointComplete(countdown.id);
-							lastSuccessCheckpointId = countdown.id;
-							iterator.remove();
-						}
-					}
-
-					int r = random.nextInt(10);
-					if (r < 6) {
-						// with 60% chance we add some data
-						int size = Math.min(data.size(), random.nextInt(MAX_RESULTS_PER_BATCH * 3) + 1);
-						for (int i = 0; i < size; i++) {
-							function.invoke(data.removeFirst(), null);
-						}
-					} else if (r < 9) {
-						// with 30% chance we make a checkpoint
-						checkpointId++;
-
-						if (random.nextBoolean()) {
-							// with 50% chance this checkpoint will succeed in the future
-							checkpointCountdowns.add(
-								new CheckpointCountdown(checkpointId, data, random.nextInt(3) + 1));
-						}
-
-						checkpointFunction(checkpointId);
-					} else {
-						// with 10% chance we fail
-						checkpointCountdowns.clear();
-
-						// we shuffle data to emulate jobs whose result order is undetermined
-						Collections.shuffle(checkpointedData);
-						data = new LinkedList<>(checkpointedData);
-
-						closeFuntionAbnormally();
-						openFunctionWithState();
-					}
-
-					if (random.nextBoolean()) {
-						Thread.sleep(random.nextInt(10));
-					}
-				}
-
-				finishJob();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-	}
-
-	/**
-	 * Countdown for a checkpoint which will succeed in the future.
-	 */
-	private static class CheckpointCountdown {
-
-		private long id;
-		private List<Integer> data;
-		private int countdown;
-
-		private CheckpointCountdown(long id, List<Integer> data, int countdown) {
-			this.id = id;
-			this.data = new ArrayList<>(data);
-			this.countdown = countdown;
-		}
-
-		private boolean tick() {
-			if (countdown > 0) {
-				countdown--;
-				return countdown == 0;
-			}
-			return false;
-		}
-	}
-
-	/**
-	 * A thread collecting results with the collecting iterator.
-	 */
-	private class CollectClient extends Thread {
-
-		private List<Integer> results;
-		private CollectResultIterator<Integer> iterator;
-
-		private CollectClient() {
-			this.results = new ArrayList<>();
-
-			this.iterator = new CollectResultIterator<>(
-				CompletableFuture.completedFuture(TEST_OPERATOR_ID),
-				serializer,
-				ACCUMULATOR_NAME,
-				0
-			);
-
-			TestJobClient.JobInfoProvider infoProvider = new TestJobClient.JobInfoProvider() {
-
-				@Override
-				public boolean isJobFinished() {
-					return jobFinished;
-				}
-
-				@Override
-				public Map<String, OptionalFailure<Object>> getAccumulatorResults() {
-					Map<String, OptionalFailure<Object>> accumulatorResults = new HashMap<>();
-					accumulatorResults.put(
-						ACCUMULATOR_NAME,
-						OptionalFailure.of(runtimeContext.getAccumulator(ACCUMULATOR_NAME).getLocalValue()));
-					return accumulatorResults;
-				}
-			};
-
-			TestJobClient jobClient = new TestJobClient(
-				TEST_JOB_ID,
-				TEST_OPERATOR_ID,
-				coordinator,
-				infoProvider);
-
-			iterator.setJobClient(jobClient);
-		}
-
-		@Override
-		public void run() {
-			Random random = new Random();
-
-			while (iterator.hasNext()) {
-				results.add(iterator.next());
-				if (random.nextBoolean()) {
-					try {
-						Thread.sleep(5);
-					} catch (InterruptedException e) {
-						// ignore
-					}
-				}
-			}
-
-			try {
-				iterator.close();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
+		CollectTestUtils.assertResponseEquals(response, version, lastCheckpointedOffset, expected, serializer);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/AbstractTestCoordinationRequestHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/AbstractTestCoordinationRequestHandler.java
@@ -46,53 +46,32 @@ import java.util.concurrent.CompletableFuture;
 /**
  * A {@link CoordinationRequestHandler} to test fetching SELECT query results.
  */
-public class TestCoordinationRequestHandler<T> implements CoordinationRequestHandler {
+public abstract class AbstractTestCoordinationRequestHandler<T> implements CoordinationRequestHandler {
 
-	private static final int BATCH_SIZE = 3;
+	protected static final int BATCH_SIZE = 3;
 
-	private final TypeSerializer<T> serializer;
-	private final String accumulatorName;
+	protected final TypeSerializer<T> serializer;
+	protected final String accumulatorName;
 
-	private int checkpointCountDown;
-
-	private LinkedList<T> data;
-	private List<T> checkpointingData;
-	private List<T> checkpointedData;
-
-	private LinkedList<T> buffered;
-	private List<T> checkpointingBuffered;
-	private List<T> checkpointedBuffered;
-
-	private String version;
-
-	private long offset;
-	private long checkpointingOffset;
-	private long checkpointedOffset;
+	protected LinkedList<T> buffered;
+	protected String version;
+	protected long offset;
+	protected long checkpointedOffset;
 
 	private final Map<String, OptionalFailure<Object>> accumulatorResults;
 
-	private final Random random;
-	private boolean closed;
+	protected final Random random;
+	protected boolean closed;
 
-	public TestCoordinationRequestHandler(
-			List<T> data,
+	public AbstractTestCoordinationRequestHandler(
 			TypeSerializer<T> serializer,
 			String accumulatorName) {
 		this.serializer = serializer;
 		this.accumulatorName = accumulatorName;
 
-		this.checkpointCountDown = 0;
-
-		this.data = new LinkedList<>(data);
-		this.checkpointedData = new ArrayList<>(data);
-
 		this.buffered = new LinkedList<>();
-		this.checkpointedBuffered = new ArrayList<>();
-
 		this.version = UUID.randomUUID().toString();
-
 		this.offset = 0;
-		this.checkpointingOffset = 0;
 		this.checkpointedOffset = 0;
 
 		this.accumulatorResults = new HashMap<>();
@@ -141,57 +120,7 @@ public class TestCoordinationRequestHandler<T> implements CoordinationRequestHan
 		return CompletableFuture.completedFuture(response);
 	}
 
-	private void updateBufferedResults() {
-		for (int i = random.nextInt(3) + 1; i > 0; i--) {
-			if (checkpointCountDown > 0) {
-				// countdown on-going checkpoint
-				checkpointCountDown--;
-				if (checkpointCountDown == 0) {
-					// complete a checkpoint
-					checkpointedData = checkpointingData;
-					checkpointedBuffered = checkpointingBuffered;
-					checkpointedOffset = checkpointingOffset;
-				}
-			}
-
-			int r = random.nextInt(10);
-			if (r < 6) {
-				// with 60% chance we add data
-				int size = Math.min(data.size(), BATCH_SIZE * 2 - buffered.size());
-				if (size > 0) {
-					size = random.nextInt(size) + 1;
-				}
-				for (int j = 0; j < size; j++) {
-					buffered.add(data.removeFirst());
-				}
-
-				if (data.isEmpty()) {
-					buildAccumulatorResults();
-					closed = true;
-					break;
-				}
-			} else if (r < 9) {
-				// with 30% chance we do a checkpoint completed in the future
-				if (checkpointCountDown == 0) {
-					checkpointCountDown = random.nextInt(5) + 1;
-					checkpointingData = new ArrayList<>(data);
-					checkpointingBuffered = new ArrayList<>(buffered);
-					checkpointingOffset = offset;
-				}
-			} else {
-				// with 10% chance we fail
-				checkpointCountDown = 0;
-				version = UUID.randomUUID().toString();
-
-				// we shuffle data to simulate jobs whose result order is undetermined
-				Collections.shuffle(checkpointedData);
-				data = new LinkedList<>(checkpointedData);
-
-				buffered = new LinkedList<>(checkpointedBuffered);
-				offset = checkpointedOffset;
-			}
-		}
-	}
+	protected abstract void updateBufferedResults();
 
 	public boolean isClosed() {
 		return closed;
@@ -201,7 +130,7 @@ public class TestCoordinationRequestHandler<T> implements CoordinationRequestHan
 		return accumulatorResults;
 	}
 
-	private void buildAccumulatorResults() {
+	protected void buildAccumulatorResults() {
 		List<byte[]> finalResults = CollectTestUtils.toBytesList(buffered, serializer);
 		SerializedListAccumulator<byte[]> listAccumulator = new SerializedListAccumulator<>();
 		try {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/CollectSinkFunctionTestWrapper.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/CollectSinkFunctionTestWrapper.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect.utils;
+
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.operators.collect.CollectCoordinationRequest;
+import org.apache.flink.streaming.api.operators.collect.CollectCoordinationResponse;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkFunction;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorCoordinator;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A wrapper class for creating, checkpointing and closing
+ * {@link org.apache.flink.streaming.api.operators.collect.CollectSinkFunction} for tests.
+ */
+public class CollectSinkFunctionTestWrapper<IN> {
+
+	public static final String ACCUMULATOR_NAME = "tableCollectAccumulator";
+
+	private static final int SOCKET_TIMEOUT_MILLIS = 1000;
+	private static final int FUTURE_TIMEOUT_MILLIS = 10000;
+	private static final int MAX_RETIRES = 100;
+
+	private final TypeSerializer<IN> serializer;
+	private final int maxBytesPerBatch;
+
+	private final IOManager ioManager;
+	private final StreamingRuntimeContext runtimeContext;
+	private final MockOperatorEventGateway gateway;
+	private final CollectSinkOperatorCoordinator coordinator;
+	private final MockFunctionInitializationContext functionInitializationContext;
+
+	private CollectSinkFunction<IN> function;
+
+	public CollectSinkFunctionTestWrapper(TypeSerializer<IN> serializer, int maxBytesPerBatch) throws Exception {
+		this.serializer = serializer;
+		this.maxBytesPerBatch = maxBytesPerBatch;
+
+		this.ioManager = new IOManagerAsync();
+		MockEnvironment environment = new MockEnvironmentBuilder()
+			.setTaskName("mockTask")
+			.setManagedMemorySize(4 * MemoryManager.DEFAULT_PAGE_SIZE)
+			.setIOManager(ioManager)
+			.build();
+		this.runtimeContext = new MockStreamingRuntimeContext(false, 1, 0, environment);
+		this.gateway = new MockOperatorEventGateway();
+
+		this.coordinator = new CollectSinkOperatorCoordinator(SOCKET_TIMEOUT_MILLIS);
+		this.coordinator.start();
+
+		this.functionInitializationContext = new MockFunctionInitializationContext();
+	}
+
+	public void closeWrapper() throws Exception {
+		coordinator.close();
+		ioManager.close();
+	}
+
+	public CollectSinkOperatorCoordinator getCoordinator() {
+		return coordinator;
+	}
+
+	public void openFunction() throws Exception {
+		function = new CollectSinkFunction<>(serializer, maxBytesPerBatch, ACCUMULATOR_NAME);
+		function.setRuntimeContext(runtimeContext);
+		function.setOperatorEventGateway(gateway);
+		function.open(new Configuration());
+		coordinator.handleEventFromOperator(0, gateway.getNextEvent());
+	}
+
+	public void openFunctionWithState() throws Exception {
+		functionInitializationContext.getOperatorStateStore().revertToLastSuccessCheckpoint();
+		function = new CollectSinkFunction<>(serializer, maxBytesPerBatch, ACCUMULATOR_NAME);
+		function.setRuntimeContext(runtimeContext);
+		function.setOperatorEventGateway(gateway);
+		function.initializeState(functionInitializationContext);
+		function.open(new Configuration());
+		coordinator.handleEventFromOperator(0, gateway.getNextEvent());
+	}
+
+	public void invoke(IN record) throws Exception {
+		function.invoke(record, null);
+	}
+
+	public void checkpointFunction(long checkpointId) throws Exception {
+		function.snapshotState(new MockFunctionSnapshotContext(checkpointId));
+		functionInitializationContext.getOperatorStateStore().checkpointBegin(checkpointId);
+	}
+
+	public void checkpointComplete(long checkpointId) {
+		function.notifyCheckpointComplete(checkpointId);
+		functionInitializationContext.getOperatorStateStore().checkpointSuccess(checkpointId);
+	}
+
+	public void closeFunctionNormally() throws Exception {
+		// this is a normal shutdown
+		function.accumulateFinalResults();
+		function.close();
+	}
+
+	public void closeFunctionAbnormally() throws Exception {
+		// this is an exceptional shutdown
+		function.close();
+		coordinator.subtaskFailed(0, null);
+	}
+
+	public CollectCoordinationResponse sendRequestAndGetResponse(String version, long offset) throws Exception {
+		CollectCoordinationResponse response;
+		for (int i = 0; i < MAX_RETIRES; i++) {
+			response = sendRequest(version, offset);
+			if (response.getLastCheckpointedOffset() >= 0) {
+				return response;
+			}
+		}
+		throw new RuntimeException("Too many retries in sendRequestAndGetValidResponse");
+	}
+
+	private CollectCoordinationResponse sendRequest(String version, long offset) throws Exception {
+		CollectCoordinationRequest request = new CollectCoordinationRequest(version, offset);
+		// we add a timeout to not block the tests if it fails
+		return ((CollectCoordinationResponse) coordinator
+			.handleCoordinationRequest(request).get(FUTURE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+	}
+
+	public Tuple2<Long, CollectCoordinationResponse> getAccumulatorResults() throws Exception {
+		ArrayList<byte[]> accLocalValue = getAccumulatorLocalValue();
+		List<byte[]> serializedResults =
+			SerializedListAccumulator.deserializeList(accLocalValue, BytePrimitiveArraySerializer.INSTANCE);
+		Assert.assertEquals(1, serializedResults.size());
+		byte[] serializedResult = serializedResults.get(0);
+		return CollectSinkFunction.deserializeAccumulatorResult(serializedResult);
+	}
+
+	@SuppressWarnings("unchecked")
+	public ArrayList<byte[]> getAccumulatorLocalValue() {
+		Accumulator accumulator = runtimeContext.getAccumulator(ACCUMULATOR_NAME);
+		return ((SerializedListAccumulator) accumulator).getLocalValue();
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/MockOperatorStateStore.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/MockOperatorStateStore.java
@@ -32,16 +32,19 @@ import java.util.Set;
 /**
  * An {@link OperatorStateStore} for testing purpose.
  */
+@SuppressWarnings("rawtypes")
 public class MockOperatorStateStore implements OperatorStateStore {
+
+	private final Map<Long, Map<String, TestUtils.MockListState>> historyStateMap;
 
 	private Map<String, TestUtils.MockListState> currentStateMap;
 	private Map<String, TestUtils.MockListState> lastSuccessStateMap;
-	private Map<Long, Map<String, TestUtils.MockListState>> historyStateMap;
 
 	public MockOperatorStateStore() {
+		this.historyStateMap = new HashMap<>();
+
 		this.currentStateMap = new HashMap<>();
 		this.lastSuccessStateMap = new HashMap<>();
-		this.historyStateMap = new HashMap<>();
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestCheckpointedCoordinationRequestHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestCheckpointedCoordinationRequestHandler.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect.utils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A {@link CoordinationRequestHandler} to test fetching SELECT query results.
+ * It will randomly do checkpoint or restart from checkpoint.
+ */
+public class TestCheckpointedCoordinationRequestHandler<T> extends AbstractTestCoordinationRequestHandler<T> {
+
+	private int checkpointCountDown;
+
+	private LinkedList<T> data;
+	private List<T> checkpointingData;
+	private List<T> checkpointedData;
+
+	private List<T> checkpointingBuffered;
+	private List<T> checkpointedBuffered;
+
+	private long checkpointingOffset;
+
+	public TestCheckpointedCoordinationRequestHandler(
+		List<T> data,
+		TypeSerializer<T> serializer,
+		String accumulatorName) {
+		super(serializer, accumulatorName);
+		this.checkpointCountDown = 0;
+
+		this.data = new LinkedList<>(data);
+		this.checkpointedData = new ArrayList<>(data);
+
+		this.checkpointedBuffered = new ArrayList<>();
+
+		this.checkpointingOffset = 0;
+	}
+
+	@Override
+	protected void updateBufferedResults() {
+		for (int i = random.nextInt(3) + 1; i > 0; i--) {
+			if (checkpointCountDown > 0) {
+				// countdown on-going checkpoint
+				checkpointCountDown--;
+				if (checkpointCountDown == 0) {
+					// complete a checkpoint
+					checkpointedData = checkpointingData;
+					checkpointedBuffered = checkpointingBuffered;
+					checkpointedOffset = checkpointingOffset;
+				}
+			}
+
+			int r = random.nextInt(10);
+			if (r < 6) {
+				// with 60% chance we add data
+				int size = Math.min(data.size(), BATCH_SIZE * 2 - buffered.size());
+				if (size > 0) {
+					size = random.nextInt(size) + 1;
+				}
+				for (int j = 0; j < size; j++) {
+					buffered.add(data.removeFirst());
+				}
+
+				if (data.isEmpty()) {
+					buildAccumulatorResults();
+					closed = true;
+					break;
+				}
+			} else if (r < 9) {
+				// with 30% chance we do a checkpoint completed in the future
+				if (checkpointCountDown == 0) {
+					checkpointCountDown = random.nextInt(5) + 1;
+					checkpointingData = new ArrayList<>(data);
+					checkpointingBuffered = new ArrayList<>(buffered);
+					checkpointingOffset = offset;
+				}
+			} else {
+				// with 10% chance we fail
+				checkpointCountDown = 0;
+				version = UUID.randomUUID().toString();
+
+				// we shuffle data to simulate jobs whose result order is undetermined
+				Collections.shuffle(checkpointedData);
+				data = new LinkedList<>(checkpointedData);
+
+				buffered = new LinkedList<>(checkpointedBuffered);
+				offset = checkpointedOffset;
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestUncheckpointedCoordinationRequestHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestUncheckpointedCoordinationRequestHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect.utils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A {@link CoordinationRequestHandler} to test fetching SELECT query results.
+ * It does not do checkpoint and will produce all results again when failure occurs.
+ */
+public class TestUncheckpointedCoordinationRequestHandler<T> extends AbstractTestCoordinationRequestHandler<T> {
+
+	private int failCount;
+
+	private final LinkedList<T> originalData;
+	private LinkedList<T> data;
+
+	public TestUncheckpointedCoordinationRequestHandler(
+			int failCount,
+			List<T> data,
+			TypeSerializer<T> serializer,
+			String accumulatorName) {
+		super(serializer, accumulatorName);
+		this.failCount = failCount;
+
+		this.originalData = new LinkedList<>(data);
+		this.data = new LinkedList<>(data);
+
+		this.closed = false;
+	}
+
+	@Override
+	protected void updateBufferedResults() {
+		for (int i = random.nextInt(3) + 1; i > 0; i--) {
+			int r = random.nextInt(20);
+			if (r < 19 || failCount <= 0) {
+				// with 95% chance we add data
+				int size = Math.min(data.size(), BATCH_SIZE * 2 - buffered.size());
+				if (size > 0) {
+					size = random.nextInt(size) + 1;
+				}
+				for (int j = 0; j < size; j++) {
+					buffered.add(data.removeFirst());
+				}
+
+				if (data.isEmpty()) {
+					buildAccumulatorResults();
+					closed = true;
+					break;
+				}
+			} else {
+				// with 5% chance we fail, we fail at most `failCount` times
+				failCount--;
+
+				// we shuffle data to simulate jobs whose result order is undetermined
+				data = new LinkedList<>(originalData);
+				Collections.shuffle(data);
+
+				buffered = new LinkedList<>();
+				version = UUID.randomUUID().toString();
+				offset = 0;
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -132,10 +132,22 @@ public interface TableResult {
 	 *  }
 	 * }</pre>
 	 *
-	 * <p>For streaming mode, this method guarantees end-to-end exactly-once record delivery
-	 * which requires the checkpointing mechanism to be enabled.
-	 * By default, checkpointing is disabled. To enable checkpointing, set checkpointing properties
-	 * (see ExecutionCheckpointingOptions) through {@link TableConfig#getConfiguration()}.
+	 * <p>This method has slightly different behaviors under different checkpointing settings
+	 * (to enable checkpointing for a streaming job,
+	 * set checkpointing properties through {@link TableConfig#getConfiguration()}).
+	 * <ul>
+	 *     <li>If the user is running a batch job, or does not enable checkpointing for a streaming job,
+	 *     this method has neither exactly-once nor at-least-once guarantee.
+	 *     Query results are immediately accessible by the clients once they're produced,
+	 *     but the function calls will throw an exception when the job fails and restarts.
+	 *     <li>If the user enables exactly-once checkpointing for a streaming job,
+	 *     this method guarantees an end-to-end exactly-once record delivery.
+	 *     A result will be accessible by clients only after its corresponding checkpoint completes.
+	 *     <li>If the user enables at-least-once checkpointing for a streaming job,
+	 *     this method guarantees an end-to-end at-least-once record delivery.
+	 *     Query results are immediately accessible by the clients once they're produced,
+	 *     but it is possible for the same result to be delivered multiple times.
+	 * </ul>
 	 *
 	 * <p>In order to fetch result to local, you can call either {@link #collect()} and {@link #print()}.
 	 * But, they can't be called both on the same {@link TableResult} instance,
@@ -146,10 +158,22 @@ public interface TableResult {
 	/**
 	 * Print the result contents as tableau form to client console.
 	 *
-	 * <p>For streaming mode, this method guarantees end-to-end exactly-once record delivery
-	 * which requires the checkpointing mechanism to be enabled.
-	 * By default, checkpointing is disabled. To enable checkpointing, set checkpointing properties
-	 * (see ExecutionCheckpointingOptions) through {@link TableConfig#getConfiguration()}.
+	 * <p>This method has slightly different behaviors under different checkpointing settings
+	 * (to enable checkpointing for a streaming job,
+	 * set checkpointing properties through {@link TableConfig#getConfiguration()}).
+	 * <ul>
+	 *     <li>If the user is running a batch job, or does not enable checkpointing for a streaming job,
+	 *     this method has neither exactly-once nor at-least-once guarantee.
+	 *     Query results are immediately accessible by the clients once they're produced,
+	 *     but the function calls will throw an exception when the job fails and restarts.
+	 *     <li>If the user enables exactly-once checkpointing for a streaming job,
+	 *     this method guarantees an end-to-end exactly-once record delivery.
+	 *     A result will be accessible by clients only after its corresponding checkpoint completes.
+	 *     <li>If the user enables at-least-once checkpointing for a streaming job,
+	 *     this method guarantees an end-to-end at-least-once record delivery.
+	 *     Query results are immediately accessible by the clients once they're produced,
+	 *     but it is possible for the same result to be delivered multiple times.
+	 * </ul>
 	 *
 	 * <p>In order to fetch result to local, you can call either {@link #collect()} and {@link #print()}.
 	 * But, they can't be called both on the same {@link TableResult} instance,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -136,14 +136,14 @@ public interface TableResult {
 	 * (to enable checkpointing for a streaming job,
 	 * set checkpointing properties through {@link TableConfig#getConfiguration()}).
 	 * <ul>
-	 *     <li>If the user is running a batch job, or does not enable checkpointing for a streaming job,
+	 *     <li>For batch jobs or streaming jobs without checkpointing,
 	 *     this method has neither exactly-once nor at-least-once guarantee.
 	 *     Query results are immediately accessible by the clients once they're produced,
-	 *     but the function calls will throw an exception when the job fails and restarts.
-	 *     <li>If the user enables exactly-once checkpointing for a streaming job,
+	 *     but exceptions will be thrown when the job fails and restarts.
+	 *     <li>For streaming jobs with exactly-once checkpointing,
 	 *     this method guarantees an end-to-end exactly-once record delivery.
 	 *     A result will be accessible by clients only after its corresponding checkpoint completes.
-	 *     <li>If the user enables at-least-once checkpointing for a streaming job,
+	 *     <li>For streaming jobs with at-least-once checkpointing,
 	 *     this method guarantees an end-to-end at-least-once record delivery.
 	 *     Query results are immediately accessible by the clients once they're produced,
 	 *     but it is possible for the same result to be delivered multiple times.
@@ -162,14 +162,14 @@ public interface TableResult {
 	 * (to enable checkpointing for a streaming job,
 	 * set checkpointing properties through {@link TableConfig#getConfiguration()}).
 	 * <ul>
-	 *     <li>If the user is running a batch job, or does not enable checkpointing for a streaming job,
+	 *     <li>For batch jobs or streaming jobs without checkpointing,
 	 *     this method has neither exactly-once nor at-least-once guarantee.
 	 *     Query results are immediately accessible by the clients once they're produced,
-	 *     but the function calls will throw an exception when the job fails and restarts.
-	 *     <li>If the user enables exactly-once checkpointing for a streaming job,
+	 *     but exceptions will be thrown when the job fails and restarts.
+	 *     <li>For streaming jobs with exactly-once checkpointing,
 	 *     this method guarantees an end-to-end exactly-once record delivery.
 	 *     A result will be accessible by clients only after its corresponding checkpoint completes.
-	 *     <li>If the user enables at-least-once checkpointing for a streaming job,
+	 *     <li>For streaming jobs with at-least-once checkpointing,
 	 *     this method guarantees an end-to-end at-least-once record delivery.
 	 *     Query results are immediately accessible by the clients once they're produced,
 	 *     but it is possible for the same result to be delivered multiple times.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.collect.CollectResultIterator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory;
@@ -49,19 +50,15 @@ public abstract class SelectTableSinkBase<T> implements StreamTableSink<T> {
 
 	private final TableSchema tableSchema;
 	protected final DataFormatConverters.DataFormatConverter<RowData, Row> converter;
+	private final TypeSerializer<T> typeSerializer;
 
-	private final CollectSinkOperatorFactory<T> factory;
-	private final CollectResultIterator<T> iterator;
+	private CollectResultIterator<T> iterator;
 
 	@SuppressWarnings("unchecked")
 	public SelectTableSinkBase(TableSchema schema, TypeSerializer<T> typeSerializer) {
 		this.tableSchema = schema;
 		this.converter = DataFormatConverters.getConverterForDataType(this.tableSchema.toPhysicalRowDataType());
-
-		String accumulatorName = "tableResultCollect_" + UUID.randomUUID();
-		this.factory = new CollectSinkOperatorFactory<>(typeSerializer, accumulatorName);
-		CollectSinkOperator<Row> operator = (CollectSinkOperator<Row>) factory.getOperator();
-		this.iterator = new CollectResultIterator<>(operator.getOperatorIdFuture(), typeSerializer, accumulatorName);
+		this.typeSerializer = typeSerializer;
 	}
 
 	@Override
@@ -76,8 +73,19 @@ public abstract class SelectTableSinkBase<T> implements StreamTableSink<T> {
 
 	@Override
 	public DataStreamSink<?> consumeDataStream(DataStream<T> dataStream) {
+		StreamExecutionEnvironment env = dataStream.getExecutionEnvironment();
+
+		String accumulatorName = "tableResultCollect_" + UUID.randomUUID();
+		CollectSinkOperatorFactory<T> factory = new CollectSinkOperatorFactory<>(typeSerializer, accumulatorName);
+		CollectSinkOperator<Row> operator = (CollectSinkOperator<Row>) factory.getOperator();
+		this.iterator = new CollectResultIterator<>(
+			operator.getOperatorIdFuture(),
+			typeSerializer,
+			accumulatorName,
+			env.getCheckpointConfig());
+
 		CollectStreamSink<?> sink = new CollectStreamSink<>(dataStream, factory);
-		dataStream.getExecutionEnvironment().addOperator(sink.getTransformation());
+		env.addOperator(sink.getTransformation());
 		return sink.name("Select table sink");
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Currently `TableResult#collect` and `DataStreamUtils#collect` can only produce results if users explicitly enable checkpoint for infinite streaming jobs. It would be strange to require the users to do so if they just want to take a look at their data.

This PR introduces collect iterator with at least once semantics and exactly once semantics without fault tolerance. When calling the collect method, we automatically pick an iterator for the user:
* If the user does not explicitly enable a checkpoint, we use exactly once iterator without fault tolerance. That is to say, the iterator will throw exception once the job restarts.
* If the user explicitly enables an exactly once checkpoint, we use the current implementation of collect iterator.
* If the user explicitly enables an at least once checkpoint, we use the at least once iterator. That is to say, the iterator ignores both checkpoint information and job restarts.

## Brief change log

 - Refactor tests for datastream / table collect
 - Introduce collect iterator with at least once semantics and exactly once semantics without fault tolerance

## Verifying this change

This change is already covered by existing datastream / table collect tests, and this change added tests and can be verified by running those unit test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Java doc, documentation
