### PR TITLE
[FLINK-18682][orc][hive] Vector orc reader cannot read Hive 2.0.0 table

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
@@ -130,10 +130,7 @@ public class TableEnvHiveConnectorITCase {
 	public void testDifferentFormats() throws Exception {
 		String[] formats = new String[]{"orc", "parquet", "sequencefile", "csv", "avro"};
 		for (String format : formats) {
-			if (format.equals("orc") && HiveShimLoader.getHiveVersion().startsWith("2.0")) {
-				// Ignore orc test for Hive version 2.0.x for now due to FLINK-13998
-				continue;
-			} else if (format.equals("avro") && !HiveVersionTestUtil.HIVE_110_OR_LATER) {
+			if (format.equals("avro") && !HiveVersionTestUtil.HIVE_110_OR_LATER) {
 				// timestamp is not supported for avro tables before 1.1.0
 				continue;
 			}
@@ -190,11 +187,14 @@ public class TableEnvHiveConnectorITCase {
 
 		verifyFlinkQueryResult(tableEnv.sqlQuery("select * from db1.src"), expected);
 
-		// populate dest table with source table
-		TableEnvUtil.execInsertSqlAndWaitResult(tableEnv, "insert into db1.dest select * from db1.src");
+		// Ignore orc write test for Hive version 2.0.x for now due to FLINK-13998
+		if (!format.equals("orc") || !HiveShimLoader.getHiveVersion().startsWith("2.0")) {
+			// populate dest table with source table
+			TableEnvUtil.execInsertSqlAndWaitResult(tableEnv, "insert into db1.dest select * from db1.src");
 
-		// verify data on hive side
-		verifyHiveQueryResult("select * from db1.dest", expected);
+			// verify data on hive side
+			verifyHiveQueryResult("select * from db1.dest", expected);
+		}
 
 		tableEnv.executeSql("drop database db1 cascade");
 	}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
@@ -80,7 +80,7 @@ public class OrcSplitReaderUtil {
 				LogicalType type = fullFieldTypes[selectedFields[i]].getLogicalType();
 				vectors[i] = partitionSpec.containsKey(name) ?
 						createFlinkVectorFromConstant(type, partitionSpec.get(name), batchSize) :
-						createFlinkVector(rowBatch.cols[nonPartNames.indexOf(name)]);
+						createFlinkVector(rowBatch.cols[nonPartNames.indexOf(name)], type);
 			}
 			return new VectorizedColumnBatch(vectors);
 		};

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/TimestampUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/TimestampUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.orc.vector.OrcLegacyTimestampColumnVector;
+import org.apache.flink.orc.vector.OrcTimestampColumnVector;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Util class to handle timestamp vectors. It's responsible for deciding whether new or legacy (Hive 2.0.x) timestamp
+ * column vector should be used.
+ */
+public class TimestampUtil {
+
+	private TimestampUtil() {
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(OrcLegacyTimestampColumnVector.class);
+
+	private static Class hiveTSColVectorClz = null;
+
+	static {
+		try {
+			hiveTSColVectorClz = Class.forName("org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector");
+		} catch (ClassNotFoundException e) {
+			LOG.debug("Hive TimestampColumnVector not available", e);
+		}
+	}
+
+	// whether a ColumnVector is the new TimestampColumnVector
+	public static boolean isHiveTimestampColumnVector(ColumnVector vector) {
+		return hiveTSColVectorClz != null && hiveTSColVectorClz.isAssignableFrom(vector.getClass());
+	}
+
+	// creates a Hive ColumnVector of constant timestamp value
+	public static ColumnVector createVectorFromConstant(int batchSize, Object value) {
+		if (hiveTSColVectorClz != null) {
+			return OrcTimestampColumnVector.createFromConstant(batchSize, value);
+		} else {
+			return OrcLegacyTimestampColumnVector.createFromConstant(batchSize, value);
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -20,6 +20,7 @@ package org.apache.flink.orc.vector;
 
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -27,14 +28,11 @@ import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.dateToInternal;
 
@@ -56,17 +54,21 @@ public abstract class AbstractOrcColumnVector implements
 	}
 
 	public static org.apache.flink.table.data.vector.ColumnVector createFlinkVector(
-			ColumnVector vector) {
+			ColumnVector vector, LogicalType logicalType) {
 		if (vector instanceof LongColumnVector) {
-			return new OrcLongColumnVector((LongColumnVector) vector);
+			if (logicalType.getTypeRoot() == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+				return new OrcLegacyTimestampColumnVector(vector);
+			} else {
+				return new OrcLongColumnVector((LongColumnVector) vector);
+			}
 		} else if (vector instanceof DoubleColumnVector) {
 			return new OrcDoubleColumnVector((DoubleColumnVector) vector);
 		} else if (vector instanceof BytesColumnVector) {
 			return new OrcBytesColumnVector((BytesColumnVector) vector);
 		} else if (vector instanceof DecimalColumnVector) {
 			return new OrcDecimalColumnVector((DecimalColumnVector) vector);
-		} else if (vector instanceof TimestampColumnVector) {
-			return new OrcTimestampColumnVector((TimestampColumnVector) vector);
+		} else if (OrcLegacyTimestampColumnVector.isHiveTimestampColumnVector(vector)) {
+			return new OrcTimestampColumnVector(vector);
 		} else {
 			throw new UnsupportedOperationException("Unsupport vector: " + vector.getClass().getName());
 		}
@@ -77,7 +79,7 @@ public abstract class AbstractOrcColumnVector implements
 	 */
 	public static org.apache.flink.table.data.vector.ColumnVector createFlinkVectorFromConstant(
 			LogicalType type, Object value, int batchSize) {
-		return createFlinkVector(createHiveVectorFromConstant(type, value, batchSize));
+		return createFlinkVector(createHiveVectorFromConstant(type, value, batchSize), type);
 	}
 
 	/**
@@ -112,7 +114,7 @@ public abstract class AbstractOrcColumnVector implements
 				}
 				return createLongVector(batchSize, dateToInternal((Date) value));
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				return createTimestampVector(batchSize, value);
+				return OrcLegacyTimestampColumnVector.createFromConstant(batchSize, value);
 			default:
 				throw new UnsupportedOperationException("Unsupported type: " + type);
 		}
@@ -175,20 +177,5 @@ public abstract class AbstractOrcColumnVector implements
 			dcv.isNull[0] = false;
 		}
 		return dcv;
-	}
-
-	private static TimestampColumnVector createTimestampVector(int batchSize, Object value) {
-		TimestampColumnVector lcv = new TimestampColumnVector(batchSize);
-		if (value == null) {
-			lcv.noNulls = false;
-			lcv.isNull[0] = true;
-			lcv.isRepeating = true;
-		} else {
-			Timestamp timestamp = value instanceof LocalDateTime ?
-				Timestamp.valueOf((LocalDateTime) value) : (Timestamp) value;
-			lcv.fill(timestamp);
-			lcv.isNull[0] = false;
-		}
-		return lcv;
 	}
 }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.orc.vector;
 
+import org.apache.flink.orc.TimestampUtil;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
@@ -57,7 +58,7 @@ public abstract class AbstractOrcColumnVector implements
 			ColumnVector vector, LogicalType logicalType) {
 		if (vector instanceof LongColumnVector) {
 			if (logicalType.getTypeRoot() == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
-				return new OrcLegacyTimestampColumnVector(vector);
+				return new OrcLegacyTimestampColumnVector((LongColumnVector) vector);
 			} else {
 				return new OrcLongColumnVector((LongColumnVector) vector);
 			}
@@ -67,7 +68,7 @@ public abstract class AbstractOrcColumnVector implements
 			return new OrcBytesColumnVector((BytesColumnVector) vector);
 		} else if (vector instanceof DecimalColumnVector) {
 			return new OrcDecimalColumnVector((DecimalColumnVector) vector);
-		} else if (OrcLegacyTimestampColumnVector.isHiveTimestampColumnVector(vector)) {
+		} else if (TimestampUtil.isHiveTimestampColumnVector(vector)) {
 			return new OrcTimestampColumnVector(vector);
 		} else {
 			throw new UnsupportedOperationException("Unsupport vector: " + vector.getClass().getName());
@@ -114,7 +115,7 @@ public abstract class AbstractOrcColumnVector implements
 				}
 				return createLongVector(batchSize, dateToInternal((Date) value));
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				return OrcLegacyTimestampColumnVector.createFromConstant(batchSize, value);
+				return TimestampUtil.createVectorFromConstant(batchSize, value);
 			default:
 				throw new UnsupportedOperationException("Unsupported type: " + type);
 		}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcLegacyTimestampColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcLegacyTimestampColumnVector.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.vector;
+
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+/**
+ * This class is used to adapt to Hive's legacy (2.0.x) timestamp column vector which is a LongColumnVector.
+ * This class does not import TimestampColumnVector and provides utils to decide whether new or legacy column
+ * vector should be used.
+ */
+public class OrcLegacyTimestampColumnVector extends AbstractOrcColumnVector implements
+		org.apache.flink.table.data.vector.TimestampColumnVector {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OrcLegacyTimestampColumnVector.class);
+
+	private static Class hiveTSColVectorClz;
+	private static Constructor constructor;
+	private static Method getTimeMethod;
+	private static Method getNanosMethod;
+	private static Method fillMethod;
+	private static boolean hiveTSColVectorAvailable = false;
+
+	static {
+		try {
+			hiveTSColVectorClz = Class.forName("org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector");
+			constructor = hiveTSColVectorClz.getConstructor(int.class);
+			getTimeMethod = hiveTSColVectorClz.getDeclaredMethod("getTime", int.class);
+			getNanosMethod = hiveTSColVectorClz.getDeclaredMethod("getNanos", int.class);
+			fillMethod = hiveTSColVectorClz.getDeclaredMethod("fill", Timestamp.class);
+			hiveTSColVectorAvailable = true;
+		} catch (ClassNotFoundException | NoSuchMethodException e) {
+			LOG.debug("Hive TimestampColumnVector not available", e);
+		}
+	}
+
+	private final ColumnVector hiveVector;
+
+	OrcLegacyTimestampColumnVector(ColumnVector vector) {
+		super(vector);
+		if (isHiveTimestampColumnVector(vector) || vector instanceof LongColumnVector) {
+			this.hiveVector = vector;
+		} else {
+			throw new IllegalArgumentException("Unsupported column vector type for timestamp: " + vector.getClass().getName());
+		}
+	}
+
+	@Override
+	public TimestampData getTimestamp(int i, int precision) {
+		int index = hiveVector.isRepeating ? 0 : i;
+		Timestamp timestamp;
+		if (hiveTSColVectorAvailable) {
+			timestamp = new Timestamp(getTime(index));
+			timestamp.setNanos(getNanos(index));
+		} else {
+			timestamp = toTimestamp(((LongColumnVector) hiveVector).vector[index]);
+		}
+		return TimestampData.fromTimestamp(timestamp);
+	}
+
+	private long getTime(int index) {
+		try {
+			return (long) getTimeMethod.invoke(hiveVector, index);
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new FlinkRuntimeException(e);
+		}
+	}
+
+	private int getNanos(int index) {
+		try {
+			return (int) getNanosMethod.invoke(hiveVector, index);
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new FlinkRuntimeException(e);
+		}
+	}
+
+	private void fill(Timestamp timestamp) {
+		try {
+			if (hiveTSColVectorAvailable) {
+				fillMethod.invoke(hiveVector, timestamp);
+			} else {
+				((LongColumnVector) hiveVector).fill(fromTimestamp(timestamp));
+			}
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new FlinkRuntimeException(e);
+		}
+	}
+
+	static boolean isHiveTimestampColumnVector(ColumnVector vector) {
+		return hiveTSColVectorAvailable && hiveTSColVectorClz.isAssignableFrom(vector.getClass());
+	}
+
+	// creates a Hive ColumnVector of constant timestamp value
+	static ColumnVector createFromConstant(int batchSize, Object value) {
+		OrcLegacyTimestampColumnVector columnVector = new OrcLegacyTimestampColumnVector(createHiveColumnVector(batchSize));
+		if (value == null) {
+			columnVector.hiveVector.noNulls = false;
+			columnVector.hiveVector.isNull[0] = true;
+			columnVector.hiveVector.isRepeating = true;
+		} else {
+			Timestamp timestamp = value instanceof LocalDateTime ?
+					Timestamp.valueOf((LocalDateTime) value) : (Timestamp) value;
+			columnVector.fill(timestamp);
+			columnVector.hiveVector.isNull[0] = false;
+		}
+		return columnVector.hiveVector;
+	}
+
+	private static ColumnVector createHiveColumnVector(int len) {
+		try {
+			if (hiveTSColVectorAvailable) {
+				return (ColumnVector) constructor.newInstance(len);
+			} else {
+				return new LongColumnVector(len);
+			}
+		} catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+			throw new FlinkRuntimeException(e);
+		}
+	}
+
+	// converting from/to Timestamp is copied from Hive 2.0.0 TimestampUtils
+	private static long fromTimestamp(Timestamp timestamp) {
+		long time = timestamp.getTime();
+		int nanos = timestamp.getNanos();
+		return (time * 1000000) + (nanos % 1000000);
+	}
+
+	private static Timestamp toTimestamp(long timeInNanoSec) {
+		long integralSecInMillis = (timeInNanoSec / 1000000000) * 1000; // Full seconds converted to millis.
+		long nanos = timeInNanoSec % 1000000000; // The nanoseconds.
+		if (nanos < 0) {
+			nanos = 1000000000 + nanos; // The positive nano-part that will be added to milliseconds.
+			integralSecInMillis = ((timeInNanoSec / 1000000000) - 1) * 1000; // Reduce by one second.
+		}
+		Timestamp res = new Timestamp(0);
+		res.setTime(integralSecInMillis);
+		res.setNanos((int) nanos);
+		return res;
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcTimestampColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcTimestampColumnVector.java
@@ -20,6 +20,7 @@ package org.apache.flink.orc.vector;
 
 import org.apache.flink.table.data.TimestampData;
 
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 
 import java.sql.Timestamp;
@@ -33,9 +34,9 @@ public class OrcTimestampColumnVector extends AbstractOrcColumnVector implements
 
 	private TimestampColumnVector vector;
 
-	public OrcTimestampColumnVector(TimestampColumnVector vector) {
+	public OrcTimestampColumnVector(ColumnVector vector) {
 		super(vector);
-		this.vector = vector;
+		this.vector = (TimestampColumnVector) vector;
 	}
 
 	@Override

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcTimestampColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcTimestampColumnVector.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 /**
  * This column vector is used to adapt hive's TimestampColumnVector to
@@ -45,5 +46,20 @@ public class OrcTimestampColumnVector extends AbstractOrcColumnVector implements
 		Timestamp timestamp = new Timestamp(vector.time[index]);
 		timestamp.setNanos(vector.nanos[index]);
 		return TimestampData.fromTimestamp(timestamp);
+	}
+
+	public static ColumnVector createFromConstant(int batchSize, Object value) {
+		TimestampColumnVector res = new TimestampColumnVector(batchSize);
+		if (value == null) {
+			res.noNulls = false;
+			res.isNull[0] = true;
+			res.isRepeating = true;
+		} else {
+			Timestamp timestamp = value instanceof LocalDateTime ?
+					Timestamp.valueOf((LocalDateTime) value) : (Timestamp) value;
+			res.fill(timestamp);
+			res.isNull[0] = false;
+		}
+		return res;
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the issue that vector orc reader doesn't support Hive 2.0.0. Need to solve two problems:
1. `org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector` is not available in Hive 2.0.0. `AbstractOrcColumnVector::createFlinkVector` will throw CNFE.
2. Timestamp is stored with `LongColumnVector` in 2.0.0.


## Brief change log

  - Add `OrcLegacyTimestampColumnVector` to get timestamps from `LongColumnVector`.
  - `OrcLegacyTimestampColumnVector` also provides util methods to decide whether new or legacy column vector should be used.
  - Enable orc read test for 2.0.0 in `TableEnvHiveConnectorITCase`.


## Verifying this change

Existing and new test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
