### PR TITLE
[FLINK-18690][runtime] Implement LocalInputPreferredSlotSharingStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraintDesc.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraintDesc.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.scheduler;
+
+import org.apache.flink.util.AbstractID;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A read-only and light weight version of {@link CoLocationConstraint}.
+ */
+public class CoLocationConstraintDesc {
+
+	private final AbstractID coLocationGroupId;
+
+	private final int constraintIndex;
+
+	CoLocationConstraintDesc(final AbstractID coLocationGroupId, final int constraintIndex) {
+		this.coLocationGroupId = checkNotNull(coLocationGroupId);
+		this.constraintIndex = constraintIndex;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		} else if (obj != null && obj.getClass() == getClass()) {
+			CoLocationConstraintDesc that = (CoLocationConstraintDesc) obj;
+			return Objects.equals(that.coLocationGroupId, this.coLocationGroupId) &&
+				that.constraintIndex == this.constraintIndex;
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return 31 * coLocationGroupId.hashCode() + constraintIndex;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationGroupDesc.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationGroupDesc.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.scheduler;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.AbstractID;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A read-only and light weight version of {@link CoLocationGroup}.
+ */
+public class CoLocationGroupDesc {
+
+	private final AbstractID id;
+
+	private final List<JobVertexID> vertices;
+
+	private CoLocationGroupDesc(final AbstractID id, final List<JobVertexID> vertices) {
+		this.id = checkNotNull(id);
+		this.vertices = checkNotNull(vertices);
+	}
+
+	public AbstractID getId() {
+		return id;
+	}
+
+	public List<JobVertexID> getVertices() {
+		return Collections.unmodifiableList(vertices);
+	}
+
+	public CoLocationConstraintDesc getLocationConstraint(final int index) {
+		return new CoLocationConstraintDesc(id, index);
+	}
+
+	public static CoLocationGroupDesc from(final CoLocationGroup group) {
+		return new CoLocationGroupDesc(
+			group.getId(),
+			group.getVertices().stream().map(JobVertex::getID).collect(Collectors.toList()));
+	}
+
+	@VisibleForTesting
+	public static CoLocationGroupDesc from(final JobVertexID ...ids) {
+		return new CoLocationGroupDesc(new AbstractID(), Arrays.asList(ids));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents execution vertices that will run the same shared slot.
+ */
+class ExecutionSlotSharingGroup {
+
+	private final Set<ExecutionVertexID> executionVertexIds;
+
+	ExecutionSlotSharingGroup() {
+		this.executionVertexIds = new HashSet<>();
+	}
+
+	void addVertex(final ExecutionVertexID executionVertexId) {
+		executionVertexIds.add(executionVertexId);
+	}
+
+	Set<ExecutionVertexID> getExecutionVertexIds() {
+		return Collections.unmodifiableSet(executionVertexIds);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraintDesc;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroupDesc;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * This strategy tries to reduce remote data exchanges. Execution vertices, which are connected
+ * and belong to the same SlotSharingGroup, tend to be put in the same ExecutionSlotSharingGroup.
+ * Co-location constraints will be respected.
+ */
+class LocalInputPreferredSlotSharingStrategy implements SlotSharingStrategy {
+
+	private final Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroupMap;
+
+	LocalInputPreferredSlotSharingStrategy(
+			final SchedulingTopology topology,
+			final Set<SlotSharingGroup> logicalSlotSharingGroups,
+			final Set<CoLocationGroupDesc> coLocationGroups) {
+
+		this.executionSlotSharingGroupMap = new ExecutionSlotSharingGroupBuilder(
+			topology,
+			logicalSlotSharingGroups,
+			coLocationGroups).build();
+	}
+
+	@Override
+	public ExecutionSlotSharingGroup getExecutionSlotSharingGroup(final ExecutionVertexID executionVertexId) {
+		return executionSlotSharingGroupMap.get(executionVertexId);
+	}
+
+	@Override
+	public Set<ExecutionSlotSharingGroup> getExecutionSlotSharingGroups() {
+		return new HashSet<>(executionSlotSharingGroupMap.values());
+	}
+
+	static class Factory implements SlotSharingStrategy.Factory {
+
+		public LocalInputPreferredSlotSharingStrategy create(
+				final SchedulingTopology topology,
+				final Set<SlotSharingGroup> logicalSlotSharingGroups,
+				final Set<CoLocationGroupDesc> coLocationGroups) {
+
+			return new LocalInputPreferredSlotSharingStrategy(topology, logicalSlotSharingGroups, coLocationGroups);
+		}
+	}
+
+	private static class ExecutionSlotSharingGroupBuilder {
+		private final SchedulingTopology topology;
+
+		private final Map<JobVertexID, SlotSharingGroupId> slotSharingGroupMap;
+
+		private final Map<JobVertexID, CoLocationGroupDesc> coLocationGroupMap;
+
+		private final Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroupMap;
+
+		final Map<CoLocationConstraintDesc, ExecutionSlotSharingGroup> constraintToExecutionSlotSharingGroupMap;
+
+		final Map<SlotSharingGroupId, List<ExecutionSlotSharingGroup>> executionSlotSharingGroups;
+
+		private final Map<ExecutionSlotSharingGroup, Set<JobVertexID>> assignedJobVerticesForGroups;
+
+		private ExecutionSlotSharingGroupBuilder(
+				final SchedulingTopology topology,
+				final Set<SlotSharingGroup> logicalSlotSharingGroups,
+				final Set<CoLocationGroupDesc> coLocationGroups) {
+
+			this.topology = checkNotNull(topology);
+
+			this.slotSharingGroupMap = new HashMap<>();
+			for (SlotSharingGroup slotSharingGroup : logicalSlotSharingGroups) {
+				for (JobVertexID jobVertexId : slotSharingGroup.getJobVertexIds()) {
+					slotSharingGroupMap.put(jobVertexId, slotSharingGroup.getSlotSharingGroupId());
+				}
+			}
+
+			this.coLocationGroupMap = new HashMap<>();
+			for (CoLocationGroupDesc coLocationGroup : coLocationGroups) {
+				for (JobVertexID jobVertexId : coLocationGroup.getVertices()) {
+					coLocationGroupMap.put(jobVertexId, coLocationGroup);
+				}
+			}
+
+			executionSlotSharingGroupMap = new HashMap<>();
+			constraintToExecutionSlotSharingGroupMap = new HashMap<>();
+			executionSlotSharingGroups = new HashMap<>();
+			assignedJobVerticesForGroups = new IdentityHashMap<>();
+		}
+
+		/**
+		 * Build ExecutionSlotSharingGroups for all vertices in the topology.
+		 * The ExecutionSlotSharingGroup of a vertex is determined in order below:
+		 *
+		 * <p>1. try finding an existing group of the corresponding co-location constraint.
+		 *
+		 * <p>2. try finding an available group of its producer vertex if the producer is in the same slot sharing group.
+		 *
+		 * <p>3. try finding any available group.
+		 *
+		 * <p>4. create a new group.
+		 */
+		private Map<ExecutionVertexID, ExecutionSlotSharingGroup> build() {
+			final LinkedHashMap<JobVertexID, List<SchedulingExecutionVertex>> allVertices = getExecutionVertices();
+
+			// loop on job vertices so that an execution vertex will not be added into a group
+			// if that group better fits another execution vertex
+			for (List<SchedulingExecutionVertex> executionVertices : allVertices.values()) {
+				final List<SchedulingExecutionVertex> remaining = tryFindOptimalAvailableExecutionSlotSharingGroupFor(
+					executionVertices);
+
+				findAvailableOrCreateNewExecutionSlotSharingGroupFor(remaining);
+
+				updateConstraintToExecutionSlotSharingGroupMap(executionVertices);
+			}
+
+			return executionSlotSharingGroupMap;
+		}
+
+		private LinkedHashMap<JobVertexID, List<SchedulingExecutionVertex>> getExecutionVertices() {
+			final LinkedHashMap<JobVertexID, List<SchedulingExecutionVertex>> vertices = new LinkedHashMap<>();
+			for (SchedulingExecutionVertex executionVertex : topology.getVertices()) {
+				final List<SchedulingExecutionVertex> executionVertexGroup = vertices.computeIfAbsent(
+					executionVertex.getId().getJobVertexId(),
+					k -> new ArrayList<>());
+				executionVertexGroup.add(executionVertex);
+			}
+			return vertices;
+		}
+
+		private List<SchedulingExecutionVertex> tryFindOptimalAvailableExecutionSlotSharingGroupFor(
+				final List<SchedulingExecutionVertex> executionVertices) {
+
+			final List<SchedulingExecutionVertex> remaining = new ArrayList<>();
+			for (SchedulingExecutionVertex executionVertex : executionVertices) {
+				ExecutionSlotSharingGroup group = tryFindAvailableCoLocatedExecutionSlotSharingGroupFor(executionVertex);
+
+				if (group == null) {
+					group = tryFindAvailableProducerExecutionSlotSharingGroupFor(executionVertex);
+				}
+
+				if (group == null) {
+					remaining.add(executionVertex);
+				} else {
+					addVertexToExecutionSlotSharingGroup(executionVertex, group);
+				}
+			}
+
+			return remaining;
+		}
+
+		private ExecutionSlotSharingGroup tryFindAvailableCoLocatedExecutionSlotSharingGroupFor(
+				final SchedulingExecutionVertex executionVertex) {
+
+			final ExecutionVertexID executionVertexId = executionVertex.getId();
+			final CoLocationGroupDesc coLocationGroup = coLocationGroupMap.get(executionVertexId.getJobVertexId());
+			if (coLocationGroup != null) {
+				final CoLocationConstraintDesc constraint = coLocationGroup.getLocationConstraint(
+					executionVertexId.getSubtaskIndex());
+
+				return constraintToExecutionSlotSharingGroupMap.get(constraint);
+			} else {
+				return null;
+			}
+		}
+
+		private ExecutionSlotSharingGroup tryFindAvailableProducerExecutionSlotSharingGroupFor(
+				final SchedulingExecutionVertex executionVertex) {
+
+			final ExecutionVertexID executionVertexId = executionVertex.getId();
+
+			for (SchedulingResultPartition partition : executionVertex.getConsumedResults()) {
+				final ExecutionVertexID producerVertexId = partition.getProducer().getId();
+				if (!inSameLogicalSlotSharingGroup(producerVertexId, executionVertexId)) {
+					continue;
+				}
+
+				final ExecutionSlotSharingGroup producerGroup = executionSlotSharingGroupMap.get(producerVertexId);
+
+				checkState(producerGroup != null);
+				if (isGroupAvailableForVertex(producerGroup, executionVertexId)) {
+					return producerGroup;
+				}
+			}
+
+			return null;
+		}
+
+		private boolean inSameLogicalSlotSharingGroup(
+				final ExecutionVertexID executionVertexId1,
+				final ExecutionVertexID executionVertexId2) {
+
+			return Objects.equals(getSlotSharingGroupId(executionVertexId1), getSlotSharingGroupId(executionVertexId2));
+		}
+
+		private SlotSharingGroupId getSlotSharingGroupId(final ExecutionVertexID executionVertexId) {
+			// slot sharing group of a vertex would never be null in production
+			return checkNotNull(slotSharingGroupMap.get(executionVertexId.getJobVertexId()));
+		}
+
+		private boolean isGroupAvailableForVertex(
+				final ExecutionSlotSharingGroup executionSlotSharingGroup,
+				final ExecutionVertexID executionVertexId) {
+
+			final Set<JobVertexID> assignedVertices = assignedJobVerticesForGroups.get(executionSlotSharingGroup);
+			return assignedVertices == null || !assignedVertices.contains(executionVertexId.getJobVertexId());
+		}
+
+		private void addVertexToExecutionSlotSharingGroup(
+				final SchedulingExecutionVertex vertex,
+				final ExecutionSlotSharingGroup group) {
+
+			group.addVertex(vertex.getId());
+			executionSlotSharingGroupMap.put(vertex.getId(), group);
+			assignedJobVerticesForGroups.computeIfAbsent(group, k -> new HashSet<>()).add(vertex.getId().getJobVertexId());
+		}
+
+		private void findAvailableOrCreateNewExecutionSlotSharingGroupFor(
+				final List<SchedulingExecutionVertex> executionVertices) {
+
+			for (SchedulingExecutionVertex executionVertex : executionVertices) {
+				final SlotSharingGroupId slotSharingGroupId = getSlotSharingGroupId(executionVertex.getId());
+				final List<ExecutionSlotSharingGroup> groups = executionSlotSharingGroups.computeIfAbsent(
+					slotSharingGroupId,
+					k -> new ArrayList<>());
+
+				ExecutionSlotSharingGroup group = null;
+				for (ExecutionSlotSharingGroup executionSlotSharingGroup : groups) {
+					if (isGroupAvailableForVertex(executionSlotSharingGroup, executionVertex.getId())) {
+						group = executionSlotSharingGroup;
+						break;
+					}
+				}
+
+				if (group == null) {
+					group = new ExecutionSlotSharingGroup();
+					groups.add(group);
+				}
+
+				addVertexToExecutionSlotSharingGroup(executionVertex, group);
+			}
+		}
+
+		private void updateConstraintToExecutionSlotSharingGroupMap(
+				final List<SchedulingExecutionVertex> executionVertices) {
+
+			for (SchedulingExecutionVertex executionVertex : executionVertices) {
+				final ExecutionVertexID executionVertexId = executionVertex.getId();
+				final CoLocationGroupDesc coLocationGroup = coLocationGroupMap.get(executionVertexId.getJobVertexId());
+				if (coLocationGroup != null) {
+					final CoLocationConstraintDesc constraint = coLocationGroup.getLocationConstraint(
+						executionVertexId.getSubtaskIndex());
+
+					constraintToExecutionSlotSharingGroupMap.put(
+						constraint,
+						executionSlotSharingGroupMap.get(executionVertexId));
+				}
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroupDesc;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import java.util.Set;
+
+/**
+ * Strategy which determines {@link ExecutionSlotSharingGroup} for each execution vertex.
+ */
+interface SlotSharingStrategy {
+
+	ExecutionSlotSharingGroup getExecutionSlotSharingGroup(
+		ExecutionVertexID executionVertexId);
+
+	Set<ExecutionSlotSharingGroup> getExecutionSlotSharingGroups();
+
+	@FunctionalInterface
+	interface Factory {
+		SlotSharingStrategy create(
+			SchedulingTopology topology,
+			Set<SlotSharingGroup> logicalSlotSharingGroups,
+			Set<CoLocationGroupDesc> coLocationGroups);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroupDesc;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingExecutionVertex;
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingTopology;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link LocalInputPreferredSlotSharingStrategy}.
+ */
+public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {
+
+	private TestingSchedulingTopology topology;
+
+	private static final JobVertexID JOB_VERTEX_ID_1 = new JobVertexID();
+	private static final JobVertexID JOB_VERTEX_ID_2 = new JobVertexID();
+
+	private TestingSchedulingExecutionVertex ev11;
+	private TestingSchedulingExecutionVertex ev12;
+	private TestingSchedulingExecutionVertex ev21;
+	private TestingSchedulingExecutionVertex ev22;
+
+	private Set<SlotSharingGroup> slotSharingGroups;
+
+	@Before
+	public void setUp() throws Exception {
+		topology = new TestingSchedulingTopology();
+
+		ev11 = topology.newExecutionVertex(JOB_VERTEX_ID_1, 0);
+		ev12 = topology.newExecutionVertex(JOB_VERTEX_ID_1, 1);
+
+		ev21 = topology.newExecutionVertex(JOB_VERTEX_ID_2, 0);
+		ev22 = topology.newExecutionVertex(JOB_VERTEX_ID_2, 1);
+
+		final SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
+		slotSharingGroup.addVertexToGroup(JOB_VERTEX_ID_1, ResourceSpec.UNKNOWN);
+		slotSharingGroup.addVertexToGroup(JOB_VERTEX_ID_2, ResourceSpec.UNKNOWN);
+		slotSharingGroups = Collections.singleton(slotSharingGroup);
+	}
+
+	@Test
+	public void testCoLocationConstraintIsRespected() {
+		topology.connect(ev11, ev22);
+		topology.connect(ev12, ev21);
+
+		final CoLocationGroupDesc coLocationGroup = CoLocationGroupDesc.from(JOB_VERTEX_ID_1, JOB_VERTEX_ID_2);
+		final Set<CoLocationGroupDesc> coLocationGroups = Collections.singleton(coLocationGroup);
+
+		final SlotSharingStrategy strategy = new LocalInputPreferredSlotSharingStrategy(
+			topology,
+			slotSharingGroups,
+			coLocationGroups);
+
+		assertThat(strategy.getExecutionSlotSharingGroups(), hasSize(2));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev11.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev11.getId(), ev21.getId()));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev12.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev12.getId(), ev22.getId()));
+	}
+
+	@Test
+	public void testInputLocalityIsRespected() {
+		final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+		final TestingSchedulingExecutionVertex ev11 = topology.newExecutionVertex(JOB_VERTEX_ID_1, 0);
+		final TestingSchedulingExecutionVertex ev12 = topology.newExecutionVertex(JOB_VERTEX_ID_1, 1);
+
+		final TestingSchedulingExecutionVertex ev21 = topology.newExecutionVertex(JOB_VERTEX_ID_2, 0);
+		final TestingSchedulingExecutionVertex ev22 = topology.newExecutionVertex(JOB_VERTEX_ID_2, 1);
+		final TestingSchedulingExecutionVertex ev23 = topology.newExecutionVertex(JOB_VERTEX_ID_2, 2);
+
+		topology.connect(ev11, ev21);
+		topology.connect(ev11, ev22);
+		topology.connect(ev12, ev23);
+
+		final SlotSharingStrategy strategy = new LocalInputPreferredSlotSharingStrategy(
+			topology,
+			slotSharingGroups,
+			Collections.emptySet());
+
+		assertThat(strategy.getExecutionSlotSharingGroups(), hasSize(3));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev21.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev11.getId(), ev21.getId()));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev22.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev22.getId()));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev23.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev12.getId(), ev23.getId()));
+	}
+
+	@Test
+	public void testDisjointVerticesInOneGroup() {
+		final SlotSharingStrategy strategy = new LocalInputPreferredSlotSharingStrategy(
+			topology,
+			slotSharingGroups,
+			Collections.emptySet());
+
+		assertThat(strategy.getExecutionSlotSharingGroups(), hasSize(2));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev11.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev11.getId(), ev21.getId()));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev12.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev12.getId(), ev22.getId()));
+	}
+
+	@Test
+	public void testVerticesInDifferentSlotSharingGroups() {
+		final SlotSharingGroup slotSharingGroup1 = new SlotSharingGroup();
+		slotSharingGroup1.addVertexToGroup(JOB_VERTEX_ID_1, ResourceSpec.UNKNOWN);
+		final SlotSharingGroup slotSharingGroup2 = new SlotSharingGroup();
+		slotSharingGroup2.addVertexToGroup(JOB_VERTEX_ID_2, ResourceSpec.UNKNOWN);
+
+		final Set<SlotSharingGroup> slotSharingGroups = new HashSet<>();
+		slotSharingGroups.add(slotSharingGroup1);
+		slotSharingGroups.add(slotSharingGroup2);
+
+		final SlotSharingStrategy strategy = new LocalInputPreferredSlotSharingStrategy(
+			topology,
+			slotSharingGroups,
+			Collections.emptySet());
+
+		assertThat(strategy.getExecutionSlotSharingGroups(), hasSize(4));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev11.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev11.getId()));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev12.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev12.getId()));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev21.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev21.getId()));
+		assertThat(
+			strategy.getExecutionSlotSharingGroup(ev22.getId()).getExecutionVertexIds(),
+			containsInAnyOrder(ev22.getId()));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -152,9 +152,20 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 	}
 
 	public TestingSchedulingExecutionVertex newExecutionVertex() {
-		final TestingSchedulingExecutionVertex newVertex = new TestingSchedulingExecutionVertex(new JobVertexID(), 0);
+		return newExecutionVertex(new JobVertexID(), 0);
+	}
+
+	public TestingSchedulingExecutionVertex newExecutionVertex(final JobVertexID jobVertexId, final int subtaskIndex) {
+		final TestingSchedulingExecutionVertex newVertex = new TestingSchedulingExecutionVertex(jobVertexId, subtaskIndex);
 		addSchedulingExecutionVertex(newVertex);
 		return newVertex;
+	}
+
+	public TestingSchedulingTopology connect(
+			final TestingSchedulingExecutionVertex producer,
+			final TestingSchedulingExecutionVertex consumer) {
+
+		return connect(producer, consumer, ResultPartitionType.PIPELINED);
 	}
 
 	public TestingSchedulingTopology connect(


### PR DESCRIPTION

## What is the purpose of the change

This PR introduces ExecutionSlotSharingGroup, SlotSharingStrategy and implements LocalInputPreferredSlotSharingStrategy.

The default SlotSharingStrategy would be LocalInputPreferredSlotSharingStrategy. It will try to reduce remote data exchanges. Subtasks, which are connected and belong to the same SlotSharingGroup, tend to be put in the same ExecutionSlotSharingGroup.

## Brief change log

  - Introduce ExecutionSlotSharingGroup and SlotSharingStrategy interface
  - Implement LocalInputPreferredSlotSharingStrategy


## Verifying this change

  - *Added unit tests for LocalInputPreferredSlotSharingStrategy*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
