### PR TITLE
[FLINK-18612][fs][local] Fix the issue when creating file under the current directory with relative path

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -52,6 +52,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardCopyOption;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * The class {@code LocalFileSystem} is an implementation of the {@link FileSystem} interface
@@ -307,10 +308,22 @@ public class LocalFileSystem extends FileSystem {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Converts the given Path to a File for this file system.
+	 * Converts the given Path to a File for this file system. If the path is empty,
+	 * we will return <tt>new File(".")</tt> instead of <tt>new File("")</tt>, since
+	 * the latter returns <tt>false</tt> for <tt>isDirectory</tt> judgement (See issue
+	 * https://issues.apache.org/jira/browse/FLINK-18612).
 	 */
 	public File pathToFile(Path path) {
-		return new File(path.getPath());
+		String localPath = path.getPath();
+		checkState(
+			localPath != null,
+			"Cannot convert a null path to File");
+
+		if (localPath.length() == 0) {
+			return new File(".");
+		}
+
+		return new File(localPath);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -367,6 +368,23 @@ public class LocalFileSystemTest extends TestLogger {
 		} finally {
 			final long timeout = 10000L;
 			ExecutorUtils.gracefulShutdown(timeout, TimeUnit.MILLISECONDS, executor);
+		}
+	}
+
+	/**
+	 * This test verifies the issue https://issues.apache.org/jira/browse/FLINK-18612.
+	 */
+	@Test
+	public void testCreatingFileInCurrentDirectoryWithRelativePath() throws IOException {
+		FileSystem fs = FileSystem.getLocalFileSystem();
+
+		Path filePath = new Path("local_fs_test_" + RandomStringUtils.randomAlphanumeric(16));
+		try (FSDataOutputStream outputStream = fs.create(filePath, WriteMode.OVERWRITE)) {
+			// Do nothing.
+		} finally {
+			for (int i = 0; i < 10 && fs.exists(filePath); ++i) {
+				fs.delete(filePath, true);
+			}
 		}
 	}
 


### PR DESCRIPTION
**This PR picks https://github.com/apache/flink/pull/12918 to release-1.11**

## What is the purpose of the change

Currently when we want to create a file under the current directory with relative path (e.g., `new Path("file")`), the `LocalFileSystem` fails when trying to create the parent directory. This is due to that the parent path is stored as an empty string and it is transformed to `new File("")` and `new File("").isDirectory()` returns `false`, which indicates the caller that we fail to create the parent directory.

To address this issue, we made the empty path transformed to `new File(".")`, with which `isDirectory()` returns the expected `true`. 


## Brief change log

*(for example:)*
 - ab340bf17583063fa25158c00cd3214c404ca0dd changes the method `pathToFile(Path path)` to process the empty path specially and transform it to `new File(".")`.


## Verifying this change



This change added tests and can be verified as follows:

  - Added UT to verify we could successfully create the file under current directory with relative path. Since Java could not change the current directory, we will have to try creating file under the current directory instead of an TemporaryFolder (A another option might be start a new Process to use the TemporaryFolder but it seems to be too heavy). We tried best to remove the target file after the test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**