### PR TITLE
[FLINK-16510] Allow configuring shutdown behavior to avoid JVM freeze

### DIFF
--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -21,6 +21,12 @@
             <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use 4 * the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
         </tr>
         <tr>
+            <td><h5>cluster.processes.halt-on-fatal-error</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether processes should halt on fatal errors instead of performing a graceful shutdown. In some environments (e.g. Java 8 with the G1 garbage collector), a regular graceful shutdown can lead to a JVM deadlock. See <a href="https://issues.apache.org/jira/browse/FLINK-16510">FLINK-16510</a> for details.</td>
+        </tr>
+        <tr>
             <td><h5>cluster.registration.error-delay</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>

--- a/docs/_includes/generated/expert_cluster_section.html
+++ b/docs/_includes/generated/expert_cluster_section.html
@@ -1,0 +1,18 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>cluster.processes.halt-on-fatal-error</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether processes should halt on fatal errors instead of performing a graceful shutdown. In some environments (e.g. Java 8 with the G1 garbage collector), a regular graceful shutdown can lead to a JVM deadlock. See <a href="https://issues.apache.org/jira/browse/FLINK-16510">FLINK-16510</a> for details.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -324,6 +324,10 @@ With the introduction of `state.backend.rocksdb.memory.managed` and `state.backe
 
 {% include generated/expert_fault_tolerance_section.html %}
 
+### Advanced Cluster Options
+
+{% include generated/expert_cluster_section.html %}
+
 ### Advanced Scheduling Options
 
 *These parameters can help with fine-tuning scheduling for specific situations.*

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -324,6 +324,10 @@ With the introduction of `state.backend.rocksdb.memory.managed` and `state.backe
 
 {% include generated/expert_fault_tolerance_section.html %}
 
