### PR TITLE
[FLINK-18688][table-planner-blink] Fix binary row writing with incorrect order in ProjectionCodeGenerator by removing for loop optimization

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.runtime.generated.GeneratedFunction
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
-import org.apache.calcite.plan.RelOptCluster
+
 import org.apache.calcite.rex._
 
 import scala.collection.JavaConversions._
@@ -34,10 +34,8 @@ object CalcCodeGenerator {
 
   private[flink] def generateCalcOperator(
       ctx: CodeGeneratorContext,
-      cluster: RelOptCluster,
       inputTransform: Transformation[RowData],
       outputType: RowType,
-      config: TableConfig,
       calcProgram: RexProgram,
       condition: Option[RexNode],
       retainHeader: Boolean = false,
@@ -52,8 +50,6 @@ object CalcCodeGenerator {
       inputType,
       outputType,
       classOf[BoxedWrapperRowData],
-      outputType.getFieldNames,
-      config,
       calcProgram,
       condition,
       eagerInputUnboxingCode = true,
@@ -88,8 +84,6 @@ object CalcCodeGenerator {
       inputType,
       returnType,
       outRowClass,
-      returnType.getFieldNames,
-      config,
       calcProjection,
       calcCondition,
       collectorTerm = collectorTerm,
@@ -113,8 +107,6 @@ object CalcCodeGenerator {
       inputType: RowType,
       outRowType: RowType,
       outRowClass: Class[_ <: RowData],
-      resultFieldNames: Seq[String],
-      config: TableConfig,
       calcProgram: RexProgram,
       condition: Option[RexNode],
       inputTerm: String = CodeGenUtils.DEFAULT_INPUT1_TERM,
@@ -140,23 +132,12 @@ object CalcCodeGenerator {
     }
 
     def produceProjectionCode = {
-      // we cannot use for-loop optimization if projection contains other calculations
-      // (for example "select id + 1 from T")
-      val simpleProjection = projection.forall { rexNode => rexNode.isInstanceOf[RexInputRef] }
-
-      val projectionExpression = if (simpleProjection) {
-        val inputMapping = projection.map(_.asInstanceOf[RexInputRef].getIndex).toArray
-        ProjectionCodeGenerator.generateProjectionExpression(
-          ctx, inputType, outRowType, inputMapping,
-          outRowClass, inputTerm, nullCheck = config.getNullCheck)
-      } else {
-        val projectionExprs = projection.map(exprGenerator.generateExpression)
-        exprGenerator.generateResultExpression(
-          projectionExprs,
-          outRowType,
-          outRowClass,
-          allowSplit = allowSplit)
-      }
+      val projectionExprs = projection.map(exprGenerator.generateExpression)
+      val projectionExpression = exprGenerator.generateResultExpression(
+        projectionExprs,
+        outRowType,
+        outRowClass,
+        allowSplit = allowSplit)
 
       val projectionExpressionCode = projectionExpression.code
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateRecordStatement
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
 import org.apache.flink.table.runtime.generated.{GeneratedProjection, Projection}
-import org.apache.flink.table.types.logical.{LogicalType, RowType}
+import org.apache.flink.table.types.logical.RowType
 
 import scala.collection.mutable
 
@@ -50,74 +50,18 @@ object ProjectionCodeGenerator {
       inputTerm: String = DEFAULT_INPUT1_TERM,
       outRecordTerm: String = DEFAULT_OUT_RECORD_TERM,
       outRecordWriterTerm: String = DEFAULT_OUT_RECORD_WRITER_TERM,
-      reusedOutRecord: Boolean = true,
-      nullCheck: Boolean = true): GeneratedExpression = {
-
-    // we use a for loop to do all the projections for the same field type
-    // instead of generating separated code for each field.
-    // when the number of fields of the same type is large, this can improve performance.
-    def generateLoop(
-        fieldType: LogicalType,
-        inIdxs: mutable.ArrayBuffer[Int],
-        outIdxs: mutable.ArrayBuffer[Int]): String = {
-      // this array contains the indices of the fields
-      // whose type equals to `fieldType` in the input row
-      val inIdxArr = newName("inIdx")
-      ctx.addReusableMember(s"int[] $inIdxArr = null;")
-      ctx.addReusableInitStatement(s"$inIdxArr = new int[] {${inIdxs.mkString(", ")}};")
-
-      // this array contains the indices of the fields
-      // whose type equals to `fieldType` in the output row
-      val outIdxArr = newName("outIdx")
-      ctx.addReusableMember(s"int[] $outIdxArr = null;")
-      ctx.addReusableInitStatement(s"$outIdxArr = new int[] {${outIdxs.mkString(", ")}};")
-
-      val loopIdx = newName("i")
-
-      val fieldVal = CodeGenUtils.rowFieldReadAccess(
-        ctx, s"$inIdxArr[$loopIdx]", inputTerm, fieldType)
-
-      val inIdx = s"$inIdxArr[$loopIdx]"
-      val outIdx = s"$outIdxArr[$loopIdx]"
-      val nullTerm = s"$inputTerm.isNullAt($inIdx)"
-      s"""
-         |for (int $loopIdx = 0; $loopIdx < $inIdxArr.length; $loopIdx++) {
-         |  ${CodeGenUtils.rowSetField(ctx, outClass, outRecordTerm, outIdx,
-                GeneratedExpression(fieldVal, nullTerm, "", fieldType),
-                Some(outRecordWriterTerm))}
-         |}
-       """.stripMargin
-    }
-
+      reusedOutRecord: Boolean = true): GeneratedExpression = {
     val outFieldTypes = outType.getChildren
-    val typeIdxs = new mutable.HashMap[
-      LogicalType,
-      (mutable.ArrayBuffer[Int], mutable.ArrayBuffer[Int])]()
-
-    for (i <- 0 until outFieldTypes.size()) {
-      val (inIdxs, outIdxs) = typeIdxs.getOrElseUpdate(
-        outFieldTypes.get(i), (mutable.ArrayBuffer.empty[Int], mutable.ArrayBuffer.empty[Int]))
-      inIdxs.append(inputMapping(i))
-      outIdxs.append(i)
-    }
 
     val codeBuffer = mutable.ArrayBuffer.empty[String]
-    for ((fieldType, (inIdxs, outIdxs)) <- typeIdxs) {
-      if (inIdxs.length >= FOR_LOOP_FIELD_LIMIT) {
-        // for loop optimization will only be enabled
-        // if the number of fields to be project exceeds the limit
-        codeBuffer.append(generateLoop(fieldType, inIdxs, outIdxs))
-      } else {
-        // otherwise we do not use for loop
-        for (i <- inIdxs.indices) {
-          val nullTerm = s"$inputTerm.isNullAt(${inIdxs(i)})"
-          codeBuffer.append(
-            CodeGenUtils.rowSetField(ctx, outClass, outRecordTerm, outIdxs(i).toString,
-              GeneratedExpression(rowFieldReadAccess(
-                ctx, inIdxs(i), inputTerm, fieldType), nullTerm, "", fieldType),
-              Some(outRecordWriterTerm)))
-        }
-      }
+    for (i <- inputMapping.indices) {
+      val nullTerm = s"$inputTerm.isNullAt(${inputMapping(i)})"
+      val fieldType = outFieldTypes.get(i)
+      codeBuffer.append(
+        CodeGenUtils.rowSetField(ctx, outClass, outRecordTerm, i.toString,
+          GeneratedExpression(rowFieldReadAccess(
+            ctx, inputMapping(i), inputTerm, fieldType), nullTerm, "", fieldType),
+          Some(outRecordWriterTerm)))
     }
 
     val setFieldsCode = codeBuffer.mkString("\n")
@@ -168,14 +112,13 @@ object ProjectionCodeGenerator {
       inputTerm: String = DEFAULT_INPUT1_TERM,
       outRecordTerm: String = DEFAULT_OUT_RECORD_TERM,
       outRecordWriterTerm: String = DEFAULT_OUT_RECORD_WRITER_TERM,
-      reusedOutRecord: Boolean = true,
-      nullCheck: Boolean = true): GeneratedProjection = {
+      reusedOutRecord: Boolean = true): GeneratedProjection = {
     val className = newName(name)
     val baseClass = classOf[Projection[_, _]]
 
     val expression = generateProjectionExpression(
       ctx, inType, outType, inputMapping, outClass,
-      inputTerm, outRecordTerm, outRecordWriterTerm, reusedOutRecord, nullCheck)
+      inputTerm, outRecordTerm, outRecordWriterTerm, reusedOutRecord)
 
     val code =
       s"""

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCalc.scala
@@ -61,10 +61,8 @@ class BatchExecCalc(
     val ctx = CodeGeneratorContext(config)
     val operator = CalcCodeGenerator.generateCalcOperator(
       ctx,
-      cluster,
       inputTransform,
       outputType,
-      config,
       calcProgram,
       condition,
       opName = "BatchCalc"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCalc.scala
@@ -76,10 +76,8 @@ class StreamExecCalc(
     val outputType = FlinkTypeFactory.toLogicalRowType(getRowType)
     val substituteStreamOperator = CalcCodeGenerator.generateCalcOperator(
       ctx,
-      cluster,
       inputTransform,
       outputType,
-      config,
       calcProgram,
       condition,
       retainHeader = true,


### PR DESCRIPTION
## What is the purpose of the change

If too many fields of the same type are projected, `ProjectionCodeGenerator#generateProjectionExpression` currently performs a "for loop optimization" which, instead of generating code separately for each field, they'll be squashed into a for loop.

However, if the indices of the fields with the same type are not continuous, this optimization will not write fields in index ascending order. This is not acceptable because BinaryWriter expects the users to write fields in index ascending order (that is to say, we have to first write field 0, then field 1, then...), otherwise the variable length area of the two binary rows with same data might be different. Although we can use getXX methods of BinaryRow to get the fields correctly, states for streaming jobs compare state keys with binary bits, not with the contents of the keys. So we need to make sure the binary bits of the binary rows be the same if two rows contain the same data.

What's worse, as the current implementation of ProjectionCodeGenerator#generateProjectionExpression uses a scala HashMap, the key order of the map might be different on different workers; Even if the projection does not meet the condition to be optimized, it will still be affected by this bug.

This PR simply removes this optimization. Because if we still want this optimization, we have to make sure that the fields of the same type have continuous order, which is a very strict and rare condition.

## Brief change log

 - Remove for loop optimization in `ProjectionCodeGenerator`.


## Verifying this change

This change added tests and can be verified by running the newly added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
