### PR TITLE
[FLINK-18628][table-common] Fix error message for overloaded function with same parameter names

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -170,7 +170,7 @@ public final class TypeInferenceUtil {
 			TypeInference typeInference,
 			String name,
 			FunctionDefinition definition) {
-		if (typeInference.getNamedArguments().isPresent() || typeInference.getTypedArguments().isPresent()) {
+		if (typeInference.getTypedArguments().isPresent()) {
 			return formatNamedOrTypedArguments(name, typeInference);
 		}
 		return typeInference.getInputTypeStrategy().getExpectedSignatures(definition)

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -582,7 +582,18 @@ public class InputTypeStrategiesTest extends InputTypeStrategiesTestBase {
 								"My constraint says %s must be nullable.",
 								args -> args.get(0).getLogicalType().isNullable()))))
 				.calledWithArgumentTypes(DataTypes.BOOLEAN().notNull())
-				.expectErrorMessage("My constraint says BOOLEAN NOT NULL must be nullable.")
+				.expectErrorMessage("My constraint says BOOLEAN NOT NULL must be nullable."),
+
+			TestSpec
+				.forStrategy(
+					"Same named arguments for overloaded method.",
+					or(
+						sequence(explicit(DataTypes.STRING())),
+						sequence(explicit(DataTypes.INT()))))
+				.namedArguments("sameName")
+				.calledWithArgumentTypes(DataTypes.BOOLEAN())
+				.expectErrorMessage("Invalid input arguments. Expected signatures are:\nf(STRING)\nf(INT)")
+
 		);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes error message for overloaded function with same parameter names.

## Brief change log

- We only print named arguments if there are corresponding typed arguments.

## Verifying this change

This change added tests and can be verified as follows: `InputStrategiesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
