### PR TITLE
[FLINK-18532][docs] Remove beta tag from MATCH_RECOGNIZE

### DIFF
--- a/docs/dev/table/streaming/match_recognize.md
+++ b/docs/dev/table/streaming/match_recognize.md
@@ -3,7 +3,6 @@ title: 'Detecting Patterns in Tables'
 nav-parent_id: streaming_tableapi
 nav-title: 'Detecting Patterns'
 nav-pos: 5
-is_beta: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -67,9 +66,9 @@ FROM MyTable
 
 This page will explain each keyword in more detail and will illustrate more complex examples.
 
-<span class="label label-danger">Attention</span> Flink's implementation of the `MATCH_RECOGNIZE`
+{% info Notice %} Flink's implementation of the `MATCH_RECOGNIZE`
 clause is a subset of the full standard. Only those features documented in the following sections
-are supported. Since the development is still in an early phase, please also take a look at the
+are supported. Additional features may be supported based on community feeback, please also take a look at the
 [known limitations](#known-limitations).
 
 * This will be replaced by the TOC

--- a/docs/dev/table/streaming/match_recognize.zh.md
+++ b/docs/dev/table/streaming/match_recognize.zh.md
@@ -3,7 +3,6 @@ title: 'Detecting Patterns in Tables'
 nav-parent_id: streaming_tableapi
 nav-title: 'Detecting Patterns'
 nav-pos: 5
-is_beta: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -67,9 +66,9 @@ FROM MyTable
 
 This page will explain each keyword in more detail and will illustrate more complex examples.
 
-<span class="label label-danger">Attention</span> Flink's implementation of the `MATCH_RECOGNIZE`
+{% info Notice %}  Flink's implementation of the `MATCH_RECOGNIZE`
 clause is a subset of the full standard. Only those features documented in the following sections
-are supported. Since the development is still in an early phase, please also take a look at the
+are supported. Additional features may be supported based on community feeback, please also take a look at the
 [known limitations](#known-limitations).
 
 * This will be replaced by the TOC


### PR DESCRIPTION
## What is the purpose of the change

Removes the beta tag from `MATCH_RECOGNIZE` and updates the note to better reflect community priorities. 

## Brief change log

- Update docs


## Verifying this change

This change is a trivial rework/code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

- no 

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
