### PR TITLE
[FLINK-18703][table] Use new data structure converters when legacy types are not present

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
@@ -84,11 +85,22 @@ public final class LogicalTypeChecks {
 	}
 
 	/**
-	 * Checks whether a (possibly nested) logical type contains the given root.
+	 * Checks whether a (possibly nested) logical type fulfills the given predicate.
 	 */
-	public static boolean hasNestedRoot(LogicalType logicalType, LogicalTypeRoot typeRoot) {
-		final NestedTypeSearcher rootSearcher = new NestedTypeSearcher((t) -> hasRoot(t, typeRoot));
-		return logicalType.accept(rootSearcher).isPresent();
+	public static boolean hasNested(LogicalType logicalType, Predicate<LogicalType> predicate) {
+		final NestedTypeSearcher typeSearcher = new NestedTypeSearcher(predicate);
+		return logicalType.accept(typeSearcher).isPresent();
+	}
+
+	/**
+	 * Checks whether a (possibly nested) logical type contains {@link LegacyTypeInformationType} or
+	 * {@link TypeInformationRawType}.
+	 */
+	public static boolean hasLegacyTypes(LogicalType logicalType) {
+		return hasNested(
+			logicalType,
+			t -> t instanceof LegacyTypeInformationType || t instanceof TypeInformationRawType
+		);
 	}
 
 	public static boolean hasFamily(LogicalType logicalType, LogicalTypeFamily family) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecksTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecksTest.java
@@ -38,6 +38,7 @@ import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -47,18 +48,18 @@ import static org.junit.Assert.assertThat;
 public class LogicalTypeChecksTest {
 
 	@Test
-	public void testHasNestedRoot() {
+	public void testHasNested() {
 		final DataType dataType = ROW(FIELD("f0", INT()), FIELD("f1", STRING()));
 		assertThat(
-			LogicalTypeChecks.hasNestedRoot(dataType.getLogicalType(), LogicalTypeRoot.VARCHAR),
+			LogicalTypeChecks.hasNested(dataType.getLogicalType(), t -> hasRoot(t, LogicalTypeRoot.VARCHAR)),
 			is(true));
 
 		assertThat(
-			LogicalTypeChecks.hasNestedRoot(dataType.getLogicalType(), LogicalTypeRoot.ROW),
+			LogicalTypeChecks.hasNested(dataType.getLogicalType(), t -> hasRoot(t, LogicalTypeRoot.ROW)),
 			is(true));
 
 		assertThat(
-			LogicalTypeChecks.hasNestedRoot(dataType.getLogicalType(), LogicalTypeRoot.BOOLEAN),
+			LogicalTypeChecks.hasNested(dataType.getLogicalType(), t -> hasRoot(t, LogicalTypeRoot.BOOLEAN)),
 			is(false));
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -18,11 +18,8 @@
 
 package org.apache.flink.table.planner.codegen
 
-import java.lang.reflect.Method
-import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Object => JObject, Short => JShort}
-import java.util.concurrent.atomic.AtomicInteger
-
 import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.functions.RuntimeContext
 import org.apache.flink.core.memory.MemorySegment
 import org.apache.flink.table.data._
 import org.apache.flink.table.data.binary.BinaryRowDataUtil.BYTE_ARRAY_BASE_OFFSET
@@ -41,11 +38,15 @@ import org.apache.flink.table.runtime.util.MurmurHashUtil
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCount, getPrecision, getScale, hasRoot}
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils.toInternalConversionClass
-import org.apache.flink.table.types.utils.DataTypeUtils
 import org.apache.flink.table.types.utils.DataTypeUtils.isInternal
 import org.apache.flink.types.{Row, RowKind}
+
+import java.lang.reflect.Method
+import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Object => JObject, Short => JShort}
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.annotation.tailrec
 
@@ -110,6 +111,8 @@ object CodeGenUtils {
   val BINARY_STRING_UTIL: String = className[BinaryStringDataUtil]
 
   val TIMESTAMP_DATA: String = className[TimestampData]
+
+  val RUNTIME_CONTEXT: String = className[RuntimeContext]
 
   // ----------------------------------------------------------------------------------------
 
@@ -789,6 +792,12 @@ object CodeGenUtils {
       ctx: CodeGeneratorContext,
       sourceDataType: DataType)
     : String => String = {
+
+    // fallback to old stack if at least one legacy type is present
+    if (LogicalTypeChecks.hasLegacyTypes(sourceDataType.getLogicalType)) {
+      return genToInternalConverterWithLegacy(ctx, sourceDataType)
+    }
+
     if (isInternal(sourceDataType)) {
       externalTerm => s"$externalTerm"
     } else {
@@ -805,6 +814,21 @@ object CodeGenUtils {
    * Generates code for converting the given term of external data type to an internal data
    * structure.
    *
+   * Use this function for converting at the edges of the API where primitive types CAN NOT occur
+   * and NO NULL CHECKING is required as it might have been done by surrounding layers.
+   */
+  def genToInternalConverter(
+      ctx: CodeGeneratorContext,
+      sourceDataType: DataType,
+      externalTerm: String)
+    : String = {
+    genToInternalConverter(ctx, sourceDataType)(externalTerm)
+  }
+
+  /**
+   * Generates code for converting the given term of external data type to an internal data
+   * structure.
+   *
    * Use this function for converting at the edges of the API where PRIMITIVE TYPES can occur or
    * the RESULT CAN BE NULL.
    */
@@ -813,6 +837,12 @@ object CodeGenUtils {
       sourceDataType: DataType,
       externalTerm: String)
     : GeneratedExpression = {
+
+    // fallback to old stack if at least one legacy type is present
+    if (LogicalTypeChecks.hasLegacyTypes(sourceDataType.getLogicalType)) {
+      return genToInternalConverterAllWithLegacy(ctx, sourceDataType, externalTerm)
+    }
+
     val sourceType = sourceDataType.getLogicalType
     val sourceClass = sourceDataType.getConversionClass
     // convert external source type to internal structure
@@ -841,6 +871,12 @@ object CodeGenUtils {
       targetDataType: DataType,
       internalTerm: String)
     : String = {
+
+    // fallback to old stack if at least one legacy type is present
+    if (LogicalTypeChecks.hasLegacyTypes(targetDataType.getLogicalType)) {
+      return genToExternalConverterWithLegacy(ctx, targetDataType, internalTerm)
+    }
+
     if (isInternal(targetDataType)) {
       s"$internalTerm"
     } else {
@@ -864,6 +900,12 @@ object CodeGenUtils {
       targetDataType: DataType,
       internalExpr: GeneratedExpression)
     : String = {
+
+    // fallback to old stack if at least one legacy type is present
+    if (LogicalTypeChecks.hasLegacyTypes(targetDataType.getLogicalType)) {
+      return genToExternalConverterAllWithLegacy(ctx, targetDataType, internalExpr)
+    }
+
     val targetType = targetDataType.getLogicalType
     val targetTypeTerm = boxedTypeTermForType(targetType)
 
@@ -904,13 +946,6 @@ object CodeGenUtils {
   }
 
   /**
-   * @deprecated This uses the legacy [[DataFormatConverters]] including legacy types.
-   */
-  @deprecated
-  def genToInternal(ctx: CodeGeneratorContext, t: DataType, term: String): String =
-    genToInternal(ctx, t)(term)
-
-  /**
    * Generates code for converting the given external source data type to the internal data format.
    *
    * Use this function for converting at the edges of the API where primitive types CAN NOT occur
@@ -919,7 +954,7 @@ object CodeGenUtils {
    * @deprecated This uses the legacy [[DataFormatConverters]] including legacy types.
    */
   @deprecated
-  def genToInternal(ctx: CodeGeneratorContext, t: DataType): String => String = {
+  private def genToInternalConverterWithLegacy(ctx: CodeGeneratorContext, t: DataType): String => String = {
     if (isConverterIdentity(t)) {
       term => s"$term"
     } else {
@@ -937,7 +972,7 @@ object CodeGenUtils {
    * @deprecated This uses the legacy [[DataFormatConverters]] including legacy types.
    */
   @deprecated
-  def genToInternalIfNeeded(
+  private def genToInternalConverterAllWithLegacy(
       ctx: CodeGeneratorContext,
       sourceDataType: DataType,
       externalTerm: String)
@@ -948,7 +983,7 @@ object CodeGenUtils {
     val internalResultTerm = if (isInternalClass(sourceDataType)) {
       s"$externalTerm"
     } else {
-      genToInternal(ctx, sourceDataType, externalTerm)
+      genToInternalConverterWithLegacy(ctx, sourceDataType)(externalTerm)
     }
     // extract null term from result term
     if (sourceClass.isPrimitive) {
@@ -962,7 +997,7 @@ object CodeGenUtils {
    * @deprecated This uses the legacy [[DataFormatConverters]] including legacy types.
    */
   @deprecated
-  def genToExternal(
+  def genToExternalConverterWithLegacy( // still public due to FLINK-18701
       ctx: CodeGeneratorContext,
       targetType: DataType,
       internalTerm: String): String = {
@@ -982,7 +1017,7 @@ object CodeGenUtils {
    * @deprecated This uses the legacy [[DataFormatConverters]] including legacy types.
    */
   @deprecated
-  def genToExternalIfNeeded(
+  private def genToExternalConverterAllWithLegacy(
       ctx: CodeGeneratorContext,
       targetDataType: DataType,
       internalExpr: GeneratedExpression)
@@ -999,7 +1034,7 @@ object CodeGenUtils {
     val externalResultTerm = if (isInternalClass(targetDataType)) {
       s"($targetTypeTerm) ${internalExpr.resultTerm}"
     } else {
-      genToExternal(ctx, targetDataType, internalExpr.resultTerm)
+      genToExternalConverterWithLegacy(ctx, targetDataType, internalExpr.resultTerm)
     }
     // merge null term into the result term
     if (targetDataType.getConversionClass.isPrimitive) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -954,7 +954,10 @@ object CodeGenUtils {
    * @deprecated This uses the legacy [[DataFormatConverters]] including legacy types.
    */
   @deprecated
-  private def genToInternalConverterWithLegacy(ctx: CodeGeneratorContext, t: DataType): String => String = {
+  private def genToInternalConverterWithLegacy(
+      ctx: CodeGeneratorContext,
+      t: DataType)
+    : String => String = {
     if (isConverterIdentity(t)) {
       term => s"$term"
     } else {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
@@ -197,7 +197,7 @@ object LookupJoinCodeGenerator {
           boxedTypeTermForType(e.resultType)
         }
         val assign = if (isExternalArgs) {
-          CodeGenUtils.genToExternal(ctx, dataType, e.resultTerm)
+          CodeGenUtils.genToExternalConverter(ctx, dataType, e.resultTerm)
         } else {
           e.resultTerm
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
@@ -27,7 +27,7 @@ import org.apache.flink.api.scala.createTuple2TypeInformation
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.data.util.RowDataUtil
 import org.apache.flink.table.data.{GenericRowData, RowData}
-import org.apache.flink.table.planner.codegen.CodeGenUtils.genToExternal
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{genToExternalConverter, genToExternalConverterWithLegacy}
 import org.apache.flink.table.planner.codegen.GeneratedExpression.NO_CODE
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.generateCollect
 import org.apache.flink.table.planner.sinks.TableSinkUtils
@@ -102,7 +102,8 @@ object SinkCodeGenerator {
     }
 
     val consumedDataType = sink.getConsumedDataType
-    val outTerm = genToExternal(ctx, physicalOutputType, afterIndexModify)
+    // still uses the old conversion stack due to FLINK-18701
+    val outTerm = genToExternalConverterWithLegacy(ctx, physicalOutputType, afterIndexModify)
     val retractProcessCode = if (withChangeFlag) {
       val flagResultTerm =
         s"${classOf[RowDataUtil].getCanonicalName}.isAccumulateMsg($afterIndexModify)"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
@@ -146,7 +146,8 @@ class DistinctAggCodeGen(
       val code =
         s"""
            |$MAP_VIEW $mapViewTerm = new $MAP_VIEW();
-           |$BINARY_RAW_VALUE $accTerm = ${genToInternal(ctx, externalAccType, mapViewTerm)};
+           |$BINARY_RAW_VALUE $accTerm = ${genToInternalConverter(
+              ctx, externalAccType, mapViewTerm)};
          """.stripMargin
 
       Seq(GeneratedExpression(accTerm, NEVER_NULL, code, internalAccType))
@@ -181,7 +182,8 @@ class DistinctAggCodeGen(
       val accTerm = newName("distinct_acc")
       val code =
         s"""
-           |$BINARY_RAW_VALUE $accTerm = ${genToInternal(ctx, externalAccType, distinctAccTerm)};
+           |$BINARY_RAW_VALUE $accTerm = ${genToInternalConverter(
+              ctx, externalAccType, distinctAccTerm)};
          """.stripMargin
 
       Seq(GeneratedExpression(
@@ -487,7 +489,8 @@ class DistinctAggCodeGen(
                  |${expr.code}
                  |$otherMapViewTerm = null;
                  |if (!${expr.nullTerm}) {
-                 | $otherMapViewTerm = ${genToExternal(ctx, externalAccType, expr.resultTerm)};
+                 | $otherMapViewTerm = ${genToExternalConverter(
+                      ctx, externalAccType, expr.resultTerm)};
                  |}
                """.stripMargin
             GeneratedExpression(otherMapViewTerm, expr.nullTerm, code, internalAccType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
@@ -117,7 +117,7 @@ class ImperativeAggCodeGen(
       // do not need convert to internal type
       s"($accTypeInternalTerm) $functionTerm.createAccumulator()"
     } else {
-      genToInternal(ctx, externalAccType, s"$functionTerm.createAccumulator()")
+      genToInternalConverter(ctx, externalAccType, s"$functionTerm.createAccumulator()")
     }
     val accInternal = newName("acc_internal")
     val code = s"$accTypeInternalTerm $accInternal = ($accTypeInternalTerm) $accField;"
@@ -143,7 +143,7 @@ class ImperativeAggCodeGen(
       ctx.addReusableMember(s"private $accTypeExternalTerm $accExternalTerm;")
       s"""
          |$accInternalTerm = ${expr.resultTerm};
-         |$accExternalTerm = ${genToExternal(ctx, externalAccType, accInternalTerm)};
+         |$accExternalTerm = ${genToExternalConverter(ctx, externalAccType, accInternalTerm)};
       """.stripMargin
     }
   }
@@ -154,7 +154,7 @@ class ImperativeAggCodeGen(
     } else {
       s"""
          |$accExternalTerm = ($accTypeExternalTerm) $functionTerm.createAccumulator();
-         |$accInternalTerm = ${genToInternal(ctx, externalAccType, accExternalTerm)};
+         |$accInternalTerm = ${genToInternalConverter(ctx, externalAccType, accExternalTerm)};
        """.stripMargin
     }
   }
@@ -164,7 +164,7 @@ class ImperativeAggCodeGen(
       // do not need convert to internal type
       ""
     } else {
-      s"$accInternalTerm = ${genToInternal(ctx, externalAccType, accExternalTerm)};"
+      s"$accInternalTerm = ${genToInternalConverter(ctx, externalAccType, accExternalTerm)};"
     }
     Seq(GeneratedExpression(accInternalTerm, "false", code, internalAccType))
   }
@@ -233,7 +233,7 @@ class ImperativeAggCodeGen(
       val otherAccExternal = newName("other_acc_external")
       s"""
          |$accTypeExternalTerm $otherAccExternal = ${
-            genToExternal(ctx, mergedAccExternalType, expr.resultTerm)};
+            genToExternalConverter(ctx, mergedAccExternalType, expr.resultTerm)};
          |$accIterTerm.set($otherAccExternal);
          |$functionTerm.merge($accExternalTerm, $accIterTerm);
       """.stripMargin
@@ -252,7 +252,7 @@ class ImperativeAggCodeGen(
          |$valueExternalTypeTerm $valueExternalTerm = ($valueExternalTypeTerm)
          |  $functionTerm.getValue($accTerm);
          |$valueInternalTypeTerm $valueInternalTerm =
-         |  ${genToInternal(ctx, externalResultType, valueExternalTerm)};
+         |  ${genToInternalConverter(ctx, externalResultType, valueExternalTerm)};
          |boolean $nullTerm = $valueInternalTerm == null;
       """.stripMargin
 
@@ -266,7 +266,7 @@ class ImperativeAggCodeGen(
       if (f >= inputTypes.length) {
         // index to constant
         val expr = constantExprs(f - inputTypes.length)
-        genToExternalIfNeeded(ctx, externalInputTypes(index), expr)
+        genToExternalConverterAll(ctx, externalInputTypes(index), expr)
       } else {
         // index to input field
         val inputRef = if (generator.input1Term.startsWith(DISTINCT_KEY_TERM)) {
@@ -285,7 +285,7 @@ class ImperativeAggCodeGen(
         var inputExpr = generator.generateExpression(inputRef.accept(rexNodeGen))
         if (inputFieldCopy) inputExpr = inputExpr.deepCopy(ctx)
         codes += inputExpr.code
-        genToExternalIfNeeded(ctx, externalInputTypes(index), inputExpr)
+        genToExternalConverterAll(ctx, externalInputTypes(index), inputExpr)
       }
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
@@ -124,7 +124,7 @@ class ScalarFunctionCallGen(scalarFunction: ScalarFunction) extends CallGenerato
     if (isInternalClass(t)) {
       s"(${boxedTypeTermForType(LogicalTypeDataTypeConverter.fromDataTypeToLogicalType(t))}) $term"
     } else {
-      genToInternal(ctx, t, term)
+      genToInternalConverter(ctx, t, term)
     }
   }
 
@@ -163,7 +163,7 @@ object ScalarFunctionCallGen {
           } else {
             signatureTypes(i)
           }
-        val externalResultTerm = genToExternalIfNeeded(ctx, signatureType, operandExpr)
+        val externalResultTerm = genToExternalConverterAll(ctx, signatureType, operandExpr)
         operandExpr.copy(resultTerm = externalResultTerm)
       }
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/TableFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/TableFunctionCallGen.scala
@@ -146,7 +146,7 @@ class TableFunctionCallGen(
       "TableFunctionResultConverterCollector",
       externalType,
       externalTerm,
-      CodeGenUtils.genToInternal(ctx, externalDataType),
+      CodeGenUtils.genToInternalConverter(ctx, externalDataType),
       collectorCode)
     val resultCollectorTerm = newName("resultConverterCollector")
     CollectorCodeGenerator.addToContext(ctx, resultCollectorTerm, resultCollector)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
@@ -81,7 +81,7 @@ object ScanUtil {
     val inputTerm = DEFAULT_INPUT1_TERM
     val internalInType = fromDataTypeToLogicalType(inputType)
     val (inputTermConverter, inputRowType) = {
-      val convertFunc = CodeGenUtils.genToInternal(ctx, inputType)
+      val convertFunc = CodeGenUtils.genToInternalConverter(ctx, inputType)
       internalInType match {
         case rt: RowType => (convertFunc, rt)
         case _ => ((record: String) => s"$GENERIC_ROW.of(${convertFunc(record)})",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -149,7 +149,7 @@ abstract class ExpressionTestBase {
       val richMapper = mapper.asInstanceOf[RichMapFunction[_, _]]
       val t = new RuntimeUDFContext(
         new TaskInfo("ExpressionTest", 1, 0, 1, 1),
-        null,
+        classOf[ExpressionTestBase].getClassLoader,
         env.getConfig,
         Collections.emptyMap(),
         Collections.emptyMap(),


### PR DESCRIPTION
## What is the purpose of the change

FLINK-16999 introduce the new data structure converters that are already in place for the new sources/sinks and new scalar/table functions. This can enables it for almost all usages if legacy types are not present.

## Brief change log

- Make old converter methods private
- Fallback to old converters if legacy types are present

## Verifying this change

This change is already covered by existing tests.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
