### PR TITLE
[FLINK-18639][scripts] Print raw output from BashJavaUtils in case of execution failure.

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -553,6 +553,8 @@ parseJmJvmArgsAndExportLogs() {
 
   if [[ $? -ne 0 ]]; then
     echo "[ERROR] Could not get JVM parameters and dynamic configurations properly."
+    echo "[ERROR] Raw output from BashJavaUtils:"
+    echo "$java_utils_output"
     exit 1
   fi
 

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -55,6 +55,8 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 
     if [[ $? -ne 0 ]]; then
         echo "[ERROR] Could not get JVM parameters and dynamic configurations properly."
+        echo "[ERROR] Raw output from BashJavaUtils:"
+        echo "$java_utils_output"
         exit 1
     fi
 


### PR DESCRIPTION
This PR fixes the problem that error messages from BashJavaUtils are not printed.