### PR TITLE
[FLINK-18561][python] Build manylinux1 with better compatibility instead of manylinux2014 Python Wheel Packages

### DIFF
--- a/flink-python/dev/build-wheels.sh
+++ b/flink-python/dev/build-wheels.sh
@@ -27,8 +27,26 @@ done
 
 ## 3. build wheels
 for ((i=0;i<${#py_env[@]};i++)) do
+    if [[ "$(uname)" != "Darwin" ]]; then
+        # force the linker to use the older glibc version in Linux
+        export CFLAGS="-I. -include dev/glibc_version_fix.h"
+    fi
     ${PY_ENV_DIR}/${py_env[i]}/bin/python setup.py bdist_wheel
 done
 
+## 4. convert linux_x86_64 wheel to manylinux1 wheel in Linux
+if [[ "$(uname)" != "Darwin" ]]; then
+    source `pwd`/dev/.conda/bin/activate
+    # 4.1 install patchelf
+    conda install -c conda-forge patchelf=0.11 -y
+    # 4.2 install auditwheel
+    pip install auditwheel==3.2.0
+    # 4.3 convert Linux wheel
+    for wheel_file in dist/*.whl; do
+        auditwheel repair ${wheel_file} -w dist
+        rm -f ${wheel_file}
+    done
+    source deactivate
+fi
 ## see the result
 ls -al dist/

--- a/flink-python/dev/glibc_version_fix.h
+++ b/flink-python/dev/glibc_version_fix.h
@@ -1,0 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will build manylinux1 with better compatibility instead of manylinux2014 Python Wheel Packages*


## Brief change log

  - *force the linker to use the older glibc version in Linux in  `dev/glibc_version_fix.h`*
  - *use auditwheel to convert linux_x86_64 wheel to manylinux1 wheel*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
