### PR TITLE
[FLINK-17426][blink planner] Dynamic Source supportsLimit pushdown

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import scala.Tuple2;
 
@@ -150,7 +149,7 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
 		TableSourceTable newTableSourceTable = oldTableSourceTable.copy(
 			newTableSource,
 			getNewFlinkStatistic(oldTableSourceTable, originPredicatesSize, updatedPredicatesSize),
-			getNewExtraDigests(oldTableSourceTable, result.getAcceptedFilters())
+			getNewExtraDigests(result.getAcceptedFilters())
 		);
 		TableScan newScan = LogicalTableScan.create(scan.getCluster(), newTableSourceTable, scan.getHints());
 		// check whether framework still need to do a filter
@@ -185,8 +184,7 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
 		return newStatistic;
 	}
 
-	private String[] getNewExtraDigests(TableSourceTable tableSourceTable, List<ResolvedExpression> acceptedFilters) {
-		String[] oldExtraDigests = tableSourceTable.extraDigests();
+	private String[] getNewExtraDigests(List<ResolvedExpression> acceptedFilters) {
 		String extraDigest = null;
 		if (!acceptedFilters.isEmpty()) {
 			// push filter successfully
@@ -200,9 +198,6 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
 			// try to push filter, but insuccess
 			extraDigest = "filter=[]";
 		}
-		return Stream.concat(
-				Arrays.stream(oldExtraDigests),
-				Arrays.stream(new String[]{extraDigest}))
-			.toArray(String[]::new);
+		return new String[]{extraDigest};
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -86,7 +86,7 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
 		// we can not push filter twice
 		return tableSourceTable != null
 			&& tableSourceTable.tableSource() instanceof SupportsFilterPushDown
-			&& !Arrays.stream(tableSourceTable.extraDigests()).anyMatch(str -> str.startsWith("filter=["));
+			&& Arrays.stream(tableSourceTable.extraDigests()).noneMatch(str -> str.startsWith("filter=["));
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.java
@@ -107,11 +107,7 @@ public class PushLimitIntoTableSourceScanRule extends RelOptRule {
 			.build();
 
 		// update extraDigests
-		String[] newExtraDigests = new String[0];
-		if (limit >= 0) {
-			String extraDigest = "limit=[" + limit + "]";
-			newExtraDigests = new String[]{extraDigest};
-		}
+		String[] newExtraDigests = new String[]{"limit=[" + limit + "]"};
 
 		return oldTableSourceTable.copy(
 			newTableSource,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalSort;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rex.RexLiteral;
+
+import java.util.Collections;
+
+/**
+ * Planner rule that tries to push limit into a [[FlinkLogicalTableSourceScan]].
+ * The original limit will still be retained.
+ * The reasons why the limit still be retained:
+ * 1.If the source is required to return the exact number of limit number, the implementation
+ * of the source is highly required. The source is required to accurately control the record
+ * number of split, and the parallelism setting also need to be adjusted accordingly.
+ * 2.When remove the limit, maybe filter will be pushed down to the source after limit pushed
+ * down. The source need know it should do limit first and do the filter later, it is hard to
+ * implement.
+ * 3.We can support limit with offset, we can push down offset + fetch to table source.
+ */
+public class PushLimitIntoTableSourceScanRule extends RelOptRule {
+	public static final PushLimitIntoTableSourceScanRule INSTANCE = new PushLimitIntoTableSourceScanRule();
+
+	public PushLimitIntoTableSourceScanRule() {
+		super(operand(FlinkLogicalSort.class,
+			operand(FlinkLogicalTableSourceScan.class, none())),
+			"PushLimitIntoTableSourceScanRule");
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		Sort sort = call.rel(0);
+		boolean onlyLimit = sort.getCollation().getFieldCollations().isEmpty() && sort.fetch != null;
+		if (onlyLimit) {
+			TableSourceTable tableSourceTable = call.rel(1).getTable().unwrap(TableSourceTable.class);
+			if (tableSourceTable != null && tableSourceTable.tableSource() instanceof SupportsLimitPushDown) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void onMatch(RelOptRuleCall call) {
+		Sort sort = call.rel(0);
+		FlinkLogicalTableSourceScan scan = call.rel(1);
+		TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
+		int offset = sort.offset == null ? 0 : RexLiteral.intValue(sort.offset);
+		int limit = offset + RexLiteral.intValue(sort.fetch);
+
+		TableSourceTable newTableSourceTable = applyLimit((long) limit, tableSourceTable);
+
+		FlinkLogicalTableSourceScan newScan = scan.copy(scan.getTraitSet(), newTableSourceTable);
+		call.transformTo(sort.copy(sort.getTraitSet(), Collections.singletonList(newScan)));
+	}
+
+	private TableSourceTable applyLimit(
+		Long limit,
+		FlinkPreparingTableBase relOptTable) {
+		TableSourceTable tableSourceTable = relOptTable.unwrap(TableSourceTable.class);
+		DynamicTableSource newTableSource = tableSourceTable.tableSource().copy();
+		((SupportsLimitPushDown) newTableSource).applyLimit(limit);
+
+		FlinkStatistic statistic = relOptTable.getStatistic();
+		long newRowCount = 0;
+		if (statistic.getRowCount() != null) {
+			newRowCount = Math.min(limit, statistic.getRowCount().longValue());
+		} else {
+			newRowCount = limit;
+		}
+		// Update TableStats after limit push down
+		TableStats newTableStats = new TableStats(newRowCount);
+		FlinkStatistic newStatistic = FlinkStatistic.builder()
+			.statistic(statistic)
+			.tableStats(newTableStats)
+			.build();
+
+		return new TableSourceTable(
+			tableSourceTable.getRelOptSchema(),
+			tableSourceTable.tableIdentifier(),
+			tableSourceTable.getRowType(),
+			newStatistic,
+			newTableSource,
+			tableSourceTable.isStreamingMode(),
+			tableSourceTable.catalogTable(),
+			tableSourceTable.dynamicOptions(),
+			tableSourceTable.extraDigests()
+		);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -90,6 +90,7 @@ object FlinkBatchRuleSets {
 
   private val LIMIT_RULES: RuleSet = RuleSets.ofList(
     //push down localLimit
+    PushLimitIntoTableSourceScanRule.INSTANCE,
     PushLimitIntoLegacyTableSourceScanRule.INSTANCE)
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
@@ -200,11 +200,6 @@ class CatalogSourceTable[T](
   private def validateTableSource(tableSource: DynamicTableSource): Unit = {
     // throw exception if unsupported ability interface is implemented
     val unsupportedAbilities = List(
-<<<<<<< HEAD
-      classOf[SupportsLimitPushDown],
-=======
-      classOf[SupportsFilterPushDown],
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
       classOf[SupportsPartitionPushDown],
       classOf[SupportsComputedColumnPushDown],
       classOf[SupportsWatermarkPushDown])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
@@ -200,7 +200,11 @@ class CatalogSourceTable[T](
   private def validateTableSource(tableSource: DynamicTableSource): Unit = {
     // throw exception if unsupported ability interface is implemented
     val unsupportedAbilities = List(
+<<<<<<< HEAD
       classOf[SupportsLimitPushDown],
+=======
+      classOf[SupportsFilterPushDown],
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
       classOf[SupportsPartitionPushDown],
       classOf[SupportsComputedColumnPushDown],
       classOf[SupportsWatermarkPushDown])

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.connector.source.TableFunctionProvider;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.CallExpression;
@@ -277,8 +278,12 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				lookupFunctionClass,
 				nestedProjectionSupported,
 				null,
+<<<<<<< HEAD
 				null,
 				filterableFieldsSet);
+=======
+				Long.MAX_VALUE);
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 		} else {
 			try {
 				return InstantiationUtil.instantiate(
@@ -359,7 +364,11 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 	/**
 	 * Values {@link DynamicTableSource} for testing.
 	 */
+<<<<<<< HEAD
 	private static class TestValuesTableSource implements ScanTableSource, LookupTableSource, SupportsProjectionPushDown, SupportsFilterPushDown {
+=======
+	private static class TestValuesTableSource implements ScanTableSource, LookupTableSource, SupportsProjectionPushDown, SupportsLimitPushDown {
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 
 		private TableSchema physicalSchema;
 		private final ChangelogMode changelogMode;
@@ -370,8 +379,12 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		private final @Nullable String lookupFunctionClass;
 		private final boolean nestedProjectionSupported;
 		private @Nullable int[] projectedFields;
+<<<<<<< HEAD
 		private List<ResolvedExpression> filterPredicates;
 		private final Set<String> filterableFields;
+=======
+		private long limit;
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 
 		private TestValuesTableSource(
 				TableSchema physicalSchema,
@@ -383,8 +396,12 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				@Nullable String lookupFunctionClass,
 				boolean nestedProjectionSupported,
 				int[] projectedFields,
+<<<<<<< HEAD
 				List<ResolvedExpression> filterPredicates,
 				Set<String> filterableFields) {
+=======
+				long limit) {
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 			this.physicalSchema = physicalSchema;
 			this.changelogMode = changelogMode;
 			this.bounded = bounded;
@@ -394,8 +411,12 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 			this.lookupFunctionClass = lookupFunctionClass;
 			this.nestedProjectionSupported = nestedProjectionSupported;
 			this.projectedFields = projectedFields;
+<<<<<<< HEAD
 			this.filterPredicates = filterPredicates;
 			this.filterableFields = filterableFields;
+=======
+			this.limit = limit;
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 		}
 
 		@Override
@@ -609,8 +630,12 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				lookupFunctionClass,
 				nestedProjectionSupported,
 				projectedFields,
+<<<<<<< HEAD
 				filterPredicates,
 				filterableFields);
+=======
+				limit);
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 		}
 
 		@Override
@@ -624,6 +649,7 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				DataStructureConverter converter) {
 			List<RowData> result = new ArrayList<>();
 			for (Row value : data) {
+<<<<<<< HEAD
 				if (isRetainedAfterApplyingFilterPredicates(value)) {
 					Row projectedRow;
 					if (projectedFields == null) {
@@ -639,10 +665,27 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 					if (rowData != null) {
 						rowData.setRowKind(value.getKind());
 						result.add(rowData);
+=======
+				if (result.size() >= limit) {
+					return result;
+				}
+				Row projectedRow;
+				if (projectedFields == null) {
+					projectedRow = value;
+				} else {
+					Object[] newValues = new Object[projectedFields.length];
+					for (int i = 0; i < projectedFields.length; ++i) {
+						newValues[i] = value.getField(projectedFields[i]);
+>>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 					}
 				}
 			}
 			return result;
+		}
+
+		@Override
+		public void applyLimit(long limit) {
+			this.limit = limit;
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -361,7 +361,11 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 	/**
 	 * Values {@link DynamicTableSource} for testing.
 	 */
-	private static class TestValuesTableSource implements ScanTableSource, LookupTableSource, SupportsProjectionPushDown, SupportsFilterPushDown, SupportsLimitPushDown {
+	private static class TestValuesTableSource implements ScanTableSource,
+		LookupTableSource,
+		SupportsProjectionPushDown,
+		SupportsFilterPushDown,
+		SupportsLimitPushDown {
 
 		private TableSchema physicalSchema;
 		private final ChangelogMode changelogMode;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -278,12 +278,9 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				lookupFunctionClass,
 				nestedProjectionSupported,
 				null,
-<<<<<<< HEAD
 				null,
-				filterableFieldsSet);
-=======
+				filterableFieldsSet,
 				Long.MAX_VALUE);
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 		} else {
 			try {
 				return InstantiationUtil.instantiate(
@@ -364,11 +361,7 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 	/**
 	 * Values {@link DynamicTableSource} for testing.
 	 */
-<<<<<<< HEAD
-	private static class TestValuesTableSource implements ScanTableSource, LookupTableSource, SupportsProjectionPushDown, SupportsFilterPushDown {
-=======
-	private static class TestValuesTableSource implements ScanTableSource, LookupTableSource, SupportsProjectionPushDown, SupportsLimitPushDown {
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
+	private static class TestValuesTableSource implements ScanTableSource, LookupTableSource, SupportsProjectionPushDown, SupportsFilterPushDown, SupportsLimitPushDown {
 
 		private TableSchema physicalSchema;
 		private final ChangelogMode changelogMode;
@@ -379,12 +372,9 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		private final @Nullable String lookupFunctionClass;
 		private final boolean nestedProjectionSupported;
 		private @Nullable int[] projectedFields;
-<<<<<<< HEAD
 		private List<ResolvedExpression> filterPredicates;
 		private final Set<String> filterableFields;
-=======
 		private long limit;
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 
 		private TestValuesTableSource(
 				TableSchema physicalSchema,
@@ -396,12 +386,9 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				@Nullable String lookupFunctionClass,
 				boolean nestedProjectionSupported,
 				int[] projectedFields,
-<<<<<<< HEAD
 				List<ResolvedExpression> filterPredicates,
-				Set<String> filterableFields) {
-=======
+				Set<String> filterableFields,
 				long limit) {
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 			this.physicalSchema = physicalSchema;
 			this.changelogMode = changelogMode;
 			this.bounded = bounded;
@@ -411,12 +398,9 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 			this.lookupFunctionClass = lookupFunctionClass;
 			this.nestedProjectionSupported = nestedProjectionSupported;
 			this.projectedFields = projectedFields;
-<<<<<<< HEAD
 			this.filterPredicates = filterPredicates;
 			this.filterableFields = filterableFields;
-=======
 			this.limit = limit;
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 		}
 
 		@Override
@@ -630,12 +614,9 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				lookupFunctionClass,
 				nestedProjectionSupported,
 				projectedFields,
-<<<<<<< HEAD
 				filterPredicates,
-				filterableFields);
-=======
+				filterableFields,
 				limit);
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 		}
 
 		@Override
@@ -649,7 +630,9 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 				DataStructureConverter converter) {
 			List<RowData> result = new ArrayList<>();
 			for (Row value : data) {
-<<<<<<< HEAD
+				if (result.size() >= limit) {
+					return result;
+				}
 				if (isRetainedAfterApplyingFilterPredicates(value)) {
 					Row projectedRow;
 					if (projectedFields == null) {
@@ -665,18 +648,6 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 					if (rowData != null) {
 						rowData.setRowKind(value.getKind());
 						result.add(rowData);
-=======
-				if (result.size() >= limit) {
-					return result;
-				}
-				Row projectedRow;
-				if (projectedFields == null) {
-					projectedRow = value;
-				} else {
-					Object[] newValues = new Object[projectedFields.length];
-					for (int i = 0; i < projectedFields.length; ++i) {
-						newValues[i] = value.getField(projectedFields[i]);
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
 					}
 				}
 			}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.planner.calcite.CalciteConfig;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalSort;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
+import org.apache.flink.table.planner.plan.optimize.program.BatchOptimizeContext;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgramBuilder;
+import org.apache.flink.table.planner.plan.optimize.program.HEP_RULES_EXECUTION_TYPE;
+import org.apache.flink.table.planner.utils.TableConfigUtils;
+
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.rel.rules.SortProjectTransposeRule;
+import org.apache.calcite.tools.RuleSets;
+
+/**
+ * Test for {@link PushLimitIntoTableSourceScanRule}.
+ */
+public class PushLimitIntoTableSourceScanRuleTest extends PushLimitIntoLegacyTableSourceScanRuleTest {
+	@Override
+	public void setup() {
+		util().buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE());
+		CalciteConfig calciteConfig = TableConfigUtils.getCalciteConfig(util().tableEnv().getConfig());
+		calciteConfig.getBatchProgram().get().addLast(
+			"rules",
+			FlinkHepRuleSetProgramBuilder.<BatchOptimizeContext>newBuilder()
+				.setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION())
+				.setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+				.add(RuleSets.ofList(PushLimitIntoTableSourceScanRule.INSTANCE,
+					SortProjectTransposeRule.INSTANCE,
+					// converts calcite rel(RelNode) to flink rel(FlinkRelNode)
+					FlinkLogicalSort.BATCH_CONVERTER(),
+					FlinkLogicalTableSourceScan.CONVERTER()))
+				.build()
+		);
+
+		String ddl =
+			"CREATE TABLE LimitTable (\n" +
+				"  a int,\n" +
+				"  b bigint,\n" +
+				"  c string\n" +
+				") WITH (\n" +
+				" 'connector' = 'values',\n" +
+				" 'bounded' = 'true'\n" +
+				")";
+		util().tableEnv().executeSql(ddl);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -28,7 +28,7 @@ org.apache.flink.table.planner.utils.MemoryTableSourceSinkUtil$DataTypeOutputFor
 org.apache.flink.table.planner.utils.MemoryTableSourceSinkUtil$LegacyUnsafeMemoryAppendTableFactory
 org.apache.flink.table.planner.utils.TestTableSourceFactory
 org.apache.flink.table.planner.runtime.utils.InMemoryLookupableTableFactory
-org.apache.flink.table.planner.utils.TestLimitableTableSourceFactory
+org.apache.flink.table.planner.utils.TestLegacyLimitableTableSourceFactory
 org.apache.flink.table.planner.utils.TestInputFormatTableSourceFactory
 org.apache.flink.table.planner.utils.TestDataTypeTableSourceFactory
 org.apache.flink.table.planner.utils.TestDataTypeTableSourceWithTimeFactory

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LegacyLimitTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LegacyLimitTest.xml
@@ -1,0 +1,316 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testFetch0WithoutOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable FETCH FIRST 0 ROWS ONLY]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[0])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Values(tuples=[[]], values=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFetchWithLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[10], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFetchWithOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[10], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[10], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[20], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFetchWithOffsetAndLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[10], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[10], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[20], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 20]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFetchWithoutOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable FETCH FIRST 10 ROWS ONLY]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[10], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimit0WithOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable LIMIT 0 OFFSET 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[10], fetch=[0])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Values(tuples=[[]], values=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimit0WithOffset0">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable LIMIT 0 OFFSET 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[0], fetch=[0])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Values(tuples=[[]], values=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimit0WithoutOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable LIMIT 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[0])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Values(tuples=[[]], values=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimitWithLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable LIMIT 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[10], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOrderByWithLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable ORDER BY c LIMIT 10]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimitWithOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable LIMIT 10 OFFSET 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[1], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[1], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[11], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimitWithOffset0">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable LIMIT 10 OFFSET 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[0], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[0], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[10], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimitWithoutOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable LIMIT 5]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(fetch=[5])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Limit(offset=[0], fetch=[5], global=[true])
++- Exchange(distribution=[single])
+   +- Limit(offset=[0], fetch=[5], global=[false])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyOffset">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable OFFSET 10 ROWS]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[10], fetch=[unlimited], global=[true])
+   +- Exchange(distribution=[single])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimitWithOffsetAndLimitSource">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSort(offset=[1], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- Limit(offset=[1], fetch=[10], global=[true])
+   +- Exchange(distribution=[single])
+      +- Limit(offset=[0], fetch=[11], global=[false])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 11]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
@@ -46,11 +46,10 @@ LogicalSort(fetch=[10])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, c])
-+- Limit(offset=[0], fetch=[10], global=[true])
-   +- Exchange(distribution=[single])
-      +- Limit(offset=[0], fetch=[10], global=[false])
-         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[10]]], fields=[a, b, c])
+Limit(offset=[0], fetch=[10], global=[true])
++- Exchange(distribution=[single])
+   +- Limit(offset=[0], fetch=[10], global=[false])
+      +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, project=[a, c], limit=[10]]], fields=[a, c])
 ]]>
     </Resource>
   </TestCase>
@@ -88,11 +87,10 @@ LogicalSort(offset=[10], fetch=[10])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, c])
-+- Limit(offset=[10], fetch=[10], global=[true])
-   +- Exchange(distribution=[single])
-      +- Limit(offset=[0], fetch=[20], global=[false])
-         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[20]]], fields=[a, b, c])
+Limit(offset=[10], fetch=[10], global=[true])
++- Exchange(distribution=[single])
+   +- Limit(offset=[0], fetch=[20], global=[false])
+      +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, project=[a, c], limit=[20]]], fields=[a, c])
 ]]>
     </Resource>
   </TestCase>
