### PR TITLE
[FLINK-15803][table] Unify validation for all kinds of UDFs

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.functions.AggregateFunction;
@@ -36,7 +37,7 @@ import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.
 /**
  * built-in LastValue aggregate function.
  */
-public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRowData> {
+public class LastValueAggFunction<T> extends AggregateFunction<T, RowData> {
 
 	@Override
 	public boolean isDeterministic() {
@@ -44,7 +45,7 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRowData
 	}
 
 	@Override
-	public GenericRowData createAccumulator() {
+	public RowData createAccumulator() {
 		// The accumulator schema:
 		// lastValue: T
 		// lastOrder: Long
@@ -54,31 +55,36 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRowData
 		return acc;
 	}
 
-	public void accumulate(GenericRowData acc, Object value) {
+	public void accumulate(RowData rowData, Object value) {
+		GenericRowData acc = (GenericRowData) rowData;
 		if (value != null) {
 			acc.setField(0, value);
 		}
 	}
 
-	public void accumulate(GenericRowData acc, Object value, Long order) {
+	public void accumulate(RowData rowData, Object value, Long order) {
+		GenericRowData acc = (GenericRowData) rowData;
 		if (value != null && acc.getLong(1) < order) {
 			acc.setField(0, value);
 			acc.setField(1, order);
 		}
 	}
 
-	public void resetAccumulator(GenericRowData acc) {
+	public void resetAccumulator(RowData rowData) {
+		GenericRowData acc = (GenericRowData) rowData;
 		acc.setField(0, null);
 		acc.setField(1, Long.MIN_VALUE);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public T getValue(GenericRowData acc) {
+	public T getValue(RowData rowData) {
+		GenericRowData acc = (GenericRowData) rowData;
 		return (T) acc.getField(0);
 	}
 
 	@Override
-	public TypeInformation<GenericRowData> getAccumulatorType() {
+	public TypeInformation<RowData> getAccumulatorType() {
 		LogicalType[] fieldTypes = new LogicalType[] {
 				fromTypeInfoToLogicalType(getResultType()),
 				new BigIntType()
@@ -89,7 +95,7 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, GenericRowData
 				"time"
 		};
 
-		return (TypeInformation) InternalTypeInfo.ofFields(fieldTypes, fieldNames);
+		return InternalTypeInfo.ofFields(fieldTypes, fieldNames);
 	}
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.dataview.MapViewSerializer;
@@ -58,10 +59,10 @@ import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.
 /**
  * built-in LastValue with retraction aggregate function.
  */
-public abstract class LastValueWithRetractAggFunction<T> extends AggregateFunction<T, GenericRowData> {
+public abstract class LastValueWithRetractAggFunction<T> extends AggregateFunction<T, RowData> {
 
 	@Override
-	public GenericRowData createAccumulator() {
+	public RowData createAccumulator() {
 		// The accumulator schema:
 		// lastValue: T
 		// lastOrder: Long
@@ -77,7 +78,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 		return acc;
 	}
 
-	public void accumulate(GenericRowData acc, Object value) throws Exception {
+	public void accumulate(RowData rowData, Object value) throws Exception {
+		GenericRowData acc = (GenericRowData) rowData;
 		if (value != null) {
 			T v = (T) value;
 			Long order = System.currentTimeMillis();
@@ -92,7 +94,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 		}
 	}
 
-	public void accumulate(GenericRowData acc, Object value, Long order) throws Exception {
+	public void accumulate(RowData rowData, Object value, Long order) throws Exception {
+		GenericRowData acc = (GenericRowData) rowData;
 		if (value != null) {
 			T v = (T) value;
 			Long prevOrder = (Long) acc.getField(1);
@@ -111,7 +114,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 		}
 	}
 
-	public void retract(GenericRowData acc, Object value) throws Exception {
+	public void retract(RowData rowData, Object value) throws Exception {
+		GenericRowData acc = (GenericRowData) rowData;
 		if (value != null) {
 			T v = (T) value;
 			MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
@@ -129,7 +133,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 		}
 	}
 
-	public void retract(GenericRowData acc, Object value, Long order) throws Exception {
+	public void retract(RowData rowData, Object value, Long order) throws Exception {
+		GenericRowData acc = (GenericRowData) rowData;
 		if (value != null) {
 			T v = (T) value;
 			MapView<Long, List<T>> orderToValueMapView = getOrderToValueMapViewFromAcc(acc);
@@ -170,7 +175,8 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 		}
 	}
 
-	public void resetAccumulator(GenericRowData acc) {
+	public void resetAccumulator(RowData rowData) {
+		GenericRowData acc = (GenericRowData) rowData;
 		acc.setField(0, null);
 		acc.setField(1, null);
 		MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
@@ -180,14 +186,15 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 	}
 
 	@Override
-	public T getValue(GenericRowData acc) {
+	public T getValue(RowData rowData) {
+		GenericRowData acc = (GenericRowData) rowData;
 		return (T) acc.getField(0);
 	}
 
 	protected abstract TypeSerializer<T> createValueSerializer();
 
 	@Override
-	public TypeInformation<GenericRowData> getAccumulatorType() {
+	public TypeInformation<RowData> getAccumulatorType() {
 		LogicalType[] fieldTypes = new LogicalType[] {
 				fromTypeInfoToLogicalType(getResultType()),
 				new BigIntType(),
@@ -202,7 +209,7 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 				"orderToValueMapView"
 		};
 
-		return (TypeInformation) InternalTypeInfo.ofFields(fieldTypes, fieldNames);
+		return InternalTypeInfo.ofFields(fieldTypes, fieldNames);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/aggregation.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/aggregation.scala
@@ -33,6 +33,7 @@ import scala.collection.mutable.ArrayBuffer
   * @param function AggregateFunction or DeclarativeAggregateFunction
   * @param aggIndex the index of the aggregate call in the aggregation list
   * @param argIndexes the aggregate arguments indexes in the input
+  * @param externalArgTypes  input types
   * @param externalAccTypes  accumulator types
   * @param viewSpecs  data view specs
   * @param externalResultType the result type of aggregate
@@ -43,6 +44,7 @@ case class AggregateInfo(
     function: UserDefinedFunction,
     aggIndex: Int,
     argIndexes: Array[Int],
+    externalArgTypes: Array[DataType],
     externalAccTypes: Array[DataType],
     viewSpecs: Array[DataViewSpec],
     externalResultType: DataType,

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggFunctionWithOrderTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggFunctionWithOrderTestBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils;
 import org.apache.flink.util.Preconditions;
@@ -34,7 +35,7 @@ import java.util.List;
  * Base test case for built-in FirstValue and LastValue (with retreat) aggregate function.
  * This class tests `accumulate` method with order argument.
  */
-public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggFunctionTestBase<T, GenericRowData> {
+public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggFunctionTestBase<T, RowData> {
 
 	protected Method getAccumulateFunc() throws NoSuchMethodException {
 		return getAggregator().getClass().getMethod("accumulate", getAccClass(), Object.class, Long.class);
@@ -42,7 +43,7 @@ public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggF
 
 	@Override
 	protected Class<?> getAccClass() {
-		return GenericRowData.class;
+		return RowData.class;
 	}
 
 	protected abstract List<List<Long>> getInputOrderSets();
@@ -59,20 +60,20 @@ public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggF
 				"The number of inputValueSets is not same with the number of inputOrderSets");
 		Preconditions.checkArgument(inputValueSets.size() == expectedResults.size(),
 				"The number of inputValueSets is not same with the number of expectedResults");
-		AggregateFunction<T, GenericRowData> aggregator = getAggregator();
+		AggregateFunction<T, RowData> aggregator = getAggregator();
 		int size = getInputValueSets().size();
 		// iterate over input sets
 		for (int i = 0; i < size; ++i) {
 			List<T> inputValues = inputValueSets.get(i);
 			List<Long> inputOrders = inputOrderSets.get(i);
 			T expected = expectedResults.get(i);
-			GenericRowData acc = accumulateValues(inputValues, inputOrders);
+			RowData acc = accumulateValues(inputValues, inputOrders);
 			T result = aggregator.getValue(acc);
 			validateResult(expected, result, aggregator.getResultType());
 
 			if (UserDefinedFunctionUtils.ifMethodExistInFunction("retract", aggregator)) {
 				retractValues(acc, inputValues, inputOrders);
-				GenericRowData expectedAcc = aggregator.createAccumulator();
+				RowData expectedAcc = aggregator.createAccumulator();
 				// The two accumulators should be exactly same
 				validateResult(expectedAcc, acc, aggregator.getAccumulatorType());
 			}
@@ -82,7 +83,7 @@ public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggF
 	@Test
 	@Override
 	public void testResetAccumulator() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-		AggregateFunction<T, GenericRowData> aggregator = getAggregator();
+		AggregateFunction<T, RowData> aggregator = getAggregator();
 		if (UserDefinedFunctionUtils.ifMethodExistInFunction("resetAccumulator", aggregator)) {
 			Method resetAccFunc = aggregator.getClass().getMethod("resetAccumulator", getAccClass());
 
@@ -98,26 +99,25 @@ public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggF
 			for (int i = 0; i < size; ++i) {
 				List<T> inputValues = inputValueSets.get(i);
 				List<Long> inputOrders = inputOrderSets.get(i);
-				T expected = expectedResults.get(i);
-				GenericRowData acc = accumulateValues(inputValues, inputOrders);
-				resetAccFunc.invoke(aggregator, (Object) acc);
-				GenericRowData expectedAcc = aggregator.createAccumulator();
+				RowData acc = accumulateValues(inputValues, inputOrders);
+				resetAccFunc.invoke(aggregator, acc);
+				RowData expectedAcc = aggregator.createAccumulator();
 				//The accumulator after reset should be exactly same as the new accumulator
 				validateResult(expectedAcc, acc, aggregator.getAccumulatorType());
 			}
 		}
 	}
 
-	protected GenericRowData accumulateValues(List<T> values, List<Long> orders)
+	protected RowData accumulateValues(List<T> values, List<Long> orders)
 			throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 		Preconditions.checkArgument(values.size() == orders.size(),
 				"The number of values is not same with the number of orders, " +
 						"\nvalues: " + values + "\norders: " + orders);
-		AggregateFunction<T, GenericRowData> aggregator = getAggregator();
-		GenericRowData accumulator = getAggregator().createAccumulator();
+		AggregateFunction<T, RowData> aggregator = getAggregator();
+		RowData accumulator = getAggregator().createAccumulator();
 		Method accumulateFunc = getAccumulateFunc();
 		for (int i = 0; i < values.size(); ++i) {
-			accumulateFunc.invoke(aggregator, (Object) accumulator, (Object) values.get(i), orders.get(i));
+			accumulateFunc.invoke(aggregator, accumulator, values.get(i), orders.get(i));
 		}
 		return accumulator;
 	}
@@ -127,20 +127,20 @@ public abstract class FirstLastValueAggFunctionWithOrderTestBase<T> extends AggF
 		throw new TableException("Should not call this method");
 	}
 
-	protected void retractValues(GenericRowData accumulator, List<T> values, List<Long> orders)
+	protected void retractValues(RowData accumulator, List<T> values, List<Long> orders)
 			throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 		Preconditions.checkArgument(values.size() == orders.size(),
 				"The number of values is not same with the number of orders, " +
 						"\nvalues: " + values + "\norders: " + orders);
-		AggregateFunction<T, GenericRowData> aggregator = getAggregator();
+		AggregateFunction<T, RowData> aggregator = getAggregator();
 		Method retractFunc = getRetractFunc();
 		for (int i = 0; i < values.size(); ++i) {
-			retractFunc.invoke(aggregator, (Object) accumulator, (Object) values.get(i), orders.get(i));
+			retractFunc.invoke(aggregator, accumulator, values.get(i), orders.get(i));
 		}
 	}
 
 	@Override
-	protected void retractValues(GenericRowData accumulator, List<T> values) {
+	protected void retractValues(RowData accumulator, List<T> values) {
 		throw new TableException("Should not call this method");
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.BooleanFirstValueAggFunction;
@@ -67,7 +67,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteFirstValueAggFunction();
 		}
 	}
@@ -84,7 +84,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortFirstValueAggFunction();
 		}
 	}
@@ -101,7 +101,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntFirstValueAggFunction();
 		}
 	}
@@ -118,7 +118,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongFirstValueAggFunction();
 		}
 	}
@@ -135,7 +135,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatFirstValueAggFunction();
 		}
 	}
@@ -152,7 +152,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleFirstValueAggFunction();
 		}
 	}
@@ -242,7 +242,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanFirstValueAggFunction();
 		}
 	}
@@ -322,7 +322,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalFirstValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -400,7 +400,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringFirstValueAggFunction();
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.BooleanFirstValueAggFunction;
@@ -66,7 +66,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteFirstValueAggFunction();
 		}
 	}
@@ -83,7 +83,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortFirstValueAggFunction();
 		}
 	}
@@ -100,7 +100,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntFirstValueAggFunction();
 		}
 	}
@@ -117,7 +117,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongFirstValueAggFunction();
 		}
 	}
