### PR TITLE
[FLINK-18621][sql-client] Simplify the methods of Executor interface in sql client

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -97,6 +98,20 @@ public final class CollectionUtil {
 
 		final ArrayList<E> list = new ArrayList<>();
 		iterable.iterator().forEachRemaining(list::add);
+		return list;
+	}
+
+	/**
+	 * Collects the elements in the Iterator in a List. If the iterator argument is null,
+	 * this method returns an empty list.
+	 */
+	public static <E> List<E> iteratorToList(@Nullable Iterator<E> iterator) {
+		if (iterator == null) {
+			return Collections.emptyList();
+		}
+
+		final ArrayList<E> list = new ArrayList<>();
+		iterator.forEachRemaining(list::add);
 		return list;
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.client.gateway;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.types.Row;
 
@@ -77,65 +76,14 @@ public interface Executor {
 	void setSessionProperty(String sessionId, String key, String value) throws SqlExecutionException;
 
 	/**
-	 * Lists all registered catalogs.
-	 */
-	List<String> listCatalogs(String sessionid) throws SqlExecutionException;
-
-	/**
-	 * Lists all databases in the current catalog.
-	 */
-	List<String> listDatabases(String sessionId) throws SqlExecutionException;
-
-	/**
-	 * Create a table with a DDL statement.
-	 */
-	void createTable(String sessionId, String ddl) throws SqlExecutionException;
-
-	/**
-	 * Drop a table with a DDL statement.
-	 */
-	void dropTable(String sessionId, String ddl) throws SqlExecutionException;
-
-	/**
-	 * Lists all tables in the current database of the current catalog.
-	 */
-	List<String> listTables(String sessionId) throws SqlExecutionException;
-
-	/**
-	 * Lists all user-defined functions known to the executor.
-	 */
-	List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException;
-
-	/**
-	 * Executes a SQL statement.
+	 * Executes a SQL statement, and return {@link TableResult} as execution result.
 	 */
 	TableResult executeSql(String sessionId, String statement) throws SqlExecutionException;
-
-	/**
-	 * Lists all functions known to the executor.
-	 */
-	List<String> listFunctions(String sessionId) throws SqlExecutionException;
 
 	/**
 	 * Lists all modules known to the executor in their loaded order.
 	 */
 	List<String> listModules(String sessionId) throws SqlExecutionException;
-
-	/**
-	 * Sets a catalog with given name as the current catalog.
-	 */
-	void useCatalog(String sessionId, String catalogName) throws SqlExecutionException;
-
-	/**
-	 * Sets a database with given name as the current database of the current catalog.
-	 */
-	void useDatabase(String sessionId, String databaseName) throws SqlExecutionException;
-
-	/**
-	 * Returns the schema of a table. Throws an exception if the table could not be found. The
-	 * schema might contain time attribute types for helping the user during debugging a query.
-	 */
-	TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException;
 
 	/**
 	 * Returns a sql parser instance.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -42,7 +42,6 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
@@ -303,56 +302,6 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
-	public List<String> listCatalogs(String sessionId) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listCatalogs()));
-	}
-
-	@Override
-	public List<String> listDatabases(String sessionId) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listDatabases()));
-	}
-
-	@Override
-	public void createTable(String sessionId, String ddl) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tEnv = context.getTableEnvironment();
-		try {
-			context.wrapClassLoader(() -> tEnv.executeSql(ddl));
-		} catch (Exception e) {
-			throw new SqlExecutionException("Could not create a table from statement: " + ddl, e);
-		}
-	}
-
-	@Override
-	public void dropTable(String sessionId, String ddl) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tEnv = context.getTableEnvironment();
-		try {
-			context.wrapClassLoader(() -> tEnv.executeSql(ddl));
-		} catch (Exception e) {
-			throw new SqlExecutionException("Could not drop table from statement: " + ddl, e);
-		}
-	}
-
-	@Override
-	public List<String> listTables(String sessionId) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listTables()));
-	}
-
-	@Override
-	public List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listUserDefinedFunctions()));
-	}
-
-	@Override
 	public TableResult executeSql(String sessionId, String statement) throws SqlExecutionException {
 		final ExecutionContext<?> context = getExecutionContext(sessionId);
 		final TableEnvironment tEnv = context.getTableEnvironment();
@@ -364,59 +313,10 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
-	public List<String> listFunctions(String sessionId) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listFunctions()));
-	}
-
-	@Override
 	public List<String> listModules(String sessionId) throws SqlExecutionException {
 		final ExecutionContext<?> context = getExecutionContext(sessionId);
 		final TableEnvironment tableEnv = context.getTableEnvironment();
 		return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listModules()));
-	}
-
-	@Override
-	public void useCatalog(String sessionId, String catalogName) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-
-		context.wrapClassLoader(() -> {
-			// Rely on TableEnvironment/CatalogManager to validate input
-			try {
-				tableEnv.useCatalog(catalogName);
-			} catch (CatalogException e) {
-				throw new SqlExecutionException("Failed to switch to catalog " + catalogName, e);
-			}
-		});
-	}
-
-	@Override
-	public void useDatabase(String sessionId, String databaseName) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-
-		context.wrapClassLoader(() -> {
-			// Rely on TableEnvironment/CatalogManager to validate input
-			try {
-				tableEnv.useDatabase(databaseName);
-			} catch (CatalogException e) {
-				throw new SqlExecutionException("Failed to switch to database " + databaseName, e);
-			}
-		});
-	}
-
-	@Override
-	public TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException {
-		final ExecutionContext<?> context = getExecutionContext(sessionId);
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-		try {
-			return context.wrapClassLoader(() -> tableEnv.from(name).getSchema());
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("No table with this name could be found.", t);
-		}
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -21,10 +21,10 @@ package org.apache.flink.table.client.cli;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.cli.utils.SqlParserHelper;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.cli.utils.TerminalUtils.MockOutputStream;
+import org.apache.flink.table.client.cli.utils.TestTableResult;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
@@ -109,7 +109,7 @@ public class CliClientTest extends TestLogger {
 	@Test
 	public void testUseNonExistingDB() throws Exception {
 		TestingExecutor executor = new TestingExecutorBuilder()
-			.setUseDatabaseConsumer((ignored1, ignored2) -> {
+			.setExecuteSqlConsumer((ignored1, ignored2) -> {
 				throw new SqlExecutionException("mocked exception");
 			})
 			.build();
@@ -122,7 +122,7 @@ public class CliClientTest extends TestLogger {
 			cliClient = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath());
 
 			cliClient.open();
-			assertThat(executor.getNumUseDatabaseCalls(), is(1));
+			assertThat(executor.getNumExecuteSqlCalls(), is(1));
 		} finally {
 			if (cliClient != null) {
 				cliClient.close();
@@ -133,7 +133,7 @@ public class CliClientTest extends TestLogger {
 	@Test
 	public void testUseNonExistingCatalog() throws Exception {
 		TestingExecutor executor = new TestingExecutorBuilder()
-			.setUseCatalogConsumer((ignored1, ignored2) -> {
+			.setExecuteSqlConsumer((ignored1, ignored2) -> {
 				throw new SqlExecutionException("mocked exception");
 			})
 			.build();
@@ -146,7 +146,7 @@ public class CliClientTest extends TestLogger {
 		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream())) {
 			cliClient = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath());
 			cliClient.open();
-			assertThat(executor.getNumUseCatalogCalls(), is(1));
+			assertThat(executor.getNumExecuteSqlCalls(), is(1));
 		} finally {
 			if (cliClient != null) {
 				cliClient.close();
@@ -180,29 +180,33 @@ public class CliClientTest extends TestLogger {
 	@Test
 	public void testUseCatalog() throws Exception {
 		TestingExecutor executor = new TestingExecutorBuilder()
-				.setUseCatalogConsumer((ignored1, catalogName) -> {
-					if (!catalogName.equals("cat")) {
-						throw new SqlExecutionException("unexpected catalog name: " + catalogName);
+				.setExecuteSqlConsumer((ignored1, sql) -> {
+					if (!sql.toLowerCase().equals("use catalog cat")) {
+						throw new SqlExecutionException("unexpected catalog name: cat");
+					} else {
+						return TestTableResult.OK;
 					}
 				})
 				.build();
 
 		String output = testExecuteSql(executor, "use catalog cat;");
-		assertThat(executor.getNumUseCatalogCalls(), is(1));
+		assertThat(executor.getNumExecuteSqlCalls(), is(1));
 		assertFalse(output.contains("unexpected catalog name"));
 	}
 
 	@Test
 	public void testUseDatabase() throws Exception {
 		TestingExecutor executor = new TestingExecutorBuilder()
-				.setUseDatabaseConsumer((ignored1, databaseName) -> {
-					if (!databaseName.equals("db")) {
-						throw new SqlExecutionException("unexpected database name: " + databaseName);
+				.setExecuteSqlConsumer((ignored1, sql) -> {
+					if (!sql.toLowerCase().equals("use db")) {
+						throw new SqlExecutionException("unexpected database name: db");
+					} else {
+						return TestTableResult.OK;
 					}
 				})
 				.build();
 		String output = testExecuteSql(executor, "use db;");
-		assertThat(executor.getNumUseDatabaseCalls(), is(1));
+		assertThat(executor.getNumExecuteSqlCalls(), is(1));
 		assertFalse(output.contains("unexpected database name"));
 	}
 
@@ -255,14 +259,16 @@ public class CliClientTest extends TestLogger {
 
 	@Test
 	public void testCreateCatalog() throws Exception {
-		TestingExecutor executor = new TestingExecutorBuilder().setExecuteSqlConsumer((s, s2) -> null).build();
+		TestingExecutor executor = new TestingExecutorBuilder()
+				.setExecuteSqlConsumer((s, s2) -> TestTableResult.OK).build();
 		testExecuteSql(executor, "create catalog c1 with('type'='generic_in_memory');");
 		assertThat(executor.getNumExecuteSqlCalls(), is(1));
 	}
 
 	@Test
 	public void testDropCatalog() throws Exception {
-		TestingExecutor executor = new TestingExecutorBuilder().setExecuteSqlConsumer((s, s2) -> null).build();
+		TestingExecutor executor = new TestingExecutorBuilder()
+				.setExecuteSqlConsumer((s, s2) -> TestTableResult.OK).build();
 		testExecuteSql(executor, "drop catalog c1;");
 		assertThat(executor.getNumExecuteSqlCalls(), is(1));
 	}
@@ -393,62 +399,12 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
-		public List<String> listCatalogs(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public List<String> listDatabases(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public void createTable(String sessionId, String ddl) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public void dropTable(String sessionId, String ddl) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public List<String> listTables(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
 		public TableResult executeSql(String sessionId, String statement) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public List<String> listFunctions(String sessionId) throws SqlExecutionException {
-			return null;
+			return TestTableResult.OK;
 		}
 
 		@Override
 		public List<String> listModules(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public void useCatalog(String sessionId, String catalogName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public void useDatabase(String sessionId, String databaseName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException {
 			return null;
 		}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -184,7 +184,7 @@ public class CliClientTest extends TestLogger {
 					if (!sql.toLowerCase().equals("use catalog cat")) {
 						throw new SqlExecutionException("unexpected catalog name: cat");
 					} else {
-						return TestTableResult.OK;
+						return TestTableResult.TABLE_RESULT_OK;
 					}
 				})
 				.build();
@@ -201,7 +201,7 @@ public class CliClientTest extends TestLogger {
 					if (!sql.toLowerCase().equals("use db")) {
 						throw new SqlExecutionException("unexpected database name: db");
 					} else {
-						return TestTableResult.OK;
+						return TestTableResult.TABLE_RESULT_OK;
 					}
 				})
 				.build();
@@ -260,7 +260,7 @@ public class CliClientTest extends TestLogger {
 	@Test
 	public void testCreateCatalog() throws Exception {
 		TestingExecutor executor = new TestingExecutorBuilder()
-				.setExecuteSqlConsumer((s, s2) -> TestTableResult.OK).build();
+				.setExecuteSqlConsumer((s, s2) -> TestTableResult.TABLE_RESULT_OK).build();
 		testExecuteSql(executor, "create catalog c1 with('type'='generic_in_memory');");
 		assertThat(executor.getNumExecuteSqlCalls(), is(1));
 	}
@@ -268,7 +268,7 @@ public class CliClientTest extends TestLogger {
 	@Test
 	public void testDropCatalog() throws Exception {
 		TestingExecutor executor = new TestingExecutorBuilder()
-				.setExecuteSqlConsumer((s, s2) -> TestTableResult.OK).build();
+				.setExecuteSqlConsumer((s, s2) -> TestTableResult.TABLE_RESULT_OK).build();
 		testExecuteSql(executor, "drop catalog c1;");
 		assertThat(executor.getNumExecuteSqlCalls(), is(1));
 	}
@@ -400,7 +400,7 @@ public class CliClientTest extends TestLogger {
 
 		@Override
 		public TableResult executeSql(String sessionId, String statement) throws SqlExecutionException {
-			return TestTableResult.OK;
+			return TestTableResult.TABLE_RESULT_OK;
 		}
 
 		@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -156,62 +156,12 @@ public class CliResultViewTest {
 		}
 
 		@Override
-		public List<String> listCatalogs(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public List<String> listDatabases(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public void createTable(String sessionId, String ddl) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public void dropTable(String sessionId, String ddl) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public List<String> listTables(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
 		public TableResult executeSql(String sessionId, String statement) throws SqlExecutionException {
 			return null;
 		}
 
 		@Override
-		public List<String> listFunctions(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
 		public List<String> listModules(String sessionId) throws SqlExecutionException {
-			return null;
-		}
-
-		@Override
-		public void useCatalog(String sessionId, String catalogName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public void useDatabase(String sessionId, String databaseName) throws SqlExecutionException {
-
-		}
-
-		@Override
-		public TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException {
 			return null;
 		}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.SupplierWithException;
@@ -40,8 +39,6 @@ class TestingExecutorBuilder {
 	private List<SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException>> resultChangesSupplier = Collections.emptyList();
 	private List<SupplierWithException<TypedResult<Integer>, SqlExecutionException>> snapshotResultsSupplier = Collections.emptyList();
 	private List<SupplierWithException<List<Row>, SqlExecutionException>> resultPagesSupplier = Collections.emptyList();
-	private BiConsumerWithException<String, String, SqlExecutionException> setUseCatalogConsumer = (ignoredA, ignoredB) -> {};
-	private BiConsumerWithException<String, String, SqlExecutionException> setUseDatabaseConsumer = (ignoredA, ignoredB) -> {};
 	private BiFunctionWithException<String, String, TableResult, SqlExecutionException> setExecuteSqlConsumer = (ignoredA, ignoredB) -> null;
 	private TriFunctionWithException<String, String, String, Void, SqlExecutionException> setSessionPropertyFunction = (ignoredA, ignoredB, ignoredC) -> null;
 	private FunctionWithException<String, Void, SqlExecutionException> resetSessionPropertiesFunction = (ignoredA) -> null;
@@ -61,16 +58,6 @@ class TestingExecutorBuilder {
 	@SafeVarargs
 	public final TestingExecutorBuilder setResultPageSupplier(SupplierWithException<List<Row>, SqlExecutionException> ... resultPageSupplier) {
 		resultPagesSupplier = Arrays.asList(resultPageSupplier);
-		return this;
-	}
-
-	public final TestingExecutorBuilder setUseCatalogConsumer(BiConsumerWithException<String, String, SqlExecutionException> useCatalogConsumer) {
-		this.setUseCatalogConsumer = useCatalogConsumer;
-		return this;
-	}
-
-	public final TestingExecutorBuilder setUseDatabaseConsumer(BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer) {
-		this.setUseDatabaseConsumer = useDatabaseConsumer;
 		return this;
 	}
 
@@ -95,8 +82,6 @@ class TestingExecutorBuilder {
 			resultChangesSupplier,
 			snapshotResultsSupplier,
 			resultPagesSupplier,
-			setUseCatalogConsumer,
-			setUseDatabaseConsumer,
 			setExecuteSqlConsumer,
 			setSessionPropertyFunction,
 			resetSessionPropertiesFunction);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
@@ -37,7 +37,7 @@ public class TestTableResult implements TableResult {
 	private final ResultKind resultKind;
 	private final CloseableIterator<Row> data;
 
-	public static TestTableResult TABLE_RESULT_OK = new TestTableResult(
+	public static final TestTableResult TABLE_RESULT_OK = new TestTableResult(
 			ResultKind.SUCCESS,
 			TableSchema.builder().field("result", DataTypes.STRING()).build(),
 			CloseableIterator.adapterForIterator(Collections.singletonList(Row.of("OK")).iterator()));

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
@@ -37,7 +37,7 @@ public class TestTableResult implements TableResult {
 	private final ResultKind resultKind;
 	private final CloseableIterator<Row> data;
 
-	public static TestTableResult OK = new TestTableResult(
+	public static TestTableResult TABLE_RESULT_OK = new TestTableResult(
 			ResultKind.SUCCESS,
 			TableSchema.builder().field("result", DataTypes.STRING()).build(),
 			CloseableIterator.adapterForIterator(Collections.singletonList(Row.of("OK")).iterator()));

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli.utils;
+
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * {@link TableResult} for testing.
+ */
+public class TestTableResult implements TableResult {
+	private final TableSchema tableSchema;
+	private final ResultKind resultKind;
+	private final CloseableIterator<Row> data;
+
+	public static TestTableResult OK = new TestTableResult(
+			ResultKind.SUCCESS,
+			TableSchema.builder().field("result", DataTypes.STRING()).build(),
+			CloseableIterator.adapterForIterator(Collections.singletonList(Row.of("OK")).iterator()));
+
+	public TestTableResult(ResultKind resultKind, TableSchema tableSchema) {
+		this(resultKind, tableSchema, CloseableIterator.empty());
+	}
+
+	public TestTableResult(ResultKind resultKind, TableSchema tableSchema, CloseableIterator<Row> data) {
+		this.resultKind = resultKind;
+		this.tableSchema = tableSchema;
+		this.data = data;
+	}
+
+	@Override
+	public Optional<JobClient> getJobClient() {
+		return Optional.empty();
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return tableSchema;
+	}
+
+	@Override
+	public ResultKind getResultKind() {
+		return resultKind;
+	}
+
+	@Override
+	public CloseableIterator<Row> collect() {
+		return data;
+	}
+
+	@Override
+	public void print() {
+		// do nothing
+	}
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -20,8 +20,6 @@
 package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
@@ -32,7 +30,9 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.api.config.TableConfigOptions;
@@ -49,18 +49,20 @@ import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
 import org.apache.flink.table.client.gateway.utils.SimpleCatalogFactory;
 import org.apache.flink.table.client.gateway.utils.TestUserClassLoaderJar;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
 
+import org.hamcrest.Matcher;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -86,6 +88,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.client.gateway.local.ExecutionContextTest.CATALOGS_ENVIRONMENT_FILE;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -176,16 +179,17 @@ public class LocalExecutorITCase extends TestLogger {
 		executor.executeSql(sessionId,
 				"CREATE TEMPORARY VIEW IF NOT EXISTS AdditionalView2 AS SELECT * FROM AdditionalView1");
 
-		List<String> actualTables = executor.listTables(sessionId);
-		List<String> expectedTables = Arrays.asList(
-				"AdditionalView1",
-				"AdditionalView2",
-				"TableNumber1",
-				"TableNumber2",
-				"TableSourceSink",
-				"TestView1",
-				"TestView2");
-		assertEquals(expectedTables, actualTables);
+		assertShowResult(
+				executor.executeSql(sessionId, "SHOW TABLES"),
+				Arrays.asList(
+						"AdditionalView1",
+						"AdditionalView2",
+						"TableNumber1",
+						"TableNumber2",
+						"TableSourceSink",
+						"TestView1",
+						"TestView2")
+		);
 
 		// Although AdditionalView2 needs AdditionalView1, dropping AdditionalView1 first does not
 		// throw.
@@ -201,15 +205,15 @@ public class LocalExecutorITCase extends TestLogger {
 		executor.executeSql(sessionId, "DROP VIEW AdditionalView1");
 		executor.executeSql(sessionId, "DROP TEMPORARY VIEW AdditionalView2");
 
-		actualTables = executor.listTables(sessionId);
-		expectedTables = Arrays.asList(
-				"TableNumber1",
-				"TableNumber2",
-				"TableSourceSink",
-				"TestView1",
-				"TestView2");
-		assertEquals(expectedTables, actualTables);
-
+		assertShowResult(
+				executor.executeSql(sessionId, "SHOW TABLES"),
+				Arrays.asList(
+						"TableNumber1",
+						"TableNumber2",
+						"TableSourceSink",
+						"TestView1",
+						"TestView2")
+		);
 		executor.closeSession(sessionId);
 	}
 
@@ -220,14 +224,13 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		final List<String> actualCatalogs = executor.listCatalogs(sessionId);
-
-		final List<String> expectedCatalogs = Arrays.asList(
-			"catalog1",
-			"default_catalog",
-			"simple-catalog");
-		assertEquals(expectedCatalogs, actualCatalogs);
-
+		assertShowResult(
+				executor.executeSql(sessionId, "SHOW CATALOGS"),
+				Arrays.asList(
+						"catalog1",
+						"default_catalog",
+						"simple-catalog")
+		);
 		executor.closeSession(sessionId);
 	}
 
@@ -238,10 +241,10 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		final List<String> actualDatabases = executor.listDatabases(sessionId);
-
-		final List<String> expectedDatabases = Collections.singletonList("default_database");
-		assertEquals(expectedDatabases, actualDatabases);
+		assertShowResult(
+				executor.executeSql(sessionId, "SHOW DATABASES"),
+				Collections.singletonList("default_database")
+		);
 
 		executor.closeSession(sessionId);
 	}
@@ -255,10 +258,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 		executor.executeUpdate(sessionId, "create database db1");
 
-		final List<String> actualDatabases = executor.listDatabases(sessionId);
-		final List<String> expectedDatabases = Arrays.asList("default_database", "db1");
-		assertEquals(expectedDatabases, actualDatabases);
-
+		assertShowResult(executor.executeSql(sessionId, "SHOW DATABASES"), Arrays.asList("default_database", "db1"));
 		executor.closeSession(sessionId);
 	}
 
@@ -269,17 +269,12 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		executor.executeUpdate(sessionId, "create database db1");
+		executor.executeSql(sessionId, "create database db1");
 
-		List<String> actualDatabases = executor.listDatabases(sessionId);
-		List<String> expectedDatabases = Arrays.asList("default_database", "db1");
-		assertEquals(expectedDatabases, actualDatabases);
+		assertShowResult(executor.executeSql(sessionId, "SHOW DATABASES"), Arrays.asList("default_database", "db1"));
 
-		executor.executeUpdate(sessionId, "drop database if exists db1");
-
-		actualDatabases = executor.listDatabases(sessionId);
-		expectedDatabases = Arrays.asList("default_database");
-		assertEquals(expectedDatabases, actualDatabases);
+		executor.executeSql(sessionId, "drop database if exists db1");
+		assertShowResult(executor.executeSql(sessionId, "SHOW DATABASES"), Collections.singletonList("default_database"));
 
 		executor.closeSession(sessionId);
 	}