@@ -181,11 +179,10 @@ LogicalSort(fetch=[10])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, c])
-+- Limit(offset=[0], fetch=[10], global=[true])
-   +- Exchange(distribution=[single])
-      +- Limit(offset=[0], fetch=[10], global=[false])
-         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[10]]], fields=[a, b, c])
+Limit(offset=[0], fetch=[10], global=[true])
++- Exchange(distribution=[single])
+   +- Limit(offset=[0], fetch=[10], global=[false])
+      +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, project=[a, c], limit=[10]]], fields=[a, c])
 ]]>
     </Resource>
   </TestCase>
@@ -304,11 +301,10 @@ LogicalSort(offset=[1], fetch=[10])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, c])
-+- Limit(offset=[1], fetch=[10], global=[true])
-   +- Exchange(distribution=[single])
-      +- Limit(offset=[0], fetch=[11], global=[false])
-         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[11]]], fields=[a, b, c])
+Limit(offset=[1], fetch=[10], global=[true])
++- Exchange(distribution=[single])
+   +- Limit(offset=[0], fetch=[11], global=[false])
+      +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, project=[a, c], limit=[11]]], fields=[a, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LimitTest.xml
@@ -50,7 +50,7 @@ Calc(select=[a, c])
 +- Limit(offset=[0], fetch=[10], global=[true])
    +- Exchange(distribution=[single])
       +- Limit(offset=[0], fetch=[10], global=[false])
-         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[10]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -92,7 +92,7 @@ Calc(select=[a, c])
 +- Limit(offset=[10], fetch=[10], global=[true])
    +- Exchange(distribution=[single])
       +- Limit(offset=[0], fetch=[20], global=[false])
-         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 20]]], fields=[a, b, c])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[20]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -185,7 +185,7 @@ Calc(select=[a, c])
 +- Limit(offset=[0], fetch=[10], global=[true])
    +- Exchange(distribution=[single])
       +- Limit(offset=[0], fetch=[10], global=[false])
