### PR TITLE
 [FLINK-18600] Upgrade kerberized yarn docker image to use openjdk 

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -132,13 +132,10 @@ if [[ ${PROFILE} != *"jdk11"* ]]; then
 
 	if [[ `uname -i` != 'aarch64' ]]; then
 		# Hadoop YARN deosn't support aarch64 at this moment. See: https://issues.apache.org/jira/browse/HADOOP-16723
-
-		# YARN tests disabled because we can no longer download oracle jdk. See FLINK-18600
-		#run_test "Running Kerberized YARN per-job on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_job_kerberos_docker.sh"
-		#run_test "Running Kerberized YARN per-job on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_job_kerberos_docker.sh dummy-fs"
-		#run_test "Running Kerberized YARN application on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_application_kerberos_docker.sh"
-		#run_test "Running Kerberized YARN application on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_application_kerberos_docker.sh dummy-fs"
-
+		run_test "Running Kerberized YARN per-job on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_job_kerberos_docker.sh"
+		run_test "Running Kerberized YARN per-job on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_job_kerberos_docker.sh dummy-fs"
+		run_test "Running Kerberized YARN application on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_application_kerberos_docker.sh"
+		run_test "Running Kerberized YARN application on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_application_kerberos_docker.sh dummy-fs"
 		run_test "Run Mesos WordCount test" "$END_TO_END_DIR/test-scripts/test_mesos_wordcount.sh"
 		run_test "Run Mesos multiple submission test" "$END_TO_END_DIR/test-scripts/test_mesos_multiple_submissions.sh"
 

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
@@ -24,7 +24,7 @@
 #
 # Creates multi-node, kerberized Hadoop cluster on Docker
 
-FROM sequenceiq/pam:ubuntu-14.04
+FROM openjdk:8
 
 RUN set -x \
     && addgroup hadoop \
@@ -35,7 +35,7 @@ RUN set -x \
 
 # install dev tools
 RUN set -x \
-    && apt-get update && apt-get install -y \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl tar sudo openssh-server openssh-client rsync unzip krb5-user
 
 # Kerberos client
@@ -50,15 +50,6 @@ RUN set -x \
     && ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key \
     && ssh-keygen -q -N "" -t rsa -f /root/.ssh/id_rsa \
     && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-
-# java
-RUN set -x \
-    && mkdir -p /usr/java/default \
-    && curl -Ls 'https://download.oracle.com/otn-pub/java/jdk/8u251-b08/3d5a2bb8f8d4428bbe94aed7ec7ae784/jdk-8u251-linux-x64.tar.gz' -H 'Cookie: oraclelicense=accept-securebackup-cookie' | \
-        tar --strip-components=1 -xz -C /usr/java/default/
-
-ENV JAVA_HOME /usr/java/default
-ENV PATH $PATH:$JAVA_HOME/bin
 
 RUN sed -i 's/^#crypto.policy=unlimited/crypto.policy=unlimited/' $JAVA_HOME/jre/lib/security/java.security
 

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -162,50 +162,49 @@ wait_job_terminal_state "$JOB_ID" "FINISHED"
 stop_cluster
 
 # These tests are known to fail on JDK11. See FLINK-13719
-# YARN tests disabled because we can no longer download oracle jdk. See FLINK-18600
-#if [[ ${PROFILE} != *"jdk11"* ]]; then
-#    cd "${CURRENT_DIR}/../"
-#    source "${CURRENT_DIR}"/common_yarn_docker.sh
-#    # test submitting on yarn
-#    start_hadoop_cluster_and_prepare_flink
-#
-#    # copy test files
-#    docker cp "${FLINK_PYTHON_DIR}/dev/lint-python.sh" master:/tmp/
-#    docker cp "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar" master:/tmp/
-#    docker cp "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" master:/tmp/
-#    docker cp "${REQUIREMENTS_PATH}" master:/tmp/
-#    docker cp "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" master:/tmp/
-#    PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache-flink-*.tar.gz)
-#    docker cp "${FLINK_PYTHON_DIR}/dist/${PYFLINK_PACKAGE_FILE}" master:/tmp/
-#
-#    # prepare environment
-#    docker exec master bash -c "
-#    /tmp/lint-python.sh -s miniconda
-#    source /tmp/.conda/bin/activate
-#    pip install /tmp/${PYFLINK_PACKAGE_FILE}
-#    conda install -y -q zip=3.0
-#    rm -rf /tmp/.conda/pkgs
-#    cd /tmp
-#    zip -q -r /tmp/venv.zip .conda
-#    echo \"taskmanager.memory.task.off-heap.size: 100m\" >> \"/home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml\"
-#    "
-#
-#    docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
-#        export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
-#        /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
-#        -pyfs /tmp/add_one.py \
-#        -pyreq /tmp/requirements.txt \
-#        -pyarch /tmp/venv.zip \
-#        -pyexec venv.zip/.conda/bin/python \
-#        /tmp/PythonUdfSqlJobExample.jar"
-#
-#    docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
-#        export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
-#        /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
-#        -pyfs /tmp/add_one.py \
-#        -pyreq /tmp/requirements.txt \
-#        -pyarch /tmp/venv.zip \
-#        -pyexec venv.zip/.conda/bin/python \
-#        -py /tmp/python_job.py \
-#        pipeline.jars file:/tmp/PythonUdfSqlJobExample.jar"
-#fi
+if [[ ${PROFILE} != *"jdk11"* ]]; then
+    cd "${CURRENT_DIR}/../"
+    source "${CURRENT_DIR}"/common_yarn_docker.sh
+    # test submitting on yarn
+    start_hadoop_cluster_and_prepare_flink
+
+    # copy test files
+    docker cp "${FLINK_PYTHON_DIR}/dev/lint-python.sh" master:/tmp/
+    docker cp "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar" master:/tmp/
+    docker cp "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" master:/tmp/
+    docker cp "${REQUIREMENTS_PATH}" master:/tmp/
+    docker cp "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" master:/tmp/
+    PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache-flink-*.tar.gz)
+    docker cp "${FLINK_PYTHON_DIR}/dist/${PYFLINK_PACKAGE_FILE}" master:/tmp/
+
+    # prepare environment
+    docker exec master bash -c "
+    /tmp/lint-python.sh -s miniconda
+    source /tmp/.conda/bin/activate
+    pip install /tmp/${PYFLINK_PACKAGE_FILE}
+    conda install -y -q zip=3.0
+    rm -rf /tmp/.conda/pkgs
+    cd /tmp
+    zip -q -r /tmp/venv.zip .conda
+    echo \"taskmanager.memory.task.off-heap.size: 100m\" >> \"/home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml\"
+    "
+
+    docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+        export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+        /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
+        -pyfs /tmp/add_one.py \
+        -pyreq /tmp/requirements.txt \
+        -pyarch /tmp/venv.zip \
+        -pyexec venv.zip/.conda/bin/python \
+        /tmp/PythonUdfSqlJobExample.jar"
+
+    docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+        export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+        /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ytm 1500 -yjm 1000 \
+        -pyfs /tmp/add_one.py \
+        -pyreq /tmp/requirements.txt \
+        -pyarch /tmp/venv.zip \
+        -pyexec venv.zip/.conda/bin/python \
+        -py /tmp/python_job.py \
+        pipeline.jars file:/tmp/PythonUdfSqlJobExample.jar"
+fi


### PR DESCRIPTION

## What is the purpose of the change

Upgrade yarn tests to use openjdk and reenable tests that were affected by oracle jdk issue.

## Brief change log

  - Updated base image to openjdk:8
  - Reenabled test


## Verifying this change

Tests run on Azure

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
