### PR TITLE
[FLINK-9992][tests] Fix FsStorageLocationReferenceTest#testEncodeAndDecode by adding retries to generate a valid path

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStorageLocationReferenceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStorageLocationReferenceTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
-import java.net.URISyntaxException;
 import java.util.Random;
 
 import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage.decodePathFromReference;
@@ -73,8 +72,7 @@ public class FsStorageLocationReferenceTest extends TestLogger {
 	// ------------------------------------------------------------------------
 
 	private static Path randomPath(Random rnd) {
-		int retries = 5;
-		for (int i = 0; i < retries; i++) {
+		while (true) {
 			try {
 				final StringBuilder path = new StringBuilder();
 
@@ -82,6 +80,7 @@ public class FsStorageLocationReferenceTest extends TestLogger {
 				path.append(StringUtils.getRandomString(rnd, 1, 5, 'a', 'z'));
 				path.append("://");
 				path.append(StringUtils.getRandomString(rnd, 10, 20)); // authority
+				path.append(":");
 				path.append(rnd.nextInt(50000) + 1); // port
 
 				for (int j = rnd.nextInt(5) + 1; j > 0; j--) {
@@ -90,14 +89,9 @@ public class FsStorageLocationReferenceTest extends TestLogger {
 				}
 
 				return new Path(path.toString());
-			} catch (IllegalArgumentException e) {
-				Throwable cause = e.getCause();
-				if (!(cause instanceof URISyntaxException) || !cause.getMessage().contains("Illegal character in hostname at index")) {
-					throw e;
-				}
+			} catch (Throwable t) {
 				// ignore the exception and retry
 			}
 		}
-		throw new RuntimeException("Failed to generate a valid path after retrying 5 times");
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

*Not all the characters could be used in the hostname: https://stackoverflow.com/questions/28568188/java-net-uri-get-host-with-underscores. For example, underscores could not be used in the hostname. Currently, FsStorageLocationReferenceTest#testEncodeAndDecode will generate the hostname randomly and it may happen that it generates a character which is not supported. This PR fixes this problem by adding retries to generate a valid path*

## Brief change log

  - *Add retries to generate a valid path in FsStorageLocationReferenceTest.randomPath*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
