### PR TITLE
Flink 18661 efo de registration

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -34,6 +34,7 @@ under the License.
 	<name>flink-connector-kinesis</name>
 	<properties>
 		<aws.sdk.version>1.11.754</aws.sdk.version>
+		<aws.sdkv2.version>2.13.52</aws.sdkv2.version>
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
@@ -97,6 +98,13 @@ under the License.
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
+			<artifactId>amazon-kinesis-aggregator</artifactId>
+			<version>1.0.3</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-kinesis</artifactId>
 			<version>${aws.sdk.version}</version>
 		</dependency>
@@ -154,6 +162,25 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- Amazon AWS SDK v2.x dependencies -->
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>kinesis</artifactId>
+			<version>${aws.sdkv2.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>netty-nio-client</artifactId>
+			<version>${aws.sdkv2.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sts</artifactId>
+			<version>${aws.sdkv2.version}</version>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>
@@ -204,6 +231,12 @@ under the License.
 									<include>com.amazonaws:*</include>
 									<include>com.google.protobuf:*</include>
 									<include>org.apache.httpcomponents:*</include>
+									<include>software.amazon.awssdk:*</include>
+									<include>software.amazon.eventstream:*</include>
+									<include>software.amazon.ion:*</include>
+									<include>org.reactivestreams:*</include>
+									<include>io.netty:*</include>
+									<include>com.typesafe.netty:*</include>
 								</includes>
 							</artifactSet>
 							<relocations combine.children="override">
@@ -220,6 +253,22 @@ under the License.
 								<relocation>
 									<pattern>org.apache.http</pattern>
 									<shadedPattern>org.apache.flink.kinesis.shaded.org.apache.http</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>software.amazon</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.software.amazon</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.io.netty</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.typesafe.netty</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.com.typesafe.netty</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.reactivestreams</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.org.reactivestreams</shadedPattern>
 								</relocation>
 							</relocations>
 							<filters>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -211,7 +211,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 		this.configProps = checkNotNull(configProps, "configProps can not be null");
 
 		// check the configuration properties for any conflicting settings
-		KinesisConfigUtil.validateConsumerConfiguration(this.configProps);
+		KinesisConfigUtil.validateConsumerConfiguration(this.configProps, streams);
 
 		checkNotNull(deserializer, "deserializer can not be null");
 		checkArgument(

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -56,6 +56,45 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 		}
 	}
 
+	/**
+	 * The record publisher type represents the record-consume style.
+	 */
+	public enum RecordPublisherType {
+
+		/** Consume the Kinesis records using AWS SDK v2 with the enhanced fan-out consumer. */
+		EFO,
+		/** Consume the Kinesis records using AWS SDK v1 with the get-records method. */
+		POLLING
+	}
+
+	/**
+	 * The EFO registration type reprsents how we are going to de-/register efo consumer.
+	 */
+	public enum EFORegistrationType {
+
+		/** Delay the registration of efo consumer for taskmanager to execute.
+		 * De-register the efo consumer for taskmanager to execute when task is shut down. */
+		LAZY,
+		/** Register the efo consumer eagerly for jobmanager to execute.
+		 * De-register the efo consumer the same way as lazy does. */
+		EAGER,
+		/** Do not register efo consumer programmatically.
+		 * Do not de-register either. */
+		NONE
+	}
+
+	/** The RecordPublisher type (EFO|POLLING, default is POLLING). */
+	public static final String RECORD_PUBLISHER_TYPE = "flink.stream.recordpublisher";
+
+	/** The name of the EFO consumer to register with KDS. */
+	public static final String EFO_CONSUMER_NAME = "flink.stream.efo.consumername";
+
+	/** Determine how and when consumer de-/registration is performed (LAZY|EAGER|NONE, default is LAZY). */
+	public static final String EFO_REGISTRATION_TYPE = "flink.stream.efo.registration";
+
+	/** The prefix of consumer ARN for a given stream. */
+	public static final String EFO_CONSUMER_ARN_PREFIX = "flink.stream.efo.consumerarn";
+
 	/** The initial position to start reading Kinesis streams from (LATEST is used if not set). */
 	public static final String STREAM_INITIAL_POSITION = "flink.stream.initpos";
 
@@ -85,6 +124,54 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	/** The power constant for exponential backoff between each listShards attempt. */
 	public static final String LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.list.shards.backoff.expconst";
+
+	/** The maximum number of registerStream attempts if we get a recoverable exception. */
+	public static final String REGISTER_STREAM_RETRIES = "flink.stream.registerstreamconsumer.maxretries";
+
+	/** The base backoff time between each registerStream attempt. */
+	public static final String REGISTER_STREAM_BACKOFF_BASE = "flink.stream.registerstreamconsumer.backoff.base";
+
+	/** The maximum backoff time between each registerStream attempt. */
+	public static final String REGISTER_STREAM_BACKOFF_MAX = "flink.stream.registerstreamconsumer.backoff.max";
+
+	/** The power constant for exponential backoff between each registerStream attempt. */
+	public static final String REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.registerstreamconsumer.backoff.expconst";
+
+	/** The maximum number of deregisterStream attempts if we get a recoverable exception. */
+	public static final String DEREGISTER_STREAM_RETRIES = "flink.stream.deregisterstreamconsumer.maxretries";
+
+	/** The base backoff time between each deregisterStream attempt. */
+	public static final String DEREGISTER_STREAM_BACKOFF_BASE = "flink.stream.deregisterstreamconsumer.backoff.base";
+
+	/** The maximum backoff time between each deregisterStream attempt. */
+	public static final String DEREGISTER_STREAM_BACKOFF_MAX = "flink.stream.deregisterstreamconsumer.backoff.max";
+
+	/** The power constant for exponential backoff between each deregisterStream attempt. */
+	public static final String DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.deregisterstreamconsumer.backoff.expconst";
+
+	/** The maximum number of listStream attempts if we get a recoverable exception. */
+	public static final String LIST_STREAM_CONSUMERS_RETRIES = "flink.stream.liststreamconsumer.maxretries";
+
+	/** The base backoff time between each listStream attempt. */
+	public static final String LIST_STREAM_CONSUMERS_BACKOFF_BASE = "flink.stream.liststreamconsumer.backoff.base";
+
+	/** The maximum backoff time between each listStream attempt. */
+	public static final String LIST_STREAM_CONSUMERS_BACKOFF_MAX = "flink.stream.liststreamconsumer.backoff.max";
+
+	/** The power constant for exponential backoff between each listStream attempt. */
+	public static final String LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.liststreamconsumer.backoff.expconst";
+
+	/** The maximum number of subscribeToShard attempts if we get a recoverable exception. */
+	public static final String SUBSCRIBE_TO_SHARD_RETRIES = "flink.shard.subscribetoshard.maxretries";
+
+	/** The base backoff time between each subscribeToShard  attempt. */
+	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_BASE = "flink.shard.subscribetoshard.backoff.base";
+
+	/** The maximum backoff time between each subscribeToShard  attempt. */
+	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_MAX = "flink.shard.subscribetoshard.backoff.max";
+
+	/** The power constant for exponential backoff between each subscribeToShard  attempt. */
+	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT = "flink.shard.subscribetoshard.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */
 	public static final String SHARD_GETRECORDS_MAX = "flink.shard.getrecords.maxrecordcount";
@@ -155,6 +242,38 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final double DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_LIST_SHARDS_RETRIES = 10;
+
+	public static final int DEFAULT_REGISTER_STREAM_RETRIES = 10;
+
+	public static final long DEFAULT_REGISTER_STREAM_BACKOFF_BASE = 200L;
+
+	public static final long DEFAULT_REGISTER_STREAM_BACKOFF_MAX = 1000L;
+
+	public static final double DEFAULT_REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final int DEFAULT_DEREGISTER_STREAM_RETRIES = 10;
+
+	public static final long DEFAULT_DEREGISTER_STREAM_BACKOFF_BASE = 200L;
+
+	public static final long DEFAULT_DEREGISTER_STREAM_BACKOFF_MAX = 1000L;
+
+	public static final double DEFAULT_DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final int DEFAULT_LIST_STREAM_CONSUMERS_RETRIES = 10;
+
+	public static final long DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_BASE = 200L;
+
+	public static final long DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_MAX = 1000L;
+
+	public static final double DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final int DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES = 5;
+
+	public static final long DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE = 1000L;
+
+	public static final long DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_MAX = 2000L;
+
+	public static final double DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_SHARD_GETRECORDS_MAX = 10000;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -104,6 +104,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The date format of initial timestamp to start reading Kinesis stream from (when AT_TIMESTAMP is set for STREAM_INITIAL_POSITION). */
 	public static final String STREAM_TIMESTAMP_DATE_FORMAT = "flink.stream.initpos.timestamp.format";
 
+	/** The maximum number of describeStream attempts if we get a recoverable exception. */
+	public static final String STREAM_DESCRIBE_RETRIES = "flink.stream.describe.maxretries";
+
 	/** The base backoff time between each describeStream attempt (for consuming from DynamoDB streams). */
 	public static final String STREAM_DESCRIBE_BACKOFF_BASE = "flink.stream.describe.backoff.base";
 
@@ -124,6 +127,18 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	/** The power constant for exponential backoff between each listShards attempt. */
 	public static final String LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.list.shards.backoff.expconst";
+
+	/** The maximum number of describeStreamConsumer attempts if we get a recoverable exception. */
+	public static final String DESCRIBE_STREAM_CONSUMER_RETRIES = "flink.stream.describestreamconsumer.maxretries";
+
+	/** The base backoff time between each describeStreamConsumer attempt. */
+	public static final String DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE = "flink.stream.describestreamconsumer.backoff.base";
+
+	/** The maximum backoff time between each describeStreamConsumer attempt. */
+	public static final String DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX = "flink.stream.describestreamconsumer.backoff.max";
+
+	/** The power constant for exponential backoff between each describeStreamConsumer attempt. */
+	public static final String DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describestreamconsumer.backoff.expconst";
 
 	/** The maximum number of registerStream attempts if we get a recoverable exception. */
 	public static final String REGISTER_STREAM_RETRIES = "flink.stream.registerstreamconsumer.maxretries";
@@ -229,6 +244,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
+	public static final int DEFAULT_STREAM_DESCRIBE_RETRIES = 10;
+
 	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE = 1000L;
 
 	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX = 5000L;
@@ -242,6 +259,14 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final double DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_LIST_SHARDS_RETRIES = 10;
+
+	public static final int DEFAULT_DESCRIBE_STREAM_CONSUMER_RETRIES = 10;
+
+	public static final long DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE = 200L;
+
+	public static final long DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX = 1000L;
+
+	public static final double DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_REGISTER_STREAM_RETRIES = 10;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -149,28 +149,28 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The power constant for exponential backoff between each deregisterStream attempt. */
 	public static final String DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.deregisterstreamconsumer.backoff.expconst";
 
-	/** The maximum number of listStream attempts if we get a recoverable exception. */
+	/** The maximum number of listStreamConsumers attempts if we get a recoverable exception. */
 	public static final String LIST_STREAM_CONSUMERS_RETRIES = "flink.stream.liststreamconsumer.maxretries";
 
-	/** The base backoff time between each listStream attempt. */
+	/** The base backoff time between each listStreamConsumers attempt. */
 	public static final String LIST_STREAM_CONSUMERS_BACKOFF_BASE = "flink.stream.liststreamconsumer.backoff.base";
 
-	/** The maximum backoff time between each listStream attempt. */
+	/** The maximum backoff time between each listStreamConsumer attempt. */
 	public static final String LIST_STREAM_CONSUMERS_BACKOFF_MAX = "flink.stream.liststreamconsumer.backoff.max";
 
-	/** The power constant for exponential backoff between each listStream attempt. */
+	/** The power constant for exponential backoff between each listStreamConsumers attempt. */
 	public static final String LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.liststreamconsumer.backoff.expconst";
 
 	/** The maximum number of subscribeToShard attempts if we get a recoverable exception. */
 	public static final String SUBSCRIBE_TO_SHARD_RETRIES = "flink.shard.subscribetoshard.maxretries";
 
-	/** The base backoff time between each subscribeToShard  attempt. */
+	/** The base backoff time between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_BASE = "flink.shard.subscribetoshard.backoff.base";
 
-	/** The maximum backoff time between each subscribeToShard  attempt. */
+	/** The maximum backoff time between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_MAX = "flink.shard.subscribetoshard.backoff.max";
 
-	/** The power constant for exponential backoff between each subscribeToShard  attempt. */
+	/** The power constant for exponential backoff between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT = "flink.shard.subscribetoshard.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -27,8 +27,13 @@ import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.connectors.kinesis.KinesisShardAssigner;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
+import org.apache.flink.streaming.connectors.kinesis.internals.fanout.FanOutStreamInfo;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling.PollingRecordPublisherFactory;
 import org.apache.flink.streaming.connectors.kinesis.metrics.KinesisConsumerMetricConstants;
-import org.apache.flink.streaming.connectors.kinesis.metrics.ShardMetricsReporter;
+import org.apache.flink.streaming.connectors.kinesis.metrics.ShardConsumerMetricsReporter;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
 import org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
@@ -37,6 +42,8 @@ import org.apache.flink.streaming.connectors.kinesis.model.StreamShardMetadata;
 import org.apache.flink.streaming.connectors.kinesis.proxy.GetShardListResult;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyV2;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyV2Interface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 import org.apache.flink.streaming.connectors.kinesis.util.RecordEmitter;
 import org.apache.flink.streaming.connectors.kinesis.util.WatermarkTracker;
@@ -52,6 +59,8 @@ import com.amazonaws.services.kinesis.model.Shard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,6 +70,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -116,6 +126,13 @@ public class KinesisDataFetcher<T> {
 	 * The function that determines which subtask a shard should be assigned to.
 	 */
 	private final KinesisShardAssigner shardAssigner;
+
+	// ------------------------------------------------------------------------
+	//  Enhanced fan-out settings
+	// ------------------------------------------------------------------------
+	/** A List of {@link FanOutStreamInfo}, could only be set is the record publisher type is efo and the efo registration type is EAGER. */
+	@Nullable
+	private List<FanOutStreamInfo> streamInfoList;
 
 	// ------------------------------------------------------------------------
 	//  Consumer metrics
@@ -181,6 +198,14 @@ public class KinesisDataFetcher<T> {
 	/** The Kinesis proxy that the fetcher will be using to discover new shards. */
 	private final KinesisProxyInterface kinesis;
 
+	/** The Kinesis proxy v2 factory that will be used to create instances for describe stream and register stream consumers. */
+	@Nullable
+	private FlinkKinesisProxyV2Factory kinesisProxyV2Factory;
+
+	/** The Kinesis proxy v2 that the fetcher will be using to describe stream and register stream consumers. */
+	@Nullable
+	private KinesisProxyV2Interface kinesisV2;
+
 	/** Thread that executed runFetcher(). */
 	private volatile Thread mainThread;
 
@@ -232,6 +257,13 @@ public class KinesisDataFetcher<T> {
 	 */
 	public interface FlinkKinesisProxyFactory {
 		KinesisProxyInterface create(Properties configProps);
+	}
+
+	/**
+	 * Factory to create Kinesis proxy V2 instances used by a fetcher.
+	 */
+	public interface FlinkKinesisProxyV2Factory {
+		KinesisProxyV2Interface create(Properties configProps, List<String> streams);
 	}
 
 	/**
@@ -330,7 +362,50 @@ public class KinesisDataFetcher<T> {
 			new AtomicReference<>(),
 			new ArrayList<>(),
 			createInitialSubscribedStreamsToLastDiscoveredShardsState(streams),
-			KinesisProxy::create);
+			KinesisProxy::create,
+			KinesisProxyV2::create);
+	}
+
+	/**
+	 * Creates a Kinesis Data Fetcher.
+	 *
+	 * @param streams the streams to subscribe to
+	 * @param sourceContext context of the source function
+	 * @param runtimeContext this subtask's runtime context
+	 * @param configProps the consumer configuration properties
+	 * @param deserializationSchema deserialization schema
+	 */
+	@VisibleForTesting
+	protected KinesisDataFetcher(
+		List<String> streams,
+		SourceFunction.SourceContext<T> sourceContext,
+		Object checkpointLock,
+		RuntimeContext runtimeContext,
+		Properties configProps,
+		KinesisDeserializationSchema<T> deserializationSchema,
+		KinesisShardAssigner shardAssigner,
+		AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner,
+		WatermarkTracker watermarkTracker,
+		AtomicReference<Throwable> error,
+		List<KinesisStreamShardState> subscribedShardsState,
+		HashMap<String, String> subscribedStreamsToLastDiscoveredShardIds,
+		FlinkKinesisProxyFactory kinesisProxyFactory) {
+		this(
+			streams,
+			sourceContext,
+			checkpointLock,
+			runtimeContext,
+			configProps,
+			deserializationSchema,
+			shardAssigner,
+			periodicWatermarkAssigner,
+			watermarkTracker,
+			error,
+			subscribedShardsState,
+			subscribedStreamsToLastDiscoveredShardIds,
+			kinesisProxyFactory,
+			KinesisProxyV2::create
+		);
 	}
 
 	@VisibleForTesting
@@ -346,7 +421,8 @@ public class KinesisDataFetcher<T> {
 								AtomicReference<Throwable> error,
 								List<KinesisStreamShardState> subscribedShardsState,
 								HashMap<String, String> subscribedStreamsToLastDiscoveredShardIds,
-								FlinkKinesisProxyFactory kinesisProxyFactory) {
+								FlinkKinesisProxyFactory kinesisProxyFactory,
+								FlinkKinesisProxyV2Factory kinesisProxyV2Factory) {
 		this.streams = checkNotNull(streams);
 		this.configProps = checkNotNull(configProps);
 		this.sourceContext = checkNotNull(sourceContext);
@@ -360,6 +436,10 @@ public class KinesisDataFetcher<T> {
 		this.watermarkTracker = watermarkTracker;
 		this.kinesisProxyFactory = checkNotNull(kinesisProxyFactory);
 		this.kinesis = kinesisProxyFactory.create(configProps);
+		this.kinesisProxyV2Factory = checkNotNull(kinesisProxyV2Factory);
+		if (shouldRegisterConsumerEagerly()) {
+			this.kinesisV2 = kinesisProxyV2Factory.create(configProps, streams);
+		}
 
 		this.consumerMetricGroup = runtimeContext.getMetricGroup()
 			.addGroup(KinesisConsumerMetricConstants.KINESIS_CONSUMER_METRICS_GROUP);
@@ -389,23 +469,60 @@ public class KinesisDataFetcher<T> {
 	 * @param subscribedShardStateIndex the state index of the shard this consumer is subscribed to
 	 * @param subscribedShard the shard this consumer is subscribed to
 	 * @param lastSequenceNum the sequence number in the shard to start consuming
-	 * @param shardMetricsReporter the reporter to report metrics to
+	 * @param metricGroup the metric group to report metrics to
 	 * @return shard consumer
 	 */
 	protected ShardConsumer<T> createShardConsumer(
 		Integer subscribedShardStateIndex,
 		StreamShardHandle subscribedShard,
 		SequenceNumber lastSequenceNum,
-		ShardMetricsReporter shardMetricsReporter,
+		MetricGroup metricGroup,
 		KinesisDeserializationSchema<T> shardDeserializer) {
-		return new ShardConsumer<>(
-			this,
+		return createShardConsumer(
 			subscribedShardStateIndex,
 			subscribedShard,
 			lastSequenceNum,
-			this.kinesisProxyFactory.create(configProps),
-			shardMetricsReporter,
-			shardDeserializer);
+			metricGroup,
+			shardDeserializer,
+			null
+		);
+	}
+
+	/**
+	 * Create a new shard consumer.
+	 * Override this method to customize shard consumer behavior in subclasses.
+	 * @param subscribedShardStateIndex the state index of the shard this consumer is subscribed to
+	 * @param subscribedShard the shard this consumer is subscribed to
+	 * @param lastSequenceNum the sequence number in the shard to start consuming
+	 * @param metricGroup the metric group to report metrics to
+	 * @param streamInfoList the stream info used for enhanced fan-out to consume from
+	 * @return shard consumer
+	 */
+	protected ShardConsumer<T> createShardConsumer(
+		Integer subscribedShardStateIndex,
+		StreamShardHandle subscribedShard,
+		SequenceNumber lastSequenceNum,
+		MetricGroup metricGroup,
+		KinesisDeserializationSchema<T> shardDeserializer,
+		@Nullable List<FanOutStreamInfo> streamInfoList) {
+
+		final KinesisProxyInterface kinesis = kinesisProxyFactory.create(configProps);
+
+		final RecordPublisher recordPublisher = new PollingRecordPublisherFactory()
+			.create(configProps, metricGroup, subscribedShard, kinesis);
+
+		return new ShardConsumer<T>(
+			this,
+			recordPublisher,
+			subscribedShardStateIndex,
+			subscribedShard,
+			lastSequenceNum,
+			new ShardConsumerMetricsReporter(metricGroup),
+			shardDeserializer,
+			configProps,
+			streams,
+			kinesisProxyV2Factory,
+			streamInfoList);
 	}
 
 	/**
@@ -415,7 +532,6 @@ public class KinesisDataFetcher<T> {
 	 * @throws Exception the first error or exception thrown by the fetcher or any of the threads created by the fetcher.
 	 */
 	public void runFetcher() throws Exception {
-
 		// check that we are running before proceeding
 		if (!running) {
 			return;
@@ -426,8 +542,11 @@ public class KinesisDataFetcher<T> {
 		// ------------------------------------------------------------------------
 		//  Procedures before starting the infinite while loop:
 		// ------------------------------------------------------------------------
-
-		//  1. check that there is at least one shard in the subscribed streams to consume from (can be done by
+		//  1. check if the record publisher type is efo and the efo registration type is EAGER. If so register stream consumers here and send the fan out stream info into the KinesisConsumer.
+		if (streamInfoList == null & shouldRegisterConsumerEagerly()) {
+			streamInfoList = registerConsumer();
+		}
+		//  2. check that there is at least one shard in the subscribed streams to consume from (can be done by
 		//     checking if at least one value in subscribedStreamsToLastDiscoveredShardIds is not null)
 		boolean hasShards = false;
 		StringBuilder streamsWithNoShardsFound = new StringBuilder();
@@ -448,7 +567,7 @@ public class KinesisDataFetcher<T> {
 			throw new RuntimeException("No shards can be found for all subscribed streams: " + streams);
 		}
 
-		//  2. start consuming any shard state we already have in the subscribedShardState up to this point; the
+		//  3. start consuming any shard state we already have in the subscribedShardState up to this point; the
 		//     subscribedShardState may already be seeded with values due to step 1., or explicitly added by the
 		//     consumer using a restored state checkpoint
 		for (int seededStateIndex = 0; seededStateIndex < subscribedShardsState.size(); seededStateIndex++) {
@@ -475,8 +594,10 @@ public class KinesisDataFetcher<T> {
 						seededStateIndex,
 						streamShardHandle,
 						subscribedShardsState.get(seededStateIndex).getLastProcessedSequenceNum(),
-						registerShardMetrics(consumerMetricGroup, subscribedShardsState.get(seededStateIndex)),
-						shardDeserializationSchema));
+						registerShardMetricGroup(consumerMetricGroup, subscribedShardsState.get(seededStateIndex)),
+						shardDeserializationSchema,
+						streamInfoList
+					));
 			}
 		}
 
@@ -533,7 +654,7 @@ public class KinesisDataFetcher<T> {
 		// we will escape from this loop only when shutdownFetcher() or stopWithError() is called
 		// TODO: have this thread emit the records for tracking backpressure
 
-		final long discoveryIntervalMillis = Long.valueOf(
+		final long discoveryIntervalMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_DISCOVERY_INTERVAL_MILLIS,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_DISCOVERY_INTERVAL_MILLIS)));
@@ -576,8 +697,9 @@ public class KinesisDataFetcher<T> {
 						newStateIndex,
 						newShardState.getStreamShardHandle(),
 						newShardState.getLastProcessedSequenceNum(),
-						registerShardMetrics(consumerMetricGroup, newShardState),
-						shardDeserializationSchema));
+						registerShardMetricGroup(consumerMetricGroup, newShardState),
+						shardDeserializationSchema,
+						streamInfoList));
 			}
 
 			// we also check if we are running here so that we won't start the discovery sleep
@@ -610,6 +732,18 @@ public class KinesisDataFetcher<T> {
 				throw new Exception(throwable);
 			}
 		}
+	}
+
+	private List<FanOutStreamInfo> registerConsumer() throws ExecutionException, InterruptedException {
+		Map<String, String> streamArns = kinesisV2.describeStream(streams);
+		return kinesisV2.registerStreamConsumer(streamArns);
+	}
+
+	private boolean shouldRegisterConsumerEagerly() {
+		return configProps.containsKey(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE) &&
+			configProps.containsKey(ConsumerConfigConstants.EFO_REGISTRATION_TYPE) &&
+			configProps.getProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE).equals(RecordPublisherType.EFO.toString()) &&
+			configProps.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE).equals(EFORegistrationType.EAGER.toString());
 	}
 
 	/**
@@ -1057,29 +1191,16 @@ public class KinesisDataFetcher<T> {
 	/**
 	 * Registers a metric group associated with the shard id of the provided {@link KinesisStreamShardState shardState}.
 	 *
-	 * @return a {@link ShardMetricsReporter} that can be used to update metric values
+	 * @return a {@link MetricGroup} that can be used to update metric values
 	 */
