### PR TITLE
[FLINK-16566][mesos] Change the log level of the launching command and dynamic properties from DEBUG to INFO in Mesos

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -71,7 +71,7 @@ public class MesosTaskExecutorRunner {
 		final Configuration configuration;
 		try {
 			Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
+			LOG.info("Mesos dynamic properties: {}", dynamicProperties);
 
 			configuration = MesosUtils.loadConfiguration(dynamicProperties, LOG);
 		}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.Map;
 
 /**
  * The entry point for running a TaskManager in a Mesos container.
@@ -81,8 +80,6 @@ public class MesosTaskExecutorRunner {
 			System.exit(INIT_ERROR_EXIT_CODE);
 			return;
 		}
-
-		final Map<String, String> envs = System.getenv();
 
 		final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -343,7 +343,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		containerInfo.addAllVolumes(params.containerVolumes());
 		taskInfo.setContainer(containerInfo);
 
-		LOG.debug("Starting TaskExecutor {} with command: {}", slaveId, taskInfo.getCommand().getValue());
+		LOG.info("Starting TaskExecutor {} with command: {}", slaveId, taskInfo.getCommand().getValue());
 
 		return taskInfo.build();
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -89,7 +89,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 	 * @param containerSpec an abstract container specification for launch time.
 	 * @param taskID the taskID for this worker.
 	 */
-	public LaunchableMesosWorker(
+	LaunchableMesosWorker(
 			MesosArtifactResolver resolver,
 			MesosTaskManagerParameters params,
 			ContainerSpecification containerSpec,
@@ -131,7 +131,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 			return params.cpus();
 		}
 
-		public double getGPUs() {
+		double getGPUs() {
 			return params.gpus();
 		}
 


### PR DESCRIPTION

## What is the purpose of the change

Change the log level of the launching command and dynamic properties from DEBUG to INFO in Mesos

## Brief change log

- Change the log level of the launching command and dynamic properties from DEBUG to INFO in Mesos

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

