### PR TITLE
[FLINK-18777][catalog] Supports schema registry catalog

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
 	<properties>
 		<kafka.version>2.4.1</kafka.version>
-		<confluent.version>5.4.2</confluent.version>
+		<confluent.version>5.5.1</confluent.version>
 	</properties>
 
 	<repositories>

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/avro/Schemas.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/avro/Schemas.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro;
+
+//CHECKSTYLE.OFF: IllegalImport
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+//CHECKSTYLE.ON: IllegalImport
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collection;
+
+/**
+ * The file is copied until https://github.com/confluentinc/schema-registry/issues/1432
+ * is resolved.
+ */
+public class Schemas {
+
+	private static final JsonFactory FACTORY = new JsonFactory();
+
+	public static String toString(Schema schema, Collection<Schema> schemas) {
+		return toString(schema, schemas, false);
+	}
+
+	public static String toString(Schema schema, Collection<Schema> schemas, boolean pretty) {
+		try {
+			StringWriter writer = new StringWriter();
+			JsonGenerator gen = FACTORY.createJsonGenerator(writer);
+			if (pretty) {
+				gen.useDefaultPrettyPrinter();
+			}
+			Schema.Names names = new Schema.Names();
+			if (schemas != null) {
+				for (Schema s : schemas) {
+					names.add(s);
+				}
+			}
+			schema.toJson(names, gen);
+			gen.flush();
+			return writer.toString();
+		} catch (IOException e) {
+			throw new AvroRuntimeException(e);
+		}
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/catalog/SchemaRegistryCatalog.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/catalog/SchemaRegistryCatalog.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent.catalog;
+
+import org.apache.flink.formats.avro.registry.confluent.RegistryAvroOptions;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+/**
+ * Catalog for
+ * <a href="https://docs.confluent.io/current/schema-registry/schema_registry_tutorial.html">Confluent Schema Registry</a>.
+ * It allows to access all the topics of current Confluent Schema Registry Service
+ * through SQL or TableAPI, there is no need to create any table explicitly.
+ *
+ * <p>The code snippet below illustrates how to use this catalog:
+ * <pre>
+ *      String schemaRegistryURL = ...;
+ * 		Map&lt;String, String&gt; kafkaProps = ...;
+ * 		SchemaRegistryCatalog catalog = SchemaRegistryCatalog.builder()
+ * 				.schemaRegistryURL(schemaRegistryURL)
+ * 				.kafkaOptions(kafkaProps)
+ * 				.catalogName("myCatalog")
+ * 				.dbName("myDB")
+ * 				.build();
+ * 		tEnv.registerCatalog("catalog1", catalog);
+ *
+ * 		// ---------- Consume stream from Kafka -------------------
+ *
+ * 		// Assumes there is a topic named 'transactions'
+ * 		String query = "SELECT\n" +
+ * 			"  id, amount\n" +
+ * 			"FROM myCatalog.myDB.transactions";
+ * </pre>
+ *
+ * <p>We only support TopicNameStrategy for subject naming strategy,
+ * for which all the records in one topic has the same schema, see
+ * <a href="https://docs.confluent.io/current/schema-registry/serializer-formatter.html#how-the-naming-strategies-work">How the Naming Strategies Work</a>
+ * for details.
+ *
+ * <p>You can specify some common options for these topics. All the tables from this catalog
+ * would take the same options. If this is not your request, use dynamic table options setting up
+ * within per-table scope.
+ *
+ * <p>The limitations:
+ * <ul>
+ *     <li>The catalog only supports reading messages with the latest enabled schema for any given
+ *     Kafka topic at the time when the SQL query was compiled.</li>
+ *     <li>No time-column and watermark support.</li>
+ *     <li>The catalog is read-only. It does not support table creations
+ *     or deletions or modifications.</li>
+ *     <li>The catalog only supports Kafka message values prefixed with schema id,
+ *     this is also the default behavior for the SchemaRegistry Kafka producer format.</li>
+ * </ul>
+ */
+public class SchemaRegistryCatalog extends TableCatalog {
+	private static final int DEFAULT_IDENTITY_MAP_CAPACITY = 1000;
+
+	private static final String CONNECTOR_PROPS_ERROR_FORMAT =
+			"No need to specify property '%s' for "
+					+ SchemaRegistryCatalog.class.getSimpleName();
+
+	/** URL to connect to the Schema Registry Service. */
+	private String schemaRegistryURL;
+
+	/** Client to interact with the Confluent Schema Registry. */
+	private SchemaRegistryClient client;
+
+	/** All topic name list snapshot of the schema registry when this catalog is open. */
+	private List<String> allTopics = Collections.emptyList();
+
+	// Singleton database for this catalog with default name.
+	private CatalogDatabase database;
+
+	/** Additional connector options for all the Kafka topics. */
+	private Map<String, String> connectorOptions;
+
+	private Cache<String, CatalogBaseTable> tableCache;
+
+	private SchemaRegistryCatalog(
+			Map<String, String> connectorOptions,
+			String schemaRegistryURL,
+			SchemaRegistryClient client,
+			String defaultDatabase) {
+		// The catalog name is actually useless.
+		super("kafka", defaultDatabase);
+
+		this.schemaRegistryURL = schemaRegistryURL;
+
+		this.connectorOptions = connectorOptions;
+
+		this.client = client;
+
+		this.tableCache = CacheBuilder.newBuilder()
+				.maximumSize(DEFAULT_IDENTITY_MAP_CAPACITY)
+				.softValues()
+				.build();
+	}
+
+	/**
+	 * Returns a builder to construct the catalog.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public void open() throws CatalogException {
+		this.database = new CatalogDatabaseImpl(Collections.emptyMap(),
+				String.format("SchemaRegistryCatalog database: %s", getDefaultDatabase()));
+		try {
+			this.allTopics = client.getAllSubjects().stream()
+					.filter(sub -> sub.endsWith("-value"))
+					// Strips out the "-value" suffix.
+					.map(sub -> sub.substring(0, sub.length() - 6))
+					.collect(Collectors.toList());
+		} catch (IOException | RestClientException e) {
+			throw new CatalogException("Error when fetching topic name list", e);
+		}
+	}
+
+	@Override
+	public void close() throws CatalogException {
+		this.allTopics.clear();
+		this.tableCache.invalidateAll();
+	}
+
+	@Override
+	public List<String> listDatabases() throws CatalogException {
+		return Collections.singletonList(getDefaultDatabase());
+	}
+
+	@Override
+	public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
+		Preconditions.checkNotNull(databaseName);
+		if (!databaseName.equals(getDefaultDatabase())) {
+			throw new DatabaseNotExistException(getName(), databaseName);
+		}
+		return database;
+	}
+
+	@Override
+	public boolean databaseExists(String databaseName) throws CatalogException {
+		return Objects.equals(databaseName, getDefaultDatabase());
+	}
+
+	@Override
+	public List<String> listTables(String databaseName) throws CatalogException {
+		return this.allTopics;
+	}
+
+	@Override
+	public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+		if (!tableExists(tablePath)) {
+			throw new TableNotExistException(getName(), tablePath);
+		} else {
+			final String tableName = tablePath.getObjectName();
+			try {
+				return this.tableCache.get(tableName, () -> generatesCatalogTable(tableName));
+			} catch (ExecutionException e) {
+				throw new RuntimeException("Error while get table from the cache.");
+			}
+		}
+	}
+
+	@Override
+	public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+		String dbName = tablePath.getDatabaseName();
+		return databaseExists(dbName) && allTopics.contains(tablePath.getObjectName());
+	}
+
+	@Override
+	public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists) throws CatalogException {
+		// Can be supported in the near future.
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	//~ Tools ------------------------------------------------------------------
+
+	private CatalogBaseTable generatesCatalogTable(String topicName) throws RestClientException {
+		try {
+			final String subject = String.format("%s-value", topicName);
+			SchemaMetadata metadata = this.client.getLatestSchemaMetadata(subject);
+			DataType dataType = AvroSchemaConverter.convertToDataType(metadata.getSchema());
+			Preconditions.checkState(dataType.getLogicalType() instanceof RowType,
+					String.format("The schema string: %s for subject %s can not be parsed as a row type",
+							metadata.getSchema(),
+							subject));
+			RowType rowType = (RowType) dataType.getLogicalType();
+			TableSchema tableSchema = TableSchema.builder()
+					.fields(
+							rowType.getFieldNames().toArray(new String[0]),
+							dataType.getChildren().toArray(new DataType[0]))
+					.build();
+			Map<String, String> connectorProps = new HashMap<>(this.connectorOptions);
+			final String format = metadata.getSchemaType().toLowerCase() + "-confluent";
+			// Reference KafkaOptions for the keys.
+			connectorProps.put("topic", topicName);
+			connectorProps.put(FactoryUtil.FORMAT.key(), format);
+			connectorProps.put(
+					format + "." + RegistryAvroOptions.SCHEMA_REGISTRY_URL.key(),
+					this.schemaRegistryURL);
+			connectorProps.put(
+					format + "." + RegistryAvroOptions.SCHEMA_REGISTRY_SUBJECT.key(),
+					subject);
+
+			return new CatalogTableImpl(
+					tableSchema,
+					connectorProps,
+					"Schema Registry table for topic: " + topicName);
+		} catch (IOException e) {
+			throw new CatalogException("Error while fetching schema info "
+					+ "from Confluent Schema Registry", e);
+		}
+	}
+
+	//~ Inner Class ------------------------------------------------------------
+
+	/** Builder for {@link SchemaRegistryCatalog}. */
+	public static class Builder {
+		private Map<String, String> kafkaOptions;
+		private String schemaRegistryURL;
+		private String defaultDatabase;
+
+		@Nullable
+		private SchemaRegistryClient client;
+
+		private Builder () {
+			this.defaultDatabase = "kafka";
+			this.kafkaOptions = Collections.emptyMap();
+		}
+
+		/**
+		 * Sets up the Kafka connector table options for all the tables read from the catalog,
+		 * the options are shared for all the tables, if you want to tweak or override per-table scope,
+		 * use the dynamic table options or CREATE TABLE LIKE syntax.
+		 */
+		public Builder kafkaOptions(Map<String, String> props) {
+			Objects.requireNonNull(props);
+			validateForbiddenOptions(props);
+
+			Map<String, String> overriddenProps = new HashMap<>(props);
+			overriddenProps.put(FactoryUtil.CONNECTOR.key(), "kafka");
+			this.kafkaOptions = Collections.unmodifiableMap(overriddenProps);
+			return this;
+		}
+
+		/**
+		 * Sets up the Schema Registry URL to connect to the registry service.
+		 */
+		public Builder schemaRegistryURL(String schemaRegistryURL) {
+			Objects.requireNonNull(schemaRegistryURL);
+			this.schemaRegistryURL = schemaRegistryURL;
+			return this;
+		}
+
+		/** Sets up the database name, default is 'kafka'. */
+		public Builder dbName(String dbName) {
+			this.defaultDatabase = Objects.requireNonNull(dbName);
+			return this;
+		}
+
+		/**
+		 * Sets up the {@link SchemaRegistryClient} to connect to the registry service.
+		 * By default, the catalog holds a {@link CachedSchemaRegistryClient} with 1000
+		 * as {@code identityMapCapacity}.
+		 *
+		 * <p>This method is used for custom client configuration, i.e. the SSL configurations
+		 * or to change the default {@code identityMapCapacity}.
+		 */
+		public Builder registryClient(SchemaRegistryClient client) {
+			this.client = Objects.requireNonNull(client);
+			return this;
+		}
+
+		public SchemaRegistryCatalog build() {
+			Preconditions.checkState(schemaRegistryURL != null,
+					"Schema Registry URL should be set through Builder.schemaRegistryURL.");
+			// Validate required keys for Kafka.
+			String serverKey = "properties.bootstrap.servers";
+			boolean missingKeys = this.kafkaOptions.keySet().stream()
+					.noneMatch(k -> k.equalsIgnoreCase(serverKey));
+			if (missingKeys) {
+				throw new ValidationException(String.format("Option %s is required for Kafka, " +
+						"please configure through Builder.kafkaOptions.", serverKey));
+			}
+			return new SchemaRegistryCatalog(
+					this.kafkaOptions,
+					this.schemaRegistryURL,
+					this.client == null
+							? new CachedSchemaRegistryClient(schemaRegistryURL, DEFAULT_IDENTITY_MAP_CAPACITY)
+							: this.client,
+					this.defaultDatabase);
+		}
+
+		private static void validateForbiddenOptions(Map<String, String> connectorProps) {
+			// validate the connector properties are valid.
+			DescriptorProperties descriptorProperties = new DescriptorProperties();
+			descriptorProperties.putProperties(Objects.requireNonNull(connectorProps));
+			Set<String> forbiddenConnectorProps = new HashSet<>(2);
+			forbiddenConnectorProps.add(FactoryUtil.CONNECTOR.key());
+			forbiddenConnectorProps.add(FactoryUtil.FORMAT.key());
+			for (String forbidden : forbiddenConnectorProps) {
+				if (descriptorProperties.containsKey(forbidden)) {
+					throw new ValidationException(String.format(CONNECTOR_PROPS_ERROR_FORMAT,
+							forbidden));
+				}
+			}
+		}
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/catalog/TableCatalog.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/catalog/TableCatalog.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent.catalog;
+
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.expressions.Expression;
+
+import java.util.List;
+
+/** Catalog that only allows operations of table. */
+public abstract class TableCatalog extends AbstractCatalog {
+
+	public TableCatalog(String name, String defaultDatabase) {
+		super(name, defaultDatabase);
+	}
+
+	@Override
+	public List<String> listDatabases() throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean databaseExists(String databaseName) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> listViews(String databaseName) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<CatalogPartitionSpec> listPartitionsByFilter(ObjectPath tablePath, List<Expression> filters) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition partition, boolean ignoreIfExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void dropPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition newPartition, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> listFunctions(String dbName) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogFunction getFunction(ObjectPath functionPath) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean functionExists(ObjectPath functionPath) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createFunction(ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterFunction(ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws CatalogException {
+		return CatalogTableStatistics.UNKNOWN;
+	}
+
+	@Override
+	public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath) throws CatalogException {
+		return CatalogColumnStatistics.UNKNOWN;
+	}
+
+	@Override
+	public CatalogTableStatistics getPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+		return CatalogTableStatistics.UNKNOWN;
+	}
+
+	@Override
+	public CatalogColumnStatistics getPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+		return CatalogColumnStatistics.UNKNOWN;
+	}
+
+	@Override
+	public void alterTableStatistics(ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTableColumnStatistics(ObjectPath tablePath, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogTableStatistics partitionStatistics, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -10,6 +10,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
-- io.confluent:common-utils:5.4.2
-- io.confluent:kafka-schema-registry-client:5.4.2
+- io.confluent:common-utils:5.5.1
+- io.confluent:kafka-schema-registry-client:5.5.1
 - org.apache.zookeeper:zookeeper:3.4.10

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/catalog/SchemaRegistryCatalogTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/catalog/SchemaRegistryCatalogTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent.catalog;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link SchemaRegistryCatalog}. */
+public class SchemaRegistryCatalogTest {
+	private static SchemaRegistryCatalog catalog;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@BeforeClass
+	public static void beforeClass() throws IOException, RestClientException {
+		Map<String, String> kafkaOptions = new HashMap<>(1);
+		kafkaOptions.put("properties.bootstrap.servers", "localhost:9092");
+
+		String avroSchemaString = "" +
+				"{\"namespace\": \"org.apache.flink.formats.avro.generated\",\n" +
+				" \"type\": \"record\",\n" +
+				" \"name\": \"Address\",\n" +
+				" \"fields\": [\n" +
+				"     {\"name\": \"num\", \"type\": \"int\"},\n" +
+				"     {\"name\": \"street\", \"type\": \"string\"},\n" +
+				"     {\"name\": \"city\", \"type\": \"string\"},\n" +
+				"     {\"name\": \"state\", \"type\": \"string\"},\n" +
+				"     {\"name\": \"zip\", \"type\": \"string\"}\n" +
+				"  ]\n" +
+				"}";
+		AvroSchema avroSchema = new AvroSchema(avroSchemaString);
+		MockSchemaRegistryClient client = new MockSchemaRegistryClient(
+				Collections.singletonList(new AvroSchemaProvider()));
+		client.register("address-value", avroSchema);
+		catalog = SchemaRegistryCatalog.builder()
+				.dbName("myDB")
+				.kafkaOptions(kafkaOptions)
+				.schemaRegistryURL("http://localhost:8081")
+				.registryClient(client)
+				.build();
+		catalog.open();
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		catalog.close();
+		catalog = null;
+	}
+
+	@Test
+	public void testListDatabases() {
+		List<String> databases = catalog.listDatabases();
+		assertThat(databases.size(), is(1));
+		assertEquals("myDB", databases.get(0));
+	}
+
+	@Test
+	public void testListTables() {
+		List<String> tables = catalog.listTables("myDB");
+		assertThat(tables.size(), is(1));
+		assertEquals("address", tables.get(0));
+	}
+
+	@Test
+	public void testGetTable() throws TableNotExistException {
+		final ObjectPath objectPath = ObjectPath.fromString("myDB.address");
+		assertThat(catalog.tableExists(objectPath), is(true));
+		CatalogBaseTable table = catalog.getTable(objectPath);
+		final String expectedSchema = "root\n" +
+				" |-- num: INT NOT NULL\n" +
+				" |-- street: STRING NOT NULL\n" +
+				" |-- city: STRING NOT NULL\n" +
+				" |-- state: STRING NOT NULL\n" +
+				" |-- zip: STRING NOT NULL\n";
+		assertThat(table.getSchema().toString(), is(expectedSchema));
+		final String expectedOptions = ""
+				+ "{properties.bootstrap.servers=localhost:9092, "
+				+ "format=avro-confluent, "
+				+ "topic=address, "
+				+ "avro-confluent.schema-registry.subject=address-value, "
+				+ "avro-confluent.schema-registry.url=http://localhost:8081, "
+				+ "connector=kafka}";
+		assertThat(table.getOptions().toString(), is(expectedOptions));
+	}
+
+	@Test
+	public void testMissingKafkaOptions() {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("Option properties.bootstrap.servers is required for Kafka,"
+				+ " please configure through Builder.kafkaOptions.");
+
+		MockSchemaRegistryClient client = new MockSchemaRegistryClient();
+		catalog = SchemaRegistryCatalog.builder()
+				.dbName("myDB")
+				.kafkaOptions(Collections.emptyMap())
+				.schemaRegistryURL("http://localhost:8081")
+				.registryClient(client)
+				.build();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Supports a catalog that can read the kafka topics flexibly.
The demo code:
```java
        String schemaRegistryURL = ...;
        Map<String, String> kafkaProps = ...;
        SchemaRegistryCatalog catalog = SchemaRegistryCatalog.builder()
                .schemaRegistryURL(schemaRegistryURL)
                .kafkaOptions(kafkaProps)
                .dbName("myDB")
                .build();
        tEnv.registerCatalog("myCatalog", catalog);
 
        // ---------- Consume stream from Kafka -------------------
 
        // Assumes there is a topic named 'transactions'
        String query = "SELECT\n" +
            " id, amount\n" +
            "FROM myCatalog.myDB.transactions";
```

## Brief change log

  - Add a new Catalog named `SchemaRegistryCatalog`
  - Add tests for the table attributes


## Verifying this change
Added UTs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, schema registry client 5.4.2 -> 5.5.1
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
