### PR TITLE
[FLINK-18627] Get unmatch filter method records to side output

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -97,6 +97,7 @@ import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ShufflePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.util.keys.KeySelectorUtil;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
@@ -739,6 +740,28 @@ public class DataStream<T> {
 	 */
 	public SingleOutputStreamOperator<T> filter(FilterFunction<T> filter) {
 		return transform("Filter", getType(), new StreamFilter<>(clean(filter)));
+
+	}
+
+	/**
+	 * Applies a Filter transformation on a {@link DataStream}. The
+	 * transformation calls a {@link FilterFunction} for each element of the
+	 * DataStream and retains only those element for which the function returns
+	 * true. Elements for which the function returns false are collected into the
+	 * given {@link OutputTag}.
+	 * The user can also extend {@link RichFilterFunction} to gain access to other
+	 * features provided by the
+	 * {@link org.apache.flink.api.common.functions.RichFunction} interface.
+	 *
+	 * @param filter
+	 *            The FilterFunction that is called for each element of the
+	 *            DataStream.
+	 * @param outputTag
+	 * 			  The {@link OutputTag} that filtered records will be collected.
+	 * @return The filtered DataStream.
+	 */
+	public SingleOutputStreamOperator<T> filter(FilterFunction<T> filter, OutputTag<T> outputTag) {
+		return transform("Filter", getType(), new StreamFilter<>(clean(filter),outputTag));
 
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFilter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFilter.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 
 /**
  * A {@link StreamOperator} for executing {@link FilterFunction FilterFunctions}.
@@ -28,16 +29,25 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class StreamFilter<IN> extends AbstractUdfStreamOperator<IN, FilterFunction<IN>> implements OneInputStreamOperator<IN, IN> {
 
 	private static final long serialVersionUID = 1L;
+	private OutputTag<IN> outputTag;
 
 	public StreamFilter(FilterFunction<IN> filterFunction) {
 		super(filterFunction);
 		chainingStrategy = ChainingStrategy.ALWAYS;
 	}
 
+	public StreamFilter(FilterFunction<IN> filterFunction, OutputTag<IN> outputTag) {
+		super(filterFunction);
+		chainingStrategy = ChainingStrategy.ALWAYS;
+		this.outputTag = outputTag;
+	}
+
 	@Override
 	public void processElement(StreamRecord<IN> element) throws Exception {
 		if (userFunction.filter(element.getValue())) {
 			output.collect(element);
+		} else if (this.outputTag != null) {
+			output.collect(this.outputTag, element);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Improvment of usage syntx of FilterFunction of datastream


## Verifying this change

Adding new UnitTests to the changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? On the method description