-         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[10]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -202,11 +202,10 @@ LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, c])
-+- SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[true])
-   +- Exchange(distribution=[single])
-      +- SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[false])
-         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[true])
++- Exchange(distribution=[single])
+   +- SortLimit(orderBy=[c ASC], offset=[0], fetch=[10], global=[false])
+      +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, project=[a, c]]], fields=[a, c])
 ]]>
     </Resource>
   </TestCase>
@@ -309,7 +308,7 @@ Calc(select=[a, c])
 +- Limit(offset=[1], fetch=[10], global=[true])
    +- Exchange(distribution=[single])
       +- Limit(offset=[0], fetch=[11], global=[false])
-         +- LegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 11]]], fields=[a, b, c])
+         +- TableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[11]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testCanPushdownLimitWithoutOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(fetch=[5])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- FlinkLogicalSort(fetch=[5])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 5]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushdownFetchWithOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[10], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[10], fetch=[10])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 20]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushdownFetchWithoutOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(fetch=[10])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 10]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDownWithOrderBy">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable ORDER BY c LIMIT 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(sort0=[$2], dir0=[ASC-nulls-first], fetch=[10])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushdownLimitWithOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[1], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[1], fetch=[10])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 11]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testLimitWithoutOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(fetch=[5])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- FlinkLogicalSort(fetch=[5])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 5]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDownWithoutLimit">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[10])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDownWithoutFetch">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10 ROWS]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[10])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.xml
@@ -111,25 +111,6 @@ LogicalProject(a=[$0], c=[$2])
 ]]>
 		</Resource>
 	</TestCase>
