### PR TITLE
[FLINK-18536][kinesis] Adding enhanced fan-out related configurations.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -211,7 +211,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 		this.configProps = checkNotNull(configProps, "configProps can not be null");
 
 		// check the configuration properties for any conflicting settings
-		KinesisConfigUtil.validateConsumerConfiguration(this.configProps);
+		KinesisConfigUtil.validateConsumerConfiguration(this.configProps, streams);
 
 		checkNotNull(deserializer, "deserializer can not be null");
 		checkArgument(

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -56,6 +56,45 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 		}
 	}
 
+	/**
+	 * The record publisher type represents the record-consume style.
+	 */
+	public enum RecordPublisherType {
+
+		/** Consume the Kinesis records using AWS SDK v2 with the enhanced fan-out consumer. */
+		EFO,
+		/** Consume the Kinesis records using AWS SDK v1 with the get-records method. */
+		POLLING
+	}
+
+	/**
+	 * The EFO registration type reprsents how we are going to de-/register efo consumer.
+	 */
+	public enum EFORegistrationType {
+
+		/** Delay the registration of efo consumer for taskmanager to execute.
+		 * De-register the efo consumer for taskmanager to execute when task is shut down. */
+		LAZY,
+		/** Register the efo consumer eagerly for jobmanager to execute.
+		 * De-register the efo consumer the same way as lazy does. */
+		EAGER,
+		/** Do not register efo consumer programmatically.
+		 * Do not de-register either. */
+		NONE
+	}
+
+	/** The RecordPublisher type (EFO|POLLING, default is POLLING). */
+	public static final String RECORD_PUBLISHER_TYPE = "flink.stream.recordpublisher";
+
+	/** The name of the EFO consumer to register with KDS. */
+	public static final String EFO_CONSUMER_NAME = "flink.stream.efo.consumername";
+
+	/** Determine how and when consumer de-/registration is performed (LAZY|EAGER|NONE, default is LAZY). */
+	public static final String EFO_REGISTRATION_TYPE = "flink.stream.efo.registration";
+
+	/** The prefix of consumer ARN for a given stream. */
+	public static final String EFO_CONSUMER_ARN_PREFIX = "flink.stream.efo.consumerarn";
+
 	/** The initial position to start reading Kinesis streams from (LATEST is used if not set). */
 	public static final String STREAM_INITIAL_POSITION = "flink.stream.initpos";
 
@@ -85,6 +124,54 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	/** The power constant for exponential backoff between each listShards attempt. */
 	public static final String LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.list.shards.backoff.expconst";
+
+	/** The maximum number of registerStream attempts if we get a recoverable exception. */
+	public static final String REGISTER_STREAM_RETRIES = "flink.stream.registerstreamconsumer.maxretries";
+
+	/** The base backoff time between each registerStream attempt. */
+	public static final String REGISTER_STREAM_BACKOFF_BASE = "flink.stream.registerstreamconsumer.backoff.base";
+
+	/** The maximum backoff time between each registerStream attempt. */
+	public static final String REGISTER_STREAM_BACKOFF_MAX = "flink.stream.registerstreamconsumer.backoff.max";
+
+	/** The power constant for exponential backoff between each registerStream attempt. */
+	public static final String REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.registerstreamconsumer.backoff.expconst";
+
+	/** The maximum number of deregisterStream attempts if we get a recoverable exception. */
+	public static final String DEREGISTER_STREAM_RETRIES = "flink.stream.deregisterstreamconsumer.maxretries";
+
+	/** The base backoff time between each deregisterStream attempt. */
+	public static final String DEREGISTER_STREAM_BACKOFF_BASE = "flink.stream.deregisterstreamconsumer.backoff.base";
+
+	/** The maximum backoff time between each deregisterStream attempt. */
+	public static final String DEREGISTER_STREAM_BACKOFF_MAX = "flink.stream.deregisterstreamconsumer.backoff.max";
+
+	/** The power constant for exponential backoff between each deregisterStream attempt. */
+	public static final String DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.deregisterstreamconsumer.backoff.expconst";
+
+	/** The maximum number of listStream attempts if we get a recoverable exception. */
+	public static final String LIST_STREAM_CONSUMERS_RETRIES = "flink.stream.liststreamconsumer.maxretries";
+
+	/** The base backoff time between each listStream attempt. */
+	public static final String LIST_STREAM_CONSUMERS_BACKOFF_BASE = "flink.stream.liststreamconsumer.backoff.base";
+
+	/** The maximum backoff time between each listStream attempt. */
+	public static final String LIST_STREAM_CONSUMERS_BACKOFF_MAX = "flink.stream.liststreamconsumer.backoff.max";
+
+	/** The power constant for exponential backoff between each listStream attempt. */
+	public static final String LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.liststreamconsumer.backoff.expconst";
+
+	/** The maximum number of subscribeToShard attempts if we get a recoverable exception. */
+	public static final String SUBSCRIBE_TO_SHARD_RETRIES = "flink.shard.subscribetoshard.maxretries";
+
+	/** The base backoff time between each subscribeToShard  attempt. */
+	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_BASE = "flink.shard.subscribetoshard.backoff.base";
+
+	/** The maximum backoff time between each subscribeToShard  attempt. */
+	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_MAX = "flink.shard.subscribetoshard.backoff.max";
+
+	/** The power constant for exponential backoff between each subscribeToShard  attempt. */
+	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT = "flink.shard.subscribetoshard.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */
 	public static final String SHARD_GETRECORDS_MAX = "flink.shard.getrecords.maxrecordcount";