-	private static ShardMetricsReporter registerShardMetrics(MetricGroup metricGroup, KinesisStreamShardState shardState) {
-		ShardMetricsReporter shardMetrics = new ShardMetricsReporter();
-
-		MetricGroup streamShardMetricGroup = metricGroup
+	private MetricGroup registerShardMetricGroup(final MetricGroup metricGroup, final KinesisStreamShardState shardState) {
+		return metricGroup
 			.addGroup(
 				KinesisConsumerMetricConstants.STREAM_METRICS_GROUP,
 				shardState.getStreamShardHandle().getStreamName())
 			.addGroup(
 				KinesisConsumerMetricConstants.SHARD_METRICS_GROUP,
 				shardState.getStreamShardHandle().getShard().getShardId());
-
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.MILLIS_BEHIND_LATEST_GAUGE, shardMetrics::getMillisBehindLatest);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.MAX_RECORDS_PER_FETCH, shardMetrics::getMaxNumberOfRecordsPerFetch);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.NUM_AGGREGATED_RECORDS_PER_FETCH, shardMetrics::getNumberOfAggregatedRecords);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.NUM_DEAGGREGATED_RECORDS_PER_FETCH, shardMetrics::getNumberOfDeaggregatedRecords);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.AVG_RECORD_SIZE_BYTES, shardMetrics::getAverageRecordSizeBytes);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.BYTES_PER_READ, shardMetrics::getBytesPerRead);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.RUNTIME_LOOP_NANOS, shardMetrics::getRunLoopTimeNanos);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.LOOP_FREQUENCY_HZ, shardMetrics::getLoopFrequencyHz);
-		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.SLEEP_TIME_MILLIS, shardMetrics::getSleepTimeMillis);
-		return shardMetrics;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 
@@ -114,17 +115,17 @@ public class FanOutProperties {
 	private final int deregisterStreamMaxRetries;
 
 	/**
-	 * Base backoff millis for the list stream operation.
+	 * Base backoff millis for the list stream consumers operation.
 	 */
 	private final long listStreamConsumersBaseBackoffMillis;
 
 	/**
-	 * Maximum backoff millis for the list stream operation.
+	 * Maximum backoff millis for the list stream consumers operation.
 	 */
 	private final long listStreamConsumersMaxBackoffMillis;
 
 	/**
-	 * Exponential backoff power constant for the list stream operation.
+	 * Exponential backoff power constant for the list stream consumers operation.
 	 */
 	private final double listStreamConsumersExpConstant;
 
@@ -133,9 +134,6 @@ public class FanOutProperties {
 	 */
 	private final int listStreamConsumersMaxRetries;
 
-	// ------------------------------------------------------------------------
-	//  registerStream() related performance settings
-	// ------------------------------------------------------------------------
 	/**
 	 * Creates a FanOutProperties.
 	 *
@@ -255,10 +253,10 @@ public class FanOutProperties {
 	public double getSubscribeToShardExpConstant() {
 		return subscribeToShardExpConstant;
 	}
+
 	// ------------------------------------------------------------------------
 	//  registerStream() related performance settings
 	// ------------------------------------------------------------------------
-
 	/**
 	 * Get base backoff millis for the register stream operation.
 	 */
@@ -290,7 +288,6 @@ public class FanOutProperties {
 	// ------------------------------------------------------------------------
 	//  deregisterStream() related performance settings
 	// ------------------------------------------------------------------------
-
 	/**
 	 * Get base backoff millis for the deregister stream operation.
 	 */
@@ -318,10 +315,10 @@ public class FanOutProperties {
 	public int getDeregisterStreamMaxRetries() {
 		return deregisterStreamMaxRetries;
 	}
-	// ------------------------------------------------------------------------
-	//  listStream() related performance settings
-	// ------------------------------------------------------------------------
 
+	// ------------------------------------------------------------------------
+	//  listStreamConsumers() related performance settings
+	// ------------------------------------------------------------------------
 	/**
 	 * Get base backoff millis for the list stream consumers operation.
 	 */
@@ -360,27 +357,21 @@ public class FanOutProperties {
 	/**
 	 * Get consumer name, will be null if efo registration type is 'NONE'.
 	 */
-	@Nullable
-	public String getConsumerName() {
-		return consumerName;
+	public Optional<String> getConsumerName() {
+		return Optional.ofNullable(consumerName);
 	}
 
 	/**
 	 * Get stream consumer arns, will be null if efo registration type is 'LAZY' or 'EAGER'.
 	 */
-	@Nullable
-	public Map<String, String> getStreamConsumerArns() {
-		return streamConsumerArns;
+	public Optional<Map<String, String>> getStreamConsumerArns() {
+		return Optional.ofNullable(streamConsumerArns);
 	}
 
 	/**
 	 * Get the according consumer arn to the stream, will be null if efo registration type is 'LAZY' or 'EAGER'.
 	 */
-	@Nullable
-	public String getStreamConsumerArn(String stream) {
-		if (this.streamConsumerArns == null) {
-			return null;
-		}
-		return streamConsumerArns.get(stream);
+	public Optional<String> getStreamConsumerArn(String stream) {
+		return Optional.ofNullable(streamConsumerArns).map(arns -> arns.get(stream));
 	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.fanout;
+
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
+import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+
+/**
+ * This is a configuration class for enhanced fan-out components.
+ */
+public class FanOutProperties {
+
+	/**
+	 * The efo registration type for de-/registration of streams.
+	 */
+	private final EFORegistrationType efoRegistrationType;
+
+	/**
+	 * The efo stream consumer name. Should not be Null if the efoRegistrationType is either LAZY or EAGER.
+	 */
+	@Nullable
+	private String consumerName;
+
+	/**
+	 * The manual set efo consumer arns for each stream. Should not be Null if the efoRegistrationType is NONE
+	 */
+	@Nullable
+	private Map<String, String> streamConsumerArns;
+
+	/**
+	 * Base backoff millis for the deregister stream operation.
+	 */
+	private final int subscribeToShardMaxRetries;
+
+	/**
+	 * Maximum backoff millis for the subscribe to shard operation.
+	 */
+	private final long subscribeToShardMaxBackoffMillis;
+
+	/**
+	 * Base backoff millis for the subscribe to shard operation.
+	 */
+	private final long subscribeToShardBaseBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the subscribe to shard operation.
+	 */
+	private final double subscribeToShardExpConstant;
+
+	/**
+	 * Base backoff millis for the register stream operation.
+	 */
+	private final long registerStreamBaseBackoffMillis;
+
+	/**
+	 * Maximum backoff millis for the register stream operation.
+	 */
+	private final long registerStreamMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the register stream operation.
+	 */
+	private final double registerStreamExpConstant;
+
+	/**
+	 * Maximum retry attempts for the register stream operation.
+	 */
+	private final int registerStreamMaxRetries;
+
+	/**
+	 * Base backoff millis for the deregister stream operation.
+	 */
+	private final long deregisterStreamBaseBackoffMillis;
+
+	/**
+	 * Maximum backoff millis for the deregister stream operation.
+	 */
+	private final long deregisterStreamMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the deregister stream operation.
+	 */
+	private final double deregisterStreamExpConstant;
+
+	/**
+	 * Maximum retry attempts for the deregister stream operation.
+	 */
+	private final int deregisterStreamMaxRetries;
+
+	/**
+	 * Base backoff millis for the list stream operation.
+	 */
+	private final long listStreamConsumersBaseBackoffMillis;
+
+	/**
+	 * Maximum backoff millis for the list stream operation.
+	 */
+	private final long listStreamConsumersMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the list stream operation.
+	 */
+	private final double listStreamConsumersExpConstant;
+
+	/**
+	 * Maximum retry attempts for the list stream operation.
+	 */
+	private final int listStreamConsumersMaxRetries;
+
+	// ------------------------------------------------------------------------
+	//  registerStream() related performance settings
+	// ------------------------------------------------------------------------
+	/**
+	 * Creates a FanOutProperties.
+	 *
+	 * @param configProps the configuration properties from config file.
+	 * @param streams     the streams which is sent to match the EFO consumer arn if the EFO registration mode is set to `NONE`.
+	 */
+	public FanOutProperties(Properties configProps, List<String> streams) {
+		Preconditions.checkArgument(configProps.getProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE).equals(RecordPublisherType.EFO.toString()), "Only efo record publisher can register a FanOutProperties.");
+		KinesisConfigUtil.validateEfoConfiguration(configProps, streams);
+
+		efoRegistrationType = EFORegistrationType.valueOf(configProps.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.EAGER.toString()));
+		//if efo registration type is EAGER|LAZY, then user should explicitly provide a consumer name for each stream.
+		if (efoRegistrationType == EFORegistrationType.EAGER || efoRegistrationType == EFORegistrationType.LAZY) {
+			consumerName = configProps.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		} else {
+			//else users should explicitly provide consumer arns.
+			streamConsumerArns = new HashMap<>();
+			for (String stream : streams) {
+				String key = ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + stream;
+				streamConsumerArns.put(stream, configProps.getProperty(key));
+			}
+		}
+
+		this.subscribeToShardMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES)));
+		this.subscribeToShardBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE)));
+		this.subscribeToShardMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_MAX)));
+		this.subscribeToShardExpConstant = Double.parseDouble(
+			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT)));
+
+		this.registerStreamBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_BACKOFF_BASE)));
+		this.registerStreamMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_BACKOFF_MAX)));
+		this.registerStreamExpConstant = Double.parseDouble(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT)));
+		this.registerStreamMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.REGISTER_STREAM_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_REGISTER_STREAM_RETRIES)));
+
+		this.deregisterStreamBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_BACKOFF_BASE)));
+		this.deregisterStreamMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_BACKOFF_MAX)));
+		this.deregisterStreamExpConstant = Double.parseDouble(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT)));
+		this.deregisterStreamMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.DEREGISTER_STREAM_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DEREGISTER_STREAM_RETRIES)));
+
+		this.listStreamConsumersBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_BASE)));
+		this.listStreamConsumersMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_MAX)));
+		this.listStreamConsumersExpConstant = Double.parseDouble(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT)));
+		this.listStreamConsumersMaxRetries = Integer.parseInt(
+			configProps.getProperty(
+				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_RETRIES,
+				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_RETRIES)));
+	}
+
+	// ------------------------------------------------------------------------
+	//  subscribeToShard() related performance settings
+	// ------------------------------------------------------------------------
+	/**
+	 * Get maximum retry attempts for the subscribe to shard operation.
+	 */
+	public int getSubscribeToShardMaxRetries() {
+		return subscribeToShardMaxRetries;
+	}
+
+	/**
+	 * Get maximum backoff millis for the subscribe to shard operation.
+	 */
+	public long getSubscribeToShardMaxBackoffMillis() {
+		return subscribeToShardMaxBackoffMillis;
+	}
+
+	/**
+	 * Get base backoff millis for the subscribe to shard operation.
+	 */
+	public long getSubscribeToShardBaseBackoffMillis() {
+		return subscribeToShardBaseBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the subscribe to shard operation.
+	 */
+	public double getSubscribeToShardExpConstant() {
+		return subscribeToShardExpConstant;
+	}
+	// ------------------------------------------------------------------------
+	//  registerStream() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get base backoff millis for the register stream operation.
+	 */
+	public long getRegisterStreamBaseBackoffMillis() {
+		return registerStreamBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the register stream operation.
+	 */
+	public long getRegisterStreamMaxBackoffMillis() {
+		return registerStreamMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the register stream operation.
+	 */
+	public double getRegisterStreamExpConstant() {
+		return registerStreamExpConstant;
+	}
+
+	/**
+	 * Get maximum retry attempts for the register stream operation.
+	 */
+	public int getRegisterStreamMaxRetries() {
+		return registerStreamMaxRetries;
+	}
+
+	// ------------------------------------------------------------------------
+	//  deregisterStream() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get base backoff millis for the deregister stream operation.
+	 */
+	public long getDeregisterStreamBaseBackoffMillis() {
+		return deregisterStreamBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the deregister stream operation.
+	 */
+	public long getDeregisterStreamMaxBackoffMillis() {
+		return deregisterStreamMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the deregister stream operation.
+	 */
+	public double getDeregisterStreamExpConstant() {
+		return deregisterStreamExpConstant;
+	}
+
+	/**
+	 * Get maximum retry attempts for the register stream operation.
+	 */
+	public int getDeregisterStreamMaxRetries() {
+		return deregisterStreamMaxRetries;
+	}
+	// ------------------------------------------------------------------------
+	//  listStream() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get base backoff millis for the list stream consumers operation.
+	 */
+	public long getListStreamConsumersBaseBackoffMillis() {
+		return listStreamConsumersBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the list stream consumers operation.
+	 */
+	public long getListStreamConsumersMaxBackoffMillis() {
+		return listStreamConsumersMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the list stream consumers operation.
+	 */
+	public double getListStreamConsumersExpConstant() {
+		return listStreamConsumersExpConstant;
+	}
+
+	/**
+	 * Get maximum retry attempts for the list stream consumers operation.
+	 */
+	public int getListStreamConsumersMaxRetries() {
+		return listStreamConsumersMaxRetries;
+	}
+
+	/**
+	 * Get efo registration type.
+	 */
+	public EFORegistrationType getEfoRegistrationType() {
+		return efoRegistrationType;
+	}
+
+	/**
+	 * Get consumer name, will be null if efo registration type is 'NONE'.
+	 */
+	@Nullable
+	public String getConsumerName() {
+		return consumerName;
+	}
+
+	/**
+	 * Get stream consumer arns, will be null if efo registration type is 'LAZY' or 'EAGER'.
+	 */
+	@Nullable
+	public Map<String, String> getStreamConsumerArns() {
+		return streamConsumerArns;
+	}
+
+	/**
+	 * Get the according consumer arn to the stream, will be null if efo registration type is 'LAZY' or 'EAGER'.
+	 */
+	@Nullable
+	public String getStreamConsumerArn(String stream) {
+		if (this.streamConsumerArns == null) {
+			return null;
+		}
+		return streamConsumerArns.get(stream);
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutProperties.java
@@ -135,6 +135,46 @@ public class FanOutProperties {
 	private final int listStreamConsumersMaxRetries;
 
 	/**
+	 * Max retries for the describe stream operation.
+	 */
+	private final int describeStreamMaxRetries;
+
+	/**
+	 * Backoff millis for the describe stream operation.
+	 */
+	private final long describeStreamBaseBackoffMillis;
+
+	/**
+	 *  Maximum backoff millis for the describe stream operation.
+	 */
+	private final long describeStreamMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the describe stream operation.
+	 */
+	private final double describeStreamExpConstant;
+
+	/**
+	 * Max retries for the describe stream consumer operation.
+	 */
+	private final int describeStreamConsumerMaxRetries;
+
+	/**
+	 * Backoff millis for the describe stream consumer operation.
+	 */
+	private final long describeStreamConsumerBaseBackoffMillis;
+
+	/**
+	 *  Maximum backoff millis for the describe stream consumer operation.
+	 */
+	private final long describeStreamConsumerMaxBackoffMillis;
+
+	/**
+	 * Exponential backoff power constant for the describe stream consumer operation.
+	 */
+	private final double describeStreamConsumerExpConstant;
+
+	/**
 	 * Creates a FanOutProperties.
 	 *
 	 * @param configProps the configuration properties from config file.
@@ -221,6 +261,30 @@ public class FanOutProperties {
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_STREAM_CONSUMERS_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_STREAM_CONSUMERS_RETRIES)));
+		this.describeStreamMaxRetries = Integer.parseInt(
+			configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_RETRIES,
+				Integer.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_RETRIES)));
+		this.describeStreamBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE)));
+		this.describeStreamMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX)));
+		this.describeStreamExpConstant = Double.parseDouble(
+			configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT)));
+		this.describeStreamConsumerMaxRetries = Integer.parseInt(
+			configProps.getProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_RETRIES,
+				Integer.toString(ConsumerConfigConstants.DEFAULT_DESCRIBE_STREAM_CONSUMER_RETRIES)));
+		this.describeStreamConsumerBaseBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE)));
+		this.describeStreamConsumerMaxBackoffMillis = Long.parseLong(
+			configProps.getProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX)));
+		this.describeStreamConsumerExpConstant = Double.parseDouble(
+			configProps.getProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT)));
 	}
 
 	// ------------------------------------------------------------------------
@@ -345,6 +409,70 @@ public class FanOutProperties {
 	 */
 	public int getListStreamConsumersMaxRetries() {
 		return listStreamConsumersMaxRetries;
+	}
+
+	// ------------------------------------------------------------------------
+	//  describeStream() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get maximum retry attempts for the describe stream operation.
+	 */
+	public int getDescribeStreamMaxRetries() {
+		return describeStreamMaxRetries;
+	}
+
+	/**
+	 * Get base backoff millis for the describe stream operation.
+	 */
+	public long getDescribeStreamBaseBackoffMillis() {
+		return describeStreamBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the describe stream operation.
+	 */
+	public long getDescribeStreamMaxBackoffMillis() {
+		return describeStreamMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the describe stream operation.
+	 */
+	public double getDescribeStreamExpConstant() {
+		return describeStreamExpConstant;
+	}
+
+	// ------------------------------------------------------------------------
+	//  describeStreamConsumer() related performance settings
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get maximum retry attempts for the describe stream operation.
+	 */
+	public int getDescribeStreamConsumerMaxRetries() {
+		return describeStreamConsumerMaxRetries;
+	}
+
+	/**
+	 * Get base backoff millis for the describe stream operation.
+	 */
+	public long getDescribeStreamConsumerBaseBackoffMillis() {
+		return describeStreamConsumerBaseBackoffMillis;
+	}
+
+	/**
+	 * Get maximum backoff millis for the describe stream operation.
+	 */
+	public long getDescribeStreamConsumerMaxBackoffMillis() {
+		return describeStreamConsumerMaxBackoffMillis;
+	}
+
+	/**
+	 * Get exponential backoff power constant for the describe stream operation.
+	 */
+	public double getDescribeStreamConsumerExpConstant() {
+		return describeStreamConsumerExpConstant;
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutStreamInfo.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutStreamInfo.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.fanout;
+
+import java.util.Objects;
+
+/**
+ * This is a data class which describe all related information when de-/registering streams.
+ */
+public class FanOutStreamInfo {
+	/** Kinesis stream name. */
+	private final String stream;
+
+	/** Kinesis stream arn. */
+	private final String streamArn;
+
+	/** Registered consumer name for the related stream. */
+	private final String consumerName;
+
+	/** Registered consumer arn for the related stream. */
+	private final String consumerArn;
+
+	/**
+	 * Return the Kinesis stream name.
+	 */
+	public String getStream() {
+		return stream;
+	}
+
+	/**
+	 * Return the Kinesis stream arn.
+	 */
+	public String getStreamArn() {
+		return streamArn;
+	}
+
+	/**
+	 * Return the Kinesis consumer name for an enhanced fan-out consumer.
+	 */
+	public String getConsumerName() {
+		return consumerName;
+	}
+
+	/**
+	 * Return the Kinesis consumer arn for an enhanced fan-out consumer.
+	 */
+	public String getConsumerArn() {
+		return consumerArn;
+	}
+
+	/**
+	 * Public constructor for fan out stream info.
+	 */
+	public FanOutStreamInfo(String stream, String streamArn, String consumerName, String consumerArn) {
+		this.stream = stream;
+		this.streamArn = streamArn;
+		this.consumerName = consumerName;
+		this.consumerArn = consumerArn;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		FanOutStreamInfo that = (FanOutStreamInfo) o;
+		return stream.equals(that.stream) &&
+			streamArn.equals(that.streamArn) &&
+			consumerName.equals(that.consumerName) &&
+			consumerArn.equals(that.consumerArn);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(stream, streamArn, consumerName, consumerArn);
+	}
+
+	@Override
+	public String toString() {
+		return "FanOutStreamInfo{" +
+			"stream='" + stream + '\'' +
+			", streamArn='" + streamArn + '\'' +
+			", consumerName='" + consumerName + '\'' +
+			", consumerArn='" + consumerArn + '\'' +
+			'}';
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordBatch.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordBatch.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher;
+
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord;
+import com.amazonaws.services.kinesis.model.Record;
+
+import javax.annotation.Nullable;
+
+import java.math.BigInteger;
+import java.util.List;
+
+/**
+ * A batch of UserRecords received from Kinesis.
+ * Input records are de-aggregated using KCL 1.x library.
+ * It is expected that AWS SDK v2.x messages are converted to KCL 1.x {@link UserRecord}.
+ */
+public class RecordBatch {
+
+	private final int aggregatedRecordSize;
+
+	private final List<UserRecord> deaggregatedRecords;
+
+	private final long totalSizeInBytes;
+
+	private final Long millisBehindLatest;
+
+	public RecordBatch(final List<Record> records, final StreamShardHandle subscribedShard, final Long millisBehindLatest) {
+		this.aggregatedRecordSize = records.size();
+		this.deaggregatedRecords = deaggregateRecords(records, subscribedShard);
+		this.totalSizeInBytes = this.deaggregatedRecords.stream().mapToInt(r -> r.getData().remaining()).sum();
+		this.millisBehindLatest = millisBehindLatest;
+	}
+
+	public int getAggregatedRecordSize() {
+		return aggregatedRecordSize;
+	}
+
+	public int getDeaggregatedRecordSize() {
+		return deaggregatedRecords.size();
+	}
+
+	public List<UserRecord> getDeaggregatedRecords() {
+		return deaggregatedRecords;
+	}
+
+	public long getTotalSizeInBytes() {
+		return totalSizeInBytes;
+	}
+
+	public long getAverageRecordSizeBytes() {
+		return deaggregatedRecords.isEmpty() ? 0 : getTotalSizeInBytes() / getDeaggregatedRecordSize();
+	}
+
+	@Nullable
+	public Long getMillisBehindLatest() {
+		return millisBehindLatest;
+	}
+
+	private List<UserRecord> deaggregateRecords(final List<Record> records, final StreamShardHandle subscribedShard) {
+		BigInteger start = new BigInteger(subscribedShard.getShard().getHashKeyRange().getStartingHashKey());
+		BigInteger end = new BigInteger(subscribedShard.getShard().getHashKeyRange().getEndingHashKey());
+
+		return UserRecord.deaggregate(records, start, end);
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisher.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
+
+import java.util.function.Consumer;
+
+/**
+ * A {@code RecordPublisher} will consume records from an external stream and deliver them to the registered subscriber.
+ */
+@Internal
+public interface RecordPublisher {
+
+	/**
+	 * Run the record publisher. Records will be consumed from the stream and published to the consumer.
+	 * The number of batches retrieved by a single invocation will vary based on implementation.
+	 *
+	 * @param startingPosition the position in the stream from which to consume
+	 * @param recordConsumer the record consumer in which to output records
+	 * @return a status enum to represent whether a shard has been fully consumed
+	 * @throws InterruptedException
+	 */
+	RecordPublisherRunResult run(StartingPosition startingPosition, Consumer<RecordBatch> recordConsumer) throws InterruptedException;
+
+	/**
+	 * A status enum to represent whether a shard has been fully consumed.
+	 */
+	enum RecordPublisherRunResult {
+		/** There are no more records to consume from this shard. */
+		COMPLETE,
+
+		/** There are more records to consume from this shard. */
+		INCOMPLETE
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisherFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisherFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyMarker;
+
+import java.util.Properties;
+
+/**
+ * A factory interface used to create instances of {@link RecordPublisher}.
+ * @param <T> the generic type of the {@link RecordPublisher}
+ * @param <P> the generic type of the {@link KinesisProxyMarker}
+ */
+@Internal
+public interface RecordPublisherFactory<T extends RecordPublisher, P extends KinesisProxyMarker> {
+
+	/**
+	 * Create a {@link RecordPublisher} of type {@code T}.
+	 *
+	 * @param consumerConfig the properties used to configure the {@link RecordPublisher}.
+	 * @param metricGroup the {@link MetricGroup} used to report metrics to
+	 * @param streamShardHandle the stream shard in which to consume from
+	 * @param kinesis the proxy used to communicate with kinesis
+	 * @return the constructed {@link RecordPublisher}
+	 */
+	T create(Properties consumerConfig, MetricGroup metricGroup, StreamShardHandle streamShardHandle, P kinesis);
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/AdaptivePollingRecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/AdaptivePollingRecordPublisher.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordBatch;
+import org.apache.flink.streaming.connectors.kinesis.metrics.PollingRecordPublisherMetricsReporter;
+import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+
+import java.util.function.Consumer;
+
+/**
+ * An adaptive record publisher to add a dynamic loop delay and batch read size for {@link PollingRecordPublisher}.
+ * Kinesis Streams have quotas on the transactions per second, and throughout. This class attempts to balance
+ * quotas and mitigate back off errors.
+ */
+@Internal
+public class AdaptivePollingRecordPublisher extends PollingRecordPublisher {
+	// AWS Kinesis has a read limit of 2 Mb/sec
+	// https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html
+	private static final long KINESIS_SHARD_BYTES_PER_SECOND_LIMIT = 2 * 1024L * 1024L;
+
+	private int lastRecordBatchSize = 0;
+
+	private long lastRecordBatchSizeInBytes = 0;
+
+	private long processingStartTimeNanos = System.nanoTime();
+
+	private int maxNumberOfRecordsPerFetch;
+
+	private final long fetchIntervalMillis;
+
+	private final PollingRecordPublisherMetricsReporter metricsReporter;
+
+	public AdaptivePollingRecordPublisher(
+			final StreamShardHandle subscribedShard,
+			final PollingRecordPublisherMetricsReporter metricsReporter,
+			final KinesisProxyInterface kinesisProxy,
+			final int maxNumberOfRecordsPerFetch,
+			final long fetchIntervalMillis) {
+		super(subscribedShard, metricsReporter, kinesisProxy, maxNumberOfRecordsPerFetch, fetchIntervalMillis);
+		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
+		this.fetchIntervalMillis = fetchIntervalMillis;
+		this.metricsReporter = metricsReporter;
+	}
+
+	@Override
+	public RecordPublisherRunResult run(final StartingPosition startingPosition, final Consumer<RecordBatch> consumer) throws InterruptedException {
+		final RecordPublisherRunResult result = super.run(startingPosition, batch -> {
+			consumer.accept(batch);
+			lastRecordBatchSize = batch.getDeaggregatedRecordSize();
+			lastRecordBatchSizeInBytes = batch.getTotalSizeInBytes();
+		}, maxNumberOfRecordsPerFetch);
+
+		long adjustmentEndTimeNanos = adjustRunLoopFrequency(processingStartTimeNanos, System.nanoTime());
+		long runLoopTimeNanos = adjustmentEndTimeNanos - processingStartTimeNanos;
+		maxNumberOfRecordsPerFetch = adaptRecordsToRead(runLoopTimeNanos, lastRecordBatchSize, lastRecordBatchSizeInBytes, maxNumberOfRecordsPerFetch);
+		processingStartTimeNanos = adjustmentEndTimeNanos;
+		metricsReporter.setRunLoopTimeNanos(runLoopTimeNanos);
+
+		return result;
+	}
+
+	/**
+	 * Adjusts loop timing to match target frequency if specified.
+	 * @param processingStartTimeNanos The start time of the run loop "work"
+	 * @param processingEndTimeNanos The end time of the run loop "work"
+	 * @return The System.nanoTime() after the sleep (if any)
+	 * @throws InterruptedException
+	 */
+	private long adjustRunLoopFrequency(long processingStartTimeNanos, long processingEndTimeNanos)
+			throws InterruptedException {
+		long endTimeNanos = processingEndTimeNanos;
+		if (fetchIntervalMillis != 0) {
+			long processingTimeNanos = processingEndTimeNanos - processingStartTimeNanos;
+			long sleepTimeMillis = fetchIntervalMillis - (processingTimeNanos / 1_000_000);
+			if (sleepTimeMillis > 0) {
+				Thread.sleep(sleepTimeMillis);
+				endTimeNanos = System.nanoTime();
+				metricsReporter.setSleepTimeMillis(sleepTimeMillis);
+			}
+		}
+		return endTimeNanos;
+	}
+
+	/**
+	 * Calculates how many records to read each time through the loop based on a target throughput
+	 * and the measured frequenecy of the loop.
+	 * @param runLoopTimeNanos The total time of one pass through the loop
+	 * @param numRecords The number of records of the last read operation
+	 * @param recordBatchSizeBytes The total batch size of the last read operation
+	 * @param maxNumberOfRecordsPerFetch The current maxNumberOfRecordsPerFetch
+	 */
+	private int adaptRecordsToRead(long runLoopTimeNanos, int numRecords, long recordBatchSizeBytes,
+			int maxNumberOfRecordsPerFetch) {
+		if (numRecords != 0 && runLoopTimeNanos != 0) {
+			long averageRecordSizeBytes = recordBatchSizeBytes / numRecords;
+			// Adjust number of records to fetch from the shard depending on current average record size
+			// to optimize 2 Mb / sec read limits
+			double loopFrequencyHz = 1000000000.0d / runLoopTimeNanos;
+			double bytesPerRead = KINESIS_SHARD_BYTES_PER_SECOND_LIMIT / loopFrequencyHz;
+			maxNumberOfRecordsPerFetch = (int) (bytesPerRead / averageRecordSizeBytes);
+			// Ensure the value is greater than 0 and not more than 10000L
+			maxNumberOfRecordsPerFetch = Math.max(1, Math.min(maxNumberOfRecordsPerFetch, ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_MAX));
+
+			// Set metrics
+			metricsReporter.setLoopFrequencyHz(loopFrequencyHz);
+			metricsReporter.setBytesPerRead(bytesPerRead);
+		}
+		return maxNumberOfRecordsPerFetch;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisher.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordBatch;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
+import org.apache.flink.streaming.connectors.kinesis.metrics.PollingRecordPublisherMetricsReporter;
+import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
+import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+
+import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Consumer;
+
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
+import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
+import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
+
+/**
+ * A {@link RecordPublisher} that will read records from Kinesis and forward them to the subscriber.
+ * Records are consumed by polling the GetRecords KDS API using a ShardIterator.
+ */
+@Internal
+public class PollingRecordPublisher implements RecordPublisher {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PollingRecordPublisher.class);
+
+	private final PollingRecordPublisherMetricsReporter metricsReporter;
+
+	private final KinesisProxyInterface kinesisProxy;
+
+	private final StreamShardHandle subscribedShard;
+
+	private String nextShardItr;
+
+	private final int maxNumberOfRecordsPerFetch;
+
+	private final long expiredIteratorBackoffMillis;
+
+	/**
+	 * A Polling implementation of {@link RecordPublisher} that polls kinesis for records.
+	 * The following KDS services are used: GetRecords and GetShardIterator.
+	 *
+	 * @param subscribedShard the shard in which to consume from
+	 * @param metricsReporter a metric reporter used to output metrics
+	 * @param kinesisProxy the proxy used to communicate with kinesis
+	 * @param maxNumberOfRecordsPerFetch the maximum number of records to retrieve per batch
+	 * @param expiredIteratorBackoffMillis the duration to sleep in the event of an {@link ExpiredIteratorException}
+	 */
+	public PollingRecordPublisher(
+			final StreamShardHandle subscribedShard,
+			final PollingRecordPublisherMetricsReporter metricsReporter,
+			final KinesisProxyInterface kinesisProxy,
+			final int maxNumberOfRecordsPerFetch,
+			final long expiredIteratorBackoffMillis) {
+		this.subscribedShard = subscribedShard;
+		this.metricsReporter = metricsReporter;
+		this.kinesisProxy = kinesisProxy;
+		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
+		this.expiredIteratorBackoffMillis = expiredIteratorBackoffMillis;
+	}
+
+	@Override
+	public RecordPublisherRunResult run(final StartingPosition startingPosition, final Consumer<RecordBatch> consumer) throws InterruptedException {
+		return run(startingPosition, consumer, maxNumberOfRecordsPerFetch);
+	}
+
+	public RecordPublisherRunResult run(final StartingPosition startingPosition, final Consumer<RecordBatch> consumer, int maxNumberOfRecords) throws InterruptedException {
+		if (nextShardItr == null) {
+			nextShardItr = getShardIterator(startingPosition);
+		}
+
+		if (nextShardItr == null) {
+			return COMPLETE;
+		}
+
+		metricsReporter.setMaxNumberOfRecordsPerFetch(maxNumberOfRecords);
+
+		GetRecordsResult result = getRecords(nextShardItr, startingPosition, maxNumberOfRecords);
+
+		consumer.accept(new RecordBatch(result.getRecords(), subscribedShard, result.getMillisBehindLatest()));
+
+		nextShardItr = result.getNextShardIterator();
+		return nextShardItr == null ? COMPLETE : INCOMPLETE;
+	}
+
+	/**
+	 * Calls {@link KinesisProxyInterface#getRecords(String, int)}, while also handling unexpected
+	 * AWS {@link ExpiredIteratorException}s to assure that we get results and don't just fail on
+	 * such occasions. The returned shard iterator within the successful {@link GetRecordsResult} should
+	 * be used for the next call to this method.
+	 *
+	 * <p>Note: it is important that this method is not called again before all the records from the last result have been
+	 * fully collected with {@code ShardConsumer#deserializeRecordForCollectionAndUpdateState(UserRecord)}, otherwise
+	 * {@code ShardConsumer#lastSequenceNum} may refer to a sub-record in the middle of an aggregated record, leading to
+	 * incorrect shard iteration if the iterator had to be refreshed.
+	 *
+	 * @param shardItr shard iterator to use
+	 * @param startingPosition the position in the stream in which to consume from
+	 * @param maxNumberOfRecords the maximum number of records to fetch for this getRecords attempt
+	 * @return get records result
+	 */
+	private GetRecordsResult getRecords(String shardItr, final StartingPosition startingPosition, int maxNumberOfRecords) throws InterruptedException {
+		GetRecordsResult getRecordsResult = null;
+		while (getRecordsResult == null) {
+			try {
+				getRecordsResult = kinesisProxy.getRecords(shardItr, maxNumberOfRecords);
+			} catch (ExpiredIteratorException eiEx) {
+				LOG.warn("Encountered an unexpected expired iterator {} for shard {};" +
+					" refreshing the iterator ...", shardItr, subscribedShard);
+
+				shardItr = getShardIterator(startingPosition);
+
+				// sleep for the fetch interval before the next getRecords attempt with the refreshed iterator
+				if (expiredIteratorBackoffMillis != 0) {
+					Thread.sleep(expiredIteratorBackoffMillis);
+				}
+			}
+		}
+		return getRecordsResult;
+	}
+
+	/**
+	 * Returns a shard iterator for the given {@link SequenceNumber}.
+	 *
+	 * @return shard iterator
+	 */
+	@Nullable
+	private String getShardIterator(final StartingPosition startingPosition) throws InterruptedException {
+		if (startingPosition.getShardIteratorType() == LATEST && subscribedShard.isClosed()) {
+			return null;
+		}
+
+		return kinesisProxy.getShardIterator(
+				subscribedShard,
+				startingPosition.getShardIteratorType().toString(),
+				startingPosition.getStartingMarker());
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherConfiguration.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+
+import java.util.Properties;
+
+/**
+ * A configuration class for {@link PollingRecordPublisher} instantiated from a properties map.
+ */
+@Internal
+public class PollingRecordPublisherConfiguration {
+
+	private final boolean adaptiveReads;
+
+	private final int maxNumberOfRecordsPerFetch;
+
+	private final long fetchIntervalMillis;
+
+	public PollingRecordPublisherConfiguration(final Properties consumerConfig) {
+		this.maxNumberOfRecordsPerFetch = Integer.parseInt(consumerConfig.getProperty(
+			ConsumerConfigConstants.SHARD_GETRECORDS_MAX,
+			Integer.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_MAX)));
+
+		this.fetchIntervalMillis = Long.parseLong(consumerConfig.getProperty(
+			ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS,
+			Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_INTERVAL_MILLIS)));
+
+		this.adaptiveReads = Boolean.parseBoolean(consumerConfig.getProperty(
+			ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS,
+			Boolean.toString(ConsumerConfigConstants.DEFAULT_SHARD_USE_ADAPTIVE_READS)));
+	}
+
+	public boolean isAdaptiveReads() {
+		return adaptiveReads;
+	}
+
+	public int getMaxNumberOfRecordsPerFetch() {
+		return maxNumberOfRecordsPerFetch;
+	}
+
+	public long getFetchIntervalMillis() {
+		return fetchIntervalMillis;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisherFactory;
+import org.apache.flink.streaming.connectors.kinesis.metrics.PollingRecordPublisherMetricsReporter;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+
+import java.util.Properties;
+
+/**
+ * A {@link RecordPublisher} factory used to create instances of {@link PollingRecordPublisher}.
+ */
+@Internal
+public class PollingRecordPublisherFactory implements RecordPublisherFactory<PollingRecordPublisher, KinesisProxyInterface> {
+
+	/**
+	 * Create a {@link PollingRecordPublisher}.
+	 * An {@link AdaptivePollingRecordPublisher} will be created should adaptive reads be enabled in the configuration.
+	 *
+	 * @param consumerConfig the consumer configuration properties
+	 * @param metricGroup the metric group to report metrics to
+	 * @param streamShardHandle the shard this consumer is subscribed to
+	 * @param kinesisProxy the proxy instance to interact with Kinesis
+	 * @return a {@link PollingRecordPublisher}
+	 */
+	@Override
+	public PollingRecordPublisher create(
+			final Properties consumerConfig,
+			final MetricGroup metricGroup,
+			final StreamShardHandle streamShardHandle,
+			final KinesisProxyInterface kinesisProxy) {
+
+		final PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(consumerConfig);
+		final PollingRecordPublisherMetricsReporter metricsReporter = new PollingRecordPublisherMetricsReporter(metricGroup);
+
+		if (configuration.isAdaptiveReads()) {
+			return new AdaptivePollingRecordPublisher(
+				streamShardHandle,
+				metricsReporter,
+				kinesisProxy,
+				configuration.getMaxNumberOfRecordsPerFetch(),
+				configuration.getFetchIntervalMillis());
+		} else {
+			return new PollingRecordPublisher(
+				streamShardHandle,
+				metricsReporter,
+				kinesisProxy,
+				configuration.getMaxNumberOfRecordsPerFetch(),
+				configuration.getFetchIntervalMillis());
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/PollingRecordPublisherMetricsReporter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/PollingRecordPublisherMetricsReporter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.metrics;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling.PollingRecordPublisher;
+
+/**
+ * A container for {@link PollingRecordPublisher}s to report metric values.
+ */
+@Internal
+public class PollingRecordPublisherMetricsReporter {
+
+	private volatile double loopFrequencyHz = 0.0;
+	private volatile double bytesPerRead = 0.0;
+	private volatile long runLoopTimeNanos = 0L;
+	private volatile long sleepTimeMillis = 0L;
+	private volatile int maxNumberOfRecordsPerFetch = 0;
+
+	public PollingRecordPublisherMetricsReporter(final MetricGroup metricGroup) {
+		metricGroup.gauge(KinesisConsumerMetricConstants.MAX_RECORDS_PER_FETCH, this::getMaxNumberOfRecordsPerFetch);
+		metricGroup.gauge(KinesisConsumerMetricConstants.BYTES_PER_READ, this::getBytesPerRead);
+		metricGroup.gauge(KinesisConsumerMetricConstants.RUNTIME_LOOP_NANOS, this::getRunLoopTimeNanos);
+		metricGroup.gauge(KinesisConsumerMetricConstants.LOOP_FREQUENCY_HZ, this::getLoopFrequencyHz);
+		metricGroup.gauge(KinesisConsumerMetricConstants.SLEEP_TIME_MILLIS, this::getSleepTimeMillis);
+	}
+
+	public double getLoopFrequencyHz() {
+		return loopFrequencyHz;
+	}
+
+	public void setLoopFrequencyHz(double loopFrequencyHz) {
+		this.loopFrequencyHz = loopFrequencyHz;
+	}
+
+	public double getBytesPerRead() {
+		return bytesPerRead;
+	}
+
+	public void setBytesPerRead(double bytesPerRead) {
+		this.bytesPerRead = bytesPerRead;
+	}
+
+	public long getRunLoopTimeNanos() {
+		return runLoopTimeNanos;
+	}
+
+	public void setRunLoopTimeNanos(long runLoopTimeNanos) {
+		this.runLoopTimeNanos = runLoopTimeNanos;
+	}
+
+	public long getSleepTimeMillis() {
+		return sleepTimeMillis;
+	}
+
+	public void setSleepTimeMillis(long sleepTimeMillis) {
+		this.sleepTimeMillis = sleepTimeMillis;
+	}
+
+	public int getMaxNumberOfRecordsPerFetch() {
+		return maxNumberOfRecordsPerFetch;
+	}
+
+	public void setMaxNumberOfRecordsPerFetch(int maxNumberOfRecordsPerFetch) {
+		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
+	}
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporter.java
@@ -19,23 +19,26 @@
 package org.apache.flink.streaming.connectors.kinesis.metrics;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer;
 
 /**
  * A container for {@link ShardConsumer}s to report metric values.
  */
 @Internal
-public class ShardMetricsReporter {
+public class ShardConsumerMetricsReporter {
 
 	private volatile long millisBehindLatest = -1;
-	private volatile double loopFrequencyHz = 0.0;
-	private volatile double bytesPerRead = 0.0;
-	private volatile long runLoopTimeNanos = 0L;
 	private volatile long averageRecordSizeBytes = 0L;
-	private volatile long sleepTimeMillis = 0L;
 	private volatile int numberOfAggregatedRecords = 0;
 	private volatile int numberOfDeaggregatedRecords = 0;
-	private volatile int maxNumberOfRecordsPerFetch = 0;
+
+	public ShardConsumerMetricsReporter(final MetricGroup metricGroup) {
+		metricGroup.gauge(KinesisConsumerMetricConstants.MILLIS_BEHIND_LATEST_GAUGE, this::getMillisBehindLatest);
+		metricGroup.gauge(KinesisConsumerMetricConstants.NUM_AGGREGATED_RECORDS_PER_FETCH, this::getNumberOfAggregatedRecords);
+		metricGroup.gauge(KinesisConsumerMetricConstants.NUM_DEAGGREGATED_RECORDS_PER_FETCH, this::getNumberOfDeaggregatedRecords);
+		metricGroup.gauge(KinesisConsumerMetricConstants.AVG_RECORD_SIZE_BYTES, this::getAverageRecordSizeBytes);
+	}
 
 	public long getMillisBehindLatest() {
 		return millisBehindLatest;
@@ -45,44 +48,12 @@ public class ShardMetricsReporter {
 		this.millisBehindLatest = millisBehindLatest;
 	}
 
-	public double getLoopFrequencyHz() {
-		return loopFrequencyHz;
-	}
-
-	public void setLoopFrequencyHz(double loopFrequencyHz) {
-		this.loopFrequencyHz = loopFrequencyHz;
-	}
-
-	public double getBytesPerRead() {
-		return bytesPerRead;
-	}
-
-	public void setBytesPerRead(double bytesPerRead) {
-		this.bytesPerRead = bytesPerRead;
-	}
-
-	public long getRunLoopTimeNanos() {
-		return runLoopTimeNanos;
-	}
-
-	public void setRunLoopTimeNanos(long runLoopTimeNanos) {
-		this.runLoopTimeNanos = runLoopTimeNanos;
-	}
-
 	public long getAverageRecordSizeBytes() {
 		return averageRecordSizeBytes;
 	}
 
 	public void setAverageRecordSizeBytes(long averageRecordSizeBytes) {
 		this.averageRecordSizeBytes = averageRecordSizeBytes;
-	}
-
-	public long getSleepTimeMillis() {
-		return sleepTimeMillis;
-	}
-
-	public void setSleepTimeMillis(long sleepTimeMillis) {
-		this.sleepTimeMillis = sleepTimeMillis;
 	}
 
 	public int getNumberOfAggregatedRecords() {
@@ -99,14 +70,6 @@ public class ShardMetricsReporter {
 
 	public void setNumberOfDeaggregatedRecords(int numberOfDeaggregatedRecords) {
 		this.numberOfDeaggregatedRecords = numberOfDeaggregatedRecords;
-	}
-
-	public int getMaxNumberOfRecordsPerFetch() {
-		return maxNumberOfRecordsPerFetch;
-	}
-
-	public void setMaxNumberOfRecordsPerFetch(int maxNumberOfRecordsPerFetch) {
-		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
 	}
 
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/StartingPosition.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/StartingPosition.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.model;
+
+import com.amazonaws.services.kinesis.model.ShardIteratorType;
+
+import javax.annotation.Nullable;
+
+import java.util.Date;
+
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.AFTER_SEQUENCE_NUMBER;
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.AT_SEQUENCE_NUMBER;
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.AT_TIMESTAMP;
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.TRIM_HORIZON;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.isSentinelSequenceNumber;
+
+/**
+ * The position in which to start consuming from a stream.
+ */
+public class StartingPosition {
+
+	private final ShardIteratorType shardIteratorType;
+
+	private final Object startingMarker;
+
+	private StartingPosition(final ShardIteratorType shardIteratorType, @Nullable final Object startingMarker) {
+		this.shardIteratorType = shardIteratorType;
+		this.startingMarker = startingMarker;
+	}
+
+	public ShardIteratorType getShardIteratorType() {
+		return shardIteratorType;
+	}
+
+	@Nullable
+	public Object getStartingMarker() {
+		return startingMarker;
+	}
+
+	public static StartingPosition fromTimestamp(final Date date) {
+		return new StartingPosition(AT_TIMESTAMP, date);
+	}
+
+	/**
+	 * Returns the starting position for the next record to consume from the given sequence number.
+	 * The difference between {@code restartFromSequenceNumber()} and {@code continueFromSequenceNumber()} is that
+	 * for {@code restartFromSequenceNumber()} aggregated records are reread to support subsequence failure.
+	 *
+	 * @param sequenceNumber the last successful sequence number, or sentinel marker
+	 * @return the start position in which to consume from
+	 */
+	public static StartingPosition continueFromSequenceNumber(final SequenceNumber sequenceNumber) {
+		return fromSequenceNumber(sequenceNumber, false);
+	}
+
+	/**
+	 * Returns the starting position to restart record consumption from the given sequence number after failure.
+	 * The difference between {@code restartFromSequenceNumber()} and {@code continueFromSequenceNumber()} is that
+	 * for {@code restartFromSequenceNumber()} aggregated records are reread to support subsequence failure.
+	 *
+	 * @param sequenceNumber the last successful sequence number, or sentinel marker
+	 * @return the start position in which to consume from
+	 */
+	public static StartingPosition restartFromSequenceNumber(final SequenceNumber sequenceNumber) {
+		return fromSequenceNumber(sequenceNumber, true);
+	}
+
+	private static StartingPosition fromSequenceNumber(final SequenceNumber sequenceNumber, final boolean restart) {
+		if (isSentinelSequenceNumber(sequenceNumber)) {
+			return new StartingPosition(fromSentinelSequenceNumber(sequenceNumber), null);
+		} else {
+			// we will be starting from an actual sequence number (due to restore from failure).
+			return new StartingPosition(getShardIteratorType(sequenceNumber, restart), sequenceNumber.getSequenceNumber());
+		}
+	}
+
+	private static ShardIteratorType getShardIteratorType(final SequenceNumber sequenceNumber, final boolean restart) {
+		return restart && sequenceNumber.isAggregated() ? AT_SEQUENCE_NUMBER : AFTER_SEQUENCE_NUMBER;
+	}
+
+	private static ShardIteratorType fromSentinelSequenceNumber(final SequenceNumber sequenceNumber) {
+		if (sequenceNumber.equals(SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM.get())) {
+			return LATEST;
+		} else if (sequenceNumber.equals(SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM.get())) {
+			return TRIM_HORIZON;
+		} else {
+			throw new IllegalArgumentException("Unexpected sentinel type: " + sequenceNumber);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -148,65 +148,64 @@ public class KinesisProxy implements KinesisProxyInterface {
 
 		this.kinesisClient = createKinesisClient(configProps);
 
-		this.listShardsBaseBackoffMillis = Long.valueOf(
+		this.listShardsBaseBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE,
 				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_BACKOFF_BASE)));
-		this.listShardsMaxBackoffMillis = Long.valueOf(
+		this.listShardsMaxBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_BACKOFF_MAX,
 				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_BACKOFF_MAX)));
-		this.listShardsExpConstant = Double.valueOf(
+		this.listShardsExpConstant = Double.parseDouble(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
 				Double.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.listShardsMaxRetries = Integer.valueOf(
+		this.listShardsMaxRetries = Integer.parseInt(
 			configProps.getProperty(
 				ConsumerConfigConstants.LIST_SHARDS_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_LIST_SHARDS_RETRIES)));
-		this.describeStreamBaseBackoffMillis = Long.valueOf(
+		this.describeStreamBaseBackoffMillis = Long.parseLong(
 				configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE,
 						Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE)));
-		this.describeStreamMaxBackoffMillis = Long.valueOf(
+		this.describeStreamMaxBackoffMillis = Long.parseLong(
 				configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX,
 						Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX)));
-		this.describeStreamExpConstant = Double.valueOf(
+		this.describeStreamExpConstant = Double.parseDouble(
 				configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT,
 						Double.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.getRecordsBaseBackoffMillis = Long.valueOf(
+		this.getRecordsBaseBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_BASE,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_BACKOFF_BASE)));
-		this.getRecordsMaxBackoffMillis = Long.valueOf(
+		this.getRecordsMaxBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_MAX,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_BACKOFF_MAX)));
-		this.getRecordsExpConstant = Double.valueOf(
+		this.getRecordsExpConstant = Double.parseDouble(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT,
 				Double.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.getRecordsMaxRetries = Integer.valueOf(
+		this.getRecordsMaxRetries = Integer.parseInt(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETRECORDS_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_RETRIES)));
 
-		this.getShardIteratorBaseBackoffMillis = Long.valueOf(
+		this.getShardIteratorBaseBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_BASE,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_BACKOFF_BASE)));
-		this.getShardIteratorMaxBackoffMillis = Long.valueOf(
+		this.getShardIteratorMaxBackoffMillis = Long.parseLong(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_MAX,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_BACKOFF_MAX)));
-		this.getShardIteratorExpConstant = Double.valueOf(
+		this.getShardIteratorExpConstant = Double.parseDouble(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_EXPONENTIAL_CONSTANT,
 				Double.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_BACKOFF_EXPONENTIAL_CONSTANT)));
-		this.getShardIteratorMaxRetries = Integer.valueOf(
+		this.getShardIteratorMaxRetries = Integer.parseInt(
 			configProps.getProperty(
 				ConsumerConfigConstants.SHARD_GETITERATOR_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_GETITERATOR_RETRIES)));
-
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -128,13 +128,13 @@ public class KinesisProxy implements KinesisProxyInterface {
 	/** Maximum retry attempts for the get shard iterator operation. */
 	private final int getShardIteratorMaxRetries;
 
-	/* Backoff millis for the describe stream operation. */
+	/** Backoff millis for the describe stream operation. */
 	private final long describeStreamBaseBackoffMillis;
 
-	/* Maximum backoff millis for the describe stream operation. */
+	/** Maximum backoff millis for the describe stream operation. */
 	private final long describeStreamMaxBackoffMillis;
 
-	/* Exponential backoff power constant for the describe stream operation. */
+	/** Exponential backoff power constant for the describe stream operation. */
 	private final double describeStreamExpConstant;
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyInterface.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyInterface.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * Interface for a Kinesis proxy that operates on multiple Kinesis streams within the same AWS service region.
  */
 @Internal
-public interface KinesisProxyInterface {
+public interface KinesisProxyInterface extends KinesisProxyMarker {
 
 	/**
 	 * Get a shard iterator from the specified position in a shard.

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyMarker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyMarker.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.proxy;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A marker interface for generic Kinesis Proxy.
+ */
+@Internal
+public interface KinesisProxyMarker {
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.proxy;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.internals.fanout.FanOutProperties;
+import org.apache.flink.streaming.connectors.kinesis.internals.fanout.FanOutStreamInfo;
+import org.apache.flink.streaming.connectors.kinesis.util.AwsV2Util;
+import org.apache.flink.util.Preconditions;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.ClientConfigurationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerResponse;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Kinesis proxy implementation using AWS SDK v2.x - a utility class that is used as a proxy to make
+ * calls to AWS Kinesis for several EFO (Enhanced Fan Out) functions, such as de-/registering stream consumers,
+ * subscribing to a shard and receiving records from a shard.
+ */
+@Internal
+public class KinesisProxyV2 implements KinesisProxyV2Interface {
+	private static final Logger LOG = LoggerFactory.getLogger(KinesisProxyV2.class);
+
+	/** Random seed used to calculate backoff jitter for Kinesis operations. */
+	private static final Random seed = new Random();
+
+	private final KinesisAsyncClient kinesisAsyncClient;
+
+	private final FanOutProperties fanOutProperties;
+
+	/**
+	 * Create a new KinesisProxyV2 based on the supplied configuration properties.
+	 *
+	 * @param configProps configuration properties containing AWS credential and AWS region info
+	 */
+	public KinesisProxyV2(final Properties configProps, List<String> streams) {
+		this.kinesisAsyncClient = createKinesisAsyncClient(configProps);
+		this.fanOutProperties = new FanOutProperties(configProps, streams);
+	}
+
+	/**
+	 * Creates a Kinesis proxy V2.
+	 *
+	 * @param configProps configuration properties
+	 * @param streams list of kinesis stream names
+	 * @return the created kinesis proxy v2
+	 */
+	public static KinesisProxyV2Interface create(Properties configProps, List<String> streams) {
+		return new KinesisProxyV2(configProps, streams);
+	}
+
+	/**
+	 * Create the Kinesis client, using the provided configuration properties.
+	 * Derived classes can override this method to customize the client configuration.
+	 *
+	 * @param configProps the properties map used to create the Kinesis Client
+	 * @return a Kinesis Client
+	 */
+	protected KinesisAsyncClient createKinesisAsyncClient(final Properties configProps) {
+		final ClientConfiguration config = new ClientConfigurationFactory().getConfig();
+		return AwsV2Util.createKinesisAsyncClient(configProps, config);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Map<String, String> describeStream(List<String> streams) throws InterruptedException, ExecutionException {
+		Map<String, String> result = new HashMap<>();
+		for (String stream : streams) {
+			DescribeStreamRequest describeStreamRequest = DescribeStreamRequest
+				.builder()
+				.streamName(stream)
+				.build();
+			DescribeStreamResponse describeStreamResponse = null;
+
+			int retryCount = 0;
+			while (retryCount <= fanOutProperties.getDescribeStreamMaxRetries() && describeStreamResponse == null) {
+				try {
+					describeStreamResponse = kinesisAsyncClient.describeStream(describeStreamRequest).get();
+				} catch (ExecutionException ex) {
+					if (AwsV2Util.isRecoverableException(ex)) {
+						long backoffMillis = fullJitterBackoff(
+							fanOutProperties.getDescribeStreamBaseBackoffMillis(), fanOutProperties.getDescribeStreamMaxBackoffMillis(), fanOutProperties.getDescribeStreamExpConstant(), retryCount++);
+						LOG.warn("Got recoverable AmazonServiceException when trying to describe stream " + stream + ". Backing off for "
+							+ backoffMillis + " millis (" + ex.getClass().getName() + ": " + ex.getMessage() + ")");
+						Thread.sleep(backoffMillis);
+					} else {
+						throw ex;
+					}
+				}
+			}
+			if (describeStreamResponse == null) {
+				throw new RuntimeException("Retries exceeded for describeStream operation - all " + fanOutProperties.getDescribeStreamMaxRetries() +
+					" retry attempts failed.");
+			}
+			result.put(stream, describeStreamResponse.streamDescription().streamARN());
+		}
+		return result;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<FanOutStreamInfo> registerStreamConsumer(Map<String, String> streamArns) throws InterruptedException, ExecutionException {
+		Preconditions.checkArgument(fanOutProperties.getConsumerName().isPresent());
+		String consumerName = fanOutProperties.getConsumerName().get();
+		List<FanOutStreamInfo> result = new ArrayList<>();
+		for (Map.Entry<String, String> entry : streamArns.entrySet()) {
+			String stream = entry.getKey();
+			String streamArn = entry.getValue();
+			RegisterStreamConsumerRequest registerStreamConsumerRequest = RegisterStreamConsumerRequest
+				.builder()
+				.consumerName(consumerName)
+				.streamARN(streamArn)
+				.build();
+			FanOutStreamInfo fanOutStreamInfo = null;
+			int retryCount = 0;
+			while (retryCount <= fanOutProperties.getRegisterStreamMaxRetries() && fanOutStreamInfo == null) {
+				try {
+					RegisterStreamConsumerResponse registerStreamConsumerResponse = kinesisAsyncClient.registerStreamConsumer(registerStreamConsumerRequest).get();
+					fanOutStreamInfo = new FanOutStreamInfo(stream, streamArn, consumerName, registerStreamConsumerResponse.consumer().consumerARN());
+				} catch (ExecutionException ex) {
+					if (AwsV2Util.isResourceInUse(ex)) {
+						fanOutStreamInfo = describeStreamConsumer(stream, streamArn, consumerName);
+					} else if (AwsV2Util.isRecoverableException(ex)) {
+						long backoffMillis = fullJitterBackoff(
+							fanOutProperties.getRegisterStreamBaseBackoffMillis(), fanOutProperties.getRegisterStreamMaxBackoffMillis(), fanOutProperties.getRegisterStreamExpConstant(), retryCount++);
+						LOG.warn("Got recoverable AmazonServiceException when trying to register " + stream + ". Backing off for "
+							+ backoffMillis + " millis (" + ex.getClass().getName() + ": " + ex.getMessage() + ")");
+						Thread.sleep(backoffMillis);
+					} else {
+						throw ex;
+					}
+				}
+			}
+
+			if (fanOutStreamInfo == null) {
+				throw new RuntimeException("Retries exceeded for registerStream operation - all " + fanOutProperties.getRegisterStreamMaxRetries() +
+					" retry attempts failed.");
+			}
+			result.add(fanOutStreamInfo);
+		}
+		return result;
+	}
+
+	public FanOutStreamInfo describeStreamConsumer(String stream, String streamArn, String consumerName) throws InterruptedException, ExecutionException  {
+		DescribeStreamConsumerRequest describeStreamConsumerRequest = DescribeStreamConsumerRequest
+			.builder()
+			.streamARN(streamArn)
+			.consumerName(consumerName)
+			.build();
+		FanOutStreamInfo fanOutStreamInfo = null;
+		int retryCount = 0;
+		while (retryCount <= fanOutProperties.getDescribeStreamConsumerMaxRetries() && fanOutStreamInfo == null) {
+			try {
+				DescribeStreamConsumerResponse describeStreamConsumerResponse = kinesisAsyncClient.describeStreamConsumer(describeStreamConsumerRequest).get();
+				fanOutStreamInfo = new FanOutStreamInfo(stream, streamArn, consumerName, describeStreamConsumerResponse.consumerDescription().consumerARN());
+			} catch (ExecutionException ex) {
+				if (AwsV2Util.isRecoverableException(ex)) {
+					long backoffMillis = fullJitterBackoff(
+						fanOutProperties.getDescribeStreamConsumerBaseBackoffMillis(), fanOutProperties.getDescribeStreamConsumerMaxBackoffMillis(), fanOutProperties.getDescribeStreamConsumerExpConstant(), retryCount++);
+					LOG.warn("Got recoverable AmazonServiceException when trying to describe stream consumer " + stream + ". Backing off for "
+						+ backoffMillis + " millis (" + ex.getClass().getName() + ": " + ex.getMessage() + ")");
+					Thread.sleep(backoffMillis);
+				} else {
+					throw ex;
+				}
+			}
+		}
+
+		if (fanOutStreamInfo == null) {
+			throw new RuntimeException("Retries exceeded for registerStream operation - all " + fanOutProperties.getRegisterStreamMaxRetries() +
+				" retry attempts failed.");
+		}
+		return fanOutStreamInfo;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void deregisterStreamConsumer(List<FanOutStreamInfo> fanOutStreamInfos) throws InterruptedException, ExecutionException {
+		for (FanOutStreamInfo fanOutStreamInfo : fanOutStreamInfos) {
+			DeregisterStreamConsumerRequest deregisterStreamConsumerRequest = DeregisterStreamConsumerRequest
+				.builder()
+				.consumerARN(fanOutStreamInfo.getConsumerArn())
+				.consumerName(fanOutStreamInfo.getConsumerName())
+				.build();
+
+			int retryCount = 0;
+			boolean deregisterSuccessFlag = false;
+			while (retryCount <= fanOutProperties.getDeregisterStreamMaxRetries() && !deregisterSuccessFlag) {
+				try {
+					kinesisAsyncClient.deregisterStreamConsumer(deregisterStreamConsumerRequest).get();
+					deregisterSuccessFlag = true;
+				} catch (ExecutionException ex) {
+					if (AwsV2Util.isResourceNotFound(ex)) {
+						deregisterSuccessFlag = true;
+						break;
+					}
+					if (AwsV2Util.isRecoverableException(ex)) {
+						long backoffMillis = fullJitterBackoff(
+							fanOutProperties.getDeregisterStreamBaseBackoffMillis(), fanOutProperties.getDeregisterStreamMaxBackoffMillis(), fanOutProperties.getDeregisterStreamExpConstant(), retryCount++);
+						LOG.warn("Got recoverable AmazonServiceException when trying to deregister " + fanOutStreamInfo.getStream() + ". Backing off for "
+							+ backoffMillis + " millis (" + ex.getClass().getName() + ": " + ex.getMessage() + ")");
+						Thread.sleep(backoffMillis);
+					} else {
+						throw ex;
+					}
+				}
+			}
+			if (!deregisterSuccessFlag) {
+				throw new RuntimeException("Retries exceeded for deregisterStream operation - all " + fanOutProperties.getDeregisterStreamMaxRetries() +
+					" retry attempts failed.");
+			}
+		}
+	}
+
+	/**
+	 * Return a random jitter between 0 and the exponential backoff.
+	 */
+	protected static long fullJitterBackoff(long base, long max, double power, int attempt) {
+		long exponentialBackoff = (long) Math.min(max, base * Math.pow(power, attempt));
+		return (long) (seed.nextDouble() * exponentialBackoff);
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Interface.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Interface.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.proxy;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.internals.fanout.FanOutProperties;
+import org.apache.flink.streaming.connectors.kinesis.internals.fanout.FanOutStreamInfo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Interface for a Kinesis proxy using AWS SDK v2.x operating on multiple Kinesis streams within the same AWS service region.
+ */
+@Internal
+public interface KinesisProxyV2Interface {
+	/**
+	 * Send a describeStream request via AWS SDK v2.x to get the stream arn for each stream.
+	 * @param streams The stream names to be described.
+	 * @return a map where key is the stream name and value is the streamArn.
+	 * @throws InterruptedException this method will retry with backoff if AWS Kinesis complains that the
+	 * 	                                 operation has exceeded the rate limit; this exception will be thrown
+	 * 	                                 if the backoff is interrupted.
+	 */
+	Map<String, String> describeStream(List<String> streams) throws InterruptedException, ExecutionException;
+
+	/**
+	 * Send a registerStream request via AWS SDK v2.x to get the consumer arn for each stream consumer, consumer name is set via {@link FanOutProperties}.
+	 * @param streamArns a map where key is the stream name and value is the stream arn.
+	 * @return a list of fan out stream info. {@link FanOutStreamInfo}
+	 * @throws InterruptedException this method will retry with backoff if AWS Kinesis complains that the
+	 * 	  	                             operation has exceeded the rate limit; this exception will be thrown
+	 * 	  	                             if the backoff is interrupted.
+	 */
+	List<FanOutStreamInfo> registerStreamConsumer(Map<String, String> streamArns) throws InterruptedException, ExecutionException;
+
+	/**
+	 * Send a deregisterStream request via AWS SDK v2.x to derigster each consumer.
+	 * @param fanOutStreamInfos a list of fan out stream info. {@link FanOutStreamInfo}
+	 * @throws InterruptedException this method will retry with backoff if AWS Kinesis complains that the
+	 * 	  	  	                         operation has exceeded the rate limit; this exception will be thrown
+	 * 	  	  	                         if the backoff is interrupted.
+	 */
+	void deregisterStreamConsumer(List<FanOutStreamInfo> fanOutStreamInfos) throws InterruptedException, ExecutionException;
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -76,9 +76,7 @@ public class AWSUtil {
 	 */
 	public static AmazonKinesis createKinesisClient(Properties configProps, ClientConfiguration awsClientConfig) {
 		// set a Flink-specific user agent
-		awsClientConfig.setUserAgentPrefix(String.format(USER_AGENT_FORMAT,
-				EnvironmentInformation.getVersion(),
-				EnvironmentInformation.getRevisionInformation().commitId));
+		awsClientConfig.setUserAgentPrefix(formatFlinkUserAgentPrefix());
 
 		// utilize automatic refreshment of credentials by directly passing the AWSCredentialsProvider
 		AmazonKinesisClientBuilder builder = AmazonKinesisClientBuilder.standard()
@@ -98,6 +96,19 @@ public class AWSUtil {
 	}
 
 	/**
+	 * Creates a user agent prefix for Flink.
+	 * This can be used by HTTP Clients.
+	 *
+	 * @return a user agent prefix for Flink
+	 */
+	public static String formatFlinkUserAgentPrefix() {
+		return String.format(
+			USER_AGENT_FORMAT,
+			EnvironmentInformation.getVersion(),
+			EnvironmentInformation.getRevisionInformation().commitId);
+	}
+
+	/**
 	 * Return a {@link AWSCredentialsProvider} instance corresponding to the configuration properties.
 	 *
 	 * @param configProps the configuration properties
@@ -105,6 +116,26 @@ public class AWSUtil {
 	 */
 	public static AWSCredentialsProvider getCredentialsProvider(final Properties configProps) {
 		return getCredentialsProvider(configProps, AWSConfigConstants.AWS_CREDENTIALS_PROVIDER);
+	}
+
+	/**
+	 * Determines and returns the credential provider type from the given properties.
+	 *
+	 * @return the credential provider type
+	 */
+	static CredentialProvider getCredentialProviderType(final Properties configProps, final String configPrefix) {
+		if (!configProps.containsKey(configPrefix)) {
+			if (configProps.containsKey(AWSConfigConstants.accessKeyId(configPrefix))
+				&& configProps.containsKey(AWSConfigConstants.secretKey(configPrefix))) {
+				// if the credential provider type is not specified, but the Access Key ID and Secret Key are given, it will default to BASIC
+				return CredentialProvider.BASIC;
+			} else {
+				// if the credential provider type is not specified, it will default to AUTO
+				return CredentialProvider.AUTO;
+			}
+		} else {
+			return CredentialProvider.valueOf(configProps.getProperty(configPrefix));
+		}
 	}
 
 	/**
@@ -118,19 +149,7 @@ public class AWSUtil {
 	 *                     for assuming a role, and so on.
 	 */
 	private static AWSCredentialsProvider getCredentialsProvider(final Properties configProps, final String configPrefix) {
-		CredentialProvider credentialProviderType;
-		if (!configProps.containsKey(configPrefix)) {
-			if (configProps.containsKey(AWSConfigConstants.accessKeyId(configPrefix))
-				&& configProps.containsKey(AWSConfigConstants.secretKey(configPrefix))) {
-				// if the credential provider type is not specified, but the Access Key ID and Secret Key are given, it will default to BASIC
-				credentialProviderType = CredentialProvider.BASIC;
-			} else {
-				// if the credential provider type is not specified, it will default to AUTO
-				credentialProviderType = CredentialProvider.AUTO;
-			}
-		} else {
-			credentialProviderType = CredentialProvider.valueOf(configProps.getProperty(configPrefix));
-		}
+		CredentialProvider credentialProviderType = getCredentialProviderType(configProps, configPrefix);
 
 		switch (credentialProviderType) {
 			case ENV_VAR:
@@ -182,9 +201,11 @@ public class AWSUtil {
 						.webIdentityTokenFile(configProps.getProperty(AWSConfigConstants.webIdentityTokenFile(configPrefix), null))
 						.build();
 
-			default:
 			case AUTO:
 				return new DefaultAWSCredentialsProviderChain();
+
+			default:
+				throw new IllegalArgumentException("Credential provider not supported: " + credentialProviderType);
 		}
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AwsV2Util.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AwsV2Util.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClientBuilder;
+import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
+import software.amazon.awssdk.services.kinesis.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
+import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import java.net.URI;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Utility methods specific to Amazon Web Service SDK v2.x.
+ */
+@Internal
+public class AwsV2Util {
+
+	/**
+	 * Creates an Amazon Kinesis Async Client from the provided properties.
+	 * Configuration is copied from AWS SDK v1 configuration class as per:
+	 * - https://github.com/aws/aws-sdk-java-v2/blob/2.13.52/docs/LaunchChangelog.md#134-client-override-retry-configuration
+	 *
+	 * @param configProps configuration properties
+	 * @param config the AWS SDK v1.x client configuration used to create the client
+	 * @return a new Amazon Kinesis Client
+	 */
+	public static KinesisAsyncClient createKinesisAsyncClient(final Properties configProps, final ClientConfiguration config) {
+		final SdkAsyncHttpClient httpClient = createHttpClient(config, NettyNioAsyncHttpClient.builder());
+		final ClientOverrideConfiguration overrideConfiguration = createClientOverrideConfiguration(config, ClientOverrideConfiguration.builder());
+		final KinesisAsyncClientBuilder clientBuilder = KinesisAsyncClient.builder();
+
+		return createKinesisAsyncClient(configProps, clientBuilder, httpClient, overrideConfiguration);
+	}
+
+	@VisibleForTesting
+	static SdkAsyncHttpClient createHttpClient(
+			final ClientConfiguration config,
+			final NettyNioAsyncHttpClient.Builder httpClientBuilder) {
+		httpClientBuilder
+			.maxConcurrency(config.getMaxConnections())
+			.connectionTimeout(Duration.ofMillis(config.getConnectionTimeout()))
+			.writeTimeout(Duration.ofMillis(config.getSocketTimeout()))
+			.connectionMaxIdleTime(Duration.ofMillis(config.getConnectionMaxIdleMillis()))
+			.useIdleConnectionReaper(config.useReaper());
+
+		if (config.getConnectionTTL() > -1) {
+			httpClientBuilder.connectionTimeToLive(Duration.ofMillis(config.getConnectionTTL()));
+		}
+
+		return httpClientBuilder.build();
+	}
+
+	@VisibleForTesting
+	static ClientOverrideConfiguration createClientOverrideConfiguration(
+			final ClientConfiguration config,
+			final ClientOverrideConfiguration.Builder overrideConfigurationBuilder) {
+
+		overrideConfigurationBuilder
+			.putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, AWSUtil.formatFlinkUserAgentPrefix())
+			.putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX, config.getUserAgentSuffix());
+
+		if (config.getRequestTimeout() > 0) {
+			overrideConfigurationBuilder.apiCallAttemptTimeout(Duration.ofMillis(config.getRequestTimeout()));
+		}
+
+		if (config.getClientExecutionTimeout() > 0) {
+			overrideConfigurationBuilder.apiCallTimeout(Duration.ofMillis(config.getClientExecutionTimeout()));
+		}
+
+		return overrideConfigurationBuilder.build();
+	}
+
+	@VisibleForTesting
+	static KinesisAsyncClient createKinesisAsyncClient(
+			final Properties configProps,
+			final KinesisAsyncClientBuilder clientBuilder,
+			final SdkAsyncHttpClient httpClient,
+			final ClientOverrideConfiguration overrideConfiguration) {
+
+		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
+			final URI endpointOverride = URI.create(configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT));
+			clientBuilder.endpointOverride(endpointOverride);
+		}
+
+		return clientBuilder
+			.httpClient(httpClient)
+			.overrideConfiguration(overrideConfiguration)
+			.credentialsProvider(getCredentialsProvider(configProps))
+			.region(getRegion(configProps))
+			.build();
+	}
+
+	/**
+	 * Return a {@link AWSCredentialsProvider} instance corresponding to the configuration properties.
+	 *
+	 * @param configProps the configuration properties
+	 * @return The corresponding AWS Credentials Provider instance
+	 */
+	public static AwsCredentialsProvider getCredentialsProvider(final Properties configProps) {
+		return getCredentialsProvider(configProps, AWSConfigConstants.AWS_CREDENTIALS_PROVIDER);
+	}
+
+	private static AwsCredentialsProvider getCredentialsProvider(final Properties configProps, final String configPrefix) {
+		CredentialProvider credentialProviderType = AWSUtil.getCredentialProviderType(configProps, configPrefix);
+
+		switch (credentialProviderType) {
+			case ENV_VAR:
+				return EnvironmentVariableCredentialsProvider.create();
+
+			case SYS_PROP:
+				return SystemPropertyCredentialsProvider.create();
+
+			case PROFILE:
+				return getProfileCredentialProvider(configProps, configPrefix);
+
+			case BASIC:
+				return () -> AwsBasicCredentials.create(
+					configProps.getProperty(AWSConfigConstants.accessKeyId(configPrefix)),
+					configProps.getProperty(AWSConfigConstants.secretKey(configPrefix)));
+
+			case ASSUME_ROLE:
+				return getAssumeRoleCredentialProvider(configProps, configPrefix);
+
+			case WEB_IDENTITY_TOKEN:
+				return getWebIdentityTokenFileCredentialsProvider(WebIdentityTokenFileCredentialsProvider.builder(), configProps, configPrefix);
+
+			case AUTO:
+				return DefaultCredentialsProvider.create();
+
+			default:
+				throw new IllegalArgumentException("Credential provider not supported: " + credentialProviderType);
+		}
+	}
+
+	private static AwsCredentialsProvider getProfileCredentialProvider(final Properties configProps, final String configPrefix) {
+		String profileName = configProps.getProperty(AWSConfigConstants.profileName(configPrefix), null);
+		String profileConfigPath = configProps.getProperty(AWSConfigConstants.profilePath(configPrefix), null);
+
+		ProfileCredentialsProvider.Builder profileBuilder = ProfileCredentialsProvider
+			.builder()
+			.profileName(profileName);
+
+		if (profileConfigPath != null) {
+			profileBuilder.profileFile(ProfileFile
+				.builder()
+				.type(ProfileFile.Type.CREDENTIALS)
+				.content(Paths.get(profileConfigPath))
+				.build());
+		}
+
+		return profileBuilder.build();
+	}
+
+	private static AwsCredentialsProvider getAssumeRoleCredentialProvider(final Properties configProps, final String configPrefix) {
+		return StsAssumeRoleCredentialsProvider
+			.builder()
+			.refreshRequest(AssumeRoleRequest
+				.builder()
+				.roleArn(configProps.getProperty(AWSConfigConstants.roleArn(configPrefix)))
+				.roleSessionName(configProps.getProperty(AWSConfigConstants.roleSessionName(configPrefix)))
+				.externalId(configProps.getProperty(AWSConfigConstants.externalId(configPrefix)))
+				.build())
+			.stsClient(StsClient
+				.builder()
+				.credentialsProvider(getCredentialsProvider(configProps, AWSConfigConstants.roleCredentialsProvider(configPrefix)))
+				.region(getRegion(configProps))
+				.build())
+			.build();
+	}
+
+	@VisibleForTesting
+	static AwsCredentialsProvider getWebIdentityTokenFileCredentialsProvider(
+			final WebIdentityTokenFileCredentialsProvider.Builder webIdentityBuilder,
+			final Properties configProps,
+			final String configPrefix) {
+
+		webIdentityBuilder
+			.roleArn(configProps.getProperty(AWSConfigConstants.roleArn(configPrefix), null))
+			.roleSessionName(configProps.getProperty(AWSConfigConstants.roleSessionName(configPrefix), null));
+
+		Optional.ofNullable(configProps.getProperty(AWSConfigConstants.webIdentityTokenFile(configPrefix), null))
+			.map(Paths::get)
+			.ifPresent(webIdentityBuilder::webIdentityTokenFile);
+
+		return webIdentityBuilder.build();
+	}
+
+	/**
+	 * Creates a {@link Region} object from the given Properties.
+	 *
+	 * @param configProps the properties containing the region
+	 * @return the region specified by the properties
+	 */
+	public static Region getRegion(final Properties configProps) {
+		return Region.of(configProps.getProperty(AWSConfigConstants.AWS_REGION));
+	}
+
+	/**
+	 * Whether or not an exception is recoverable.
+	 */
+	public static boolean isRecoverableException(ExecutionException e) {
+		if (!(e.getCause() instanceof SdkException)) {
+			return false;
+		}
+		SdkException ase = (SdkException) e.getCause();
+		return ase instanceof LimitExceededException || ase instanceof ProvisionedThroughputExceededException || ase instanceof ResourceInUseException;
+	}
+
+	/**
+	 * Whether or not the exception is ResourceInUse.
+	 */
+	public static boolean isResourceInUse(ExecutionException ex) {
+		return ex.getCause() instanceof ResourceInUseException;
+	}
+
+	/**
+	 * Whether or not the exception is ResourceNotFoundException.
+	 */
+	public static boolean isResourceNotFound(ExecutionException ex) {
+		return ex.getCause() instanceof ResourceNotFoundException;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -248,7 +248,7 @@ public class KinesisConfigUtil {
 	/**
 	 * Validate the record publisher type.
 	 * @param config config properties
-	 * @return if `ConsumerConfigConstants.RECORD_PUBLISHER_TYPE` is set, return the parsed record publisher type. Else return polling record publisher type.
+	 * @return if {@code ConsumerConfigConstants.RECORD_PUBLISHER_TYPE} is set, return the parsed record publisher type. Else return polling record publisher type.
 	 */
 	public static RecordPublisherType validateRecordPublisherType(Properties config) {
 		if (config.containsKey(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE)) {
@@ -273,21 +273,21 @@ public class KinesisConfigUtil {
 	 * @param streams the streams which is sent to match the EFO consumer arn if the EFO registration mode is set to `NONE`.
 	 */
 	public static void validateEfoConfiguration(Properties config, List<String> streams) {
-		String efoRegistrationType;
+		EFORegistrationType efoRegistrationType;
 		if (config.containsKey(ConsumerConfigConstants.EFO_REGISTRATION_TYPE)) {
-			efoRegistrationType = config.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE);
+			String typeInString = config.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE);
 			// specified efo registration type in stream must be either LAZY, EAGER or NONE.
 			try {
-				EFORegistrationType.valueOf(efoRegistrationType);
+				efoRegistrationType = EFORegistrationType.valueOf(typeInString);
 			} catch (IllegalArgumentException e) {
 				String errorMessage = Arrays.stream(EFORegistrationType.values())
 					.map(Enum::name).collect(Collectors.joining(", "));
 				throw new IllegalArgumentException("Invalid efo registration type in stream set in config. Valid values are: " + errorMessage);
 			}
 		} else {
-			efoRegistrationType = EFORegistrationType.LAZY.toString();
+			efoRegistrationType = EFORegistrationType.LAZY;
 		}
-		if (EFORegistrationType.valueOf(efoRegistrationType) == EFORegistrationType.NONE) {
+		if (efoRegistrationType == EFORegistrationType.NONE) {
 			//if the registration type is NONE, then for each stream there must be an according consumer ARN
 			List<String> missingConsumerArnKeys = new ArrayList<>();
 			for (String stream : streams) {

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -187,14 +187,26 @@ public class KinesisConfigUtil {
 		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
 			"Invalid value given for list shards operation backoff exponential constant. Must be a valid non-negative double value.");
 
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE,
+			"Invalid value given for describe stream consumer operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX,
+			"Invalid value given for describe stream consumer operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for describe stream consumer operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE,
+			"Invalid value given for describe stream consumer operation base backoff milliseconds. Must be a valid non-negative long value.");
+
 		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.REGISTER_STREAM_RETRIES,
 			"Invalid value given for maximum retry attempts for register stream operation. Must be a valid non-negative integer value.");
 
-		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE,
-			"Invalid value given for register stream operation base backoff milliseconds. Must be a valid non-negative long value.");
-
 		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX,
 			"Invalid value given for register stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE,
+			"Invalid value given for register stream operation base backoff milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
 			"Invalid value given for register stream operation backoff exponential constant. Must be a valid non-negative double value.");

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -23,7 +23,9 @@ import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisProducer;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.InitialPosition;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
 import org.apache.flink.streaming.connectors.kinesis.config.ProducerConfigConstants;
 
 import com.amazonaws.regions.Regions;
@@ -31,9 +33,14 @@ import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -44,13 +51,18 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class KinesisConfigUtil {
 
-	/** Maximum number of items to pack into an PutRecords request. **/
+	/**
+	 * Maximum number of items to pack into an PutRecords request.
+	 **/
 	protected static final String COLLECTION_MAX_COUNT = "CollectionMaxCount";
 
-	/** Maximum number of items to pack into an aggregated record. **/
+	/**
+	 * Maximum number of items to pack into an aggregated record.
+	 **/
 	protected static final String AGGREGATION_MAX_COUNT = "AggregationMaxCount";
 
-	/** Limits the maximum allowed put rate for a shard, as a percentage of the backend limits.
+	/**
+	 * Limits the maximum allowed put rate for a shard, as a percentage of the backend limits.
 	 * The default value is set as 100% in Flink. KPL's default value is 150% but it makes KPL throw
 	 * RateLimitExceededException too frequently and breaks Flink sink as a result.
 	 **/
@@ -66,27 +78,46 @@ public class KinesisConfigUtil {
 	 **/
 	protected static final String THREAD_POOL_SIZE = "ThreadPoolSize";
 
-	/** Default values for RateLimit. **/
+	/**
+	 * Default values for RateLimit.
+	 **/
 	protected static final long DEFAULT_RATE_LIMIT = 100L;
 
-	/** Default value for ThreadingModel. **/
+	/**
+	 * Default value for ThreadingModel.
+	 **/
 	protected static final KinesisProducerConfiguration.ThreadingModel DEFAULT_THREADING_MODEL = KinesisProducerConfiguration.ThreadingModel.POOLED;
 
-	/** Default values for ThreadPoolSize. **/
+	/**
+	 * Default values for ThreadPoolSize.
+	 **/
 	protected static final int DEFAULT_THREAD_POOL_SIZE = 10;
 
 	/**
 	 * Validate configuration properties for {@link FlinkKinesisConsumer}.
 	 */
 	public static void validateConsumerConfiguration(Properties config) {
+		validateConsumerConfiguration(config, Collections.emptyList());
+	}
+
+	/**
+	 * Validate configuration properties for {@link FlinkKinesisConsumer}.
+	 */
+	public static void validateConsumerConfiguration(Properties config, List<String> streams) {
 		checkNotNull(config, "config can not be null");
 
 		validateAwsConfiguration(config);
 
+		RecordPublisherType recordPublisherType = validateRecordPublisherType(config);
+
+		if (recordPublisherType == RecordPublisherType.EFO) {
+			validateEfoConfiguration(config, streams);
+		}
+
 		if (!(config.containsKey(AWSConfigConstants.AWS_REGION) || config.containsKey(ConsumerConfigConstants.AWS_ENDPOINT))) {
 			// per validation in AwsClientBuilder
 			throw new IllegalArgumentException(String.format("For FlinkKinesisConsumer AWS region ('%s') and/or AWS endpoint ('%s') must be set in the config.",
-					AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT));
+				AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT));
 		}
 
 		if (config.containsKey(ConsumerConfigConstants.STREAM_INITIAL_POSITION)) {
@@ -96,11 +127,9 @@ public class KinesisConfigUtil {
 			try {
 				InitialPosition.valueOf(initPosType);
 			} catch (IllegalArgumentException e) {
-				StringBuilder sb = new StringBuilder();
-				for (InitialPosition pos : InitialPosition.values()) {
-					sb.append(pos.toString()).append(", ");
-				}
-				throw new IllegalArgumentException("Invalid initial position in stream set in config. Valid values are: " + sb.toString());
+				String errorMessage = Arrays.stream(InitialPosition.values())
+					.map(Enum::name).collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid initial position in stream set in config. Valid values are: " + errorMessage);
 			}
 
 			// specified initial timestamp in stream when using AT_TIMESTAMP
@@ -116,7 +145,6 @@ public class KinesisConfigUtil {
 						+ "Must be a valid format: yyyy-MM-dd'T'HH:mm:ss.SSSXXX or non-negative double value. For example, 2016-04-04T19:58:46.480-00:00 or 1459799926.480 .");
 			}
 		}
-
 		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.SHARD_GETRECORDS_MAX,
 			"Invalid value given for maximum records per getRecords shard operation. Must be a valid non-negative integer value.");
 
@@ -159,6 +187,54 @@ public class KinesisConfigUtil {
 		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
 			"Invalid value given for list shards operation backoff exponential constant. Must be a valid non-negative double value.");
 
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.REGISTER_STREAM_RETRIES,
+			"Invalid value given for maximum retry attempts for register stream operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE,
+			"Invalid value given for register stream operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX,
+			"Invalid value given for register stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for register stream operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_RETRIES,
+			"Invalid value given for maximum retry attempts for deregister stream operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE,
+			"Invalid value given for deregister stream operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX,
+			"Invalid value given for deregister stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for deregister stream operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_RETRIES,
+			"Invalid value given for maximum retry attempts for list stream operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_BASE,
+			"Invalid value given for list stream operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_MAX,
+			"Invalid value given for list stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.LIST_STREAM_CONSUMERS_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for list stream operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveIntProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES,
+			"Invalid value given for maximum retry attempts for subscribe to shard operation. Must be a valid non-negative integer value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE,
+			"Invalid value given for subscribe to shard operation base backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX,
+			"Invalid value given for subscribe to shard operation max backoff milliseconds. Must be a valid non-negative long value.");
+
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for subscribe to shard operation backoff exponential constant. Must be a valid non-negative double value.");
+
 		if (config.containsKey(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS)) {
 			checkArgument(
 				Long.parseLong(config.getProperty(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS))
@@ -166,6 +242,72 @@ public class KinesisConfigUtil {
 				"Invalid value given for getRecords sleep interval in milliseconds. Must be lower than " +
 					ConsumerConfigConstants.MAX_SHARD_GETRECORDS_INTERVAL_MILLIS + " milliseconds."
 			);
+		}
+	}
+
+	/**
+	 * Validate the record publisher type.
+	 * @param config config properties
+	 * @return if `ConsumerConfigConstants.RECORD_PUBLISHER_TYPE` is set, return the parsed record publisher type. Else return polling record publisher type.
+	 */
+	public static RecordPublisherType validateRecordPublisherType(Properties config) {
+		if (config.containsKey(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE)) {
+			String recordPublisherType = config.getProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE);
+
+			// specified record publisher type in stream must be either EFO or POLLING
+			try {
+				return RecordPublisherType.valueOf(recordPublisherType);
+			} catch (IllegalArgumentException e) {
+				String errorMessage = Arrays.stream(RecordPublisherType.values())
+					.map(Enum::name).collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid record publisher type in stream set in config. Valid values are: " + errorMessage);
+			}
+		} else {
+			return RecordPublisherType.POLLING;
+		}
+	}
+
+	/**
+	 * Validate if the given config is a valid EFO configuration.
+	 * @param config  config properties.
+	 * @param streams the streams which is sent to match the EFO consumer arn if the EFO registration mode is set to `NONE`.
+	 */
+	public static void validateEfoConfiguration(Properties config, List<String> streams) {
+		String efoRegistrationType;
+		if (config.containsKey(ConsumerConfigConstants.EFO_REGISTRATION_TYPE)) {
+			efoRegistrationType = config.getProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE);
+			// specified efo registration type in stream must be either LAZY, EAGER or NONE.
+			try {
+				EFORegistrationType.valueOf(efoRegistrationType);
+			} catch (IllegalArgumentException e) {
+				String errorMessage = Arrays.stream(EFORegistrationType.values())
+					.map(Enum::name).collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid efo registration type in stream set in config. Valid values are: " + errorMessage);
+			}
+		} else {
+			efoRegistrationType = EFORegistrationType.LAZY.toString();
+		}
+		if (EFORegistrationType.valueOf(efoRegistrationType) == EFORegistrationType.NONE) {
+			//if the registration type is NONE, then for each stream there must be an according consumer ARN
+			List<String> missingConsumerArnKeys = new ArrayList<>();
+			for (String stream : streams) {
+				String efoConsumerARNKey = ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + stream;
+				if (!config.containsKey(efoConsumerARNKey)) {
+					missingConsumerArnKeys.add(efoConsumerARNKey);
+				}
+			}
+			if (!missingConsumerArnKeys.isEmpty()) {
+				String errorMessage = Arrays
+					.stream(missingConsumerArnKeys.toArray())
+					.map(Object::toString)
+					.collect(Collectors.joining(", "));
+				throw new IllegalArgumentException("Invalid efo consumer arn settings for not providing consumer arns: " + errorMessage);
+			}
+		} else {
+			//if the registration type is LAZY or EAGER, then user must provide a self-defined consumer name.
+			if (!config.containsKey(ConsumerConfigConstants.EFO_CONSUMER_NAME)) {
+				throw new IllegalArgumentException("No valid enhanced fan-out consumer name is set through " + ConsumerConfigConstants.EFO_CONSUMER_NAME);
+			}
 		}
 	}
 
@@ -178,13 +320,13 @@ public class KinesisConfigUtil {
 		// Replace deprecated key
 		if (configProps.containsKey(ProducerConfigConstants.COLLECTION_MAX_COUNT)) {
 			configProps.setProperty(COLLECTION_MAX_COUNT,
-					configProps.getProperty(ProducerConfigConstants.COLLECTION_MAX_COUNT));
+				configProps.getProperty(ProducerConfigConstants.COLLECTION_MAX_COUNT));
 			configProps.remove(ProducerConfigConstants.COLLECTION_MAX_COUNT);
 		}
 		// Replace deprecated key
 		if (configProps.containsKey(ProducerConfigConstants.AGGREGATION_MAX_COUNT)) {
 			configProps.setProperty(AGGREGATION_MAX_COUNT,
-					configProps.getProperty(ProducerConfigConstants.AGGREGATION_MAX_COUNT));
+				configProps.getProperty(ProducerConfigConstants.AGGREGATION_MAX_COUNT));
 			configProps.remove(ProducerConfigConstants.AGGREGATION_MAX_COUNT);
 		}
 		return configProps;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
@@ -18,9 +18,11 @@
 package org.apache.flink.streaming.connectors.kinesis.internals;
 
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
-import org.apache.flink.streaming.connectors.kinesis.metrics.ShardMetricsReporter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling.PollingRecordPublisherFactory;
+import org.apache.flink.streaming.connectors.kinesis.metrics.ShardConsumerMetricsReporter;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
-import org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
@@ -37,12 +39,25 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.math.BigInteger;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS;
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP;
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for the {@link ShardConsumer}.
@@ -51,148 +66,123 @@ public class ShardConsumerTest {
 
 	@Test
 	public void testMetricsReporting() {
-		StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("fakeStream", 0);
+		KinesisProxyInterface kinesis = FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(500, 5, 500);
 
-		LinkedList<KinesisStreamShardState> subscribedShardsStateUnderTest = new LinkedList<>();
-		subscribedShardsStateUnderTest.add(
-			new KinesisStreamShardState(
-				KinesisDataFetcher.convertToStreamShardMetadata(fakeToBeConsumedShard),
-				fakeToBeConsumedShard,
-				new SequenceNumber("fakeStartingState")));
-
-		TestSourceContext<String> sourceContext = new TestSourceContext<>();
-
-		KinesisDeserializationSchemaWrapper<String> deserializationSchema = new KinesisDeserializationSchemaWrapper<>(
-			new SimpleStringSchema());
-		TestableKinesisDataFetcher<String> fetcher =
-			new TestableKinesisDataFetcher<>(
-				Collections.singletonList("fakeStream"),
-				sourceContext,
-				new Properties(),
-				deserializationSchema,
-				10,
-				2,
-				new AtomicReference<>(),
-				subscribedShardsStateUnderTest,
-				KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(Collections.singletonList("fakeStream")),
-				Mockito.mock(KinesisProxyInterface.class));
-
-		ShardMetricsReporter shardMetricsReporter = new ShardMetricsReporter();
-		long millisBehindLatest = 500L;
-		new ShardConsumer<>(
-			fetcher,
-			0,
-			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
-			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
-			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9, millisBehindLatest),
-			shardMetricsReporter,
-			deserializationSchema)
-			.run();
-
-		// the millisBehindLatest metric should have been reported
-		assertEquals(millisBehindLatest, shardMetricsReporter.getMillisBehindLatest());
+		ShardConsumerMetricsReporter metrics = assertNumberOfMessagesReceivedFromKinesis(500, kinesis, fakeSequenceNumber());
+		assertEquals(500, metrics.getMillisBehindLatest());
 	}
 
 	@Test
-	public void testCorrectNumOfCollectedRecordsAndUpdatedState() {
-		StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("fakeStream", 0);
+	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithStartingSequenceNumber() throws Exception {
+		KinesisProxyInterface kinesis = spy(FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9, 500L));
 
-		LinkedList<KinesisStreamShardState> subscribedShardsStateUnderTest = new LinkedList<>();
-		subscribedShardsStateUnderTest.add(
-			new KinesisStreamShardState(KinesisDataFetcher.convertToStreamShardMetadata(fakeToBeConsumedShard),
-				fakeToBeConsumedShard, new SequenceNumber("fakeStartingState")));
+		assertNumberOfMessagesReceivedFromKinesis(1000, kinesis, fakeSequenceNumber());
+		verify(kinesis).getShardIterator(any(), eq("AFTER_SEQUENCE_NUMBER"), eq("fakeStartingState"));
+	}
 
-		TestSourceContext<String> sourceContext = new TestSourceContext<>();
+	@Test
+	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithStartingSequenceSentinelTimestamp() throws Exception {
+		String format = "yyyy-MM-dd'T'HH:mm";
+		String timestamp = "2020-07-02T09:14";
+		Date expectedTimestamp = new SimpleDateFormat(format).parse(timestamp);
 
-		KinesisDeserializationSchemaWrapper<String> deserializationSchema = new KinesisDeserializationSchemaWrapper<>(
-			new SimpleStringSchema());
-		TestableKinesisDataFetcher<String> fetcher =
-			new TestableKinesisDataFetcher<>(
-				Collections.singletonList("fakeStream"),
-				sourceContext,
-				new Properties(),
-				deserializationSchema,
-				10,
-				2,
-				new AtomicReference<>(),
-				subscribedShardsStateUnderTest,
-				KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(Collections.singletonList("fakeStream")),
-				Mockito.mock(KinesisProxyInterface.class));
+		Properties consumerProperties = new Properties();
+		consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, timestamp);
+		consumerProperties.setProperty(STREAM_TIMESTAMP_DATE_FORMAT, format);
+		SequenceNumber sequenceNumber = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
 
-		int shardIndex = fetcher.registerNewSubscribedShardState(subscribedShardsStateUnderTest.get(0));
-		new ShardConsumer<>(
-			fetcher,
-			shardIndex,
-			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
-			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
-			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9, 500L),
-			new ShardMetricsReporter(),
-			deserializationSchema)
-			.run();
+		KinesisProxyInterface kinesis = spy(FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(10, 1, 0));
 
-		assertEquals(1000, sourceContext.getCollectedOutputs().size());
-		assertEquals(
-			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
-			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
+		assertNumberOfMessagesReceivedFromKinesis(10, kinesis, sequenceNumber, consumerProperties);
+		verify(kinesis).getShardIterator(any(), eq("AT_TIMESTAMP"), eq(expectedTimestamp));
+	}
+
+	@Test
+	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithStartingSequenceSentinelEarliest() throws Exception {
+		SequenceNumber sequenceNumber = SENTINEL_EARLIEST_SEQUENCE_NUM.get();
+
+		KinesisProxyInterface kinesis = spy(FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(50, 2, 0));
+
+		assertNumberOfMessagesReceivedFromKinesis(50, kinesis, sequenceNumber);
+		verify(kinesis).getShardIterator(any(), eq("TRIM_HORIZON"), eq(null));
 	}
 
 	@Test
 	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithUnexpectedExpiredIterator() {
-		StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("fakeStream", 0);
+		KinesisProxyInterface kinesis = FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(1000, 9, 7, 500L);
 
-		LinkedList<KinesisStreamShardState> subscribedShardsStateUnderTest = new LinkedList<>();
-		subscribedShardsStateUnderTest.add(
-			new KinesisStreamShardState(KinesisDataFetcher.convertToStreamShardMetadata(fakeToBeConsumedShard),
-				fakeToBeConsumedShard, new SequenceNumber("fakeStartingState")));
-
-		TestSourceContext<String> sourceContext = new TestSourceContext<>();
-
-		KinesisDeserializationSchemaWrapper<String> deserializationSchema = new KinesisDeserializationSchemaWrapper<>(
-			new SimpleStringSchema());
-		TestableKinesisDataFetcher<String> fetcher =
-			new TestableKinesisDataFetcher<>(
-				Collections.singletonList("fakeStream"),
-				sourceContext,
-				new Properties(),
-				deserializationSchema,
-				10,
-				2,
-				new AtomicReference<>(),
-				subscribedShardsStateUnderTest,
-				KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(Collections.singletonList("fakeStream")),
-				Mockito.mock(KinesisProxyInterface.class));
-
-		int shardIndex = fetcher.registerNewSubscribedShardState(subscribedShardsStateUnderTest.get(0));
-		new ShardConsumer<>(
-			fetcher,
-			shardIndex,
-			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
-			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
-			// Get a total of 1000 records with 9 getRecords() calls,
-			// and the 7th getRecords() call will encounter an unexpected expired shard iterator
-			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(
-				1000, 9, 7, 500L),
-			new ShardMetricsReporter(),
-			deserializationSchema)
-			.run();
-
-		assertEquals(1000, sourceContext.getCollectedOutputs().size());
-		assertEquals(
-			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
-			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
+		// Get a total of 1000 records with 9 getRecords() calls,
+		// and the 7th getRecords() call will encounter an unexpected expired shard iterator
+		assertNumberOfMessagesReceivedFromKinesis(1000, kinesis, fakeSequenceNumber());
 	}
 
 	@Test
 	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithAdaptiveReads() {
 		Properties consumerProperties = new Properties();
-		consumerProperties.put("flink.shard.adaptivereads", "true");
+		consumerProperties.setProperty(SHARD_USE_ADAPTIVE_READS, "true");
+
+		KinesisProxyInterface kinesis = FakeKinesisBehavioursFactory.initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(10, 2, 500L);
+
+		// Avg record size for first batch --> 10 * 10 Kb/10 = 10 Kb
+		// Number of records fetched in second batch --> 2 Mb/10Kb * 5 = 40
+		// Total number of records = 10 + 40 = 50
+		assertNumberOfMessagesReceivedFromKinesis(50, kinesis, fakeSequenceNumber(), consumerProperties);
+	}
+
+	@Test
+	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithAggregatedRecords() throws Exception {
+		KinesisProxyInterface kinesis = spy(FakeKinesisBehavioursFactory.aggregatedRecords(3, 5, 10));
+
+		// Expecting to receive all messages
+		// 10 batches of 3 aggregated records each with 5 child records
+		// 10 * 3 * 5 = 150
+		ShardConsumerMetricsReporter metrics = assertNumberOfMessagesReceivedFromKinesis(150, kinesis, fakeSequenceNumber());
+		assertEquals(3, metrics.getNumberOfAggregatedRecords());
+		assertEquals(15, metrics.getNumberOfDeaggregatedRecords());
+
+		verify(kinesis).getShardIterator(any(), eq("AFTER_SEQUENCE_NUMBER"), eq("fakeStartingState"));
+	}
+
+	@Test
+	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithAggregatedRecordsWithSubSequenceStartingNumber() throws Exception {
+		SequenceNumber sequenceNumber = new SequenceNumber("0", 5);
+		KinesisProxyInterface kinesis = spy(FakeKinesisBehavioursFactory.aggregatedRecords(1, 10, 5));
+
+		// Expecting to start consuming from last sub sequence number
+		// 5 batches of 1 aggregated record each with 10 child records
+		// Last consumed message was sub-sequence 5 (6/10) (zero based) (remaining are 6, 7, 8, 9)
+		// 5 * 1 * 10 - 6 = 44
+		ShardConsumerMetricsReporter metrics = assertNumberOfMessagesReceivedFromKinesis(44, kinesis, sequenceNumber);
+		assertEquals(1, metrics.getNumberOfAggregatedRecords());
+		assertEquals(10, metrics.getNumberOfDeaggregatedRecords());
+
+		verify(kinesis).getShardIterator(any(), eq("AT_SEQUENCE_NUMBER"), eq("0"));
+	}
+
+	private SequenceNumber fakeSequenceNumber() {
+		return new SequenceNumber("fakeStartingState");
+	}
+
+	private ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+		final int expectedNumberOfMessages,
+		final KinesisProxyInterface kinesis,
+		final SequenceNumber startingSequenceNumber) {
+		return assertNumberOfMessagesReceivedFromKinesis(expectedNumberOfMessages, kinesis, startingSequenceNumber, new Properties());
+	}
+
+	private ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+		final int expectedNumberOfMessages,
+		final KinesisProxyInterface kinesis,
+		final SequenceNumber startingSequenceNumber,
+		final Properties consumerProperties) {
+		ShardConsumerMetricsReporter shardMetricsReporter = new ShardConsumerMetricsReporter(mock(MetricGroup.class));
 
 		StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("fakeStream", 0);
 
 		LinkedList<KinesisStreamShardState> subscribedShardsStateUnderTest = new LinkedList<>();
 		subscribedShardsStateUnderTest.add(
 			new KinesisStreamShardState(KinesisDataFetcher.convertToStreamShardMetadata(fakeToBeConsumedShard),
-				fakeToBeConsumedShard, new SequenceNumber("fakeStartingState")));
+				fakeToBeConsumedShard, startingSequenceNumber));
 
 		TestSourceContext<String> sourceContext = new TestSourceContext<>();
 
@@ -211,25 +201,28 @@ public class ShardConsumerTest {
 				KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(Collections.singletonList("fakeStream")),
 				Mockito.mock(KinesisProxyInterface.class));
 
+		final StreamShardHandle shardHandle = subscribedShardsStateUnderTest.get(0).getStreamShardHandle();
+
+		final RecordPublisher recordPublisher = new PollingRecordPublisherFactory()
+			.create(fetcher.getConsumerConfiguration(), mock(MetricGroup.class), shardHandle, kinesis);
+
 		int shardIndex = fetcher.registerNewSubscribedShardState(subscribedShardsStateUnderTest.get(0));
 		new ShardConsumer<>(
 			fetcher,
+			recordPublisher,
 			shardIndex,
-			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
+			shardHandle,
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
-			// Initial number of records to fetch --> 10
-			FakeKinesisBehavioursFactory.initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(10, 2, 500L),
-			new ShardMetricsReporter(),
+			shardMetricsReporter,
 			deserializationSchema)
 			.run();
 
-		// Avg record size for first batch --> 10 * 10 Kb/10 = 10 Kb
-		// Number of records fetched in second batch --> 2 Mb/10Kb * 5 = 40
-		// Total number of records = 10 + 40 = 50
-		assertEquals(50, sourceContext.getCollectedOutputs().size());
+		assertEquals(expectedNumberOfMessages, sourceContext.getCollectedOutputs().size());
 		assertEquals(
-			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
+			SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
+
+		return shardMetricsReporter;
 	}
 
 	private static StreamShardHandle getMockStreamShard(String streamName, int shardId) {

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -66,7 +67,7 @@ public class FanOutPropertiesTest extends TestLogger {
 		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
 		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, fakedConsumerName);
 		FanOutProperties fanOutProperties = new FanOutProperties(testConfig, new ArrayList<>());
-		assertEquals(fanOutProperties.getConsumerName(), fakedConsumerName);
+		assertEquals(fanOutProperties.getConsumerName(), Optional.of(fakedConsumerName));
 	}
 
 	@Test
@@ -96,8 +97,8 @@ public class FanOutPropertiesTest extends TestLogger {
 		expectedStreamArns.put("fakedstream1", "fakedstream1");
 		expectedStreamArns.put("fakedstream2", "fakedstream2");
 
-		assertEquals(fanOutProperties.getStreamConsumerArn("fakedstream1"), "fakedstream1");
-		assertEquals(fanOutProperties.getStreamConsumerArns(), expectedStreamArns);
+		assertEquals(fanOutProperties.getStreamConsumerArn("fakedstream1"), Optional.of("fakedstream1"));
+		assertEquals(fanOutProperties.getStreamConsumerArns(), Optional.of(expectedStreamArns));
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/fanout/FanOutPropertiesTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.fanout;
+
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FanOutProperties}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(FanOutProperties.class)
+public class FanOutPropertiesTest extends TestLogger {
+	@Rule
+	private ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testPollingRecordPublisher() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Only efo record publisher can register a FanOutProperties.");
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.POLLING.toString());
+
+		new FanOutProperties(testConfig, new ArrayList<>());
+	}
+
+	@Test
+	public void testEagerStrategyWithConsumerName() {
+		String fakedConsumerName = "fakedconsumername";
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, fakedConsumerName);
+		FanOutProperties fanOutProperties = new FanOutProperties(testConfig, new ArrayList<>());
+		assertEquals(fanOutProperties.getConsumerName(), fakedConsumerName);
+	}
+
+	@Test
+	public void testEagerStrategyWithNoConsumerName() {
+		String msg = "No valid enhanced fan-out consumer name is set through " + ConsumerConfigConstants.EFO_CONSUMER_NAME;
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(msg);
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		new FanOutProperties(testConfig, new ArrayList<>());
+	}
+
+	@Test
+	public void testNoneStrategyWithStreams() {
+		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.NONE.toString());
+		streams.forEach(
+			stream ->
+				testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + stream, stream)
+		);
+		FanOutProperties fanOutProperties = new FanOutProperties(testConfig, streams);
+		Map<String, String> expectedStreamArns = new HashMap<>();
+		expectedStreamArns.put("fakedstream1", "fakedstream1");
+		expectedStreamArns.put("fakedstream2", "fakedstream2");
+
+		assertEquals(fanOutProperties.getStreamConsumerArn("fakedstream1"), "fakedstream1");
+		assertEquals(fanOutProperties.getStreamConsumerArns(), expectedStreamArns);
+	}
+
+	@Test
+	public void testNoneStrategyWithNoStreams() {
+		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+
+		String msg = "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream1, flink.stream.efo.consumerarn.fakedstream2";
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(msg);
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.NONE.toString());
+
+		new FanOutProperties(testConfig, streams);
+	}
+
+	@Test
+	public void testNoneStrategyWithNotEnoughStreams() {
+		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
+
+		String msg = "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream2";
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(msg);
+
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, RecordPublisherType.EFO.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, EFORegistrationType.NONE.toString());
+		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + "fakedstream1", "fakedstream1");
+
+		new FanOutProperties(testConfig, streams);
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordBatchTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordBatchTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
+
+import com.amazonaws.services.kinesis.model.Record;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils.createDummyStreamShardHandle;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link RecordBatch}.
+ */
+public class RecordBatchTest {
+
+	@Test
+	public void testDeaggregateRecordsPassThrough() {
+		RecordBatch result = new RecordBatch(Arrays.asList(
+			record("1"),
+			record("2"),
+			record("3"),
+			record("4")
+		), createDummyStreamShardHandle(), 100L);
+
+		assertEquals(4, result.getAggregatedRecordSize());
+		assertEquals(4, result.getDeaggregatedRecordSize());
+		assertEquals(128, result.getTotalSizeInBytes());
+		assertEquals(32, result.getAverageRecordSizeBytes());
+	}
+
+	@Test
+	public void testDeaggregateRecordsWithAggregatedRecords() {
+		final List<Record> records = TestUtils.createAggregatedRecordBatch(5, 5, new AtomicInteger());
+		RecordBatch result = new RecordBatch(records, createDummyStreamShardHandle(), 100L);
+
+		assertEquals(5, result.getAggregatedRecordSize());
+		assertEquals(25, result.getDeaggregatedRecordSize());
+		assertEquals(25 * 1024, result.getTotalSizeInBytes());
+		assertEquals(1024, result.getAverageRecordSizeBytes());
+	}
+
+	@Test
+	public void testGetAverageRecordSizeBytesEmptyList() {
+		RecordBatch result = new RecordBatch(emptyList(), createDummyStreamShardHandle(), 100L);
+
+		assertEquals(0, result.getAggregatedRecordSize());
+		assertEquals(0, result.getDeaggregatedRecordSize());
+		assertEquals(0, result.getAverageRecordSizeBytes());
+	}
+
+	@Test
+	public void testGetMillisBehindLatest() {
+		RecordBatch result = new RecordBatch(singletonList(record("1")), createDummyStreamShardHandle(), 100L);
+
+		assertEquals(Long.valueOf(100), result.getMillisBehindLatest());
+	}
+
+	private Record record(final String sequenceNumber) {
+		byte[] data = RandomStringUtils.randomAlphabetic(32)
+			.getBytes(ConfigConstants.DEFAULT_CHARSET);
+
+		return new Record()
+			.withData(ByteBuffer.wrap(data))
+			.withPartitionKey("pk")
+			.withSequenceNumber(sequenceNumber);
+	}
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherConfigurationTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherConfigurationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS;
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.SHARD_GETRECORDS_MAX;
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link PollingRecordPublisherConfiguration}.
+ */
+public class PollingRecordPublisherConfigurationTest {
+
+	@Test
+	public void testDefaults() {
+		PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(new Properties());
+		assertEquals(configuration.getFetchIntervalMillis(), 200);
+		assertEquals(configuration.getMaxNumberOfRecordsPerFetch(), 10000);
+		assertFalse(configuration.isAdaptiveReads());
+	}
+
+	@Test
+	public void testGetFetchIntervalMillis() {
+		Properties properties = properties(SHARD_GETRECORDS_INTERVAL_MILLIS, "1");
+		PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(properties);
+
+		assertEquals(configuration.getFetchIntervalMillis(), 1);
+	}
+
+	@Test
+	public void testGetMaxNumberOfRecordsPerFetch() {
+		Properties properties = properties(SHARD_GETRECORDS_MAX, "2");
+		PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(properties);
+
+		assertEquals(configuration.getMaxNumberOfRecordsPerFetch(), 2);
+	}
+
+	@Test
+	public void testIsAdaptiveReads() {
+		Properties properties = properties(SHARD_USE_ADAPTIVE_READS, "true");
+		PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(properties);
+
+		assertTrue(configuration.isAdaptiveReads());
+	}
+
+	private Properties properties(final String key, final String value) {
+		final Properties properties = new Properties();
+		properties.setProperty(key, value);
+		return properties;
+	}
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link PollingRecordPublisherFactory}.
+ */
+public class PollingRecordPublisherFactoryTest {
+
+	private final PollingRecordPublisherFactory factory = new PollingRecordPublisherFactory();
+
+	@Test
+	public void testBuildPollingRecordPublisher() {
+		RecordPublisher recordPublisher = factory.create(
+			new Properties(),
+			mock(MetricGroup.class),
+			mock(StreamShardHandle.class),
+			mock(KinesisProxyInterface.class));
+
+		assertTrue(recordPublisher instanceof PollingRecordPublisher);
+		assertFalse(recordPublisher instanceof AdaptivePollingRecordPublisher);
+	}
+
+	@Test
+	public void testBuildAdaptivePollingRecordPublisher() {
+		Properties properties = new Properties();
+		properties.setProperty(SHARD_USE_ADAPTIVE_READS, "true");
+
+		RecordPublisher recordPublisher = factory.create(
+			properties,
+			mock(MetricGroup.class),
+			mock(StreamShardHandle.class),
+			mock(KinesisProxyInterface.class));
+
+		assertTrue(recordPublisher instanceof PollingRecordPublisher);
+		assertTrue(recordPublisher instanceof AdaptivePollingRecordPublisher);
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordBatch;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult;
+import org.apache.flink.streaming.connectors.kinesis.metrics.PollingRecordPublisherMetricsReporter;
+import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
+import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
+import static org.apache.flink.streaming.connectors.kinesis.model.StartingPosition.continueFromSequenceNumber;
+import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link PollingRecordPublisher}.
+ */
+public class PollingRecordPublisherTest {
+
+	@Test
+	public void testRunPublishesRecordsToConsumer() throws InterruptedException {
+		KinesisProxyInterface fakeKinesis = totalNumOfRecordsAfterNumOfGetRecordsCalls(5, 1, 100);
+		PollingRecordPublisher recordPublisher = createPollingRecordPublisher(fakeKinesis);
+
+		TestConsumer consumer = new TestConsumer();
+		RecordPublisherRunResult result = recordPublisher.run(earliest(), consumer);
+
+		assertEquals(1, consumer.recordBatches.size());
+		assertEquals(5, consumer.recordBatches.get(0).getDeaggregatedRecordSize());
+		assertEquals(100L, consumer.recordBatches.get(0).getMillisBehindLatest(), 0);
+	}
+
+	@Test
+	public void testRunReturnsCompleteWhenShardExpires() throws InterruptedException {
+		// There are 2 batches available in the stream
+		KinesisProxyInterface fakeKinesis = totalNumOfRecordsAfterNumOfGetRecordsCalls(5, 2, 100);
+		PollingRecordPublisher recordPublisher = createPollingRecordPublisher(fakeKinesis);
+
+		// First call results in INCOMPLETE, there is one batch left
+		assertEquals(INCOMPLETE, recordPublisher.run(earliest(), batch -> {}));
+
+		// After second call the shard is complete
+		assertEquals(COMPLETE, recordPublisher.run(earliest(), batch -> {}));
+	}
+
+	@Test
+	public void testRunOnCompletelyConsumedShardReturnsComplete() throws InterruptedException {
+		KinesisProxyInterface fakeKinesis = totalNumOfRecordsAfterNumOfGetRecordsCalls(5, 1, 100);
+		PollingRecordPublisher recordPublisher = createPollingRecordPublisher(fakeKinesis);
+
+		assertEquals(COMPLETE, recordPublisher.run(earliest(), batch -> {}));
+		assertEquals(COMPLETE, recordPublisher.run(earliest(), batch -> {}));
+	}
+
+	@Test
+	public void testRunGetShardIteratorReturnsNullIsComplete() throws InterruptedException {
+		KinesisProxyInterface fakeKinesis = FakeKinesisBehavioursFactory.noShardsFoundForRequestedStreamsBehaviour();
+		PollingRecordPublisher recordPublisher = createPollingRecordPublisher(fakeKinesis);
+
+		assertEquals(COMPLETE, recordPublisher.run(earliest(), batch -> {}));
+	}
+
+	@Test
+	public void testRunGetRecordsRecoversFromExpiredIteratorException() throws InterruptedException {
+		KinesisProxyInterface fakeKinesis = spy(FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(2, 2, 1, 500));
+		PollingRecordPublisher recordPublisher = createPollingRecordPublisher(fakeKinesis);
+
+		recordPublisher.run(earliest(), batch -> {});
+
+		// Get shard iterator is called twice, once during first run, secondly to refresh expired iterator
+		verify(fakeKinesis, times(2)).getShardIterator(any(), any(), any());
+	}
+
+	private StartingPosition latest() {
+		return continueFromSequenceNumber(SENTINEL_LATEST_SEQUENCE_NUM.get());
+	}
+
+	private StartingPosition earliest() {
+		return continueFromSequenceNumber(SENTINEL_EARLIEST_SEQUENCE_NUM.get());
+	}
+
+	PollingRecordPublisher createPollingRecordPublisher(final KinesisProxyInterface kinesis) {
+		PollingRecordPublisherMetricsReporter metricsReporter = new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class));
+
+		return new PollingRecordPublisher(
+			TestUtils.createDummyStreamShardHandle(),
+			metricsReporter,
+			kinesis,
+			10000,
+			500L);
+	}
+
+	private static class TestConsumer implements Consumer<RecordBatch> {
+		private final List<RecordBatch> recordBatches = new ArrayList<>();
+
+		@Override
+		public void accept(final RecordBatch batch) {
+			recordBatches.add(batch);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/PollingRecordPublisherMetricsReporterTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/PollingRecordPublisherMetricsReporterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link PollingRecordPublisherMetricsReporter}.
+ */
+public class PollingRecordPublisherMetricsReporterTest {
+
+	@InjectMocks
+	private PollingRecordPublisherMetricsReporter metricsReporter;
+
+	@Mock
+	private MetricGroup metricGroup;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testMetricIdentifiers() {
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.BYTES_PER_READ), any());
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.LOOP_FREQUENCY_HZ), any());
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.MAX_RECORDS_PER_FETCH), any());
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.RUNTIME_LOOP_NANOS), any());
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.SLEEP_TIME_MILLIS), any());
+	}
+
+	@Test
+	public void testGettersAndSetters() {
+		metricsReporter.setBytesPerRead(1);
+		metricsReporter.setLoopFrequencyHz(2);
+		metricsReporter.setMaxNumberOfRecordsPerFetch(3);
+		metricsReporter.setRunLoopTimeNanos(4);
+		metricsReporter.setSleepTimeMillis(5);
+
+		assertEquals(1, metricsReporter.getBytesPerRead(), 0);
+		assertEquals(2, metricsReporter.getLoopFrequencyHz(), 0);
+		assertEquals(3, metricsReporter.getMaxNumberOfRecordsPerFetch());
+		assertEquals(4, metricsReporter.getRunLoopTimeNanos());
+		assertEquals(5, metricsReporter.getSleepTimeMillis());
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporterTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link ShardConsumerMetricsReporter}.
+ */
+public class ShardConsumerMetricsReporterTest {
+
+	@InjectMocks
+	private ShardConsumerMetricsReporter metricsReporter;
+
+	@Mock
+	private MetricGroup metricGroup;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testMetricIdentifiers() {
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.AVG_RECORD_SIZE_BYTES), any());
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.MILLIS_BEHIND_LATEST_GAUGE), any());
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.NUM_AGGREGATED_RECORDS_PER_FETCH), any());
+		verify(metricGroup).gauge(eq(KinesisConsumerMetricConstants.NUM_DEAGGREGATED_RECORDS_PER_FETCH), any());
+	}
+
+	@Test
+	public void testGettersAndSetters() {
+		metricsReporter.setAverageRecordSizeBytes(1);
+		metricsReporter.setMillisBehindLatest(2);
+		metricsReporter.setNumberOfAggregatedRecords(3);
+		metricsReporter.setNumberOfDeaggregatedRecords(4);
+
+		assertEquals(1, metricsReporter.getAverageRecordSizeBytes());
+		assertEquals(2, metricsReporter.getMillisBehindLatest());
+		assertEquals(3, metricsReporter.getNumberOfAggregatedRecords());
+		assertEquals(4, metricsReporter.getNumberOfDeaggregatedRecords());
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/StartingPositionTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/StartingPositionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.model;
+
+import com.amazonaws.services.kinesis.model.ShardIteratorType;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link StartingPosition}.
+ */
+public class StartingPositionTest {
+
+	@Test
+	public void testStartingPositionFromTimestamp() {
+		Date date = new Date();
+		StartingPosition position = StartingPosition.fromTimestamp(date);
+		assertEquals(ShardIteratorType.AT_TIMESTAMP, position.getShardIteratorType());
+		assertEquals(date, position.getStartingMarker());
+	}
+
+	@Test
+	public void testStartingPositionRestartFromSequenceNumber() {
+		SequenceNumber sequenceNumber = new SequenceNumber("100");
+		StartingPosition position = StartingPosition.restartFromSequenceNumber(sequenceNumber);
+		assertEquals(ShardIteratorType.AFTER_SEQUENCE_NUMBER, position.getShardIteratorType());
+		assertEquals("100", position.getStartingMarker());
+	}
+
+	@Test
+	public void testStartingPositionRestartFromAggregatedSequenceNumber() {
+		SequenceNumber sequenceNumber = new SequenceNumber("200", 3);
+		StartingPosition position = StartingPosition.restartFromSequenceNumber(sequenceNumber);
+		assertEquals(ShardIteratorType.AT_SEQUENCE_NUMBER, position.getShardIteratorType());
+		assertEquals("200", position.getStartingMarker());
+	}
+
+	@Test
+	public void testStartingPositionContinueFromAggregatedSequenceNumber() {
+		SequenceNumber sequenceNumber = new SequenceNumber("200", 3);
+		StartingPosition position = StartingPosition.continueFromSequenceNumber(sequenceNumber);
+		assertEquals(ShardIteratorType.AFTER_SEQUENCE_NUMBER, position.getShardIteratorType());
+		assertEquals("200", position.getStartingMarker());
+	}
+
+	@Test
+	public void testStartingPositionRestartFromSentinelEarliest() {
+		SequenceNumber sequenceNumber = SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM.get();
+		StartingPosition position = StartingPosition.restartFromSequenceNumber(sequenceNumber);
+		assertEquals(ShardIteratorType.TRIM_HORIZON, position.getShardIteratorType());
+		assertNull(position.getStartingMarker());
+	}
+
+	@Test
+	public void testStartingPositionRestartFromSentinelLatest() {
+		SequenceNumber sequenceNumber = SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM.get();
+		StartingPosition position = StartingPosition.restartFromSequenceNumber(sequenceNumber);
+		assertEquals(ShardIteratorType.LATEST, position.getShardIteratorType());
+		assertNull(position.getStartingMarker());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testStartingPositionRestartFromSentinelEnding() {
+		SequenceNumber sequenceNumber = SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get();
+		StartingPosition position = StartingPosition.restartFromSequenceNumber(sequenceNumber);
+		assertEquals(ShardIteratorType.LATEST, position.getShardIteratorType());
+		assertNull(position.getStartingMarker());
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Test.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Test.java
@@ -1,0 +1,660 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.proxy;
+
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.internals.fanout.FanOutStreamInfo;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.shaded.com.google.common.collect.Lists;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.model.Consumer;
+import software.amazon.awssdk.services.kinesis.model.ConsumerDescription;
+import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
+import software.amazon.awssdk.services.kinesis.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerResponse;
+import software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
+import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kinesis.model.StreamDescription;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test for methods in the {@link KinesisProxyV2} class.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(KinesisProxyV2.class)
+public class KinesisProxyV2Test {
+	@Rule
+	private ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testDescribeStreamNormal() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		DescribeStreamResponse expectedResponse = DescribeStreamResponse
+			.builder()
+			.streamDescription(
+				StreamDescription
+					.builder()
+					.streamARN(fakedStreamArn)
+					.build()
+			)
+			.build();
+		Mockito
+			.when(mockClient.describeStream((DescribeStreamRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DescribeStreamResponse>>) invocationOnMock -> CompletableFuture.completedFuture(expectedResponse));
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+
+		Map<String, String> streamArns = kinesisProxy.describeStream(streams);
+		assertEquals(streamArns.get(fakedStream1), fakedStreamArn);
+		assertEquals(streamArns.get(fakedStream2), fakedStreamArn);
+	}
+
+	@Test
+	public void testDescribeStreamWithUnrecoverableException() throws Exception {
+		exception.expect(ExecutionException.class);
+		exception.expectCause(CoreMatchers.isA(ResourceNotFoundException.class));
+
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+
+		Properties kinesisConsumerConfig = getProperties();
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		Mockito
+			.when(mockClient.describeStream((DescribeStreamRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DescribeStreamResponse>>) invocationOnMock ->
+				CompletableFuture.failedFuture(ResourceNotFoundException.builder().build())
+			);
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+
+		kinesisProxy.describeStream(streams);
+	}
+
+	@Test
+	public void testDescribeStreamWithRecoverableException() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		DescribeStreamResponse expectedResponse = DescribeStreamResponse
+			.builder()
+			.streamDescription(
+				StreamDescription
+					.builder()
+					.streamARN(fakedStreamArn)
+					.build()
+			)
+			.build();
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			ProvisionedThroughputExceededException.builder().build()
+		};
+		Mockito
+			.when(mockClient.describeStream((DescribeStreamRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DescribeStreamResponse>>) invocationOnMock -> {
+					if (retries.intValue() < retriableExceptions.length) {
+						retries.increment();
+						return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+					}
+					return CompletableFuture.completedFuture(expectedResponse);
+				}
+			);
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+
+		Map<String, String> streamArns = kinesisProxy.describeStream(streams);
+		assertEquals(streamArns.get(fakedStream1), fakedStreamArn);
+		assertEquals(streamArns.get(fakedStream2), fakedStreamArn);
+	}
+
+	@Test
+	public void testDescribeStreamWithRecoverableExceptionExceedsMaxRetry() throws Exception {
+		exception.expect(RuntimeException.class);
+		exception.expectMessage(CoreMatchers.containsString("Retries exceeded for describeStream operation - all 2 retry attempts failed."));
+
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_RETRIES, "2");
+
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		DescribeStreamResponse expectedResponse = DescribeStreamResponse
+			.builder()
+			.streamDescription(
+				StreamDescription
+					.builder()
+					.streamARN(fakedStreamArn)
+					.build()
+			)
+			.build();
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			ProvisionedThroughputExceededException.builder().build(),
+			ProvisionedThroughputExceededException.builder().build(),
+			ProvisionedThroughputExceededException.builder().build()
+		};
+		Mockito
+			.when(mockClient.describeStream((DescribeStreamRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DescribeStreamResponse>>) invocationOnMock -> {
+					if (retries.intValue() < retriableExceptions.length) {
+						retries.increment();
+						return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+					}
+					return CompletableFuture.completedFuture(expectedResponse);
+				}
+			);
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+
+		Map<String, String> streamArns = kinesisProxy.describeStream(streams);
+		assertEquals(streamArns.get(fakedStream1), fakedStreamArn);
+		assertEquals(streamArns.get(fakedStream2), fakedStreamArn);
+	}
+
+	@Test
+	public void testRegisterStreamConsumerNormal() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		RegisterStreamConsumerResponse expectedResponse = RegisterStreamConsumerResponse
+			.builder()
+			.consumer(
+				Consumer
+					.builder()
+					.consumerARN(fakedConsumerArn)
+					.consumerName(consumerName)
+					.build()
+			)
+			.build();
+		Mockito
+			.when(mockClient.registerStreamConsumer((RegisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<RegisterStreamConsumerResponse>>) invocationOnMock -> CompletableFuture.completedFuture(expectedResponse));
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		Map<String, String> streamArns = new HashMap<>();
+		streamArns.put(fakedStream1, fakedStreamArn);
+		streamArns.put(fakedStream2, fakedStreamArn);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> result = kinesisProxy.registerStreamConsumer(streamArns);
+		List<FanOutStreamInfo> expectedResult = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		assertEquals(result, expectedResult);
+	}
+
+	@Test
+	public void testRegisterStreamConsumerWithUnrecoverableException() throws Exception {
+		exception.expect(ExecutionException.class);
+		exception.expectCause(CoreMatchers.isA(ResourceNotFoundException.class));
+
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		Mockito
+			.when(mockClient.registerStreamConsumer((RegisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<RegisterStreamConsumerResponse>>) invocationOnMock -> CompletableFuture.failedFuture(ResourceNotFoundException.builder().build()));
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		Map<String, String> streamArns = new HashMap<>();
+		streamArns.put(fakedStream1, fakedStreamArn);
+		streamArns.put(fakedStream2, fakedStreamArn);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> result = kinesisProxy.registerStreamConsumer(streamArns);
+	}
+
+	@Test
+	public void testRegisterStreamConsumerWithResourceInUseException() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			LimitExceededException.builder().build()
+		};
+
+		DescribeStreamConsumerResponse expectedResponse = DescribeStreamConsumerResponse
+			.builder()
+			.consumerDescription(
+				ConsumerDescription
+					.builder()
+					.consumerARN(fakedConsumerArn)
+					.consumerName(consumerName)
+					.build()
+			)
+			.build();
+		Mockito
+			.when(mockClient.registerStreamConsumer((RegisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<RegisterStreamConsumerResponse>>) invocationOnMock -> CompletableFuture.failedFuture(ResourceInUseException.builder().build())
+			);
+		Mockito
+			.when(mockClient.describeStreamConsumer((DescribeStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DescribeStreamConsumerResponse>>) invocationOnMock -> {
+					if (retries.intValue() < retriableExceptions.length) {
+						retries.increment();
+						return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+					}
+					return CompletableFuture.completedFuture(expectedResponse);
+				}
+			);
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		Map<String, String> streamArns = new HashMap<>();
+		streamArns.put(fakedStream1, fakedStreamArn);
+		streamArns.put(fakedStream2, fakedStreamArn);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> result = kinesisProxy.registerStreamConsumer(streamArns);
+		List<FanOutStreamInfo> expectedResult = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		assertEquals(result, expectedResult);
+	}
+
+	@Test
+	public void testRegisterStreamConsumerWithResourceInUseExceptionExceedsMaxRetry() throws Exception {
+		exception.expect(RuntimeException.class);
+		exception.expectMessage(CoreMatchers.containsString("Retries exceeded for registerStream operation - all 3 retry attempts failed."));
+
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_RETRIES, "2");
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.REGISTER_STREAM_RETRIES, "3");
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			LimitExceededException.builder().build(),
+			ProvisionedThroughputExceededException.builder().build()
+		};
+
+		DescribeStreamConsumerResponse expectedResponse = DescribeStreamConsumerResponse
+			.builder()
+			.consumerDescription(
+				ConsumerDescription
+					.builder()
+					.consumerARN(fakedConsumerArn)
+					.consumerName(consumerName)
+					.build()
+			)
+			.build();
+		Mockito
+			.when(mockClient.registerStreamConsumer((RegisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<RegisterStreamConsumerResponse>>) invocationOnMock -> CompletableFuture.failedFuture(ResourceInUseException.builder().build())
+			);
+		Mockito
+			.when(mockClient.describeStreamConsumer((DescribeStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DescribeStreamConsumerResponse>>) invocationOnMock -> {
+					if (retries.intValue() < retriableExceptions.length) {
+						retries.increment();
+						return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+					}
+					return CompletableFuture.completedFuture(expectedResponse);
+				}
+			);
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		Map<String, String> streamArns = new HashMap<>();
+		streamArns.put(fakedStream1, fakedStreamArn);
+		streamArns.put(fakedStream2, fakedStreamArn);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> result = kinesisProxy.registerStreamConsumer(streamArns);
+		List<FanOutStreamInfo> expectedResult = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		assertEquals(result, expectedResult);
+	}
+
+	@Test
+	public void testRegisterStreamConsumerWithRecoverableException() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		RegisterStreamConsumerResponse expectedResponse = RegisterStreamConsumerResponse
+			.builder()
+			.consumer(
+				Consumer
+					.builder()
+					.consumerARN(fakedConsumerArn)
+					.consumerName(consumerName)
+					.build()
+			)
+			.build();
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			LimitExceededException.builder().build()
+		};
+
+		Mockito
+			.when(mockClient.registerStreamConsumer((RegisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<RegisterStreamConsumerResponse>>) invocationOnMock -> {
+					if (retries.intValue() < retriableExceptions.length) {
+						retries.increment();
+						return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+					}
+					return CompletableFuture.completedFuture(expectedResponse);
+				}
+			);
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		Map<String, String> streamArns = new HashMap<>();
+		streamArns.put(fakedStream1, fakedStreamArn);
+		streamArns.put(fakedStream2, fakedStreamArn);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> result = kinesisProxy.registerStreamConsumer(streamArns);
+		List<FanOutStreamInfo> expectedResult = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		assertEquals(result, expectedResult);
+	}
+
+	@Test
+	public void testRegisterStreamConsumerWithRecoverableExceptionExceedsMaxRetry() throws Exception {
+		exception.expect(RuntimeException.class);
+		exception.expectMessage(CoreMatchers.containsString("Retries exceeded for registerStream operation - all 2 retry attempts failed."));
+
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+
+		Properties kinesisConsumerConfig = getProperties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.REGISTER_STREAM_RETRIES, "2");
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		RegisterStreamConsumerResponse expectedResponse = RegisterStreamConsumerResponse
+			.builder()
+			.consumer(
+				Consumer
+					.builder()
+					.consumerARN(fakedConsumerArn)
+					.consumerName(consumerName)
+					.build()
+			)
+			.build();
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			LimitExceededException.builder().build(),
+			LimitExceededException.builder().build()
+		};
+
+		Mockito
+			.when(mockClient.registerStreamConsumer((RegisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<RegisterStreamConsumerResponse>>) invocationOnMock -> {
+					if (retries.intValue() < retriableExceptions.length) {
+						retries.increment();
+						return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+					}
+					return CompletableFuture.completedFuture(expectedResponse);
+				}
+			);
+
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		Map<String, String> streamArns = new HashMap<>();
+		streamArns.put(fakedStream1, fakedStreamArn);
+		streamArns.put(fakedStream2, fakedStreamArn);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		kinesisProxy.registerStreamConsumer(streamArns);
+	}
+
+	@Test
+	public void testDeregisterStreamConsumerNormal() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+		Properties kinesisConsumerConfig = getProperties();
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		DeregisterStreamConsumerResponse expectedResponse = DeregisterStreamConsumerResponse.builder().build();
+		Mockito
+			.when(mockClient.deregisterStreamConsumer((DeregisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DeregisterStreamConsumerResponse>>) invocationOnMock -> CompletableFuture.completedFuture(expectedResponse));
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> deregisterStreams = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		kinesisProxy.deregisterStreamConsumer(deregisterStreams);
+	}
+
+	@Test
+	public void testDeregisterStreamConsumerWithUnrecoverableException() throws Exception {
+		exception.expect(ExecutionException.class);
+		exception.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
+
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+		Properties kinesisConsumerConfig = getProperties();
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+
+		Mockito
+			.when(mockClient.deregisterStreamConsumer((DeregisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DeregisterStreamConsumerResponse>>) invocationOnMock -> CompletableFuture.failedFuture(new IllegalArgumentException()));
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> deregisterStreams = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		kinesisProxy.deregisterStreamConsumer(deregisterStreams);
+	}
+
+	@Test
+	public void testDeregisterStreamConsumerWithResourceNotFoundException() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+		Properties kinesisConsumerConfig = getProperties();
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+
+		Mockito
+			.when(mockClient.deregisterStreamConsumer((DeregisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DeregisterStreamConsumerResponse>>) invocationOnMock -> CompletableFuture.failedFuture(ResourceNotFoundException.builder().build()));
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> deregisterStreams = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		kinesisProxy.deregisterStreamConsumer(deregisterStreams);
+	}
+
+	@Test
+	public void testDeregisterStreamConsumerWithRecoverableException() throws Exception {
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+		Properties kinesisConsumerConfig = getProperties();
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		DeregisterStreamConsumerResponse expectedResponse = DeregisterStreamConsumerResponse.builder().build();
+
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			LimitExceededException.builder().build()
+		};
+		Mockito
+			.when(mockClient.deregisterStreamConsumer((DeregisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DeregisterStreamConsumerResponse>>) invocationOnMock -> {
+				if (retries.intValue() < retriableExceptions.length) {
+					retries.increment();
+					return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+				}
+				return CompletableFuture.completedFuture(expectedResponse);
+			});
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> deregisterStreams = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		kinesisProxy.deregisterStreamConsumer(deregisterStreams);
+	}
+
+	@Test
+	public void testDeregisterStreamConsumerWithRecoverableExceptionExceedsRetry() throws Exception {
+		exception.expect(RuntimeException.class);
+		exception.expectMessage(CoreMatchers.containsString("Retries exceeded for deregisterStream operation - all 2 retry attempts failed."));
+
+		final String fakedStream1 = "fakedstream1";
+		final String fakedStream2 = "fakedstream2";
+		final String fakedStreamArn = "fakedstreamarn";
+		final String fakedConsumerArn = "fakedconsumerarn";
+		Properties kinesisConsumerConfig = getProperties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.DEREGISTER_STREAM_RETRIES, "2");
+		final String consumerName = kinesisConsumerConfig.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		KinesisAsyncClient mockClient = mock(KinesisAsyncClient.class);
+		DeregisterStreamConsumerResponse expectedResponse = DeregisterStreamConsumerResponse.builder().build();
+
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			LimitExceededException.builder().build(),
+			LimitExceededException.builder().build(),
+			ProvisionedThroughputExceededException.builder().build()
+		};
+		Mockito
+			.when(mockClient.deregisterStreamConsumer((DeregisterStreamConsumerRequest) any()))
+			.thenAnswer((Answer<CompletableFuture<DeregisterStreamConsumerResponse>>) invocationOnMock -> {
+				if (retries.intValue() < retriableExceptions.length) {
+					retries.increment();
+					return CompletableFuture.failedFuture(retriableExceptions[retries.intValue() - 1]);
+				}
+				return CompletableFuture.completedFuture(expectedResponse);
+			});
+		List<String> streams = Lists.newArrayList(fakedStream1, fakedStream2);
+		KinesisProxyV2 kinesisProxy = new KinesisProxyV2(kinesisConsumerConfig, streams);
+
+		Whitebox.getField(KinesisProxyV2.class, "kinesisAsyncClient").set(kinesisProxy, mockClient);
+		List<FanOutStreamInfo> deregisterStreams = Lists.newArrayList(
+			new FanOutStreamInfo(fakedStream2, fakedStreamArn, consumerName, fakedConsumerArn),
+			new FanOutStreamInfo(fakedStream1, fakedStreamArn, consumerName, fakedConsumerArn)
+		);
+		kinesisProxy.deregisterStreamConsumer(deregisterStreams);
+	}
+
+	private Properties getProperties() {
+		Properties kinesisConsumerConfig = new Properties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, "EFO");
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "fakedConsumer");
+		return kinesisConsumerConfig;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -107,6 +108,25 @@ public class FakeKinesisBehavioursFactory {
 				millisBehindLatest);
 	}
 
+	/**
+	 * Creates a mocked Kinesis Proxy that will Emit aggregated records from a fake stream:
+	 * - There will be {@code numOfGetRecordsCalls} batches available in the stream
+	 * - Each batch will contain {@code numOfAggregatedRecords} aggregated records
+	 * - Each aggregated record will contain {@code numOfChildRecords} child records
+	 * Therefore this class will emit a total of
+	 * {@code numOfGetRecordsCalls * numOfAggregatedRecords * numOfChildRecords} records.
+	 *
+	 * @param numOfAggregatedRecords the number of records per batch
+	 * @param numOfChildRecords the number of child records in each aggregated record
+	 * @param numOfGetRecordsCalls the number batches available in the fake stream
+	 */
+	public static KinesisProxyInterface aggregatedRecords(
+		final int numOfAggregatedRecords,
+		final int numOfChildRecords,
+		final int numOfGetRecordsCalls) {
+		return new SingleShardEmittingAggregatedRecordsKinesis(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls);
+	}
+
 	public static KinesisProxyInterface blockingQueueGetRecords(Map<String, List<BlockingQueue<String>>> streamsToShardQueues) {
 		return new BlockingQueueKinesis(streamsToShardQueues);
 	}
@@ -133,7 +153,7 @@ public class FakeKinesisBehavioursFactory {
 
 		@Override
 		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) {
-			if ((Integer.valueOf(shardIterator) == orderOfCallToExpire - 1) && !expiredOnceAlready) {
+			if ((Integer.parseInt(shardIterator) == orderOfCallToExpire - 1) && !expiredOnceAlready) {
 				// we fake only once the expired iterator exception at the specified get records attempt order
 				expiredOnceAlready = true;
 				throw new ExpiredIteratorException("Artificial expired shard iterator");
@@ -147,8 +167,8 @@ public class FakeKinesisBehavioursFactory {
 					.withRecords(shardItrToRecordBatch.get(shardIterator))
 					.withMillisBehindLatest(millisBehindLatest)
 					.withNextShardIterator(
-						(Integer.valueOf(shardIterator) == totalNumOfGetRecordsCalls - 1)
-							? null : String.valueOf(Integer.valueOf(shardIterator) + 1)); // last next shard iterator is null
+						(Integer.parseInt(shardIterator) == totalNumOfGetRecordsCalls - 1)
+							? null : String.valueOf(Integer.parseInt(shardIterator) + 1)); // last next shard iterator is null
 			}
 		}
 
@@ -214,8 +234,8 @@ public class FakeKinesisBehavioursFactory {
 				.withRecords(shardItrToRecordBatch.get(shardIterator))
 				.withMillisBehindLatest(millisBehindLatest)
 				.withNextShardIterator(
-					(Integer.valueOf(shardIterator) == totalNumOfGetRecordsCalls - 1)
-						? null : String.valueOf(Integer.valueOf(shardIterator) + 1)); // last next shard iterator is null
+					(Integer.parseInt(shardIterator) == totalNumOfGetRecordsCalls - 1)
+						? null : String.valueOf(Integer.parseInt(shardIterator) + 1)); // last next shard iterator is null
 		}
 
 		@Override
@@ -245,73 +265,43 @@ public class FakeKinesisBehavioursFactory {
 
 	}
 
-	private static class SingleShardEmittingAdaptiveNumOfRecordsKinesis implements
-			KinesisProxyInterface {
+	private static class SingleShardEmittingAdaptiveNumOfRecordsKinesis extends SingleShardEmittingKinesis {
 
-		protected final int totalNumOfGetRecordsCalls;
-
-		protected final int totalNumOfRecords;
-
-		private final long millisBehindLatest;
-
-		protected final Map<String, List<Record>> shardItrToRecordBatch;
-
-		protected static long averageRecordSizeBytes;
+		protected static long averageRecordSizeBytes = 0L;
 
 		private static final long KINESIS_SHARD_BYTES_PER_SECOND_LIMIT = 2 * 1024L * 1024L;
 
-		public SingleShardEmittingAdaptiveNumOfRecordsKinesis(final int numOfRecords,
+		public SingleShardEmittingAdaptiveNumOfRecordsKinesis(
+				final int numOfRecords,
 				final int numOfGetRecordsCalls,
 				final long millisBehindLatest) {
-			this.totalNumOfRecords = numOfRecords;
-			this.totalNumOfGetRecordsCalls = numOfGetRecordsCalls;
-			this.millisBehindLatest = millisBehindLatest;
-			this.averageRecordSizeBytes = 0L;
+			super(initShardItrToRecordBatch(numOfRecords, numOfGetRecordsCalls), millisBehindLatest);
+		}
 
+		private static Map<String, List<Record>> initShardItrToRecordBatch(
+				final int numOfRecords,
+				final int numOfGetRecordsCalls) {
 			// initialize the record batches that we will be fetched
-			this.shardItrToRecordBatch = new HashMap<>();
+			Map<String, List<Record>> shardItrToRecordBatch = new HashMap<>();
 
 			int numOfAlreadyPartitionedRecords = 0;
 			int numOfRecordsPerBatch = numOfRecords;
-			for (int batch = 0; batch < totalNumOfGetRecordsCalls; batch++) {
-					shardItrToRecordBatch.put(
-							String.valueOf(batch),
-							createRecordBatchWithRange(
-									numOfAlreadyPartitionedRecords,
-									numOfAlreadyPartitionedRecords + numOfRecordsPerBatch));
-					numOfAlreadyPartitionedRecords += numOfRecordsPerBatch;
+			for (int batch = 0; batch < numOfGetRecordsCalls; batch++) {
+				shardItrToRecordBatch.put(
+					String.valueOf(batch),
+					createRecordBatchWithRange(
+						numOfAlreadyPartitionedRecords,
+						numOfAlreadyPartitionedRecords + numOfRecordsPerBatch));
+				numOfAlreadyPartitionedRecords += numOfRecordsPerBatch;
 
 				numOfRecordsPerBatch = (int) (KINESIS_SHARD_BYTES_PER_SECOND_LIMIT /
-						(averageRecordSizeBytes * 1000L / ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_INTERVAL_MILLIS));
+					(averageRecordSizeBytes * 1000L / ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_INTERVAL_MILLIS));
 			}
+
+			return shardItrToRecordBatch;
 		}
 
-		@Override
-		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) {
-			// assuming that the maxRecordsToGet is always large enough
-			return new GetRecordsResult()
-					.withRecords(shardItrToRecordBatch.get(shardIterator))
-					.withMillisBehindLatest(millisBehindLatest)
-					.withNextShardIterator(
-							(Integer.valueOf(shardIterator) == totalNumOfGetRecordsCalls - 1)
-									? null : String
-									.valueOf(Integer.valueOf(shardIterator) + 1)); // last next shard iterator is null
-		}
-
-		@Override
-		public String getShardIterator(StreamShardHandle shard, String shardIteratorType,
-				Object startingMarker) {
-			// this will be called only one time per ShardConsumer;
-			// so, simply return the iterator of the first batch of records
-			return "0";
-		}
-
-		@Override
-		public GetShardListResult getShardList(Map<String, String> streamNamesWithLastSeenShardIds) {
-			return null;
-		}
-
-		public static List<Record> createRecordBatchWithRange(int min, int max) {
+		private static List<Record> createRecordBatchWithRange(int min, int max) {
 			List<Record> batch = new LinkedList<>();
 			long	sumRecordBatchBytes = 0L;
 			// Create record of size 10Kb
@@ -320,7 +310,7 @@ public class FakeKinesisBehavioursFactory {
 			for (int i = min; i < max; i++) {
 				Record record = new Record()
 								.withData(
-										ByteBuffer.wrap(String.valueOf(data).getBytes(ConfigConstants.DEFAULT_CHARSET)))
+										ByteBuffer.wrap(data.getBytes(ConfigConstants.DEFAULT_CHARSET)))
 								.withPartitionKey(UUID.randomUUID().toString())
 								.withApproximateArrivalTimestamp(new Date(System.currentTimeMillis()))
 								.withSequenceNumber(String.valueOf(i));
@@ -335,17 +325,84 @@ public class FakeKinesisBehavioursFactory {
 			return batch;
 		}
 
-		private static String createDataSize(long msgSize) {
+		private static String createDataSize(final long msgSize) {
 			char[] data = new char[(int) msgSize];
 			return new String(data);
+		}
+	}
 
+	private static class SingleShardEmittingAggregatedRecordsKinesis extends SingleShardEmittingKinesis {
+
+		public SingleShardEmittingAggregatedRecordsKinesis(
+				final int numOfAggregatedRecords,
+			final int numOfChildRecords,
+			final int numOfGetRecordsCalls) {
+			super(initShardItrToRecordBatch(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls));
 		}
 
+		private static Map<String, List<Record>> initShardItrToRecordBatch(final int numOfAggregatedRecords,
+			final int numOfChildRecords,
+			final int numOfGetRecordsCalls) {
+
+			Map<String, List<Record>> shardToRecordBatch = new HashMap<>();
+
+			AtomicInteger sequenceNumber = new AtomicInteger();
+			for (int batch = 0; batch < numOfGetRecordsCalls; batch++) {
+				List<Record> recordBatch = TestUtils.createAggregatedRecordBatch(
+					numOfAggregatedRecords, numOfChildRecords, sequenceNumber);
+
+				shardToRecordBatch.put(String.valueOf(batch), recordBatch);
+			}
+
+			return shardToRecordBatch;
+		}
+	}
+
+	/** A helper base class used to emit records from a single sharded fake Kinesis Stream. */
+	private abstract static class SingleShardEmittingKinesis implements KinesisProxyInterface {
+
+		private final long millisBehindLatest;
+
+		private final Map<String, List<Record>> shardItrToRecordBatch;
+
+		protected SingleShardEmittingKinesis(final Map<String, List<Record>> shardItrToRecordBatch) {
+			this(shardItrToRecordBatch, 0L);
+		}
+
+		protected SingleShardEmittingKinesis(final Map<String, List<Record>> shardItrToRecordBatch, final long millisBehindLatest) {
+			this.millisBehindLatest = millisBehindLatest;
+			this.shardItrToRecordBatch = shardItrToRecordBatch;
+		}
+
+		@Override
+		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) {
+			int index = Integer.parseInt(shardIterator);
+			// last next shard iterator is null
+			String nextShardIterator = (index == shardItrToRecordBatch.size() - 1) ? null : String.valueOf(index + 1);
+
+			// assuming that the maxRecordsToGet is always large enough
+			return new GetRecordsResult()
+				.withRecords(shardItrToRecordBatch.get(shardIterator))
+				.withNextShardIterator(nextShardIterator)
+				.withMillisBehindLatest(millisBehindLatest);
+		}
+
+		@Override
+		public String getShardIterator(StreamShardHandle shard, String shardIteratorType, Object startingMarker) {
+			// this will be called only one time per ShardConsumer;
+			// so, simply return the iterator of the first batch of records
+			return "0";
+		}
+
+		@Override
+		public GetShardListResult getShardList(Map<String, String> streamNamesWithLastSeenShardIds) {
+			return null;
+		}
 	}
 
 	private static class NonReshardedStreamsKinesis implements KinesisProxyInterface {
 
-		private Map<String, List<StreamShardHandle>> streamsWithListOfShards = new HashMap<>();
+		private final Map<String, List<StreamShardHandle>> streamsWithListOfShards = new HashMap<>();
 
 		public NonReshardedStreamsKinesis(Map<String, Integer> streamsToShardCount) {
 			for (Map.Entry<String, Integer> streamToShardCount : streamsToShardCount.entrySet()) {
@@ -436,8 +493,8 @@ public class FakeKinesisBehavioursFactory {
 
 	private static class BlockingQueueKinesis implements KinesisProxyInterface {
 
-		private Map<String, List<StreamShardHandle>> streamsWithListOfShards = new HashMap<>();
-		private Map<String, BlockingQueue<String>> shardIteratorToQueueMap = new HashMap<>();
+		private final Map<String, List<StreamShardHandle>> streamsWithListOfShards = new HashMap<>();
+		private final Map<String, BlockingQueue<String>> shardIteratorToQueueMap = new HashMap<>();
 
 		private static String getShardIterator(StreamShardHandle shardHandle) {
 			return shardHandle.getStreamName() + "-" + shardHandle.getShard().getShardId();

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
@@ -17,9 +17,27 @@
 
 package org.apache.flink.streaming.connectors.kinesis.testutils;
 
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 
+import com.amazonaws.kinesis.agg.AggRecord;
+import com.amazonaws.kinesis.agg.RecordAggregator;
+import com.amazonaws.services.kinesis.model.HashKeyRange;
+import com.amazonaws.services.kinesis.model.Record;
+import com.amazonaws.services.kinesis.model.SequenceNumberRange;
+import com.amazonaws.services.kinesis.model.Shard;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * General test utils.
@@ -36,4 +54,62 @@ public class TestUtils {
 
 		return config;
 	}
+
+	/**
+	 * Creates a batch of {@code numOfAggregatedRecords} aggregated records.
+	 * Each aggregated record contains {@code numOfChildRecords} child records.
+	 * Each record is assigned the sequence number: {@code sequenceNumber + index * numOfChildRecords}.
+	 * The next sequence number is output to the {@code sequenceNumber}.
+	 *
+	 * @param numOfAggregatedRecords the number of records in the batch
+	 * @param numOfChildRecords the number of child records for each aggregated record
+	 * @param sequenceNumber the starting sequence number, outputs the next sequence number
+	 * @return the batch af aggregated records
+	 */
+	public static List<Record> createAggregatedRecordBatch(
+			final int numOfAggregatedRecords,
+			final int numOfChildRecords,
+			final AtomicInteger sequenceNumber) {
+		List<Record> recordBatch = new ArrayList<>();
+		RecordAggregator recordAggregator = new RecordAggregator();
+
+		for (int record = 0; record < numOfAggregatedRecords; record++) {
+			String partitionKey = UUID.randomUUID().toString();
+
+			for (int child = 0; child < numOfChildRecords; child++) {
+				byte[] data = RandomStringUtils.randomAlphabetic(1024)
+					.getBytes(ConfigConstants.DEFAULT_CHARSET);
+
+				try {
+					recordAggregator.addUserRecord(partitionKey, data);
+				} catch (Exception e) {
+					throw new IllegalStateException("Error aggregating message", e);
+				}
+			}
+
+			AggRecord aggRecord = recordAggregator.clearAndGet();
+
+			recordBatch.add(new Record()
+				.withData(ByteBuffer.wrap(aggRecord.toRecordBytes()))
+				.withPartitionKey(partitionKey)
+				.withApproximateArrivalTimestamp(new Date(System.currentTimeMillis()))
+				.withSequenceNumber(String.valueOf(sequenceNumber.getAndAdd(numOfChildRecords))));
+		}
+
+		return recordBatch;
+	}
+
+	public static StreamShardHandle createDummyStreamShardHandle() {
+		final Shard shard = new Shard()
+			.withSequenceNumberRange(new SequenceNumberRange()
+				.withStartingSequenceNumber("0")
+				.withEndingSequenceNumber("9999999999999"))
+			.withHashKeyRange(new HashKeyRange()
+				.withStartingHashKey("0")
+				.withEndingHashKey(new BigInteger(StringUtils.repeat("FF", 16), 16).toString()))
+			.withShardId("000000");
+
+		return new StreamShardHandle("stream-name", shard);
+	}
+
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
@@ -18,10 +18,15 @@
 package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -31,6 +36,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Properties;
 
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.AWS_CREDENTIALS_PROVIDER;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider.ASSUME_ROLE;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider.AUTO;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider.BASIC;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.CredentialProvider.WEB_IDENTITY_TOKEN;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -55,10 +66,86 @@ public class AWSUtilTest {
 	@Test
 	public void testGetCredentialsProvider() {
 		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_CREDENTIALS_PROVIDER, "WEB_IDENTITY_TOKEN");
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "WEB_IDENTITY_TOKEN");
 
 		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
 		assertTrue(credentialsProvider instanceof WebIdentityTokenCredentialsProvider);
+	}
+
+	@Test
+	public void testGetCredentialsProviderTypeDefaultsAuto() {
+		assertEquals(AUTO, AWSUtil.getCredentialProviderType(new Properties(), AWS_CREDENTIALS_PROVIDER));
+	}
+
+	@Test
+	public void testGetCredentialsProviderTypeBasic() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.accessKeyId(AWS_CREDENTIALS_PROVIDER), "ak");
+		testConfig.setProperty(AWSConfigConstants.secretKey(AWS_CREDENTIALS_PROVIDER), "sk");
+
+		assertEquals(BASIC, AWSUtil.getCredentialProviderType(testConfig, AWS_CREDENTIALS_PROVIDER));
+	}
+
+	@Test
+	public void testGetCredentialsProviderTypeWebIdentityToken() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "WEB_IDENTITY_TOKEN");
+
+		CredentialProvider type = AWSUtil.getCredentialProviderType(testConfig, AWS_CREDENTIALS_PROVIDER);
+		assertEquals(WEB_IDENTITY_TOKEN, type);
+	}
+
+	@Test
+	public void testGetCredentialsProviderTypeAssumeRole() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "ASSUME_ROLE");
+
+		CredentialProvider type = AWSUtil.getCredentialProviderType(testConfig, AWS_CREDENTIALS_PROVIDER);
+		assertEquals(ASSUME_ROLE, type);
+	}
+
+	@Test
+	public void testGetCredentialsProviderEnvironmentVariables() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "ENV_VAR");
+
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
+
+		assertTrue(credentialsProvider instanceof EnvironmentVariableCredentialsProvider);
+	}
+
+	@Test
+	public void testGetCredentialsProviderSystemProperties() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "SYS_PROP");
+
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
+
+		assertTrue(credentialsProvider instanceof SystemPropertiesCredentialsProvider);
+	}
+
+	@Test
+	public void testGetCredentialsProviderBasic() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "BASIC");
+
+		testConfig.setProperty(AWSConfigConstants.accessKeyId(AWS_CREDENTIALS_PROVIDER), "ak");
+		testConfig.setProperty(AWSConfigConstants.secretKey(AWS_CREDENTIALS_PROVIDER), "sk");
+
+		AWSCredentials credentials = AWSUtil.getCredentialsProvider(testConfig).getCredentials();
+
+		assertEquals("ak", credentials.getAWSAccessKeyId());
+		assertEquals("sk", credentials.getAWSSecretKey());
+	}
+
+	@Test
+	public void testGetCredentialsProviderAuto() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "AUTO");
+
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
+
+		assertTrue(credentialsProvider instanceof DefaultAWSCredentialsProviderChain);
 	}
 
 	@Test
@@ -66,9 +153,41 @@ public class AWSUtilTest {
 		exception.expect(IllegalArgumentException.class);
 
 		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_CREDENTIALS_PROVIDER, "INVALID_PROVIDER");
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "INVALID_PROVIDER");
 
 		AWSUtil.getCredentialsProvider(testConfig);
+	}
+
+	@Test
+	public void testGetCredentialsProviderProfile() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "PROFILE");
+		testConfig.setProperty(AWSConfigConstants.profileName(AWS_CREDENTIALS_PROVIDER), "default");
+		testConfig.setProperty(AWSConfigConstants.profilePath(AWS_CREDENTIALS_PROVIDER), "src/test/resources/profile");
+
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
+
+		assertTrue(credentialsProvider instanceof ProfileCredentialsProvider);
+
+		AWSCredentials credentials = credentialsProvider.getCredentials();
+		assertEquals("11111111111111111111", credentials.getAWSAccessKeyId());
+		assertEquals("wJalrXUtnFEMI/K7MDENG/bPxRfiCY1111111111", credentials.getAWSSecretKey());
+	}
+
+	@Test
+	public void testGetCredentialsProviderNamedProfile() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "PROFILE");
+		testConfig.setProperty(AWSConfigConstants.profileName(AWS_CREDENTIALS_PROVIDER), "foo");
+		testConfig.setProperty(AWSConfigConstants.profilePath(AWS_CREDENTIALS_PROVIDER), "src/test/resources/profile");
+
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
+
+		assertTrue(credentialsProvider instanceof ProfileCredentialsProvider);
+
+		AWSCredentials credentials = credentialsProvider.getCredentials();
+		assertEquals("22222222222222222222", credentials.getAWSAccessKeyId());
+		assertEquals("wJalrXUtnFEMI/K7MDENG/bPxRfiCY2222222222", credentials.getAWSSecretKey());
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AwsV2UtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AwsV2UtilTest.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.util;
+
+import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.ClientConfigurationFactory;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClientBuilder;
+import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
+import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+import java.net.URI;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.AWS_CREDENTIALS_PROVIDER;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.AWS_REGION;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.roleArn;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.roleSessionName;
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.webIdentityTokenFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link AwsV2Util}.
+ */
+public class AwsV2UtilTest {
+
+	@Test
+	public void testGetCredentialsProviderEnvironmentVariables() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "ENV_VAR");
+
+		AwsCredentialsProvider credentialsProvider = AwsV2Util.getCredentialsProvider(properties);
+
+		assertTrue(credentialsProvider instanceof EnvironmentVariableCredentialsProvider);
+	}
+
+	@Test
+	public void testGetCredentialsProviderSystemProperties() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "SYS_PROP");
+
+		AwsCredentialsProvider credentialsProvider = AwsV2Util.getCredentialsProvider(properties);
+
+		assertTrue(credentialsProvider instanceof SystemPropertyCredentialsProvider);
+	}
+
+	@Test
+	public void testGetCredentialsProviderWebIdentityTokenFileCredentialsProvider() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "WEB_IDENTITY_TOKEN");
+
+		AwsCredentialsProvider credentialsProvider = AwsV2Util.getCredentialsProvider(properties);
+
+		assertTrue(credentialsProvider instanceof WebIdentityTokenFileCredentialsProvider);
+	}
+
+	@Test
+	public void testGetWebIdentityTokenFileCredentialsProvider() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "WEB_IDENTITY_TOKEN");
+		properties.setProperty(roleArn(AWS_CREDENTIALS_PROVIDER), "roleArn");
+		properties.setProperty(roleSessionName(AWS_CREDENTIALS_PROVIDER), "roleSessionName");
+
+		WebIdentityTokenFileCredentialsProvider.Builder builder = mockWebIdentityTokenFileCredentialsProviderBuilder();
+
+		AwsV2Util.getWebIdentityTokenFileCredentialsProvider(builder, properties, AWS_CREDENTIALS_PROVIDER);
+
+		verify(builder).roleArn("roleArn");
+		verify(builder).roleSessionName("roleSessionName");
+		verify(builder, never()).webIdentityTokenFile(any());
+	}
+
+	@Test
+	public void testGetWebIdentityTokenFileCredentialsProviderWithWebIdentityFile() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "WEB_IDENTITY_TOKEN");
+		properties.setProperty(webIdentityTokenFile(AWS_CREDENTIALS_PROVIDER), "webIdentityTokenFile");
+
+		WebIdentityTokenFileCredentialsProvider.Builder builder = mockWebIdentityTokenFileCredentialsProviderBuilder();
+
+		AwsV2Util.getWebIdentityTokenFileCredentialsProvider(builder, properties, AWS_CREDENTIALS_PROVIDER);
+
+		verify(builder).webIdentityTokenFile(Paths.get("webIdentityTokenFile"));
+	}
+
+	@Test
+	public void testGetCredentialsProviderAuto() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "AUTO");
+
+		AwsCredentialsProvider credentialsProvider = AwsV2Util.getCredentialsProvider(properties);
+
+		assertTrue(credentialsProvider instanceof DefaultCredentialsProvider);
+	}
+
+	@Test
+	public void testGetCredentialsProviderAssumeRole() {
+		Properties properties = spy(properties(AWS_CREDENTIALS_PROVIDER, "ASSUME_ROLE"));
+		properties.setProperty(AWS_REGION, "eu-west-2");
+
+		AwsCredentialsProvider credentialsProvider = AwsV2Util.getCredentialsProvider(properties);
+
+		assertTrue(credentialsProvider instanceof StsAssumeRoleCredentialsProvider);
+
+		verify(properties).getProperty(AWSConfigConstants.roleArn(AWS_CREDENTIALS_PROVIDER));
+		verify(properties).getProperty(AWSConfigConstants.roleSessionName(AWS_CREDENTIALS_PROVIDER));
+		verify(properties).getProperty(AWSConfigConstants.externalId(AWS_CREDENTIALS_PROVIDER));
+		verify(properties).getProperty(AWS_REGION);
+	}
+
+	@Test
+	public void testGetCredentialsProviderBasic() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "BASIC");
+		properties.setProperty(AWSConfigConstants.accessKeyId(AWS_CREDENTIALS_PROVIDER), "ak");
+		properties.setProperty(AWSConfigConstants.secretKey(AWS_CREDENTIALS_PROVIDER), "sk");
+
+		AwsCredentials credentials = AwsV2Util.getCredentialsProvider(properties).resolveCredentials();
+
+		assertEquals("ak", credentials.accessKeyId());
+		assertEquals("sk", credentials.secretAccessKey());
+	}
+
+	@Test
+	public void testGetCredentialsProviderProfile() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "PROFILE");
+		properties.put(AWSConfigConstants.profileName(AWS_CREDENTIALS_PROVIDER), "default");
+		properties.put(AWSConfigConstants.profilePath(AWS_CREDENTIALS_PROVIDER), "src/test/resources/profile");
+
+		AwsCredentialsProvider credentialsProvider = AwsV2Util.getCredentialsProvider(properties);
+
+		assertTrue(credentialsProvider instanceof ProfileCredentialsProvider);
+
+		AwsCredentials credentials = credentialsProvider.resolveCredentials();
+		assertEquals("11111111111111111111", credentials.accessKeyId());
+		assertEquals("wJalrXUtnFEMI/K7MDENG/bPxRfiCY1111111111", credentials.secretAccessKey());
+	}
+
+	@Test
+	public void testGetCredentialsProviderNamedProfile() {
+		Properties properties = properties(AWS_CREDENTIALS_PROVIDER, "PROFILE");
+		properties.setProperty(AWSConfigConstants.profileName(AWS_CREDENTIALS_PROVIDER), "foo");
+		properties.setProperty(AWSConfigConstants.profilePath(AWS_CREDENTIALS_PROVIDER), "src/test/resources/profile");
+
+		AwsCredentialsProvider credentialsProvider = AwsV2Util.getCredentialsProvider(properties);
+
+		assertTrue(credentialsProvider instanceof ProfileCredentialsProvider);
+
+		AwsCredentials credentials = credentialsProvider.resolveCredentials();
+		assertEquals("22222222222222222222", credentials.accessKeyId());
+		assertEquals("wJalrXUtnFEMI/K7MDENG/bPxRfiCY2222222222", credentials.secretAccessKey());
+	}
+
+	@Test
+	public void testGetRegion() {
+		Region region = AwsV2Util.getRegion(properties(AWS_REGION, "eu-west-2"));
+
+		assertEquals(Region.EU_WEST_2, region);
+	}
+
+	@Test
+	public void testCreateKinesisAsyncClient() {
+		Properties properties = properties(AWS_REGION, "eu-west-2");
+		KinesisAsyncClientBuilder builder = mockKinesisAsyncClientBuilder();
+		ClientOverrideConfiguration clientOverrideConfiguration = ClientOverrideConfiguration.builder().build();
+		SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
+
+		AwsV2Util.createKinesisAsyncClient(properties, builder, httpClient, clientOverrideConfiguration);
+
+		verify(builder).overrideConfiguration(clientOverrideConfiguration);
+		verify(builder).httpClient(httpClient);
+		verify(builder).region(Region.of("eu-west-2"));
+		verify(builder).credentialsProvider(argThat(cp -> cp instanceof DefaultCredentialsProvider));
+		verify(builder, never()).endpointOverride(any());
+	}
+
+	@Test
+	public void testCreateKinesisAsyncClientWithEndpointOverride() {
+		Properties properties = properties(AWS_REGION, "eu-west-2");
+		properties.setProperty(ConsumerConfigConstants.AWS_ENDPOINT, "https://localhost");
+
+		KinesisAsyncClientBuilder builder = mockKinesisAsyncClientBuilder();
+		ClientOverrideConfiguration clientOverrideConfiguration = ClientOverrideConfiguration.builder().build();
+		SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
+
+		AwsV2Util.createKinesisAsyncClient(properties, builder, httpClient, clientOverrideConfiguration);
+
+		verify(builder).endpointOverride(URI.create("https://localhost"));
+	}
+
+	@Test
+	public void testCreateNettyHttpClientWithDefaults() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		NettyNioAsyncHttpClient.Builder builder = mockHttpClientBuilder();
+
+		AwsV2Util.createHttpClient(clientConfiguration, builder);
+
+		verify(builder).build();
+		verify(builder).maxConcurrency(50);
+		verify(builder).connectionTimeout(Duration.ofSeconds(10));
+		verify(builder).writeTimeout(Duration.ofSeconds(50));
+		verify(builder).connectionMaxIdleTime(Duration.ofMinutes(1));
+		verify(builder).useIdleConnectionReaper(true);
+		verify(builder, never()).connectionTimeToLive(any());
+	}
+
+	@Test
+	public void testCreateNettyHttpClientMaxConcurrency() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setMaxConnections(100);
+
+		NettyNioAsyncHttpClient.Builder builder = mockHttpClientBuilder();
+
+		AwsV2Util.createHttpClient(clientConfiguration, builder);
+
+		verify(builder).maxConcurrency(100);
+	}
+
+	@Test
+	public void testCreateNettyHttpClientConnectionTimeout() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setConnectionTimeout(1000);
+
+		NettyNioAsyncHttpClient.Builder builder = mockHttpClientBuilder();
+
+		AwsV2Util.createHttpClient(clientConfiguration, builder);
+
+		verify(builder).connectionTimeout(Duration.ofSeconds(1));
+	}
+
+	@Test
+	public void testCreateNettyHttpClientWriteTimeout() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setSocketTimeout(3000);
+
+		NettyNioAsyncHttpClient.Builder builder = mockHttpClientBuilder();
+
+		AwsV2Util.createHttpClient(clientConfiguration, builder);
+
+		verify(builder).writeTimeout(Duration.ofSeconds(3));
+	}
+
+	@Test
+	public void testCreateNettyHttpClientConnectionMaxIdleTime() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setConnectionMaxIdleMillis(2000);
+
+		NettyNioAsyncHttpClient.Builder builder = mockHttpClientBuilder();
+
+		AwsV2Util.createHttpClient(clientConfiguration, builder);
+
+		verify(builder).connectionMaxIdleTime(Duration.ofSeconds(2));
+	}
+
+	@Test
+	public void testCreateNettyHttpClientIdleConnectionReaper() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setUseReaper(false);
+
+		NettyNioAsyncHttpClient.Builder builder = mockHttpClientBuilder();
+
+		AwsV2Util.createHttpClient(clientConfiguration, builder);
+
+		verify(builder).useIdleConnectionReaper(false);
+	}
+
+	@Test
+	public void testCreateNettyHttpClientIdleConnectionTtl() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setConnectionTTL(5000);
+
+		NettyNioAsyncHttpClient.Builder builder = mockHttpClientBuilder();
+
+		AwsV2Util.createHttpClient(clientConfiguration, builder);
+
+		verify(builder).connectionTimeToLive(Duration.ofSeconds(5));
+	}
+
+	@Test
+	public void testClientOverrideConfigurationWithDefaults() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		ClientOverrideConfiguration.Builder builder = mockClientOverrideConfigurationBuilder();
+
+		AwsV2Util.createClientOverrideConfiguration(clientConfiguration, builder);
+
+		verify(builder).build();
+		verify(builder).putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, AWSUtil.formatFlinkUserAgentPrefix());
+		verify(builder).putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX, null);
+		verify(builder, never()).apiCallAttemptTimeout(any());
+		verify(builder, never()).apiCallTimeout(any());
+	}
+
+	@Test
+	public void testClientOverrideConfigurationUserAgentSuffix() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setUserAgentSuffix("suffix");
+
+		ClientOverrideConfiguration.Builder builder = mockClientOverrideConfigurationBuilder();
+
+		AwsV2Util.createClientOverrideConfiguration(clientConfiguration, builder);
+
+		verify(builder).putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX, "suffix");
+	}
+
+	@Test
+	public void testClientOverrideConfigurationApiCallAttemptTimeout() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setRequestTimeout(500);
+
+		ClientOverrideConfiguration.Builder builder = mockClientOverrideConfigurationBuilder();
+
+		AwsV2Util.createClientOverrideConfiguration(clientConfiguration, builder);
+
+		verify(builder).apiCallAttemptTimeout(Duration.ofMillis(500));
+	}
+
+	@Test
+	public void testClientOverrideConfigurationApiCallTimeout() {
+		ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		clientConfiguration.setClientExecutionTimeout(600);
+
+		ClientOverrideConfiguration.Builder builder = mockClientOverrideConfigurationBuilder();
+
+		AwsV2Util.createClientOverrideConfiguration(clientConfiguration, builder);
+
+		verify(builder).apiCallTimeout(Duration.ofMillis(600));
+	}
+
+	@Test
+	public void testIsRecoverableException() {
+		Exception notAwsEx = new IllegalArgumentException("abc");
+		Exception awsNotRecoverableEx = ResourceNotFoundException.builder().cause(notAwsEx).build();
+		Exception awsRecoverableEx = LimitExceededException.builder().cause(notAwsEx).build();
+		assertFalse(AwsV2Util.isRecoverableException(new ExecutionException(notAwsEx)));
+		assertFalse(AwsV2Util.isRecoverableException(new ExecutionException(awsNotRecoverableEx)));
+		assertTrue(AwsV2Util.isRecoverableException(new ExecutionException(awsRecoverableEx)));
+	}
+
+	private Properties properties(final String key, final String value) {
+		Properties properties = new Properties();
+		properties.setProperty(key, value);
+		return properties;
+	}
+
+	private KinesisAsyncClientBuilder mockKinesisAsyncClientBuilder() {
+		KinesisAsyncClientBuilder builder = mock(KinesisAsyncClientBuilder.class);
+		when(builder.overrideConfiguration(any(ClientOverrideConfiguration.class))).thenReturn(builder);
+		when(builder.httpClient(any())).thenReturn(builder);
+		when(builder.credentialsProvider(any())).thenReturn(builder);
+		when(builder.region(any())).thenReturn(builder);
+
+		return builder;
+	}
+
+	private NettyNioAsyncHttpClient.Builder mockHttpClientBuilder() {
+		NettyNioAsyncHttpClient.Builder builder = mock(NettyNioAsyncHttpClient.Builder.class);
+		when(builder.maxConcurrency(anyInt())).thenReturn(builder);
+		when(builder.connectionTimeout(any())).thenReturn(builder);
+		when(builder.writeTimeout(any())).thenReturn(builder);
+		when(builder.connectionMaxIdleTime(any())).thenReturn(builder);
+		when(builder.useIdleConnectionReaper(anyBoolean())).thenReturn(builder);
+
+		return builder;
+	}
+
+	private ClientOverrideConfiguration.Builder mockClientOverrideConfigurationBuilder() {
+		ClientOverrideConfiguration.Builder builder = mock(ClientOverrideConfiguration.Builder.class);
+		when(builder.putAdvancedOption(any(), any())).thenReturn(builder);
+		when(builder.apiCallAttemptTimeout(any())).thenReturn(builder);
+		when(builder.apiCallTimeout(any())).thenReturn(builder);
+
+		return builder;
+	}
+
+	private WebIdentityTokenFileCredentialsProvider.Builder mockWebIdentityTokenFileCredentialsProviderBuilder() {
+		WebIdentityTokenFileCredentialsProvider.Builder builder = mock(WebIdentityTokenFileCredentialsProvider.Builder.class);
+		when(builder.roleArn(any())).thenReturn(builder);
+		when(builder.roleSessionName(any())).thenReturn(builder);
+		when(builder.webIdentityTokenFile(any())).thenReturn(builder);
+
+		return builder;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -204,10 +204,10 @@ public class KinesisConfigUtilTest {
 
 		KinesisConfigUtil.validateRecordPublisherType(testConfig);
 	}
+
 	// ----------------------------------------------------------------------
 	// validateEfoConfiguration() tests
 	// ----------------------------------------------------------------------
-
 	@Test
 	public void testNoEfoRegistrationTypeInConfig() {
 		Properties testConfig = TestUtils.getStandardProperties();

--- a/flink-connectors/flink-connector-kinesis/src/test/resources/profile
+++ b/flink-connectors/flink-connector-kinesis/src/test/resources/profile
@@ -1,0 +1,7 @@
+[default]
+aws_access_key_id=11111111111111111111
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCY1111111111
+
+[foo]
+aws_access_key_id=22222222222222222222
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCY2222222222


### PR DESCRIPTION

## What is the purpose of the change

*This is the milestone of [FLIP-128](https://cwiki.apache.org/confluence/display/FLINK/FLIP-128%3A+Enhanced+Fan+Out+for+AWS+Kinesis+Consumers) to add EFO support to the FlinkKinesisConsumer. 
The de-/regisiterStream operations has been introduce.* 
[JIRA issue](https://issues.apache.org/jira/browse/FLINK-18661)

## Note
This PR is blocked by:
- Test coverage improvements:
  - [JIRA issue](https://issues.apache.org/jira/browse/FLINK-18483)
  - [Pull request](https://github.com/apache/flink/pull/12850)
- Introducing RecordPublisher.
   - [JIRA issue](https://issues.apache.org/jira/browse/FLINK-18512)
   - [Pull request](https://github.com/apache/flink/pull/12881)
 - Add AWS SDK v2.x dependency and KinesisProxyV2
   - [JIRA issue](https://issues.apache.org/jira/browse/FLINK-18513)
   - [Pull request](https://github.com/apache/flink/pull/12944)
-  Configuration deserialisation and validation
   - [JIRA issue](https://issues.apache.org/jira/browse/FLINK-18536)
   - [Pull request](https://github.com/apache/flink/pull/12920)
   
 

## Brief change log

  - `ConsumerConstants`
    - *Add the describe stream and descrbie stream consumer operation parameters.* 
  - `KinesisConfigUtil`
      - *Add the validation of the above parameter*
   - `FanOutStreamInfo`
       - *Add a new data class for storing enhanced fan-out consumer info.*
   - `FlinkDataFetcher`
       - *Add a KinesisProxyV2Interface in order to register stream consumers when the efo registration mode is set to eager.*
   - `ShardConsumer`
     - *Add a KinesisProxyV2Interface in order to de-/register stream consumers when the efo registration mode is set to lazy.*
   - `KinesisProxyV2Interface` & `KinesisProxyV2`
     - *Add the de-/register stream consumer operations here.*
   - `AwsV2Util`
     - *Add several methods to classify exceptions.* 


## Verifying this change

This change added tests and can be verified as follows:

  - *`KinesisProxyV2Test`*
  - *`AwsV2UtilTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
