### PR TITLE
[FLINK-18699][table-api-scala] Allow selecting fields without string interpolation in Scala

### DIFF
--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
@@ -77,9 +77,9 @@ object StreamSQLExample {
       Order(4L, "beer", 1)))
 
     // convert DataStream to Table
-    val tableA = tEnv.fromDataStream(orderA, 'user, 'product, 'amount)
+    val tableA = tEnv.fromDataStream(orderA, $"user", $"product", $"amount")
     // register DataStream as Table
-    tEnv.createTemporaryView("OrderB", orderB, 'user, 'product, 'amount)
+    tEnv.createTemporaryView("OrderB", orderB, $"user", $"product", $"amount")
 
     // union the two tables
     val result = tEnv.sqlQuery(

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountTable.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountTable.scala
@@ -45,9 +45,9 @@ object WordCountTable {
     val input = env.fromElements(WC("hello", 1), WC("hello", 1), WC("ciao", 1))
     val expr = input.toTable(tEnv)
     val result = expr
-      .groupBy('word)
-      .select('word, 'frequency.sum as 'frequency)
-      .filter('frequency === 2)
+      .groupBy($"word")
+      .select($"word", $"frequency".sum as "frequency")
+      .filter($"frequency" === 2)
       .toDataSet[WC]
 
     result.print()

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -364,6 +364,20 @@ trait ImplicitExpressionConversions {
   // ----------------------------------------------------------------------------------------------
 
   /**
+   * Creates an unresolved reference to a table's field.
+   *
+   * For example:
+   *
+   * ```
+   * tab.select($("key"), $("value"))
+   * ```
+   *
+   * This method is useful in cases where the field name is calculated and the recommended way of
+   * using string interpolation like `$"key"` would be inconvenient.
+   */
+  def $(name: String): Expression = Expressions.$(name)
+
+  /**
    * Creates a SQL literal.
    *
    * The data type is derived from the object's class and its value.

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ExpressionsConsistencyCheckTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ExpressionsConsistencyCheckTest.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.api
 
-import org.apache.flink.table.api.Expressions._
 import org.apache.flink.table.expressions.ApiExpressionUtils._
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{EQUALS, PLUS, TRIM}
@@ -253,7 +252,7 @@ class ExpressionsConsistencyCheckTest {
   def testInteroperability(): Unit = {
     // In most cases it should be just fine to mix the two APIs.
     // It should be discouraged though as it might have unforeseen side effects
-    val expr = lit("ABC") === $"f0".plus($("f1")).trim()
+    val expr = lit("ABC") === $"f0".plus(Expressions.$("f1")).plus($("f2")).trim()
 
     assertThat(
       expr,
@@ -268,8 +267,12 @@ class ExpressionsConsistencyCheckTest {
             valueLiteral(" "),
             unresolvedCall(
               PLUS,
-              unresolvedRef("f0"),
-              unresolvedRef("f1")
+              unresolvedCall(
+              PLUS,
+                unresolvedRef("f0"),
+                unresolvedRef("f1")
+              ),
+              unresolvedRef("f2")
             )
           )
         )


### PR DESCRIPTION
## What is the purpose of the change

User have reported that the Scala API lacks a way to reference columns via a name that is stored in a variable. String interpolation is inconvenient in this case.

## Brief change log

- Add `$(..)` in the Scala API

## Verifying this change

This change added tests and can be verified as follows: `ExpressionsConsistencyCheckTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
