### PR TITLE
[FLINK-18585][elasticsearch] Dynamic index can not work in new DynamicTableSink

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/IndexGeneratorFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/IndexGeneratorFactory.java
@@ -55,7 +55,7 @@ import java.util.regex.Pattern;
  * convert a field value of TIMESTAMP/DATE/TIME type into the format specified by date_format_string. The
  * date_format_string is compatible with {@link java.text.SimpleDateFormat}. For example, if the option
  * value is 'myusers_{log_ts|yyyy-MM-dd}', then a record with log_ts field value 2020-03-27 12:25:55 will
- * be written into "myusers-2020-03-27" index.
+ * be written into "myusers_2020-03-27" index.
  */
 @Internal
 final class IndexGeneratorFactory {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RowElasticsearchSinkFunction.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RowElasticsearchSinkFunction.java
@@ -69,6 +69,11 @@ class RowElasticsearchSinkFunction implements ElasticsearchSinkFunction<RowData>
 	}
 
 	@Override
+	public void open() {
+		indexGenerator.open();
+	}
+
+	@Override
 	public void process(
 			RowData element,
 			RuntimeContext ctx,

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -241,32 +241,30 @@ public class Elasticsearch7DynamicSinkITCase {
 
 	@Test
 	public void testWritingDocumentsWithDynamicIndex() throws Exception {
-		TableSchema schema = TableSchema.builder()
-			.field("a", DataTypes.BIGINT().notNull())
-			.field("b", DataTypes.TIMESTAMP().notNull())
-			.primaryKey("a")
-			.build();
-		GenericRowData rowData = GenericRowData.of(
-			1L,
-			TimestampData.fromLocalDateTime(LocalDateTime.parse("2012-12-12T12:12:12")));
+		TableEnvironment tableEnvironment = TableEnvironment.create(EnvironmentSettings.newInstance()
+			.useBlinkPlanner()
+			.inStreamingMode()
+			.build());
 
 		String index = "dynamic-index-{b|yyyy-MM-dd}";
-		Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+		tableEnvironment.executeSql("CREATE TABLE esTable (" +
+			"a BIGINT NOT NULL,\n" +
+			"b TIMESTAMP NOT NULL,\n" +
+			"PRIMARY KEY (a) NOT ENFORCED\n" +
+			")\n" +
+			"WITH (\n" +
+			String.format("'%s'='%s',\n", "connector", "elasticsearch-7") +
+			String.format("'%s'='%s',\n", ElasticsearchOptions.INDEX_OPTION.key(), index) +
+			String.format("'%s'='%s',\n", ElasticsearchOptions.HOSTS_OPTION.key(), "http://127.0.0.1:9200") +
+			String.format("'%s'='%s'\n", ElasticsearchOptions.FLUSH_ON_CHECKPOINT_OPTION.key(), "false") +
+			")");
 
-		SinkFunctionProvider sinkRuntimeProvider = (SinkFunctionProvider) sinkFactory.createDynamicTableSink(
-			context()
-				.withSchema(schema)
-				.withOption(ElasticsearchOptions.INDEX_OPTION.key(), index)
-				.withOption(ElasticsearchOptions.HOSTS_OPTION.key(), "http://127.0.0.1:9200")
-				.withOption(ElasticsearchOptions.FLUSH_ON_CHECKPOINT_OPTION.key(), "false")
-				.build()
-		).getSinkRuntimeProvider(new MockContext());
-
-		SinkFunction<RowData> sinkFunction = sinkRuntimeProvider.createSinkFunction();
-		StreamExecutionEnvironment environment = StreamExecutionEnvironment.getExecutionEnvironment();
-		rowData.setRowKind(RowKind.UPDATE_AFTER);
-		environment.<RowData>fromElements(rowData).addSink(sinkFunction);
-		environment.execute();
+		tableEnvironment.fromValues(row(1L, LocalDateTime.parse("2012-12-12T12:12:12")))
+			.executeInsert("esTable")
+			.getJobClient()
+			.get()
+			.getJobExecutionResult(this.getClass().getClassLoader())
+			.get();
 
 		Client client = elasticsearchResource.getClient();
 		Map<String, Object> response = client.get(new GetRequest("dynamic-index-2012-12-12", "1"))

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -239,6 +239,45 @@ public class Elasticsearch7DynamicSinkITCase {
 		assertThat(result, equalTo(expectedMap));
 	}
 
+	@Test
+	public void testWritingDocumentsWithDynamicIndex() throws Exception {
+		TableSchema schema = TableSchema.builder()
+			.field("a", DataTypes.BIGINT().notNull())
+			.field("b", DataTypes.TIMESTAMP().notNull())
+			.primaryKey("a")
+			.build();
+		GenericRowData rowData = GenericRowData.of(
+			1L,
+			TimestampData.fromLocalDateTime(LocalDateTime.parse("2012-12-12T12:12:12")));
+
+		String index = "dynamic-index-{b|yyyy-MM-dd}";
+		Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+
+		SinkFunctionProvider sinkRuntimeProvider = (SinkFunctionProvider) sinkFactory.createDynamicTableSink(
+			context()
+				.withSchema(schema)
+				.withOption(ElasticsearchOptions.INDEX_OPTION.key(), index)
+				.withOption(ElasticsearchOptions.HOSTS_OPTION.key(), "http://127.0.0.1:9200")
+				.withOption(ElasticsearchOptions.FLUSH_ON_CHECKPOINT_OPTION.key(), "false")
+				.build()
+		).getSinkRuntimeProvider(new MockContext());
+
+		SinkFunction<RowData> sinkFunction = sinkRuntimeProvider.createSinkFunction();
+		StreamExecutionEnvironment environment = StreamExecutionEnvironment.getExecutionEnvironment();
+		rowData.setRowKind(RowKind.UPDATE_AFTER);
+		environment.<RowData>fromElements(rowData).addSink(sinkFunction);
+		environment.execute();
+
+		Client client = elasticsearchResource.getClient();
+		Map<String, Object> response = client.get(new GetRequest("dynamic-index-2012-12-12", "1"))
+			.actionGet()
+			.getSource();
+		Map<Object, Object> expectedMap = new HashMap<>();
+		expectedMap.put("a", 1);
+		expectedMap.put("b", "2012-12-12 12:12:12");
+		assertThat(response, equalTo(expectedMap));
+	}
+
 	private static class MockContext implements DynamicTableSink.Context {
 		@Override
 		public boolean isBounded() {


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix Dynamic index can not work in new DynamicTableSink.


## Brief change log

  - Init indexGenerator.open() proberly


## Verifying this change

* Add ITCase to cover this issue for Es6 and Es7 connector.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
