### PR TITLE
[FLINK-18663][rest] Fix AbstractHandler throw NPE cause by FlinkHttpObjectAggregator is null

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -79,6 +79,12 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 	 */
 	private static final int OTHER_RESP_PAYLOAD_OVERHEAD = 1024;
 
+	/**
+	 * default is {@link org.apache.flink.configuration.RestOptions#SERVER_MAX_CONTENT_LENGTH} - {@link AbstractHandler#OTHER_RESP_PAYLOAD_OVERHEAD}
+	 * if FlinkHttpObjectAggregator is null use this value.
+	 */
+	private static final int REST_SERVER_MAX_CONTENT_LENGTH_DEFAULT = 104856576;
+
 	private final UntypedResponseMessageHeaders<R, M> untypedResponseMessageHeaders;
 
 	/**
@@ -199,7 +205,10 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 
 	private CompletableFuture<Void> handleException(Throwable throwable, ChannelHandlerContext ctx, HttpRequest httpRequest) {
 		FlinkHttpObjectAggregator flinkHttpObjectAggregator = ctx.pipeline().get(FlinkHttpObjectAggregator.class);
-		int maxLength = flinkHttpObjectAggregator.maxContentLength() - OTHER_RESP_PAYLOAD_OVERHEAD;
+		int maxLength = REST_SERVER_MAX_CONTENT_LENGTH_DEFAULT;
+		if (null != flinkHttpObjectAggregator) {
+			maxLength = flinkHttpObjectAggregator.maxContentLength() - OTHER_RESP_PAYLOAD_OVERHEAD;
+		}
 		if (throwable instanceof RestHandlerException) {
 			RestHandlerException rhe = (RestHandlerException) throwable;
 			String stackTrace = ExceptionUtils.stringifyException(rhe);


### PR DESCRIPTION
## What is the purpose of the change

Fix AbstractHandler throw NPE cause by FlinkHttpObjectAggregator is null

## Brief change log

if FlinkHttpObjectAggregator is null use the ```REST_SERVER_MAX_CONTENT_LENGTH_DEFAULT``` as ```maxLength```

## Verifying this change

no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
