### PR TITLE
[FLINK-18607][build] Give the maven module a human readable name

### DIFF
--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-annotations</artifactId>
-	<name>flink-annotations</name>
+	<name>Flink : Annotations</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-clients_${scala.binary.version}</artifactId>
-	<name>flink-clients</name>
+	<name>Flink : Clients</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -30,7 +30,7 @@
 	</parent>
 
 	<artifactId>flink-connector-base</artifactId>
-	<name>flink-connector-base</name>
+	<name>Flink : Connectors : Base</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-cassandra_${scala.binary.version}</artifactId>
-	<name>flink-connector-cassandra</name>
+	<name>Flink : Connectors : Cassandra</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch-base/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch-base_${scala.binary.version}</artifactId>
-	<name>flink-connector-elasticsearch-base</name>
+	<name>Flink : Connectors : Elasticsearch base</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch5_${scala.binary.version}</artifactId>
-	<name>flink-connector-elasticsearch5</name>
+	<name>Flink : Connectors : Elasticsearch 5</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch6_${scala.binary.version}</artifactId>
-	<name>flink-connector-elasticsearch6</name>
+	<name>Flink : Connectors : Elasticsearch 6</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch7/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch7_${scala.binary.version}</artifactId>
-	<name>flink-connector-elasticsearch7</name>
+	<name>Flink : Connectors : Elasticsearch 7</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-connectors/flink-connector-filesystem/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-filesystem_${scala.binary.version}</artifactId>
-	<name>flink-connector-filesystem</name>
+	<name>Flink : Connectors : Filesystem</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-gcp-pubsub/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-gcp-pubsub_${scala.binary.version}</artifactId>
-	<name>flink-connector-gcp-pubsub</name>
+	<name>Flink : Connectors : Google PubSub</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-hbase/pom.xml
+++ b/flink-connectors/flink-connector-hbase/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-hbase_${scala.binary.version}</artifactId>
-	<name>flink-connector-hbase</name>
+	<name>Flink : Connectors : HBase</name>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-hive_${scala.binary.version}</artifactId>
-	<name>flink-connector-hive</name>
+	<name>Flink : Connectors : Hive</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-jdbc_${scala.binary.version}</artifactId>
-	<name>flink-connector-jdbc</name>
+	<name>Flink : Connectors : JDBC</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
-	<name>flink-connector-kafka-0.10</name>
+	<name>Flink : Connectors : Kafka 0.10</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.11/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-kafka-0.11_${scala.binary.version}</artifactId>
-	<name>flink-connector-kafka-0.11</name>
+	<name>Flink : Connectors : Kafka 0.11</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-kafka-base/pom.xml
+++ b/flink-connectors/flink-connector-kafka-base/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-kafka-base_${scala.binary.version}</artifactId>
-	<name>flink-connector-kafka-base</name>
+	<name>Flink : Connectors : Kafka base</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-kafka_${scala.binary.version}</artifactId>
-	<name>flink-connector-kafka</name>
+	<name>Flink : Connectors : Kafka</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
-	<name>flink-connector-kinesis</name>
+	<name>Flink : Connectors : Kinesis</name>
 	<properties>
 		<aws.sdk.version>1.11.754</aws.sdk.version>
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>

--- a/flink-connectors/flink-connector-nifi/pom.xml
+++ b/flink-connectors/flink-connector-nifi/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-nifi_${scala.binary.version}</artifactId>
-	<name>flink-connector-nifi</name>
+	<name>Flink : Connectors : Nifi</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-rabbitmq_${scala.binary.version}</artifactId>
-	<name>flink-connector-rabbitmq</name>
+	<name>Flink : Connectors : RabbitMQ</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-connector-twitter/pom.xml
+++ b/flink-connectors/flink-connector-twitter/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-twitter_${scala.binary.version}</artifactId>
-	<name>flink-connector-twitter</name>
+	<name>Flink : Connectors : Twitter</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-hadoop-compatibility_${scala.binary.version}</artifactId>
-	<name>flink-hadoop-compatibility</name>
+	<name>Flink : Connectors : Hadoop compatibility</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-hcatalog_${scala.binary.version}</artifactId>
-	<name>flink-hcatalog</name>
+	<name>Flink : Connectors : HCatalog</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-elasticsearch6_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-elasticsearch6</name>
+	<name>Flink : Connectors : SQL : Elasticsearch 6</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-elasticsearch7_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-elasticsearch7</name>
+	<name>Flink : Connectors : SQL : Elasticsearch 7</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-hbase/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-sql-connector-hbase_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-hbase</name>
+	<name>Flink : Connectors : SQL : HBase</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-hive-1.2.2_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-hive-1.2.2</name>
+	<name>Flink : Connectors : SQL : Hive 1.2.2</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-hive-2.2.0_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-hive-2.2.0</name>
+	<name>Flink : Connectors : SQL : Hive 2.2.0</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-hive-2.3.6_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-hive-2.3.6</name>
+	<name>Flink : Connectors : SQL : Hive 2.3.6</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-hive-3.1.2_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-hive-3.1.2</name>
+	<name>Flink : Connectors : SQL : Hive 3.1.2</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-kafka-0.10_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-kafka-0.10</name>
+	<name>Flink : Connectors : SQL : Kafka 0.10</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-kafka-0.11_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-kafka-0.11</name>
+	<name>Flink : Connectors : SQL : Kafka 0.11</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-connector-kafka_${scala.binary.version}</artifactId>
-	<name>flink-sql-connector-kafka</name>
+	<name>Flink : Connectors : SQL : Kafka</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -32,7 +32,7 @@ under the License.
 
 
 	<artifactId>flink-connectors</artifactId>
