### PR TITLE
[FLINK-18493][Deployment / YARN]Make target home directory used to store yarn files configurable

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -141,6 +141,12 @@
             <td>A semicolon-separated list of directories to be shipped to the YARN cluster.</td>
         </tr>
         <tr>
+            <td><h5>yarn.staging-directory</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Staging directory used to store YARN files while submitting applications. Per default, it uses the home directory of the configured file system.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.tags</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -196,6 +196,12 @@ public class YarnConfigOptions {
 
 	// ----------------------- YARN CLI OPTIONS ------------------------------------
 
+	public static final ConfigOption<String> STAGING_DIRECTORY =
+		key("yarn.staging-directory")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Staging directory used to store YARN files while submitting applications. Per default, it uses the home directory of the configured file system.");
+
 	public static final ConfigOption<List<String>> SHIP_DIRECTORIES =
 			key("yarn.ship-directories")
 				.stringType()


### PR DESCRIPTION
## What is the purpose of the change

When submitting applications to yarn, the file system's default home directory, like /user/user_name on hdfs, is used as the base directory to store flink files. But in different file system access control strategies, the default home directory may be inaccessible, and it's more preferable for users to specify thier own paths if they wish to.


## Brief change log

  - Add a configuration entry yarn.staging-directory
  - if yarn.staging-directory is set, use it as staging directory
  - if yarn.staging-directory is not set, use default home directory as staging directory

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: ()

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
