### PR TITLE
[FLINK-13689] [Connectors/ElasticSearch] Fix thread leak in Elasticsearch connector when cluster is down

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -50,7 +50,7 @@ public interface ElasticsearchApiCallBridge<C extends AutoCloseable> extends Ser
 	 * @param clientConfig The configuration to use when constructing the client.
 	 * @return The created client.
 	 */
-	C createClient(Map<String, String> clientConfig) throws IOException;
+	C createClient(Map<String, String> clientConfig);
 
 	/**
 	 * Creates a {@link BulkProcessor.Builder} for creating the bulk processor.
@@ -79,6 +79,16 @@ public interface ElasticsearchApiCallBridge<C extends AutoCloseable> extends Ser
 	void configureBulkProcessorBackoff(
 		BulkProcessor.Builder builder,
 		@Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy);
+
+	/**
+	 * Verify the client connection by making a test request/ping to the Elasticsearch cluster.
+	 *
+	 * <p>Called by {@link ElasticsearchSinkBase#open(org.apache.flink.configuration.Configuration)} after creating the client. This makes sure the underlying
+	 * client is closed if the connection is not successful and preventing thread leak.
+	 *
+	 * @param client the Elasticsearch client.
+	 */
+	void verifyClientConnection(C client) throws IOException;
 
 	/**
 	 * Creates a {@link RequestIndexer} that is able to work with {@link BulkProcessor} binary compatible.

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -297,6 +297,7 @@ public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends 
 	@Override
 	public void open(Configuration parameters) throws Exception {
 		client = callBridge.createClient(userConfig);
+		callBridge.verifyClientConnection(client);
 		bulkProcessor = buildBulkProcessor(new BulkProcessorListener());
 		requestIndexer = callBridge.createBulkProcessorIndexer(bulkProcessor, flushOnCheckpoint, numPendingRequests);
 		failureRequestIndexer = new BufferingNoOpRequestIndexer();

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -559,6 +559,11 @@ public class ElasticsearchSinkBaseTest {
 		public void configureBulkProcessorBackoff(BulkProcessor.Builder builder, @Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy) {
 			// no need for this in the test cases here
 		}
+
+		@Override
+		public void verifyClientConnection(Client client) {
+			// no need for this in the test cases here
+		}
 	}
 
 	private static class SimpleSinkFunction<String> implements ElasticsearchSinkFunction<String> {

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
@@ -71,19 +71,6 @@ public class Elasticsearch2ApiCallBridge implements ElasticsearchApiCallBridge<T
 			transportClient.addTransportAddress(address);
 		}
 
-		// verify that we actually are connected to a cluster
-		if (transportClient.connectedNodes().isEmpty()) {
-
-			// close the transportClient here
-			IOUtils.closeQuietly(transportClient);
-
-			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", transportClient.connectedNodes());
-		}
-
 		return transportClient;
 	}
 
@@ -125,5 +112,20 @@ public class Elasticsearch2ApiCallBridge implements ElasticsearchApiCallBridge<T
 		}
 
 		builder.setBackoffPolicy(backoffPolicy);
+	}
+
+	@Override
+	public void verifyClientConnection(TransportClient client) {
+		// verify that we actually are connected to a cluster
+		if (client.connectedNodes().isEmpty()) {
+			// close the transportClient here
+			IOUtils.closeQuietly(client);
+
+			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Elasticsearch TransportClient is connected to nodes {}", client.connectedNodes());
+		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
@@ -78,19 +78,6 @@ public class Elasticsearch5ApiCallBridge implements ElasticsearchApiCallBridge<T
 			transportClient.addTransportAddress(transport);
 		}
 
-		// verify that we actually are connected to a cluster
-		if (transportClient.connectedNodes().isEmpty()) {
-
-			// close the transportClient here
-			IOUtils.closeQuietly(transportClient);
-
-			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", transportClient.connectedNodes());
-		}
-
 		return transportClient;
 	}
 
@@ -132,5 +119,20 @@ public class Elasticsearch5ApiCallBridge implements ElasticsearchApiCallBridge<T
 		}
 
 		builder.setBackoffPolicy(backoffPolicy);
+	}
+
+	@Override
+	public void verifyClientConnection(TransportClient client) {
+		// verify that we actually are connected to a cluster
+		if (client.connectedNodes().isEmpty()) {
+			// close the transportClient here
+			IOUtils.closeQuietly(client);
+
+			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Elasticsearch TransportClient is connected to nodes {}", client.connectedNodes());
+		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
@@ -68,23 +68,11 @@ public class Elasticsearch6ApiCallBridge implements ElasticsearchApiCallBridge<R
 	}
 
 	@Override
-	public RestHighLevelClient createClient(Map<String, String> clientConfig) throws IOException {
+	public RestHighLevelClient createClient(Map<String, String> clientConfig) {
 		RestClientBuilder builder = RestClient.builder(httpHosts.toArray(new HttpHost[httpHosts.size()]));
 		restClientFactory.configureRestClientBuilder(builder);
 
 		RestHighLevelClient rhlClient = new RestHighLevelClient(builder);
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
-		}
-
-		if (!rhlClient.ping()) {
-			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
-		}
 
 		return rhlClient;
 	}
@@ -138,5 +126,20 @@ public class Elasticsearch6ApiCallBridge implements ElasticsearchApiCallBridge<R
 			bulkProcessor,
 			flushOnCheckpoint,
 			numPendingRequestsRef);
+	}
+
+	@Override
+	public void verifyClientConnection(RestHighLevelClient client) throws IOException {
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
+		}
+
+		if (!client.ping()) {
+			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Elasticsearch RestHighLevelClient is connected to {}", httpHosts.toString());
+		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
@@ -69,23 +69,11 @@ public class Elasticsearch7ApiCallBridge implements ElasticsearchApiCallBridge<R
 	}
 
 	@Override
-	public RestHighLevelClient createClient(Map<String, String> clientConfig) throws IOException {
+	public RestHighLevelClient createClient(Map<String, String> clientConfig) {
 		RestClientBuilder builder = RestClient.builder(httpHosts.toArray(new HttpHost[httpHosts.size()]));
 		restClientFactory.configureRestClientBuilder(builder);
 
 		RestHighLevelClient rhlClient = new RestHighLevelClient(builder);
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
-		}
-
-		if (!rhlClient.ping(RequestOptions.DEFAULT)) {
-			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
-		}
 
 		return rhlClient;
 	}
@@ -139,5 +127,20 @@ public class Elasticsearch7ApiCallBridge implements ElasticsearchApiCallBridge<R
 			bulkProcessor,
 			flushOnCheckpoint,
 			numPendingRequestsRef);
+	}
+
+	@Override
+	public void verifyClientConnection(RestHighLevelClient client) throws IOException {
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
+		}
+
+		if (!client.ping(RequestOptions.DEFAULT)) {
+			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Elasticsearch RestHighLevelClient is connected to {}", httpHosts.toString());
+		}
 	}
 }


### PR DESCRIPTION
1.10 back port of #10936, see also [FLINK-18702](https://issues.apache.org/jira/browse/FLINK-18702)