-	<name>flink-connectors</name>
+	<name>Flink : Connectors : </name>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-container_${scala.binary.version}</artifactId>
-	<name>flink-container</name>
+	<name>Flink : Container</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-contrib/flink-connector-wikiedits/pom.xml
+++ b/flink-contrib/flink-connector-wikiedits/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-wikiedits_${scala.binary.version}</artifactId>
-	<name>flink-connector-wikiedits</name>
+	<name>Flink : Contrib : Connectors : Wikiedits</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-contrib/pom.xml
+++ b/flink-contrib/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-contrib</artifactId>
-	<name>flink-contrib</name>
+	<name>Flink : Contrib : </name>
 
 	<packaging>pom</packaging>
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-core</artifactId>
-	<name>flink-core</name>
+	<name>Flink : Core</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-dist_${scala.binary.version}</artifactId>
-	<name>flink-dist</name>
+	<name>Flink : Dist</name>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-docs</artifactId>
-	<name>flink-docs</name>
+	<name>Flink : Docs</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
@@ -31,7 +31,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-batch-sql-test_${scala.binary.version}</artifactId>
-	<name>flink-batch-sql-test</name>
+	<name>Flink : E2E Tests : Batch SQL</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
@@ -31,7 +31,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-bucketing-sink-test</artifactId>
-	<name>flink-bucketing-sink-test</name>
+	<name>Flink : E2E Tests : Bucketing sink</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-cli-test/pom.xml
+++ b/flink-end-to-end-tests/flink-cli-test/pom.xml
@@ -31,7 +31,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-cli-test_${scala.binary.version}</artifactId>
-	<name>flink-cli-test</name>
+	<name>Flink : E2E Tests : CLI</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -27,6 +27,8 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-confluent-schema-registry</artifactId>
+	<name>Flink : E2E Tests : Confluent schema registry</name>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<confluent.version>4.1.0</confluent.version>

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-connector-gcp-pubsub-emulator-tests</artifactId>
-	<name>flink-connector-gcp-pubsub-emulator-tests</name>
+	<name>Flink : E2E Tests : Connectors : Google PubSub</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-dataset-allround-test</artifactId>
-	<name>flink-dataset-allround-test</name>
+	<name>Flink : E2E Tests : Dataset allround</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-dataset-fine-grained-recovery-test</artifactId>
-	<name>flink-dataset-fine-grained-recovery-test</name>
+	<name>Flink : E2E Tests : Dataset Fine-grained recovery</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-datastream-allround-test</artifactId>
-	<name>flink-datastream-allround-test</name>
+	<name>Flink : E2E Tests : Datastream allround</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
@@ -31,7 +31,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-distributed-cache-via-blob-test_${scala.binary.version}</artifactId>
-	<name>flink-distributed-cache-via-blob</name>
+	<name>Flink : E2E Tests : Distributed cache via blob</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-elasticsearch5-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch5-test/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-elasticsearch5-test</artifactId>
-	<name>flink-elasticsearch5-test</name>
+	<name>Flink : E2E Tests : Elasticsearch 5</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-elasticsearch6-test</artifactId>
-	<name>flink-elasticsearch6-test</name>
+	<name>Flink : E2E Tests : Elasticsearch 6</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-elasticsearch7-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch7-test/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-elasticsearch7-test</artifactId>
-	<name>flink-elasticsearch7-test</name>
+	<name>Flink : E2E Tests : Elasticsearch 7</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -28,6 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-end-to-end-tests-common-kafka</artifactId>
+	<name>Flink : E2E Tests : Common Kafka</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -28,6 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-end-to-end-tests-common</artifactId>
+	<name>Flink : E2E Tests : Common</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
@@ -28,6 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-end-to-end-tests-hbase</artifactId>
+	<name>Flink : E2E Tests : HBase</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
+++ b/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-heavy-deployment-stress-test</artifactId>
-	<name>flink-heavy-deployment-stress-test</name>
+	<name>Flink : E2E Tests : Heavy deployment</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
+++ b/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-high-parallelism-iterations-test</artifactId>
-	<name>flink-high-parallelism-iterations-test</name>
+	<name>Flink : E2E Tests : High parallelism iterations</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
+++ b/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-local-recovery-and-allocation-test</artifactId>
-	<name>flink-local-recovery-and-allocation-test</name>
+	<name>Flink : E2E Tests : Local recovery and allocation</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
@@ -29,6 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-metrics-availability-test</artifactId>
+	<name>Flink : E2E Tests : Metrics availability</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
@@ -29,6 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-metrics-reporter-prometheus-test</artifactId>
+	<name>Flink : E2E Tests : Metrics reporter prometheus</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-netty-shuffle-memory-control-test</artifactId>
-	<name>flink-netty-shuffle-memory-control-test</name>
+	<name>Flink : E2E Tests : Netty shuffle memory control</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
@@ -36,7 +36,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-parent-child-classloading-test-lib-package_${scala.binary.version}</artifactId>
-	<name>flink-parent-child-classloading-test-lib-package</name>
+	<name>Flink : E2E Tests : Parent Child classloading lib-package</name>
 	<packaging>jar</packaging>
 
 	<build>

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
@@ -36,7 +36,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-parent-child-classloading-test-program_${scala.binary.version}</artifactId>
-	<name>flink-parent-child-classloading-test-program</name>
+	<name>Flink : E2E Tests : Parent Child classloading program</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/pom.xml
@@ -28,6 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>another-dummy-fs</artifactId>
+	<name>Flink : E2E Tests : Plugins : Another dummy fs</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-end-to-end-tests/flink-plugins-test/dummy-fs/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/dummy-fs/pom.xml
@@ -28,6 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>dummy-fs</artifactId>
+	<name>Flink : E2E Tests : Plugins : Dummy fs</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-end-to-end-tests/flink-plugins-test/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <packaging>pom</packaging>
 
     <artifactId>flink-plugins-test</artifactId>
