### PR TITLE
[FLINK-18658][tests] Forward RpcServiceSharing setting

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -172,6 +172,7 @@ public class MiniClusterResource extends ExternalResource {
 			.setConfiguration(configuration)
 			.setNumTaskManagers(miniClusterResourceConfiguration.getNumberTaskManagers())
 			.setNumSlotsPerTaskManager(miniClusterResourceConfiguration.getNumberSlotsPerTaskManager())
+			.setRpcServiceSharing(miniClusterResourceConfiguration.getRpcServiceSharing())
 			.build();
 
 		miniCluster = new MiniCluster(miniClusterConfiguration);


### PR DESCRIPTION
Fixes a tiny issue where the `MiniClusterResource` was not properly forwarding a setting from the `MiniClusterResourceConfiguration` to the `MiniClusterConfiguration`.