### PR TITLE
[FLINK-16619][coordination] Log reception of slot reports only once

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -504,11 +504,10 @@ public class SlotManagerImpl implements SlotManager {
 	public boolean reportSlotStatus(InstanceID instanceId, SlotReport slotReport) {
 		checkInit();
 
-		LOG.debug("Received slot report from instance {}: {}.", instanceId, slotReport);
-
 		TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(instanceId);
 
 		if (null != taskManagerRegistration) {
+			LOG.debug("Received slot report from instance {}: {}.", instanceId, slotReport);
 
 			for (SlotStatus slotStatus : slotReport) {
 				updateSlot(slotStatus.getSlotID(), slotStatus.getAllocationID(), slotStatus.getJobID());


### PR DESCRIPTION
Small adjustment to the logging in `SlotManagerImpl#reportSlotStatus` to prevent us from logging twice that we received a slot  report, if the reporter was unknown.