### PR TITLE
[FLINK-16245] Decoupling user classloader from context classloader. 

### DIFF
--- a/docs/_includes/generated/all_taskmanager_network_section.html
+++ b/docs/_includes/generated/all_taskmanager_network_section.html
@@ -57,12 +57,6 @@
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.retries</h5></td>
-            <td style="word-wrap: break-word;">0</td>
-            <td>Integer</td>
-            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>
@@ -103,6 +97,12 @@
             <td style="word-wrap: break-word;">10000</td>
             <td>Integer</td>
             <td>Maximum backoff in milliseconds for partition requests of input channels.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.retries</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -9,6 +9,14 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>classloader.check-leaked-classloader</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Fails attempts at loading classes if the user classloader of a job is used after it has terminated.
+This is usually caused by the classloader being leaked by lingering threads or misbehaving libraries, which may also result in the classloader being used by other jobs.
+This check should only be disabled if such a leak prevents further jobs from running.</td>
+        </tr>
+        <tr>
             <td><h5>classloader.fail-on-metaspace-oom-error</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/_includes/generated/expert_class_loading_section.html
+++ b/docs/_includes/generated/expert_class_loading_section.html
@@ -9,6 +9,14 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>classloader.check-leaked-classloader</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Fails attempts at loading classes if the user classloader of a job is used after it has terminated.
+This is usually caused by the classloader being leaked by lingering threads or misbehaving libraries, which may also result in the classloader being used by other jobs.
+This check should only be disabled if such a leak prevents further jobs from running.</td>
+        </tr>
+        <tr>
             <td><h5>classloader.fail-on-metaspace-oom-error</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -75,12 +75,6 @@
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.retries</h5></td>
-            <td style="word-wrap: break-word;">0</td>
-            <td>Integer</td>
-            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>
@@ -121,6 +115,12 @@
             <td style="word-wrap: break-word;">10000</td>
             <td>Integer</td>
             <td>Maximum backoff in milliseconds for partition requests of input channels.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.retries</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
         </tr>
     </tbody>
 </table>

--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -54,7 +55,7 @@ public enum ClientUtils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
 
