### PR TITLE
[FLINK-18258][hive] Implement SHOW PARTITIONS for Hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -475,6 +475,25 @@ public class HiveDialectITCase {
 
 		tableEnv.executeSql("alter table tbl drop partition (dt='2020-04-30',country='china'),partition (dt='2020-05-01',country='belgium')");
 		assertEquals(1, hiveCatalog.listPartitions(tablePath).size());
+
+		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30 01:02:03',country='china') partition (dt='2020-04-30 04:05:06',country='us')");
+
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
+		assertEquals(3, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30 01:02:03/country=china"));
+		assertTrue(partitions.toString().contains("dt=2020-04-30 04:05:06/country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30 01:02:03')").collect());
+		assertEquals(1, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30 01:02:03/country=china"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30 04:05:06')").collect());
+		assertEquals(1, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30 04:05:06/country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30 01:02:03',country='china')").collect());
+		assertEquals(1, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30 01:02:03/country=china"));
+
+		tableEnv.executeSql("alter table tbl drop partition (dt='2020-04-30 01:02:03',country='china'),partition (dt='2020-04-30 04:05:06',country='us')");
+		assertEquals(1, hiveCatalog.listPartitions(tablePath).size());
 	}
 
 	private static String locationPath(String locationURI) throws URISyntaxException {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -475,6 +475,21 @@ public class HiveDialectITCase {
 
 		List<Row> partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
 		assertEquals(2, partitions.size());
+		assertTrue(partitions.toString().contains("country=china"));
+		assertTrue(partitions.toString().contains("country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (country='china')").collect());
+		assertEquals(1, partitions.size());
+		assertTrue(partitions.toString().contains("country=china"));
+
+		tableEnv.executeSql("alter table tbl drop partition (country='china'),partition (country='us')");
+		assertEquals(0, hiveCatalog.listPartitions(tablePath).size());
+
+		tableEnv.executeSql("drop table tbl");
+		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt date, country string)");
+		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30',country='china') partition (dt='2020-04-30',country='us')");
+
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
+		assertEquals(2, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
 		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30')").collect());
@@ -488,6 +503,8 @@ public class HiveDialectITCase {
 		tableEnv.executeSql("alter table tbl drop partition (dt='2020-04-30',country='china'),partition (dt='2020-04-30',country='us')");
 		assertEquals(0, hiveCatalog.listPartitions(tablePath).size());
 
+		tableEnv.executeSql("drop table tbl");
+		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt timestamp, country string)");
 		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30 01:02:03',country='china') partition (dt='2020-04-30 04:05:06',country='us')");
 
 		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
@@ -503,9 +520,6 @@ public class HiveDialectITCase {
 		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30 01:02:03',country='china')").collect());
 		assertEquals(1, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30 01:02:03/country=china"));
-
-		tableEnv.executeSql("alter table tbl drop partition (dt='2020-04-30 01:02:03',country='china'),partition (dt='2020-04-30 04:05:06',country='us')");
-		assertEquals(1, hiveCatalog.listPartitions(tablePath).size());
 	}
 
 	private static String locationPath(String locationURI) throws URISyntaxException {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -450,6 +450,18 @@ public class HiveDialectITCase {
 		ObjectPath tablePath = new ObjectPath("default", "tbl");
 		assertEquals(2, hiveCatalog.listPartitions(tablePath).size());
 
+		List<Row> partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
+		assertEquals(2, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30')").collect());
+		assertEquals(2, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30',country='china')").collect());
+		assertEquals(1, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
+
 		String partLocation = warehouse + "/part3_location";
 		tableEnv.executeSql(String.format(
 				"alter table tbl add partition (dt='2020-05-01',country='belgium') location '%s'", partLocation));

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -467,28 +467,13 @@ public class HiveDialectITCase {
 
 	@Test
 	public void testShowPartitions() throws Exception {
-		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (country string)");
-		tableEnv.executeSql("alter table tbl add partition (country='china') partition (country='us')");
+		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt date, country string)");
+		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30',country='china') partition (dt='2020-04-30',country='us')");
 
 		ObjectPath tablePath = new ObjectPath("default", "tbl");
 		assertEquals(2, hiveCatalog.listPartitions(tablePath).size());
 
 		List<Row> partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
-		assertEquals(2, partitions.size());
-		assertTrue(partitions.toString().contains("country=china"));
-		assertTrue(partitions.toString().contains("country=us"));
-		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (country='china')").collect());
-		assertEquals(1, partitions.size());
-		assertTrue(partitions.toString().contains("country=china"));
-
-		tableEnv.executeSql("alter table tbl drop partition (country='china'),partition (country='us')");
-		assertEquals(0, hiveCatalog.listPartitions(tablePath).size());
-
-		tableEnv.executeSql("drop table tbl");
-		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt date, country string)");
-		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30',country='china') partition (dt='2020-04-30',country='us')");
-
-		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
 		assertEquals(2, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
@@ -496,6 +481,9 @@ public class HiveDialectITCase {
 		assertEquals(2, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (country='china')").collect());
+		assertEquals(1, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
 		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30',country='china')").collect());
 		assertEquals(1, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -467,8 +467,8 @@ public class HiveDialectITCase {
 
 	@Test
 	public void testShowPartitions() throws Exception {
-		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt date,country string)");
-		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30',country='china') partition (dt='2020-04-30',country='us')");
+		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (country string)");
+		tableEnv.executeSql("alter table tbl add partition (country='china') partition (country='us')");
 
 		ObjectPath tablePath = new ObjectPath("default", "tbl");
 		assertEquals(2, hiveCatalog.listPartitions(tablePath).size());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -450,18 +450,6 @@ public class HiveDialectITCase {
 		ObjectPath tablePath = new ObjectPath("default", "tbl");
 		assertEquals(2, hiveCatalog.listPartitions(tablePath).size());
 
-		List<Row> partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
-		assertEquals(2, partitions.size());
-		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
-		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
-		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30')").collect());
-		assertEquals(2, partitions.size());
-		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
-		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
-		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30',country='china')").collect());
-		assertEquals(1, partitions.size());
-		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
-
 		String partLocation = warehouse + "/part3_location";
 		tableEnv.executeSql(String.format(
 				"alter table tbl add partition (dt='2020-05-01',country='belgium') location '%s'", partLocation));
@@ -475,11 +463,35 @@ public class HiveDialectITCase {
 
 		tableEnv.executeSql("alter table tbl drop partition (dt='2020-04-30',country='china'),partition (dt='2020-05-01',country='belgium')");
 		assertEquals(1, hiveCatalog.listPartitions(tablePath).size());
+	}
+
+	@Test
+	public void testShowPartitions() throws Exception {
+		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt date,country string)");
+		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30',country='china') partition (dt='2020-04-30',country='us')");
+
+		ObjectPath tablePath = new ObjectPath("default", "tbl");
+		assertEquals(2, hiveCatalog.listPartitions(tablePath).size());
+
+		List<Row> partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
+		assertEquals(2, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30')").collect());
+		assertEquals(2, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30',country='china')").collect());
+		assertEquals(1, partitions.size());
+		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
+
+		tableEnv.executeSql("alter table tbl drop partition (dt='2020-04-30',country='china'),partition (dt='2020-04-30',country='us')");
+		assertEquals(0, hiveCatalog.listPartitions(tablePath).size());
 
 		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30 01:02:03',country='china') partition (dt='2020-04-30 04:05:06',country='us')");
 
 		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
-		assertEquals(3, partitions.size());
+		assertEquals(2, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30 01:02:03/country=china"));
 		assertTrue(partitions.toString().contains("dt=2020-04-30 04:05:06/country=us"));
 		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30 01:02:03')").collect());

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -305,7 +305,7 @@ public class CliClient {
 				callShowModules();
 				break;
 			case SHOW_PARTITIONS:
-				callShowPartitions();
+				callShowPartitions(cmdCall);
 				break;
 			case USE_CATALOG:
 				callUseCatalog(cmdCall);
@@ -535,6 +535,14 @@ public class CliClient {
 				.collect(Collectors.toList());
 	}
 
+	private List<String> getShowResult(String objectToShow, SqlCommandCall cmdCall) {
+		TableResult tableResult = executor.executeSql(sessionId, "SHOW " + objectToShow + " " + cmdCall.operands[0]);
+		return CollectionUtil.iteratorToList(tableResult.collect())
+			.stream()
+			.map(r -> checkNotNull(r.getField(0)).toString())
+			.collect(Collectors.toList());
+	}
+
 	private void callShowModules() {
 		final List<String> modules;
 		try {
@@ -552,10 +560,10 @@ public class CliClient {
 		terminal.flush();
 	}
 
-	private void callShowPartitions() {
+	private void callShowPartitions(SqlCommandCall cmdCall) {
 		final List<String> partitions;
 		try {
-			partitions = getShowResult("PARTITIONS");
+			partitions = getShowResult("PARTITIONS", cmdCall);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -304,6 +304,9 @@ public class CliClient {
 			case SHOW_MODULES:
 				callShowModules();
 				break;
+			case SHOW_PARTITIONS:
+				callShowPartitions();
+				break;
 			case USE_CATALOG:
 				callUseCatalog(cmdCall);
 				break;
@@ -545,6 +548,22 @@ public class CliClient {
 		} else {
 			// modules are already in the loaded order
 			modules.forEach((v) -> terminal.writer().println(v));
+		}
+		terminal.flush();
+	}
+
+	private void callShowPartitions() {
+		final List<String> partitions;
+		try {
+			partitions = getShowResult("PARTITIONS");
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+		if (partitions.isEmpty()) {
+			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
+		} else {
+			partitions.forEach((v) -> terminal.writer().println(v));
 		}
 		terminal.flush();
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -535,8 +535,8 @@ public class CliClient {
 				.collect(Collectors.toList());
 	}
 
-	private List<String> getShowResult(String objectToShow, SqlCommandCall cmdCall) {
-		TableResult tableResult = executor.executeSql(sessionId, "SHOW " + objectToShow + " " + cmdCall.operands[0]);
+	private List<String> getShowResult(SqlCommandCall cmdCall) {
+		TableResult tableResult = executor.executeSql(sessionId, cmdCall.operands[0]);
 		return CollectionUtil.iteratorToList(tableResult.collect())
 			.stream()
 			.map(r -> checkNotNull(r.getField(0)).toString())
@@ -563,7 +563,7 @@ public class CliClient {
 	private void callShowPartitions(SqlCommandCall cmdCall) {
 		final List<String> partitions;
 		try {
-			partitions = getShowResult("PARTITIONS", cmdCall);
+			partitions = getShowResult(cmdCall);
 		} catch (SqlExecutionException e) {
 			printExecutionException(e);
 			return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.operations.ShowCurrentCatalogOperation;
 import org.apache.flink.table.operations.ShowCurrentDatabaseOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
+import org.apache.flink.table.operations.ShowPartitionsOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
@@ -157,6 +158,8 @@ public final class SqlCommandParser {
 		} else if (operation instanceof ShowFunctionsOperation) {
 			cmd = SqlCommand.SHOW_FUNCTIONS;
 			operands = new String[0];
+		} else if (operation instanceof ShowPartitionsOperation) {
+			cmd = SqlCommand.SHOW_PARTITIONS;
 		} else if (operation instanceof CreateCatalogFunctionOperation ||
 				operation instanceof CreateTempSystemFunctionOperation) {
 			cmd = SqlCommand.CREATE_FUNCTION;
@@ -247,6 +250,8 @@ public final class SqlCommandParser {
 		SHOW_MODULES(
 			"SHOW\\s+MODULES",
 			NO_OPERANDS),
+
+		SHOW_PARTITIONS,
 
 		USE_CATALOG,
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -302,8 +302,6 @@ public class SqlCommandParserTest {
 
 	@Test
 	public void testHiveCommands() throws Exception {
-		SqlParserHelper helper = new SqlParserHelper(SqlDialect.HIVE);
-		parser = helper.getSqlParser();
 		List<TestItem> testItems = Collections.singletonList(
 			// show partitions
 			TestItem.validSql(SqlDialect.HIVE, "SHOW PARTITIONS t1", SqlCommand.SHOW_PARTITIONS, "SHOW PARTITIONS t1")

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -303,10 +304,9 @@ public class SqlCommandParserTest {
 	public void testHiveCommands() throws Exception {
 		SqlParserHelper helper = new SqlParserHelper(SqlDialect.HIVE);
 		parser = helper.getSqlParser();
-		List<TestItem> testItems = Arrays.asList(
+		List<TestItem> testItems = Collections.singletonList(
 			// show partitions
-			TestItem.invalidSql("SHOW PARTITIONS ", SqlExecutionException.class, "Encountered \"<EOF>\""),
-			TestItem.validSql("SHOW PARTITIONS t1", SqlDialect.HIVE, SqlCommand.SHOW_PARTITIONS, "SHOW PARTITIONS t1")
+			TestItem.validSql(SqlDialect.HIVE, "SHOW PARTITIONS t1", SqlCommand.SHOW_PARTITIONS, "SHOW PARTITIONS t1")
 		);
 		for (TestItem item : testItems) {
 			tableEnv.getConfig().setSqlDialect(item.sqlDialect);
@@ -385,11 +385,6 @@ public class SqlCommandParserTest {
 			this.sql = sql;
 		}
 
-		private TestItem(String sql, SqlDialect sqlDialect) {
-			this.sql = sql;
-			this.sqlDialect = sqlDialect;
-		}
-
 		public static TestItem invalidSql(
 				String sql,
 				Class<? extends Throwable> expectedException,
@@ -403,15 +398,6 @@ public class SqlCommandParserTest {
 		public static TestItem validSql(
 				String sql, SqlCommand expectedCmd, String... expectedOperands) {
 			TestItem testItem = new TestItem(sql);
-			testItem.expectedCmd = expectedCmd;
-			testItem.expectedOperands = expectedOperands;
-			testItem.cannotParseComment = false; // default is false
-			return testItem;
-		}
-
-		public static TestItem validSql(
-			String sql, SqlDialect sqlDialect, SqlCommand expectedCmd, String... expectedOperands) {
-			TestItem testItem = new TestItem(sql, sqlDialect);
 			testItem.expectedCmd = expectedCmd;
 			testItem.expectedOperands = expectedOperands;
 			testItem.cannotParseComment = false; // default is false

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
@@ -19,8 +19,11 @@
 package org.apache.flink.table.client.cli.utils;
 
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
+import org.apache.flink.table.catalog.hive.HiveCatalog;
+import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.delegation.Parser;
 
 /**
@@ -28,10 +31,22 @@ import org.apache.flink.table.delegation.Parser;
  */
 public class SqlParserHelper {
 	// return the sql parser instance hold by this table evn.
-	private final TableEnvironment tableEnv;
+	private TableEnvironment tableEnv;
 
 	public SqlParserHelper() {
 		tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+	}
+
+	public SqlParserHelper(SqlDialect sqlDialect) {
+		if (sqlDialect == null || SqlDialect.DEFAULT == sqlDialect) {
+			tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+		} else if (SqlDialect.HIVE == sqlDialect) {
+			HiveCatalog hiveCatalog = HiveTestUtils.createHiveCatalog();
+			tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+			tableEnv.getConfig().setSqlDialect(sqlDialect);
+			tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
+			tableEnv.useCatalog(hiveCatalog.getName());
+		}
 	}
 
 	/**

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
@@ -84,6 +84,7 @@
     "org.apache.flink.sql.parser.dql.SqlShowCurrentDatabase"
     "org.apache.flink.sql.parser.dql.SqlShowFunctions"
     "org.apache.flink.sql.parser.dql.SqlShowTables"
+    "org.apache.flink.sql.parser.dql.SqlShowPartitions"
     "org.apache.flink.sql.parser.dql.SqlRichDescribeTable"
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec"
     "org.apache.flink.sql.parser.type.ExtendedSqlRowTypeNameSpec"
@@ -131,6 +132,7 @@
     "OVERWRITE"
     "OWNER"
     "PARTITIONED"
+    "PARTITIONS"
     "RAW"
     "RELY"
     "RENAME"
@@ -521,6 +523,7 @@
     "SqlShowFunctions()"
     "SqlAlterTable()"
     "SqlAlterView()"
+    "SqlShowPartitions()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
@@ -1469,3 +1469,21 @@ SqlAlterTable SqlDropPartitions(SqlParserPos startPos, SqlIdentifier tableIdenti
   )*
   { return new SqlDropPartitions(startPos.plus(getPos()), tableIdentifier, ifExists, partSpecs); }
 }
+
+/**
+ * Hive syntax:
+ *
+ * SHOW PARTITIONS table_name [PARTITION partition_spec];
+ */
+SqlShowPartitions SqlShowPartitions() :
+{
+     SqlParserPos pos;
+     SqlIdentifier tableIdentifier;
+     SqlNodeList partitionSpec = null;
+}
+{
+    <SHOW> <PARTITIONS> { pos = getPos(); }
+        tableIdentifier = CompoundIdentifier()
+    [ <PARTITION> { partitionSpec = new SqlNodeList(getPos()); PartitionSpecCommaList(new SqlNodeList(getPos()), partitionSpec); } ]
+    { return new SqlShowPartitions(pos, tableIdentifier, partitionSpec); }
+}

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -432,4 +432,12 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
 						"PARTITION (`P1` = 'b', `P2` = 2)");
 		// TODO: support IGNORE PROTECTION, PURGE
 	}
+
+	@Test
+	public void testShowPartitions() {
+		sql("show partitions tbl")
+			.ok("SHOW PARTITIONS `TBL`");
+		sql("show partitions tbl partition (p=1)")
+			.ok("SHOW PARTITIONS `TBL` PARTITION (`P` = 1)");
+	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowPartitions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowPartitions.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.flink.sql.parser.SqlPartitionUtils;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * SHOW PARTITIONS sql call.
+ */
+public class SqlShowPartitions extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("SHOW PARTITIONS", SqlKind.OTHER);
+
+	protected final SqlIdentifier tableIdentifier;
+	protected final SqlNodeList partitionSpec;
+
+	public SqlShowPartitions(SqlParserPos pos, SqlIdentifier tableName, @Nullable SqlNodeList partitionSpec) {
+		super(pos);
+		this.tableIdentifier = requireNonNull(tableName, "tableName should not be null");
+		this.partitionSpec = partitionSpec;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		List<SqlNode> operands = new ArrayList<>();
+		operands.add(tableIdentifier);
+		operands.add(partitionSpec);
+		return operands;
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("SHOW PARTITIONS");
+		tableIdentifier.unparse(writer, leftPrec, rightPrec);
+		SqlNodeList partitionSpec = getPartitionSpec();
+		if (partitionSpec != null && partitionSpec.size() > 0) {
+			writer.keyword("PARTITION");
+			partitionSpec.unparse(writer, getOperator().getLeftPrec(), getOperator().getRightPrec());
+		}
+	}
+
+	public String[] fullTableName() {
+		return tableIdentifier.names.toArray(new String[0]);
+	}
+
+	/**
+	 * Returns the partition spec if the SHOW should be applied to partitions, and null otherwise.
+	 */
+	public SqlNodeList getPartitionSpec() {
+		return partitionSpec;
+	}
+
+	/**
+	 * Get partition spec as key-value strings.
+	 */
+	public LinkedHashMap<String, String> getPartitionKVs() {
+		return SqlPartitionUtils.getPartitionKVs(getPartitionSpec());
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -92,6 +92,7 @@ import org.apache.flink.table.operations.ShowCurrentCatalogOperation;
 import org.apache.flink.table.operations.ShowCurrentDatabaseOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
+import org.apache.flink.table.operations.ShowPartitionsOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
 import org.apache.flink.table.operations.ShowViewsOperation;
 import org.apache.flink.table.operations.TableSourceQueryOperation;
@@ -178,7 +179,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			"Unsupported SQL query! executeSql() only accepts a single SQL statement of type " +
 			"CREATE TABLE, DROP TABLE, ALTER TABLE, CREATE DATABASE, DROP DATABASE, ALTER DATABASE, " +
 			"CREATE FUNCTION, DROP FUNCTION, ALTER FUNCTION, CREATE CATALOG, DROP CATALOG, " +
-			"USE CATALOG, USE [CATALOG.]DATABASE, SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, " +
+			"USE CATALOG, USE [CATALOG.]DATABASE, SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, SHOW PARTITIONS" +
 			"CREATE VIEW, DROP VIEW, SHOW VIEWS, INSERT, DESCRIBE.";
 
 	/**
@@ -1021,6 +1022,28 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			return buildShowResult("function name", listFunctions());
 		} else if (operation instanceof ShowViewsOperation) {
 			return buildShowResult("view name", listViews());
+		} else if (operation instanceof ShowPartitionsOperation) {
+			String exMsg = getDQLOpExecuteErrorMsg(operation.asSummaryString());
+			try {
+				ShowPartitionsOperation showPartitionsOperation = (ShowPartitionsOperation) operation;
+				Catalog catalog = getCatalogOrThrowException(showPartitionsOperation.getTableIdentifier().getCatalogName());
+				ObjectPath tablePath = showPartitionsOperation.getTableIdentifier().toObjectPath();
+				CatalogPartitionSpec partitionSpec = showPartitionsOperation.getPartitionSpec();
+				List<CatalogPartitionSpec> partitionSpecs = partitionSpec == null ? catalog.listPartitions(tablePath) : catalog.listPartitions(tablePath, partitionSpec);
+				List<String> partitionNames = new ArrayList<>(partitionSpecs.size());
+				for (CatalogPartitionSpec spec: partitionSpecs) {
+					List<String> partitionKVs = new ArrayList<>(spec.getPartitionSpec().size());
+					for (Map.Entry<String, String> partitionKV: spec.getPartitionSpec().entrySet()) {
+						partitionKVs.add(partitionKV.getKey() + "=" + partitionKV.getValue());
+					}
+					partitionNames.add(String.join("/", partitionKVs));
+				}
+				return buildShowResult("partition name", partitionNames.toArray(new String[0]));
+			} catch (TableNotExistException e) {
+				throw new ValidationException(exMsg, e);
+			} catch (Exception e) {
+				throw new TableException(exMsg, e);
+			}
 		} else if (operation instanceof ExplainOperation) {
 			String explanation = planner.explain(Collections.singletonList(((ExplainOperation) operation).getChild()));
 			return TableResultImpl.builder()
@@ -1155,6 +1178,10 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	}
 
 	private String getDDLOpExecuteErrorMsg(String action) {
+		return String.format("Could not execute %s", action);
+	}
+
+	private String getDQLOpExecuteErrorMsg(String action) {
 		return String.format("Could not execute %s", action);
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -1023,7 +1023,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 		} else if (operation instanceof ShowViewsOperation) {
 			return buildShowResult("view name", listViews());
 		} else if (operation instanceof ShowPartitionsOperation) {
-			String exMsg = getDQLOpExecuteErrorMsg(operation.asSummaryString());
+			String exMsg = getDDLOpExecuteErrorMsg(operation.asSummaryString());
 			try {
 				ShowPartitionsOperation showPartitionsOperation = (ShowPartitionsOperation) operation;
 				Catalog catalog = getCatalogOrThrowException(showPartitionsOperation.getTableIdentifier().getCatalogName());
@@ -1178,10 +1178,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	}
 
 	private String getDDLOpExecuteErrorMsg(String action) {
-		return String.format("Could not execute %s", action);
-	}
-
-	private String getDQLOpExecuteErrorMsg(String action) {
 		return String.format("Could not execute %s", action);
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowOperation.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 
 /**
  * An {@link Operation} that show one kind of objects,
- * e.g. USE CATALOGS, USE DATABASES, SHOW TABLES, SHOW FUNCTIONS.
+ * e.g. USE CATALOGS, USE DATABASES, SHOW TABLES, SHOW FUNCTIONS, SHOW PARTITIONS.
  */
 @Internal
 public interface ShowOperation extends Operation {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowPartitionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowPartitionsOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/**
+ * Operation to describe a SHOW PARTITIONS statement.
+ */
+public class ShowPartitionsOperation implements ShowOperation {
+
+	protected final ObjectIdentifier tableIdentifier;
+	private final CatalogPartitionSpec partitionSpec;
+
+	public ShowPartitionsOperation(ObjectIdentifier tableIdentifier, CatalogPartitionSpec partitionSpec) {
+		this.tableIdentifier = tableIdentifier;
+		this.partitionSpec = partitionSpec;
+	}
+
+	public ObjectIdentifier getTableIdentifier() {
+		return tableIdentifier;
+	}
+
+	public CatalogPartitionSpec getPartitionSpec() {
+		return partitionSpec;
+	}
+
+	@Override
+	public String asSummaryString() {
+		StringBuilder builder = new StringBuilder(String.format("SHOW PARTITIONS %s", tableIdentifier.asSummaryString()));
+		if (partitionSpec != null) {
+			builder.append(String.format(" PARTITION (%s)", OperationUtils.formatPartitionSpec(partitionSpec)));
+		}
+		return builder.toString();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.sql.parser.ExtendedSqlNode
-import org.apache.flink.sql.parser.dql.{SqlRichDescribeTable, SqlShowCatalogs, SqlShowCurrentCatalog, SqlShowCurrentDatabase, SqlShowDatabases, SqlShowFunctions, SqlShowTables, SqlShowViews}
+import org.apache.flink.sql.parser.dql.{SqlRichDescribeTable, SqlShowCatalogs, SqlShowCurrentCatalog, SqlShowCurrentDatabase, SqlShowDatabases, SqlShowFunctions, SqlShowPartitions, SqlShowTables, SqlShowViews}
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader
 
@@ -131,6 +131,7 @@ class FlinkPlannerImpl(
         || sqlNode.isInstanceOf[SqlShowTables]
         || sqlNode.isInstanceOf[SqlShowFunctions]
         || sqlNode.isInstanceOf[SqlShowViews]
+        || sqlNode.isInstanceOf[SqlShowPartitions]
         || sqlNode.isInstanceOf[SqlRichDescribeTable]) {
         return sqlNode
       }


### PR DESCRIPTION
## What is the purpose of the change

*Currently Hive dialect supports `ADD PARTITION` and `DROP PARTITION`, lack of support for `SHOW PARTITIONS`. It's necessary to implement `SHOW PARTITIONS` for Hive dialect.*

## Brief change log

  - *Add `SqlShowPartitions` and `ShowPartitionsOperation` to support `SqlToOperationConverter` for `SHOW PARTITIONS` convert.*
  - *Method `executeOperation` of `TableEnvironmentImpl` support execution of `ShowPartitionsOperation`.*

## Verifying this change

  - *`FlinkHiveSqlParserImplTest` add method `testShowPartitions` to verify the parser of `SHOW PARTITIONS` dialect.*
  - *Method `testAddDropPartitions` of `HiveDialectITCase` add execution of `SHOW PARTITIONS` dialect to verify the result of the operation.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