@@ -134,7 +134,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatFirstValueAggFunction();
 		}
 	}
@@ -151,7 +151,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleFirstValueAggFunction();
 		}
 	}
@@ -207,7 +207,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanFirstValueAggFunction();
 		}
 	}
@@ -259,7 +259,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalFirstValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -309,7 +309,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringFirstValueAggFunction();
 		}
 	}
@@ -325,10 +325,10 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 	 * The base test class for FirstValueAggFunction without order.
 	 */
 	public abstract static class FirstValueAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, GenericRowData> {
+		extends AggFunctionTestBase<T, RowData> {
 		@Override
 		protected Class<?> getAccClass() {
-			return GenericRowData.class;
+			return RowData.class;
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.BooleanFirstValueWithRetractAggFunction;
@@ -68,7 +68,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteFirstValueWithRetractAggFunction();
 		}
 	}
@@ -85,7 +85,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortFirstValueWithRetractAggFunction();
 		}
 	}
@@ -102,7 +102,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntFirstValueWithRetractAggFunction();
 		}
 	}
@@ -119,7 +119,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongFirstValueWithRetractAggFunction();
 		}
 	}
@@ -136,7 +136,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatFirstValueWithRetractAggFunction();
 		}
 	}
@@ -153,7 +153,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleFirstValueWithRetractAggFunction();
 		}
 	}
