### PR TITLE
[FLINK-18596] [table] Derive format schema from table schema may get error result

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TableFormatFactoryBaseTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TableFormatFactoryBaseTest.java
@@ -19,7 +19,10 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.Rowtime;
+import org.apache.flink.table.descriptors.Schema;
 
 import org.junit.Test;
 
@@ -79,6 +82,25 @@ public class TableFormatFactoryBaseTest {
 			.field("csvField", Types.STRING) // aliased
 			.field("abcField", Types.STRING)
 			.field("myTime", Types.SQL_TIMESTAMP)
+			.build();
+		assertEquals(expectedSchema, actualSchema);
+	}
+
+	@Test
+	public void testSchemaDerivationWithRowtimeFromExistField() {
+		Schema schema = new Schema()
+			.field("f1", DataTypes.STRING())
+			.field("f2", DataTypes.BIGINT()).from("t")
+			.field("r", DataTypes.TIMESTAMP(3))
+			.rowtime(
+				new Rowtime().timestampsFromField("t").watermarksPeriodicBounded(3));
+
+		final Map<String, String> properties = schema.toProperties();
+
+		final TableSchema actualSchema = TableFormatFactoryBase.deriveSchema(properties);
+		final TableSchema expectedSchema = TableSchema.builder()
+			.field("f1", Types.STRING)
+			.field("t", Types.LONG)
 			.build();
 		assertEquals(expectedSchema, actualSchema);
 	}


### PR DESCRIPTION
## What is the purpose of the change

If rowtime attribute references a regular field, derive format schema from table schema may get error result. This pull request fixs this problem.

## Verifying this change

This change added tests and can be verified as follows:
  - Add test case *TableFormatFactoryBaseTest#testSchemaDerivationWithRowtimeFromExistField*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
