### PR TITLE
[FLINK-18727][network] Remove and recycle the finished empty Buffer in PipelinedSubpartition when adding a new one

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -99,7 +99,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 		subpartition.release();
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testAddTwoNonFinishedBuffer() throws IOException {
 		subpartition.add(createBufferBuilder().createBufferConsumer());
 		subpartition.add(createBufferBuilder().createBufferConsumer());
@@ -120,8 +120,8 @@ public class PipelinedSubpartitionWithReadViewTest {
 		bufferBuilder = createBufferBuilder();
 		subpartition.add(bufferBuilder.createBufferConsumer());
 
-		assertEquals(1, subpartition.getBuffersInBacklog());
-		assertEquals(1, availablityListener.getNumNotifications()); // notification from finishing previous buffer.
+		assertEquals(0, subpartition.getBuffersInBacklog());
+		assertEquals(0, availablityListener.getNumNotifications());
 		assertNull(readView.getNextBuffer());
 		assertEquals(0, subpartition.getBuffersInBacklog());
 	}
@@ -213,14 +213,14 @@ public class PipelinedSubpartitionWithReadViewTest {
 		assertEquals(0, availablityListener.getNumNotifications());
 
 		subpartition.add(createFilledFinishedBufferConsumer(0));
-		assertEquals(1, availablityListener.getNumNotifications());
+		assertEquals(0, availablityListener.getNumNotifications());
 
 		subpartition.add(createFilledFinishedBufferConsumer(0));
-		assertEquals(1, availablityListener.getNumNotifications());
-		assertEquals(2, subpartition.getBuffersInBacklog());
+		assertEquals(0, availablityListener.getNumNotifications());
+		assertEquals(0, subpartition.getBuffersInBacklog());
 
 		subpartition.add(createFilledFinishedBufferConsumer(1024));
-		assertEquals(1, availablityListener.getNumNotifications());
+		assertEquals(0, availablityListener.getNumNotifications());
 
 		assertNextBuffer(readView, 1024, false, 0, false, true);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -45,6 +45,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -342,6 +343,7 @@ public class ResultPartitionTest {
 			for (int i = 0; i < numAllBuffers; ++i) {
 				BufferBuilder bufferBuilder = resultPartition.getBufferPool().requestBufferBuilderBlocking();
 				resultPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(), 0);
+				bufferBuilder.appendAndCommit(ByteBuffer.wrap(new byte[1]));
 			}
 			resultPartition.finish();
 


### PR DESCRIPTION
## What is the purpose of the change

For current implementation of PipelinedSubpartition, empty Buffer consumes credit, which means we need at lease one credit to handle the finished empty Buffer without any data. We can remove and recycle the finished empty Buffer in the queue when adding a new Buffer, after which, the reader does not need any available credit to handle the finished empty buffer. For example, if the new buffer is an event and the previous buffer is finished but without any data, after it is removed, the reader is able to process the new added event without any available credit.

## Brief change log

  - Remove and recycle the finished empty Buffer in PipelinedSubpartition when adding a new one


## Verifying this change

New test case PipelinedSubpartitionTest#testRemoveFinishedEmptyBuffer is added to verify the change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
