### PR TITLE
[FLINK-18355][tests] Simplify tests of SlotPoolImpl

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImplTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.executiongraph.TestingComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmanager.scheduler.DummyScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link SchedulerImpl}.
+ */
+public class SchedulerImplTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.seconds(1L);
+
+	@ClassRule
+	public static final TestingComponentMainThreadExecutor.Resource EXECUTOR_RESOURCE =
+		new TestingComponentMainThreadExecutor.Resource(10L);
+
+	private final TestingComponentMainThreadExecutor testMainThreadExecutor =
+		EXECUTOR_RESOURCE.getComponentMainThreadTestExecutor();
+
+	private TestingResourceManagerGateway resourceManagerGateway;
+	private SlotPoolBuilder slotPoolBuilder;
+
+	@Before
+	public void setUp() throws Exception {
+		resourceManagerGateway = new TestingResourceManagerGateway();
+		slotPoolBuilder = new SlotPoolBuilder(testMainThreadExecutor.getMainThreadExecutor())
+			.setResourceManagerGateway(resourceManagerGateway);
+	}
+
+	/**
+	 * This case make sure when allocateSlot in ProviderAndOwner timeout,
+	 * it will automatically call cancelSlotAllocation as will inject future.whenComplete in ProviderAndOwner.
+	 */
+	@Test
+	public void testProviderAndOwnerSlotAllocationTimeout() throws Exception {
+
+		try (TestingSlotPoolImpl slotPool = createAndSetUpSlotPool()) {
+
+			final CompletableFuture<SlotRequestId> releaseSlotFuture = new CompletableFuture<>();
+
+			slotPool.setReleaseSlotConsumer(releaseSlotFuture::complete);
+
+			final Scheduler scheduler = createAndSetUpScheduler(slotPool);
+
+			// test the pending request is clear when timed out
+			final CompletableFuture<LogicalSlot> allocateSlotFuture = allocateSlot(scheduler);
+			try {
+				allocateSlotFuture.get();
+				fail("We expected a TimeoutException.");
+			} catch (ExecutionException e) {
+				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof TimeoutException);
+			}
+
+			// wait for the cancel call on the SlotPoolImpl
+			releaseSlotFuture.get();
+
+			assertEquals(0L, slotPool.getNumberOfPendingRequests());
+		}
+	}
+
+	private Scheduler createAndSetUpScheduler(SlotPool slotPool) {
+		final Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
+		scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
+		return scheduler;
+	}
+
+	private TestingSlotPoolImpl createAndSetUpSlotPool() throws Exception {
+		return slotPoolBuilder.build();
+	}
+
+	private CompletableFuture<LogicalSlot> allocateSlot(Scheduler scheduler) {
+		return testMainThreadExecutor.execute(() -> scheduler.allocateSlot(
+			new DummyScheduledUnit(),
+			SlotProfile.noRequirements(),
+			TIMEOUT
+		));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -25,16 +25,20 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnfulfillableSlotRequestException;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
-import org.apache.flink.util.clock.ManualClock;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.ManualClock;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -81,8 +85,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 	 */
 	@Test
 	public void testPendingBatchSlotRequestTimeout() throws Exception {
-		try (final SlotPoolImpl slotPool = new SlotPoolBuilder(mainThreadExecutor)
-				.build()) {
+		try (final SlotPoolImpl slotPool = createAndSetUpSlotPool(mainThreadExecutor, null, Time.milliseconds(2L))) {
 			final CompletableFuture<PhysicalSlot> slotFuture = SlotPoolUtils.requestNewAllocatedBatchSlot(
 				slotPool,
 				mainThreadExecutor,
@@ -107,10 +110,11 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
 		final ManualClock clock = new ManualClock();
 
-		try (final TestingSlotPoolImpl slotPool = new SlotPoolBuilder(directMainThreadExecutor)
-				.setClock(clock)
-				.setBatchSlotTimeout(batchSlotTimeout)
-				.build()) {
+		try (final TestingSlotPoolImpl slotPool = createAndSetUpSlotPool(
+				directMainThreadExecutor,
+				null,
+				batchSlotTimeout,
+				clock)) {
 
 			SlotPoolUtils.offerSlots(slotPool, directMainThreadExecutor, Collections.singletonList(resourceProfile));
 
@@ -141,10 +145,10 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
 
 		final Time batchSlotTimeout = Time.milliseconds(1000L);
-		try (final SlotPoolImpl slotPool = new SlotPoolBuilder(directMainThreadExecutor)
-			.setBatchSlotTimeout(batchSlotTimeout)
-			.setResourceManagerGateway(testingResourceManagerGateway)
-			.build()) {
+		try (final SlotPoolImpl slotPool = createAndSetUpSlotPool(
+				directMainThreadExecutor,
+				testingResourceManagerGateway,
+				batchSlotTimeout)) {
 
 			final CompletableFuture<PhysicalSlot> slotFuture = SlotPoolUtils.requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
 
@@ -191,10 +195,10 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ComponentMainThreadExecutor directMainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
 
 		final Time batchSlotTimeout = Time.milliseconds(1000L);
-		try (final SlotPoolImpl slotPool = new SlotPoolBuilder(directMainThreadExecutor)
-			.setBatchSlotTimeout(batchSlotTimeout)
-			.setResourceManagerGateway(testingResourceManagerGateway)
-			.build()) {
+		try (final SlotPoolImpl slotPool = createAndSetUpSlotPool(
+				directMainThreadExecutor,
+				testingResourceManagerGateway,
+				batchSlotTimeout)) {
 
 			final CompletableFuture<PhysicalSlot> slotFuture = SlotPoolUtils.requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
 
@@ -233,10 +237,12 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 		final ManualClock clock = new ManualClock();
 		final Time batchSlotTimeout = Time.milliseconds(1000L);
 
-		try (final TestingSlotPoolImpl slotPool = new SlotPoolBuilder(directMainThreadExecutor)
-				.setClock(clock)
-				.setBatchSlotTimeout(batchSlotTimeout)
-				.build()) {
+		try (final TestingSlotPoolImpl slotPool = createAndSetUpSlotPool(
+				directMainThreadExecutor,
+				null,
+				batchSlotTimeout,
+				clock)) {
+
 			final ResourceID taskManagerResourceId = SlotPoolUtils.offerSlots(slotPool, directMainThreadExecutor, Collections.singletonList(resourceProfile));
 			final CompletableFuture<PhysicalSlot> firstSlotFuture = SlotPoolUtils.requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, resourceProfile);
 			final CompletableFuture<PhysicalSlot> secondSlotFuture = SlotPoolUtils.requestNewAllocatedBatchSlot(slotPool, directMainThreadExecutor, ResourceProfile.UNKNOWN);
@@ -275,5 +281,29 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 
 		// timeout all as unfulfillable marked slots
 		slotPool.triggerCheckBatchSlotTimeout();
+	}
+
+	private TestingSlotPoolImpl createAndSetUpSlotPool(
+			final ComponentMainThreadExecutor componentMainThreadExecutor,
+			@Nullable final ResourceManagerGateway resourceManagerGateway,
+			final Time batchSlotTimeout) throws Exception {
+
+		return new SlotPoolBuilder(componentMainThreadExecutor)
+			.setResourceManagerGateway(resourceManagerGateway)
+			.setBatchSlotTimeout(batchSlotTimeout)
+			.build();
+	}
+
+	private TestingSlotPoolImpl createAndSetUpSlotPool(
+			final ComponentMainThreadExecutor componentMainThreadExecutor,
+			@Nullable final ResourceManagerGateway resourceManagerGateway,
+			final Time batchSlotTimeout,
+			final Clock clock) throws Exception {
+
+		return new SlotPoolBuilder(componentMainThreadExecutor)
+			.setResourceManagerGateway(resourceManagerGateway)
+			.setBatchSlotTimeout(batchSlotTimeout)
+			.setClock(clock)
+			.build();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -208,39 +208,23 @@ public class SlotPoolImplTest extends TestLogger {
 		try (SlotPoolImpl slotPool = createAndSetUpSlotPool()) {
 			slotPool.registerTaskManager(taskManagerLocation.getResourceID());
 
-			final SlotRequestId requestId1 = new SlotRequestId();
-			final CompletableFuture<PhysicalSlot> future1 = requestNewAllocatedSlot(
-				slotPool,
-				requestId1
-			);
-			assertFalse(future1.isDone());
-
-			final SlotRequest slotRequest = slotRequestFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
+			final AllocationID allocationId = new AllocationID();
 			final SlotOffer slotOffer = new SlotOffer(
-				slotRequest.getAllocationId(),
+				allocationId,
 				0,
 				DEFAULT_TESTING_PROFILE);
-
 			assertTrue(slotPool.offerSlot(taskManagerLocation, taskManagerGateway, slotOffer));
-
-			final PhysicalSlot slot1 = future1.get(1, TimeUnit.SECONDS);
-			assertTrue(future1.isDone());
-
-			// return this slot to pool
-			slotPool.releaseSlot(requestId1, null);
 
 			assertEquals(1, slotPool.getAvailableSlots().size());
 			assertEquals(0, slotPool.getAllocatedSlots().size());
 
-			final Optional<PhysicalSlot> physicalSlot = slotPool.allocateAvailableSlot(
+			Optional<PhysicalSlot> physicalSlot = slotPool.allocateAvailableSlot(
 				new SlotRequestId(),
-				slotRequest.getAllocationId());
+				allocationId);
 
-			// second allocation fulfilled by previous slot returning
 			assertTrue(physicalSlot.isPresent());
-			final PhysicalSlot slot2 = physicalSlot.get();
-			assertEquals(slot1, slot2);
+			assertEquals(0, slotPool.getAvailableSlots().size());
+			assertEquals(1, slotPool.getAllocatedSlots().size());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
@@ -21,14 +21,11 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.TestingComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.jobmanager.scheduler.DummyScheduledUnit;
-import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
-import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
@@ -50,7 +47,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getExecution;
 import static org.apache.flink.runtime.jobmaster.slotpool.AvailableSlotsTest.DEFAULT_TESTING_PROFILE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -87,13 +83,10 @@ public class SlotPoolInteractionsTest extends TestLogger {
 		)) {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
-			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
 
-			CompletableFuture<LogicalSlot> future = testMainThreadExecutor.execute(() -> scheduler.allocateSlot(
+			final CompletableFuture<PhysicalSlot> future = testMainThreadExecutor.execute(() -> pool.requestNewAllocatedSlot(
 				new SlotRequestId(),
-				new ScheduledUnit(getExecution()),
-				SlotProfile.noLocality(DEFAULT_TESTING_PROFILE),
+				ResourceProfile.UNKNOWN,
 				fastTimeout));
 
 			try {
@@ -114,14 +107,11 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			final CompletableFuture<SlotRequestId> timeoutFuture = new CompletableFuture<>();
 			pool.setTimeoutPendingSlotRequestConsumer(timeoutFuture::complete);
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
-			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
 
 			SlotRequestId requestId = new SlotRequestId();
-			CompletableFuture<LogicalSlot> future = testMainThreadExecutor.execute(() -> scheduler.allocateSlot(
+			final CompletableFuture<PhysicalSlot> future = testMainThreadExecutor.execute(() -> pool.requestNewAllocatedSlot(
 				requestId,
-				new ScheduledUnit(getExecution()),
-				SlotProfile.noLocality(DEFAULT_TESTING_PROFILE),
+				ResourceProfile.UNKNOWN,
 				fastTimeout));
 
 			try {
@@ -165,14 +155,10 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 			pool.connectToResourceManager(resourceManagerGateway);
 
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
-			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
-
 			SlotRequestId requestId = new SlotRequestId();
-			CompletableFuture<LogicalSlot> future = testMainThreadExecutor.execute(() -> scheduler.allocateSlot(
+			final CompletableFuture<PhysicalSlot> future = testMainThreadExecutor.execute(() -> pool.requestNewAllocatedSlot(
 				requestId,
-				new DummyScheduledUnit(),
-				SlotProfile.noLocality(DEFAULT_TESTING_PROFILE),
+				ResourceProfile.UNKNOWN,
 				fastTimeout));
 
 			try {
@@ -200,9 +186,6 @@ public class SlotPoolInteractionsTest extends TestLogger {
 
 			pool.start(JobMasterId.generate(), "foobar", testMainThreadExecutor.getMainThreadExecutor());
 
-			Scheduler scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), pool);
-			scheduler.start(testMainThreadExecutor.getMainThreadExecutor());
-
 			final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
 
 			TestingResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
@@ -215,10 +198,9 @@ public class SlotPoolInteractionsTest extends TestLogger {
 			pool.connectToResourceManager(resourceManagerGateway);
 
 			SlotRequestId requestId = new SlotRequestId();
-			CompletableFuture<LogicalSlot> future = testMainThreadExecutor.execute(() -> scheduler.allocateSlot(
+			final CompletableFuture<PhysicalSlot> future = testMainThreadExecutor.execute(() -> pool.requestNewAllocatedSlot(
 				requestId,
-				new ScheduledUnit(getExecution()),
-				SlotProfile.noLocality(DEFAULT_TESTING_PROFILE),
+				ResourceProfile.UNKNOWN,
 				fastTimeout));
 
 			try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
@@ -18,17 +18,22 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.FlinkException;
+
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -45,14 +50,45 @@ import static org.hamcrest.Matchers.is;
  */
 public class SlotPoolUtils {
 
+	public static final Time TIMEOUT = Time.seconds(10L);
+
 	private SlotPoolUtils() {
 		throw new UnsupportedOperationException("Cannot instantiate this class.");
+	}
+
+	static TestingSlotPoolImpl createAndSetUpSlotPool(
+			@Nullable final ResourceManagerGateway resourceManagerGateway) throws Exception {
+
+		return new SlotPoolBuilder(ComponentMainThreadExecutorServiceAdapter.forMainThread())
+			.setResourceManagerGateway(resourceManagerGateway).build();
+	}
+
+	static CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
+			final SlotPool slotPool,
+			final SlotRequestId slotRequestId) {
+
+		return requestNewAllocatedSlot(slotPool, slotRequestId, TIMEOUT);
+	}
+
+	static CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
+			final SlotPool slotPool,
+			final SlotRequestId slotRequestId,
+			final Time timeout) {
+
+		return slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, timeout);
+	}
+
+	static void requestNewAllocatedSlots(final SlotPool slotPool, final SlotRequestId... slotRequestIds) {
+		for (SlotRequestId slotRequestId : slotRequestIds) {
+			requestNewAllocatedSlot(slotPool, slotRequestId);
+		}
 	}
 
 	public static CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
 		SlotPool slotPool,
 		ComponentMainThreadExecutor mainThreadExecutor,
 		ResourceProfile resourceProfile) {
+
 		return CompletableFuture
 			.supplyAsync(() -> slotPool.requestNewAllocatedBatchSlot(new SlotRequestId(), resourceProfile), mainThreadExecutor)
 			.thenCompose(Function.identity());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
@@ -22,14 +22,17 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.SystemClock;
 
 import javax.annotation.Nullable;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
  * Testing extension of the {@link SlotPoolImpl} which adds additional methods
@@ -38,6 +41,10 @@ import java.util.concurrent.CompletableFuture;
 public class TestingSlotPoolImpl extends SlotPoolImpl {
 
 	private ResourceProfile lastRequestedSlotResourceProfile;
+
+	private volatile Consumer<SlotRequestId> releaseSlotConsumer;
+
+	private volatile Consumer<SlotRequestId> timeoutPendingSlotRequestConsumer;
 
 	public TestingSlotPoolImpl(JobID jobId) {
 		this(
@@ -54,7 +61,10 @@ public class TestingSlotPoolImpl extends SlotPoolImpl {
 			Time rpcTimeout,
 			Time idleSlotTimeout,
 			Time batchSlotTimeout) {
+
 		super(jobId, clock, rpcTimeout, idleSlotTimeout, batchSlotTimeout);
+		releaseSlotConsumer = null;
+		timeoutPendingSlotRequestConsumer = null;
 	}
 
 	void triggerCheckIdleSlot() {
@@ -82,5 +92,54 @@ public class TestingSlotPoolImpl extends SlotPoolImpl {
 
 	public ResourceProfile getLastRequestedSlotResourceProfile() {
 		return lastRequestedSlotResourceProfile;
+	}
+
+	public void setReleaseSlotConsumer(Consumer<SlotRequestId> releaseSlotConsumer) {
+		this.releaseSlotConsumer = Preconditions.checkNotNull(releaseSlotConsumer);
+	}
+
+	public void setTimeoutPendingSlotRequestConsumer(Consumer<SlotRequestId> timeoutPendingSlotRequestConsumer) {
+		this.timeoutPendingSlotRequestConsumer = Preconditions.checkNotNull(timeoutPendingSlotRequestConsumer);
+	}
+
+	@Override
+	public void releaseSlot(
+			SlotRequestId slotRequestId,
+			@Nullable Throwable cause) {
+
+		final Consumer<SlotRequestId> currentReleaseSlotConsumer = releaseSlotConsumer;
+
+		super.releaseSlot(slotRequestId, cause);
+
+		if (currentReleaseSlotConsumer != null) {
+			currentReleaseSlotConsumer.accept(slotRequestId);
+		}
+	}
+
+	@Override
+	protected void timeoutPendingSlotRequest(SlotRequestId slotRequestId) {
+		final Consumer<SlotRequestId> currentTimeoutPendingSlotRequestConsumer = timeoutPendingSlotRequestConsumer;
+
+		super.timeoutPendingSlotRequest(slotRequestId);
+
+		if (currentTimeoutPendingSlotRequestConsumer != null) {
+			currentTimeoutPendingSlotRequestConsumer.accept(slotRequestId);
+		}
+	}
+
+	boolean containsAllocatedSlot(AllocationID allocationId) {
+		return getAllocatedSlots().contains(allocationId);
+	}
+
+	boolean containsAvailableSlot(AllocationID allocationId) {
+		return getAvailableSlots().contains(allocationId);
+	}
+
+	int getNumberOfPendingRequests() {
+		return getPendingRequests().size();
+	}
+
+	int getNumberOfWaitingForResourceRequests() {
+		return getWaitingForResourceManager().size();
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Tests of SlotPoolImpl, including SlotPoolImplTest and SlotPoolInteractionsTest, are somehow unnecessarily complicated in the code involvement. E.g. SchedulerImp built on top of SlotPoolImpl is used to allocate slots from SlotPoolImpl, which can be simplified by directly invoke slot allocation on SlotPoolImpl.*

*Besides that, there are quite some duplications between tests classes of SlotPoolImpl, this further includes SlotPoolPendingRequestFailureTest, SlotPoolRequestCompletionTest and SlotPoolBatchSlotRequestTest.*

## Brief change log

 - *Use `SlotPoolBuilder` and `SlotPoolUtils` to refactor test cases related to `SlotPoolImpl`*
 - *Remove the usages of `SchedulerImp` for slotpool testing*
 - *Other possible simplifications*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