+### Advanced Cluster Options
+
+{% include generated/expert_cluster_section.html %}
+
 ### Advanced Scheduling Options
 
 *These parameters can help with fine-tuning scheduling for specific situations.*

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
@@ -91,6 +91,7 @@ public final class Documentation {
 		public static final String EXPERT_ZOOKEEPER_HIGH_AVAILABILITY = "expert_high_availability_zk";
 		public static final String EXPERT_SECURITY_SSL = "expert_security_ssl";
 		public static final String EXPERT_ROCKSDB = "expert_rocksdb";
+		public static final String EXPERT_CLUSTER = "expert_cluster";
 
 		public static final String ALL_JOB_MANAGER = "all_jobmanager";
 		public static final String ALL_TASK_MANAGER = "all_taskmanager";

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 
+import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
 
 /**
@@ -77,5 +79,17 @@ public class ClusterOptions {
 			Description.builder()
 				.text("Enable the slot spread out allocation strategy. This strategy tries to spread out " +
 					"the slots evenly across all available %s.", code("TaskExecutors"))
+				.build());
+
+	@Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
+	public static final ConfigOption<Boolean> HALT_ON_FATAL_ERROR =
+		key("cluster.processes.halt-on-fatal-error")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription(Description.builder().text(
+				"Whether processes should halt on fatal errors instead of performing a graceful shutdown. " +
+					"In some environments (e.g. Java 8 with the G1 garbage collector), a regular graceful shutdown can lead " +
+					"to a JVM deadlock. See %s for details.",
+				link("https://issues.apache.org/jira/browse/FLINK-16510", "FLINK-16510"))
 				.build());
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -92,6 +92,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.runtime.security.ExitTrappingSecurityManager.replaceGracefulExitWithHaltIfConfigured;
+
 /**
  * Base class for the Flink cluster entry points.
  *
@@ -162,6 +164,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 		LOG.info("Starting {}.", getClass().getSimpleName());
 
 		try {
+			replaceGracefulExitWithHaltIfConfigured(configuration);
 			PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
 			configureFileSystems(configuration, pluginManager);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/ExitTrappingSecurityManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/ExitTrappingSecurityManager.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.security.Permission;
+import java.util.function.Consumer;
+
+import static org.apache.flink.configuration.ClusterOptions.HALT_ON_FATAL_ERROR;
+
+/**
+ * A SecurityManager to execute logic on exit requests.
+ * */
+public final class ExitTrappingSecurityManager extends SecurityManager {
+
+	/** The behavior to execute when the JVM exists. */
+	private final Consumer<Integer> onExitBehavior;
+
+	/** An already in-use SecurityManager. */
+	@Nullable
+	private final SecurityManager existingManager;
+
+	public ExitTrappingSecurityManager(Consumer<Integer> onExitBehavior, @Nullable SecurityManager existingManager) {
+		this.onExitBehavior = Preconditions.checkNotNull(onExitBehavior);
+		this.existingManager = existingManager;
+	}
+
+	@Override
+	public void checkExit(int status) {
+		// Check if the existing SecurityManager has a policy.
+		if (existingManager != null) {
+			existingManager.checkExit(status);
+		}
+		// Unset ourselves to allow exiting.
+		System.setSecurityManager(null);
+		// Execute the desired behavior, e.g. forceful exit instead of proceeding with System.exit().
+		onExitBehavior.accept(status);
+	}
+
+	@Override
+	public void checkPermission(Permission perm) {
+		if (existingManager != null) {
+			existingManager.checkPermission(perm);
+		}
+	}
+
+	/**
+	 * If configured, registers a custom SecurityManager which converts graceful exists calls using
+	 * {@code System#exit} into forceful exit calls using {@code Runtime#halt}. The latter does not
+	 * perform a clean shutdown using the registered shutdown hooks.
+	 * <p></p>
+	 * This may be configured to prevent deadlocks with Java 8 and the G1 garbage collection,
+	 * see https://issues.apache.org/jira/browse/FLINK-16510.
+	 *
+	 * @param configuration The Flink configuration
+	 */
+	public static void replaceGracefulExitWithHaltIfConfigured(Configuration configuration) {
+		if (configuration.get(HALT_ON_FATAL_ERROR)) {
+			SecurityManager forcefulShutdownManager = new ExitTrappingSecurityManager(
+				status -> Runtime.getRuntime().halt(status),
+				System.getSecurityManager());
+			try {
+				System.setSecurityManager(forcefulShutdownManager);
+			} catch (Exception e) {
+				throw new IllegalConfigurationException(
+					String.format("Could not register forceful shutdown handler. This feature requires the permission to " +
+							"set a SecurityManager. Either update your existing SecurityManager to allow setting a SecurityManager " +
+							"or disable this feature by updating your Flink config with the following: " +
+							"'%s: %s'",
+						HALT_ON_FATAL_ERROR.key(),
+						HALT_ON_FATAL_ERROR.defaultValue()),
+					e);
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
@@ -37,8 +37,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
 	@SuppressWarnings("finally")
 	public void uncaughtException(Thread t, Throwable e) {
 		try {
-			LOG.error("FATAL: Thread '" + t.getName() +
-				"' produced an uncaught exception. Stopping the process...", e);
+			LOG.error("FATAL: Thread '{}' produced an uncaught exception. Stopping the process...", t.getName(), e);
 		}
 		finally {
 			System.exit(-17);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/ExitTrappingSecurityManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/ExitTrappingSecurityManagerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.Permission;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Unit tests for {@link ExitTrappingSecurityManager}. */
+public class ExitTrappingSecurityManagerTest extends TestLogger {
+
+	private SecurityManager existingManager;
+
+	@Before
+	public void before() {
+		existingManager = System.getSecurityManager();
+	}
+
+	@After
+	public void after() {
+		System.setSecurityManager(existingManager);
+	}
+
+	@Test
+	public void testExitWithNoExistingSecurityManager() {
+		AtomicInteger customExitExecuted = new AtomicInteger(0);
+		ExitTrappingSecurityManager exitTrappingSecurityManager =
+			new ExitTrappingSecurityManager(customExitExecuted::set, null);
+
+		exitTrappingSecurityManager.checkExit(42);
+
+		assertThat(customExitExecuted.get(), is(42));
+	}
+
+	@Test
+	public void testExistingSecurityManagerRespected() {
+		SecurityManager securityManager = new SecurityManager() {
+			@Override
+			public void checkPermission(Permission perm) {
+				throw new SecurityException("not allowed");
+			}
+		};
+
+		ExitTrappingSecurityManager exitTrappingSecurityManager =
+			new ExitTrappingSecurityManager(status -> Assert.fail(), securityManager);
+
+		assertThrows("not allowed", SecurityException.class, () -> {
+			exitTrappingSecurityManager.checkExit(42);
+			return null;
+		});
+	}
+
+	@Test
+	public void testExitCodeHandling() {
+		AtomicInteger exitingSecurityManagerCalled = new AtomicInteger(0);
+		SecurityManager securityManager = new SecurityManager() {
+			@Override
+			public void checkExit(int status) {
+				exitingSecurityManagerCalled.set(status);
+			}
+		};
+
+		AtomicInteger customExitExecuted = new AtomicInteger(0);
+		ExitTrappingSecurityManager exitTrappingSecurityManager =
+			new ExitTrappingSecurityManager(customExitExecuted::set, securityManager);
+
+		exitTrappingSecurityManager.checkExit(42);
+
+		assertThat(exitingSecurityManagerCalled.get(), is(42));
+		assertThat(customExitExecuted.get(), is(42));
+	}
+
+	@Test
+	public void testNotRegisteredByDefault() {
+		ExitTrappingSecurityManager.replaceGracefulExitWithHaltIfConfigured(new Configuration());
+
+		assertThat(System.getSecurityManager(), not(instanceOf(ExitTrappingSecurityManager.class)));
+	}
+
+	@Test
+	public void testRegisteredWhenConfigValueSet() {
+		Configuration configuration = new Configuration();
+		configuration.set(ClusterOptions.HALT_ON_FATAL_ERROR, true);
+
+		ExitTrappingSecurityManager.replaceGracefulExitWithHaltIfConfigured(configuration);
+
+		assertThat(System.getSecurityManager(), is(instanceOf(ExitTrappingSecurityManager.class)));
+	}
+
+	@Test
+	public void testRegistrationNotAllowedByExistingSecurityManager() {
+		Configuration configuration = new Configuration();
+		configuration.set(ClusterOptions.HALT_ON_FATAL_ERROR, true);
+
+		System.setSecurityManager(new SecurityManager() {
+
+			private boolean fired;
+
+			@Override
+			public void checkPermission(Permission perm) {
+				if (!fired && perm.getName().equals("setSecurityManager")) {
+					try {
+						throw new SecurityException("not allowed");
+					} finally {
+						// Allow removing this manager again
+						fired = true;
+					}
+				}
+			}
+		});
+
+		assertThrows("Could not register forceful shutdown handler.", IllegalConfigurationException.class, () -> {
+			ExitTrappingSecurityManager.replaceGracefulExitWithHaltIfConfigured(configuration);
+			return null;
+		});
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.modules.HadoopModule;
 import org.apache.flink.runtime.security.modules.SecurityModule;
@@ -56,7 +57,10 @@ public class YarnTaskExecutorRunnerTest extends TestLogger {
 		envs.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, YarnConfigOptions.LOCALIZED_KEYTAB_PATH.defaultValue());
 
 		Configuration configuration = new Configuration();
-		YarnTaskExecutorRunner.setupConfigurationAndInstallSecurityContext(configuration, resourceDirPath, envs);
+		YarnTaskExecutorRunner.setupAndModifyConfiguration(configuration, resourceDirPath, envs);
+
+		// the SecurityContext is installed on TaskManager startup
+		SecurityUtils.install(new SecurityConfiguration(configuration));
 
 		final List<SecurityModule> modules = SecurityUtils.getInstalledModules();
 		Optional<SecurityModule> moduleOpt = modules.stream().filter(module -> module instanceof HadoopModule).findFirst();
@@ -83,7 +87,10 @@ public class YarnTaskExecutorRunnerTest extends TestLogger {
 		envs.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, "src/test/resources/krb5.keytab");
 
 		Configuration configuration = new Configuration();
-		YarnTaskExecutorRunner.setupConfigurationAndInstallSecurityContext(configuration, resourceDirPath, envs);
+		YarnTaskExecutorRunner.setupAndModifyConfiguration(configuration, resourceDirPath, envs);
+
+		// the SecurityContext is installed on TaskManager startup
+		SecurityUtils.install(new SecurityConfiguration(configuration));
 
 		final List<SecurityModule> modules = SecurityUtils.getInstalledModules();
 		Optional<SecurityModule> moduleOpt = modules.stream().filter(module -> module instanceof HadoopModule).findFirst();


### PR DESCRIPTION
## What is the purpose of the change

This adds the configuration option `cluster.processes.halt-on-fatal-error`
which defaults to `false`. If set to `true`, a custom SecurityManager will be
installed on top of the existing SecurityManager to exit forcefully via
`Runtime#halt`.

Exiting that way may be necessary due to the Java 8 JVM freezing during a
graceful shutdown when using the G1 garbage collector.

## Brief change log

- If `cluster.processes.halt-on-fatal-error: true` is set in the config,
the shutdown will be performed via `Runtime#halt` instead of `System#exit`.

## Verifying this change

This change added tests and can be verified as follows:
  - Addded unit tests
  - Added integration test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs / auto-generated configuration