@@ -291,13 +286,11 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		executor.executeUpdate(sessionId, "create database db1 comment 'db1_comment' with ('k1' = 'v1')");
+		executor.executeSql(sessionId, "create database db1 comment 'db1_comment' with ('k1' = 'v1')");
 
-		executor.executeUpdate(sessionId, "alter database db1 set ('k1' = 'a', 'k2' = 'b')");
+		executor.executeSql(sessionId, "alter database db1 set ('k1' = 'a', 'k2' = 'b')");
 
-		final List<String> actualDatabases = executor.listDatabases(sessionId);
-		final List<String> expectedDatabases = Arrays.asList("default_database", "db1");
-		assertEquals(expectedDatabases, actualDatabases);
+		assertShowResult(executor.executeSql(sessionId, "SHOW DATABASES"), Arrays.asList("default_database", "db1"));
 		//todo: we should compare the new db1 properties after we support describe database in LocalExecutor.
 
 		executor.closeSession(sessionId);
@@ -306,20 +299,14 @@ public class LocalExecutorITCase extends TestLogger {
 	@Test
 	public void testAlterTable() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
-		final LocalExecutor localExecutor = (LocalExecutor) executor;
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
-		executor.useCatalog(sessionId, "simple-catalog");
-		executor.useDatabase(sessionId, "default_database");
-		List<String> actualTables = executor.listTables(sessionId);
-		List<String> expectedTables = Arrays.asList("test-table");
-		assertEquals(expectedTables, actualTables);
-		executor.executeUpdate(sessionId, "alter table `test-table` rename to t1");
-		actualTables = executor.listTables(sessionId);
-		expectedTables = Arrays.asList("t1");
-		assertEquals(expectedTables, actualTables);
-		//todo: we should add alter table set test when we support create table in executor.
+		executor.executeSql(sessionId, "use catalog `simple-catalog`");
+		executor.executeSql(sessionId, "use default_database");
+		assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("test-table"));
+		executor.executeSql(sessionId, "alter table `test-table` rename to t1");
+		assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("t1"));
 		executor.closeSession(sessionId);
 	}
 
