### PR TITLE
[FLINK-18421][checkpointing] Fix logging of RejectedExecutionException logging

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -78,6 +78,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
+import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -587,7 +588,7 @@ public class CheckpointCoordinator {
 					.exceptionally(error -> {
 						if (!isShutdown()) {
 							throw new CompletionException(error);
-						} else if (error instanceof RejectedExecutionException) {
+						} else if (findThrowable(error, RejectedExecutionException.class).isPresent()) {
 							LOG.debug("Execution rejected during shutdown");
 						} else {
 							LOG.warn("Error encountered during shutdown", error);
@@ -1745,7 +1746,7 @@ public class CheckpointCoordinator {
 		CheckpointFailureReason defaultReason, Throwable throwable) {
 
 		final Optional<CheckpointException> checkpointExceptionOptional =
-			ExceptionUtils.findThrowable(throwable, CheckpointException.class);
+			findThrowable(throwable, CheckpointException.class);
 		return checkpointExceptionOptional
 			.orElseGet(() -> new CheckpointException(defaultReason, throwable));
 	}


### PR DESCRIPTION
## What is the purpose of the change

If `CheckpointCoordinator` is shutting down then `RejectedExecutionException`s are possible. They are logged separately at `DEBUG` level.
However, they can be wrapped into `CompletionException`, in which case they are logged fully at `WARN` level, which fails e2e tests.

This PR fixes it by searching for `RejectedExecutionException` in cause chain of the exception.

## Verifying this change

This change is a trivial rework; e2e tests already cover this issue.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no