### PR TITLE
[FLINK-18796][kinesis] Make backpressureLatch volatile

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
@@ -95,7 +95,7 @@ public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements 
 	private transient KinesisProducer producer;
 
 	/* Backpressuring waits for this latch, triggered by record callback */
-	private transient TimeoutLatch backpressureLatch;
+	private transient volatile TimeoutLatch backpressureLatch;
 
 	/* Callback handling failures */
 	private transient FutureCallback<UserRecordResult> callback;


### PR DESCRIPTION
## What is the purpose of the change

Add `volatile` modifier to `FlinkKinesisProducer.backpressureLatch` as it can be accessed from different threads.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no

cc: @zentol  