@@ -330,15 +317,15 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		final List<String> actualTables = executor.listTables(sessionId);
-
-		final List<String> expectedTables = Arrays.asList(
-			"TableNumber1",
-			"TableNumber2",
-			"TableSourceSink",
-			"TestView1",
-			"TestView2");
-		assertEquals(expectedTables, actualTables);
+		assertShowResult(
+				executor.executeSql(sessionId, "SHOW TABLES"),
+				Arrays.asList(
+						"TableNumber1",
+						"TableNumber2",
+						"TableSourceSink",
+						"TestView1",
+						"TestView2")
+		);
 		executor.closeSession(sessionId);
 	}
 
@@ -349,11 +336,10 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		final List<String> actualTables = executor.listUserDefinedFunctions(sessionId);
-
-		final List<String> expectedTables = Arrays.asList("aggregateudf", "tableudf", "scalarudf");
-		assertEquals(expectedTables, actualTables);
-
+		assertShowResult(
+				executor.executeSql(sessionId, "SHOW FUNCTIONS"),
+				hasItems("aggregateudf", "tableudf", "scalarudf")
+		);
 		executor.closeSession(sessionId);
 	}
 
@@ -440,13 +426,21 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		final TableSchema actualTableSchema = executor.getTableSchema(sessionId, "TableNumber2");
-
-		final TableSchema expectedTableSchema = new TableSchema(
-			new String[]{"IntegerField2", "StringField2", "TimestampField2"},
-			new TypeInformation[]{Types.INT, Types.STRING, Types.SQL_TIMESTAMP});
-
-		assertEquals(expectedTableSchema, actualTableSchema);
+		TableResult tableResult = executor.executeSql(sessionId, "DESCRIBE TableNumber2");
+		assertEquals(
+				tableResult.getTableSchema(),
+				TableSchema.builder().fields(
+						new String[] { "name", "type", "null", "key", "computed column", "watermark" },
+						new DataType[] { DataTypes.STRING(), DataTypes.STRING(), DataTypes.BOOLEAN(),
+								DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING() }
+				).build()
+		);
+		List<Row> schemaData = Arrays.asList(
+				Row.of("IntegerField2", "INT", true, null, null, null),
+				Row.of("StringField2", "STRING", true, null, null, null),
+				Row.of("TimestampField2", "TIMESTAMP(3)", true, null, null, null)
+		);
+		assertEquals(schemaData, CollectionUtil.iteratorToList(tableResult.collect()));
 		executor.closeSession(sessionId);
 	}
 
