### PR TITLE
[FLINK-18581] Do not run GC phantom cleaners for Java < 8u72

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
@@ -159,7 +159,10 @@ class UnsafeMemoryBudget {
 
 			// no luck
 			throw new MemoryReservationException(String.format(
-				"Could not allocate %d bytes, only %d bytes are remaining, try to upgrade to Java 8u72 or higher",
+				"Could not allocate %d bytes, only %d bytes are remaining. This usually indicates " +
+					"that you are requesting more memory than you have reserved. " +
+					"However, when running an old JVM version it can also be caused by slow garbage collection. " +
+					"Try to upgrade to Java 8u72 or higher if running on an old Java version.",
 				size,
 				availableOrReserved));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
@@ -158,8 +158,10 @@ class UnsafeMemoryBudget {
 			}
 
 			// no luck
-			throw new MemoryReservationException(
-				String.format("Could not allocate %d bytes, only %d bytes are remaining", size, availableOrReserved));
+			throw new MemoryReservationException(String.format(
+				"Could not allocate %d bytes, only %d bytes are remaining, try to upgrade to Java 8u72 or higher",
+				size,
+				availableOrReserved));
 
 		} finally {
 			if (interrupted) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -292,7 +292,8 @@ public class TaskManagerServices {
 			taskManagerServicesConfiguration.getNumberOfSlots(),
 			taskManagerServicesConfiguration.getTaskExecutorResourceSpec(),
 			taskManagerServicesConfiguration.getTimerServiceShutdownTimeout(),
-			taskManagerServicesConfiguration.getPageSize());
+			taskManagerServicesConfiguration.getPageSize(),
+			ioExecutor);
 
 		final JobTable jobTable = DefaultJobTable.create();
 