-	public static ClassLoader buildUserCodeClassLoader(
+	public static URLClassLoader buildUserCodeClassLoader(
 			List<URL> jars,
 			List<URL> classpaths,
 			ClassLoader parent,

--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -72,7 +72,14 @@ public enum ClientUtils {
 			configuration.getString(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
 		FlinkUserCodeClassLoaders.ResolveOrder resolveOrder =
 			FlinkUserCodeClassLoaders.ResolveOrder.fromString(classLoaderResolveOrder);
-		return FlinkUserCodeClassLoaders.create(resolveOrder, urls, parent, alwaysParentFirstLoaderPatterns, NOOP_EXCEPTION_HANDLER);
+		final boolean checkClassloaderLeak = configuration.getBoolean(CoreOptions.CHECK_LEAKED_CLASSLOADER);
+		return FlinkUserCodeClassLoaders.create(
+			resolveOrder,
+			urls,
+			parent,
+			alwaysParentFirstLoaderPatterns,
+			NOOP_EXCEPTION_HANDLER,
+			checkClassloaderLeak);
 	}
 
 	public static JobExecutionResult submitJob(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -25,6 +25,7 @@ import org.apache.flink.connectors.hive.write.HiveOutputFormatFactory;
 import org.apache.flink.connectors.hive.write.HiveWriterFactory;
 import org.apache.flink.formats.parquet.row.ParquetRowDataBuilder;
 import org.apache.flink.orc.OrcSplitReaderUtil;
+import org.apache.flink.orc.writer.ThreadLocalClassLoaderConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.HadoopPathBasedBulkFormatBuilder;
@@ -241,12 +242,14 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 			formatTypes[i] = tableSchema.getFieldDataType(i).get().getLogicalType();
 		}
 		RowType formatType = RowType.of(formatTypes, formatNames);
-		Configuration formatConf = new Configuration(jobConf);
-		sd.getSerdeInfo().getParameters().forEach(formatConf::set);
 		if (serLib.contains("parquet")) {
+			Configuration formatConf = new Configuration(jobConf);
+			sd.getSerdeInfo().getParameters().forEach(formatConf::set);
 			return Optional.of(ParquetRowDataBuilder.createWriterFactory(
 					formatType, formatConf, hiveVersion.startsWith("3.")));
 		} else if (serLib.contains("orc")) {
+			Configuration formatConf = new ThreadLocalClassLoaderConfiguration(jobConf);
+			sd.getSerdeInfo().getParameters().forEach(formatConf::set);
 			TypeDescription typeDescription = OrcSplitReaderUtil.logicalTypeToOrcType(formatType);
 			return Optional.of(hiveShim.createOrcBulkWriterFactory(
 					formatConf, typeDescription.toString(), formatTypes));

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -124,6 +124,17 @@ public class CoreOptions {
 		return parseParentFirstLoaderPatterns(base, append);
 	}
 
+	@Documentation.Section(Documentation.Sections.EXPERT_CLASS_LOADING)
+	public static final ConfigOption<Boolean> CHECK_LEAKED_CLASSLOADER = ConfigOptions
+		.key("classloader.check-leaked-classloader")
+		.booleanType()
+		.defaultValue(true)
+		.withDescription("Fails attempts at loading classes if the user classloader of a job is used after it has " +
+			"terminated.\n" +
+			"This is usually caused by the classloader being leaked by lingering threads or misbehaving libraries, " +
+			"which may also result in the classloader being used by other jobs.\n" +
+			"This check should only be disabled if such a leak prevents further jobs from running.");
+
 	/**
 	 * Plugin-specific option of {@link #ALWAYS_PARENT_FIRST_LOADER_PATTERNS}. Plugins use this parent first list
 	 * instead of the global version.

--- a/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
@@ -43,7 +43,7 @@ public abstract class FlinkUserCodeClassLoader extends URLClassLoader {
 	}
 
 	@Override
-	protected final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+	public final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
 		try {
 			return loadClassWithoutExceptionHandling(name, resolve);
 		} catch (Throwable classLoadingException) {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoClassloadingTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoClassloadingTest.java
@@ -75,7 +75,8 @@ public class AvroKryoClassloadingTest {
 				new URL[] { avroLocation, kryoLocation },
 				parentClassLoader,
 				CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS.defaultValue().split(";"),
-			NOOP_EXCEPTION_HANDLER);
+				NOOP_EXCEPTION_HANDLER,
+				true);
 
 		final Class<?> userLoadedAvroClass = Class.forName(avroClass.getName(), false, userAppClassLoader);
 		assertNotEquals(avroClass, userLoadedAvroClass);

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/writer/OrcBulkWriterFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/writer/OrcBulkWriterFactory.java
@@ -111,7 +111,7 @@ public class OrcBulkWriterFactory<T> implements BulkWriter.Factory<T> {
 
 	private OrcFile.WriterOptions getWriterOptions() {
 		if (null == writerOptions) {
-			Configuration conf = new Configuration();
+			Configuration conf = new ThreadLocalClassLoaderConfiguration();
 			for (Map.Entry<String, String> entry : confMap.entrySet()) {
 				conf.set(entry.getKey(), entry.getValue());
 			}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/writer/ThreadLocalClassLoaderConfiguration.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/writer/ThreadLocalClassLoaderConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.writer;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URL;
+
+/**
+ * Workaround for https://issues.apache.org/jira/browse/ORC-653.
+ *
+ * <p>Since the conf is effectively cached across Flink jobs, at least force the thread local classloader to avoid
+ * classloader leaks.
+ */
+@Internal
+public final class ThreadLocalClassLoaderConfiguration extends Configuration {
+	public ThreadLocalClassLoaderConfiguration() {
+	}
+
+	public ThreadLocalClassLoaderConfiguration(Configuration other) {
+		super(other);
+	}
+
+	@Override
+	public ClassLoader getClassLoader() {
+		return Thread.currentThread().getContextClassLoader();
+	}
+
+	@Override
+	public Class<?> getClassByNameOrNull(String name) {
+		try {
+			return Class.forName(name, true, getClassLoader());
+		} catch (ClassNotFoundException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public URL getResource(String name) {
+		return getClassLoader().getResource(name);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -148,13 +148,20 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 		 */
 		private final Consumer<Throwable> classLoadingExceptionHandler;
 
+		/**
+		 * Test if classloader is used outside of job.
+		 */
+		private final boolean checkClassLoaderLeak;
+
 		private DefaultClassLoaderFactory(
 				FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder,
 				String[] alwaysParentFirstPatterns,
-				Consumer<Throwable> classLoadingExceptionHandler) {
+				Consumer<Throwable> classLoadingExceptionHandler,
+				boolean checkClassLoaderLeak) {
 			this.classLoaderResolveOrder = classLoaderResolveOrder;
 			this.alwaysParentFirstPatterns = alwaysParentFirstPatterns;
 			this.classLoadingExceptionHandler = classLoadingExceptionHandler;
+			this.checkClassLoaderLeak = checkClassLoaderLeak;
 		}
 
 		@Override
@@ -164,18 +171,21 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 				libraryURLs,
 				FlinkUserCodeClassLoaders.class.getClassLoader(),
 				alwaysParentFirstPatterns,
-				classLoadingExceptionHandler);
+				classLoadingExceptionHandler,
+				checkClassLoaderLeak);
 		}
 	}
 
 	public static ClassLoaderFactory defaultClassLoaderFactory(
 			FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder,
 			String[] alwaysParentFirstPatterns,
-			@Nullable FatalErrorHandler fatalErrorHandlerJvmMetaspaceOomError) {
+			@Nullable FatalErrorHandler fatalErrorHandlerJvmMetaspaceOomError,
+			boolean checkClassLoaderLeak) {
 		return new DefaultClassLoaderFactory(
 			classLoaderResolveOrder,
 			alwaysParentFirstPatterns,
-			createClassLoadingExceptionHandler(fatalErrorHandlerJvmMetaspaceOomError));
+			createClassLoadingExceptionHandler(fatalErrorHandlerJvmMetaspaceOomError),
+			checkClassLoaderLeak);
 	}
 
 	private static Consumer<Throwable> createClassLoadingExceptionHandler(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
@@ -21,8 +21,14 @@ package org.apache.flink.runtime.execution.librarycache;
 import org.apache.flink.util.ChildFirstClassLoader;
 import org.apache.flink.util.FlinkUserCodeClassLoader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Enumeration;
 import java.util.function.Consumer;
 
 /**
@@ -38,7 +44,9 @@ public class FlinkUserCodeClassLoaders {
 			URL[] urls,
 			ClassLoader parent,
 			Consumer<Throwable> classLoadingExceptionHandler) {
-		return new ParentFirstClassLoader(urls, parent, classLoadingExceptionHandler);
+		return new SafetyNetWrapperClassLoader(
+			new ParentFirstClassLoader(urls, parent, classLoadingExceptionHandler),
+			parent);
 	}
 
 	public static URLClassLoader childFirst(
@@ -46,7 +54,9 @@ public class FlinkUserCodeClassLoaders {
 			ClassLoader parent,
 			String[] alwaysParentFirstPatterns,
 			Consumer<Throwable> classLoadingExceptionHandler) {
-		return new ChildFirstClassLoader(urls, parent, alwaysParentFirstPatterns, classLoadingExceptionHandler);
+		return new SafetyNetWrapperClassLoader(
+			new ChildFirstClassLoader(urls, parent, alwaysParentFirstPatterns, classLoadingExceptionHandler),
+			parent);
 	}
 
 	public static URLClassLoader create(
@@ -90,6 +100,70 @@ public class FlinkUserCodeClassLoaders {
 
 		ParentFirstClassLoader(URL[] urls, ClassLoader parent, Consumer<Throwable> classLoadingExceptionHandler) {
 			super(urls, parent, classLoadingExceptionHandler);
+		}
+	}
+
+	/**
+	 * Ensures that holding a reference on the context class loader outliving the scope of user code does not prevent
+	 * the user classloader to be garbage collected (FLINK-16245).
+	 *
+	 * <p>This classloader delegates to the actual user classloader. Upon {@link #close()}, the delegate is nulled
+	 * and can be garbage collected. Additional class resolution will be resolved solely through the bootstrap
+	 * classloader and most likely result in ClassNotFound exceptions.
+	 */
+	private static class SafetyNetWrapperClassLoader extends URLClassLoader implements Closeable {
+		private static final Logger LOG = LoggerFactory.getLogger(SafetyNetWrapperClassLoader.class);
+
+		private volatile FlinkUserCodeClassLoader inner;
+
+		SafetyNetWrapperClassLoader(FlinkUserCodeClassLoader inner, ClassLoader parent) {
+			super(new URL[0], parent);
+			this.inner = inner;
+		}
+
+		@Override
+		public void close() {
+			final FlinkUserCodeClassLoader inner = this.inner;
+			if (inner != null) {
+				try {
+					inner.close();
+				} catch (IOException e) {
+					LOG.warn("Could not close user classloader", e);
+				}
+			}
+			this.inner = null;
+		}
+
+		private FlinkUserCodeClassLoader ensureInner() {
+			if (inner == null) {
+				throw new IllegalStateException("Trying to access closed classloader");
+			}
+			return inner;
+		}
+
+		@Override
+		public Class<?> loadClass(String name) throws ClassNotFoundException {
+			return ensureInner().loadClass(name);
+		}
+
+		@Override
+		protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+			// called for dynamic class loading
+			return ensureInner().loadClass(name, resolve);
+		}
+
+		@Override
+		public URL getResource(String name) {
+			return ensureInner().getResource(name);
+		}
+
+		@Override
+		public Enumeration<URL> getResources(String name) throws IOException {
+			return ensureInner().getResources(name);
+		}
+
+		static {
+			ClassLoader.registerAsParallelCapable();
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.util.ChildFirstClassLoader;
 import org.apache.flink.util.FlinkUserCodeClassLoader;
 
@@ -43,20 +44,24 @@ public class FlinkUserCodeClassLoaders {
 	public static URLClassLoader parentFirst(
 			URL[] urls,
 			ClassLoader parent,
-			Consumer<Throwable> classLoadingExceptionHandler) {
-		return new SafetyNetWrapperClassLoader(
-			new ParentFirstClassLoader(urls, parent, classLoadingExceptionHandler),
-			parent);
+			Consumer<Throwable> classLoadingExceptionHandler,
+			boolean checkClassLoaderLeak) {
+		FlinkUserCodeClassLoader classLoader = new ParentFirstClassLoader(urls,	parent,	classLoadingExceptionHandler);
+		return wrapWithSafetyNet(classLoader, checkClassLoaderLeak);
 	}
 
 	public static URLClassLoader childFirst(
 			URL[] urls,
 			ClassLoader parent,
 			String[] alwaysParentFirstPatterns,
-			Consumer<Throwable> classLoadingExceptionHandler) {
-		return new SafetyNetWrapperClassLoader(
-			new ChildFirstClassLoader(urls, parent, alwaysParentFirstPatterns, classLoadingExceptionHandler),
-			parent);
+			Consumer<Throwable> classLoadingExceptionHandler,
+			boolean checkClassLoaderLeak) {
+		FlinkUserCodeClassLoader classLoader = new ChildFirstClassLoader(
+			urls,
+			parent,
+			alwaysParentFirstPatterns,
+			classLoadingExceptionHandler);
+		return wrapWithSafetyNet(classLoader, checkClassLoaderLeak);
 	}
 
 	public static URLClassLoader create(
@@ -64,16 +69,26 @@ public class FlinkUserCodeClassLoaders {
 			URL[] urls,
 			ClassLoader parent,
 			String[] alwaysParentFirstPatterns,
-			Consumer<Throwable> classLoadingExceptionHandler) {
+			Consumer<Throwable> classLoadingExceptionHandler,
+			boolean checkClassLoaderLeak) {
 
 		switch (resolveOrder) {
 			case CHILD_FIRST:
-				return childFirst(urls, parent, alwaysParentFirstPatterns, classLoadingExceptionHandler);
+				return childFirst(
+					urls,
+					parent,
+					alwaysParentFirstPatterns,
+					classLoadingExceptionHandler,
+					checkClassLoaderLeak);
 			case PARENT_FIRST:
-				return parentFirst(urls, parent, classLoadingExceptionHandler);
+				return parentFirst(urls, parent, classLoadingExceptionHandler, checkClassLoaderLeak);
 			default:
 				throw new IllegalArgumentException("Unknown class resolution order: " + resolveOrder);
 		}
+	}
+
+	private static URLClassLoader wrapWithSafetyNet(FlinkUserCodeClassLoader classLoader, boolean check) {
+		return check ? new SafetyNetWrapperClassLoader(classLoader, classLoader.getParent()) : classLoader;
 	}
 
 	/**
@@ -136,7 +151,10 @@ public class FlinkUserCodeClassLoaders {
 
 		private FlinkUserCodeClassLoader ensureInner() {
 			if (inner == null) {
-				throw new IllegalStateException("Trying to access closed classloader");
+				throw new IllegalStateException("Trying to access closed classloader. Please check if you store " +
+					"classloaders directly or indirectly in static fields. If the stacktrace suggests that the leak " +
+					"occurs in a third party library and cannot be fixed immediately, you can disable this check " +
+					"with the configuration '" + CoreOptions.CHECK_LEAKED_CLASSLOADER.key() + "'.");
 			}
 			return inner;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
@@ -138,13 +138,15 @@ public class JobManagerSharedServices {
 		final String[] alwaysParentFirstLoaderPatterns = CoreOptions.getParentFirstLoaderPatterns(config);
 
 		final boolean failOnJvmMetaspaceOomError = config.getBoolean(CoreOptions.FAIL_ON_USER_CLASS_LOADING_METASPACE_OOM);
+		final boolean checkClassLoaderLeak = config.getBoolean(CoreOptions.CHECK_LEAKED_CLASSLOADER);
 		final BlobLibraryCacheManager libraryCacheManager =
 			new BlobLibraryCacheManager(
 				blobServer,
 				BlobLibraryCacheManager.defaultClassLoaderFactory(
 					FlinkUserCodeClassLoaders.ResolveOrder.fromString(classLoaderResolveOrder),
 					alwaysParentFirstLoaderPatterns,
-					failOnJvmMetaspaceOomError ? fatalErrorHandler : null));
+					failOnJvmMetaspaceOomError ? fatalErrorHandler : null,
+					checkClassLoaderLeak));
 
 		final Duration akkaTimeout;
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -314,12 +314,15 @@ public class TaskManagerServices {
 
 		final boolean failOnJvmMetaspaceOomError =
 			taskManagerServicesConfiguration.getConfiguration().getBoolean(CoreOptions.FAIL_ON_USER_CLASS_LOADING_METASPACE_OOM);
+		final boolean checkClassLoaderLeak =
+			taskManagerServicesConfiguration.getConfiguration().getBoolean(CoreOptions.CHECK_LEAKED_CLASSLOADER);
 		final LibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(
 			permanentBlobService,
 			BlobLibraryCacheManager.defaultClassLoaderFactory(
 				taskManagerServicesConfiguration.getClassLoaderResolveOrder(),
 				taskManagerServicesConfiguration.getAlwaysParentFirstLoaderPatterns(),
-				failOnJvmMetaspaceOomError ? fatalErrorHandler : null));
+				failOnJvmMetaspaceOomError ? fatalErrorHandler : null,
+				checkClassLoaderLeak));
 
 		return new TaskManagerServices(
 			unresolvedTaskManagerLocation,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -520,7 +520,8 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			.defaultClassLoaderFactory(
 				FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 				new String[0],
-				null);
+				null,
+				true);
 
 		private TestingBlobLibraryCacheManagerBuilder() throws IOException {
 			final Configuration blobClientConfig = new Configuration();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -80,7 +80,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			final BlobLibraryCacheManager.ClassLoaderFactory classLoaderFactory = BlobLibraryCacheManager.defaultClassLoaderFactory(
 				FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 				new String[0],
-				null);
+				null,
+				true);
 
 			for (int i = 0; i < server.length; i++) {
 				server[i] = new BlobServer(config, blobStoreService);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
@@ -179,7 +179,8 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 			new URL[] { childCodePath },
 			parentClassLoader,
 			new String[] { parentFirstPattern },
-			NOOP_EXCEPTION_HANDLER);
+			NOOP_EXCEPTION_HANDLER,
+			true);
 
 		final Class<?> clazz1 = Class.forName(className, false, parentClassLoader);
 		final Class<?> clazz2 = Class.forName(className, false, childClassLoader);
@@ -197,7 +198,8 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 		return FlinkUserCodeClassLoaders.parentFirst(
 			new URL[] { childCodePath },
 			parentClassLoader,
-			NOOP_EXCEPTION_HANDLER);
+			NOOP_EXCEPTION_HANDLER,
+			true);
 	}
 
 	private static URLClassLoader createChildFirstClassLoader(URL childCodePath, ClassLoader parentClassLoader) {
@@ -205,7 +207,8 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 			new URL[] { childCodePath },
 			parentClassLoader,
 			new String[0],
-			NOOP_EXCEPTION_HANDLER);
+			NOOP_EXCEPTION_HANDLER,
+			true);
 	}
 
 	@Test

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDbMultiClassLoaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDbMultiClassLoaderTest.java
@@ -48,8 +48,18 @@ public class RocksDbMultiClassLoaderTest {
 		final URL codePath2 = RocksDB.class.getProtectionDomain().getCodeSource().getLocation();
 
 		final ClassLoader parent = getClass().getClassLoader();
-		final ClassLoader loader1 = FlinkUserCodeClassLoaders.childFirst(new URL[] { codePath1, codePath2 }, parent, new String[0], NOOP_EXCEPTION_HANDLER);
-		final ClassLoader loader2 = FlinkUserCodeClassLoaders.childFirst(new URL[] { codePath1, codePath2 }, parent, new String[0], NOOP_EXCEPTION_HANDLER);
+		final ClassLoader loader1 = FlinkUserCodeClassLoaders.childFirst(
+			new URL[]{codePath1, codePath2},
+			parent,
+			new String[0],
+			NOOP_EXCEPTION_HANDLER,
+			true);
+		final ClassLoader loader2 = FlinkUserCodeClassLoaders.childFirst(
+			new URL[]{codePath1, codePath2},
+			parent,
+			new String[0],
+			NOOP_EXCEPTION_HANDLER,
+			true);
 
 		final String className = RocksDBStateBackend.class.getName();
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -106,9 +106,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -139,7 +141,7 @@ public class ExecutionContext<ClusterID> {
 
 	private final Environment environment;
 	private final SessionContext originalSessionContext;
-	private final ClassLoader classLoader;
+	private final URLClassLoader classLoader;
 
 	private final Configuration flinkConfig;
 	private final ClusterClientFactory<ClusterID> clusterClientFactory;
@@ -305,6 +307,11 @@ public class ExecutionContext<ClusterID> {
 	/** Close resources associated with this ExecutionContext, e.g. catalogs. */
 	public void close() {
 		wrapClassLoader(() -> getCatalogs().values().forEach(Catalog::close));
+		try {
+			classLoader.close();
+		} catch (IOException e) {
+			LOG.debug("Error while closing class loader.", e);
+		}
 	}
 
 	//------------------------------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -383,14 +383,16 @@ public class ExecutionContextTest {
 			.parentFirst(
 				new URL[0],
 				TestClassLoaderCatalog.class.getClassLoader(),
-				NOOP_EXCEPTION_HANDLER)
+				NOOP_EXCEPTION_HANDLER,
+				true)
 			.getClass();
 		private static final Class childFirstCL = FlinkUserCodeClassLoaders
 			.childFirst(
 				new URL[0],
 				TestClassLoaderCatalog.class.getClassLoader(),
 				new String[0],
-				NOOP_EXCEPTION_HANDLER)
+				NOOP_EXCEPTION_HANDLER,
+				true)
 			.getClass();
 
 		TestClassLoaderCatalog(String name) {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -59,6 +59,7 @@ import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TemporaryClassLoaderContext;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -393,14 +394,16 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 		@Override
 		void fail(int trackingIndex) throws Exception {
 			//noinspection OverlyBroadCatchBlock
-			try {
-				restartTaskManager();
-			} catch (InterruptedException e) {
-				// ignore the exception, task should have been failed while stopping TM
-				Thread.currentThread().interrupt();
-			} catch (Throwable t) {
-				failureTracker.unrelatedFailure(t);
-				throw t;
+			try (TemporaryClassLoaderContext unused = TemporaryClassLoaderContext.of(ClassLoader.getSystemClassLoader())) {
+				try {
+					restartTaskManager();
+				} catch (InterruptedException e) {
+					// ignore the exception, task should have been failed while stopping TM
+					Thread.currentThread().interrupt();
+				} catch (Throwable t) {
+					failureTracker.unrelatedFailure(t);
+					throw t;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

This is a follow-up PR of https://github.com/apache/flink/pull/11303 after https://github.com/apache/flink/pull/11611 disabled it because of performance regression in blink e2e test.

## What is the purpose of the change

Decoupling user class loader from context classloader.

Thus, user classloader can be unloaded even though a reference on the context classloader outlives the user code.

## Brief change log

- Adding SafetyNetWrapperClassLoader
- Use it for FlinkUserCodeClassLoaders
- Make sure LocalExecutor closes user classloader

Compared to the original PR, it includes the following changes
- Use the parent classloader of the FlinkUserCodeClassLoader in SafetyNetWrapperClassLoader to address the performance concerns.
- Further, improve performance by enabling parallel class loading in all involved classloaders.

## Verifying this change

Added unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
