### PR TITLE
[FLINK-18655][flink-runtime] Set failOnUnableToExtractRepoInfo to false for git-commit-id-plugin

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -503,6 +503,7 @@ under the License.
 					<dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
 					<skipPoms>false</skipPoms>
 					<failOnNoGitDirectory>false</failOnNoGitDirectory>
+					<failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
 					<gitDescribe>
 						<!-- Don't generate the describe property -->
 						<!-- It is useless due to the way Flink does branches and tags -->


### PR DESCRIPTION

## What is the purpose of the change

This pull request sets failOnUnableToExtractRepoInfo to false for git-commit-id-plugin in module flink-runtime. More details can be found in the jira description: FLINK-18655.

