### PR TITLE
[hotfix][docs] Rephrase the docs about file names in StreamingFileSink

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -61,12 +61,13 @@ import java.io.Serializable;
  * {@link StreamingFileSink#forBulkFormat(Path, BulkWriter.Factory)}.
  *
  *
- * <p>The filenames of the part files could be defined using {@link OutputFileConfig}, this configuration contain
- * a part prefix and part suffix, that will be used with the parallel subtask index of the sink
- * and a rolling counter. For example for a prefix "prefix" and a suffix ".ext" the file create will have a name
- * {@code "prefix-1-17.ext"} containing the data from {@code subtask 1} of the sink and is the {@code 17th} bucket
+ * <p>The names of the part files could be defined using {@link OutputFileConfig}. This configuration contains
+ * a part prefix and a part suffix that will be used with the parallel subtask index of the sink and a rolling counter
+ * to determine the file names. For example with a prefix "prefix" and a suffix ".ext", a file named
+ * {@code "prefix-1-17.ext"} contains the data from {@code subtask 1} of the sink and is the {@code 17th} bucket
  * created by that subtask.
- * Part files roll based on the user-specified {@link RollingPolicy}. By default, a {@link DefaultRollingPolicy}
+ *
+ * <p>Part files roll based on the user-specified {@link RollingPolicy}. By default, a {@link DefaultRollingPolicy}
  * is used for row-encoded sink output; a {@link OnCheckpointRollingPolicy} is used for bulk-encoded sink output.
  *
  * <p>In some scenarios, the open buckets are required to change based on time. In these cases, the user


### PR DESCRIPTION
## What is the purpose of the change

Rephrase the docs about file names in StreamingFileSink.


## Brief change log

- Rephrase the docs about file names in StreamingFileSink.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?