-	<TestCase name="testLimitWithoutOffset">
-		<Resource name="sql">
-			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
-		</Resource>
-		<Resource name="planBefore">
-			<![CDATA[
-LogicalSort(fetch=[5])
-+- LogicalProject(a=[$0], b=[$1], c=[$2])
-   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
-]]>
-		</Resource>
-		<Resource name="planAfter">
-			<![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
-+- FlinkLogicalSort(fetch=[5])
-   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 5]]], fields=[a, b, c])
-]]>
-		</Resource>
-	</TestCase>
 	<TestCase name="testCannotPushDownWithoutLimit">
 		<Resource name="sql">
 			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.xml
@@ -18,18 +18,18 @@ limitations under the License.
 <Root>
 	<TestCase name="testCanPushdownLimitWithoutOffset">
 		<Resource name="sql">
-			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
+			<![CDATA[SELECT a, c FROM LimitTable LIMIT 5]]>
 		</Resource>
 		<Resource name="planBefore">
 			<![CDATA[
 LogicalSort(fetch=[5])
-+- LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
 ]]>
 		</Resource>
 		<Resource name="planAfter">
 			<![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
+LogicalProject(a=[$0], c=[$2])
 +- FlinkLogicalSort(fetch=[5])
    +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 5]]], fields=[a, b, c])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.xml
