### PR TITLE
[FLINK-18731][table-planner-blink] Fix monotonicity logic of UNIX_TIMESTAMP & UUID functions

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -561,7 +561,11 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 
 		@Override
 		public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
-			return SqlMonotonicity.INCREASING;
+			if (call.getOperandCount() == 0) {
+				return SqlMonotonicity.INCREASING;
+			} else {
+				return SqlMonotonicity.NOT_MONOTONIC;
+			}
 		}
 	};
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -634,11 +634,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 		public boolean isDeterministic() {
 			return false;
 		}
-
-		@Override
-		public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
-			return SqlMonotonicity.INCREASING;
-		}
 	};
 
 	public static final SqlFunction SUBSTRING = new SqlFunction(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCollationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCollationTest.scala
@@ -122,6 +122,15 @@ class FlinkRelMdRowCollationTest extends FlinkRelMdHandlerTestBase {
       relBuilder.call(FlinkSqlOperatorTable.UNIX_TIMESTAMP) // UNIX_TIMESTAMP()
     ).build()
     assertEquals(ImmutableList.of(RelCollations.of(1)), mq.collations(project3))
+
+    // SELECT a, UUID() as ts FROM (VALUES (3, '2015-07-24 10:00:00')) T(a, b)
+    relBuilder.clear()
+    relBuilder.values(tupleList, valuesType)
+    val project4 = relBuilder.project(
+      relBuilder.field(0), // a
+      relBuilder.call(FlinkSqlOperatorTable.UUID) // UUID()
+    ).build()
+    assertTrue(mq.collations(project4).isEmpty)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCollationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCollationTest.scala
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
+
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.rel.logical.{LogicalFilter, LogicalProject, LogicalValues}
 import org.apache.calcite.rel.{RelCollation, RelCollations, RelFieldCollation}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.fun.SqlStdOperatorTable.{LESS_THAN, PLUS}
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
 import scala.collection.JavaConversions._
@@ -94,6 +96,32 @@ class FlinkRelMdRowCollationTest extends FlinkRelMdHandlerTestBase {
       relBuilder.project(projects).build().asInstanceOf[LogicalProject]
     }
     assertEquals(ImmutableList.of(RelCollations.of(2)), mq.collations(project))
+
+    // SELECT a, UNIX_TIMESTAMP(b) as ts FROM (VALUES (3, '2015-07-24 10:00:00')) T(a, b)
+    relBuilder.clear()
+    val valuesType = relBuilder.getTypeFactory
+      .builder()
+      .add("a", SqlTypeName.BIGINT)
+      .add("ts", SqlTypeName.VARCHAR)
+      .build()
+    val tupleList = List(List("3", "2015-07-24 10:00:00")).map(createLiteralList(valuesType, _))
+    relBuilder.values(tupleList, valuesType)
+    val project2 = relBuilder.project(
+      // a
+      relBuilder.field(0),
+      // UNIX_TIMESTAMP(ts)
+      relBuilder.call(FlinkSqlOperatorTable.UNIX_TIMESTAMP, relBuilder.field(1))
+    ).build()
+    assertTrue(mq.collations(project2).isEmpty)
+
+    // SELECT a, UNIX_TIMESTAMP() as ts FROM (VALUES (3, '2015-07-24 10:00:00')) T(a, b)
+    relBuilder.clear()
+    relBuilder.values(tupleList, valuesType)
+    val project3 = relBuilder.project(
+      relBuilder.field(0), // a
+      relBuilder.call(FlinkSqlOperatorTable.UNIX_TIMESTAMP) // UNIX_TIMESTAMP()
+    ).build()
+    assertEquals(ImmutableList.of(RelCollations.of(1)), mq.collations(project3))
   }
 
   @Test


### PR DESCRIPTION

## What is the purpose of the change

*UNIX_TIMESTAMP function has INCREASING monotonicity only if it has empty function arguments, else has NOT_MONOTONIC monotonicity*


## Brief change log

  - *Correct the monotonicity logic of UNIX_TIMESTAMP function in FlinkSqlOperatorTable*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