@@ -859,8 +853,8 @@ public class LocalExecutorITCase extends TestLogger {
 			executeAndVerifySinkResult(executor, sessionId, statement2, csvOutputPath);
 
 			// Case 2: Temporary sink
-			executor.useCatalog(sessionId, "simple-catalog");
-			executor.useDatabase(sessionId, "default_database");
+			executor.executeSql(sessionId, "use catalog `simple-catalog`");
+			executor.executeSql(sessionId, "use default_database");
 			// all queries are pipelined to an in-memory sink, check it is properly registered
 			final ResultDescriptor otherCatalogDesc = executor.executeQuery(sessionId, "SELECT * FROM `test-table`");
 
@@ -900,20 +894,26 @@ public class LocalExecutorITCase extends TestLogger {
 		assertEquals("test-session", sessionId);
 
 		try {
-			assertEquals(Collections.singletonList("mydatabase"), executor.listDatabases(sessionId));
+			assertShowResult(executor.executeSql(sessionId, "SHOW DATABASES"), Collections.singletonList("mydatabase"));
 
-			executor.useCatalog(sessionId, "hivecatalog");
+			executor.executeSql(sessionId, "use catalog hivecatalog");
 
-			assertEquals(
-				Arrays.asList(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE, HiveCatalog.DEFAULT_DB),
-				executor.listDatabases(sessionId));
+			assertShowResult(
+					executor.executeSql(sessionId, "SHOW DATABASES"),
+					Arrays.asList(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE, HiveCatalog.DEFAULT_DB)
+			);
 
-			assertEquals(Collections.singletonList(DependencyTest.TestHiveCatalogFactory.TABLE_WITH_PARAMETERIZED_TYPES),
-				executor.listTables(sessionId));
+			assertShowResult(
+					executor.executeSql(sessionId, "SHOW TABLES"),
+					Collections.singletonList(DependencyTest.TestHiveCatalogFactory.TABLE_WITH_PARAMETERIZED_TYPES)
+			);
 
-			executor.useDatabase(sessionId, DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE);
+			executor.executeSql(sessionId, "use " + DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE);
 
-			assertEquals(Collections.singletonList(DependencyTest.TestHiveCatalogFactory.TEST_TABLE), executor.listTables(sessionId));
+			assertShowResult(
+					executor.executeSql(sessionId, "SHOW TABLES"),
+					Collections.singletonList(DependencyTest.TestHiveCatalogFactory.TEST_TABLE)
+			);
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -927,7 +927,7 @@ public class LocalExecutorITCase extends TestLogger {
 		assertEquals("test-session", sessionId);
 
 		exception.expect(SqlExecutionException.class);
-		executor.useDatabase(sessionId, "nonexistingdb");
+		executor.executeSql(sessionId, "use nonexistingdb");
 	}
 
 	@Test
@@ -938,7 +938,7 @@ public class LocalExecutorITCase extends TestLogger {
 		assertEquals("test-session", sessionId);
 
 		exception.expect(SqlExecutionException.class);
-		executor.useCatalog(sessionId, "nonexistingcatalog");
+		executor.executeSql(sessionId, "use catalog nonexistingcatalog");
 		executor.closeSession(sessionId);
 	}
 
@@ -964,13 +964,13 @@ public class LocalExecutorITCase extends TestLogger {
 		String sessionId = executor.openSession(session);
 		assertEquals("test-session", sessionId);
 
-		executor.useCatalog(sessionId, "hivecatalog");
+		executor.executeSql(sessionId, "use catalog hivecatalog");
 		String resultID = executor.executeQuery(sessionId,
 			"select * from " + DependencyTest.TestHiveCatalogFactory.TABLE_WITH_PARAMETERIZED_TYPES).getResultId();
 		retrieveTableResult(executor, sessionId, resultID);
 
 		// make sure legacy types still work
-		executor.useCatalog(sessionId, "default_catalog");
+		executor.executeSql(sessionId, "use catalog default_catalog");
 		resultID = executor.executeQuery(sessionId, "select * from TableNumber3").getResultId();
 		retrieveTableResult(executor, sessionId, resultID);
 		executor.closeSession(sessionId);
@@ -992,32 +992,33 @@ public class LocalExecutorITCase extends TestLogger {
 				")\n";
 		try {
 			// Test create table with simple name.
-			executor.useCatalog(sessionId, "catalog1");
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable2"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2"), executor.listTables(sessionId));
+			executor.executeSql(sessionId, "use catalog catalog1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable2"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable1", "MyTable2"));
 
 			// Test create table with full qualified name.
-			executor.useCatalog(sessionId, "catalog1");
-			executor.createTable(sessionId, String.format(ddlTemplate, "`simple-catalog`.`default_database`.MyTable3"));
-			executor.createTable(sessionId, String.format(ddlTemplate, "`simple-catalog`.`default_database`.MyTable4"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2"), executor.listTables(sessionId));
-			executor.useCatalog(sessionId, "simple-catalog");
-			assertEquals(Arrays.asList("MyTable3", "MyTable4", "test-table"), executor.listTables(sessionId));
+			executor.executeSql(sessionId, "use catalog catalog1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "`simple-catalog`.`default_database`.MyTable3"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "`simple-catalog`.`default_database`.MyTable4"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable1", "MyTable2"));
+			executor.executeSql(sessionId, "use catalog `simple-catalog`");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable3", "MyTable4", "test-table"));
 
 			// Test create table with db and table name.
-			executor.useCatalog(sessionId, "catalog1");
-			executor.createTable(sessionId, String.format(ddlTemplate, "`default`.MyTable5"));
-			executor.createTable(sessionId, String.format(ddlTemplate, "`default`.MyTable6"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2", "MyTable5", "MyTable6"), executor.listTables(sessionId));
+			executor.executeSql(sessionId, "use catalog catalog1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "`default`.MyTable5"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "`default`.MyTable6"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable1", "MyTable2", "MyTable5", "MyTable6"));
 		} finally {
 			executor.closeSession(sessionId);
 		}
 	}
 
-	@Test @Ignore // TODO: reopen when FLINK-15075 was fixed.
+	@Test
 	public void testCreateTableWithComputedColumn() throws Exception {
+		// only blink planner support computed column for DDL
 		Assume.assumeTrue(planner.equals("blink"));
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_PLANNER", planner);
@@ -1040,18 +1041,20 @@ public class LocalExecutorITCase extends TestLogger {
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		try {
-			executor.useCatalog(sessionId, "catalog1");
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable2"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2"), executor.listTables(sessionId));
+			executor.executeSql(sessionId, "use catalog catalog1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable2"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable1", "MyTable2"));
 		} finally {
 			executor.closeSession(sessionId);
 		}
 	}
 
-	@Test @Ignore // TODO: reopen when FLINK-15075 was fixed.
+	@Test
 	public void testCreateTableWithWatermark() throws Exception {
+		// only blink planner supports watermark expression for DDL
+		Assume.assumeTrue(planner.equals("blink"));
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_PLANNER", planner);
 		replaceVars.put("$VAR_SOURCE_PATH1", "file:///fakePath1");
@@ -1073,11 +1076,11 @@ public class LocalExecutorITCase extends TestLogger {
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		try {
-			executor.useCatalog(sessionId, "catalog1");
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable2"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2"), executor.listTables(sessionId));
+			executor.executeSql(sessionId, "use catalog catalog1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable2"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable1", "MyTable2"));
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -1089,7 +1092,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		try {
-			executor.useCatalog(sessionId, "catalog1");
+			executor.executeSql(sessionId, "use catalog catalog1");
 			executor.setSessionProperty(sessionId, "execution.type", "batch");
 			final String ddlTemplate = "create table %s(\n" +
 					"  a int,\n" +
@@ -1101,16 +1104,18 @@ public class LocalExecutorITCase extends TestLogger {
 					"  'connector.path'='xxx',\n" +
 					"  'update-mode'='append'\n" +
 					")\n";
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
 			// Change the session property to trigger `new ExecutionContext`.
 			executor.setSessionProperty(sessionId, "execution.restart-strategy.failure-rate-interval", "12345");
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable2"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2"), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable2"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable1", "MyTable2"));
 
 			// Reset the session properties.
 			executor.resetSessionProperties(sessionId);
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable3"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2", "MyTable3"), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable3"));
+			assertShowResult(
+					executor.executeSql(sessionId, "SHOW TABLES"),
+					Arrays.asList("MyTable1", "MyTable2", "MyTable3"));
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -1122,7 +1127,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		try {
-			executor.useCatalog(sessionId, "catalog1");
+			executor.executeSql(sessionId, "use catalog catalog1");
 			executor.setSessionProperty(sessionId, "execution.type", "batch");
 			final String ddlTemplate = "create table %s(\n" +
 					"  a int,\n" +
@@ -1135,57 +1140,59 @@ public class LocalExecutorITCase extends TestLogger {
 					"  'update-mode'='append'\n" +
 					")\n";
 			// Test drop table.
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE MyTable1");
-			assertEquals(Collections.emptyList(), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, "DROP TABLE MyTable1");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.emptyList());
 
 			// Test drop table if exists.
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE IF EXISTS MyTable1");
-			assertEquals(Collections.emptyList(), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, "DROP TABLE IF EXISTS MyTable1");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.emptyList());
 
 			// Test drop table with full qualified name.
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE catalog1.`default`.MyTable1");
-			assertEquals(Collections.emptyList(), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, "DROP TABLE catalog1.`default`.MyTable1");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.emptyList());
 
 			// Test drop table with db and table name.
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE `default`.MyTable1");
-			assertEquals(Collections.emptyList(), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, "DROP TABLE `default`.MyTable1");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.emptyList());
 
 			// Test drop table that does not exist.
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE IF EXISTS catalog2.`default`.MyTable1");
-			assertEquals(Collections.singletonList("MyTable1"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE `default`.MyTable1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, "DROP TABLE IF EXISTS catalog2.`default`.MyTable1");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.singletonList("MyTable1"));
+			executor.executeSql(sessionId, "DROP TABLE `default`.MyTable1");
 
 			// Test drop table with properties changed.
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
 			// Change the session property to trigger `new ExecutionContext`.
 			executor.setSessionProperty(sessionId, "execution.restart-strategy.failure-rate-interval", "12345");
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable2"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE MyTable1");
-			executor.dropTable(sessionId, "DROP TABLE MyTable2");
-			assertEquals(Collections.emptyList(), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable2"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Arrays.asList("MyTable1", "MyTable2"));
+			executor.executeSql(sessionId, "DROP TABLE MyTable1");
+			executor.executeSql(sessionId, "DROP TABLE MyTable2");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.emptyList());
 
 			// Test drop table with properties reset.
 			// Reset the session properties.
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable1"));
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable2"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable1"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable2"));
 			executor.resetSessionProperties(sessionId);
-			executor.createTable(sessionId, String.format(ddlTemplate, "MyTable3"));
-			assertEquals(Arrays.asList("MyTable1", "MyTable2", "MyTable3"), executor.listTables(sessionId));
-			executor.dropTable(sessionId, "DROP TABLE MyTable1");
-			executor.dropTable(sessionId, "DROP TABLE MyTable2");
-			executor.dropTable(sessionId, "DROP TABLE MyTable3");
-			assertEquals(Collections.emptyList(), executor.listTables(sessionId));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "MyTable3"));
+			assertShowResult(
+					executor.executeSql(sessionId, "SHOW TABLES"),
+					Arrays.asList("MyTable1", "MyTable2", "MyTable3"));
+			executor.executeSql(sessionId, "DROP TABLE MyTable1");
+			executor.executeSql(sessionId, "DROP TABLE MyTable2");
+			executor.executeSql(sessionId, "DROP TABLE MyTable3");
+			assertShowResult(executor.executeSql(sessionId, "SHOW TABLES"), Collections.emptyList());
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -1201,25 +1208,25 @@ public class LocalExecutorITCase extends TestLogger {
 				+ "as 'org.apache.flink.table.client.gateway.local.LocalExecutorITCase$TestScalaFunction' LANGUAGE JAVA";
 		try {
 			// Test create table with simple name.
-			executor.useCatalog(sessionId, "catalog1");
+			executor.executeSql(sessionId, "use catalog catalog1");
 			executor.executeSql(sessionId, String.format(ddlTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			executor.executeSql(sessionId, String.format(ddlTemplate, "TEMPORARY", "IF NOT EXISTS", "func2"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1", "func2"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1", "func2"));
 
 			// Test create function with full qualified name.
-			executor.useCatalog(sessionId, "catalog1");
-			executor.createTable(sessionId, String.format(ddlTemplate, "", "", "`simple-catalog`.`default_database`.func3"));
-			executor.createTable(sessionId, String.format(ddlTemplate, "TEMPORARY", "IF NOT EXISTS", "`simple-catalog`.`default_database`.func4"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1", "func2"));
-			executor.useCatalog(sessionId, "simple-catalog");
-			assertThat(executor.listFunctions(sessionId), hasItems("func3", "func4"));
+			executor.executeSql(sessionId, "use catalog catalog1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "", "", "`simple-catalog`.`default_database`.func3"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "TEMPORARY", "IF NOT EXISTS", "`simple-catalog`.`default_database`.func4"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1", "func2"));
+			executor.executeSql(sessionId, "use catalog `simple-catalog`");
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func3", "func4"));
 
 			// Test create function with db and table name.
-			executor.useCatalog(sessionId, "catalog1");
-			executor.createTable(sessionId, String.format(ddlTemplate, "TEMPORARY", "", "`default`.func5"));
-			executor.createTable(sessionId, String.format(ddlTemplate, "TEMPORARY", "", "`default`.func6"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1", "func2", "func5", "func6"));
+			executor.executeSql(sessionId, "use catalog catalog1");
+			executor.executeSql(sessionId, String.format(ddlTemplate, "TEMPORARY", "", "`default`.func5"));
+			executor.executeSql(sessionId, String.format(ddlTemplate, "TEMPORARY", "", "`default`.func6"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1", "func2", "func5", "func6"));
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -1231,7 +1238,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		try {
-			executor.useCatalog(sessionId, "catalog1");
+			executor.executeSql(sessionId, "use catalog catalog1");
 			executor.setSessionProperty(sessionId, "execution.type", "batch");
 			// arguments: [TEMPORARY|TEMPORARY SYSTEM], [IF NOT EXISTS], func_name
 			final String createTemplate = "create %s function %s %s \n"
@@ -1240,38 +1247,38 @@ public class LocalExecutorITCase extends TestLogger {
 			final String dropTemplate = "drop %s function %s %s";
 			// Test drop function.
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), not(hasItems("func1")));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), not(hasItems("func1")));
 
 			// Test drop function if exists.
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "IF EXISTS", "func1"));
-			assertThat(executor.listFunctions(sessionId), not(hasItems("func1")));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), not(hasItems("func1")));
 
 			// Test drop function with full qualified name.
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "IF EXISTS", "catalog1.`default`.func1"));
-			assertThat(executor.listFunctions(sessionId), not(hasItems("func1")));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), not(hasItems("func1")));
 
 			// Test drop function with db and function name.
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "IF EXISTS", "`default`.func1"));
-			assertThat(executor.listFunctions(sessionId), not(hasItems("func1")));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), not(hasItems("func1")));
 
 			// Test drop function that does not exist.
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			try {
 				executor.executeSql(sessionId, String.format(dropTemplate, "", "IF EXISTS", "catalog2.`default`.func1"));
 				fail("unexpected");
 			} catch (Exception e) {
 				assertThat(e.getCause().getMessage(), is("Catalog catalog2 does not exist"));
 			}
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "", "`default`.func1"));
 
 			// Test drop function with properties changed.
