### PR TITLE
fixFlinkSqlInsertQuerySinkFieldNotMatch

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CatalogSinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CatalogSinkModifyOperation.java
@@ -21,9 +21,7 @@ package org.apache.flink.table.operations;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * DML operation that tells to write to a sink. The sink has to be looked up in a
@@ -37,6 +35,8 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 	private final QueryOperation child;
 	private final boolean overwrite;
 	private final Map<String, String> dynamicOptions;
+	private final List<String> targetColumns;
+
 
 	public CatalogSinkModifyOperation(ObjectIdentifier tableIdentifier, QueryOperation child) {
 		this(tableIdentifier, child, Collections.emptyMap(), false, Collections.emptyMap());
@@ -48,11 +48,22 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 			Map<String, String> staticPartitions,
 			boolean overwrite,
 			Map<String, String> dynamicOptions) {
+		this(tableIdentifier, child, staticPartitions, overwrite, dynamicOptions, Collections.EMPTY_LIST);
+	}
+
+	public CatalogSinkModifyOperation(
+		ObjectIdentifier tableIdentifier,
+		QueryOperation child,
+		Map<String, String> staticPartitions,
+		boolean overwrite,
+		Map<String, String> dynamicOptions,
+		List<String> targetColumns) {
 		this.tableIdentifier = tableIdentifier;
 		this.child = child;
 		this.staticPartitions = staticPartitions;
 		this.overwrite = overwrite;
 		this.dynamicOptions = dynamicOptions;
+		this.targetColumns = targetColumns;
 	}
 
 	public ObjectIdentifier getTableIdentifier() {
@@ -74,6 +85,10 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 	@Override
 	public QueryOperation getChild() {
 		return child;
+	}
+
+	public List<String> getTargetColumns() {
+		return targetColumns;
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -141,6 +141,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Mix-in tool class for {@code SqlNode} that allows DDL commands to be
@@ -537,12 +538,19 @@ public class SqlToOperationConverter {
 			.orElseThrow(() -> new TableException(
 				"Unsupported node type " + insert.getSource().getClass().getSimpleName()));
 
+		List<String> targetColumns = new ArrayList<>();
+		if (insert.getTargetColumnList() != null) {
+			targetColumns = insert.getTargetColumnList().getList()
+				.stream().map(SqlNode::toString).collect(Collectors.toList());
+		}
+
 		return new CatalogSinkModifyOperation(
 			identifier,
 			query,
 			insert.getStaticPartitionKVs(),
 			insert.isOverwrite(),
-			dynamicOptions);
+			dynamicOptions,
+			targetColumns);
 	}
 
 	/** Convert use catalog statement. */


### PR DESCRIPTION
## problem 
 sql insert  into column size not equal to the size defined in DDL
 throw exception (Field types of query result and registered TableSink)

FOR EXAMPLE:  

DDL student (id, name, age)
DDL stuout(id, name, age)

insert into stuout( name, age ) select name, age from student ;

throw ValidationException: Field types of query result and registered TableSink
for jdbc catalog or self defined catalog that get ddl from database meta it is a problem

## how to solve 
use insert into column to rebuild TableSchema before create TableSink

