### PR TITLE
 [FLINK-18608] Fix null handling when converting CAST expression 

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/CustomizedConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/CustomizedConvertRule.java
@@ -97,11 +97,12 @@ public class CustomizedConvertRule implements CallExpressionConvertRule {
 
 	private static RexNode convertCast(CallExpression call, ConvertContext context) {
 		checkArgumentNumber(call, 2);
-		RexNode child = context.toRexNode(call.getChildren().get(0));
-		TypeLiteralExpression type = (TypeLiteralExpression) call.getChildren().get(1);
+		final RexNode child = context.toRexNode(call.getChildren().get(0));
+		final TypeLiteralExpression targetType = (TypeLiteralExpression) call.getChildren().get(1);
+		final RelDataType targetRelDataType = context.getTypeFactory()
+			.createFieldTypeFromLogicalType(targetType.getOutputDataType().getLogicalType());
 		return context.getRelBuilder().getRexBuilder().makeAbstractCast(
-			context.getTypeFactory().createFieldTypeFromLogicalType(
-				type.getOutputDataType().getLogicalType().copy(child.getType().isNullable())),
+			targetRelDataType,
 			child);
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
@@ -335,6 +335,23 @@ public class ValuesITCase extends StreamingTestBase {
 		assertThat(results, equalTo(Collections.singletonList(row)));
 	}
 
+	@Test
+	public void testNullabilityOverwriting() {
+		Row row = Row.of(1, "ABC");
+		Table values = tEnv().fromValues(
+			DataTypes.ROW(
+				DataTypes.FIELD("f0", DataTypes.INT().nullable()),
+				DataTypes.FIELD("f1", DataTypes.STRING().nullable())
+			),
+			Collections.singletonList(row));
+		tEnv().createTemporaryView("values_t", values);
+		Iterator<Row> iter = tEnv().executeSql("select * from values_t").collect();
+
+		List<Row> results = new ArrayList<>();
+		iter.forEachRemaining(results::add);
+		assertThat(results, equalTo(Collections.singletonList(row)));
+	}
+
 	/**
 	 * A {@link ScalarFunction} that takes all supported types as parameters and
 	 * converts them to String.

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/ValuesTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/ValuesTest.xml
@@ -33,11 +33,11 @@ Values(tuples=[[{ 1, 2, _UTF-16LE'JKL' }, { 2, 3, _UTF-16LE'GHI' }, { 3, 4, _UTF
       <![CDATA[
 LogicalUnion(all=[true])
 :- LogicalValues(tuples=[[{ null }]])
-:- LogicalProject(f0=[1:FLOAT])
+:- LogicalProject(f0=[CAST(1:FLOAT):FLOAT])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[3.1E0:FLOAT])
+:- LogicalProject(f0=[CAST(3.1E0:FLOAT):FLOAT])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-+- LogicalProject(f0=[99:FLOAT])
++- LogicalProject(f0=[CAST(99:FLOAT):FLOAT])
    +- LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
@@ -49,7 +49,7 @@ Union(all=[true], union=[f0])
 :  +- Values(tuples=[[{ 0 }]], reuse_id=[1])
 :- Calc(select=[CAST(3.1E0:FLOAT) AS f0])
 :  +- Reused(reference_id=[1])
-+- Calc(select=[CAST(9.9E1:FLOAT) AS f0])
++- Calc(select=[CAST(99:FLOAT) AS f0])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>
@@ -60,13 +60,13 @@ Union(all=[true], union=[f0])
 LogicalUnion(all=[true])
 :- LogicalProject(f0=[1:DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[null:INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[3.141592653589793E0:DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[1])
+:- LogicalProject(f0=[3.141592653589793E0:DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[CAST(1):INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[3.1E0:DOUBLE], f1=[_UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[2])
+:- LogicalProject(f0=[3.1E0:DOUBLE], f1=[_UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[CAST(2):INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
 :- LogicalProject(f0=[99:DOUBLE], f1=[_UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[null:INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-+- LogicalProject(f0=[0E-1:DOUBLE], f1=[_UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[4])
++- LogicalProject(f0=[0E-1:DOUBLE], f1=[_UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[CAST(4):INTEGER])
    +- LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
@@ -75,13 +75,13 @@ LogicalUnion(all=[true])
 Union(all=[true], union=[f0, f1, f2])
 :- Calc(select=[1:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, null:INTEGER AS f2])
 :  +- Values(tuples=[[{ 0 }]], reuse_id=[1])
-:- Calc(select=[3.1415926535897931159E0:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(1) AS f2])
+:- Calc(select=[3.141592653589793E0:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(1) AS f2])
 :  +- Reused(reference_id=[1])
-:- Calc(select=[3.1000000000000000888E0:DOUBLE AS f0, _UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(2) AS f2])
+:- Calc(select=[3.1E0:DOUBLE AS f0, _UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(2) AS f2])
 :  +- Reused(reference_id=[1])
 :- Calc(select=[99:DOUBLE AS f0, _UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, null:INTEGER AS f2])
 :  +- Reused(reference_id=[1])
-+- Calc(select=[0E0:DOUBLE AS f0, _UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(4) AS f2])
++- Calc(select=[0E-1:DOUBLE AS f0, _UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(4) AS f2])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>
@@ -110,34 +110,34 @@ Union(all=[true], union=[f0, f1, f2])
     <Resource name="planBefore">
       <![CDATA[
 LogicalUnion(all=[true])
-:- LogicalProject(f0=[CAST(+(1, 3)):DOUBLE NOT NULL], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 3.0E0:DOUBLE)])
+:- LogicalProject(f0=[CAST(+(1, 3)):DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 3.0E0:DOUBLE)])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[CAST(+(ABS(-1), 2)):DOUBLE NOT NULL], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", CAST(+(ABS(-5), -5)):DOUBLE NOT NULL)])
+:- LogicalProject(f0=[CAST(+(ABS(-1), 2)):DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", CAST(+(ABS(-5), -5)):DOUBLE)])
 :  +- LogicalValues(tuples=[[{ 0 }]])
 :- LogicalProject(f0=[PI], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'abc':VARCHAR(4) CHARACTER SET "UTF-16LE", 3.0E0:DOUBLE)])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[3.1E0:DOUBLE], f1=[_UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'abcd':VARCHAR(4) CHARACTER SET "UTF-16LE", 3:DOUBLE)])
+:- LogicalProject(f0=[CAST(3.1E0:DOUBLE):DOUBLE], f1=[_UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'abcd':VARCHAR(4) CHARACTER SET "UTF-16LE", 3:DOUBLE)])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[99:DOUBLE], f1=[_UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 1:DOUBLE)])
+:- LogicalProject(f0=[CAST(99:DOUBLE):DOUBLE], f1=[_UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 1:DOUBLE)])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-+- LogicalProject(f0=[0E-1:DOUBLE], f1=[_UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[null:(VARCHAR(4) CHARACTER SET "UTF-16LE", DOUBLE) MAP])
++- LogicalProject(f0=[CAST(0E-1:DOUBLE):DOUBLE], f1=[_UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[null:(VARCHAR(4) CHARACTER SET "UTF-16LE", DOUBLE) MAP])
    +- LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Union(all=[true], union=[f0, f1, f2])
-:- Calc(select=[4E0:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 3.0E0:DOUBLE) AS f2])
+:- Calc(select=[CAST(4E0:DOUBLE) AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 3.0E0:DOUBLE) AS f2])
 :  +- Values(tuples=[[{ 0 }]], reuse_id=[1])
-:- Calc(select=[3E0:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", CAST(+(ABS(-5), -5))) AS f2])
+:- Calc(select=[CAST(3E0:DOUBLE) AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", CAST(+(ABS(-5), -5))) AS f2])
 :  +- Reused(reference_id=[1])
-:- Calc(select=[3.1415926535897931159E0:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'abc':VARCHAR(4) CHARACTER SET "UTF-16LE", 3.0E0:DOUBLE) AS f2])
+:- Calc(select=[CAST(3.1415926535897931159E0:DOUBLE) AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'abc':VARCHAR(4) CHARACTER SET "UTF-16LE", 3.0E0:DOUBLE) AS f2])
 :  +- Reused(reference_id=[1])
-:- Calc(select=[3.1E0:DOUBLE AS f0, _UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'abcd':VARCHAR(4) CHARACTER SET "UTF-16LE", 3:DOUBLE) AS f2])
+:- Calc(select=[CAST(3.1E0:DOUBLE) AS f0, _UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'abcd':VARCHAR(4) CHARACTER SET "UTF-16LE", 3:DOUBLE) AS f2])
 :  +- Reused(reference_id=[1])
-:- Calc(select=[99:DOUBLE AS f0, _UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 1:DOUBLE) AS f2])
+:- Calc(select=[CAST(99:DOUBLE) AS f0, _UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, MAP(_UTF-16LE'a':VARCHAR(4) CHARACTER SET "UTF-16LE", 1:DOUBLE) AS f2])
 :  +- Reused(reference_id=[1])
-+- Calc(select=[0E-1:DOUBLE AS f0, _UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, null:(VARCHAR(4) CHARACTER SET "UTF-16LE", DOUBLE) MAP AS f2])
++- Calc(select=[CAST(0E-1:DOUBLE) AS f0, _UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, null:(VARCHAR(4) CHARACTER SET "UTF-16LE", DOUBLE) MAP AS f2])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>
@@ -148,13 +148,13 @@ Union(all=[true], union=[f0, f1, f2])
 LogicalUnion(all=[true])
 :- LogicalProject(f0=[1:DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[null:INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[3.141592653589793E0:DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[1])
+:- LogicalProject(f0=[3.141592653589793E0:DOUBLE], f1=[_UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[CAST(1):INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[3.1E0:DOUBLE], f1=[_UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[2])
+:- LogicalProject(f0=[3.1E0:DOUBLE], f1=[_UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[CAST(2):INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-:- LogicalProject(f0=[99:DOUBLE], f1=[_UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[3])
+:- LogicalProject(f0=[99:DOUBLE], f1=[_UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[CAST(3):INTEGER])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-+- LogicalProject(f0=[0E-1:DOUBLE], f1=[_UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[4])
++- LogicalProject(f0=[0E-1:DOUBLE], f1=[_UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE"], f2=[CAST(4):INTEGER])
    +- LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
@@ -163,13 +163,13 @@ LogicalUnion(all=[true])
 Union(all=[true], union=[f0, f1, f2])
 :- Calc(select=[1:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, null:INTEGER AS f2])
 :  +- Values(tuples=[[{ 0 }]], reuse_id=[1])
-:- Calc(select=[3.1415926535897931159E0:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(1) AS f2])
+:- Calc(select=[3.141592653589793E0:DOUBLE AS f0, _UTF-16LE'ABC':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(1) AS f2])
 :  +- Reused(reference_id=[1])
-:- Calc(select=[3.1000000000000000888E0:DOUBLE AS f0, _UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(2) AS f2])
+:- Calc(select=[3.1E0:DOUBLE AS f0, _UTF-16LE'DEF':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(2) AS f2])
 :  +- Reused(reference_id=[1])
 :- Calc(select=[99:DOUBLE AS f0, _UTF-16LE'DEFG':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(3) AS f2])
 :  +- Reused(reference_id=[1])
-+- Calc(select=[0E0:DOUBLE AS f0, _UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(4) AS f2])
++- Calc(select=[0E-1:DOUBLE AS f0, _UTF-16LE'D':VARCHAR(4) CHARACTER SET "UTF-16LE" AS f1, CAST(4) AS f2])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>
@@ -178,18 +178,18 @@ Union(all=[true], union=[f0, f1, f2])
     <Resource name="planBefore">
       <![CDATA[
 LogicalUnion(all=[true])
-:- LogicalProject(a=[CAST(+(1, 2)):BIGINT NOT NULL], b=[_UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+:- LogicalProject(a=[CAST(+(1, 2)):BIGINT], b=[CAST(_UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-+- LogicalProject(a=[2:BIGINT], b=[_UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
++- LogicalProject(a=[CAST(2:BIGINT):BIGINT], b=[CAST(_UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
    +- LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Union(all=[true], union=[a, b])
-:- Calc(select=[3:BIGINT AS a, _UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS b])
+:- Calc(select=[CAST(3:BIGINT) AS a, CAST(_UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS b])
 :  +- Values(tuples=[[{ 0 }]], reuse_id=[1])
-+- Calc(select=[2:BIGINT AS a, _UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS b])
++- Calc(select=[CAST(2:BIGINT) AS a, CAST(_UTF-16LE'ABC':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS b])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>
@@ -230,18 +230,18 @@ Union(all=[true], union=[a, b])
     <Resource name="planBefore">
       <![CDATA[
 LogicalUnion(all=[true])
-:- LogicalProject(number=[1:DOUBLE], row=[ROW(_UTF-16LE'A    ', 2:DECIMAL(10, 2), ROW(00:00:00))], array=[ARRAY(1:BIGINT)])
+:- LogicalProject(number=[CAST(1:DOUBLE):DOUBLE], row=[ROW(_UTF-16LE'A    ', 2:DECIMAL(10, 2), ROW(00:00:00))], array=[ARRAY(1:BIGINT)])
 :  +- LogicalValues(tuples=[[{ 0 }]])
-+- LogicalProject(number=[3.141592653589793E0:DOUBLE], row=[ROW(_UTF-16LE'ABC  ', 3.0E0:DECIMAL(10, 2), ROW(00:00:00))], array=[ARRAY(3:BIGINT)])
++- LogicalProject(number=[CAST(3.141592653589793E0:DOUBLE):DOUBLE], row=[ROW(_UTF-16LE'ABC  ', 3.0E0:DECIMAL(10, 2), ROW(00:00:00))], array=[ARRAY(3:BIGINT)])
    +- LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Union(all=[true], union=[number, row, array])
-:- Calc(select=[1:DOUBLE AS number, ROW(_UTF-16LE'A    ', 2:DECIMAL(10, 2), ROW(00:00:00)) AS row, ARRAY(1:BIGINT) AS array])
+:- Calc(select=[CAST(1:DOUBLE) AS number, ROW(_UTF-16LE'A    ', 2:DECIMAL(10, 2), ROW(00:00:00)) AS row, ARRAY(1:BIGINT) AS array])
 :  +- Values(tuples=[[{ 0 }]], reuse_id=[1])
-+- Calc(select=[3.141592653589793E0:DOUBLE AS number, ROW(_UTF-16LE'ABC  ', 3.0E0:DECIMAL(10, 2), ROW(00:00:00)) AS row, ARRAY(3:BIGINT) AS array])
++- Calc(select=[CAST(3.141592653589793E0:DOUBLE) AS number, ROW(_UTF-16LE'ABC  ', 3.0E0:DECIMAL(10, 2), ROW(00:00:00)) AS row, ARRAY(3:BIGINT) AS array])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>


### PR DESCRIPTION
## What is the purpose of the change

Make the CAST preserve nullability when converting from Expression to RexCall. This has been done in master branch as part of https://issues.apache.org/jira/browse/FLINK-13784. This  PR adds a test case and backports the changes from master.


## Verifying this change

* Added test `org.apache.flink.table.planner.runtime.stream.table.ValuesITCase#testNullabilityOverwriting`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