@@ -243,7 +243,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanFirstValueWithRetractAggFunction();
 		}
 	}
@@ -323,7 +323,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalFirstValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -401,7 +401,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringFirstValueWithRetractAggFunction();
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.BooleanFirstValueWithRetractAggFunction;
@@ -67,7 +67,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteFirstValueWithRetractAggFunction();
 		}
 	}
@@ -84,7 +84,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortFirstValueWithRetractAggFunction();
 		}
 	}
@@ -101,7 +101,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntFirstValueWithRetractAggFunction();
 		}
 	}
@@ -118,7 +118,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongFirstValueWithRetractAggFunction();
 		}
 	}
@@ -135,7 +135,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatFirstValueWithRetractAggFunction();
 		}
 	}
@@ -152,7 +152,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleFirstValueWithRetractAggFunction();
 		}
 	}
@@ -208,7 +208,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanFirstValueWithRetractAggFunction();
 		}
 	}
@@ -260,7 +260,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalFirstValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -310,7 +310,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringFirstValueWithRetractAggFunction();
 		}
 	}
@@ -327,11 +327,11 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 	 * The base test class for FirstValueWithRetractAggFunction without order.
 	 */
 	public abstract static class FirstValueWithRetractAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, GenericRowData> {
+		extends AggFunctionTestBase<T, RowData> {
 
 		@Override
 		protected Class<?> getAccClass() {
-			return GenericRowData.class;
+			return RowData.class;
 		}
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.BooleanLastValueAggFunction;
@@ -67,7 +67,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteLastValueAggFunction();
 		}
 	}
