### PR TITLE
[FLINK-18548][table-planner] Improve FlinkCalcMergeRule to merge calc nodes better

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.scala
@@ -18,13 +18,14 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.RelOptUtil.InputFinder
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel.core.{Calc, RelFactories}
-import org.apache.calcite.rex.{RexOver, RexProgramBuilder, RexUtil}
+import org.apache.calcite.rex.{RexNode, RexOver, RexProgramBuilder, RexUtil}
 import org.apache.calcite.tools.RelBuilderFactory
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 
@@ -33,7 +34,8 @@ import scala.collection.JavaConversions._
   *
   * Modification:
   * - Condition in the merged program will be simplified if it exists.
-  * - Don't merge calcs which contain non-deterministic expr
+  * - If the two [[Calc]] can merge into one, each non-deterministic [[RexNode]] of bottom [[Calc]]
+  *   should appear at most once in the project list and filter list of top [[Calc]].
   */
 
 /**
@@ -60,9 +62,49 @@ class FlinkCalcMergeRule(relBuilderFactory: RelBuilderFactory) extends RelOptRul
       return false
     }
 
-    // Don't merge Calcs which contain non-deterministic expr
-    topProgram.getExprList.forall(RexUtil.isDeterministic) &&
-      bottomCalc.getProgram.getExprList.forall(RexUtil.isDeterministic)
+    isMergeable(topCalc, bottomCalc)
+  }
+
+  /**
+   * Return two neighbouring [[Calc]] can merge into one [[Calc]] or not. If the two [[Calc]] can
+   * merge into one, each non-deterministic [[RexNode]] of bottom [[Calc]] should appear at most
+   * once in the project list and filter list of top [[Calc]].
+   */
+  private def isMergeable(topCalc: Calc, bottomCalc: Calc): Boolean = {
+    val topProgram = topCalc.getProgram
+    val bottomProgram = bottomCalc.getProgram
+
+    val topProjectInputIndices = topProgram.getProjectList
+      .map(r => topProgram.expandLocalRef(r))
+      .map(r => InputFinder.bits(r).toArray)
+
+    val topFilterInputIndices = if (topProgram.getCondition != null) {
+      InputFinder.bits(topProgram.expandLocalRef(topProgram.getCondition)).toArray
+    } else {
+      new Array[Int](0)
+    }
+
+    val bottomProjectList = bottomProgram.getProjectList
+      .map(r => bottomProgram.expandLocalRef(r))
+      .toArray
+
+    val topInputIndices = topProjectInputIndices :+ topFilterInputIndices
+
+    bottomProjectList.zipWithIndex.forall {
+      case (project: RexNode, index: Int) => {
+        var nonDeterministicRexRefCnt = 0
+        if (!RexUtil.isDeterministic(project)) {
+          topInputIndices.foreach(
+            indices => indices.foreach(
+              ref => if (ref == index) {
+                nonDeterministicRexRefCnt += 1
+              }
+            )
+          )
+        }
+        nonDeterministicRexRefCnt <= 1
+      }
+    }
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRuleTest.xml
@@ -70,11 +70,124 @@ LogicalProject(a=[$0])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-FlinkLogicalCalc(select=[a])
-+- FlinkLogicalCalc(select=[a], where=[>(random_udf(a), 10)])
-   +- FlinkLogicalCalc(select=[a])
-      +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+FlinkLogicalCalc(select=[a], where=[>(random_udf(a), 10)])
++- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
+  </TestCase>
+  <TestCase name="testCalcMergeWithNestedNonDeterministicExpr">
+    <Resource name="sql">
+      <![CDATA[SELECT random_udf(a1) as a2 FROM (SELECT random_udf(a) as a1, b FROM MyTable) t WHERE b > 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a2=[random_udf($0)])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalProject(a1=[random_udf($0)], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[random_udf(random_udf(a)) AS a2], where=[>(b, 10)])
++- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcMergeWithTopMultiNonDeterministicExpr">
+    <Resource name="sql">
+      <![CDATA[SELECT random_udf(a1) as a2, random_udf(a1) as a3 FROM (SELECT random_udf(a) as a1, b FROM MyTable) t WHERE b > 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a2=[random_udf($0)], a3=[random_udf($0)])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalProject(a1=[random_udf($0)], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[random_udf(a1) AS a2, random_udf(a1) AS a3])
++- FlinkLogicalCalc(select=[random_udf(a) AS a1, b], where=[>(b, 10)])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcMergeTopFilterHasNonDeterministicExpr">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM (SELECT a, random_udf(b) as b1, c FROM MyTable) t WHERE b1 > 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalProject(a=[$0], b1=[random_udf($1)], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, c], where=[>(random_udf(b), 10)])
++- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcMergeWithBottomMultiNonDeterministicExpr">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, b2 FROM (SELECT random_udf(a) as a1, random_udf(b) as b2, c FROM MyTable) t WHERE c > 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0], b2=[$1])
++- LogicalFilter(condition=[>(CAST($2):BIGINT, 10)])
+   +- LogicalProject(a1=[random_udf($0)], b2=[random_udf($1)], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[random_udf(a) AS a1, random_udf(b) AS b2], where=[>(CAST(c), 10:BIGINT)])
++- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcMergeWithBottomMultiNonDeterministicInConditionExpr">
+    <Resource name="sql">
+      <![CDATA[SELECT c FROM (SELECT random_udf(a) as a1, random_udf(b) as b2, c FROM MyTable) t WHERE a1 > b2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2])
++- LogicalFilter(condition=[>($0, $1)])
+   +- LogicalProject(a1=[random_udf($0)], b2=[random_udf($1)], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[c], where=[>(random_udf(a), random_udf(b))])
++- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcMergeWithoutInnerNonDeterministicExpr">
+  <Resource name="sql">
+    <![CDATA[SELECT a, c FROM (SELECT a, random_udf(a) as a1, c FROM MyTable) t WHERE c > 10]]>
+  </Resource>
+  <Resource name="planBefore">
+    <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalFilter(condition=[>(CAST($2):BIGINT, 10)])
+   +- LogicalProject(a=[$0], a1=[random_udf($0)], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+  </Resource>
+  <Resource name="planAfter">
+    <![CDATA[
+FlinkLogicalCalc(select=[a, c], where=[>(CAST(c), 10:BIGINT)])
++- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+  </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRuleTest.scala
@@ -62,6 +62,7 @@ class FlinkCalcMergeRuleTest extends TableTestBase {
     util.replaceBatchProgram(programs)
 
     util.addTableSource[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
+    util.addFunction("random_udf", new NonDeterministicUdf)
   }
 
   @Test
@@ -71,15 +72,54 @@ class FlinkCalcMergeRuleTest extends TableTestBase {
 
   @Test
   def testCalcMergeWithNonDeterministicExpr1(): Unit = {
-    util.addFunction("random_udf", new NonDeterministicUdf)
     val sqlQuery = "SELECT a, a1 FROM (SELECT a, random_udf(a) AS a1 FROM MyTable) t WHERE a1 > 10"
     util.verifyPlan(sqlQuery)
   }
 
   @Test
   def testCalcMergeWithNonDeterministicExpr2(): Unit = {
-    util.addFunction("random_udf", new NonDeterministicUdf)
     val sqlQuery = "SELECT a FROM (SELECT a FROM MyTable) t WHERE random_udf(a) > 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testCalcMergeWithNestedNonDeterministicExpr(): Unit = {
+    val sqlQuery = "SELECT random_udf(a1) as a2 FROM (SELECT random_udf(a) as" +
+      " a1, b FROM MyTable) t WHERE b > 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testCalcMergeWithTopMultiNonDeterministicExpr(): Unit = {
+    val sqlQuery = "SELECT random_udf(a1) as a2, random_udf(a1) as a3 FROM" +
+      " (SELECT random_udf(a) as a1, b FROM MyTable) t WHERE b > 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testCalcMergeTopFilterHasNonDeterministicExpr(): Unit = {
+    val sqlQuery = "SELECT a, c FROM" +
+      " (SELECT a, random_udf(b) as b1, c FROM MyTable) t WHERE b1 > 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testCalcMergeWithBottomMultiNonDeterministicExpr(): Unit = {
+    val sqlQuery = "SELECT a1, b2 FROM" +
+      " (SELECT random_udf(a) as a1, random_udf(b) as b2, c FROM MyTable) t WHERE c > 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testCalcMergeWithBottomMultiNonDeterministicInConditionExpr(): Unit = {
+    val sqlQuery = "SELECT c FROM" +
+      " (SELECT random_udf(a) as a1, random_udf(b) as b2, c FROM MyTable) t WHERE a1 > b2"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testCalcMergeWithoutInnerNonDeterministicExpr(): Unit = {
+    val sqlQuery = "SELECT a, c FROM (SELECT a, random_udf(a) as a1, c FROM MyTable) t WHERE c > 10"
     util.verifyPlan(sqlQuery)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

* This pull request Improve FlinkCalcMergeRule to merge calc nodes better.

## Brief change log

  -   Improve the  logic to judge two Calc node can merge or not: If two Calcs can merge, each bottomCalc's non-deterministic RexNode should appear at most once in topCalc's project fields and condition field.


## Verifying this change

Add plan tests to cover, checked other plan tests are still ok.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
