### PR TITLE
[FLINK-18629] Add type to ConnectedStreams#keyBy

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
@@ -188,7 +188,9 @@ public class ConnectedStreams<IN1, IN2> {
 	 *            The {@link KeySelector} used for grouping the second input
 	 * @return The partitioned {@link ConnectedStreams}
 	 */
-	public ConnectedStreams<IN1, IN2> keyBy(KeySelector<IN1, ?> keySelector1, KeySelector<IN2, ?> keySelector2) {
+	public <KEY> ConnectedStreams<IN1, IN2> keyBy(
+			KeySelector<IN1, KEY> keySelector1,
+			KeySelector<IN2, KEY> keySelector2) {
 		return new ConnectedStreams<>(environment, inputStream1.keyBy(keySelector1),
 				inputStream2.keyBy(keySelector2));
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/IterativeStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/IterativeStream.java
@@ -202,7 +202,7 @@ public class IterativeStream<T> extends SingleOutputStreamOperator<T> {
 		}
 
 		@Override
-		public ConnectedStreams<I, F> keyBy(KeySelector<I, ?> keySelector1, KeySelector<F, ?> keySelector2) {
+		public <KEY> ConnectedStreams<I, F> keyBy(KeySelector<I, KEY> keySelector1, KeySelector<F, KEY> keySelector2) {
 			throw groupingException;
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -96,9 +97,11 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1024,6 +1027,22 @@ public class DataStreamTest extends TestLogger {
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
+	}
+
+	@Test
+	public void testKeyedConnectedStreamsType() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStreamSource<Integer> stream1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> stream2 = env.fromElements(1, 2);
+
+		ConnectedStreams<Integer, Integer> connectedStreams = stream1.connect(stream2)
+			.keyBy(v -> v, v -> v);
+
+		KeyedStream<?, ?> firstKeyedInput = (KeyedStream<?, ?>) connectedStreams.getFirstInput();
+		KeyedStream<?, ?> secondKeyedInput = (KeyedStream<?, ?>) connectedStreams.getSecondInput();
+		assertThat(firstKeyedInput.getKeyType(), equalTo(Types.INT));
+		assertThat(secondKeyedInput.getKeyType(), equalTo(Types.INT));
 	}
 
 	@Test

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -261,6 +261,7 @@ under the License.
 							Can be removed once https://github.com/siom79/japicmp/issues/176 will be fixed -->
 							<exclude>org.apache.flink.streaming.api.scala.DataStream#iterate\$default\$3()</exclude>
 							<exclude>org.apache.flink.streaming.api.scala.DataStream#assignTimestamps(org.apache.flink.streaming.api.functions.TimestampExtractor)</exclude>
+							<exclude>org.apache.flink.streaming.api.scala.ConnectedStreams#keyBy(scala.Function1,scala.Function1,org.apache.flink.api.common.typeinfo.TypeInformation,org.apache.flink.api.common.typeinfo.TypeInformation)</exclude>
 						</excludes>
 					</parameter>
 				</configuration>

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnConnectedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnConnectedStream.scala
@@ -72,7 +72,7 @@ class OnConnectedStream[IN1, IN2](stream: ConnectedStreams[IN1, IN2]) {
     * @return The key-grouped connected streams
     */
   @PublicEvolving
-  def keyingBy[K1: TypeInformation, K2: TypeInformation](key1: IN1 => K1, key2: IN2 => K2):
+  def keyingBy[KEY: TypeInformation](key1: IN1 => KEY, key2: IN2 => KEY):
       ConnectedStreams[IN1, IN2] =
     stream.keyBy(key1, key2)
 


### PR DESCRIPTION
## What is the purpose of the change

Adding a generic type to the method makes it possible to pass the type
from a lambda function. Otherwise a wildcard type '?' is derived as
Object and thus TypeExtractor extract a GenericTypeInfo<Object> for the
key.

## Brief change log

* Changed method ConnctedStream#keyBy to accept `KeySelector` of the same generic type in both scala and java API
* Replaced an internal KeySelectorWithType class in scala API with explicitly passing the keyType to the underlying java API.

## Verifying this change

Added test:
* `DataStreamTest#testKeyedConnectedStreamsType`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (**yes** / no / don't know) -> can change serializer for keys in StateBackends
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