@@ -84,7 +84,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortLastValueAggFunction();
 		}
 	}
@@ -101,7 +101,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntLastValueAggFunction();
 		}
 	}
@@ -118,7 +118,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongLastValueAggFunction();
 		}
 	}
@@ -135,7 +135,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatLastValueAggFunction();
 		}
 	}
@@ -152,7 +152,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleLastValueAggFunction();
 		}
 	}
@@ -242,7 +242,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanLastValueAggFunction();
 		}
 	}
@@ -322,7 +322,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalLastValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -400,7 +400,7 @@ public final class LastValueAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringLastValueAggFunction();
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.BooleanLastValueAggFunction;
@@ -66,7 +66,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteLastValueAggFunction();
 		}
 	}
@@ -83,7 +83,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortLastValueAggFunction();
 		}
 	}
@@ -100,7 +100,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntLastValueAggFunction();
 		}
 	}
@@ -117,7 +117,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongLastValueAggFunction();
 		}
 	}
@@ -134,7 +134,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatLastValueAggFunction();
 		}
 	}
@@ -151,7 +151,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleLastValueAggFunction();
 		}
 	}
@@ -207,7 +207,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanLastValueAggFunction();
 		}
 	}
@@ -259,7 +259,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalLastValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -310,7 +310,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringLastValueAggFunction();
 		}
 	}
