### PR TITLE
[FLINK-18477][examples-table] Fix packaging of ChangelogSocketExample

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -398,6 +398,7 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableFactory;
 
@@ -429,6 +430,10 @@ public class ChangelogCsvFormatFactory implements DeserializationFormatFactory {
   public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
       DynamicTableFactory.Context context,
       ReadableConfig formatOptions) {
+    // either implement your custom validation logic here ...
+    // or use the provided helper method
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
+
     // get the validated options
     final String columnDelimiter = formatOptions.get(COLUMN_DELIMITER);
 

--- a/docs/dev/table/sourceSinks.zh.md
+++ b/docs/dev/table/sourceSinks.zh.md
@@ -398,6 +398,7 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableFactory;
 
@@ -429,6 +430,10 @@ public class ChangelogCsvFormatFactory implements DeserializationFormatFactory {
   public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
       DynamicTableFactory.Context context,
       ReadableConfig formatOptions) {
+    // either implement your custom validation logic here ...
+    // or use the provided helper method
+    FactoryUtil.validateFactoryOptions(this, formatOptions);
+
     // get the validated options
     final String columnDelimiter = formatOptions.get(COLUMN_DELIMITER);
 

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -203,7 +203,7 @@ under the License.
 							</archive>
 
 							<includes>
-								<include>org/apache/flink/table/examples/java/connectors/ChangelogSocketExample*</include>
+								<include>org/apache/flink/table/examples/java/connectors/*</include>
 								<include>**/META-INF/services/*</include>
 							</includes>
 						</configuration>

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/ChangelogCsvFormatFactory.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/ChangelogCsvFormatFactory.java
@@ -67,6 +67,10 @@ public final class ChangelogCsvFormatFactory implements DeserializationFormatFac
 
 	@Override
 	public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+		// either implement your custom validation logic here ...
+		// or use the provided helper method
+		FactoryUtil.validateFactoryOptions(this, formatOptions);
+
 		// get the validated options
 		final String columnDelimiter = formatOptions.get(COLUMN_DELIMITER);
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes the packaging of the `ChangelogSocketExample` to run the example with a `flink run` command.

## Brief change log

See commit messages.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. But manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? docs
