### PR TITLE
[FLINK-18728][network] Make initialCredit of RemoteInputChannel final

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentProvider.java
@@ -25,7 +25,7 @@ import java.util.Collection;
  * The provider used for requesting and releasing batch of memory segments.
  */
 public interface MemorySegmentProvider {
-	Collection<MemorySegment> requestMemorySegments() throws IOException;
+	Collection<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest) throws IOException;
 
 	void recycleMemorySegments(Collection<MemorySegment> segments) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -112,7 +112,6 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
 			config.numNetworkBuffers(),
 			config.networkBufferSize(),
-			config.networkBuffersPerChannel(),
 			config.getRequestSegmentsTimeout());
 
 		registerShuffleMetrics(metricGroup, networkBufferPool);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -127,8 +127,8 @@ public class BufferManager implements BufferListener, BufferRecycler {
 	/**
 	 * Requests exclusive buffers from the provider.
 	 */
-	void requestExclusiveBuffers() throws IOException {
-		Collection<MemorySegment> segments = globalPool.requestMemorySegments();
+	void requestExclusiveBuffers(int numExclusiveBuffers) throws IOException {
+		Collection<MemorySegment> segments = globalPool.requestMemorySegments(numExclusiveBuffers);
 		checkArgument(!segments.isEmpty(), "The number of exclusive buffers per channel should be larger than 0.");
 
 		synchronized (bufferQueue) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -327,7 +327,7 @@ public class BufferManager implements BufferListener, BufferRecycler {
 		}
 	}
 
-	int unsynchronizedGetExclusiveBuffersUsed() {
+	int unsynchronizedGetAvailableExclusiveBuffers() {
 		return bufferQueue.exclusiveBuffers.size();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -125,9 +125,9 @@ public class BufferManager implements BufferListener, BufferRecycler {
 	}
 
 	/**
-	 * Requests exclusive buffers from the provider and returns the number of requested amount.
+	 * Requests exclusive buffers from the provider.
 	 */
-	int requestExclusiveBuffers() throws IOException {
+	void requestExclusiveBuffers() throws IOException {
 		Collection<MemorySegment> segments = globalPool.requestMemorySegments();
 		checkArgument(!segments.isEmpty(), "The number of exclusive buffers per channel should be larger than 0.");
 
@@ -136,7 +136,6 @@ public class BufferManager implements BufferListener, BufferRecycler {
 				bufferQueue.addExclusiveBuffer(new NetworkBuffer(segment, this), numRequiredBuffers);
 			}
 		}
-		return segments.size();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -84,7 +84,7 @@ public class RemoteInputChannel extends InputChannel {
 	private int expectedSequenceNumber = 0;
 
 	/** The initial number of exclusive buffers assigned to this channel. */
-	private int initialCredit;
+	private final int initialCredit;
 
 	/** The number of available buffers that have not been announced to the producer yet. */
 	private final AtomicInteger unannouncedCredit = new AtomicInteger(0);
@@ -109,11 +109,13 @@ public class RemoteInputChannel extends InputChannel {
 		ConnectionManager connectionManager,
 		int initialBackOff,
 		int maxBackoff,
+		int networkBuffersPerChannel,
 		Counter numBytesIn,
 		Counter numBuffersIn) {
 
 		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, numBytesIn, numBuffersIn);
 
+		this.initialCredit = networkBuffersPerChannel;
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
 		this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
@@ -124,10 +126,10 @@ public class RemoteInputChannel extends InputChannel {
 	 * after this input channel is created.
 	 */
 	void assignExclusiveSegments() throws IOException {
-		checkState(initialCredit == 0, "Bug in input channel setup logic: exclusive buffers have " +
-			"already been set for this input channel.");
+		checkState(bufferManager.unsynchronizedGetAvailableExclusiveBuffers() == 0,
+			"Bug in input channel setup logic: exclusive buffers have already been set for this input channel.");
 
-		initialCredit = bufferManager.requestExclusiveBuffers();
+		bufferManager.requestExclusiveBuffers();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -129,7 +129,7 @@ public class RemoteInputChannel extends InputChannel {
 		checkState(bufferManager.unsynchronizedGetAvailableExclusiveBuffers() == 0,
 			"Bug in input channel setup logic: exclusive buffers have already been set for this input channel.");
 
-		bufferManager.requestExclusiveBuffers();
+		bufferManager.requestExclusiveBuffers(initialCredit);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -381,7 +381,7 @@ public class RemoteInputChannel extends InputChannel {
 	}
 
 	public int unsynchronizedGetExclusiveBuffersUsed() {
-		return Math.max(0, initialCredit - bufferManager.unsynchronizedGetExclusiveBuffersUsed());
+		return Math.max(0, initialCredit - bufferManager.unsynchronizedGetAvailableExclusiveBuffers());
 	}
 
 	public int unsynchronizedGetFloatingBuffersAvailable() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
@@ -36,6 +36,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 	private final ConnectionID connectionId;
 	private final ConnectionManager connectionManager;
+	private final int networkBuffersPerChannel;
 
 	private boolean exclusiveBuffersAssigned;
 
@@ -47,11 +48,13 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 			ConnectionManager connectionManager,
 			int initialBackOff,
 			int maxBackoff,
+			int networkBuffersPerChannel,
 			InputChannelMetrics metrics) {
 		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, metrics.getNumBytesInRemoteCounter(), metrics.getNumBuffersInRemoteCounter());
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
+		this.networkBuffersPerChannel = networkBuffersPerChannel;
 	}
 
 	@Override
@@ -64,6 +67,7 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
+			networkBuffersPerChannel,
 			numBytesIn,
 			numBuffersIn);
 		remoteInputChannel.assignExclusiveSegments();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
@@ -77,7 +77,7 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 	void assignExclusiveSegments() throws IOException {
 		checkState(!exclusiveBuffersAssigned, "Exclusive buffers should be assigned only once.");
 
-		bufferManager.requestExclusiveBuffers();
+		bufferManager.requestExclusiveBuffers(networkBuffersPerChannel);
 		exclusiveBuffersAssigned = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -72,7 +72,7 @@ public class SingleInputGateFactory {
 	@Nonnull
 	protected final NetworkBufferPool networkBufferPool;
 
-	private final int networkBuffersPerChannel;
+	protected final int networkBuffersPerChannel;
 
 	private final int floatingNetworkBuffersPerGate;
 
@@ -188,6 +188,7 @@ public class SingleInputGateFactory {
 					connectionManager,
 					partitionRequestInitialBackoff,
 					partitionRequestMaxBackoff,
+					networkBuffersPerChannel,
 					metrics);
 			},
 			nettyShuffleDescriptor ->
@@ -230,6 +231,7 @@ public class SingleInputGateFactory {
 				connectionManager,
 				partitionRequestInitialBackoff,
 				partitionRequestMaxBackoff,
+				networkBuffersPerChannel,
 				metrics);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -48,6 +48,8 @@ class UnknownInputChannel extends InputChannel {
 
 	private final int maxBackoff;
 
+	private final int networkBuffersPerChannel;
+
 	private final InputChannelMetrics metrics;
 
 	public UnknownInputChannel(
@@ -59,6 +61,7 @@ class UnknownInputChannel extends InputChannel {
 			ConnectionManager connectionManager,
 			int initialBackoff,
 			int maxBackoff,
+			int networkBuffersPerChannel,
 			InputChannelMetrics metrics) {
 
 		super(gate, channelIndex, partitionId, initialBackoff, maxBackoff, null, null);
@@ -69,6 +72,7 @@ class UnknownInputChannel extends InputChannel {
 		this.metrics = checkNotNull(metrics);
 		this.initialBackoff = initialBackoff;
 		this.maxBackoff = maxBackoff;
+		this.networkBuffersPerChannel = networkBuffersPerChannel;
 	}
 
 	@Override
@@ -127,6 +131,7 @@ class UnknownInputChannel extends InputChannel {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
+			networkBuffersPerChannel,
 			metrics.getNumBytesInRemoteCounter(),
 			metrics.getNumBuffersInRemoteCounter());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegateTest.java
@@ -61,7 +61,7 @@ public class RecordWriterDelegateTest extends TestLogger {
 
 	@Before
 	public void setup() {
-		globalPool = new NetworkBufferPool(numberOfBuffers, memorySegmentSize, numberOfSegmentsToRequest);
+		globalPool = new NetworkBufferPool(numberOfBuffers, memorySegmentSize);
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -413,7 +413,7 @@ public class RecordWriterTest {
 	@Test
 	public void testIsAvailableOrNot() throws Exception {
 		// setup
-		final NetworkBufferPool globalPool = new NetworkBufferPool(10, 128, 2);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(10, 128);
 		final BufferPool localPool = globalPool.createBufferPool(1, 1, null, 1, Integer.MAX_VALUE);
 		final ResultPartitionWriter resultPartition = new ResultPartitionBuilder()
 			.setBufferPoolFactory(p -> localPool)
@@ -455,7 +455,7 @@ public class RecordWriterTest {
 		final int[] records = {5, 6, 7, 8};
 		final int bufferSize = states.length * Integer.BYTES;
 
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, bufferSize, 1);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, bufferSize);
 		final ChannelStateReader stateReader = new ResultPartitionTest.FiniteChannelStateReader(totalStates, states);
 		final ResultPartition partition = new ResultPartitionBuilder()
 			.setNetworkBufferPool(globalPool)
@@ -507,7 +507,7 @@ public class RecordWriterTest {
 	@Test
 	public void testIdleTime() throws IOException, InterruptedException {
 		// setup
-		final NetworkBufferPool globalPool = new NetworkBufferPool(10, 128, 2);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(10, 128);
 		final BufferPool localPool = globalPool.createBufferPool(1, 1, null, 1, Integer.MAX_VALUE);
 		final ResultPartitionWriter resultPartition = new ResultPartitionBuilder()
 			.setBufferPoolFactory(p -> localPool)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
@@ -54,7 +54,7 @@ public class BufferPoolFactoryTest {
 
 	@Before
 	public void setupNetworkBufferPool() {
-		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize, 1);
+		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize);
 	}
 
 	@After
@@ -244,7 +244,7 @@ public class BufferPoolFactoryTest {
 
 	@Test
 	public void testUniformDistributionBounded3() throws IOException {
-		NetworkBufferPool globalPool = new NetworkBufferPool(3, 128, 1);
+		NetworkBufferPool globalPool = new NetworkBufferPool(3, 128);
 		try {
 			BufferPool first = globalPool.createBufferPool(0, 10);
 			assertEquals(3, first.getNumBuffers());
@@ -277,12 +277,12 @@ public class BufferPoolFactoryTest {
 	 */
 	@Test
 	public void testUniformDistributionBounded4() throws IOException {
-		NetworkBufferPool globalPool = new NetworkBufferPool(10, 128, 2);
+		NetworkBufferPool globalPool = new NetworkBufferPool(10, 128);
 		try {
 			BufferPool first = globalPool.createBufferPool(0, 10);
 			assertEquals(10, first.getNumBuffers());
 
-			List<MemorySegment> segmentList1 = globalPool.requestMemorySegments();
+			List<MemorySegment> segmentList1 = globalPool.requestMemorySegments(2);
 			assertEquals(2, segmentList1.size());
 			assertEquals(8, first.getNumBuffers());
 
@@ -290,12 +290,12 @@ public class BufferPoolFactoryTest {
 			assertEquals(4, first.getNumBuffers());
 			assertEquals(4, second.getNumBuffers());
 
-			List<MemorySegment> segmentList2 = globalPool.requestMemorySegments();
+			List<MemorySegment> segmentList2 = globalPool.requestMemorySegments(2);
 			assertEquals(2, segmentList2.size());
 			assertEquals(3, first.getNumBuffers());
 			assertEquals(3, second.getNumBuffers());
 
-			List<MemorySegment> segmentList3 = globalPool.requestMemorySegments();
+			List<MemorySegment> segmentList3 = globalPool.requestMemorySegments(2);
 			assertEquals(2, segmentList3.size());
 			assertEquals(2, first.getNumBuffers());
 			assertEquals(2, second.getNumBuffers());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
@@ -48,7 +48,7 @@ public class LocalBufferPoolDestroyTest {
 		LocalBufferPool localBufferPool = null;
 
 		try {
-			networkBufferPool = new NetworkBufferPool(1, 4096, 1);
+			networkBufferPool = new NetworkBufferPool(1, 4096);
 			localBufferPool = new LocalBufferPool(networkBufferPool, 1);
 
 			// Drain buffer pool

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -71,7 +71,7 @@ public class LocalBufferPoolTest extends TestLogger {
 
 	@Before
 	public void setupLocalBufferPool() {
-		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize, 1);
+		networkBufferPool = new NetworkBufferPool(numBuffers, memorySegmentSize);
 		localBufferPool = new LocalBufferPool(networkBufferPool, 1);
 
 		assertEquals(0, localBufferPool.getNumberOfAvailableMemorySegments());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -635,6 +635,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 				new TestingConnectionManager(),
 				0,
 				100,
+				2,
 				new SimpleCounter(),
 				new SimpleCounter());
 			this.expectedMessage = expectedMessage;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -154,7 +154,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 	 */
 	@Test
 	public void testReceiveBuffer() throws Exception {
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate);
 		try {
@@ -191,7 +191,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		String compressionCodec = "LZ4";
 		BufferCompressor compressor = new BufferCompressor(bufferSize, compressionCodec);
 		BufferDecompressor decompressor = new BufferDecompressor(bufferSize, compressionCodec);
-		NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize, 2);
+		NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
 		SingleInputGate inputGate = new SingleInputGateBuilder()
 			.setBufferDecompressor(decompressor)
 			.setSegmentProvider(networkBufferPool)
@@ -313,7 +313,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		final PartitionRequestClient client = new NettyPartitionRequestClient(
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
 		final SingleInputGate inputGate = createSingleInputGate(2, networkBufferPool);
 		final RemoteInputChannel[] inputChannels = new RemoteInputChannel[2];
 		inputChannels[0] = createRemoteInputChannel(inputGate, client);
@@ -424,7 +424,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		final PartitionRequestClient client = new NettyPartitionRequestClient(
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 		try {
@@ -493,7 +493,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		// Setup
 		final int bufferSize = 1024;
 		final String expectedMessage = "test exception on buffer";
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = new TestRemoteInputChannelForError(inputGate, expectedMessage);
 		final CreditBasedPartitionRequestClientHandler handler = new CreditBasedPartitionRequestClientHandler();
@@ -535,7 +535,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 
 		int bufferSize = 1024;
 
-		NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize, 2);
+		NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
 		SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		RemoteInputChannel inputChannel = new InputChannelBuilder()
 			.buildRemoteChannel(inputGate);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
@@ -80,16 +80,14 @@ public class NettyMessageClientDecoderDelegateTest extends TestLogger {
 	@Before
 	public void setup() throws IOException, InterruptedException {
 		CreditBasedPartitionRequestClientHandler handler = new CreditBasedPartitionRequestClientHandler();
-		networkBufferPool = new NetworkBufferPool(
-			NUMBER_OF_BUFFER_RESPONSES,
-			BUFFER_SIZE,
-			NUMBER_OF_BUFFER_RESPONSES);
+		networkBufferPool = new NetworkBufferPool(NUMBER_OF_BUFFER_RESPONSES, BUFFER_SIZE);
 		channel = new EmbeddedChannel(new NettyMessageClientDecoderDelegate(handler));
 
 		inputGate = createSingleInputGate(1, networkBufferPool);
 		RemoteInputChannel inputChannel = createRemoteInputChannel(
 			inputGate,
-			new TestingPartitionRequestClient());
+			new TestingPartitionRequestClient(),
+			NUMBER_OF_BUFFER_RESPONSES);
 		inputGate.setInputChannels(inputChannel);
 		inputGate.assignExclusiveSegments();
 		inputChannel.requestSubpartition(0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
@@ -77,7 +77,7 @@ public class NettyMessageClientSideSerializationTest extends TestLogger {
 
 	@Before
 	public void setup() throws IOException, InterruptedException {
-		networkBufferPool = new NetworkBufferPool(8, BUFFER_SIZE, 8);
+		networkBufferPool = new NetworkBufferPool(8, BUFFER_SIZE);
 		inputGate = createSingleInputGate(1, networkBufferPool);
 		RemoteInputChannel inputChannel = createRemoteInputChannel(
 			inputGate,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
@@ -62,7 +62,7 @@ public class NettyPartitionRequestClientTest {
 		final PartitionRequestClient client = createPartitionRequestClient(channel, handler);
 
 		final int numExclusiveBuffers = 2;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, numExclusiveBuffers);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = InputChannelBuilder.newBuilder()
 			.setConnectionManager(mockConnectionManagerWithPartitionRequestClient(client))
@@ -120,7 +120,7 @@ public class NettyPartitionRequestClientTest {
 		final PartitionRequestClient client = createPartitionRequestClient(channel, handler);
 
 		final int numExclusiveBuffers = 2;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, numExclusiveBuffers);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 
@@ -154,7 +154,7 @@ public class NettyPartitionRequestClientTest {
 		final EmbeddedChannel channel = new EmbeddedChannel(handler);
 		final PartitionRequestClient client = createPartitionRequestClient(channel, handler);
 
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -143,6 +143,15 @@ public class InputChannelTestUtils {
 			.buildRemoteChannel(inputGate);
 	}
 
+	public static RemoteInputChannel createRemoteInputChannel(
+		SingleInputGate inputGate,
+		int numExclusiveSegments) {
+
+		return InputChannelBuilder.newBuilder()
+			.setNetworkBuffersPerChannel(numExclusiveSegments)
+			.buildRemoteChannel(inputGate);
+	}
+
 	public static ConnectionManager mockConnectionManagerWithPartitionRequestClient(PartitionRequestClient client) {
 		return new ConnectionManager() {
 			@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -152,6 +152,17 @@ public class InputChannelTestUtils {
 			.buildRemoteChannel(inputGate);
 	}
 
+	public static RemoteInputChannel createRemoteInputChannel(
+		SingleInputGate inputGate,
+		PartitionRequestClient client,
+		int numExclusiveSegments) {
+
+		return InputChannelBuilder.newBuilder()
+			.setConnectionManager(mockConnectionManagerWithPartitionRequestClient(client))
+			.setNetworkBuffersPerChannel(numExclusiveSegments)
+			.buildRemoteChannel(inputGate);
+	}
+
 	public static ConnectionManager mockConnectionManagerWithPartitionRequestClient(PartitionRequestClient client) {
 		return new ConnectionManager() {
 			@Override
@@ -202,7 +213,7 @@ public class InputChannelTestUtils {
 		}
 
 		@Override
-		public Collection<MemorySegment> requestMemorySegments() {
+		public Collection<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest) {
 			return Collections.emptyList();
 		}
 
@@ -222,7 +233,7 @@ public class InputChannelTestUtils {
 		}
 
 		@Override
-		public Collection<MemorySegment> requestMemorySegments() {
+		public Collection<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest) {
 			return Collections.singletonList(MemorySegmentFactory.allocateUnpooledSegment(pageSize));
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -50,7 +50,7 @@ public class ResultPartitionBuilder {
 
 	private FileChannelManager channelManager = NoOpFileChannelManager.INSTANCE;
 
-	private NetworkBufferPool networkBufferPool = new NetworkBufferPool(1, 1, 1);
+	private NetworkBufferPool networkBufferPool = new NetworkBufferPool(1, 1);
 
 	private int networkBuffersPerChannel = 1;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -93,7 +93,7 @@ public class ResultPartitionFactoryTest extends TestLogger {
 		ResultPartitionFactory factory = new ResultPartitionFactory(
 			new ResultPartitionManager(),
 			fileChannelManager,
-			new NetworkBufferPool(1, SEGMENT_SIZE, 1),
+			new NetworkBufferPool(1, SEGMENT_SIZE),
 			BoundedBlockingSubpartitionType.AUTO,
 			1,
 			1,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -403,7 +403,7 @@ public class ResultPartitionTest {
 		//setup
 		final int networkBuffersPerChannel = 2;
 		final int floatingNetworkBuffersPerGate = 8;
-		final NetworkBufferPool globalPool = new NetworkBufferPool(20, 1, 1);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(20, 1);
 		final ResultPartition partition = new ResultPartitionBuilder()
 			.setResultPartitionType(type)
 			.setFileChannelManager(fileChannelManager)
@@ -449,7 +449,7 @@ public class ResultPartitionTest {
 	@Test
 	public void testInitializeEmptyState() throws Exception {
 		final int totalBuffers = 2;
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 1, 1);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 1);
 		final ResultPartition partition = new ResultPartitionBuilder()
 			.setNetworkBufferPool(globalPool)
 			.build();
@@ -480,7 +480,7 @@ public class ResultPartitionTest {
 		final int[] states = {1, 2, 3, 4};
 		final int bufferSize = states.length * Integer.BYTES;
 
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, bufferSize, 1);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, bufferSize);
 		final ChannelStateReader stateReader = new FiniteChannelStateReader(totalStates, states);
 		final ResultPartition partition = new ResultPartitionBuilder()
 			.setNetworkBufferPool(globalPool)
@@ -540,7 +540,7 @@ public class ResultPartitionTest {
 	@Test
 	public void testReadRecoveredStateWithException() throws Exception {
 		final int totalBuffers = 2;
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 1, 1);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 1);
 		final ResultPartition partition = new ResultPartitionBuilder()
 			.setNetworkBufferPool(globalPool)
 			.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -49,6 +49,7 @@ public class InputChannelBuilder {
 	private ConnectionManager connectionManager = new TestingConnectionManager();
 	private int initialBackoff = 0;
 	private int maxBackoff = 0;
+	private int networkBuffersPerChannel = 2;
 	private InputChannelMetrics metrics = InputChannelTestUtils.newUnregisteredInputChannelMetrics();
 
 	public static InputChannelBuilder newBuilder() {
@@ -90,6 +91,11 @@ public class InputChannelBuilder {
 		return this;
 	}
 
+	public InputChannelBuilder setNetworkBuffersPerChannel(int networkBuffersPerChannel) {
+		this.networkBuffersPerChannel = networkBuffersPerChannel;
+		return this;
+	}
+
 	public InputChannelBuilder setMetrics(InputChannelMetrics metrics) {
 		this.metrics = metrics;
 		return this;
@@ -100,6 +106,7 @@ public class InputChannelBuilder {
 		this.connectionManager = network.getConnectionManager();
 		this.initialBackoff = network.getConfiguration().partitionRequestInitialBackoff();
 		this.maxBackoff = network.getConfiguration().partitionRequestMaxBackoff();
+		this.networkBuffersPerChannel = network.getConfiguration().networkBuffersPerChannel();
 		return this;
 	}
 
@@ -113,6 +120,7 @@ public class InputChannelBuilder {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
+			networkBuffersPerChannel,
 			metrics);
 	}
 
@@ -138,6 +146,7 @@ public class InputChannelBuilder {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
+			networkBuffersPerChannel,
 			metrics.getNumBytesInRemoteCounter(),
 			metrics.getNumBuffersInRemoteCounter());
 	}
@@ -163,6 +172,7 @@ public class InputChannelBuilder {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
+			networkBuffersPerChannel,
 			metrics);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -123,7 +123,7 @@ public class LocalInputChannelTest {
 
 		final NetworkBufferPool networkBuffers = new NetworkBufferPool(
 			(parallelism * producerBufferPoolSize) + (parallelism * parallelism),
-			TestBufferFactory.BUFFER_SIZE, 1);
+			TestBufferFactory.BUFFER_SIZE);
 
 		final ResultPartitionManager partitionManager = new ResultPartitionManager();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
@@ -104,7 +104,7 @@ public class RecoveredInputChannelTest {
 	private void testReadEmptyStateOrThrowException(boolean isRemote, ChannelStateReader reader) throws Exception {
 		// setup
 		final int totalBuffers = 10;
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32);
 		final SingleInputGate inputGate = createInputGate(globalPool);
 		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
 
@@ -137,7 +137,7 @@ public class RecoveredInputChannelTest {
 	private void testConcurrentReadStateAndProcess(boolean isRemote) throws Exception {
 		// setup
 		final int totalBuffers = 10;
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32);
 		final SingleInputGate inputGate = createInputGate(globalPool);
 		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
 
@@ -167,7 +167,7 @@ public class RecoveredInputChannelTest {
 	private void testConcurrentReadStateAndRelease(boolean isRemote) throws Exception {
 		// setup
 		final int totalBuffers = 10;
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32);
 		final SingleInputGate inputGate = createInputGate(globalPool);
 		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
 
@@ -196,7 +196,7 @@ public class RecoveredInputChannelTest {
 	private void testConcurrentReadStateAndProcessAndRelease(boolean isRemote) throws Exception {
 		// setup
 		final int totalBuffers = 10;
-		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32);
 		final SingleInputGate inputGate = createInputGate(globalPool);
 		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -360,7 +360,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testAvailableBuffersLessThanRequiredBuffers() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32);
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
@@ -499,7 +499,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testAvailableBuffersEqualToRequiredBuffers() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32);
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
@@ -574,7 +574,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testAvailableBuffersMoreThanRequiredBuffers() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(16, 32);
 		final int numFloatingBuffers = 14;
 
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
@@ -664,7 +664,7 @@ public class RemoteInputChannelTest {
 	public void testFairDistributionFloatingBuffers() throws Exception {
 		// Setup
 		final int numExclusiveBuffers = 2;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(12, 32, numExclusiveBuffers);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(12, 32);
 		final int numFloatingBuffers = 3;
 
 		final SingleInputGate inputGate = createSingleInputGate(3, networkBufferPool);
@@ -727,8 +727,7 @@ public class RemoteInputChannelTest {
 		final int numExclusiveBuffers = 1;
 		final int numFloatingBuffers = 1;
 		final int numTotalBuffers = numExclusiveBuffers + numFloatingBuffers;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(
-			numTotalBuffers, 32, numExclusiveBuffers);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(numTotalBuffers, 32);
 
 		final SingleInputGate inputGate = createSingleInputGate(1);
 		final RemoteInputChannel successfulRemoteIC = createRemoteInputChannel(inputGate);
@@ -786,7 +785,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testConcurrentOnSenderBacklogAndRelease() throws Exception {
 		// Setup
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(130, 32, 2);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(130, 32);
 		final int numFloatingBuffers = 128;
 
 		final ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -847,7 +846,7 @@ public class RemoteInputChannelTest {
 	public void testConcurrentOnSenderBacklogAndRecycle() throws Exception {
 		// Setup
 		final int numExclusiveSegments = 120;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32, numExclusiveSegments);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32);
 		final int numFloatingBuffers = 128;
 		final int backlog = 128;
 
@@ -899,13 +898,13 @@ public class RemoteInputChannelTest {
 	public void testConcurrentRecycleAndRelease() throws Exception {
 		// Setup
 		final int numExclusiveSegments = 120;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32, numExclusiveSegments);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(248, 32);
 		final int numFloatingBuffers = 128;
 
 		final ExecutorService executor = Executors.newFixedThreadPool(3);
 
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = InputChannelTestUtils.createRemoteInputChannel(inputGate, numExclusiveSegments);
 		inputGate.setInputChannels(inputChannel);
 		Throwable thrown = null;
 		try {
@@ -953,8 +952,7 @@ public class RemoteInputChannelTest {
 		final int numExclusiveBuffers = 2;
 		final int numFloatingBuffers = 2;
 		final int numTotalBuffers = numExclusiveBuffers + numFloatingBuffers;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(
-			numTotalBuffers, 32, numExclusiveBuffers);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(numTotalBuffers, 32);
 
 		final ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -1026,9 +1024,8 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testConcurrentGetNextBufferAndRelease() throws Exception {
 		final int numTotalBuffers  = 1_000;
-		final int numExclusiveBuffers = 2;
 		final int numFloatingBuffers = 998;
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(numTotalBuffers, 32, numExclusiveBuffers);
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(numTotalBuffers, 32);
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
 		inputGate.setInputChannels(inputChannel);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -854,7 +854,7 @@ public class RemoteInputChannelTest {
 		final ExecutorService executor = Executors.newFixedThreadPool(3);
 
 		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+		final RemoteInputChannel inputChannel = InputChannelTestUtils.createRemoteInputChannel(inputGate, numExclusiveSegments);
 		inputGate.setInputChannels(inputChannel);
 		Throwable thrown = null;
 		try {
@@ -1227,7 +1227,7 @@ public class RemoteInputChannelTest {
 		TestBufferReceivedListener listener = new TestBufferReceivedListener();
 		SingleInputGate inputGate = new SingleInputGateBuilder().build();
 		inputGate.registerBufferReceivedListener(listener);
-		RemoteInputChannel channel = InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate);
+		RemoteInputChannel channel = InputChannelTestUtils.createRemoteInputChannel(inputGate, 0);
 		channel.onBuffer(toBuffer(new CheckpointBarrier(123L, 123L, new CheckpointOptions(SAVEPOINT, CheckpointStorageLocationReference.getDefault()))), 0, 0);
 		channel.checkError();
 		assertTrue(listener.notifiedOnBarriers.isEmpty());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -955,6 +955,7 @@ public class SingleInputGateTest extends InputGateTestBase {
 			.setChannelIndex(0)
 			.setupFromNettyShuffleEnvironment(network)
 			.setConnectionManager(new TestingConnectionManager())
+			.setNetworkBuffersPerChannel(0)
 			.buildRemoteChannel(inputGate);
 
 		List<Buffer> inflightBuffers = new ArrayList<>();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
@@ -57,8 +57,8 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 		NetworkBufferPool networkBufferPool1 = null;
 		NetworkBufferPool networkBufferPool2 = null;
 		try {
-			networkBufferPool1 = new NetworkBufferPool(100, PAGE_SIZE, 1);
-			networkBufferPool2 = new NetworkBufferPool(100, PAGE_SIZE, 1);
+			networkBufferPool1 = new NetworkBufferPool(100, PAGE_SIZE);
+			networkBufferPool2 = new NetworkBufferPool(100, PAGE_SIZE);
 			BufferPool pool1 = networkBufferPool1.createBufferPool(100, 100);
 			BufferPool pool2 = networkBufferPool2.createBufferPool(100, 100);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -37,7 +37,6 @@ import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
-import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
@@ -67,6 +66,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -123,11 +123,11 @@ public class StreamTaskNetworkInputTest {
 	@Test
 	public void testSnapshotWithTwoInputGates() throws Exception {
 		SingleInputGate inputGate1 = new SingleInputGateBuilder().setSingleInputGateIndex(0).build();
-		RemoteInputChannel channel1 = InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate1);
+		RemoteInputChannel channel1 = createRemoteInputChannel(inputGate1, 0);
 		inputGate1.setInputChannels(channel1);
 
 		SingleInputGate inputGate2 = new SingleInputGateBuilder().setSingleInputGateIndex(1).build();
-		RemoteInputChannel channel2 = InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate2);
+		RemoteInputChannel channel2 = createRemoteInputChannel(inputGate2, 0);
 		inputGate2.setInputChannels(channel2);
 
 		CheckpointBarrierUnaligner unaligner = new CheckpointBarrierUnaligner(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -85,6 +85,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				connectionManager,
 				partitionRequestInitialBackoff,
 				partitionRequestMaxBackoff,
+				networkBuffersPerChannel,
 				metrics);
 		}
 	}
@@ -149,6 +150,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				ConnectionManager connectionManager,
 				int initialBackOff,
 				int maxBackoff,
+				int networkBuffersPerChannel,
 				InputChannelMetrics metrics) {
 			super(
 				inputGate,
@@ -158,6 +160,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				connectionManager,
 				initialBackOff,
 				maxBackoff,
+				networkBuffersPerChannel,
 				metrics.getNumBytesInRemoteCounter(),
 				metrics.getNumBuffersInRemoteCounter());
 		}


### PR DESCRIPTION
## What is the purpose of the change

The filed initialCredit of RemoteInputChannel is set only once and can be accessed by multi threads. This patch makes the filed final and moves the initialization to the constructor of RemoteInputChannel to avoid potential thread safety issues.

## Brief change log

  - Make initialCredit of RemoteInputChannel final

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