-    <name>flink-plugins-test</name>
+    <name>Flink : E2E Tests : Plugins : </name>
 
     <modules>
         <module>dummy-fs</module>

--- a/flink-end-to-end-tests/flink-python-test/pom.xml
+++ b/flink-end-to-end-tests/flink-python-test/pom.xml
@@ -28,7 +28,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-python-test_${scala.binary.version}</artifactId>
-	<name>flink-python-test</name>
+	<name>Flink : E2E Tests : Python</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
@@ -28,7 +28,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-queryable-state-test_${scala.binary.version}</artifactId>
-	<name>flink-queryable-state-test</name>
+	<name>Flink : E2E Tests : Queryable state</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-end-to-end-tests/flink-quickstart-test/pom.xml
+++ b/flink-end-to-end-tests/flink-quickstart-test/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-quickstart-test</artifactId>
-	<name>flink-quickstart-test</name>
+	<name>Flink : E2E Tests : Quickstart</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
@@ -29,6 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-rocksdb-state-memory-control-test</artifactId>
+	<name>Flink : E2E Tests : RocksDB state memory control</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-sql-client-test</artifactId>
-	<name>flink-sql-client-test</name>
+	<name>Flink : E2E Tests : SQL client</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
+++ b/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-state-evolution-test</artifactId>
-	<name>flink-state-evolution-test</name>
+	<name>Flink : E2E Tests : State evolution</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
@@ -31,7 +31,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-stream-sql-test_${scala.binary.version}</artifactId>
-	<name>flink-stream-sql-test</name>
+	<name>Flink : E2E Tests : Stream SQL</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-stream-state-ttl-test</artifactId>
-	<name>flink-stream-state-ttl-test</name>
+	<name>Flink : E2E Tests : Stream state TTL</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-stream-stateful-job-upgrade-test</artifactId>
-	<name>flink-stream-stateful-job-upgrade-test</name>
+	<name>Flink : E2E Tests : Stream stateful job upgrade</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
@@ -28,6 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-streaming-file-sink-test</artifactId>
+	<name>Flink : E2E Tests : Streaming file sink</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-streaming-kafka-test-base_${scala.binary.version}</artifactId>
-	<name>flink-streaming-kafka-test-base</name>
+	<name>Flink : E2E Tests : Streaming Kafka base</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-streaming-kafka-test_${scala.binary.version}</artifactId>
-	<name>flink-streaming-kafka-test</name>
+	<name>Flink : E2E Tests : Streaming Kafka</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-streaming-kafka010-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka010-test/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-streaming-kafka010-test_${scala.binary.version}</artifactId>
-	<name>flink-streaming-kafka010-test</name>
+	<name>Flink : E2E Tests : Streaming Kafka 0.10</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-streaming-kafka011-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka011-test/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-streaming-kafka011-test_${scala.binary.version}</artifactId>
-	<name>flink-streaming-kafka011-test</name>
+	<name>Flink : E2E Tests : Streaming Kafka 0.11</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-streaming-kinesis-test_${scala.binary.version}</artifactId>
-	<name>flink-streaming-kinesis-test</name>
+	<name>Flink : E2E Tests : Streaming Kinesis</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-end-to-end-tests/flink-tpcds-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpcds-test/pom.xml
@@ -27,6 +27,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-tpcds-test</artifactId>
+	<name>Flink : E2E Tests : TPCDS</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-tpch-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpch-test/pom.xml
@@ -27,6 +27,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-tpch-test</artifactId>
+	<name>Flink : E2E Tests : TPCH</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<artifactId>flink-end-to-end-tests</artifactId>
-	<name>flink-end-to-end-tests</name>
+	<name>Flink : E2E Tests : </name>
 
 	<properties>
 		<!-- functions as a global exclude; required since an empty set of included groups implicitly includes all -->