@@ -340,7 +341,8 @@ public class TaskManagerServices {
 			final int numberOfSlots,
 			final TaskExecutorResourceSpec taskExecutorResourceSpec,
 			final long timerServiceShutdownTimeout,
-			final int pageSize) {
+			final int pageSize,
+			final Executor memoryVerificationExecutor) {
 		final TimerService<AllocationID> timerService = new TimerService<>(
 			new ScheduledThreadPoolExecutor(1),
 			timerServiceShutdownTimeout);
@@ -349,7 +351,8 @@ public class TaskManagerServices {
 			TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(taskExecutorResourceSpec),
 			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberOfSlots),
 			pageSize,
-			timerService);
+			timerService,
+			memoryVerificationExecutor);
 	}
 
 	private static ShuffleEnvironment<?, ?> createShuffleEnvironment(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -318,8 +318,9 @@ public class TaskSlot<T extends TaskSlotPayload> implements AutoCloseableAsync {
 			() -> {
 				if (!memoryManager.verifyEmpty()) {
 					LOG.warn(
-						"Not all slot managed memory is freed, potential memory leak at {}, " +
-							"try to upgrade to Java 8u72 or higher",
+						"Not all slot managed memory is freed at {}. This usually indicates memory leak. " +
+							"However, when running an old JVM version it can also be caused by slow garbage collection. " +
+							"Try to upgrade to Java 8u72 or higher if running on an old Java version.",
 						this);
 				}
 			},

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 /**
@@ -84,15 +85,22 @@ public class TaskSlot<T extends TaskSlotPayload> implements AutoCloseableAsync {
 	/** The closing future is completed when the slot is freed and closed. */
 	private final CompletableFuture<Void> closingFuture;
 
+	/**
+	 * {@link ExecutorService} for background actions, e.g. verify all managed memory released.
+	 */
+	private final ExecutorService asyncExecutor;
+
 	public TaskSlot(
 		final int index,
 		final ResourceProfile resourceProfile,
 		final int memoryPageSize,
 		final JobID jobId,
-		final AllocationID allocationId) {
+		final AllocationID allocationId,
+		final ExecutorService asyncExecutor) {
 
 		this.index = index;
 		this.resourceProfile = Preconditions.checkNotNull(resourceProfile);
+		this.asyncExecutor = Preconditions.checkNotNull(asyncExecutor);
 
 		this.tasks = new HashMap<>(4);
 		this.state = TaskSlotState.ALLOCATED;
@@ -295,22 +303,25 @@ public class TaskSlot<T extends TaskSlotPayload> implements AutoCloseableAsync {
 				// and set the slot state to releasing so that it gets eventually freed
 				tasks.values().forEach(task -> task.failExternally(cause));
 			}
+
 			final CompletableFuture<Void> cleanupFuture = FutureUtils
 				.waitForAll(tasks.values().stream().map(TaskSlotPayload::getTerminationFuture).collect(Collectors.toList()))
-				.thenRun(() -> {
-					verifyMemoryFreed();
-					this.memoryManager.shutdown();
-				});
-
+				.thenRun(memoryManager::shutdown);
+			verifyAllManagedMemoryIsReleasedAfter(cleanupFuture);
 			FutureUtils.forward(cleanupFuture, closingFuture);
 		}
 		return closingFuture;
 	}
 
-	private void verifyMemoryFreed() {
-		if (!memoryManager.verifyEmpty()) {
-			LOG.warn("Not all slot memory is freed, potential memory leak at {}", this);
-		}
+	private void verifyAllManagedMemoryIsReleasedAfter(CompletableFuture<Void> after) {
+		FutureUtils.runAfterwardsAsync(
+			after,
+			() -> {
+				if (!memoryManager.verifyEmpty()) {
+					LOG.warn("Not all slot memory is freed, potential memory leak at {}", this);
+				}
+			},
+			asyncExecutor);
 	}
 
 	private static MemoryManager createMemoryManager(ResourceProfile resourceProfile, int pageSize) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -317,7 +317,10 @@ public class TaskSlot<T extends TaskSlotPayload> implements AutoCloseableAsync {
 		after.thenRunAsync(
 			() -> {
 				if (!memoryManager.verifyEmpty()) {
-					LOG.warn("Not all slot memory is freed, potential memory leak at {}", this);
+					LOG.warn(
+						"Not all slot managed memory is freed, potential memory leak at {}, " +
+							"try to upgrade to Java 8u72 or higher",
+						this);
 				}
 			},
 			asyncExecutor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -364,6 +364,16 @@ public class MemoryManagerTest {
 		memoryManager.computeMemorySize(-0.1);
 	}
 
+	@Test
+	public void testVerifyEmptyCanBeDoneAfterShutdown() throws MemoryAllocationException, MemoryReservationException {
+		memoryManager.release(memoryManager.allocatePages(new Object(), 1));
+		Object owner = new Object();
+		memoryManager.reserveMemory(owner, MemoryManager.DEFAULT_PAGE_SIZE);
+		memoryManager.releaseMemory(owner, MemoryManager.DEFAULT_PAGE_SIZE);
+		memoryManager.shutdown();
+		memoryManager.verifyEmpty();
+	}
+
 	private void testCannotAllocateAnymore(Object owner, int numPages) {
 		try {
 			memoryManager.allocatePages(owner, numPages);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -2054,7 +2054,13 @@ public class TaskExecutorTest extends TestLogger {
 		private final OneShotLatch allocateSlotLatch;
 
 		private AllocateSlotNotifyingTaskSlotTable(OneShotLatch allocateSlotLatch) {
-			super(1, createTotalResourceProfile(1), DEFAULT_RESOURCE_PROFILE, MemoryManager.MIN_PAGE_SIZE, createDefaultTimerService(timeout.toMilliseconds()));
+			super(
+				1,
+				createTotalResourceProfile(1),
+				DEFAULT_RESOURCE_PROFILE,
+				MemoryManager.MIN_PAGE_SIZE,
+				createDefaultTimerService(timeout.toMilliseconds()),
+				Executors.newDirectExecutorService());
 			this.allocateSlotLatch = allocateSlotLatch;
 		}
 
@@ -2080,7 +2086,13 @@ public class TaskExecutorTest extends TestLogger {
 		private final CountDownLatch slotsToActivate;
 
 		private ActivateSlotNotifyingTaskSlotTable(int numberOfDefaultSlots, CountDownLatch slotsToActivate) {
-			super(numberOfDefaultSlots, createTotalResourceProfile(numberOfDefaultSlots), DEFAULT_RESOURCE_PROFILE, MemoryManager.MIN_PAGE_SIZE, createDefaultTimerService(timeout.toMilliseconds()));
+			super(
+				numberOfDefaultSlots,
+				createTotalResourceProfile(numberOfDefaultSlots),
+				DEFAULT_RESOURCE_PROFILE,
+				MemoryManager.MIN_PAGE_SIZE,
+				createDefaultTimerService(timeout.toMilliseconds()),
+				Executors.newDirectExecutorService());
 			this.slotsToActivate = slotsToActivate;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor.slot;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.TestLogger;
@@ -55,6 +56,6 @@ public class TaskSlotTest extends TestLogger {
 	}
 
 	private static <T extends TaskSlotPayload> TaskSlot<T> createTaskSlot() {
-		return new TaskSlot<>(0, ResourceProfile.ZERO, MemoryManager.MIN_PAGE_SIZE, JOB_ID, ALLOCATION_ID);
+		return new TaskSlot<>(0, ResourceProfile.ZERO, MemoryManager.MIN_PAGE_SIZE, JOB_ID, ALLOCATION_ID, Executors.newDirectExecutorService());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
@@ -59,7 +60,8 @@ public enum TaskSlotUtils {
 			createTotalResourceProfile(numberOfSlots),
 			DEFAULT_RESOURCE_PROFILE,
 			MemoryManager.MIN_PAGE_SIZE,
-			timerService);
+			timerService,
+			Executors.newDirectExecutorService());
 	}
 
 	public static ResourceProfile createTotalResourceProfile(int numberOfSlots) {


### PR DESCRIPTION
The private JVM method `Reference.tryHandlePending` was introduced at Java 8u72.
The explicit processing of queued phantom GC cleaners was exposed before 8u72, also is was not used while reserving JVM direct memory.
Therefore, we can only hope that the GC will be triggered and the cleaners get processed in GC after some timeout.
This is suboptimal, therefore the PR changes Flink to not fail if the method is unavailable but logs a warning to upgrade Java.