### PR TITLE
[FLINK-18760][runtime] Redundant task managers should be released when there's no job running in session cluster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -1255,7 +1255,10 @@ public class SlotManagerImpl implements SlotManager {
 			}
 
 			int slotsDiff = redundantTaskManagerNum * numSlotsPerWorker - freeSlots.size();
-			if (slotsDiff > 0) {
+			if (freeSlots.size() == slots.size()) {
+				// No need to keep redundant taskManagers if no job is running.
+				releaseTaskExecutors(timedOutTaskManagers, timedOutTaskManagers.size());
+			} else if (slotsDiff > 0) {
 				// Keep enough redundant taskManagers from time to time.
 				int requiredTaskManagers = MathUtils.divideRoundUp(slotsDiff, numSlotsPerWorker);
 				allocateRedundantTaskManagers(requiredTaskManagers);


### PR DESCRIPTION
## What is the purpose of the change

Flink supports redundant task managers in [FLINK-18625](https://issues.apache.org/jira/browse/FLINK-18625). For a session cluster, there are no redundant task managers at first. After submitting a job, redundant task managers will be allocated. After cancelling the job, redundant task managers will not be released. It would be better to not keep such redundant resources when no job is running. 


## Brief change log

  - If freeSlots' size equals slots' size in SlotManagerImpl, no job is running and no need to keep redundant taskManagers. Just release timeout task managers in this case.


## Verifying this change

This change added tests and can be verified as follows:

  - Added test to verify that timeout task managers will be released if no job is running regardless of redundantTaskManagerNum.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