--- a/flink-examples/flink-examples-batch/pom.xml
+++ b/flink-examples/flink-examples-batch/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-examples-batch_${scala.binary.version}</artifactId>
-	<name>flink-examples-batch</name>
+	<name>Flink : Examples : Batch</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-examples-streaming-gcp-pubsub_${scala.binary.version}</artifactId>
-	<name>flink-examples-streaming-gcp-pubsub</name>
+	<name>Flink : Examples : Build Helper : Streaming Google PubSub</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-examples-streaming-state-machine_${scala.binary.version}</artifactId>
-	<name>flink-examples-streaming-state-machine</name>
+	<name>Flink : Examples : Build Helper : Streaming State machine</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-twitter/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-twitter/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-examples-streaming-twitter_${scala.binary.version}</artifactId>
-	<name>flink-examples-streaming-twitter</name>
+	<name>Flink : Examples : Build Helper : Streaming Twitter</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-examples/flink-examples-build-helper/pom.xml
+++ b/flink-examples/flink-examples-build-helper/pom.xml
@@ -29,6 +29,8 @@ under the License.
 	</parent>
 
 	<artifactId>flink-examples-build-helper</artifactId>
+	<name>Flink : Examples : Build Helper : </name>
+
 	<packaging>pom</packaging>
 	<description>This is a utility module for building example jars to be used in flink-dist.</description>
 

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-examples-streaming_${scala.binary.version}</artifactId>
-	<name>flink-examples-streaming</name>
+	<name>Flink : Examples : Streaming</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<name>flink-examples-table</name>
+	<name>Flink : Examples : Table</name>
 	<artifactId>flink-examples-table_${scala.binary.version}</artifactId>
 	<packaging>jar</packaging>
 

--- a/flink-examples/pom.xml
+++ b/flink-examples/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-examples</artifactId>
-	<name>flink-examples</name>
+	<name>Flink : Examples : </name>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/flink-external-resources/flink-external-resource-gpu/pom.xml
+++ b/flink-external-resources/flink-external-resource-gpu/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-external-resource-gpu</artifactId>
-	<name>flink-external-resource-gpu</name>
+	<name>Flink : External resources : GPU</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-external-resources/pom.xml
+++ b/flink-external-resources/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-external-resources</artifactId>
-	<name>flink-external-resources</name>
+	<name>Flink : External resources : </name>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-azure-fs-hadoop</artifactId>
-	<name>flink-azure-fs-hadoop</name>
+	<name>Flink : FileSystems : Azure FS Hadoop</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-fs-hadoop-shaded</artifactId>
-	<name>flink-filesystems :: flink-fs-hadoop-shaded</name>
+	<name>Flink : FileSystems : Hadoop FS shaded</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-hadoop-fs</artifactId>
-	<name>flink-hadoop-fs</name>
+	<name>Flink : FileSystems : Hadoop FS</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-filesystems/flink-mapr-fs/pom.xml
+++ b/flink-filesystems/flink-mapr-fs/pom.xml
@@ -28,8 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-mapr-fs</artifactId>
-	<name>flink-mapr-fs</name>
-
+	<name>Flink : FileSystems : Mapr FS</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -26,6 +26,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-oss-fs-hadoop</artifactId>
+	<name>Flink : FileSystems : OSS FS</name>
 
 	<properties>
 		<fs.oss.sdk.version>3.4.1</fs.oss.sdk.version>

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -28,8 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-s3-fs-base</artifactId>
-	<name>flink-s3-fs-base</name>
-
+	<name>Flink : FileSystems : S3 FS Base</name>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-s3-fs-hadoop</artifactId>
-	<name>flink-s3-fs-hadoop</name>
+	<name>Flink : FileSystems : S3 FS Hadoop</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-s3-fs-presto</artifactId>
-	<name>flink-s3-fs-presto</name>
+	<name>Flink : FileSystems : S3 FS Presto</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-filesystems/flink-swift-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-swift-fs-hadoop/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-swift-fs-hadoop</artifactId>
-	<name>flink-swift-fs-hadoop</name>
+	<name>Flink : FileSystems : Swift FS Hadoop</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-filesystems</artifactId>
-	<name>flink-filesystems</name>
+	<name>Flink : FileSystems : </name>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -29,6 +29,8 @@ under the License.
 
 	<artifactId>flink-avro-confluent-registry</artifactId>
 
