### PR TITLE
[FLINK-18756][table-api] Support IF NOT EXISTS for CREATE TABLE statement

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -721,6 +721,7 @@ SqlNodeList TableProperties():
 SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
 {
     final SqlParserPos startPos = s.pos();
+    boolean ifNotExists = false;
     SqlIdentifier tableName;
     List<SqlTableConstraint> constraints = new ArrayList<SqlTableConstraint>();
     SqlWatermark watermark = null;
@@ -734,6 +735,11 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
 }
 {
     <TABLE>
+
+    [
+        LOOKAHEAD(3)
+        <IF> <NOT> <EXISTS> { ifNotExists = true; }
+    ]
 
     tableName = CompoundIdentifier()
     [
@@ -776,7 +782,8 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
                 watermark,
                 comment,
                 tableLike,
-                isTemporary);
+                isTemporary,
+                ifNotExists);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -736,10 +736,7 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
 {
     <TABLE>
 
-    [
-        LOOKAHEAD(3)
-        <IF> <NOT> <EXISTS> { ifNotExists = true; }
-    ]
+    ifNotExists = IfNotExistsOpt()
 
     tableName = CompoundIdentifier()
     [

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
@@ -85,32 +85,6 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 			@Nullable SqlWatermark watermark,
 			@Nullable SqlCharStringLiteral comment,
 			@Nullable SqlTableLike tableLike,
-			boolean isTemporary
-	) {
-		this(
-			pos,
-			tableName,
-			columnList,
-			tableConstraints,
-			propertyList,
-			partitionKeyList,
-			watermark,
-			comment,
-			tableLike,
-			isTemporary,
-			false);
-	}
-
-	public SqlCreateTable(
-			SqlParserPos pos,
-			SqlIdentifier tableName,
-			SqlNodeList columnList,
-			List<SqlTableConstraint> tableConstraints,
-			SqlNodeList propertyList,
-			SqlNodeList partitionKeyList,
-			@Nullable SqlWatermark watermark,
-			@Nullable SqlCharStringLiteral comment,
-			@Nullable SqlTableLike tableLike,
 			boolean isTemporary,
 			boolean ifNotExists) {
 		super(OPERATOR, pos, false, ifNotExists);
@@ -283,6 +257,9 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 			writer.keyword("TEMPORARY");
 		}
 		writer.keyword("TABLE");
+		if (isIfNotExists()) {
+			writer.keyword("IF NOT EXISTS");
+		}
 		tableName.unparse(writer, leftPrec, rightPrec);
 		SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.create("sds"), "(", ")");
 		for (SqlNode column : columnList) {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -283,39 +283,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
-	public void testCreateTemporaryTableIfNotExists() {
-		final String sql = "CREATE TEMPORARY TABLE IF NOT EXISTS tbl1 (\n" +
-			"  a bigint,\n" +
-			"  h varchar, \n" +
-			"  g as 2 * (a + 1), \n" +
-			"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'), \n" +
-			"  b varchar,\n" +
-			"  proc as PROCTIME(), \n" +
-			"  PRIMARY KEY (a, b)\n" +
-			")\n" +
-			"PARTITIONED BY (a, h)\n" +
-			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
-			"    'kafka.topic' = 'log.test'\n" +
-			")\n";
-		final String expected = "CREATE TEMPORARY TABLE IF NOT EXISTS `TBL1` (\n" +
-			"  `A`  BIGINT,\n" +
-			"  `H`  VARCHAR,\n" +
-			"  `G` AS (2 * (`A` + 1)),\n" +
-			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-			"  `B`  VARCHAR,\n" +
-			"  `PROC` AS `PROCTIME`(),\n" +
-			"  PRIMARY KEY (`A`, `B`)\n" +
-			")\n" +
-			"PARTITIONED BY (`A`, `H`)\n" +
-			"WITH (\n" +
-			"  'connector' = 'kafka',\n" +
-			"  'kafka.topic' = 'log.test'\n" +
-			")";
-		sql(sql).ok(expected);
-	}
-
-	@Test
 	public void testCreateTableWithComment() {
 		final String sql = "CREATE TABLE tbl1 (\n" +
 				"  a bigint comment 'test column comment AAA.',\n" +

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -250,6 +250,72 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testCreateTableIfNotExists() {
+		final String sql = "CREATE TABLE IF NOT EXISTS tbl1 (\n" +
+			"  a bigint,\n" +
+			"  h varchar, \n" +
+			"  g as 2 * (a + 1), \n" +
+			"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'), \n" +
+			"  b varchar,\n" +
+			"  proc as PROCTIME(), \n" +
+			"  PRIMARY KEY (a, b)\n" +
+			")\n" +
+			"PARTITIONED BY (a, h)\n" +
+			"  with (\n" +
+			"    'connector' = 'kafka', \n" +
+			"    'kafka.topic' = 'log.test'\n" +
+			")\n";
+		final String expected = "CREATE TABLE IF NOT EXISTS `TBL1` (\n" +
+			"  `A`  BIGINT,\n" +
+			"  `H`  VARCHAR,\n" +
+			"  `G` AS (2 * (`A` + 1)),\n" +
+			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  `B`  VARCHAR,\n" +
+			"  `PROC` AS `PROCTIME`(),\n" +
+			"  PRIMARY KEY (`A`, `B`)\n" +
+			")\n" +
+			"PARTITIONED BY (`A`, `H`)\n" +
+			"WITH (\n" +
+			"  'connector' = 'kafka',\n" +
+			"  'kafka.topic' = 'log.test'\n" +
+			")";
+		sql(sql).ok(expected);
+	}
+
+	@Test
+	public void testCreateTemporaryTableIfNotExists() {
+		final String sql = "CREATE TEMPORARY TABLE IF NOT EXISTS tbl1 (\n" +
+			"  a bigint,\n" +
+			"  h varchar, \n" +
+			"  g as 2 * (a + 1), \n" +
+			"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'), \n" +
+			"  b varchar,\n" +
+			"  proc as PROCTIME(), \n" +
+			"  PRIMARY KEY (a, b)\n" +
+			")\n" +
+			"PARTITIONED BY (a, h)\n" +
+			"  with (\n" +
+			"    'connector' = 'kafka', \n" +
+			"    'kafka.topic' = 'log.test'\n" +
+			")\n";
+		final String expected = "CREATE TEMPORARY TABLE IF NOT EXISTS `TBL1` (\n" +
+			"  `A`  BIGINT,\n" +
+			"  `H`  VARCHAR,\n" +
+			"  `G` AS (2 * (`A` + 1)),\n" +
+			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  `B`  VARCHAR,\n" +
+			"  `PROC` AS `PROCTIME`(),\n" +
+			"  PRIMARY KEY (`A`, `B`)\n" +
+			")\n" +
+			"PARTITIONED BY (`A`, `H`)\n" +
+			"WITH (\n" +
+			"  'connector' = 'kafka',\n" +
+			"  'kafka.topic' = 'log.test'\n" +
+			")";
+		sql(sql).ok(expected);
+	}
+
+	@Test
 	public void testCreateTableWithComment() {
 		final String sql = "CREATE TABLE tbl1 (\n" +
 				"  a bigint comment 'test column comment AAA.',\n" +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -136,6 +136,82 @@ class TableEnvironmentTest {
   }
 
   @Test
+  def testExecuteSqlWithCreateTableAlterDropIfNotExists(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TABLE IF NOT EXISTS tbl1 (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+    assertTrue(tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
+      .tableExists(ObjectPath.fromString(s"${tableEnv.getCurrentDatabase}.tbl1")))
+
+    val tableResult2 = tableEnv.executeSql("ALTER TABLE tbl1 SET ('k1' = 'a', 'k2' = 'b')")
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+    assertEquals(
+      Map("connector" -> "COLLECTION", "is-bounded" -> "false", "k1" -> "a", "k2" -> "b").asJava,
+      tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
+        .getTable(ObjectPath.fromString(s"${tableEnv.getCurrentDatabase}.tbl1")).getProperties)
+
+    val tableResult3 = tableEnv.executeSql("DROP TABLE tbl1")
+    assertEquals(ResultKind.SUCCESS, tableResult3.getResultKind)
+    assertFalse(tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
+      .tableExists(ObjectPath.fromString(s"${tableEnv.getCurrentDatabase}.tbl1")))
+  }
+
+  @Test
+  def testExecuteSqlWithCreateTableIfNotExistsTwice(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TABLE IF NOT EXISTS tbl1 (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val tableResult2 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+
+    assertTrue(tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
+      .tableExists(ObjectPath.fromString(s"${tableEnv.getCurrentDatabase}.tbl1")))
+  }
+
+  @Test
+  def testExecuteSqlWithCreateTemporaryTableIfNotExistsTwice(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TEMPORARY TABLE IF NOT EXISTS tbl1 (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val tableResult2 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+
+    assertTrue(tableEnv.listTables().contains("tbl1"))
+  }
+
+  @Test
   def testExecuteSqlWithCreateDropTemporaryTable(): Unit = {
     val createTableStmt =
       """


### PR DESCRIPTION
## What is the purpose of the change

* This pull request support `IF NOT EXISTS` for create table statement.


## Brief change log

 - Support parse `IF NOT EXISTS` in `parserImpls.ftl`
 - Simplify `SqlCreateTable.java` 's constructor

## Verifying this change
- Add parse tests in `FlinkSqlParserImplTest.java`
- Add catalog related test in `TableEnvironmentTest.scala`
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
