### PR TITLE
[FLINK-18625][runtime] Maintain redundant taskmanagers to speed up failover

### DIFF
--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -38,5 +38,11 @@
             <td>Integer</td>
             <td>Defines the maximum number of slots that the Flink cluster allocates. This configuration option is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
         </tr>
+        <tr>
+            <td><h5>slotmanager.redundant-taskmanager-num</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The number of redundant task managers. Redundant task managers are extra task managers started by Flink, in order to speed up job recovery in case of failures due to task manager lost. Note that this feature is available only to the active deployments (native K8s, Yarn and Mesos).</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -68,6 +68,19 @@ public class ResourceManagerOptions {
 			"effect for standalone clusters, where how many slots are allocated is not controlled by Flink.");
 
 	/**
+	 * The number of redundant task managers. Redundant task managers are extra task managers started by Flink,
+	 * in order to speed up job recovery in case of failures due to task manager lost.
+	 * Note that this feature is available only to the active deployments (native K8s, Yarn and Mesos).
+	 */
+	public static final ConfigOption<Integer> REDUNDANT_TASK_MANAGER_NUM = ConfigOptions
+		.key("slotmanager.redundant-taskmanager-num")
+		.intType()
+		.defaultValue(0)
+		.withDescription("The number of redundant task managers. Redundant task managers are extra task managers " +
+			"started by Flink, in order to speed up job recovery in case of failures due to task manager lost. " +
+			"Note that this feature is available only to the active deployments (native K8s, Yarn and Mesos).");
+
+	/**
 	 * The timeout for a slot request to be discarded, in milliseconds.
 	 * @deprecated Use {@link JobManagerOptions#SLOT_REQUEST_TIMEOUT}.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -48,6 +48,7 @@ public class SlotManagerConfiguration {
 	private final WorkerResourceSpec defaultWorkerResourceSpec;
 	private final int numSlotsPerWorker;
 	private final int maxSlotNum;
+	private final int redundantTaskManagerNum;
 
 	public SlotManagerConfiguration(
 			Time taskManagerRequestTimeout,
@@ -57,7 +58,8 @@ public class SlotManagerConfiguration {
 			SlotMatchingStrategy slotMatchingStrategy,
 			WorkerResourceSpec defaultWorkerResourceSpec,
 			int numSlotsPerWorker,
-			int maxSlotNum) {
+			int maxSlotNum,
+			int redundantTaskManagerNum) {
 
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
@@ -69,6 +71,8 @@ public class SlotManagerConfiguration {
 		Preconditions.checkState(maxSlotNum > 0);
 		this.numSlotsPerWorker = numSlotsPerWorker;
 		this.maxSlotNum = maxSlotNum;
+		Preconditions.checkState(redundantTaskManagerNum >= 0);
+		this.redundantTaskManagerNum = redundantTaskManagerNum;
 	}
 
 	public Time getTaskManagerRequestTimeout() {
@@ -103,6 +107,10 @@ public class SlotManagerConfiguration {
 		return maxSlotNum;
 	}
 
+	public int getRedundantTaskManagerNum() {
+		return redundantTaskManagerNum;
+	}
+
 	public static SlotManagerConfiguration fromConfiguration(
 			Configuration configuration,
 			WorkerResourceSpec defaultWorkerResourceSpec) throws ConfigurationException {
@@ -130,6 +138,8 @@ public class SlotManagerConfiguration {
 
 		int maxSlotNum = configuration.getInteger(ResourceManagerOptions.MAX_SLOT_NUM);
 
+		int redundantTaskManagerNum = configuration.getInteger(ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM);
+
 		return new SlotManagerConfiguration(
 			rpcTimeout,
 			slotRequestTimeout,
@@ -138,7 +148,8 @@ public class SlotManagerConfiguration {
 			slotMatchingStrategy,
 			defaultWorkerResourceSpec,
 			numSlotsPerWorker,
-			maxSlotNum);
+			maxSlotNum,
+			redundantTaskManagerNum);
 	}
 
 	private static Time getSlotRequestTimeout(final Configuration configuration) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -76,7 +76,8 @@ public class ResourceManagerHATest extends TestLogger {
 				AnyMatchingSlotMatchingStrategy.INSTANCE,
 				WorkerResourceSpec.ZERO,
 				1,
-				ResourceManagerOptions.MAX_SLOT_NUM.defaultValue()));
+				ResourceManagerOptions.MAX_SLOT_NUM.defaultValue(),
+				ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue()));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -40,6 +40,7 @@ public class SlotManagerBuilder {
 	private int numSlotsPerWorker;
 	private SlotManagerMetricGroup slotManagerMetricGroup;
 	private int maxSlotNum;
+	private int redundantTaskManagerNum;
 
 	private SlotManagerBuilder() {
 		this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -52,6 +53,7 @@ public class SlotManagerBuilder {
 		this.numSlotsPerWorker = 1;
 		this.slotManagerMetricGroup = UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
 		this.maxSlotNum = ResourceManagerOptions.MAX_SLOT_NUM.defaultValue();
+		this.redundantTaskManagerNum = ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue();
 	}
 
 	public static SlotManagerBuilder newBuilder() {
@@ -108,6 +110,11 @@ public class SlotManagerBuilder {
 		return this;
 	}
 
+	public SlotManagerBuilder setRedundantTaskManagerNum(int redundantTaskManagerNum) {
+		this.redundantTaskManagerNum = redundantTaskManagerNum;
+		return this;
+	}
+
 	public SlotManagerImpl build() {
 		final SlotManagerConfiguration slotManagerConfiguration = new SlotManagerConfiguration(
 			taskManagerRequestTimeout,
@@ -117,7 +124,8 @@ public class SlotManagerBuilder {
 			slotMatchingStrategy,
 			defaultWorkerResourceSpec,
 			numSlotsPerWorker,
-			maxSlotNum);
+			maxSlotNum,
+			redundantTaskManagerNum);
 
 		return new SlotManagerImpl(
 			scheduledExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -908,6 +908,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		try (final SlotManagerImpl slotManager = createSlotManagerBuilder()
 			.setTaskManagerTimeout(Time.of(taskManagerTimeout, TimeUnit.MILLISECONDS))
+			.setRedundantTaskManagerNum(0)
 			.build()) {
 
 			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
@@ -976,6 +977,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 		try (final SlotManager slotManager = createSlotManagerBuilder()
 			.setTaskManagerTimeout(taskManagerTimeout)
+			.setRedundantTaskManagerNum(0)
 			.buildAndStartWithDirectExec(resourceManagerId, resourceActions)) {
 
 			slotManager.registerTaskManager(taskExecutorConnection, initialSlotReport);
@@ -1299,6 +1301,7 @@ public class SlotManagerImplTest extends TestLogger {
 	private SlotManagerImpl createSlotManager(ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions, int numSlotsPerWorker) {
 		SlotManagerImpl slotManager = createSlotManagerBuilder()
 			.setNumSlotsPerWorker(numSlotsPerWorker)
+			.setRedundantTaskManagerNum(0)
 			.buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions);
 		return slotManager;
 	}
@@ -1595,6 +1598,7 @@ public class SlotManagerImplTest extends TestLogger {
 		try (SlotManagerImpl slotManager = createSlotManagerBuilder()
 			.setNumSlotsPerWorker(numberSlots)
 			.setMaxSlotNum(maxSlotNum)
+			.setRedundantTaskManagerNum(0)
 			.buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions)) {
 			slotManager.registerTaskManager(taskManagerConnection1, slotReport1);
 			slotManager.registerTaskManager(taskManagerConnection2, slotReport2);


### PR DESCRIPTION
## What is the purpose of the change

When flink job fails because of killed taskmanagers, it will request new containers when restarting. Requesting new containers can be very slow, sometimes it takes dozens of seconds even more. The reasons can be different, for example, yarn and hdfs are slow, machine performance is poor.  

To speed up the failover process, we can maintain redundant slots. Once job restarts, it can use the redundant slots at once instead of requesting new taskmanagers.


## Brief change log
  - *Add config slotmanager.redundant-slot-num in ResourceManagerOptions*
  - *Allocate redundant slots when start SlotManagerImpl*
  - *Change method taskManagerTimeoutCheck to checkValidTaskManagers*
  - *In method checkValidTaskManagers, maintain enough redundant slots. Under this premise, release timeout taskmanager*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add test case in SlotManagerImplTest*
  - *Change class TaskManagerReleaseInSlotManagerTest to TaskManagerValidateInSlotManagerTest and add tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