+	<name>Flink : Formats : Avro confluent registry</name>
+
 	<properties>
 		<confluent.schema.registry.version>4.1.0</confluent.schema.registry.version>
 	</properties>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-avro</artifactId>
-	<name>flink-avro</name>
+	<name>Flink : Formats : Avro</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-compress/pom.xml
+++ b/flink-formats/flink-compress/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-compress</artifactId>
-	<name>flink-compress</name>
+	<name>Flink : Formats : Compress</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-csv</artifactId>
-	<name>flink-csv</name>
+	<name>Flink : Formats : Csv</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-hadoop-bulk/pom.xml
+++ b/flink-formats/flink-hadoop-bulk/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-hadoop-bulk_${scala.binary.version}</artifactId>
-	<name>flink-hadoop-bulk</name>
+	<name>Flink : Formats : Hadoop bulk</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-json</artifactId>
-	<name>flink-json</name>
+	<name>Flink : Formats : Json</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-orc-nohive/pom.xml
+++ b/flink-formats/flink-orc-nohive/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-orc-nohive_${scala.binary.version}</artifactId>
-	<name>flink-orc-nohive</name>
+	<name>Flink : Formats : Orc nohive</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-orc_${scala.binary.version}</artifactId>
-	<name>flink-orc</name>
+	<name>Flink : Formats : Orc</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-parquet_${scala.binary.version}</artifactId>
-	<name>flink-parquet</name>
+	<name>Flink : Formats : Parquet</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sequence-file</artifactId>
-	<name>flink-sequence-file</name>
+	<name>Flink : Formats : Sequence file</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-sql-orc/pom.xml
+++ b/flink-formats/flink-sql-orc/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-orc_${scala.binary.version}</artifactId>
-	<name>flink-sql-orc</name>
+	<name>Flink : Formats : SQL Orc</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-parquet_${scala.binary.version}</artifactId>
-	<name>flink-sql-parquet</name>
+	<name>Flink : Formats : SQL Parquet</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	</properties>
 
 	<artifactId>flink-formats</artifactId>
-	<name>flink-formats</name>
+	<name>Flink : Formats : </name>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-fs-tests</artifactId>
-	<name>flink-fs-tests</name>
+	<name>Flink : FileSystems : Tests</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-java</artifactId>
-	<name>flink-java</name>
+	<name>Flink : Java</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-kubernetes_${scala.binary.version}</artifactId>
-	<name>flink-kubernetes</name>
+	<name>Flink : Kubernetes</name>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -31,7 +31,7 @@ under the License.
     </parent>
     
     <artifactId>flink-cep-scala_${scala.binary.version}</artifactId>
-    <name>flink-cep-scala</name>
+    <name>Flink : Libraries : CEP Scala</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flink-libraries/flink-cep/pom.xml
+++ b/flink-libraries/flink-cep/pom.xml
@@ -31,7 +31,7 @@ under the License.
     </parent>
 
     <artifactId>flink-cep_${scala.binary.version}</artifactId>
-    <name>flink-cep</name>
+    <name>Flink : Libraries : CEP</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -28,7 +28,7 @@
 	</parent>
 
 	<artifactId>flink-gelly-examples_${scala.binary.version}</artifactId>
-	<name>flink-gelly-examples</name>
+	<name>Flink : Libraries : Gelly Examples</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flink-gelly-scala_${scala.binary.version}</artifactId>
-    <name>flink-gelly-scala</name>
+    <name>Flink : Libraries : Gelly scala</name>
 
     <packaging>jar</packaging>
 

--- a/flink-libraries/flink-gelly/pom.xml
+++ b/flink-libraries/flink-gelly/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-gelly_${scala.binary.version}</artifactId>
-	<name>flink-gelly</name>
+	<name>Flink : Libraries : Gelly </name>
 
 	<packaging>jar</packaging>
 

--- a/flink-libraries/flink-state-processing-api/pom.xml
+++ b/flink-libraries/flink-state-processing-api/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-state-processor-api_${scala.binary.version}</artifactId>
-	<name>flink-state-processor-api</name>
+	<name>Flink : Libraries : State processor API</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-libraries/pom.xml
+++ b/flink-libraries/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-libraries</artifactId>
-	<name>flink-libraries</name>
+	<name>Flink : Libraries : </name>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 	
 	<artifactId>flink-mesos_${scala.binary.version}</artifactId>
-	<name>flink-mesos</name>
+	<name>Flink : Mesos</name>
 	<packaging>jar</packaging>
 	
 	<properties>

