### PR TITLE
[FLINK-15803][table] Use AggregateInfo as the single source of types

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -22,26 +22,24 @@ import org.apache.flink.runtime.util.SingleElementIterator
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.data.{GenericRowData, RowData}
 import org.apache.flink.table.expressions.ApiExpressionUtils.localRef
-import org.apache.flink.table.expressions.{Expression, _}
-import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
+import org.apache.flink.table.expressions._
+import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
+import org.apache.flink.table.planner.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.STREAM_RECORD
 import org.apache.flink.table.planner.codegen._
 import org.apache.flink.table.planner.expressions.DeclarativeExpressionResolver
 import org.apache.flink.table.planner.expressions.DeclarativeExpressionResolver.toRexInputRef
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
-import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils.{getAccumulatorTypeOfAggregateFunction, getAggUserDefinedInputTypes}
+import org.apache.flink.table.planner.plan.utils.AggregateInfo
 import org.apache.flink.table.runtime.context.ExecutionContextImpl
 import org.apache.flink.table.runtime.generated.{GeneratedAggsHandleFunction, GeneratedOperator}
-import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.{fromDataTypeToLogicalType, fromLogicalTypeToDataType}
+import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter._
 import org.apache.flink.table.runtime.typeutils.InternalSerializers
-import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.{DistinctType, LogicalType, RowType}
 
-import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.rex.RexNode
 import org.apache.calcite.tools.RelBuilder
 
 import scala.annotation.tailrec
