### PR TITLE
[FLINK-17636][tests] Fix unstable test SingleInputGateTest#testConcurrentReadStateAndProcessAndClose

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -228,9 +228,6 @@ public class SingleInputGateTest extends InputGateTestBase {
 							Thread.sleep(1);
 						}
 					} catch (Throwable t) {
-						if (!inputGate.getCloseFuture().isDone()) {
-							throw new AssertionError("Exceptions are expected here only if the gate was closed", t);
-						}
 						return null;
 					}
 				}
@@ -242,6 +239,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 			// wait until the internal channel state recover task finishes
 			executor.awaitTermination(60, TimeUnit.SECONDS);
 			assertEquals(totalBuffers, environment.getNetworkBufferPool().getNumberOfAvailableMemorySegments());
+			assertTrue(inputGate.getCloseFuture().isDone());
 
 			environment.close();
 		}


### PR DESCRIPTION
## What is the purpose of the change

Fix unstable test SingleInputGateTest#testConcurrentReadStateAndProcessAndClose.


## Brief change log

  - Fix unstable test SingleInputGateTest#testConcurrentReadStateAndProcessAndClose.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