@@ -324,11 +324,11 @@ public final class LastValueAggFunctionWithoutOrderTest {
 	 * The base test class for LastValueAggFunction without order.
 	 */
 	public abstract static class LastValueAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, GenericRowData> {
+		extends AggFunctionTestBase<T, RowData> {
 
 		@Override
 		protected Class<?> getAccClass() {
-			return GenericRowData.class;
+			return RowData.class;
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.BooleanLastValueWithRetractAggFunction;
@@ -68,7 +68,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteLastValueWithRetractAggFunction();
 		}
 	}
@@ -85,7 +85,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortLastValueWithRetractAggFunction();
 		}
 	}
@@ -102,7 +102,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntLastValueWithRetractAggFunction();
 		}
 	}
@@ -119,7 +119,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongLastValueWithRetractAggFunction();
 		}
 	}
@@ -136,7 +136,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatLastValueWithRetractAggFunction();
 		}
 	}
@@ -153,7 +153,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleLastValueWithRetractAggFunction();
 		}
 	}
@@ -243,7 +243,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanLastValueWithRetractAggFunction();
 		}
 	}
@@ -323,7 +323,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalLastValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -407,7 +407,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringLastValueWithRetractAggFunction();
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.BooleanLastValueWithRetractAggFunction;
@@ -67,7 +67,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, GenericRowData> getAggregator() {
+		protected AggregateFunction<Byte, RowData> getAggregator() {
 			return new ByteLastValueWithRetractAggFunction();
 		}
 	}
@@ -84,7 +84,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, GenericRowData> getAggregator() {
+		protected AggregateFunction<Short, RowData> getAggregator() {
 			return new ShortLastValueWithRetractAggFunction();
 		}
 	}
@@ -101,7 +101,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, GenericRowData> getAggregator() {
+		protected AggregateFunction<Integer, RowData> getAggregator() {
 			return new IntLastValueWithRetractAggFunction();
 		}
 	}
@@ -118,7 +118,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, GenericRowData> getAggregator() {
+		protected AggregateFunction<Long, RowData> getAggregator() {
 			return new LongLastValueWithRetractAggFunction();
 		}
 	}
@@ -135,7 +135,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, GenericRowData> getAggregator() {
+		protected AggregateFunction<Float, RowData> getAggregator() {
 			return new FloatLastValueWithRetractAggFunction();
 		}
 	}
@@ -152,7 +152,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, GenericRowData> getAggregator() {
+		protected AggregateFunction<Double, RowData> getAggregator() {
 			return new DoubleLastValueWithRetractAggFunction();
 		}
 	}
@@ -208,7 +208,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, GenericRowData> getAggregator() {
+		protected AggregateFunction<Boolean, RowData> getAggregator() {
 			return new BooleanLastValueWithRetractAggFunction();
 		}
 	}
@@ -260,7 +260,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, GenericRowData> getAggregator() {
+		protected AggregateFunction<DecimalData, RowData> getAggregator() {
 			return new DecimalLastValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
 		}
 	}
@@ -310,7 +310,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, GenericRowData> getAggregator() {
+		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new StringLastValueWithRetractAggFunction();
 		}
 	}