--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-core</artifactId>
-	<name>flink-metrics-core</name>
+	<name>Flink : Metrics : Core</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-metrics/flink-metrics-datadog/pom.xml
+++ b/flink-metrics/flink-metrics-datadog/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-datadog</artifactId>
-	<name>flink-metrics-datadog</name>
+	<name>Flink : Metrics : Datadog</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-dropwizard</artifactId>
-	<name>flink-metrics-dropwizard</name>
+	<name>Flink : Metrics : Dropwizard</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/flink-metrics-graphite/pom.xml
+++ b/flink-metrics/flink-metrics-graphite/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-graphite</artifactId>
-	<name>flink-metrics-graphite</name>
+	<name>Flink : Metrics : Graphite</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-influxdb_${scala.binary.version}</artifactId>
-	<name>flink-metrics-influxdb</name>
+	<name>Flink : Metrics : InfluxDB</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/flink-metrics-jmx/pom.xml
+++ b/flink-metrics/flink-metrics-jmx/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
-	<name>flink-metrics-jmx</name>
+	<name>Flink : Metrics : JMX</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-prometheus_${scala.binary.version}</artifactId>
-	<name>flink-metrics-prometheus</name>
+	<name>Flink : Metrics : Prometheus</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/flink-metrics-slf4j/pom.xml
+++ b/flink-metrics/flink-metrics-slf4j/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-slf4j</artifactId>
-	<name>flink-metrics-slf4j</name>
+	<name>Flink : Metrics : Slf4j</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/flink-metrics-statsd/pom.xml
+++ b/flink-metrics/flink-metrics-statsd/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics-statsd</artifactId>
-	<name>flink-metrics-statsd</name>
+	<name>Flink : Metrics : StatsD</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-metrics</artifactId>
-	<name>flink-metrics</name>
+	<name>Flink : Metrics : </name>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/flink-ml-parent/flink-ml-api/pom.xml
+++ b/flink-ml-parent/flink-ml-api/pom.xml
@@ -29,6 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-ml-api</artifactId>
+	<name>Flink : ML : API</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-ml-parent/flink-ml-lib/pom.xml
+++ b/flink-ml-parent/flink-ml-lib/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-ml-lib_${scala.binary.version}</artifactId>
-	<name>flink-ml-lib</name>
+	<name>Flink : ML : Lib</name>
 
 	<dependencies>
 		<dependency>

--- a/flink-ml-parent/flink-ml-uber/pom.xml
+++ b/flink-ml-parent/flink-ml-uber/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-ml-uber_${scala.binary.version}</artifactId>
-	<name>flink-ml-uber</name>
+	<name>Flink : ML : Uber</name>
 	<description>
 		This module contains both the api and libraries for writing Flink ML programs.
 	</description>

--- a/flink-ml-parent/pom.xml
+++ b/flink-ml-parent/pom.xml
@@ -30,6 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-ml-parent</artifactId>
+	<name>Flink : ML : </name>
 
 	<packaging>pom</packaging>
 

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-optimizer_${scala.binary.version}</artifactId>
-	<name>flink-optimizer</name>
+	<name>Flink : Optimizer</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-python_${scala.binary.version}</artifactId>
-	<name>flink-python</name>
+	<name>Flink : Python</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-queryable-state/flink-queryable-state-client-java/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-client-java/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-queryable-state-client-java</artifactId>
-	<name>flink-queryable-state-client-java</name>
+	<name>Flink : Queryable state : Client Java</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-queryable-state-runtime_${scala.binary.version}</artifactId>
-	<name>flink-queryable-state-runtime</name>
+	<name>Flink : Queryable state : Runtime</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-queryable-state/pom.xml
+++ b/flink-queryable-state/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-queryable-state</artifactId>
-	<name>flink-queryable-state</name>
+	<name>Flink : Queryable state : </name>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/flink-quickstart/flink-quickstart-java/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/pom.xml
@@ -33,5 +33,6 @@ under the License.
 
 	<artifactId>flink-quickstart-java</artifactId>
 	<packaging>maven-archetype</packaging>
+	<name>Flink : Quickstart : Java</name>
 
 </project>

--- a/flink-quickstart/flink-quickstart-scala/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/pom.xml
@@ -33,5 +33,6 @@ under the License.
 
 	<artifactId>flink-quickstart-scala</artifactId>
 	<packaging>maven-archetype</packaging>
+	<name>Flink : Quickstart : Scala</name>
 
 </project>

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	<artifactId>flink-quickstart</artifactId>
 	<packaging>pom</packaging>
 