@@ -155,6 +242,38 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final double DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_LIST_SHARDS_RETRIES = 10;
+
+	public static final int DEFAULT_REGISTER_STREAM_RETRIES = 10;
+
+	public static final long DEFAULT_REGISTER_STREAM_BACKOFF_BASE = 200L;
+
+	public static final long DEFAULT_REGISTER_STREAM_BACKOFF_MAX = 1000L;
+
+	public static final double DEFAULT_REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final int DEFAULT_DEREGISTER_STREAM_RETRIES = 10;
+
+	public static final long DEFAULT_DEREGISTER_STREAM_BACKOFF_BASE = 200L;
+
+	public static final long DEFAULT_DEREGISTER_STREAM_BACKOFF_MAX = 1000L;
+
+	public static final double DEFAULT_DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final int DEFAULT_LIST_STREAM_CONSUMERS_RETRIES = 10;
+
+	public static final long DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_BASE = 200L;
+
+	public static final long DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_MAX = 1000L;
+
+	public static final double DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final int DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES = 5;
+
+	public static final long DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE = 1000L;
+
+	public static final long DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_MAX = 2000L;
+
+	public static final double DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_SHARD_GETRECORDS_MAX = 10000;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -149,28 +149,28 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The power constant for exponential backoff between each deregisterStream attempt. */
 	public static final String DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.deregisterstreamconsumer.backoff.expconst";
 
-	/** The maximum number of listStream attempts if we get a recoverable exception. */
+	/** The maximum number of listStreamConsumers attempts if we get a recoverable exception. */
 	public static final String LIST_STREAM_CONSUMERS_RETRIES = "flink.stream.liststreamconsumer.maxretries";
 
-	/** The base backoff time between each listStream attempt. */
+	/** The base backoff time between each listStreamConsumers attempt. */
 	public static final String LIST_STREAM_CONSUMERS_BACKOFF_BASE = "flink.stream.liststreamconsumer.backoff.base";
 
-	/** The maximum backoff time between each listStream attempt. */
+	/** The maximum backoff time between each listStreamConsumer attempt. */
 	public static final String LIST_STREAM_CONSUMERS_BACKOFF_MAX = "flink.stream.liststreamconsumer.backoff.max";
 
-	/** The power constant for exponential backoff between each listStream attempt. */
+	/** The power constant for exponential backoff between each listStreamConsumers attempt. */
 	public static final String LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.liststreamconsumer.backoff.expconst";
 
 	/** The maximum number of subscribeToShard attempts if we get a recoverable exception. */
 	public static final String SUBSCRIBE_TO_SHARD_RETRIES = "flink.shard.subscribetoshard.maxretries";
 
-	/** The base backoff time between each subscribeToShard  attempt. */
+	/** The base backoff time between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_BASE = "flink.shard.subscribetoshard.backoff.base";
 
-	/** The maximum backoff time between each subscribeToShard  attempt. */
+	/** The maximum backoff time between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_MAX = "flink.shard.subscribetoshard.backoff.max";
 
-	/** The power constant for exponential backoff between each subscribeToShard  attempt. */
+	/** The power constant for exponential backoff between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT = "flink.shard.subscribetoshard.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 
@@ -114,17 +115,17 @@ public class FanOutProperties {
 	private final int deregisterStreamMaxRetries;
 
 	/**
-	 * Base backoff millis for the list stream operation.
+	 * Base backoff millis for the list stream consumers operation.
 	 */
 	private final long listStreamConsumersBaseBackoffMillis;
 
 	/**
-	 * Maximum backoff millis for the list stream operation.
+	 * Maximum backoff millis for the list stream consumers operation.
 	 */
 	private final long listStreamConsumersMaxBackoffMillis;
 
 	/**
-	 * Exponential backoff power constant for the list stream operation.
+	 * Exponential backoff power constant for the list stream consumers operation.
 	 */
 	private final double listStreamConsumersExpConstant;
 