@@ -18,18 +18,18 @@ limitations under the License.
 <Root>
 	<TestCase name="testCanPushdownLimitWithoutOffset">
 		<Resource name="sql">
-			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
+			<![CDATA[SELECT a, c FROM LimitTable LIMIT 5]]>
 		</Resource>
 		<Resource name="planBefore">
 			<![CDATA[
 LogicalSort(fetch=[5])
-+- LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalProject(a=[$0], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
 ]]>
 		</Resource>
 		<Resource name="planAfter">
 			<![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
+LogicalProject(a=[$0], c=[$2])
 +- FlinkLogicalSort(fetch=[5])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[5]]], fields=[a, b, c])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.xml
@@ -111,25 +111,6 @@ LogicalProject(a=[$0], c=[$2])
 ]]>
 		</Resource>
 	</TestCase>
-	<TestCase name="testLimitWithoutOffset">
-		<Resource name="sql">
-			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
-		</Resource>
-		<Resource name="planBefore">
-			<![CDATA[
-LogicalSort(fetch=[5])
-+- LogicalProject(a=[$0], b=[$1], c=[$2])
-   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
-]]>
-		</Resource>
-		<Resource name="planAfter">
-			<![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
-+- FlinkLogicalSort(fetch=[5])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 5]]], fields=[a, b, c])
-]]>
-		</Resource>
-	</TestCase>
 	<TestCase name="testCannotPushDownWithoutLimit">
 		<Resource name="sql">
 			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRuleTest.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testCanPushdownLimitWithoutOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(fetch=[5])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- FlinkLogicalSort(fetch=[5])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[5]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushdownFetchWithOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[10], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[10], fetch=[10])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[20]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushdownFetchWithoutOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(fetch=[10])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[10]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDownWithOrderBy">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable ORDER BY c LIMIT 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(sort0=[$2], dir0=[ASC-nulls-first], fetch=[10])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCanPushdownLimitWithOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[1], fetch=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[1], fetch=[10])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable, limit=[11]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testLimitWithoutOffset">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM LimitTable LIMIT 5]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(fetch=[5])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- FlinkLogicalSort(fetch=[5])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable, source: [limit: 5]]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDownWithoutLimit">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[10])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testCannotPushDownWithoutFetch">
+		<Resource name="sql">
+			<![CDATA[SELECT a, c FROM LimitTable OFFSET 10 ROWS]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalSort(offset=[10])
++- LogicalProject(a=[$0], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, LimitTable]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- FlinkLogicalSort(offset=[10])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LimitTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LegacyLimitTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LegacyLimitTest.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.batch.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{SqlParserException, _}
+import org.apache.flink.table.planner.utils.TableTestBase
+import org.junit.{Before, Test}
+
+class LegacyLimitTest extends TableTestBase {
+
+  protected val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    util.addTableSource[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+    val ddl =
+      s"""
+         |CREATE TABLE LimitTable (
+         |  a int,
+         |  b bigint,
+         |  c string
+         |) WITH (
+         |  'connector.type' = 'TestLimitableTableSource',
+         |  'is-bounded' = 'true'
+         |)
+       """.stripMargin
+    util.tableEnv.executeSql(ddl)
+  }
+
+  @Test
+  def testLimitWithoutOffset(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable LIMIT 5")
+  }
+
+  @Test
+  def testLimit0WithoutOffset(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable LIMIT 0")
+  }
+
+  @Test(expected = classOf[SqlParserException])
+  def testNegativeLimitWithoutOffset(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable LIMIT -1")
+  }
+
+  @Test
+  def testLimitWithOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 10 OFFSET 1")
+  }
+
+  @Test
+  def testLimitWithOffset0(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 10 OFFSET 0")
+  }
+
+  @Test
+  def testLimit0WithOffset0(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 0 OFFSET 0")
+  }
+
+  @Test
+  def testLimit0WithOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 0 OFFSET 10")
+  }
+
+  @Test(expected = classOf[SqlParserException])
+  def testLimitWithNegativeOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 10 OFFSET -1")
+  }
+
+  @Test
+  def testFetchWithOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY")
+  }
+
+  @Test
+  def testFetchWithoutOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable FETCH FIRST 10 ROWS ONLY")
+  }
+
+  @Test
+  def testFetch0WithoutOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable FETCH FIRST 0 ROWS ONLY")
+  }
+
+  @Test
+  def testOnlyOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable OFFSET 10 ROWS")
+  }
+
+  @Test
+  def testFetchWithLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testOrderByWithLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable ORDER BY c LIMIT 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testLimitWithLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable LIMIT 10"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testLimitWithOffsetAndLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testFetchWithOffsetAndLimitSource(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY"
+    util.verifyPlan(sqlQuery)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
@@ -22,6 +22,17 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown
 
