### PR TITLE
[FLINK-18677] Added handling of suspended or lost connections

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -184,9 +184,9 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 				LOG.debug("Connected to ZooKeeper quorum. Leader retrieval can start.");
 				break;
 			case SUSPENDED:
+				LOG.warn("Connection to ZooKeeper suspended. Can no longer retrieve the leader from " +
+						"ZooKeeper.");
 				synchronized (lock) {
-					LOG.warn("Connection to ZooKeeper suspended. Can no longer retrieve the leader from " +
-							"ZooKeeper.");
 					notifyLeaderLoss();
 				}
 				break;
@@ -194,9 +194,9 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 				LOG.info("Connection to ZooKeeper was reconnected. Leader retrieval can be restarted.");
 				break;
 			case LOST:
+				LOG.warn("Connection to ZooKeeper lost. Can no longer retrieve the leader from " +
+						"ZooKeeper.");
 				synchronized (lock) {
-					LOG.warn("Connection to ZooKeeper lost. Can no longer retrieve the leader from " +
-							"ZooKeeper.");
 					notifyLeaderLoss();
 				}
 				break;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -32,6 +32,8 @@ import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.Conne
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -165,17 +167,7 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 						}
 					}
 
-					if (!(Objects.equals(leaderAddress, lastLeaderAddress) &&
-						Objects.equals(leaderSessionID, lastLeaderSessionID))) {
-						LOG.debug(
-							"New leader information: Leader={}, session ID={}.",
-							leaderAddress,
-							leaderSessionID);
-
-						lastLeaderAddress = leaderAddress;
-						lastLeaderSessionID = leaderSessionID;
-						leaderListener.notifyLeaderAddress(leaderAddress, leaderSessionID);
-					}
+					notifyIfNewLeaderAddress(leaderAddress, leaderSessionID);
 				} catch (Exception e) {
 					leaderListener.handleError(new Exception("Could not handle node changed event.", e));
 					throw e;
@@ -192,17 +184,21 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 				LOG.debug("Connected to ZooKeeper quorum. Leader retrieval can start.");
 				break;
 			case SUSPENDED:
-				LOG.warn("Connection to ZooKeeper suspended. Can no longer retrieve the leader from " +
-					"ZooKeeper.");
-				notifyLeaderLoss();
+				synchronized (lock) {
+					LOG.warn("Connection to ZooKeeper suspended. Can no longer retrieve the leader from " +
+							"ZooKeeper.");
+					notifyLeaderLoss();
+				}
 				break;
 			case RECONNECTED:
 				LOG.info("Connection to ZooKeeper was reconnected. Leader retrieval can be restarted.");
 				break;
 			case LOST:
-				LOG.warn("Connection to ZooKeeper lost. Can no longer retrieve the leader from " +
-					"ZooKeeper.");
-				notifyLeaderLoss();
+				synchronized (lock) {
+					LOG.warn("Connection to ZooKeeper lost. Can no longer retrieve the leader from " +
+							"ZooKeeper.");
+					notifyLeaderLoss();
+				}
 				break;
 		}
 	}
@@ -212,14 +208,27 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 		leaderListener.handleError(new FlinkException("Unhandled error in ZooKeeperLeaderRetrievalService:" + s, throwable));
 	}
 