@@ -133,9 +134,6 @@ public class FanOutProperties {
 	 */
 	private final int listStreamConsumersMaxRetries;
 
-	// ------------------------------------------------------------------------
-	//  registerStream() related performance settings
-	// ------------------------------------------------------------------------
 	/**
 	 * Creates a FanOutProperties.
 	 *
@@ -255,10 +253,10 @@ public class FanOutProperties {
 	public double getSubscribeToShardExpConstant() {
 		return subscribeToShardExpConstant;
 	}
+
 	// ------------------------------------------------------------------------
 	//  registerStream() related performance settings
 	// ------------------------------------------------------------------------
-
 	/**
 	 * Get base backoff millis for the register stream operation.
 	 */
@@ -290,7 +288,6 @@ public class FanOutProperties {
 	// ------------------------------------------------------------------------
 	//  deregisterStream() related performance settings
 	// ------------------------------------------------------------------------
-
 	/**
 	 * Get base backoff millis for the deregister stream operation.
 	 */
@@ -318,10 +315,10 @@ public class FanOutProperties {
 	public int getDeregisterStreamMaxRetries() {
 		return deregisterStreamMaxRetries;
 	}
-	// ------------------------------------------------------------------------
-	//  listStream() related performance settings
-	// ------------------------------------------------------------------------
 
+	// ------------------------------------------------------------------------
+	//  listStreamConsumers() related performance settings
+	// ------------------------------------------------------------------------
 	/**
 	 * Get base backoff millis for the list stream consumers operation.
 	 */
@@ -360,27 +357,21 @@ public class FanOutProperties {
 	/**
 	 * Get consumer name, will be null if efo registration type is 'NONE'.
 	 */
-	@Nullable
-	public String getConsumerName() {
-		return consumerName;
+	public Optional<String> getConsumerName() {
+		return Optional.ofNullable(consumerName);
 	}
 
 	/**
 	 * Get stream consumer arns, will be null if efo registration type is 'LAZY' or 'EAGER'.
 	 */
-	@Nullable
-	public Map<String, String> getStreamConsumerArns() {
-		return streamConsumerArns;
+	public Optional<Map<String, String>> getStreamConsumerArns() {
+		return Optional.ofNullable(streamConsumerArns);
 	}
 
 	/**
 	 * Get the according consumer arn to the stream, will be null if efo registration type is 'LAZY' or 'EAGER'.
 	 */
-	@Nullable
-	public String getStreamConsumerArn(String stream) {
-		if (this.streamConsumerArns == null) {
-			return null;
-		}
-		return streamConsumerArns.get(stream);
+	public Optional<String> getStreamConsumerArn(String stream) {
+		return Optional.ofNullable(streamConsumerArns).map(arns -> arns.get(stream));
 	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.fanout;
+
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
+import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+
+/**
+ * This is a configuration class for enhanced fan-out components.
+ */
+public class FanOutProperties {
+
+	/**
+	 * The efo registration type for de-/registration of streams.
+	 */
+	private final EFORegistrationType efoRegistrationType;
+
+	/**
+	 * The efo stream consumer name. Should not be Null if the efoRegistrationType is either LAZY or EAGER.
+	 */
+	@Nullable
+	private String consumerName;
+
+	/**
+	 * The manual set efo consumer arns for each stream. Should not be Null if the efoRegistrationType is NONE
+	 */
+	@Nullable
+	private Map<String, String> streamConsumerArns;
+
+	/**
+	 * Base backoff millis for the deregister stream operation.
+	 */
+	private final int subscribeToShardMaxRetries;
+
+	/**
+	 * Maximum backoff millis for the subscribe to shard operation.
+	 */
+	private final long subscribeToShardMaxBackoffMillis;
+
+	/**
+	 * Base backoff millis for the subscribe to shard operation.
+	 */
+	private final long subscribeToShardBaseBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the subscribe to shard operation.
+	 */
+	private final double subscribeToShardExpConstant;
+
+	/**
+	 * Base backoff millis for the register stream operation.
+	 */
+	private final long registerStreamBaseBackoffMillis;
+
+	/**
+	 * Maximum backoff millis for the register stream operation.
+	 */
+	private final long registerStreamMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the register stream operation.
+	 */
+	private final double registerStreamExpConstant;
+
+	/**
+	 * Maximum retry attempts for the register stream operation.
+	 */
+	private final int registerStreamMaxRetries;
+
+	/**
+	 * Base backoff millis for the deregister stream operation.
+	 */
+	private final long deregisterStreamBaseBackoffMillis;
+
+	/**
+	 * Maximum backoff millis for the deregister stream operation.
+	 */
+	private final long deregisterStreamMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the deregister stream operation.
+	 */
+	private final double deregisterStreamExpConstant;
+
+	/**
+	 * Maximum retry attempts for the deregister stream operation.
+	 */
+	private final int deregisterStreamMaxRetries;
+
+	/**
+	 * Base backoff millis for the list stream operation.
+	 */
+	private final long listStreamConsumersBaseBackoffMillis;
+
+	/**
+	 * Maximum backoff millis for the list stream operation.
+	 */
+	private final long listStreamConsumersMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the list stream operation.
+	 */
+	private final double listStreamConsumersExpConstant;
+
+	/**
+	 * Maximum retry attempts for the list stream operation.
+	 */
+	private final int listStreamConsumersMaxRetries;
+
+	// ------------------------------------------------------------------------
+	//  registerStream() related performance settings
+	// ------------------------------------------------------------------------
+	/**
+	 * Creates a FanOutProperties.
+	 *
+	 * @param configProps the configuration properties from config file.
+	 * @param streams     the streams which is sent to match the EFO consumer arn if the EFO registration mode is set to `NONE`.
+	 */
+	public FanOutProperties(Properties configProps, List<String> streams) {
+		Preconditions.checkArgument(configProps.getProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE).equals(RecordPublisherType.EFO.toString()), "Only efo record publisher can register a FanOutProperties.");
+		KinesisConfigUtil.validateEfoConfiguration(configProps, streams);
+
+		efoRegistrationType = EFORegistrationType.valueOf(configProps.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.EAGER.toString()));
+		//if efo registration type is EAGER|LAZY, then user should explicitly provide a consumer name for each stream.
+		if (efoRegistrationType == EFORegistrationType.EAGER || efoRegistrationType == EFORegistrationType.LAZY) {
+			consumerName = configProps.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		} else {
+			//else users should explicitly provide consumer arns.
+			streamConsumerArns = new HashMap<>();
+			for (String stream : streams) {
+				String key = ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + stream;
+				streamConsumerArns.put(stream, configProps.getProperty(key));
+			}
+		}
+
+		this.subscribeToShardMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES)));
+		this.subscribeToShardBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE)));
+		this.subscribeToShardMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_MAX)));
+		this.subscribeToShardExpConstant = Double.parseDouble(
+			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT)));
+
+		this.registerStreamBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_BACKOFF_BASE)));
+		this.registerStreamMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_BACKOFF_MAX)));
+		this.registerStreamExpConstant = Double.parseDouble(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT)));
+		this.registerStreamMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_RETRIES)));
+
+		this.deregisterStreamBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_BACKOFF_BASE)));
+		this.deregisterStreamMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_BACKOFF_MAX)));
+		this.deregisterStreamExpConstant = Double.parseDouble(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT)));
+		this.deregisterStreamMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_RETRIES)));
+
+		this.listStreamConsumersBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_BASE)));
+		this.listStreamConsumersMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_MAX)));
+		this.listStreamConsumersExpConstant = Double.parseDouble(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT)));
+		this.listStreamConsumersMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_RETRIES)));
+	}
+
+	// ------------------------------------------------------------------------
+	//  subscribeToShard() related performance settings
+	// ------------------------------------------------------------------------
+	/**
+	 * Get maximum retry attempts for the subscribe to shard operation.
+	 */
+	public int getSubscribeToShardMaxRetries() {
+		return subscribeToShardMaxRetries;
+	}
+
+	/**
+	 * Get maximum backoff millis for the subscribe to shard operation.
+	 */
+	public long getSubscribeToShardMaxBackoffMillis() {
+		return subscribeToShardMaxBackoffMillis;
+	}
+
+	/**
+	 * Get base backoff millis for the subscribe to shard operation.
+	 */
+	public long getSubscribeToShardBaseBackoffMillis() {
+		return subscribeToShardBaseBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the subscribe to shard operation.
+	 */
+	public double getSubscribeToShardExpConstant() {
+		return subscribeToShardExpConstant;
+	}
+	// ------------------------------------------------------------------------
+	//  registerStream() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get base backoff millis for the register stream operation.
+	 */
+	public long getRegisterStreamBaseBackoffMillis() {
+		return registerStreamBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the register stream operation.
+	 */
+	public long getRegisterStreamMaxBackoffMillis() {
+		return registerStreamMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the register stream operation.
+	 */
+	public double getRegisterStreamExpConstant() {
+		return registerStreamExpConstant;
+	}
+
+	/**
+	 * Get maximum retry attempts for the register stream operation.
+	 */
+	public int getRegisterStreamMaxRetries() {
+		return registerStreamMaxRetries;
+	}
+
+	// ------------------------------------------------------------------------
+	//  deregisterStream() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get base backoff millis for the deregister stream operation.
+	 */
+	public long getDeregisterStreamBaseBackoffMillis() {
+		return deregisterStreamBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the deregister stream operation.
+	 */
+	public long getDeregisterStreamMaxBackoffMillis() {
+		return deregisterStreamMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the deregister stream operation.
+	 */
+	public double getDeregisterStreamExpConstant() {
+		return deregisterStreamExpConstant;
+	}
+
+	/**
+	 * Get maximum retry attempts for the register stream operation.
+	 */
+	public int getDeregisterStreamMaxRetries() {
+		return deregisterStreamMaxRetries;
+	}
+	// ------------------------------------------------------------------------
+	//  listStream() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get base backoff millis for the list stream consumers operation.
+	 */
+	public long getListStreamConsumersBaseBackoffMillis() {
+		return listStreamConsumersBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the list stream consumers operation.
+	 */
+	public long getListStreamConsumersMaxBackoffMillis() {
+		return listStreamConsumersMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the list stream consumers operation.
+	 */
+	public double getListStreamConsumersExpConstant() {
+		return listStreamConsumersExpConstant;
+	}
+
+	/**
+	 * Get maximum retry attempts for the list stream consumers operation.
+	 */
+	public int getListStreamConsumersMaxRetries() {
+		return listStreamConsumersMaxRetries;
+	}
+
+	/**
+	 * Get efo registration type.
+	 */
+	public EFORegistrationType getEfoRegistrationType() {
+		return efoRegistrationType;
+	}
+
+	/**
+	 * Get consumer name, will be null if efo registration type is 'NONE'.
+	 */
+	@Nullable
+	public String getConsumerName() {
+		return consumerName;
+	}
+
+	/**
+	 * Get stream consumer arns, will be null if efo registration type is 'LAZY' or 'EAGER'.
+	 */
+	@Nullable
+	public Map<String, String> getStreamConsumerArns() {
+		return streamConsumerArns;
+	}
+
+	/**
+	 * Get the according consumer arn to the stream, will be null if efo registration type is 'LAZY' or 'EAGER'.
+	 */
+	@Nullable
+	public String getStreamConsumerArn(String stream) {
+		if (this.streamConsumerArns == null) {
+			return null;
+		}
+		return streamConsumerArns.get(stream);
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -148,65 +148,64 @@ public class KinesisProxy implements KinesisProxyInterface {
 
 		this.kinesisClient = createKinesisClient(configProps);
 
-		this.listShardsBaseBackoffMillis = Long.valueOf(
+		this.listShardsBaseBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE,
 				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_BACKOFF_BASE)));
-		this.listShardsMaxBackoffMillis = Long.valueOf(
+		this.listShardsMaxBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_BACKOFF_MAX,
 				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_BACKOFF_MAX)));
-		this.listShardsExpConstant = Double.valueOf(
+		this.listShardsExpConstant = Double.parseDouble(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
 				Double.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.listShardsMaxRetries = Integer.valueOf(
+		this.listShardsMaxRetries = Integer.parseInt(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_RETRIES)));
-		this.describeStreamBaseBackoffMillis = Long.valueOf(
+		this.describeStreamBaseBackoffMillis = Long.parseLong(
 				configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE,
 						Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE)));
-		this.describeStreamMaxBackoffMillis = Long.valueOf(
+		this.describeStreamMaxBackoffMillis = Long.parseLong(
 				configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX,
 						Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX)));
-		this.describeStreamExpConstant = Double.valueOf(
+		this.describeStreamExpConstant = Double.parseDouble(
 				configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT,
 						Double.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.getRecordsBaseBackoffMillis = Long.valueOf(
+		this.getRecordsBaseBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_BASE,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_BACKOFF_BASE)));
-		this.getRecordsMaxBackoffMillis = Long.valueOf(
+		this.getRecordsMaxBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_MAX,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_BACKOFF_MAX)));
-		this.getRecordsExpConstant = Double.valueOf(
+		this.getRecordsExpConstant = Double.parseDouble(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT,
 				Double.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.getRecordsMaxRetries = Integer.valueOf(
+		this.getRecordsMaxRetries = Integer.parseInt(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_RETRIES)));
 
-		this.getShardIteratorBaseBackoffMillis = Long.valueOf(
+		this.getShardIteratorBaseBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_BASE,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_BACKOFF_BASE)));
-		this.getShardIteratorMaxBackoffMillis = Long.valueOf(
+		this.getShardIteratorMaxBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_MAX,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_BACKOFF_MAX)));
-		this.getShardIteratorExpConstant = Double.valueOf(
+		this.getShardIteratorExpConstant = Double.parseDouble(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_EXPONENTIAL_CONSTANT,
 				Double.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.getShardIteratorMaxRetries = Integer.valueOf(
+		this.getShardIteratorMaxRetries = Integer.parseInt(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_RETRIES)));
-
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -248,7 +248,7 @@ public class KinesisConfigUtil {
 	/**
 	 * Validate the record publisher type.
 	 * @param config config properties
-	 * @return if `ConsumerConfigConstants.RECORD_PUBLISHER_TYPE` is set, return the parsed record publisher type. Else return polling record publisher type.
+	 * @return if {@code ConsumerConfigConstants.RECORD_PUBLISHER_TYPE} is set, return the parsed record publisher type. Else return polling record publisher type.
 	 */
 	public static RecordPublisherType validateRecordPublisherType(Properties config) {
 		if (config.containsKey(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE)) {
@@ -273,21 +273,21 @@ public class KinesisConfigUtil {
 	 * @param streams the streams which is sent to match the EFO consumer arn if the EFO registration mode is set to `NONE`.
 	 */
 	public static void validateEfoConfiguration(Properties config, List<String> streams) {
-		String efoRegistrationType;
+		EFORegistrationType efoRegistrationType;
 		if (config.containsKey(ConsumerConfigConstants.EFO_REGISTRATION_TYPE)) {
-			efoRegistrationType = config.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE);
+			String typeInString = config.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE);
 			// specified efo registration type in stream must be either LAZY, EAGER or NONE.
 			try {
-				EFORegistrationType.valueOf(efoRegistrationType);
+				efoRegistrationType = EFORegistrationType.valueOf(typeInString);
 			} catch (IllegalArgumentException e) {
 				String errorMessage = Arrays.stream(EFORegistrationType.values())
 					.map(Enum::name).collect(Collectors.joining(", "));
 				throw new IllegalArgumentException("Invalid efo registration type in stream set in config. Valid values are: " + errorMessage);
 			}
 		} else {
-			efoRegistrationType = EFORegistrationType.LAZY.toString();
+			efoRegistrationType = EFORegistrationType.LAZY;
 		}
-		if (EFORegistrationType.valueOf(efoRegistrationType) == EFORegistrationType.NONE) {
+		if (efoRegistrationType == EFORegistrationType.NONE) {
 			//if the registration type is NONE, then for each stream there must be an according consumer ARN
 			List<String> missingConsumerArnKeys = new ArrayList<>();
 			for (String stream : streams) {

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -23,7 +23,9 @@ import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisProducer;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.InitialPosition;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
 import org.apache.flink.streaming.connectors.kinesis.config.ProducerConfigConstants;
 
 import com.amazonaws.regions.Regions;
@@ -31,9 +33,14 @@ import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -44,13 +51,18 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class KinesisConfigUtil {
 
-	/** Maximum number of items to pack into an PutRecords request. **/
+	/**
+	 * Maximum number of items to pack into an PutRecords request.
+	 **/
 	protected static final String COLLECTION_MAX_COUNT = "CollectionMaxCount";
 
-	/** Maximum number of items to pack into an aggregated record. **/
+	/**
+	 * Maximum number of items to pack into an aggregated record.
+	 **/
 	protected static final String AGGREGATION_MAX_COUNT = "AggregationMaxCount";
 
-	/** Limits the maximum allowed put rate for a shard, as a percentage of the backend limits.
+	/**
+	 * Limits the maximum allowed put rate for a shard, as a percentage of the backend limits.
 	 * The default value is set as 100% in Flink. KPL's default value is 150% but it makes KPL throw
 	 * RateLimitExceededException too frequently and breaks Flink sink as a result.
 	 **/
@@ -66,27 +78,46 @@ public class KinesisConfigUtil {
 	 **/
 	protected static final String THREAD_POOL_SIZE = "ThreadPoolSize";
 
-	/** Default values for RateLimit. **/
+	/**
+	 * Default values for RateLimit.
+	 **/
 	protected static final long DEFAULT_RATE_LIMIT = 100L;
 
-	/** Default value for ThreadingModel. **/
+	/**
+	 * Default value for ThreadingModel.
+	 **/
 	protected static final KinesisProducerConfiguration.ThreadingModel DEFAULT_THREADING_MODEL = KinesisProducerConfiguration.ThreadingModel.POOLED;
 
-	/** Default values for ThreadPoolSize. **/
+	/**
+	 * Default values for ThreadPoolSize.
+	 **/
 	protected static final int DEFAULT_THREAD_POOL_SIZE = 10;
 
 	/**
 	 * Validate configuration properties for {@link FlinkKinesisConsumer}.
 	 */
 	public static void validateConsumerConfiguration(Properties config) {
+		validateConsumerConfiguration(config, Collections.emptyList());
+	}
+
+	/**
+	 * Validate configuration properties for {@link FlinkKinesisConsumer}.
+	 */
+	public static void validateConsumerConfiguration(Properties config, List<String> streams) {
 		checkNotNull(config, "config can not be null");
 
 		validateAwsConfiguration(config);
 
+		RecordPublisherType recordPublisherType = validateRecordPublisherType(config);
+
+		if (recordPublisherType == RecordPublisherType.EFO) {
+			validateEfoConfiguration(config, streams);
+		}
+
 		if (!(config.containsKey(AWSConfigConstants.AWS_REGION) || config.containsKey(ConsumerConfigConstants.AWS_ENDPOINT))) {
 			// per validation in AwsClientBuilder
 			throw new IllegalArgumentException(String.format("For FlinkKinesisConsumer AWS region ('%s') and/or AWS endpoint ('%s') must be set in the config.",
-					AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT));
+				AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT));
 		}
 
 		if (config.containsKey(ConsumerConfigConstants.STREAM_INITIAL_POSITION)) {
@@ -96,11 +127,9 @@ public class KinesisConfigUtil {
 			try {
 				InitialPosition.valueOf(initPosType);
 			} catch (IllegalArgumentException e) {
-				StringBuilder sb = new StringBuilder();
-				for (InitialPosition pos : InitialPosition.values()) {
-					sb.append(pos.toString()).append(", ");
-				}
-				throw new IllegalArgumentException("Invalid initial position in stream set in config. Valid values are: " + sb.toString());
+				String errorMessage = Arrays.stream(InitialPosition.values())
+					.map(Enum::name).collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid initial position in stream set in config. Valid values are: " + errorMessage);
 			}
 
 			// specified initial timestamp in stream when using AT_TIMESTAMP
@@ -116,7 +145,6 @@ public class KinesisConfigUtil {
 						+ "Must be a valid format: yyyy-MM-dd'T'HH:mm:ss.SSSXXX or non-negative double value. For example, 2016-04-04T19:58:46.480-00:00 or 1459799926.480 .");
 			}
 		}
-
 		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.SHARD_GETRECORDS_MAX,
 			"Invalid value given for maximum records per getRecords shard operation. Must be a valid non-negative integer value.");
 
@@ -159,6 +187,54 @@ public class KinesisConfigUtil {
 		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
 			"Invalid value given for list shards operation backoff exponential constant. Must be a valid non-negative double value.");
 
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.REGISTER_STREAM_RETRIES,
+			"Invalid value given for maximum retry attempts for register stream operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE,
+			"Invalid value given for register stream operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX,
+			"Invalid value given for register stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for register stream operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_RETRIES,
+			"Invalid value given for maximum retry attempts for deregister stream operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE,
+			"Invalid value given for deregister stream operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX,
+			"Invalid value given for deregister stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for deregister stream operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_RETRIES,
+			"Invalid value given for maximum retry attempts for list stream operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_BASE,
+			"Invalid value given for list stream operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_MAX,
+			"Invalid value given for list stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for list stream operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES,
+			"Invalid value given for maximum retry attempts for subscribe to shard operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE,
+			"Invalid value given for subscribe to shard operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX,
+			"Invalid value given for subscribe to shard operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for subscribe to shard operation backoff exponential constant. Must be a valid non-negative double value.");
+
 		if (config.containsKey(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS)) {
 			checkArgument(
 				Long.parseLong(config.getProperty(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS))
@@ -166,6 +242,72 @@ public class KinesisConfigUtil {
 				"Invalid value given for getRecords sleep interval in milliseconds. Must be lower than " +
 					ConsumerConfigConstants.MAX_SHARD_GETRECORDS_INTERVAL_MILLIS + " milliseconds."
 			);
+		}
+	}
+
+	/**
+	 * Validate the record publisher type.
+	 * @param config config properties
+	 * @return if `ConsumerConfigConstants.RECORD_PUBLISHER_TYPE` is set, return the parsed record publisher type. Else return polling record publisher type.
+	 */
+	public static RecordPublisherType validateRecordPublisherType(Properties config) {
+		if (config.containsKey(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE)) {
+			String recordPublisherType = config.getProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE);
+
+			// specified record publisher type in stream must be either EFO or POLLING
+			try {
+				return RecordPublisherType.valueOf(recordPublisherType);
+			} catch (IllegalArgumentException e) {
+				String errorMessage = Arrays.stream(RecordPublisherType.values())
+					.map(Enum::name).collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid record publisher type in stream set in config. Valid values are: " + errorMessage);
+			}
+		} else {
+			return RecordPublisherType.POLLING;
+		}
+	}
+
+	/**
+	 * Validate if the given config is a valid EFO configuration.
+	 * @param config  config properties.
+	 * @param streams the streams which is sent to match the EFO consumer arn if the EFO registration mode is set to `NONE`.
+	 */
+	public static void validateEfoConfiguration(Properties config, List<String> streams) {
+		String efoRegistrationType;
+		if (config.containsKey(ConsumerConfigConstants.EFO_REGISTRATION_TYPE)) {
+			efoRegistrationType = config.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE);
+			// specified efo registration type in stream must be either LAZY, EAGER or NONE.
+			try {
+				EFORegistrationType.valueOf(efoRegistrationType);
+			} catch (IllegalArgumentException e) {
+				String errorMessage = Arrays.stream(EFORegistrationType.values())
+					.map(Enum::name).collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid efo registration type in stream set in config. Valid values are: " + errorMessage);
+			}
+		} else {
+			efoRegistrationType = EFORegistrationType.LAZY.toString();
+		}
+		if (EFORegistrationType.valueOf(efoRegistrationType) == EFORegistrationType.NONE) {
+			//if the registration type is NONE, then for each stream there must be an according consumer ARN
+			List<String> missingConsumerArnKeys = new ArrayList<>();
+			for (String stream : streams) {
+				String efoConsumerARNKey = ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + stream;
+				if (!config.containsKey(efoConsumerARNKey)) {
+					missingConsumerArnKeys.add(efoConsumerARNKey);
+				}
+			}
+			if (!missingConsumerArnKeys.isEmpty()) {
+				String errorMessage = Arrays
+					.stream(missingConsumerArnKeys.toArray())
+					.map(Object::toString)
+					.collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid efo consumer arn settings for not providing consumer arns: " + errorMessage);
+			}
+		} else {
+			//if the registration type is LAZY or EAGER, then user must provide a self-defined consumer name.
+			if (!config.containsKey(ConsumerConfigConstants.EFO_CONSUMER_NAME)) {
+				throw new IllegalArgumentException("No valid enhanced fan-out consumer name is set through " + ConsumerConfigConstants.EFO_CONSUMER_NAME);
+			}
 		}
 	}
 
@@ -178,13 +320,13 @@ public class KinesisConfigUtil {
 		// Replace deprecated key
 		if (configProps.containsKey(ProducerConfigConstants.COLLECTION_MAX_COUNT)) {
 			configProps.setProperty(COLLECTION_MAX_COUNT,
-					configProps.getProperty(ProducerConfigConstants.COLLECTION_MAX_COUNT));
+				configProps.getProperty(ProducerConfigConstants.COLLECTION_MAX_COUNT));
 			configProps.remove(ProducerConfigConstants.COLLECTION_MAX_COUNT);
 		}
 		// Replace deprecated key
 		if (configProps.containsKey(ProducerConfigConstants.AGGREGATION_MAX_COUNT)) {
 			configProps.setProperty(AGGREGATION_MAX_COUNT,
-					configProps.getProperty(ProducerConfigConstants.AGGREGATION_MAX_COUNT));
+				configProps.getProperty(ProducerConfigConstants.AGGREGATION_MAX_COUNT));
 			configProps.remove(ProducerConfigConstants.AGGREGATION_MAX_COUNT);
 		}
 		return configProps;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -66,7 +67,7 @@ public class FanOutPropertiesTest extends TestLogger {
 		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
 		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, fakedConsumerName);
 		FanOutProperties fanOutProperties = new FanOutProperties(testConfig, new ArrayList<>());
-		assertEquals(fanOutProperties.getConsumerName(), fakedConsumerName);
+		assertEquals(fanOutProperties.getConsumerName(), Optional.of(fakedConsumerName));
 	}
 
 	@Test
@@ -96,8 +97,8 @@ public class FanOutPropertiesTest extends TestLogger {
 		expectedStreamArns.put("fakedstream1", "fakedstream1");
 		expectedStreamArns.put("fakedstream2", "fakedstream2");
 
-		assertEquals(fanOutProperties.getStreamConsumerArn("fakedstream1"), "fakedstream1");
-		assertEquals(fanOutProperties.getStreamConsumerArns(), expectedStreamArns);
+		assertEquals(fanOutProperties.getStreamConsumerArn("fakedstream1"), Optional.of("fakedstream1"));
+		assertEquals(fanOutProperties.getStreamConsumerArns(), Optional.of(expectedStreamArns));
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.fanout;
+
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FanOutProperties}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(FanOutProperties.class)
+public class FanOutPropertiesTest extends TestLogger {
+	@Rule
+	private ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testPollingRecordPublisher() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Only efo record publisher can register a FanOutProperties.");
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.POLLING.toString());
+
+		new FanOutProperties(testConfig, new ArrayList<>());
+	}
+
+	@Test
+	public void testEagerStrategyWithConsumerName() {
+		String fakedConsumerName = "fakedconsumername";
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, fakedConsumerName);
+		FanOutProperties fanOutProperties = new FanOutProperties(testConfig, new ArrayList<>());
+		assertEquals(fanOutProperties.getConsumerName(), fakedConsumerName);
+	}
+
+	@Test
+	public void testEagerStrategyWithNoConsumerName() {
+		String msg = "No valid enhanced fan-out consumer name is set through " + ConsumerConfigConstants.EFO_CONSUMER_NAME;
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(msg);
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		new FanOutProperties(testConfig, new ArrayList<>());
+	}
+
+	@Test
+	public void testNoneStrategyWithStreams() {
+		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.NONE.toString());
+		streams.forEach(
+			stream ->
+				testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + stream, stream)
+		);
+		FanOutProperties fanOutProperties = new FanOutProperties(testConfig, streams);
+		Map<String, String> expectedStreamArns = new HashMap<>();
+		expectedStreamArns.put("fakedstream1", "fakedstream1");
+		expectedStreamArns.put("fakedstream2", "fakedstream2");
+
+		assertEquals(fanOutProperties.getStreamConsumerArn("fakedstream1"), "fakedstream1");
+		assertEquals(fanOutProperties.getStreamConsumerArns(), expectedStreamArns);
+	}
+
+	@Test
+	public void testNoneStrategyWithNoStreams() {
+		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+
+		String msg = "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream1, flink.stream.efo.consumerarn.fakedstream2";
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(msg);
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.NONE.toString());
+
+		new FanOutProperties(testConfig, streams);
+	}
+
+	@Test
+	public void testNoneStrategyWithNotEnoughStreams() {
+		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+
+		String msg = "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream2";
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(msg);
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.NONE.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + "fakedstream1", "fakedstream1");
+
+		new FanOutProperties(testConfig, streams);
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -204,10 +204,10 @@ public class KinesisConfigUtilTest {
 
 		KinesisConfigUtil.validateRecordPublisherType(testConfig);
 	}
