### PR TITLE
[FLINK-18821][network] Report PartitionRequest failures to subsequent…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -90,6 +90,21 @@ public class FutureUtils {
 		}
 	}
 
+	/**
+	 * Fakes asynchronous execution by immediately executing the operation and completing the supplied future
+	 * either noramlly or exceptionally.
+	 *
+	 * @param operation to executed
+	 * @param <T> type of the result
+	 */
+	public static <T> void completeFromCallable(CompletableFuture<T> future, Callable<T> operation) {
+		try {
+			future.complete(operation.call());
+		} catch (Exception e) {
+			future.completeExceptionally(e);
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  retrying operations
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -76,21 +76,6 @@ public class FutureUtils {
 	}
 
 	/**
-	 * Fakes asynchronous execution by immediately executing the operation and returns a (exceptionally) completed
-	 * future.
-	 *
-	 * @param operation to executed
-	 * @param <T> type of the result
-	 */
-	public static <T> CompletableFuture<T> runSync(Callable<T> operation) {
-		try {
-			return CompletableFuture.completedFuture(operation.call());
-		} catch (Exception e) {
-			return completedExceptionally(e);
-		}
-	}
-
-	/**
 	 * Fakes asynchronous execution by immediately executing the operation and completing the supplied future
 	 * either noramlly or exceptionally.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
@@ -37,6 +37,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.runtime.concurrent.FutureUtils.completeFromCallable;
+
 /**
  * Factory for {@link NettyPartitionRequestClient} instances.
  *
@@ -73,7 +75,7 @@ class PartitionRequestClientFactory {
 				return new CompletableFuture<>();
 			});
 			if (isTheFirstOne.get()) {
-				clientFuture.complete(connectWithRetries(connectionId));
+				completeFromCallable(clientFuture, () -> connectWithRetries(connectionId));
 			}
 
 			final NettyPartitionRequestClient client;


### PR DESCRIPTION
## What is the purpose of the change

Currently, an exception in `PartitionRequestClientFactory` is propagated to the client directly. 
The future in the internal `PartitionRequestClientFactory` map is not completed exceptionally.
This causes subsequent calls to wait indefinitely for the future to complete (see FLINK-18821).

This PR fixes it by completing the future exceptionally in case of error.

## Verifying this change

Added unit test: `PartitionRequestClientFactoryTest.testFailureReportedToSubsequentRequests`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