-	private void notifyLeaderLoss() {
-		if (lastLeaderAddress != null || lastLeaderSessionID != null) {
-			LOG.debug(
-					"No leader information could be retrieved. Any listeners will be notified.");
+	@GuardedBy("lock")
+	private void notifyIfNewLeaderAddress(String newLeaderAddress, UUID newLeaderSessionID) {
+		if (!(Objects.equals(newLeaderAddress, lastLeaderAddress) &&
+				Objects.equals(newLeaderSessionID, lastLeaderSessionID))) {
+			if (newLeaderAddress == null && newLeaderSessionID == null) {
+				LOG.debug("Leader information was lost: The listener will be notified accordingly.");
+			} else {
+				LOG.debug(
+						"New leader information: Leader={}, session ID={}.",
+						newLeaderAddress,
+						newLeaderSessionID);
+			}
 
-			lastLeaderAddress = null;
-			lastLeaderSessionID = null;
-			leaderListener.notifyLeaderAddress(null, null);
+			lastLeaderAddress = newLeaderAddress;
+			lastLeaderSessionID = newLeaderSessionID;
+			leaderListener.notifyLeaderAddress(newLeaderAddress, newLeaderSessionID);
 		}
+	}
+
+	@GuardedBy("lock")
+	private void notifyLeaderLoss() {
+		notifyIfNewLeaderAddress(null, null);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -41,7 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -113,7 +113,7 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 		stopTestServer();
 
 		CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
-		assertThat("The next result must not be missing.", secondAddress, not(is(nullValue())));
+		assertThat("The next result must not be missing.", secondAddress, is(notNullValue()));
 		assertThat("The next result is expected to be null.", secondAddress.get(), is(nullValue()));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -79,7 +79,7 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
 	@Test
 	public void testConnectionSuspendedHandlingDuringInitialization() throws Exception {
-		QueueLeaderElectionListener queueLeaderElectionListener = new QueueLeaderElectionListener(1, Duration.ofSeconds(1));
+		QueueLeaderElectionListener queueLeaderElectionListener = new QueueLeaderElectionListener(1, Duration.ofMillis(50));
 
 		ZooKeeperLeaderRetrievalService testInstance = ZooKeeperUtils.createLeaderRetrievalService(zooKeeperClient, config);
 		testInstance.start(queueLeaderElectionListener);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
+import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalService;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the error handling in case of a suspended connection to the ZooKeeper instance.
+ */
+public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
+
+    private TestingServer testingServer;
+
+    private Configuration config;
+
+    private CuratorFramework zooKeeperClient;
+
+    @Before
+    public void before() throws Exception {
+        testingServer = new TestingServer();
+
+        config = new Configuration();
+        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+
+        zooKeeperClient = ZooKeeperUtils.startCuratorFramework(config);
+    }
+
+    @After
+    public void after() throws Exception {
+        stopTestServer();
+
+        if (zooKeeperClient != null) {
+            zooKeeperClient.close();
+            zooKeeperClient = null;
+        }
+    }
+
+    @Test
+    public void testConnectionSuspendedHandlingDuringInitialization() throws Exception {
+        // initialize LeaderRetrievalService
+        QueueLeaderElectionListener queueLeaderElectionListener = new QueueLeaderElectionListener(1, Duration.ofSeconds(1));
+
+        ZooKeeperLeaderRetrievalService testInstance = ZooKeeperUtils.createLeaderRetrievalService(zooKeeperClient, config);
+        testInstance.start(queueLeaderElectionListener);
+
+        // do the testing
+        CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
+        assertThat("No results are expected, yet, since no leader was elected.", firstAddress, is(nullValue()));
+
+        stopTestServer();
+
+        CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
+        assertThat("No result is expected since there was no leader elected before stopping the server, yet.", secondAddress, is(nullValue()));
+    }
+
+    @Test
+    public void testConnectionSuspendedHandling() throws Exception {
+        // initialize LeaderElection-related instances
+        String leaderAddress = "localhost";
+        LeaderElectionService leaderElectionService = ZooKeeperUtils.createLeaderElectionService(zooKeeperClient, config);
+        TestingContender contender = new TestingContender(leaderAddress, leaderElectionService);
+        leaderElectionService.start(contender);
+
+        // initialize LeaderRetrievalService
+        QueueLeaderElectionListener queueLeaderElectionListener = new QueueLeaderElectionListener(2, Duration.ofSeconds(1));
+
+        ZooKeeperLeaderRetrievalService testInstance = ZooKeeperUtils.createLeaderRetrievalService(zooKeeperClient, config);
+        testInstance.start(queueLeaderElectionListener);
+
+        // do the testing
+        CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
+        assertThat("The first result is expected to be the initially set leader address.", firstAddress.get(), is(leaderAddress));
+
+        stopTestServer();
+
+        CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
+        assertThat("The next result must not be missing.", secondAddress, not(is(nullValue())));
+        assertThat("The next result is expected to be null.", secondAddress.get(), is(nullValue()));
+    }
+
+    private void stopTestServer() throws IOException {
+        if (testingServer != null) {
+            testingServer.stop();
+            testingServer = null;
+        }
+    }
+
+    private static class QueueLeaderElectionListener implements LeaderRetrievalListener {
+
+        private final BlockingQueue<CompletableFuture<String>> queue;
+        private final Duration timeout;
+
+        public QueueLeaderElectionListener(int expectedCalls, Duration timeout) {
+            this.queue = new ArrayBlockingQueue<>(expectedCalls);
+            this.timeout = timeout;
+        }
+
+        @Override
+        public void notifyLeaderAddress(String leaderAddress, UUID leaderSessionID) {
+            try {
+                this.queue.offer(CompletableFuture.completedFuture(leaderAddress), timeout.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        public CompletableFuture<String> next() {
+            try {
+                return this.queue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public void handleError(Exception exception) {
+            // nothing to do
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -156,7 +156,7 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
 		@Override
 		public void handleError(Exception exception) {
-			// nothing to do
+			throw new UnsupportedOperationException("handleError(Exception) shouldn't have been called, but it was triggered anyway.", exception);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -79,7 +79,6 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
 	@Test
 	public void testConnectionSuspendedHandlingDuringInitialization() throws Exception {
-		// initialize LeaderRetrievalService
 		QueueLeaderElectionListener queueLeaderElectionListener = new QueueLeaderElectionListener(1, Duration.ofSeconds(1));
 
 		ZooKeeperLeaderRetrievalService testInstance = ZooKeeperUtils.createLeaderRetrievalService(zooKeeperClient, config);
@@ -97,13 +96,11 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
 	@Test
 	public void testConnectionSuspendedHandling() throws Exception {
-		// initialize LeaderElection-related instances
 		String leaderAddress = "localhost";
 		LeaderElectionService leaderElectionService = ZooKeeperUtils.createLeaderElectionService(zooKeeperClient, config);
 		TestingContender contender = new TestingContender(leaderAddress, leaderElectionService);
 		leaderElectionService.start(contender);
 
-		// initialize LeaderRetrievalService
 		QueueLeaderElectionListener queueLeaderElectionListener = new QueueLeaderElectionListener(2, Duration.ofSeconds(1));
 
 		ZooKeeperLeaderRetrievalService testInstance = ZooKeeperUtils.createLeaderRetrievalService(zooKeeperClient, config);


### PR DESCRIPTION
I added handling of suspended or lost connections within the ZooKeeperLeaderRetrievalService.

The listener needs to be notified in case of a connection loss so that it is able to initiate necessary actions on its side.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

* The ZooKeeperLeaderRetrievalService needs to inform its listener in case of connection loss since it might miss a leader change. The old implementation didn't trigger the listener in such a case.
* This behavior was caused, for instance, when the TaskManager was lost its connection to the ZooKeeper and, therefore, wasn't informed about a leader change. Its tasks continued to run even though they got already recovered by another TaskManager. Hence, the same data got processed.


## Brief change log

* A method call was added when handling lost or suspended connections notifying the listener about the lost connection.
* Two test cases were added to check the behavior.

## Verifying this change

This change added tests and can be verified as follows:

* Added unit test for checking whether the listener is NOT informed when there was not leader information retrieved, yet.
* Added unit test for checking whether the listener is notified when the connection was lost but there was some previous leader information present already.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? -