@@ -1279,10 +1286,10 @@ public class LocalExecutorITCase extends TestLogger {
 			// Change the session property to trigger `new ExecutionContext`.
 			executor.setSessionProperty(sessionId, "execution.restart-strategy.failure-rate-interval", "12345");
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func2"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1", "func2"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1", "func2"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "", "func1"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "", "func2"));
-			assertThat(executor.listFunctions(sessionId), not(hasItems("func1", "func2")));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), not(hasItems("func1", "func2")));
 
 			// Test drop function with properties reset.
 			// Reset the session properties.
@@ -1290,11 +1297,11 @@ public class LocalExecutorITCase extends TestLogger {
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func2"));
 			executor.resetSessionProperties(sessionId);
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func3"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1", "func2", "func3"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1", "func2", "func3"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "", "func1"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "", "func2"));
 			executor.executeSql(sessionId, String.format(dropTemplate, "", "", "func3"));
-			assertThat(executor.listFunctions(sessionId), not(hasItems("func1", "func2", "func3")));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), not(hasItems("func1", "func2", "func3")));
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -1306,7 +1313,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 		try {
-			executor.useCatalog(sessionId, "catalog1");
+			executor.executeSql(sessionId, "use catalog catalog1");
 			executor.setSessionProperty(sessionId, "execution.type", "batch");
 			// arguments: [TEMPORARY|TEMPORARY SYSTEM], [IF NOT EXISTS], func_name
 			final String createTemplate = "create %s function %s %s \n"
@@ -1315,9 +1322,9 @@ public class LocalExecutorITCase extends TestLogger {
 			final String alterTemplate = "alter %s function %s %s AS %s";
 			// Test alter function.
 			executor.executeSql(sessionId, String.format(createTemplate, "", "", "func1"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 			executor.executeSql(sessionId, String.format(alterTemplate, "", "IF EXISTS", "`default`.func1", "'newClass'"));
-			assertThat(executor.listFunctions(sessionId), hasItems("func1"));
+			assertShowResult(executor.executeSql(sessionId, "SHOW FUNCTIONS"), hasItems("func1"));
 
 			// Test alter non temporary function with TEMPORARY keyword.
 			try {
@@ -1379,6 +1386,22 @@ public class LocalExecutorITCase extends TestLogger {
 		} finally {
 			executor.closeSession(sessionId);
 		}
+	}
+
+	private void assertShowResult(TableResult showResult, List<String> expected) {
+		List<String> actual = CollectionUtil.iteratorToList(showResult.collect())
+				.stream()
+				.map(r -> checkNotNull(r.getField(0)).toString())
+				.collect(Collectors.toList());
+		assertEquals(expected, actual);
+	}
+
+	private void assertShowResult(TableResult showResult, Matcher<Iterable<String>> matcher) {
+		List<String> actual = CollectionUtil.iteratorToList(showResult.collect())
+				.stream()
+				.map(r -> checkNotNull(r.getField(0)).toString())
+				.collect(Collectors.toList());
+		assertThat(actual, matcher);
 	}
 
 	private void verifySinkResult(String path) throws IOException {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -831,7 +831,7 @@ abstract class TableEnvImpl(
       }
     }
     buildResult(
-      Array("name", "type", "null", "key", "compute column", "watermark"),
+      Array("name", "type", "null", "key", "computed column", "watermark"),
       Array(DataTypes.STRING, DataTypes.STRING, DataTypes.BOOLEAN, DataTypes.STRING,
         DataTypes.STRING, DataTypes.STRING),
       data)


### PR DESCRIPTION


## What is the purpose of the change

*After TableEnvironment#executeSql is introduced, many methods of Executor interface in sql client can be replaced with TableEnvironment#executeSql. Those methods include:
listCatalogs, listDatabases, createTable, dropTable, listTables, listFunctions, useCatalog, useDatabase, getTableSchema (use DESCRIBE xx)*


## Brief change log

  - *remove the methods which can be replaced with executeSql method in Executor interface, and update the related logic*


## Verifying this change

Update the existing tests, such as `LocalExecutorITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
