### PR TITLE
[FLINK-18606][java-streaming] Remove unused generic parameter from SinkFunction.Context

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkContextUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkContextUtil.java
@@ -30,8 +30,8 @@ public class SinkContextUtil {
 	 * Creates a {@link SinkFunction.Context} that
 	 * throws an exception when trying to access the current watermark or processing time.
 	 */
-	public static <T> SinkFunction.Context<T> forTimestamp(long timestamp) {
-		return new SinkFunction.Context<T>() {
+	public static SinkFunction.Context forTimestamp(long timestamp) {
+		return new SinkFunction.Context() {
 			@Override
 			public long currentProcessingTime() {
 				throw new RuntimeException("Not implemented");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -59,11 +59,9 @@ public interface SinkFunction<IN> extends Function, Serializable {
 	 * <p>The context is only valid for the duration of a
 	 * {@link SinkFunction#invoke(Object, Context)} call. Do not store the context and use
 	 * afterwards!
-	 *
-	 * @param <T> The type of elements accepted by the sink.
 	 */
 	@Public // Interface might be extended in the future with additional methods.
-	interface Context<T> {
+	interface Context {
 
 		/** Returns the current processing time. */
 		long currentProcessingTime();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -70,7 +70,7 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
 		this.currentWatermark = mark.getTimestamp();
 	}
 
-	private class SimpleContext<IN> implements SinkFunction.Context<IN> {
+	private class SimpleContext<IN> implements SinkFunction.Context {
 
 		private StreamRecord<IN> element;
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
@@ -112,7 +112,7 @@ object Companion {
 
 class ResultSink extends SinkFunction[(String, Long)] {
 
-  override def invoke(value: (String, Long), context: SinkFunction.Context[_]): Unit = {
+  override def invoke(value: (String, Long), context: SinkFunction.Context): Unit = {
     Companion.results.append(value.toString())
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
@@ -118,7 +118,7 @@ public class SinkOperator extends AbstractUdfStreamOperator<Object, SinkFunction
 		this.currentWatermark = mark.getTimestamp();
 	}
 
-	private class SimpleContext implements SinkFunction.Context<RowData> {
+	private class SimpleContext implements SinkFunction.Context {
 
 		private StreamRecord<RowData> element;
 


### PR DESCRIPTION
## What is the purpose of the change

The SinkFunction.Context has an unused generic parameter which causes needless warnings in many places.

## Brief change log

Remove the type parameter from SinkFunction.Context

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