+/**
+ * The plan of following unit test in LimitTest.xml is a bit diffirent from LegacyLimitTest.xml.
+ * Because the TestValuesTableSource has implemented [[SupportsProjectionPushDown]]
+ * while the TestLegacyLimitableTableSource doesn't.
+ * So the Calc has been pushed down to the scan.
+ * 1.testFetchWithOffsetAndLimitSource
+ * 2.testOrderByWithLimitSource
+ * 3.testLimitWithLimitSource
+ * 4.testLimitWithOffsetAndLimitSource
+ * 5.testFetchWithLimitSource
+ */
 class LimitTest extends LegacyLimitTest {
 
   override def setup(): Unit = {
@@ -39,11 +50,4 @@ class LimitTest extends LegacyLimitTest {
        """.stripMargin
     util.tableEnv.executeSql(ddl)
   }
-
-  /**
-   * The plan of testOrderByWithLimitSource in LimitTest.xml is a bit diffirent from
-   * LegacyLimitTest.xml. Because the [[TestValuesTableSource]] has implemented
-   * [[SupportsProjectionPushDown]] while TestLimitableTableSource doesn't.
-   * So the Calc has pushed down to the scan.
-   */
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
@@ -41,8 +41,9 @@ class LimitTest extends LegacyLimitTest {
   }
 
   /**
-   * The plan of testOrderByWithLimitSource in LimitTest.xml is a bit diffirent from LegacyLimitTest.xml
-   * Because the [[TestValuesTableSource]] has implemented [[SupportsProjectionPushDown]] while TestLimitableTableSource doesn't.
+   * The plan of testOrderByWithLimitSource in LimitTest.xml is a bit diffirent from
+   * LegacyLimitTest.xml. Because the [[TestValuesTableSource]] has implemented
+   * [[SupportsProjectionPushDown]] while TestLimitableTableSource doesn't.
    * So the Calc has pushed down to the scan.
    */
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LimitTest.scala
@@ -18,114 +18,31 @@
 
 package org.apache.flink.table.planner.plan.batch.sql
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
-import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.{SqlParserException, TableSchema, _}
-import org.apache.flink.table.planner.utils.{TableTestBase, TestLimitableTableSource}
+import org.apache.flink.table.api._
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown
 
-import org.junit.Test
+class LimitTest extends LegacyLimitTest {
 
-class LimitTest extends TableTestBase {
-
-  private val util = batchTestUtil()
-  util.addTableSource[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
-  TestLimitableTableSource.createTemporaryTable(
-    util.tableEnv,
-    Seq(),
-    new TableSchema(
-      Array("a", "b", "c"),
-      Array[TypeInformation[_]](INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO)),
-    "LimitTable")
-
-  @Test
-  def testLimitWithoutOffset(): Unit = {
-    util.verifyPlan("SELECT * FROM MyTable LIMIT 5")
+  override def setup(): Unit = {
+    util.addTableSource[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+    val ddl =
+    s"""
+       |CREATE TABLE LimitTable (
+       |  a int,
+       |  b bigint,
+       |  c string
+       |) WITH (
+       |  'connector' = 'values',
+       |  'bounded' = 'true'
+       |)
+       """.stripMargin
+    util.tableEnv.executeSql(ddl)
   }
 
-  @Test
-  def testLimit0WithoutOffset(): Unit = {
-    util.verifyPlan("SELECT * FROM MyTable LIMIT 0")
-  }
-
-  @Test(expected = classOf[SqlParserException])
-  def testNegativeLimitWithoutOffset(): Unit = {
-    util.verifyPlan("SELECT * FROM MyTable LIMIT -1")
-  }
-
-  @Test
-  def testLimitWithOffset(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 10 OFFSET 1")
-  }
-
-  @Test
-  def testLimitWithOffset0(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 10 OFFSET 0")
-  }
-
-  @Test
-  def testLimit0WithOffset0(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 0 OFFSET 0")
-  }
-
-  @Test
-  def testLimit0WithOffset(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 0 OFFSET 10")
-  }
-
-  @Test(expected = classOf[SqlParserException])
-  def testLimitWithNegativeOffset(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable LIMIT 10 OFFSET -1")
-  }
-
-  @Test
-  def testFetchWithOffset(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY")
-  }
-
-  @Test
-  def testFetchWithoutOffset(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable FETCH FIRST 10 ROWS ONLY")
-  }
-
-  @Test
-  def testFetch0WithoutOffset(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable FETCH FIRST 0 ROWS ONLY")
-  }
-
-  @Test
-  def testOnlyOffset(): Unit = {
-    util.verifyPlan("SELECT a, c FROM MyTable OFFSET 10 ROWS")
-  }
-
-  @Test
-  def testFetchWithLimitSource(): Unit = {
-    val sqlQuery = "SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY"
-    util.verifyPlan(sqlQuery)
-  }
-
-  @Test
-  def testOrderByWithLimitSource(): Unit = {
-    val sqlQuery = "SELECT a, c FROM LimitTable ORDER BY c LIMIT 10"
-    util.verifyPlan(sqlQuery)
-  }
-
-  @Test
-  def testLimitWithLimitSource(): Unit = {
-    val sqlQuery = "SELECT a, c FROM LimitTable LIMIT 10"
-    util.verifyPlan(sqlQuery)
-  }
-
-  @Test
-  def testLimitWithOffsetAndLimitSource(): Unit = {
-    val sqlQuery = "SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1"
-    util.verifyPlan(sqlQuery)
-  }
-
-  @Test
-  def testFetchWithOffsetAndLimitSource(): Unit = {
-    val sqlQuery = "SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY"
-    util.verifyPlan(sqlQuery)
-  }
-
+  /**
+   * The plan of testOrderByWithLimitSource in LimitTest.xml is a bit diffirent from LegacyLimitTest.xml
+   * Because the [[TestValuesTableSource]] has implemented [[SupportsProjectionPushDown]] while TestLimitableTableSource doesn't.
+   * So the Calc has pushed down to the scan.
+   */
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.scala
@@ -70,7 +70,7 @@ class PushLimitIntoLegacyTableSourceScanRuleTest extends TableTestBase {
 
   @Test(expected = classOf[SqlParserException])
   def testNegativeLimitWithoutOffset(): Unit = {
-    util.verifyPlan("SELECT * FROM LimitTable LIMIT -1")
+    util.verifyPlan("SELECT a, c FROM LimitTable LIMIT -1")
   }
 
   @Test(expected = classOf[SqlParserException])
@@ -80,7 +80,7 @@ class PushLimitIntoLegacyTableSourceScanRuleTest extends TableTestBase {
 
   @Test
   def testCanPushdownLimitWithoutOffset(): Unit = {
-    util.verifyPlan("SELECT * FROM LimitTable LIMIT 5")
+    util.verifyPlan("SELECT a, c FROM LimitTable LIMIT 5")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoLegacyTableSourceScanRuleTest.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.rules.SortProjectTransposeRule
+import org.apache.calcite.tools.RuleSets
+import org.apache.flink.table.api.SqlParserException
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalLegacyTableSourceScan, FlinkLogicalSort}
+import org.apache.flink.table.planner.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
+import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase}
+import org.junit.{Before, Test}
+
+/**
+ * Test for [[PushLimitIntoLegacyTableSourceScanRule]].
+ */
+class PushLimitIntoLegacyTableSourceScanRuleTest extends TableTestBase {
+  protected val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    util.buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE)
+    val calciteConfig = TableConfigUtils.getCalciteConfig(util.tableEnv.getConfig)
+    calciteConfig.getBatchProgram.get.addLast(
+      "rules",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(RuleSets.ofList(PushLimitIntoLegacyTableSourceScanRule.INSTANCE,
+          SortProjectTransposeRule.INSTANCE,
+          // converts calcite rel(RelNode) to flink rel(FlinkRelNode)
+          FlinkLogicalSort.BATCH_CONVERTER,
+          FlinkLogicalLegacyTableSourceScan.CONVERTER))
+        .build()
+    )
+
+    val ddl =
+      s"""
+         |CREATE TABLE LimitTable (
+         |  a int,
+         |  b bigint,
+         |  c string
+         |) WITH (
+         |  'connector.type' = 'TestLimitableTableSource',
+         |  'is-bounded' = 'true'
+         |)
+       """.stripMargin
+    util.tableEnv.executeSql(ddl)
+  }
+
+  @Test(expected = classOf[SqlParserException])
+  def testLimitWithNegativeOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM LimitTable LIMIT 10 OFFSET -1")
+  }
+
+  @Test(expected = classOf[SqlParserException])
+  def testNegativeLimitWithoutOffset(): Unit = {
+    util.verifyPlan("SELECT * FROM LimitTable LIMIT -1")
+  }
+
+  @Test(expected = classOf[SqlParserException])
+  def testMysqlLimit(): Unit = {
+    util.verifyPlan("SELECT a, c FROM LimitTable LIMIT 1, 10")
+  }
+
+  @Test
+  def testCanPushdownLimitWithoutOffset(): Unit = {
+    util.verifyPlan("SELECT * FROM LimitTable LIMIT 5")
+  }
+
+  @Test
+  def testCanPushdownLimitWithOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM LimitTable LIMIT 10 OFFSET 1")
+  }
+
+  @Test
+  def testCanPushdownFetchWithOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM LimitTable OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY")
+  }
+
+  @Test
+  def testCanPushdownFetchWithoutOffset(): Unit = {
+    util.verifyPlan("SELECT a, c FROM LimitTable FETCH FIRST 10 ROWS ONLY")
+  }
+
+  @Test
+  def testCannotPushDownWithoutLimit(): Unit = {
+    util.verifyPlan("SELECT a, c FROM LimitTable OFFSET 10")
+  }
+
+  @Test
+  def testCannotPushDownWithoutFetch(): Unit = {
+    util.verifyPlan("SELECT a, c FROM LimitTable OFFSET 10 ROWS")
+  }
+
+  @Test
+  def testCannotPushDownWithOrderBy(): Unit = {
+    val sqlQuery = "SELECT a, c FROM LimitTable ORDER BY c LIMIT 10"
+    util.verifyPlan(sqlQuery)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LegacyLimitITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LegacyLimitITCase.scala
@@ -100,13 +100,6 @@ class LegacyLimitITCase extends BatchTestBase {
       5)
   }
 
-  @Test(expected = classOf[ValidationException])
-  def testTableLimitWithLimitTable(): Unit = {
-    Assert.assertEquals(
-      executeQuery(tEnv.from("LimitTable").fetch(5)).size,
-      5)
-  }
-
   @Test
   def testLessThanOffset(): Unit = {
     checkSize(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LegacyLimitITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LegacyLimitITCase.scala
@@ -18,29 +18,22 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
-<<<<<<< HEAD
 import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.TestData._
-import org.apache.flink.table.planner.utils.TestLimitableTableSource
+import org.apache.flink.table.planner.utils.TestLegacyLimitableTableSource
+
 import org.junit._
 
-class LimitITCase extends BatchTestBase {
+class LegacyLimitITCase extends BatchTestBase {
 
   @Before
-=======
-import org.apache.flink.table.planner.factories.TestValuesTableFactory
-import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
-import org.apache.flink.table.planner.runtime.utils.TestData.{data3, nullablesOfData3, type3}
-
-class LimitITCase extends LegacyLimitITCase {
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
   override def before(): Unit = {
-    BatchTestBase.configForMiniCluster(conf)
+    super.before()
     registerCollection("Table3", data3, type3, "a, b, c", nullablesOfData3)
 
-<<<<<<< HEAD
-    TestLimitableTableSource.createTemporaryTable(
+    TestLegacyLimitableTableSource.createTemporaryTable(
       tEnv, data3, new TableSchema(Array("a", "b", "c"), type3.getFieldTypes), "LimitTable")
   }
 
@@ -107,6 +100,13 @@ class LimitITCase extends LegacyLimitITCase {
       5)
   }
 
+  @Test(expected = classOf[ValidationException])
+  def testTableLimitWithLimitTable(): Unit = {
+    Assert.assertEquals(
+      executeQuery(tEnv.from("LimitTable").fetch(5)).size,
+      5)
+  }
+
   @Test
   def testLessThanOffset(): Unit = {
     checkSize(
@@ -119,23 +119,5 @@ class LimitITCase extends LegacyLimitITCase {
     checkSize(
       "SELECT * FROM LimitTable OFFSET 2 ROWS FETCH NEXT 50 ROWS ONLY",
       19)
-=======
-//    TestLimitableTableSource.createTemporaryTable(
-//      tEnv, data3, new TableSchema(Array("a", "b", "c"), type3.getFieldTypes), "LimitTable")
-    val myTableDataId = TestValuesTableFactory.registerData(TestData.data3)
-    val ddl =
-      s"""
-         |CREATE TABLE LimitTable (
-         |  a int,
-         |  b bigint,
-         |  c string
-         |) WITH (
-         |  'connector' = 'values',
-         |  'data-id' = '$myTableDataId',
-         |  'bounded' = 'true'
-         |)
-       """.stripMargin
-    tEnv.executeSql(ddl)
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/LimitITCase.scala
@@ -18,110 +18,15 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
-<<<<<<< HEAD
-import org.apache.flink.table.api.TableSchema
-import org.apache.flink.table.planner.runtime.utils.BatchTestBase
-import org.apache.flink.table.planner.runtime.utils.TestData._
-import org.apache.flink.table.planner.utils.TestLimitableTableSource
-import org.junit._
-
-class LimitITCase extends BatchTestBase {
-
-  @Before
-=======
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
-import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
 import org.apache.flink.table.planner.runtime.utils.TestData.{data3, nullablesOfData3, type3}
+import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
 
 class LimitITCase extends LegacyLimitITCase {
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
   override def before(): Unit = {
     BatchTestBase.configForMiniCluster(conf)
     registerCollection("Table3", data3, type3, "a, b, c", nullablesOfData3)
 
-<<<<<<< HEAD
-    TestLimitableTableSource.createTemporaryTable(
-      tEnv, data3, new TableSchema(Array("a", "b", "c"), type3.getFieldTypes), "LimitTable")
-  }
-
-  @Test
-  def testOffsetAndFetch(): Unit = {
-    checkSize(
-      "SELECT * FROM Table3 OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY",
-      5)
-  }
-
-  @Test
-  def testOffsetAndLimit(): Unit = {
-    checkSize(
-      "SELECT * FROM Table3 LIMIT 10 OFFSET 2",
-      10)
-  }
-
-  @Test
-  def testFetch(): Unit = {
-    checkSize(
-      "SELECT * FROM Table3 FETCH NEXT 10 ROWS ONLY",
-      10)
-  }
-
-  @Test
-  def testFetchWithLimitTable(): Unit = {
-    checkSize(
-      "SELECT * FROM LimitTable FETCH NEXT 10 ROWS ONLY",
-      10)
-  }
-
-  @Test
-  def testFetchFirst(): Unit = {
-    checkSize(
-      "SELECT * FROM Table3 FETCH FIRST 10 ROWS ONLY",
-      10)
-  }
-
-  @Test
-  def testFetchFirstWithLimitTable(): Unit = {
-    checkSize(
-      "SELECT * FROM LimitTable FETCH FIRST 10 ROWS ONLY",
-      10)
-  }
-
-  @Test
-  def testLimit(): Unit = {
-    checkSize(
-      "SELECT * FROM Table3 LIMIT 5",
-      5)
-  }
-
-  @Test
-  def testLimit0WithLimitTable(): Unit = {
-    checkSize(
-      "SELECT * FROM LimitTable LIMIT 0",
-      0)
-  }
-
-  @Test
-  def testLimitWithLimitTable(): Unit = {
-    checkSize(
-      "SELECT * FROM LimitTable LIMIT 5",
-      5)
-  }
-
-  @Test
-  def testLessThanOffset(): Unit = {
-    checkSize(
-      "SELECT * FROM Table3 OFFSET 2 ROWS FETCH NEXT 50 ROWS ONLY",
-      19)
-  }
-
-  @Test
-  def testLessThanOffsetWithLimitSource(): Unit = {
-    checkSize(
-      "SELECT * FROM LimitTable OFFSET 2 ROWS FETCH NEXT 50 ROWS ONLY",
-      19)
-=======
-//    TestLimitableTableSource.createTemporaryTable(
-//      tEnv, data3, new TableSchema(Array("a", "b", "c"), type3.getFieldTypes), "LimitTable")
     val myTableDataId = TestValuesTableFactory.registerData(TestData.data3)
     val ddl =
       s"""
@@ -136,6 +41,5 @@ class LimitITCase extends LegacyLimitITCase {
          |)
        """.stripMargin
     tEnv.executeSql(ddl)
->>>>>>> [FLINK-17426][blink-planner] DynamicSource supports SupportsLimitPushDown.
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLegacyLimitableTableSource.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TestLegacyLimitableTableSource.scala
@@ -41,7 +41,7 @@ import scala.collection.JavaConverters._
 /**
   * The table source which support push-down the limit to the source.
   */
-class TestLimitableTableSource(
+class TestLegacyLimitableTableSource(
     data: Seq[Row],
     rowType: RowTypeInfo,
     var limit: Long = -1,
@@ -66,7 +66,7 @@ class TestLimitableTableSource(
   }
 
   override def applyLimit(limit: Long): TableSource[Row] = {
-    new TestLimitableTableSource(data, rowType, limit, limitablePushedDown)
+    new TestLegacyLimitableTableSource(data, rowType, limit, limitablePushedDown)
   }
 
   override def isLimitPushedDown: Boolean = limitablePushedDown
@@ -84,7 +84,7 @@ class TestLimitableTableSource(
   override def getTableSchema: TableSchema = TableSchema.fromTypeInfo(rowType)
 }
 
-object TestLimitableTableSource {
+object TestLegacyLimitableTableSource {
   def createTemporaryTable(
       tEnv: TableEnvironment,
       data: Seq[Row],
@@ -100,7 +100,7 @@ object TestLimitableTableSource {
   }
 }
 
-class TestLimitableTableSourceFactory extends StreamTableSourceFactory[Row] {
+class TestLegacyLimitableTableSourceFactory extends StreamTableSourceFactory[Row] {
   override def createStreamTableSource(
       properties: util.Map[String, String]): StreamTableSource[Row] = {
     val dp = new DescriptorProperties
@@ -117,7 +117,7 @@ class TestLimitableTableSourceFactory extends StreamTableSourceFactory[Row] {
     val limit = dp.getOptionalLong("limit").orElse(-1L)
 
     val limitablePushedDown = dp.getOptionalBoolean("limitable-push-down").orElse(false)
-    new TestLimitableTableSource(
+    new TestLegacyLimitableTableSource(
       data, tableSchema.toRowType.asInstanceOf[RowTypeInfo], limit, limitablePushedDown)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

- make the DynamicSource supports LimitPushDown Rule

## Verifying this change

This change added tests and can be verified as follows:

- Added LimitTest to verify the plan
- Extended LimitITCase (only batch)to verify the result limit projection
- make the TestValueSource supports LimitPushDown

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): ( no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- The serializers: ( no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (JavaDocs)
