### PR TITLE
[FLINK-18665][filesystem] Filesystem connector should use TableSchema exclude computed columns.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -73,7 +73,8 @@ trait FileSystemITCaseBase {
          |  x string,
          |  y int,
          |  a int,
-         |  b bigint
+         |  b bigint,
+         |  c as b + 1
          |) partitioned by (a, b) with (
          |  'connector' = 'filesystem',
          |  'path' = '$resultPath',
@@ -183,6 +184,11 @@ trait FileSystemITCaseBase {
     check(
       "select x, y from partitionedTable where a=2 and b=1",
       data_partition_2_1
+    )
+
+    check(
+      "select x, y, a, b, c from partitionedTable where a=1 and c=2",
+      data_partition_1_2
     )
 
     check(
@@ -350,5 +356,13 @@ object FileSystemITCaseBase {
     row("x13", 13),
     row("x14", 14),
     row("x15", 15)
+  )
+
+  val data_partition_1_2: Seq[Row] = Seq(
+    row("x1", 1, 1, 1, 2),
+    row("x2", 2, 1, 1, 2),
+    row("x3", 3, 1, 1, 2),
+    row("x4", 4, 1, 1, 2),
+    row("x5", 5, 1, 1, 2)
   )
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.utils.TableSchemaUtils;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,7 +76,7 @@ public class FileSystemTableFactory implements
 		context.getTable().getOptions().forEach(conf::setString);
 
 		return new FileSystemTableSource(
-				context.getTable().getSchema(),
+				TableSchemaUtils.getPhysicalSchema(context.getTable().getSchema()),
 				getPath(conf),
 				context.getTable().getPartitionKeys(),
 				conf.get(PARTITION_DEFAULT_NAME),
@@ -90,7 +91,7 @@ public class FileSystemTableFactory implements
 		return new FileSystemTableSink(
 				context.getObjectIdentifier(),
 				context.isBounded(),
-				context.getTable().getSchema(),
+				TableSchemaUtils.getPhysicalSchema(context.getTable().getSchema()),
 				getPath(conf),
 				context.getTable().getPartitionKeys(),
 				conf.get(PARTITION_DEFAULT_NAME),


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix filesystem connector does not use TableSchema that exclude computed columns..


## Brief change log

  - Use TableSchemaUtils to get physical schema in FileSystemTableFactory


## Verifying this change

- Add test in existed ITCase(FileSystemITCaseBase).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