+
 	// ----------------------------------------------------------------------
 	// validateEfoConfiguration() tests
 	// ----------------------------------------------------------------------
-
 	@Test
 	public void testNoEfoRegistrationTypeInConfig() {
 		Properties testConfig = TestUtils.getStandardProperties();


### PR DESCRIPTION

## What is the purpose of the change

*This is the fifth milestone of [FLIP-128](https://cwiki.apache.org/confluence/display/FLINK/FLIP-128%3A+Enhanced+Fan+Out+for+AWS+Kinesis+Consumers) to add EFO support to the FlinkKinesisConsumer. The EFO related configurations has been introduced.
This change should not introduce any functional differences.*


## Brief change log

  - `ConsumerConfigConstants`
    - *Add several efo related configuration constants* 
  - `KinesisConfigUtil`
      - *Add the validation of efo related configuration constants.*
  - `KinesisProxy`
      - *Add fields about operations like `registerStream`, `deregisterStream`, `listStream`*
      - *Give initial value to those fields.*
   - `FanOutProperties`
       - *Add a new configuration class for the future `FanOutRecordPublisher`*
       - *Validate fields and give them initial values*
   - `FlinkKinesisConsumer`
       - *Since the change of the validation interface, modify the call of validation method.*


## Verifying this change

This change added tests and can be verified as follows:

  - *`KinesisConfigUtilTest`*
  - *`FanOutPropertiesTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