-	<name>flink-quickstart</name>
+	<name>Flink : Quickstart : </name>
 	<description>Parent project for different quickstart archetypes for Apache Flink</description>
 
 	<modules>

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-runtime-web_${scala.binary.version}</artifactId>
-	<name>flink-runtime-web</name>
+	<name>Flink : Runtime web</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-runtime_${scala.binary.version}</artifactId>
-	<name>flink-runtime</name>
+	<name>Flink : Runtime</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-scala-shell_${scala.binary.version}</artifactId>
-	<name>flink-scala-shell</name>
+	<name>Flink : Scala shell</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-scala_${scala.binary.version}</artifactId>
-	<name>flink-scala</name>
+	<name>Flink : Scala</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
+++ b/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-statebackend-heap-spillable_${scala.binary.version}</artifactId>
-	<name>flink-statebackend-heap-spillable</name>
+	<name>Flink : State backends : Heap spillable</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
-	<name>flink-statebackend-rocksdb</name>
+	<name>Flink : State backends : RocksDB</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-state-backends/pom.xml
+++ b/flink-state-backends/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-state-backends</artifactId>
-	<name>flink-state-backends</name>
+	<name>Flink : State backends : </name>
 
 	<packaging>pom</packaging>
 

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-	<name>flink-streaming-java</name>
+	<name>Flink : Streaming Java</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -29,7 +29,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
-	<name>flink-streaming-scala</name>
+	<name>Flink : Streaming Scala</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-client_${scala.binary.version}</artifactId>
-	<name>flink-sql-client</name>
+	<name>Flink : Table : SQL Client</name>
 	<description>
 		This module contains the SQL Client for exploring and
 		submitting SQL programs to Flink.

--- a/flink-table/flink-sql-parser-hive/pom.xml
+++ b/flink-table/flink-sql-parser-hive/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-parser-hive</artifactId>
-	<name>flink-sql-parser-hive</name>
+	<name>Flink : Table : SQL Parser Hive</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-sql-parser</artifactId>
-	<name>flink-sql-parser</name>
+	<name>Flink : Table : SQL Parser </name>
 
 	<packaging>jar</packaging>
 

--- a/flink-table/flink-table-api-java-bridge/pom.xml
+++ b/flink-table/flink-table-api-java-bridge/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
-	<name>flink-table-api-java-bridge</name>
+	<name>Flink : Table : API Java bridge</name>
 	<description>
 		This module contains the Table/SQL API for writing table programs
 		that interact with other Flink APIs using the Java programming language.

--- a/flink-table/flink-table-api-java/pom.xml
+++ b/flink-table/flink-table-api-java/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-api-java</artifactId>
-	<name>flink-table-api-java</name>
+	<name>Flink : Table : API Java</name>
 	<description>
 		This module contains the Table/SQL API for writing table programs
 		within the table ecosystem using the Java programming language.

--- a/flink-table/flink-table-api-scala-bridge/pom.xml
+++ b/flink-table/flink-table-api-scala-bridge/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-api-scala-bridge_${scala.binary.version}</artifactId>
-	<name>flink-table-api-scala-bridge</name>
+	<name>Flink : Table : API Scala bridge</name>
 	<description>
 		This module contains the Table/SQL API for writing table programs
 		that interact with other Flink APIs using the Scala programming language.

--- a/flink-table/flink-table-api-scala/pom.xml
+++ b/flink-table/flink-table-api-scala/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-api-scala_${scala.binary.version}</artifactId>
-	<name>flink-table-api-scala</name>
+	<name>Flink : Table : API Scala</name>
 	<description>
 		This module contains the Table/SQL API for writing table programs
 		within the table ecosystem using the Scala programming language.

--- a/flink-table/flink-table-common/pom.xml
+++ b/flink-table/flink-table-common/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-common</artifactId>
-	<name>flink-table-common</name>
+	<name>Flink : Table : Common</name>
 	<description>
 		This module contains extension points of the Table/SQL API.
 		It allows for implementing user-defined functions, custom

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
-	<name>flink-table-planner-blink</name>
+	<name>Flink : Table : Planner Blink</name>
 	<description>
 		This module bridges Table/SQL API and runtime. It contains
 		all resources that are required during pre-flight and runtime

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-	<name>flink-table-planner</name>
+	<name>Flink : Table : Planner</name>
 	<description>
 		This module bridges Table/SQL API and runtime. It contains
 		all resources that are required during pre-flight and runtime

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
-	<name>flink-table-runtime-blink</name>
+	<name>Flink : Table : Runtime Blink</name>
 	<description>
 		This module contains classes that are required by a task manager for
 		execution of table programs. The content of this module is work-in-progress.

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-uber-blink_${scala.binary.version}</artifactId>
-	<name>flink-table-uber-blink</name>
+	<name>Flink : Table : Uber Blink</name>
 	<description>
 		This module contains the entire Table/SQL distribution for writing table programs
 		within the table ecosystem or between other Flink APIs. This module uses the Blink planner

