### PR TITLE
[FLINK-18508][table] Dynamic table supports statistics and parallelism report

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsParallelismReport.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsParallelismReport.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.ScanTableSource;
+
+/**
+ * Enables to give {@link ScanTableSource} and {@link DynamicTableSink} the ability to report
+ * parallelism.
+ *
+ * <p>After filtering push down and partition push down, the source can have more information,
+ * which can help it infer more effective parallelism.
+ *
+ * <p>Internal: This interface is only used by Hive and Filesystem connector.
+ */
+@Internal
+public interface SupportsParallelismReport {
+
+	/**
+	 * Report parallelism from source or sink. The parallelism of an operator must be at least 1,
+	 * or -1 (use system default).
+	 */
+	int reportParallelism();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsStatisticsReport.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsStatisticsReport.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.plan.stats.TableStats;
+
+/**
+ * Enables to give {@link ScanTableSource} the ability to report table statistics.
+ *
+ * <p>Statistics can be inferred from real data in real time, it is more accurate than the
+ * statistics in the catalog.
+ *
+ * <p>After filtering push down and partition push down, the source can have more information,
+ * which can help it infer more effective table statistics.
+ *
+ * <p>Internal: This interface is only used by Hive and Filesystem connector.
+ */
+@Internal
+public interface SupportsStatisticsReport {
+
+	/**
+	 * Reports {@link TableStats} from old table stats.
+	 */
+	TableStats reportTableStatistics(TableStats oldStats);
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/SourceReportStatisticsRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/SourceReportStatisticsRule.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsStatisticsReport;
+import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * Planner rule that tries to calculate table statistics from a {@link LogicalTableScan},
+ * which table is a {@link TableSourceTable}. And the table source in the table is a
+ * {@link SupportsStatisticsReport}.
+ */
+public class SourceReportStatisticsRule extends RelOptRule {
+
+	public static final SourceReportStatisticsRule INSTANCE = new SourceReportStatisticsRule();
+	public static final String REPORTED_DIGEST = "statistics-reported=true";
+
+	public SourceReportStatisticsRule() {
+		super(operand(LogicalTableScan.class, none()), SourceReportStatisticsRule.class.getSimpleName());
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		LogicalTableScan scan = call.rel(0);
+		TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
+		// we can not push filter twice
+		return tableSourceTable != null
+			&& tableSourceTable.tableSource() instanceof SupportsStatisticsReport
+			&& Arrays.stream(tableSourceTable.extraDigests()).noneMatch(REPORTED_DIGEST::equals);
+	}
+
+	@Override
+	public void onMatch(RelOptRuleCall call) {
+		LogicalTableScan scan = call.rel(0);
+		TableSourceTable table = scan.getTable().unwrap(TableSourceTable.class);
+		report(call, scan, table);
+	}
+
+	private void report(
+		RelOptRuleCall call,
+		LogicalTableScan scan,
+		FlinkPreparingTableBase relOptTable) {
+		TableSourceTable oldTableSourceTable = relOptTable.unwrap(TableSourceTable.class);
+		DynamicTableSource newTableSource = oldTableSourceTable.tableSource().copy();
+
+		TableSourceTable newTableSourceTable = oldTableSourceTable.copy(
+			newTableSource,
+			getNewFlinkStatistic(oldTableSourceTable.getStatistic(), (SupportsStatisticsReport) newTableSource),
+			getNewExtraDigests(oldTableSourceTable)
+		);
+		TableScan newScan = LogicalTableScan.create(scan.getCluster(), newTableSourceTable, scan.getHints());
+		call.transformTo(newScan);
+	}
+
+	private FlinkStatistic getNewFlinkStatistic(FlinkStatistic oldStatistic, SupportsStatisticsReport report) {
+		return FlinkStatistic.builder()
+				.statistic(oldStatistic)
+				.tableStats(report.reportTableStatistics(oldStatistic.getTableStats()))
+				.build();
+	}
+
+	private String[] getNewExtraDigests(TableSourceTable tableSourceTable) {
+		return Stream.concat(
+				Arrays.stream(tableSourceTable.extraDigests()),
+				Arrays.stream(new String[]{REPORTED_DIGEST}))
+			.toArray(String[]::new);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -22,8 +22,10 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.rules.FlinkBatchRuleSets
+import org.apache.flink.table.planner.plan.rules.logical.SourceReportStatisticsRule
 
 import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.tools.RuleSets
 
 /**
   * Defines a sequence of programs to optimize flink batch table plan.
@@ -135,6 +137,12 @@ object FlinkBatchProgram {
             .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
             .add(FlinkBatchRuleSets.PRUNE_EMPTY_RULES)
             .build(), "prune empty after predicate push down")
+        .addProgram(
+          FlinkHepRuleSetProgramBuilder.newBuilder
+            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+            .add(RuleSets.ofList(SourceReportStatisticsRule.INSTANCE))
+            .build(), "report table statistics after predicate push down")
         .build())
 
     // join reorder

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SourceReportsTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SourceReportsTest.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testJoin">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], i=[$2], j=[$3])
++- LogicalFilter(condition=[=($2, $0)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, ReportTable]])
+
+== Optimized Logical Plan ==
+HashJoin(joinType=[InnerJoin], where=[=(i, a)], select=[a, b, i, j], build=[right])
+:- Exchange(distribution=[hash[a]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
++- Exchange(distribution=[hash[i]])
+   +- TableSourceScan(table=[[default_catalog, default_database, ReportTable, statistics-reported=true]], fields=[i, j])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : Source: Collection Source
+
+	 : Operator
+		content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [TestTableSource(a, b)]], fields=[a, b])
+		ship_strategy : FORWARD
+
+ : Data Source
+	content : Source: TableSourceScan(table=[[default_catalog, default_database, ReportTable, statistics-reported=true]], fields=[i, j])
+
+	 : Operator
+		content : HashJoin(joinType=[InnerJoin], where=[(i = a)], select=[a, b, i, j], build=[right])
+		ship_strategy : HASH[i]
+
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinWithStatistics">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], i=[$2], j=[$3])
++- LogicalFilter(condition=[=($2, $0)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, ReportTable]])
+
+== Optimized Logical Plan ==
+HashJoin(joinType=[InnerJoin], where=[=(i, a)], select=[a, b, i, j], isBroadcast=[true], build=[right])
+:- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
++- Exchange(distribution=[broadcast])
+   +- TableSourceScan(table=[[default_catalog, default_database, ReportTable, statistics-reported=true]], fields=[i, j])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : Source: Collection Source
+
+	 : Operator
+		content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [TestTableSource(a, b)]], fields=[a, b])
+		ship_strategy : FORWARD
+
+ : Data Source
+	content : Source: TableSourceScan(table=[[default_catalog, default_database, ReportTable, statistics-reported=true]], fields=[i, j])
+
+	 : Operator
+		content : HashJoin(joinType=[InnerJoin], where=[(i = a)], select=[a, b, i, j], isBroadcast=[true], build=[right])
+		ship_strategy : BROADCAST
+
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SourceReportsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SourceReportsTest.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.batch.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.transformations.SinkTransformation
+import org.apache.flink.table.api._
+import org.apache.flink.table.connector.source.abilities.{SupportsParallelismReport, SupportsStatisticsReport}
+import org.apache.flink.table.operations.ModifyOperation
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.junit.{Assert, Before, Test}
+
+import _root_.scala.collection.JavaConversions._
+
+/**
+  * Test for [[SupportsParallelismReport]] and [[SupportsStatisticsReport]].
+  */
+class SourceReportsTest extends TableTestBase {
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    util.addTableSource[(Int, Int)]("MyTable", 'a, 'b)
+  }
+
+  @Test
+  def testJoin(): Unit = {
+    // should be hash join
+    util.tableEnv.executeSql(
+      s"""
+         |create table ReportTable (i int, j int) with (
+         |'connector'='values', 'bounded'='true')
+         |""".stripMargin)
+    util.verifyExplain("SELECT * FROM MyTable, ReportTable WHERE i = a")
+  }
+
+  @Test
+  def testJoinWithStatistics(): Unit = {
+    // should be broadcast join
+    util.tableEnv.executeSql(
+      s"""
+         |create table ReportTable (i int, j int) with (
+         |'connector'='values', 'bounded'='true', 'row-count'='999')
+         |""".stripMargin)
+    util.verifyExplain("SELECT * FROM MyTable, ReportTable WHERE i = a")
+  }
+
+  @Test
+  def testParallelismReport(): Unit = {
+    util.tableEnv.executeSql(
+      s"""
+         |create table SinkTable (i int, j int) with (
+         |'connector'='values', 'bounded'='true', 'parallelism'='111')
+         |""".stripMargin)
+    util.tableEnv.executeSql(
+      s"""
+         |create table ReportTable (i int, j int) with (
+         |'connector'='values', 'bounded'='true', 'parallelism'='222')
+         |""".stripMargin)
+    val transformations = util.getPlanner.translate(
+      util.getPlanner.getParser.parse("INSERT INTO SinkTable SELECT * FROM ReportTable")
+          .map(_.asInstanceOf[ModifyOperation]))
+    Assert.assertEquals(111, transformations.head.getParallelism)
+    val source = transformations.head.asInstanceOf[SinkTransformation[_]].getInput
+    Assert.assertEquals(222, source.getParallelism)
+  }
+
+}
+
+


### PR DESCRIPTION
## What is the purpose of the change

- Introduce `SupportsStatisticsReport`: Enables to give `ScanTableSource` the ability to report table statistics.
- Introduce `SupportsParallelismReport`: Enables to give `ScanTableSource` and `DynamicTableSink` the ability to report parallelism.

## Brief change log

- Add `SupportsStatisticsReport` and `SourceReportStatisticsRule`. Rule need to be after filter pushed down and before CBO.
- Add `SupportsParallelismReport` and modify `CommonPhysicalTableSourceScan` and `CommonPhysicalSink`.

## Verifying this change

`SourceReportsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
