### PR TITLE
[FLINK-18636][rest] Asynchronous close via configurable timeout in seconds for CompletedOperationCache

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
@@ -181,6 +181,14 @@ public class WebOptions {
 		.defaultValue(10L * 60L * 1000L)
 		.withDescription("Timeout for asynchronous operations by the web monitor in milliseconds.");
 
+	/**
+	 * Timeout for asynchronous operation cache close in seconds.
+	 */
+	public static final ConfigOption<Long> OPERATION_CACHE_CLOSE_TIMEOUT =
+		key("web.operation.cache.close.timeout")
+			.defaultValue(5L * 60L)
+			.withDescription("Timeout for asynchronous operation cache close in seconds.");
+
 	// ------------------------------------------------------------------------
 
 	/** Not meant to be instantiated. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -40,12 +40,15 @@ public class RestHandlerConfiguration {
 
 	private final boolean webSubmitEnabled;
 
+	private final long operationCacheCloseTimeout;
+
 	public RestHandlerConfiguration(
 			long refreshInterval,
 			int maxCheckpointStatisticCacheEntries,
 			Time timeout,
 			File webUiDir,
-			boolean webSubmitEnabled) {
+			boolean webSubmitEnabled,
+			long operationCacheCloseTimeout) {
 		Preconditions.checkArgument(refreshInterval > 0L, "The refresh interval (ms) should be larger than 0.");
 		this.refreshInterval = refreshInterval;
 
@@ -54,6 +57,7 @@ public class RestHandlerConfiguration {
 		this.timeout = Preconditions.checkNotNull(timeout);
 		this.webUiDir = Preconditions.checkNotNull(webUiDir);
 		this.webSubmitEnabled = webSubmitEnabled;
+		this.operationCacheCloseTimeout = operationCacheCloseTimeout;
 	}
 
 	public long getRefreshInterval() {
@@ -76,6 +80,10 @@ public class RestHandlerConfiguration {
 		return webSubmitEnabled;
 	}
 
+	public long getOperationCacheCloseTimeout() {
+		return operationCacheCloseTimeout;
+	}
+
 	public static RestHandlerConfiguration fromConfiguration(Configuration configuration) {
 		final long refreshInterval = configuration.getLong(WebOptions.REFRESH_INTERVAL);
 
@@ -88,11 +96,14 @@ public class RestHandlerConfiguration {
 
 		final boolean webSubmitEnabled = configuration.getBoolean(WebOptions.SUBMIT_ENABLE);
 
+		final long operationCacheCloseTimeout = configuration.getLong(WebOptions.OPERATION_CACHE_CLOSE_TIMEOUT);
+
 		return new RestHandlerConfiguration(
 			refreshInterval,
 			maxCheckpointStatisticCacheEntries,
 			timeout,
 			webUiDir,
-			webSubmitEnabled);
+			webSubmitEnabled,
+			operationCacheCloseTimeout);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
@@ -84,7 +84,14 @@ import java.util.concurrent.CompletableFuture;
  */
 public abstract class AbstractAsynchronousOperationHandlers<K extends OperationKey, R> {
 
-	private final CompletedOperationCache<K, R> completedOperationCache = new CompletedOperationCache<>();
+	private final CompletedOperationCache<K, R> completedOperationCache;
+
+	/**
+	 * @param operationCacheCloseTimeout CompletedOperationCache Asynchronous close via configurable timeout in seconds.
+	 */
+	protected AbstractAsynchronousOperationHandlers(long operationCacheCloseTimeout) {
+		this.completedOperationCache = new CompletedOperationCache<>(operationCacheCloseTimeout);
+	}
 
 	/**
 	 * Handler which is responsible for triggering an asynchronous operation. After the operation has

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
@@ -47,6 +47,13 @@ import java.util.concurrent.CompletableFuture;
 public class ClusterDataSetDeleteHandlers extends AbstractAsynchronousOperationHandlers<OperationKey, Void> {
 
 	/**
+	 * @param operationCacheCloseTimeout CompletedOperationCache Asynchronous close via configurable timeout in seconds.
+	 */
+	public ClusterDataSetDeleteHandlers(final long operationCacheCloseTimeout) {
+		super(operationCacheCloseTimeout);
+	}
+
+	/**
 	 * {@link TriggerHandler} implementation for the cluster data set delete operation.
 	 */
 	public class ClusterDataSetDeleteTriggerHandler extends TriggerHandler<RestfulGateway, EmptyRequestBody, ClusterDataSetDeleteTriggerMessageParameters> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingHandlers.java
@@ -43,6 +43,13 @@ import java.util.concurrent.CompletableFuture;
  */
 public class RescalingHandlers extends AbstractAsynchronousOperationHandlers<AsynchronousJobOperationKey, Acknowledge> {
 
+	/**
+	 * @param operationCacheCloseTimeout CompletedOperationCache Asynchronous close via configurable timeout in seconds.
+	 */
+	public RescalingHandlers(final long operationCacheCloseTimeout) {
+		super(operationCacheCloseTimeout);
+	}
+
 	private static RestHandlerException featureDisabledException() {
 		return new RestHandlerException("Rescaling is temporarily disabled. See FLINK-12312.", HttpResponseStatus.SERVICE_UNAVAILABLE);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointDisposalHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointDisposalHandlers.java
@@ -49,6 +49,13 @@ import java.util.concurrent.CompletableFuture;
 public class SavepointDisposalHandlers extends AbstractAsynchronousOperationHandlers<OperationKey, Acknowledge> {
 
 	/**
+	 * @param operationCacheCloseTimeout CompletedOperationCache Asynchronous close via configurable timeout in seconds.
+	 */
+	public SavepointDisposalHandlers(final long operationCacheCloseTimeout) {
+		super(operationCacheCloseTimeout);
+	}
+
+	/**
 	 * {@link TriggerHandler} implementation for the savepoint disposal operation.
 	 */
 	public class SavepointDisposalTriggerHandler extends TriggerHandler<RestfulGateway, SavepointDisposalRequest, EmptyMessageParameters> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -102,7 +102,11 @@ public class SavepointHandlers extends AbstractAsynchronousOperationHandlers<Asy
 	@Nullable
 	private final String defaultSavepointDir;
 
-	public SavepointHandlers(@Nullable final String defaultSavepointDir) {
+	/**
+	 * @param operationCacheCloseTimeout CompletedOperationCache Asynchronous close via configurable timeout in seconds.
+	 */
+	public SavepointHandlers(@Nullable final String defaultSavepointDir, final long operationCacheCloseTimeout) {
+		super(operationCacheCloseTimeout);
 		this.defaultSavepointDir = defaultSavepointDir;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -447,7 +447,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
 		final String defaultSavepointDir = clusterConfiguration.getString(CheckpointingOptions.SAVEPOINT_DIRECTORY);
 
-		final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir);
+		final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir, restConfiguration.getOperationCacheCloseTimeout());
 
 		final SavepointHandlers.StopWithSavepointHandler stopWithSavepointHandler = savepointHandlers.new StopWithSavepointHandler(
 			leaderRetriever,
@@ -492,7 +492,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			executor,
 			metricFetcher);
 
-		final RescalingHandlers rescalingHandlers = new RescalingHandlers();
+		final RescalingHandlers rescalingHandlers = new RescalingHandlers(restConfiguration.getOperationCacheCloseTimeout());
 
 		final RescalingHandlers.RescalingTriggerHandler rescalingTriggerHandler = rescalingHandlers.new RescalingTriggerHandler(
 			leaderRetriever,
@@ -542,7 +542,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			executor,
 			metricFetcher);
 
-		final SavepointDisposalHandlers savepointDisposalHandlers = new SavepointDisposalHandlers();
+		final SavepointDisposalHandlers savepointDisposalHandlers = new SavepointDisposalHandlers(restConfiguration.getOperationCacheCloseTimeout());
 
 		final SavepointDisposalHandlers.SavepointDisposalTriggerHandler savepointDisposalTriggerHandler = savepointDisposalHandlers.new SavepointDisposalTriggerHandler(
 			leaderRetriever,
@@ -555,7 +555,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			responseHeaders);
 
 		final ClusterDataSetListHandler clusterDataSetListHandler = new ClusterDataSetListHandler(leaderRetriever, timeout, responseHeaders, resourceManagerRetriever);
-		final ClusterDataSetDeleteHandlers clusterDataSetDeleteHandlers = new ClusterDataSetDeleteHandlers();
+		final ClusterDataSetDeleteHandlers clusterDataSetDeleteHandlers = new ClusterDataSetDeleteHandlers(restConfiguration.getOperationCacheCloseTimeout());
 		final ClusterDataSetDeleteHandlers.ClusterDataSetDeleteTriggerHandler clusterDataSetDeleteTriggerHandler =
 			clusterDataSetDeleteHandlers.new ClusterDataSetDeleteTriggerHandler(leaderRetriever, timeout, responseHeaders, resourceManagerRetriever);
 		final ClusterDataSetDeleteHandlers.ClusterDataSetDeleteStatusHandler clusterDataSetDeleteStatusHandler =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -75,7 +75,7 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 
 	@Before
 	public void setup() {
-		testingAsynchronousOperationHandlers = new TestingAsynchronousOperationHandlers();
+		testingAsynchronousOperationHandlers = new TestingAsynchronousOperationHandlers(300L);
 
 		testingTriggerHandler = testingAsynchronousOperationHandlers.new TestingTriggerHandler(
 			() -> null,
@@ -333,6 +333,13 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 	}
 
 	private static final class TestingAsynchronousOperationHandlers extends AbstractAsynchronousOperationHandlers<TestOperationKey, String> {
+
+		/**
+		 * @param operationCacheCloseTimeout CompletedOperationCache Asynchronous close via configurable timeout in seconds.
+		 */
+		public TestingAsynchronousOperationHandlers(final long operationCacheCloseTimeout) {
+			super(operationCacheCloseTimeout);
+		}
 
 		class TestingTriggerHandler extends TriggerHandler<RestfulGateway, EmptyRequestBody, EmptyMessageParameters> {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCacheTest.java
@@ -50,7 +50,7 @@ public class CompletedOperationCacheTest extends TestLogger {
 	@Before
 	public void setUp() {
 		manualTicker = new ManualTicker();
-		completedOperationCache = new CompletedOperationCache<>(manualTicker);
+		completedOperationCache = new CompletedOperationCache<>(manualTicker, 300L);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -78,7 +78,7 @@ public class SavepointHandlersTest extends TestLogger {
 	public void setUp() throws Exception {
 		leaderRetriever = () -> CompletableFuture.completedFuture(null);
 
-		final SavepointHandlers savepointHandlers = new SavepointHandlers(null);
+		final SavepointHandlers savepointHandlers = new SavepointHandlers(null, 300L);
 		savepointTriggerHandler = savepointHandlers.new SavepointTriggerHandler(
 			leaderRetriever,
 			TIMEOUT,
@@ -125,7 +125,7 @@ public class SavepointHandlersTest extends TestLogger {
 				})
 			.build();
 		final String defaultSavepointDir = "/other/dir";
-		final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir);
+		final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir, 300L);
 		final SavepointHandlers.SavepointTriggerHandler savepointTriggerHandler = savepointHandlers.new SavepointTriggerHandler(
 			leaderRetriever,
 			TIMEOUT,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
@@ -80,7 +80,7 @@ public class StopWithSavepointHandlersTest extends TestLogger {
 	public void setUp() throws Exception {
 		leaderRetriever = () -> CompletableFuture.completedFuture(null);
 
-		final SavepointHandlers savepointHandlers = new SavepointHandlers(null);
+		final SavepointHandlers savepointHandlers = new SavepointHandlers(null, 300L);
 		savepointTriggerHandler = savepointHandlers.new StopWithSavepointHandler(
 				leaderRetriever,
 				TIMEOUT,
@@ -127,7 +127,7 @@ public class StopWithSavepointHandlersTest extends TestLogger {
 						})
 				.build();
 		final String defaultSavepointDir = "/other/dir";
-		final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir);
+		final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir, 300L);
 		final SavepointHandlers.StopWithSavepointHandler savepointTriggerHandler = savepointHandlers.new StopWithSavepointHandler(
 				leaderRetriever,
 				TIMEOUT,


### PR DESCRIPTION
## What is the purpose of the change

When flink job canceled/failed ,it need to wait all closeAsync finish.
but CompletedOperationCache’s closeAsync timeout is fixed at 300s,
so i think via configurable timeout is better.

## Brief change log

add `web.operation.cache.close.timeout` for CompletedOperationCache’s closeAsync timeout 

## Verifying this change

no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