@@ -327,11 +327,11 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 	 * The base test class for LastValueWithRetractAggFunction without order.
 	 */
 	public abstract static class LastValueWithRetractAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, GenericRowData> {
+		extends AggFunctionTestBase<T, RowData> {
 
 		@Override
 		protected Class<?> getAccClass() {
-			return GenericRowData.class;
+			return RowData.class;
 		}
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableFunction;
-import org.apache.flink.table.planner.codegen.CodeGenException;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
 import org.apache.flink.table.types.DataType;
@@ -736,13 +735,13 @@ public class FunctionITCase extends StreamingTestBase {
 				"INSERT INTO SinkTable " +
 				"SELECT CustomScalarFunction('test')");
 			fail();
-		} catch (CodeGenException e) {
+		} catch (ValidationException e) {
 			assertThat(
 				e,
 				hasMessage(
 					equalTo(
-						"Could not find an implementation method in class '" + CustomScalarFunction.class.getCanonicalName() +
-						"' for function 'CustomScalarFunction' that matches the following signature: \n" +
+						"Could not find an implementation method 'eval' in class '" + CustomScalarFunction.class +
+						"' for function 'CustomScalarFunction' that matches the following signature:\n" +
 						"java.lang.String eval(java.lang.String)")));
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
@@ -68,6 +68,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
     when(aggInfo, "agg").thenReturn(call)
     when(call, "getName").thenReturn("avg1")
     when(aggInfo, "function").thenReturn(new LongAvgAggFunction)
+    when(aggInfo, "externalArgTypes").thenReturn(Array(DataTypes.BIGINT))
     when(aggInfo, "externalAccTypes").thenReturn(Array(DataTypes.BIGINT, DataTypes.BIGINT))
     when(aggInfo, "argIndexes").thenReturn(Array(1))
     when(aggInfo, "aggIndex").thenReturn(0)
@@ -81,6 +82,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
     when(aggInfo, "agg").thenReturn(call)
     when(call, "getName").thenReturn("avg2")
     when(aggInfo, "function").thenReturn(new DoubleAvgAggFunction)
+    when(aggInfo, "externalArgTypes").thenReturn(Array(DataTypes.DOUBLE()))
     when(aggInfo, "externalAccTypes").thenReturn(Array(DataTypes.DOUBLE, DataTypes.BIGINT))
     when(aggInfo, "argIndexes").thenReturn(Array(2))
     when(aggInfo, "aggIndex").thenReturn(1)
@@ -95,6 +97,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
     when(aggInfo, "agg").thenReturn(call)
     when(call, "getName").thenReturn("avg3")
     when(aggInfo, "function").thenReturn(imperativeAggFunc)
+    when(aggInfo, "externalArgTypes").thenReturn(Array(DataTypes.BIGINT()))
     when(aggInfo, "externalAccTypes").thenReturn(
       Array(fromLegacyInfoToDataType(imperativeAggFunc.getAccumulatorType)))
     when(aggInfo, "externalResultType").thenReturn(DataTypes.BIGINT)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -749,7 +749,7 @@ class FlinkRelMdHandlerTestBase {
       false,
       false,
       false,
-      Seq(Integer.valueOf(0)).toList,
+      Seq(Integer.valueOf(3)).toList,
       -1,
       RelCollationImpl.of(),
       relDataType,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TestData.tupleData3
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestingRetractSink}
-import org.apache.flink.table.planner.utils.{TableAggSum, Top3, Top3WithMapView, Top3WithRetractInput}
+import org.apache.flink.table.planner.utils.{TableAggSum, Top3, Top3Accum, Top3WithMapView, Top3WithRetractInput}
 import org.apache.flink.types.Row
 
 import org.junit.Assert.assertEquals
@@ -206,9 +206,10 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
   @Test
   def testTableAggFunctionWithoutRetractionMethod(): Unit = {
     expectedException.expect(classOf[ValidationException])
-    expectedException.expectMessage("Function class 'org.apache.flink.table.planner.utils.Top3'" +
-      " does not implement at least one method named 'retract' which is public, " +
-      "not abstract and (in case of table functions) not static.")
+    expectedException.expectMessage(
+      s"Could not find an implementation method 'retract' in class '${classOf[Top3]}' for " +
+      s"function 'Top3' that matches the following signature:\n" +
+      s"void retract(${classOf[Top3Accum].getName}, int)")
 
     val top3 = new Top3
     val source = env.fromCollection(tupleData3).toTable(tEnv, 'a, 'b, 'c)


### PR DESCRIPTION
## What is the purpose of the change

Extracts the argument types early in order to perform the validation based on `AggregateInfo`. The validation is the same for all kind of UDFs.

## Brief change log

- Updates validation for all kinds of UDFs

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
