### PR TITLE
[hotfix][doc] fix time duration unit in filesystem doc

### DIFF
--- a/docs/dev/table/connectors/filesystem.md
+++ b/docs/dev/table/connectors/filesystem.md
@@ -130,14 +130,14 @@ a timeout that specifies the maximum duration for which a file can be open.
     </tr>
     <tr>
         <td><h5>sink.rolling-policy.rollover-interval</h5></td>
-        <td style="word-wrap: break-word;">30 m</td>
+        <td style="word-wrap: break-word;">30 min</td>
         <td>Duration</td>
         <td>The maximum time duration a part file can stay open before rolling (by default 30 min to avoid to many small files).
         The frequency at which this is checked is controlled by the 'sink.rolling-policy.check-interval' option.</td>
     </tr>
     <tr>
         <td><h5>sink.rolling-policy.check-interval</h5></td>
-        <td style="word-wrap: break-word;">1 m</td>
+        <td style="word-wrap: break-word;">1 min</td>
         <td>Duration</td>
         <td>The interval for checking time based rolling policies. This controls the frequency to check whether a part file should rollover based on 'sink.rolling-policy.rollover-interval'.</td>
     </tr>

--- a/docs/dev/table/connectors/filesystem.zh.md
+++ b/docs/dev/table/connectors/filesystem.zh.md
@@ -130,14 +130,14 @@ a timeout that specifies the maximum duration for which a file can be open.
     </tr>
     <tr>
         <td><h5>sink.rolling-policy.rollover-interval</h5></td>
-        <td style="word-wrap: break-word;">30 m</td>
+        <td style="word-wrap: break-word;">30 min</td>
         <td>Duration</td>
         <td>The maximum time duration a part file can stay open before rolling (by default 30 min to avoid to many small files).
         The frequency at which this is checked is controlled by the 'sink.rolling-policy.check-interval' option.</td>
     </tr>
     <tr>
         <td><h5>sink.rolling-policy.check-interval</h5></td>
-        <td style="word-wrap: break-word;">1 m</td>
+        <td style="word-wrap: break-word;">1 min</td>
         <td>Duration</td>
         <td>The interval for checking time based rolling policies. This controls the frequency to check whether a part file should rollover based on 'sink.rolling-policy.rollover-interval'.</td>
     </tr>


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix time duration unit in filesystem doc.


## Brief change log

* This pull request fix time duration unit in filesystem doc from `m` to `min`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)