@@ -52,34 +50,50 @@ import scala.annotation.tailrec
 object AggCodeGenHelper {
 
   def getAggBufferNames(
-      auxGrouping: Array[Int], aggregates: Seq[UserDefinedFunction]): Array[Array[String]] = {
-    auxGrouping.zipWithIndex.map {
-      case (_, index) => Array(s"aux_group$index")
-    } ++ aggregates.zipWithIndex.toArray.map {
-      case (a: DeclarativeAggregateFunction, index) =>
-        val idx = auxGrouping.length + index
-        a.aggBufferAttributes.map(attr => s"agg${idx}_${attr.getName}")
-      case (_: AggregateFunction[_, _], index) =>
-        val idx = auxGrouping.length + index
-        Array(s"agg$idx")
+      auxGrouping: Array[Int],
+      aggInfos: Seq[AggregateInfo])
+    : Array[Array[String]] = {
+    val auxGroupingNames = auxGrouping.indices
+      .map(index => Array(s"aux_group$index"))
+
+    val aggNames = aggInfos.map { aggInfo =>
+
+      val aggBufferIdx = auxGrouping.length + aggInfo.aggIndex
+
+      aggInfo.function match {
+
+        // create one buffer for each attribute in declarative functions
+        case function: DeclarativeAggregateFunction =>
+          function.aggBufferAttributes.map(attr => s"agg${aggBufferIdx}_${attr.getName}")
+
+        // create one buffer for imperative functions
+        case _: AggregateFunction[_, _] =>
+          Array(s"agg$aggBufferIdx")
+      }
     }
+
+    (auxGroupingNames ++ aggNames).toArray
   }
 
   def getAggBufferTypes(
-      inputType: RowType, auxGrouping: Array[Int], aggregates: Seq[UserDefinedFunction])
+      inputType: RowType,
+      auxGrouping: Array[Int],
+      aggInfos: Seq[AggregateInfo])
     : Array[Array[LogicalType]] = {
-    auxGrouping.map { index =>
-      Array(inputType.getTypeAt(index))
-    } ++ aggregates.map {
-      case a: DeclarativeAggregateFunction => a.getAggBufferTypes.map(_.getLogicalType)
-      case a: AggregateFunction[_, _] =>
-        Array(fromDataTypeToLogicalType(getAccumulatorTypeOfAggregateFunction(a)))
-    }.toArray[Array[LogicalType]]
+    val auxGroupingTypes = auxGrouping
+      .map { index =>
+        Array(inputType.getTypeAt(index))
+      }
+
+    val aggTypes = aggInfos
+      .map(_.externalAccTypes.map(fromDataTypeToLogicalType))
+
+    auxGroupingTypes ++ aggTypes
   }
 
-  def getUdaggs(
-      aggregates: Seq[UserDefinedFunction]): Map[AggregateFunction[_, _], String] = {
-    aggregates
+  def getFunctionIdentifiers(aggInfos: Seq[AggregateInfo]): Map[AggregateFunction[_, _], String] = {
+    aggInfos
+        .map(_.function)
         .filter(a => a.isInstanceOf[AggregateFunction[_, _]])
         .map(a => a -> CodeGenUtils.udfFieldName(a)).toMap
         .asInstanceOf[Map[AggregateFunction[_, _], String]]
@@ -95,7 +109,8 @@ object AggCodeGenHelper {
   private[flink] def addAggsHandler(
       aggsHandler: GeneratedAggsHandleFunction,
       ctx: CodeGeneratorContext,
-      aggsHandlerCtx: CodeGeneratorContext): String = {
+      aggsHandlerCtx: CodeGeneratorContext)
+    : String = {
     ctx.addReusableInnerClass(aggsHandler.getClassName, aggsHandler.getCode)
     val handler = CodeGenUtils.newName("handler")
     ctx.addReusableMember(s"${aggsHandler.getClassName} $handler = null;")
@@ -116,7 +131,8 @@ object AggCodeGenHelper {
     */
   private[flink] def genGroupKeyChangedCheckCode(
       currentKeyTerm: String,
-      lastKeyTerm: String): String = {
+      lastKeyTerm: String)
+    : String = {
     s"""
        |$currentKeyTerm.getSizeInBytes() != $lastKeyTerm.getSizeInBytes() ||
        |  !(org.apache.flink.table.data.binary.BinaryRowDataUtil.byteArrayEquals(
@@ -133,27 +149,25 @@ object AggCodeGenHelper {
       builder: RelBuilder,
       grouping: Array[Int],
       auxGrouping: Array[Int],
-      aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
-      aggArgs: Array[Array[Int]],
-      aggregates: Seq[UserDefinedFunction],
-      aggResultTypes: Seq[DataType],
-      udaggs: Map[AggregateFunction[_, _], String],
+      aggInfos: Seq[AggregateInfo],
+      functionIdentifiers: Map[AggregateFunction[_, _], String],
       inputTerm: String,
       inputType: RowType,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       outputType: RowType,
-      forHashAgg: Boolean = false): (String, String, GeneratedExpression) = {
+      forHashAgg: Boolean = false)
+    : (String, String, GeneratedExpression) = {
     // gen code to apply aggregate functions to grouping elements
     val argsMapping = buildAggregateArgsMapping(
-      isMerge, grouping.length, inputType, auxGrouping, aggArgs, aggBufferTypes)
+      isMerge, grouping.length, inputType, auxGrouping, aggInfos, aggBufferTypes)
 
     val aggBufferExprs = genFlatAggBufferExprs(
       isMerge,
       ctx,
       builder,
       auxGrouping,
-      aggregates,
+      aggInfos,
       argsMapping,
       aggBufferNames,
       aggBufferTypes)
@@ -165,8 +179,8 @@ object AggCodeGenHelper {
       inputTerm,
       grouping,
       auxGrouping,
-      aggregates,
-      udaggs,
+      aggInfos,
+      functionIdentifiers,
       aggBufferExprs,
       forHashAgg)
 
@@ -177,9 +191,8 @@ object AggCodeGenHelper {
       inputType,
       inputTerm,
       auxGrouping,
-      aggCallToAggFunction,
-      aggregates,
-      udaggs,
+      aggInfos,
+      functionIdentifiers,
       argsMapping,
       aggBufferNames,
       aggBufferTypes,
@@ -192,9 +205,8 @@ object AggCodeGenHelper {
       builder,
       grouping,
       auxGrouping,
-      aggregates,
-      aggResultTypes,
-      udaggs,
+      aggInfos,
+      functionIdentifiers,
       argsMapping,
       aggBufferNames,
       aggBufferTypes,
@@ -218,8 +230,10 @@ object AggCodeGenHelper {
       aggBufferOffset: Int,
       inputType: RowType,
       auxGrouping: Array[Int],
-      aggArgs: Array[Array[Int]],
-      aggBufferTypes: Array[Array[LogicalType]]): Array[Array[(Int, LogicalType)]] = {
+      aggInfos: Seq[AggregateInfo],
+      aggBufferTypes: Array[Array[LogicalType]])
+    : Array[Array[(Int, LogicalType)]] = {
+    val aggArgs = aggInfos.map(_.argIndexes).toArray
     val auxGroupingMapping = auxGrouping.indices.map {
       i => Array[(Int, LogicalType)]((i, aggBufferTypes(i)(0)))
     }.toArray
@@ -281,29 +295,47 @@ object AggCodeGenHelper {
       ctx: CodeGeneratorContext,
       builder: RelBuilder,
       auxGrouping: Array[Int],
-      aggregates: Seq[UserDefinedFunction],
+      aggInfos: Seq[AggregateInfo],
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]]): Seq[GeneratedExpression] = {
-    val exprCodegen = new ExprCodeGenerator(ctx, false)
+    val exprCodeGen = new ExprCodeGenerator(ctx, false)
     val converter = new ExpressionConverter(builder)
 
-    val accessAuxGroupingExprs = auxGrouping.indices.map {
-      idx => newLocalReference(aggBufferNames(idx)(0), aggBufferTypes(idx)(0))
-    }.map(_.accept(converter)).map(exprCodegen.generateExpression)
+    val accessAuxGroupingExprs = auxGrouping.indices
+      .map(idx => newLocalReference(aggBufferNames(idx).head, aggBufferTypes(idx).head))
 
-    val aggCallExprs = aggregates.zipWithIndex.flatMap {
-      case (agg: DeclarativeAggregateFunction, aggIndex: Int) =>
-        val idx = auxGrouping.length + aggIndex
-        agg.aggBufferAttributes.map(_.accept(
-          ResolveReference(ctx, builder, isMerge, agg, idx, argsMapping, aggBufferTypes)))
-      case (_: AggregateFunction[_, _], aggIndex: Int) =>
-        val idx = auxGrouping.length + aggIndex
-        val variableName = aggBufferNames(idx)(0)
-        Some(newLocalReference(variableName, aggBufferTypes(idx)(0)))
-    }.map(_.accept(converter)).map(exprCodegen.generateExpression)
+    val aggCallExprs = aggInfos.flatMap { aggInfo =>
 
-    accessAuxGroupingExprs ++ aggCallExprs
+      val aggBufferIdx = auxGrouping.length + aggInfo.aggIndex
+
+      aggInfo.function match {
+
+        // create a buffer expression for each attribute in declarative functions
+        case function: DeclarativeAggregateFunction =>
+          val ref = ResolveReference(
+            ctx,
+            builder,
+            isMerge,
+            function,
+            aggBufferIdx,
+            argsMapping,
+            aggBufferTypes)
+          function.aggBufferAttributes().map(_.accept(ref))
+
+        // create one buffer for imperative functions
+        case _: AggregateFunction[_, _] =>
+          val aggBufferName = aggBufferNames(aggBufferIdx).head
+          val aggBufferType = aggBufferTypes(aggBufferIdx).head
+          Some(newLocalReference(aggBufferName, aggBufferType))
+      }
+    }
+
+    val aggBufferExprs = accessAuxGroupingExprs ++ aggCallExprs
+
+    aggBufferExprs
+      .map(_.accept(converter))
+      .map(exprCodeGen.generateExpression)
   }
 
   /**
@@ -316,12 +348,14 @@ object AggCodeGenHelper {
       inputTerm: String,
       grouping: Array[Int],
       auxGrouping: Array[Int],
-      aggregates: Seq[UserDefinedFunction],
-      udaggs: Map[AggregateFunction[_, _], String],
+      aggInfos: Seq[AggregateInfo],
+      functionIdentifiers: Map[AggregateFunction[_, _], String],
       aggBufferExprs: Seq[GeneratedExpression],
-      forHashAgg: Boolean = false): String = {
-    val exprCodegen = new ExprCodeGenerator(ctx, false)
+      forHashAgg: Boolean = false)
+    : String = {
+    val exprCodeGen = new ExprCodeGenerator(ctx, false)
         .bindInput(inputType, inputTerm = inputTerm, inputFieldMapping = Some(auxGrouping))
+    val converter = new ExpressionConverter(builder)
 
     val initAuxGroupingExprs = {
       if (forHashAgg) {
@@ -335,25 +369,27 @@ object AggCodeGenHelper {
       GenerateUtils.generateFieldAccess(ctx, inputType, inputTerm, idx)
     }
 
-    val initAggCallBufferExprs = aggregates.flatMap {
-      case (agg: DeclarativeAggregateFunction) =>
-        agg.initialValuesExpressions
-      case (agg: AggregateFunction[_, _]) =>
-        Some(agg)
-    }.map {
-      case (expr: Expression) => expr.accept(new ExpressionConverter(builder))
-      case t@_ => t
-    }.map {
-      case (rex: RexNode) => exprCodegen.generateExpression(rex)
-      case (agg: AggregateFunction[_, _]) =>
-        val resultTerm = s"${udaggs(agg)}.createAccumulator()"
-        val nullTerm = "false"
-        val resultType = getAccumulatorTypeOfAggregateFunction(agg)
-        GeneratedExpression(
-          genToInternal(ctx, resultType, resultTerm),
-          nullTerm,
-          "",
-          fromDataTypeToLogicalType(resultType))
+    val initAggCallBufferExprs = aggInfos.flatMap { aggInfo =>
+      aggInfo.function match {
+
+        // generate code for each agg buffer in declarative functions
+        case function: DeclarativeAggregateFunction =>
+          val expressions = function.initialValuesExpressions
+          val rexNodes = expressions.map(_.accept(converter))
+          rexNodes.map(exprCodeGen.generateExpression)
+
+        // call createAccumulator() in imperative functions
+        case function: AggregateFunction[_, _] =>
+          val accTerm = s"${functionIdentifiers(function)}.createAccumulator()"
+          val externalAccType = aggInfo.externalAccTypes.head
+          val internalAccType = externalAccType.getLogicalType
+          val genExpr = GeneratedExpression(
+            genToInternal(ctx, externalAccType)(accTerm),
+            NEVER_NULL,
+            NO_CODE,
+            internalAccType)
+          Seq(genExpr)
+        }
     }
 
     val initAggBufferExprs = initAuxGroupingExprs ++ initAggCallBufferExprs
@@ -394,13 +430,13 @@ object AggCodeGenHelper {
       inputType: RowType,
       inputTerm: String,
       auxGrouping: Array[Int],
-      aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
-      aggregates: Seq[UserDefinedFunction],
-      udaggs: Map[AggregateFunction[_, _], String],
+      aggInfos: Seq[AggregateInfo],
+      functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
-      aggBufferExprs: Seq[GeneratedExpression]): String = {
+      aggBufferExprs: Seq[GeneratedExpression])
+    : String = {
     if (isMerge) {
       genMergeFlatAggregateBuffer(
         ctx,
@@ -408,8 +444,8 @@ object AggCodeGenHelper {
         inputTerm,
         inputType,
         auxGrouping,
-        aggregates,
-        udaggs,
+        aggInfos,
+        functionIdentifiers,
         argsMapping,
         aggBufferNames,
         aggBufferTypes,
@@ -421,8 +457,8 @@ object AggCodeGenHelper {
         inputTerm,
         inputType,
         auxGrouping,
-        aggCallToAggFunction,
-        udaggs,
+        aggInfos,
+        functionIdentifiers,
         argsMapping,
         aggBufferNames,
         aggBufferTypes,
@@ -437,35 +473,34 @@ object AggCodeGenHelper {
       builder: RelBuilder,
       grouping: Array[Int],
       auxGrouping: Array[Int],
-      aggregates: Seq[UserDefinedFunction],
-      aggResultTypes: Seq[DataType],
-      udaggs: Map[AggregateFunction[_, _], String],
+      aggInfos: Seq[AggregateInfo],
+      functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       aggBufferExprs: Seq[GeneratedExpression],
-      outputType: RowType): GeneratedExpression = {
+      outputType: RowType)
+    : GeneratedExpression = {
     val valueRow = CodeGenUtils.newName("valueRow")
-    val resultCodegen = new ExprCodeGenerator(ctx, false)
+    val resultCodeGen = new ExprCodeGenerator(ctx, false)
     if (isFinal) {
       val getValueExprs = genGetValueFromFlatAggregateBuffer(
         isMerge,
         ctx,
         builder,
         auxGrouping,
-        aggregates,
-        aggResultTypes,
-        udaggs,
+        aggInfos,
+        functionIdentifiers,
         argsMapping,
         aggBufferNames,
         aggBufferTypes,
         outputType)
       val valueRowType = RowType.of(getValueExprs.map(_.resultType): _*)
-      resultCodegen.generateResultExpression(
+      resultCodeGen.generateResultExpression(
         getValueExprs, valueRowType, classOf[GenericRowData], valueRow)
     } else {
       val valueRowType = RowType.of(aggBufferExprs.map(_.resultType): _*)
-      resultCodegen.generateResultExpression(
+      resultCodeGen.generateResultExpression(
         aggBufferExprs, valueRowType, classOf[GenericRowData], valueRow)
     }
   }
@@ -478,44 +513,58 @@ object AggCodeGenHelper {
       ctx: CodeGeneratorContext,
       builder: RelBuilder,
       auxGrouping: Array[Int],
-      aggregates: Seq[UserDefinedFunction],
-      aggResultTypes: Seq[DataType],
-      udaggs: Map[AggregateFunction[_, _], String],
+      aggInfos: Seq[AggregateInfo],
+      functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       outputType: RowType): Seq[GeneratedExpression] = {
-    val exprCodegen = new ExprCodeGenerator(ctx, false)
+    val exprCodeGen = new ExprCodeGenerator(ctx, false)
+    val converter = new ExpressionConverter(builder)
 
     val auxGroupingExprs = auxGrouping.indices.map { idx =>
-      val resultTerm = aggBufferNames(idx)(0)
-      val nullTerm = s"${resultTerm}IsNull"
-      GeneratedExpression(resultTerm, nullTerm, "", aggBufferTypes(idx)(0))
+      val aggBufferName = aggBufferNames(idx).head
+      val aggBufferType = aggBufferTypes(idx).head
+      val nullTerm = s"${aggBufferName}IsNull"
+      GeneratedExpression(aggBufferName, nullTerm, NO_CODE, aggBufferType)
     }
 
-    val aggExprs = aggregates.zipWithIndex.map {
-      case (agg: DeclarativeAggregateFunction, aggIndex) =>
-        val idx = auxGrouping.length + aggIndex
-        agg.getValueExpression.accept(ResolveReference(
-          ctx, builder, isMerge, agg, idx, argsMapping, aggBufferTypes))
-      case (agg: AggregateFunction[_, _], aggIndex) =>
-        val idx = auxGrouping.length + aggIndex
-        (agg, idx)
-    }.map {
-      case (expr: Expression) => expr.accept(new ExpressionConverter(builder))
-      case t@_ => t
-    }.map {
-      case (rex: RexNode) => exprCodegen.generateExpression(rex)
-      case (agg: AggregateFunction[_, _], aggIndex: Int) =>
-        val resultType = aggResultTypes(aggIndex - auxGrouping.length)
-        val accType = getAccumulatorTypeOfAggregateFunction(agg)
-        val resultTerm = genToInternal(ctx, resultType,
-          s"${udaggs(agg)}.getValue(${genToExternal(ctx, accType, aggBufferNames(aggIndex)(0))})")
-        val nullTerm = s"${aggBufferNames(aggIndex)(0)}IsNull"
-        GeneratedExpression(resultTerm, nullTerm, "", fromDataTypeToLogicalType(resultType))
+    val getValueExprs = aggInfos.map { aggInfo =>
+
+      val aggBufferIdx = auxGrouping.length + aggInfo.aggIndex
+
+      aggInfo.function match {
+
+        // evaluate the value expression in declarative functions
+        case function: DeclarativeAggregateFunction =>
+          val ref = ResolveReference(
+            ctx,
+            builder,
+            isMerge,
+            function,
+            aggBufferIdx,
+            argsMapping,
+            aggBufferTypes)
+          val getValueRexNode = function.getValueExpression
+            .accept(ref)
+            .accept(converter)
+          exprCodeGen.generateExpression(getValueRexNode)
+
+        // call getValue() for imperative functions
+        case function: AggregateFunction[_, _] =>
+          val aggBufferName = aggBufferNames(aggBufferIdx).head
+          val externalAccType = aggInfo.externalAccTypes.head
+          val externalResultType = aggInfo.externalResultType
+          val resultType = externalResultType.getLogicalType
+          val getValueCode = s"${functionIdentifiers(function)}.getValue(" +
+            s"${genToExternal(ctx, externalAccType, aggBufferName)})"
+          val resultTerm = genToInternal(ctx, externalResultType)(getValueCode)
+          val nullTerm = s"${aggBufferName}IsNull"
+          GeneratedExpression(resultTerm, nullTerm, NO_CODE, resultType)
+      }
     }
 
-    auxGroupingExprs ++ aggExprs
+    auxGroupingExprs ++ getValueExprs
   }
 
   /**
@@ -527,55 +576,81 @@ object AggCodeGenHelper {
       inputTerm: String,
       inputType: RowType,
       auxGrouping: Array[Int],
-      aggregates: Seq[UserDefinedFunction],
-      udaggs: Map[AggregateFunction[_, _], String],
+      aggInfos: Seq[AggregateInfo],
+      functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
-      aggBufferExprs: Seq[GeneratedExpression]): String = {
-    val exprCodegen = new ExprCodeGenerator(ctx, false).bindInput(inputType, inputTerm = inputTerm)
+      aggBufferExprs: Seq[GeneratedExpression])
+    : String = {
+    val exprCodeGen = new ExprCodeGenerator(ctx, false)
+      .bindInput(inputType, inputTerm = inputTerm)
+    val converter = new ExpressionConverter(builder)
 
-    // flat map to get flat agg buffers.
-    aggregates.zipWithIndex.flatMap {
-      case (agg: DeclarativeAggregateFunction, aggIndex) =>
-        val idx = auxGrouping.length + aggIndex
-        agg.mergeExpressions.map(_.accept(ResolveReference(
-          ctx, builder, isMerge = true, agg, idx, argsMapping, aggBufferTypes)))
-      case (agg: AggregateFunction[_, _], aggIndex) =>
-        val idx = auxGrouping.length + aggIndex
-        Some(agg, idx)
-    }.zip(aggBufferExprs.slice(auxGrouping.length, aggBufferExprs.size)).map {
-      // DeclarativeAggregateFunction
-      case ((expr: Expression), aggBufVar) =>
-        val mergeExpr = exprCodegen.generateExpression(
-          expr.accept(new ExpressionConverter(builder)))
-        s"""
-           |${mergeExpr.code}
-           |${aggBufVar.nullTerm} = ${mergeExpr.nullTerm};
-           |if (!${mergeExpr.nullTerm}) {
-           |  ${mergeExpr.copyResultTermToTargetIfChanged(ctx, aggBufVar.resultTerm)}
-           |}
-           """.stripMargin.trim
-      // UserDefinedAggregateFunction
-      case ((agg: AggregateFunction[_, _], aggIndex: Int), aggBufVar) =>
-        val (inputIndex, inputType) = argsMapping(aggIndex)(0)
-        val inputRef = toRexInputRef(builder, inputIndex, inputType)
-        val inputExpr = exprCodegen.generateExpression(
-          inputRef.accept(new ExpressionConverter(builder)))
-        val singleIterableClass = classOf[SingleElementIterator[_]].getCanonicalName
+    var currentAggBufferExprIdx = auxGrouping.length
 
-        val externalAccT = getAccumulatorTypeOfAggregateFunction(agg)
-        val javaField = typeTerm(externalAccT.getConversionClass)
-        val tmpAcc = newName("tmpAcc")
-        s"""
-           |final $singleIterableClass accIt$aggIndex = new  $singleIterableClass();
-           |accIt$aggIndex.set(${genToExternal(ctx, externalAccT, inputExpr.resultTerm)});
-           |$javaField $tmpAcc = ${genToExternal(ctx, externalAccT, aggBufferNames(aggIndex)(0))};
-           |${udaggs(agg)}.merge($tmpAcc, accIt$aggIndex);
-           |${aggBufferNames(aggIndex)(0)} = ${genToInternal(ctx, externalAccT, tmpAcc)};
-           |${aggBufVar.nullTerm} = ${aggBufferNames(aggIndex)(0)}IsNull || ${inputExpr.nullTerm};
-         """.stripMargin
-    } mkString "\n"
+    val mergeCode = aggInfos.map { aggInfo =>
+
+      val aggBufferIdx = auxGrouping.length + aggInfo.aggIndex
+
+      aggInfo.function match {
+
+        // merge each agg buffer for declarative functions
+        case function: DeclarativeAggregateFunction =>
+          val ref = ResolveReference(
+            ctx,
+            builder,
+            isMerge = true,
+            function,
+            aggBufferIdx,
+            argsMapping,
+            aggBufferTypes)
+          val mergeExprs = function.mergeExpressions
+            .map(_.accept(ref))
+            .map(_.accept(converter))
+            .map(exprCodeGen.generateExpression)
+          mergeExprs
+            .map { mergeExpr =>
+              val aggBufferExpr = aggBufferExprs(currentAggBufferExprIdx)
+              currentAggBufferExprIdx += 1
+              s"""
+                 |${mergeExpr.code}
+                 |${aggBufferExpr.nullTerm} = ${mergeExpr.nullTerm};
+                 |if (!${mergeExpr.nullTerm}) {
+                 |  ${mergeExpr.copyResultTermToTargetIfChanged(ctx, aggBufferExpr.resultTerm)}
+                 |}
+              """.stripMargin
+            }
+            .mkString("\n")
+
+        // call merge() for imperative functions
+        case function: AggregateFunction[_, _] =>
+          val (inputIndex, inputType) = argsMapping(aggBufferIdx).head
+          val inputRef = toRexInputRef(builder, inputIndex, inputType)
+          val inputExpr = exprCodeGen.generateExpression(
+            inputRef.accept(converter))
+          val aggBufferName = aggBufferNames(aggBufferIdx).head
+          val aggBufferExpr = aggBufferExprs(currentAggBufferExprIdx)
+          currentAggBufferExprIdx += 1
+          val iterableTypeTerm = className[SingleElementIterator[_]]
+          val externalAccType = aggInfo.externalAccTypes.head
+          val externalAccTypeTerm = typeTerm(externalAccType.getConversionClass)
+          val externalAccTerm = newName("acc")
+          val aggIndex = aggInfo.aggIndex
+          s"""
+            |$iterableTypeTerm accIt$aggIndex = new $iterableTypeTerm();
+            |accIt$aggIndex.set(${
+              genToExternal(ctx, externalAccType, inputExpr.resultTerm)});
+            |$externalAccTypeTerm $externalAccTerm = ${
+              genToExternal(ctx, externalAccType, aggBufferName)};
+            |${functionIdentifiers(function)}.merge($externalAccTerm, accIt$aggIndex);
+            |$aggBufferName = ${genToInternal(ctx, externalAccType)(externalAccTerm)};
+            |${aggBufferExpr.nullTerm} = ${aggBufferName}IsNull || ${inputExpr.nullTerm};
+          """.stripMargin
+      }
+    }
+
+    mergeCode.mkString("\n")
   }
 
   /**
@@ -587,81 +662,96 @@ object AggCodeGenHelper {
       inputTerm: String,
       inputType: RowType,
       auxGrouping: Array[Int],
-      aggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)],
-      udaggs: Map[AggregateFunction[_, _], String],
+      aggInfos: Seq[AggregateInfo],
+      functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
-      aggBufferExprs: Seq[GeneratedExpression]): String = {
-    val exprCodegen = new ExprCodeGenerator(ctx, false).bindInput(inputType, inputTerm = inputTerm)
+      aggBufferExprs: Seq[GeneratedExpression])
+    : String = {
+    val exprCodeGen = new ExprCodeGenerator(ctx, false)
+      .bindInput(inputType, inputTerm = inputTerm)
+    val converter = new ExpressionConverter(builder)
 
-    // flat map to get flat agg buffers.
-    aggCallToAggFunction.zipWithIndex.flatMap {
-      case (aggCallToAggFun, aggIndex) =>
-        val idx = auxGrouping.length + aggIndex
-        val aggCall = aggCallToAggFun._1
-        aggCallToAggFun._2 match {
-          case agg: DeclarativeAggregateFunction =>
-            agg.accumulateExpressions.map(_.accept(ResolveReference(
-              ctx, builder, isMerge = false, agg, idx, argsMapping, aggBufferTypes)))
-                .map(e => (e, aggCall))
-          case agg: AggregateFunction[_, _] =>
-            val idx = auxGrouping.length + aggIndex
-            Some(agg, idx, aggCall)
-        }
-    }.zip(aggBufferExprs.slice(auxGrouping.length, aggBufferExprs.size)).map {
-      // DeclarativeAggregateFunction
-      case ((expr: Expression, aggCall: AggregateCall), aggBufVar) =>
-        val accExpr = exprCodegen.generateExpression(expr.accept(new ExpressionConverter(builder)))
-        (s"""
-            |${accExpr.code}
-            |${aggBufVar.nullTerm} = ${accExpr.nullTerm};
-            |if (!${accExpr.nullTerm}) {
-            |  ${accExpr.copyResultTermToTargetIfChanged(ctx, aggBufVar.resultTerm)}
-            |}
-           """.stripMargin, aggCall.filterArg)
-      // UserDefinedAggregateFunction
-      case ((agg: AggregateFunction[_, _], aggIndex: Int, aggCall: AggregateCall),
-      aggBufVar) =>
-        val inFields = argsMapping(aggIndex)
-        val externalAccType = getAccumulatorTypeOfAggregateFunction(agg)
+    var currentAggBufferExprIdx = auxGrouping.length
 
-        val inputExprs = inFields.map {
-          f =>
-            val inputRef = toRexInputRef(builder, f._1, f._2)
-            exprCodegen.generateExpression(inputRef.accept(new ExpressionConverter(builder)))
-        }
+    val filteredAccCode = aggInfos.map { aggInfo =>
 
-        val externalUDITypes = getAggUserDefinedInputTypes(
-          agg, externalAccType, inputExprs.map(_.resultType))
-        val parameters = inputExprs.zipWithIndex.map {
-          case (expr, i) =>
-            genToExternalIfNeeded(ctx, externalUDITypes(i), expr)
-        }
+      val aggCall = aggInfo.agg
 
-        val javaTerm = typeTerm(externalAccType.getConversionClass)
-        val tmpAcc = newName("tmpAcc")
-        val innerCode =
+      val aggBufferIdx = auxGrouping.length + aggInfo.aggIndex
+
+      val accCode = aggInfo.function match {
+
+        // update each agg buffer for declarative functions
+        case function: DeclarativeAggregateFunction =>
+          val ref = ResolveReference(
+            ctx,
+            builder,
+            isMerge = false,
+            function,
+            aggBufferIdx,
+            argsMapping,
+            aggBufferTypes)
+          val accExprs = function.accumulateExpressions
+            .map(_.accept(ref))
+            .map(_.accept(new ExpressionConverter(builder)))
+            .map(exprCodeGen.generateExpression)
+          accExprs
+            .map { accExpr =>
+              val aggBufferExpr = aggBufferExprs(currentAggBufferExprIdx)
+              currentAggBufferExprIdx += 1
+              s"""
+                |${accExpr.code}
+                |${aggBufferExpr.nullTerm} = ${accExpr.nullTerm};
+                |if (!${accExpr.nullTerm}) {
+                |  // copy result term
+                |  ${accExpr.copyResultTermToTargetIfChanged(ctx, aggBufferExpr.resultTerm)}
+                |}
+              """.stripMargin
+            }
+            .mkString("\n")
+
+        // call accumulate() for imperative functions
+        case function: AggregateFunction[_, _] =>
+          val args = argsMapping(aggBufferIdx)
+          val inputExprs = args.map { case (argIndex, argType) =>
+              val inputRef = toRexInputRef(builder, argIndex, argType)
+              exprCodeGen.generateExpression(inputRef.accept(converter))
+          }
+          val operandTerms = inputExprs.zipWithIndex.map { case (expr, i) =>
+              genToExternalIfNeeded(ctx, aggInfo.externalArgTypes(i), expr)
+          }
+          val aggBufferName = aggBufferNames(aggBufferIdx).head
+          val aggBufferExpr = aggBufferExprs(currentAggBufferExprIdx)
+          currentAggBufferExprIdx += 1
+          val externalAccType = aggInfo.externalAccTypes.head
+          val externalAccTypeTerm = typeTerm(externalAccType.getConversionClass)
+          val externalAccTerm = newName("acc")
+          val externalAccCode = genToExternal(ctx, externalAccType, aggBufferName)
           s"""
-             |  $javaTerm $tmpAcc = ${
-            genToExternal(ctx, externalAccType, aggBufferNames(aggIndex)(0))};
-             |  ${udaggs(agg)}.accumulate($tmpAcc, ${parameters.mkString(", ")});
-             |  ${aggBufferNames(aggIndex)(0)} = ${genToInternal(ctx, externalAccType, tmpAcc)};
-             |  ${aggBufVar.nullTerm} = false;
-           """.stripMargin
-        (innerCode, aggCall.filterArg)
-    }.map({
-      case (innerCode, filterArg) =>
-        if (filterArg >= 0) {
-          s"""
-             |if ($inputTerm.getBoolean($filterArg)) {
-             | $innerCode
-             |}
+            |$externalAccTypeTerm $externalAccTerm = $externalAccCode;
+            |${functionIdentifiers(function)}.accumulate(
+            |  $externalAccTerm,
+            |  ${operandTerms.mkString(", ")});
+            |$aggBufferName = ${genToInternal(ctx, externalAccType)(externalAccTerm)};
+            |${aggBufferExpr.nullTerm} = false;
           """.stripMargin
-        } else {
-          innerCode
-        }
-    }) mkString "\n"
+      }
+
+      // apply filter if present
+      if (aggInfo.agg.filterArg >= 0) {
+        s"""
+          |if ($inputTerm.getBoolean(${aggCall.filterArg})) {
+          |  $accCode
+          |}
+        """.stripMargin
+      } else {
+        accCode
+      }
+    }
+
+    filteredAccCode.mkString("\n")
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
@@ -21,15 +21,14 @@ package org.apache.flink.table.planner.codegen.agg.batch
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.{GenericRowData, JoinedRowData, RowData}
-import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.planner.codegen.{CodeGenUtils, CodeGeneratorContext, ProjectionCodeGenerator}
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
-import org.apache.flink.table.planner.plan.utils.AggregateInfoList
+import org.apache.flink.table.planner.plan.utils.{AggregateInfo, AggregateInfoList}
 import org.apache.flink.table.runtime.generated.GeneratedOperator
 import org.apache.flink.table.runtime.operators.TableStreamOperator
 import org.apache.flink.table.runtime.operators.aggregate.{BytesHashMap, BytesHashMapSpillMemorySegmentPool}
-import org.apache.flink.table.types.logical.RowType
-
+import org.apache.flink.table.types.logical.{LogicalType, RowType}
 import org.apache.calcite.tools.RelBuilder
 
 /**
@@ -48,17 +47,20 @@ class HashAggCodeGenerator(
     isMerge: Boolean,
     isFinal: Boolean) {
 
+  private lazy val aggInfos: Array[AggregateInfo] = aggInfoList.aggInfos
+
+  private lazy val functionIdentifiers: Map[AggregateFunction[_, _], String] =
+    AggCodeGenHelper.getFunctionIdentifiers(aggInfos)
+
+  private lazy val aggBufferNames: Array[Array[String]] =
+    AggCodeGenHelper.getAggBufferNames(auxGrouping, aggInfos)
+
+  private lazy val aggBufferTypes: Array[Array[LogicalType]] = AggCodeGenHelper.getAggBufferTypes(
+    inputType,
+    auxGrouping,
+    aggInfos)
+
   private lazy val groupKeyRowType = AggCodeGenHelper.projectRowType(inputType, grouping)
-  private lazy val aggCallToAggFunction =
-    aggInfoList.aggInfos.map(info => (info.agg, info.function))
-  private lazy val aggregates: Seq[UserDefinedFunction] = aggInfoList.aggInfos.map(_.function)
-  private lazy val aggArgs: Array[Array[Int]] = aggInfoList.aggInfos.map(_.argIndexes)
-  // get udagg instance names
-  private lazy val udaggs = AggCodeGenHelper.getUdaggs(aggregates)
-  // currently put auxGrouping to aggBuffer in code-gen
-  private lazy val aggBufferNames = AggCodeGenHelper.getAggBufferNames(auxGrouping, aggregates)
-  private lazy val aggBufferTypes =
-    AggCodeGenHelper.getAggBufferTypes(inputType, auxGrouping, aggregates)
   private lazy val aggBufferRowType = RowType.of(aggBufferTypes.flatten, aggBufferNames.flatten)
 
   def genWithKeys(): GeneratedOperator[OneInputStreamOperator[RowData, RowData]] = {
@@ -119,9 +121,7 @@ class HashAggCodeGenerator(
       (grouping, auxGrouping),
       inputTerm,
       inputType,
-      aggCallToAggFunction,
-      aggArgs,
-      aggregates,
+      aggInfos,
       currentAggBufferTerm,
       aggBufferRowType,
       aggBufferTypes,
@@ -143,10 +143,8 @@ class HashAggCodeGenerator(
       ctx,
       builder,
       (grouping, auxGrouping),
-      aggCallToAggFunction,
-      aggArgs,
-      aggInfoList.aggInfos.map(_.externalResultType),
-      udaggs,
+      aggInfos,
+      functionIdentifiers,
       logTerm,
       aggregateMapTerm,
       (groupKeyTypesTerm, aggBufferTypesTerm),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashWindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashWindowCodeGenerator.scala
@@ -369,11 +369,11 @@ class HashWindowCodeGenerator(
     // build mapping for DeclarativeAggregationFunction binding references
     val offset = if (isMerge) grouping.length + 1 else grouping.length
     val argsMapping = AggCodeGenHelper.buildAggregateArgsMapping(
-      isMerge, offset, inputType,  auxGrouping, aggArgs, aggBufferTypes)
+      isMerge, offset, inputType, auxGrouping, aggInfos, aggBufferTypes)
     val aggBuffMapping = HashAggCodeGenHelper.buildAggregateAggBuffMapping(aggBufferTypes)
     // gen code to create empty agg buffer
     val initedAggBuffer = HashAggCodeGenHelper.genReusableEmptyAggBuffer(
-      ctx, builder, inputTerm, inputType, auxGrouping, aggregates, aggBufferRowType)
+      ctx, builder, inputTerm, inputType, auxGrouping, aggInfos, aggBufferRowType)
     if (auxGrouping.isEmpty) {
       // init aggBuffer in open function when there is no auxGrouping
       ctx.addReusableOpenStatement(initedAggBuffer.code)
@@ -386,8 +386,7 @@ class HashWindowCodeGenerator(
       inputType,
       inputTerm,
       auxGrouping,
-      aggregates,
-      aggCallToAggFunction,
+      aggInfos,
       argsMapping,
       aggBuffMapping,
       currentAggBufferTerm,
@@ -650,7 +649,7 @@ class HashWindowCodeGenerator(
         ctx,
         builder,
         auxGrouping,
-        aggregates,
+        aggInfos,
         argsMapping,
         aggBuffMapping,
         outputTerm,
@@ -697,7 +696,7 @@ class HashWindowCodeGenerator(
         ctx,
         builder,
         auxGrouping,
-        aggregates,
+        aggInfos,
         argsMapping,
         aggBuffMapping,
         outputTerm,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortWindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortWindowCodeGenerator.scala
@@ -88,12 +88,14 @@ class SortWindowCodeGenerator(
     isMerge,
     isFinal) {
 
+  // prepare for aggregation
+  aggInfos
+      .map(_.function)
+      .filter(_.isInstanceOf[AggregateFunction[_, _]])
+      .map(ctx.addReusableFunction(_))
+
   def genWithoutKeys(): GeneratedOperator[OneInputStreamOperator[RowData, RowData]] = {
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
-
-    aggCallToAggFunction
-        .map(_._2).filter(a => a.isInstanceOf[AggregateFunction[_, _]])
-        .map(a => ctx.addReusableFunction(a))
 
     val timeWindowType = classOf[TimeWindow].getName
     val currentWindow = CodeGenUtils.newName("currentWindow")
@@ -158,10 +160,6 @@ class SortWindowCodeGenerator(
   }
 
   def genWithKeys(): GeneratedOperator[OneInputStreamOperator[RowData, RowData]] = {
-    aggCallToAggFunction
-        .map(_._2).filter(a => a.isInstanceOf[AggregateFunction[_, _]])
-        .map(a => ctx.addReusableFunction(a))
-
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
 
     val currentKey = CodeGenUtils.newName("currentKey")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.types.utils.TypeConversions;
 @Deprecated
 public class LogicalTypeDataTypeConverter {
 
+	@Deprecated
 	public static DataType fromLogicalTypeToDataType(LogicalType logicalType) {
 		return TypeConversions.fromLogicalToDataType(logicalType);
 	}
@@ -41,6 +42,7 @@ public class LogicalTypeDataTypeConverter {
 	/**
 	 * It convert {@link LegacyTypeInformationType} to planner types.
 	 */
+	@Deprecated
 	public static LogicalType fromDataTypeToLogicalType(DataType dataType) {
 		return PlannerTypeUtils.removeLegacyTypes(dataType.getLogicalType());
 	}


### PR DESCRIPTION
## What is the purpose of the change

This refactors a lot of the code generation around aggregate functions. It does this for better code maintainability and in particular for having a single source of generating all types (arguments, accumulator, result).

## Brief change log

- Reduce number of parameters for methods
- Simplify code and improve readability by consistent naming, empty lines, and comments

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