--- a/flink-table/flink-table-uber/pom.xml
+++ b/flink-table/flink-table-uber/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-uber_${scala.binary.version}</artifactId>
-	<name>flink-table-uber</name>
+	<name>Flink : Table : Uber</name>
 	<description>
 		This module contains the entire Table/SQL distribution for writing table programs
 		within the table ecosystem or between other Flink APIs. Users can either use the

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table</artifactId>
-	<name>flink-table</name>
+	<name>Flink : Table : </name>
 
 	<packaging>pom</packaging>
 

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-test-utils-junit</artifactId>
-	<name>flink-test-utils-junit</name>
+	<name>Flink : Test utils : Junit</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
-	<name>flink-test-utils</name>
+	<name>Flink : Test utils : Utils</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-test-utils-parent/pom.xml
+++ b/flink-test-utils-parent/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-test-utils-parent</artifactId>
-	<name>flink-test-utils-parent</name>
+	<name>Flink : Test utils : </name>
 
 	<packaging>pom</packaging>
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-tests</artifactId>
-	<name>flink-tests</name>
+	<name>Flink : Tests</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-walkthroughs/flink-walkthrough-common/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-common/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-walkthrough-common_${scala.binary.version}</artifactId>
-	<name>flink-walkthrough-common</name>
+	<name>Flink : Walkthrough : Common</name>
 
 	<packaging>jar</packaging>
 

--- a/flink-walkthroughs/flink-walkthrough-datastream-java/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-java/pom.xml
@@ -33,5 +33,6 @@ under the License.
 
 	<artifactId>flink-walkthrough-datastream-java</artifactId>
 	<packaging>maven-archetype</packaging>
+	<name>Flink : Walkthrough : Datastream Java</name>
 
 </project>

--- a/flink-walkthroughs/flink-walkthrough-datastream-scala/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-scala/pom.xml
@@ -33,5 +33,6 @@ under the License.
 
 	<artifactId>flink-walkthrough-datastream-scala</artifactId>
 	<packaging>maven-archetype</packaging>
+	<name>Flink : Walkthrough : Datastream Scala</name>
 
 </project>

--- a/flink-walkthroughs/flink-walkthrough-table-java/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-table-java/pom.xml
@@ -33,5 +33,6 @@ under the License.
 
 	<artifactId>flink-walkthrough-table-java</artifactId>
 	<packaging>maven-archetype</packaging>
+	<name>Flink : Walkthrough : Table Java</name>
 
 </project>

--- a/flink-walkthroughs/flink-walkthrough-table-scala/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-table-scala/pom.xml
@@ -33,5 +33,6 @@ under the License.
 
 	<artifactId>flink-walkthrough-table-scala</artifactId>
 	<packaging>maven-archetype</packaging>
+	<name>Flink : Walkthrough : Table Scala</name>
 
 </project>

--- a/flink-walkthroughs/pom.xml
+++ b/flink-walkthroughs/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	<artifactId>flink-walkthroughs</artifactId>
 	<packaging>pom</packaging>
 
-	<name>flink-walkthroughs</name>
+	<name>Flink : Walkthrough : </name>
 
 	<modules>
 		<module>flink-walkthrough-common</module>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	-->
 	
 	<artifactId>flink-yarn-tests</artifactId>
-	<name>flink-yarn-tests</name>
+	<name>Flink : Yarn Tests</name>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	</parent>
 
 	<artifactId>flink-yarn_${scala.binary.version}</artifactId>
-	<name>flink-yarn</name>
+	<name>Flink : Yarn</name>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	<artifactId>flink-parent</artifactId>
 	<version>1.12-SNAPSHOT</version>
 
-	<name>flink</name>
+	<name>Flink : </name>
 	<packaging>pom</packaging>
 	<url>https://flink.apache.org</url>
 	<inceptionYear>2014</inceptionYear>

--- a/tools/force-shading/pom.xml
+++ b/tools/force-shading/pom.xml
@@ -39,6 +39,7 @@ under the License.
 	<groupId>org.apache.flink</groupId>
 	<artifactId>force-shading</artifactId>
 	<version>1.12-SNAPSHOT</version>
+	<name>Flink : Tools : Force Shading</name>
 
 	<packaging>jar</packaging>
 


### PR DESCRIPTION
## What is the purpose of the change

Make the build output more human readable for the developers van various situations.

## Brief change log

Add or change the `<name>` of each maven module (i.e. in every pom.xml)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

The simplest way to test is by doing a `mvn clean` and verify the list of names at the end looks good.
Also looking at the change set verify that the names for each module are correct.

In some exceptional cases I made the name reflect a bit more the purpose like in the case of 
`flink-examples/flink-examples-build-helper` where the description indicates `This is a utility module for building example jars to be used in flink-dist.` so I named it `Flink : Examples : Dist : `

Fun fact: I noticed that the ordering of the modules during the build is changed a lot by maven because apparently the ordering of the modules in the pom.xml does not meet the configured dependencies between the modules. So maven reorders the build by itself.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
