### PR TITLE
[FLINK-18751][Coordination] Implement SlotSharingExecutionSlotAllocator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProvider.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The provider serves physical slot requests.
  */
-interface PhysicalSlotProvider {
+public interface PhysicalSlotProvider {
 
 	/**
 	 * Submit a request to allocate a physical slot.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequest.java
@@ -50,7 +50,7 @@ public class PhysicalSlotRequest {
 		return slotProfile;
 	}
 
-	boolean willSlotBeOccupiedIndefinitely() {
+	public boolean willSlotBeOccupiedIndefinitely() {
 		return slotWillBeOccupiedIndefinitely;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnfulfillableSlotRequestException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.util.DualKeyLinkedMap;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocator.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotOwner;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequest;
+import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
+import org.apache.flink.runtime.scheduler.SharedSlotProfileRetriever.SharedSlotProfileRetrieverFactory;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.util.DualKeyLinkedMap;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Allocates {@link LogicalSlot}s from physical shared slots.
+ *
+ * <p>The allocator maintains a shared slot for each {@link ExecutionSlotSharingGroup}.
+ * It allocates a physical slot for the shared slot and then allocates logical slots from it for scheduled tasks.
+ * The physical slot is lazily allocated for a shared slot, upon any hosted subtask asking for the shared slot.
+ * Each subsequent sharing subtask allocates a logical slot from the existing shared slot. The shared/physical slot
+ * can be released only if all the requested logical slots are released or canceled.
+ */
+class SlotSharingExecutionSlotAllocator implements ExecutionSlotAllocator {
+	private static final Logger LOG = LoggerFactory.getLogger(SlotSharingExecutionSlotAllocator.class);
+
+	private final PhysicalSlotProvider slotProvider;
+
+	private final boolean slotWillBeOccupiedIndefinitely;
+
+	private final SlotSharingStrategy slotSharingStrategy;
+
+	private final Map<ExecutionSlotSharingGroup, SharedSlot> sharedSlots;
+
+	private final SharedSlotProfileRetrieverFactory sharedSlotProfileRetrieverFactory;
+
+	SlotSharingExecutionSlotAllocator(
+			PhysicalSlotProvider slotProvider,
+			boolean slotWillBeOccupiedIndefinitely,
+			SlotSharingStrategy slotSharingStrategy,
+			SharedSlotProfileRetrieverFactory sharedSlotProfileRetrieverFactory) {
+		this.slotProvider = slotProvider;
+		this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+		this.slotSharingStrategy = slotSharingStrategy;
+		this.sharedSlotProfileRetrieverFactory = sharedSlotProfileRetrieverFactory;
+		this.sharedSlots = new IdentityHashMap<>();
+	}
+
+	/**
+	 * Creates logical {@link SlotExecutionVertexAssignment}s from physical shared slots.
+	 *
+	 * <p>The allocation has the following steps:
+	 * <ol>
+	 *  <li>Map the executions to {@link ExecutionSlotSharingGroup}s using {@link SlotSharingStrategy}</li>
+	 *  <li>Check which {@link ExecutionSlotSharingGroup}s already have shared slot</li>
+	 *  <li>For all involved {@link ExecutionSlotSharingGroup}s which do not have a shared slot yet:</li>
+	 *  <li>Create a {@link SlotProfile} future using {@link SharedSlotProfileRetriever} and then</li>
+	 *  <li>Allocate a physical slot from the {@link PhysicalSlotProvider}</li>
+	 *  <li>Create a shared slot based on the returned physical slot futures</li>
+	 *  <li>Allocate logical slot futures for the executions from all corresponding shared slots.</li>
+	 *  <li>If a physical slot request fails, associated logical slot requests are canceled within the shared slot</li>
+	 *  <li>Generate {@link SlotExecutionVertexAssignment}s based on the logical slot futures and returns the results.</li>
+	 * </ol>
+	 *
+	 * @param executionVertexSchedulingRequirements the requirements for scheduling the executions.
+	 */
+	@Override
+	public List<SlotExecutionVertexAssignment> allocateSlotsFor(
+			List<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+		List<ExecutionVertexID> executionVertexIds = executionVertexSchedulingRequirements
+			.stream()
+			.map(ExecutionVertexSchedulingRequirements::getExecutionVertexId)
+			.collect(Collectors.toList());
+
+		SharedSlotProfileRetriever sharedSlotProfileRetriever = sharedSlotProfileRetrieverFactory
+			.createFromBulk(new HashSet<>(executionVertexIds));
+		Map<ExecutionVertexID, SlotExecutionVertexAssignment> assignments = executionVertexIds
+			.stream()
+			.collect(Collectors.groupingBy(slotSharingStrategy::getExecutionSlotSharingGroup))
+			.entrySet()
+			.stream()
+			.flatMap(entry -> allocateLogicalSlotsFromSharedSlot(sharedSlotProfileRetriever, entry.getKey(), entry.getValue()))
+			.collect(Collectors.toMap(SlotExecutionVertexAssignment::getExecutionVertexId, a -> a));
+
+		return executionVertexIds.stream().map(assignments::get).collect(Collectors.toList());
+	}
+
+	@Override
+	public void cancel(ExecutionVertexID executionVertexId) {
+		ExecutionSlotSharingGroup executionSlotSharingGroup =
+			slotSharingStrategy.getExecutionSlotSharingGroup(executionVertexId);
+		Preconditions.checkNotNull(
+			executionSlotSharingGroup,
+			"There is no ExecutionSlotSharingGroup for ExecutionVertexID " + executionVertexId);
+		SharedSlot slot = sharedSlots.get(executionSlotSharingGroup);
+		if (slot != null) {
+			slot.cancelLogicalSlotRequest(executionVertexId);
+		} else {
+			LOG.debug("There is no slot for ExecutionSlotSharingGroup of ExecutionVertexID {}", executionVertexId);
+		}
+	}
+
+	private Stream<SlotExecutionVertexAssignment> allocateLogicalSlotsFromSharedSlot(
+			SharedSlotProfileRetriever sharedSlotProfileRetriever,
+			ExecutionSlotSharingGroup executionSlotSharingGroup,
+			Collection<ExecutionVertexID> executions) {
+		SharedSlot sharedSlot = getOrAllocateSharedSlot(executionSlotSharingGroup, sharedSlotProfileRetriever);
+		return executions
+			.stream()
+			.map(execution -> new SlotExecutionVertexAssignment(execution, sharedSlot.allocateLogicalSlot(execution)));
+	}
+
+	private SharedSlot getOrAllocateSharedSlot(
+			ExecutionSlotSharingGroup executionSlotSharingGroup,
+			SharedSlotProfileRetriever sharedSlotProfileRetriever) {
+		return sharedSlots
+			.computeIfAbsent(executionSlotSharingGroup, group -> {
+				SlotRequestId physicalSlotRequestId = new SlotRequestId();
+				CompletableFuture<PhysicalSlot> physicalSlotFuture = sharedSlotProfileRetriever
+					.getSlotProfileFuture(group)
+					.thenCompose(slotProfile -> slotProvider.allocatePhysicalSlot(
+						new PhysicalSlotRequest(physicalSlotRequestId, slotProfile, slotWillBeOccupiedIndefinitely)))
+					.thenApply(PhysicalSlotRequest.Result::getPhysicalSlot);
+				return new SharedSlot(physicalSlotRequestId, group, physicalSlotFuture);
+			});
+	}
+
+	private class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
+		private final SlotRequestId physicalSlotRequestId;
+
+		private final ExecutionSlotSharingGroup executionSlotSharingGroup;
+
+		private final CompletableFuture<PhysicalSlot> slotContextFuture;
+
+		private final DualKeyLinkedMap<ExecutionVertexID, SlotRequestId, CompletableFuture<SingleLogicalSlot>> requestedLogicalSlots;
+
+		private SharedSlot(
+				SlotRequestId physicalSlotRequestId,
+				ExecutionSlotSharingGroup executionSlotSharingGroup,
+				CompletableFuture<PhysicalSlot> slotContextFuture) {
+			this.physicalSlotRequestId = physicalSlotRequestId;
+			this.executionSlotSharingGroup = executionSlotSharingGroup;
+			this.slotContextFuture = slotContextFuture.thenApply(physicalSlot -> {
+				Preconditions.checkState(
+					physicalSlot.tryAssignPayload(this),
+					"Unexpected physical slot payload assignment failure!");
+				return physicalSlot;
+			});
+			this.requestedLogicalSlots = new DualKeyLinkedMap<>(executionSlotSharingGroup.getExecutionVertexIds().size());
+		}
+
+		private CompletableFuture<LogicalSlot> allocateLogicalSlot(ExecutionVertexID executionVertexId) {
+			Preconditions.checkArgument(executionSlotSharingGroup.getExecutionVertexIds().contains(executionVertexId));
+			CompletableFuture<SingleLogicalSlot> logicalSlotFuture = requestedLogicalSlots.getValueByKeyA(executionVertexId);
+			if (logicalSlotFuture != null) {
+				LOG.debug("Request for {} already exists", getLogicalSlotString(executionVertexId));
+			} else {
+				logicalSlotFuture = allocateNonExistentLogicalSlot(executionVertexId);
+			}
+			return logicalSlotFuture.thenApply(Function.identity());
+		}
+
+		private CompletableFuture<SingleLogicalSlot> allocateNonExistentLogicalSlot(ExecutionVertexID executionVertexId) {
+			CompletableFuture<SingleLogicalSlot> logicalSlotFuture;
+			SlotRequestId logicalSlotRequestId = new SlotRequestId();
+			String logMessageBase = getLogicalSlotString(logicalSlotRequestId, executionVertexId);
+			LOG.debug("Request a {}", logMessageBase);
+
+			logicalSlotFuture = slotContextFuture
+				.thenApply(physicalSlot -> {
+					LOG.debug("Allocated {}", logMessageBase);
+					return createLogicalSlot(physicalSlot, logicalSlotRequestId);
+				});
+			requestedLogicalSlots.put(executionVertexId, logicalSlotRequestId, logicalSlotFuture);
+
+			// If the physical slot request fails (slotContextFuture), it will also fail the logicalSlotFuture.
+			// Therefore, the next `exceptionally` callback will cancelLogicalSlotRequest and do the cleanup
+			// in requestedLogicalSlots and eventually in sharedSlots
+			logicalSlotFuture.exceptionally(cause -> {
+				LOG.debug("Failed {}", logMessageBase);
+				cancelLogicalSlotRequest(logicalSlotRequestId);
+				return null;
+			});
+			return logicalSlotFuture;
+		}
+
+		private SingleLogicalSlot createLogicalSlot(PhysicalSlot physicalSlot, SlotRequestId logicalSlotRequestId) {
+			return new SingleLogicalSlot(
+				logicalSlotRequestId,
+				physicalSlot,
+				null,
+				Locality.UNKNOWN,
+				this,
+				slotWillBeOccupiedIndefinitely);
+		}
+
+		void cancelLogicalSlotRequest(ExecutionVertexID executionVertexID) {
+			cancelLogicalSlotRequest(requestedLogicalSlots.getKeyBByKeyA(executionVertexID));
+		}
+
+		void cancelLogicalSlotRequest(SlotRequestId logicalSlotRequestId) {
+			CompletableFuture<SingleLogicalSlot> logicalSlotFuture = requestedLogicalSlots.getValueByKeyB(logicalSlotRequestId);
+			if (logicalSlotFuture != null) {
+				LOG.debug("Cancel {}", getLogicalSlotString(logicalSlotRequestId));
+				logicalSlotFuture.cancel(false);
+				requestedLogicalSlots.removeKeyB(logicalSlotRequestId);
+			} else {
+				LOG.debug("No SlotExecutionVertexAssignment for logical {} from physical %s", logicalSlotRequestId);
+			}
+			removeSharedSlotIfAllLogicalDone();
+		}
+
+		private void removeSharedSlotIfAllLogicalDone() {
+			if (requestedLogicalSlots.values().isEmpty()) {
+				sharedSlots.remove(executionSlotSharingGroup);
+				slotProvider.cancelSlotRequest(
+					physicalSlotRequestId,
+					new FlinkException("Slot is being returned from SlotSharingExecutionSlotAllocator."));
+			}
+		}
+
+		@Override
+		public void returnLogicalSlot(LogicalSlot logicalSlot) {
+			cancelLogicalSlotRequest(logicalSlot.getSlotRequestId());
+		}
+
+		@Override
+		public void release(Throwable cause) {
+			Preconditions.checkState(
+				slotContextFuture.isDone(),
+				"Releasing of the shared slot is expected only from its successfully allocated physical slot ({})",
+				physicalSlotRequestId);
+			for (ExecutionVertexID executionVertexId : requestedLogicalSlots.keySetA()) {
+				LOG.debug("Release {}", getLogicalSlotString(executionVertexId));
+				CompletableFuture<SingleLogicalSlot> logicalSlotFuture =
+					requestedLogicalSlots.getValueByKeyA(executionVertexId);
+				Preconditions.checkNotNull(logicalSlotFuture);
+				Preconditions.checkState(
+					logicalSlotFuture.isDone(),
+					"Logical slot future must already done when release call comes from the successfully allocated physical slot ({})",
+					physicalSlotRequestId);
+				logicalSlotFuture.thenAccept(logicalSlot -> logicalSlot.release(cause));
+			}
+		}
+
+		@Override
+		public boolean willOccupySlotIndefinitely() {
+			return slotWillBeOccupiedIndefinitely;
+		}
+
+		private String getLogicalSlotString(SlotRequestId logicalSlotRequestId) {
+			return getLogicalSlotString(logicalSlotRequestId, requestedLogicalSlots.getKeyAByKeyB(logicalSlotRequestId));
+		}
+
+		private String getLogicalSlotString(ExecutionVertexID executionVertexId) {
+			return getLogicalSlotString(requestedLogicalSlots.getKeyBByKeyA(executionVertexId), executionVertexId);
+		}
+
+		private String getLogicalSlotString(SlotRequestId logicalSlotRequestId, ExecutionVertexID executionVertexId) {
+			return String.format(
+				"logical slot (%s) for execution vertex (id %s) from the physical slot (%s)",
+				logicalSlotRequestId,
+				executionVertexId,
+				physicalSlotRequestId);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.function.Function;
+
+/**
+ * Factory for {@link SlotSharingExecutionSlotAllocator}.
+ */
+class SlotSharingExecutionSlotAllocatorFactory implements ExecutionSlotAllocatorFactory {
+	private final PhysicalSlotProvider slotProvider;
+
+	private final boolean slotWillBeOccupiedIndefinitely;
+
+	private final SlotSharingStrategy slotSharingStrategy;
+
+	private final Function<ExecutionVertexID, ResourceProfile> resourceProfileRetriever;
+
+	private final Function<ExecutionVertexID, AllocationID> priorAllocationIdRetriever;
+
+	SlotSharingExecutionSlotAllocatorFactory(
+			PhysicalSlotProvider slotProvider,
+			boolean slotWillBeOccupiedIndefinitely,
+			SlotSharingStrategy slotSharingStrategy,
+			Function<ExecutionVertexID, ResourceProfile> resourceProfileRetriever,
+			Function<ExecutionVertexID, AllocationID> priorAllocationIdRetriever) {
+		this.slotProvider = slotProvider;
+		this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+		this.slotSharingStrategy = slotSharingStrategy;
+		this.resourceProfileRetriever = resourceProfileRetriever;
+		this.priorAllocationIdRetriever = priorAllocationIdRetriever;
+	}
+
+	@Override
+	public ExecutionSlotAllocator createInstance(PreferredLocationsRetriever preferredLocationsRetriever) {
+		return new SlotSharingExecutionSlotAllocator(
+			slotProvider,
+			slotWillBeOccupiedIndefinitely,
+			slotSharingStrategy,
+			new MergingSharedSlotProfileRetrieverFactory(
+				preferredLocationsRetriever,
+				resourceProfileRetriever,
+				priorAllocationIdRetriever));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/DualKeyLinkedMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/DualKeyLinkedMap.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobmaster.slotpool;
+package org.apache.flink.runtime.util;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 
@@ -43,63 +43,48 @@ import java.util.Set;
  * @param <B> Type of key B. Key B is the secondary key.
  * @param <V> Type of the value
  */
-class DualKeyLinkedMap<A, B, V> {
+public class DualKeyLinkedMap<A, B, V> {
 
 	private final LinkedHashMap<A, Tuple2<B, V>> aMap;
 
 	private final Map<B, A> bMap;
 
-	private transient Collection<V> values;
+	private Collection<V> values;
 
-	DualKeyLinkedMap(int initialCapacity) {
+	public DualKeyLinkedMap(int initialCapacity) {
 		this.aMap = new LinkedHashMap<>(initialCapacity);
 		this.bMap = new HashMap<>(initialCapacity);
 	}
 
-	int size() {
+	public int size() {
 		return aMap.size();
 	}
 
 	@Nullable
-	V getValueByKeyA(A aKey) {
+	public V getValueByKeyA(A aKey) {
 		final Tuple2<B, V> value = aMap.get(aKey);
-
-		if (value != null) {
-			return value.f1;
-		} else {
-			return null;
-		}
+		return value != null ? value.f1 : null;
 	}
 
 	@Nullable
-	V getValueByKeyB(B bKey) {
+	public V getValueByKeyB(B bKey) {
 		final A aKey = bMap.get(bKey);
-
-		if (aKey != null) {
-			return aMap.get(aKey).f1;
-		} else {
-			return null;
-		}
+		return aKey != null ? aMap.get(aKey).f1 : null;
 	}
 
 	@Nullable
-	A getKeyAByKeyB(B bKey) {
+	public A getKeyAByKeyB(B bKey) {
 		return bMap.get(bKey);
 	}
 
 	@Nullable
-	B getKeyBByKeyA(A aKey) {
+	public B getKeyBByKeyA(A aKey) {
 		final Tuple2<B, V> value = aMap.get(aKey);
-
-		if (value != null) {
-			return value.f0;
-		} else {
-			return null;
-		}
+		return value != null ? value.f0 : null;
 	}
 
 	@Nullable
-	V put(A aKey, B bKey, V value) {
+	public V put(A aKey, B bKey, V value) {
 		final V oldValue = getValueByKeyA(aKey);
 
 		// cleanup orphaned keys if the given primary key and secondary key were not matched previously
@@ -117,23 +102,19 @@ class DualKeyLinkedMap<A, B, V> {
 		aMap.put(aKey, Tuple2.of(bKey, value));
 		bMap.put(bKey, aKey);
 
-		if (oldValue != null) {
-			return oldValue;
-		} else {
-			return null;
-		}
+		return oldValue;
 	}
 
-	boolean containsKeyA(A aKey) {
+	public boolean containsKeyA(A aKey) {
 		return aMap.containsKey(aKey);
 	}
 
-	boolean containsKeyB(B bKey) {
+	public boolean containsKeyB(B bKey) {
 		return bMap.containsKey(bKey);
 	}
 
 	@Nullable
-	V removeKeyA(A aKey) {
+	public V removeKeyA(A aKey) {
 		Tuple2<B, V> aValue = aMap.remove(aKey);
 
 		if (aValue != null) {
@@ -145,22 +126,18 @@ class DualKeyLinkedMap<A, B, V> {
 	}
 
 	@Nullable
-	V removeKeyB(B bKey) {
+	public V removeKeyB(B bKey) {
 		A aKey = bMap.remove(bKey);
 
 		if (aKey != null) {
 			Tuple2<B, V> aValue = aMap.remove(aKey);
-			if (aValue != null) {
-				return aValue.f1;
-			} else {
-				return null;
-			}
+			return aValue != null ? aValue.f1 : null;
 		} else {
 			return null;
 		}
 	}
 
-	Collection<V> values() {
+	public Collection<V> values() {
 		Collection<V> vs = values;
 
 		if (vs == null) {
@@ -171,15 +148,15 @@ class DualKeyLinkedMap<A, B, V> {
 		return vs;
 	}
 
-	Set<A> keySetA() {
+	public Set<A> keySetA() {
 		return aMap.keySet();
 	}
 
-	Set<B> keySetB() {
+	public Set<B> keySetB() {
 		return bMap.keySet();
 	}
 
-	void clear() {
+	public void clear() {
 		aMap.clear();
 		bMap.clear();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotTestUtils.java
@@ -33,11 +33,15 @@ import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 public class PhysicalSlotTestUtils {
 
 	public static PhysicalSlot createPhysicalSlot() {
+		return createPhysicalSlot(ResourceProfile.ANY);
+	}
+
+	public static PhysicalSlot createPhysicalSlot(ResourceProfile resourceProfile) {
 		return new AllocatedSlot(
 			new AllocationID(),
 			new LocalTaskManagerLocation(),
 			0,
-			ResourceProfile.ANY,
+			resourceProfile,
 			new SimpleAckingTaskManagerGateway());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
@@ -37,7 +37,6 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.Test;
-import org.powermock.core.IdentityHashSet;
 
 import javax.annotation.Nullable;
 
@@ -56,7 +55,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -70,26 +69,32 @@ import static org.junit.Assert.fail;
  * Test suite for {@link SlotSharingExecutionSlotAllocator}.
  */
 public class SlotSharingExecutionSlotAllocatorTest {
+	private static final ExecutionVertexID EV1 = createRandomExecutionVertexId();
+	private static final ExecutionVertexID EV2 = createRandomExecutionVertexId();
+	private static final ExecutionVertexID EV3 = createRandomExecutionVertexId();
+	private static final ExecutionVertexID EV4 = createRandomExecutionVertexId();
+
 	@Test
 	public void testSlotProfileRequestAskedBulkAndGroup() {
-		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
+		AllocationContext context = AllocationContext.newBuilder().addGroup(EV1, EV2).build();
 		ExecutionSlotSharingGroup executionSlotSharingGroup =
-			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(context.getReqIds(0, 1).get(0));
+			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(EV1);
 
-		context.allocateSlotsFor(0, 2);
+		context.allocateSlotsFor(EV1, EV2);
 
-		Set<ExecutionVertexID> ids = new HashSet<>(context.getReqIds(0, 2));
-		assertThat(context.getSlotProfileRetrieverFactory().getAskedBulks(), containsInAnyOrder(ids));
+		List<Set<ExecutionVertexID>> askedBulks = context.getSlotProfileRetrieverFactory().getAskedBulks();
+		assertThat(askedBulks, hasSize(1));
+		assertThat(askedBulks.get(0), containsInAnyOrder(EV1, EV2));
 		assertThat(context.getSlotProfileRetrieverFactory().getAskedGroups(), containsInAnyOrder(executionSlotSharingGroup));
 	}
 
 	@Test
 	public void testSlotRequestCompletionAfterProfileCompletion() {
-		AllocationContext context = AllocationContext.newBuilder().setGroups(2).completeSlotProfileFutureManually().build();
+		AllocationContext context = AllocationContext.newBuilder().addGroup(EV1, EV2).completeSlotProfileFutureManually().build();
 		ExecutionSlotSharingGroup executionSlotSharingGroup =
-			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(context.getReqIds(0, 1).get(0));
+			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(EV1);
 
-		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(0, 2);
+		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(EV1, EV2);
 
 		executionVertexAssignments.forEach(assignment -> assertThat(assignment.getLogicalSlotFuture().isDone(), is(false)));
 		context.getSlotProfileRetrieverFactory().completeSlotProfileFutureFor(executionSlotSharingGroup);
@@ -99,12 +104,12 @@ public class SlotSharingExecutionSlotAllocatorTest {
 	@Test
 	public void testSlotRequestProfile() {
 		ResourceProfile physicalsSlotResourceProfile = ResourceProfile.fromResources(3, 5);
-		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
+		AllocationContext context = AllocationContext.newBuilder().addGroup(EV1, EV2).build();
 		ExecutionSlotSharingGroup executionSlotSharingGroup =
-			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(context.getReqIds(0, 1).get(0));
+			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(EV1);
 		context.getSlotProfileRetrieverFactory().addGroupResourceProfile(executionSlotSharingGroup, physicalsSlotResourceProfile);
 
-		context.allocateSlotsFor(0, 2);
+		context.allocateSlotsFor(EV1, EV2);
 
 		Optional<PhysicalSlotRequest> slotRequest = context.getSlotProvider().getRequests().values().stream().findFirst();
 		assertThat(slotRequest.isPresent(), is(true));
@@ -112,36 +117,36 @@ public class SlotSharingExecutionSlotAllocatorTest {
 	}
 
 	@Test
-	public void testNewAllocatePhysicalSlotForSharedSlot() {
-		AllocationContext context = AllocationContext.newBuilder().setGroups(2, 2).build();
+	public void testAllocatePhysicalSlotForNewSharedSlot() {
+		AllocationContext context = AllocationContext.newBuilder().addGroup(EV1, EV2).addGroup(EV3, EV4).build();
 
-		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(0, 4);
+		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(EV1, EV2, EV3, EV4);
 		Collection<ExecutionVertexID> assignIds = getAssignIds(executionVertexAssignments);
 
-		assertThat(assignIds, containsInAnyOrder(context.getReqIds(0, 4).toArray()));
+		assertThat(assignIds, containsInAnyOrder(EV1, EV2, EV3, EV4));
 		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(2));
 	}
 
 	@Test
 	public void testAllocateLogicalSlotFromAvailableSharedSlot() {
-		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
+		AllocationContext context = AllocationContext.newBuilder().addGroup(EV1, EV2).build();
 
-		context.allocateSlotsFor(0, 1);
-		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(1, 2);
+		context.allocateSlotsFor(EV1);
+		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(EV2);
 		Collection<ExecutionVertexID> assignIds = getAssignIds(executionVertexAssignments);
 
 		// execution 0 from the first allocateSlotsFor call and execution 1 from the second allocateSlotsFor call
 		// share a slot, therefore only one physical slot allocation should happen
-		assertThat(assignIds, containsInAnyOrder(context.getReqIds(1, 2).toArray()));
+		assertThat(assignIds, containsInAnyOrder(EV2));
 		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(1));
 	}
 
 	@Test
 	public void testDuplicateAllocationDoesNotRecreateLogicalSlotFuture() throws ExecutionException, InterruptedException {
-		AllocationContext context = AllocationContext.newBuilder().setGroups(1).build();
+		AllocationContext context = AllocationContext.newBuilder().addGroup(EV1).build();
 
-		SlotExecutionVertexAssignment assignment1 = context.allocateSlotsFor(0, 1).get(0);
-		SlotExecutionVertexAssignment assignment2 = context.allocateSlotsFor(0, 1).get(0);
+		SlotExecutionVertexAssignment assignment1 = context.allocateSlotsFor(EV1).get(0);
+		SlotExecutionVertexAssignment assignment2 = context.allocateSlotsFor(EV1).get(0);
 
 		assertThat(assignment1.getLogicalSlotFuture().get() == assignment2.getLogicalSlotFuture().get(), is(true));
 	}
@@ -150,18 +155,18 @@ public class SlotSharingExecutionSlotAllocatorTest {
 	public void testFailedPhysicalSlotRequestFailsLogicalSlotFuturesAndRemovesSharedSlot() {
 		AllocationContext context = AllocationContext
 			.newBuilder()
-			.setGroups(1)
+			.addGroup(EV1)
 			.completePhysicalSlotFutureManually()
 			.build();
-		CompletableFuture<LogicalSlot> logicalSlotFuture = context.allocateSlotsFor(0, 1).get(0).getLogicalSlotFuture();
-		SlotRequestId slotRequestId = context.getSlotProvider().getRequests().values().stream().findFirst().get().getSlotRequestId();
+		CompletableFuture<LogicalSlot> logicalSlotFuture = context.allocateSlotsFor(EV1).get(0).getLogicalSlotFuture();
+		SlotRequestId slotRequestId = context.getSlotProvider().getFirstRequestOrFail().getSlotRequestId();
 
 		assertThat(logicalSlotFuture.isDone(), is(false));
 		context.getSlotProvider().failPhysicalSlotFutureFor(slotRequestId, new Throwable());
 		assertThat(logicalSlotFuture.isCompletedExceptionally(), is(true));
 
 		// next allocation allocates new shared slot
-		context.allocateSlotsFor(0, 1);
+		context.allocateSlotsFor(EV1);
 		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(2));
 	}
 
@@ -178,12 +183,12 @@ public class SlotSharingExecutionSlotAllocatorTest {
 	private static void testSlotWillBeOccupiedIndefinitely(boolean slotWillBeOccupiedIndefinitely) throws ExecutionException, InterruptedException {
 		AllocationContext context = AllocationContext
 			.newBuilder()
-			.setGroups(1)
+			.addGroup(EV1)
 			.setSlotWillBeOccupiedIndefinitely(slotWillBeOccupiedIndefinitely)
 			.build();
-		context.allocateSlotsFor(0, 1);
+		context.allocateSlotsFor(EV1);
 
-		PhysicalSlotRequest slotRequest = context.getSlotProvider().getRequests().values().stream().findFirst().get();
+		PhysicalSlotRequest slotRequest = context.getSlotProvider().getFirstRequestOrFail();
 		assertThat(slotRequest.willSlotBeOccupiedIndefinitely(), is(slotWillBeOccupiedIndefinitely));
 
 		TestingPhysicalSlot physicalSlot = context.getSlotProvider().getResponses().get(slotRequest.getSlotRequestId()).get();
@@ -212,7 +217,7 @@ public class SlotSharingExecutionSlotAllocatorTest {
 				context.getAllocator().cancel(assignment.getExecutionVertexId());
 				try {
 					assignment.getLogicalSlotFuture().get();
-					fail("THe logical future must finish with the cancellation exception");
+					fail("The logical future must finish with the cancellation exception");
 				} catch (InterruptedException | ExecutionException e) {
 					assertThat(e.getCause(), instanceOf(CancellationException.class));
 				}
@@ -222,38 +227,37 @@ public class SlotSharingExecutionSlotAllocatorTest {
 	private static void testLogicalSlotRequestCancellation(
 			boolean completePhysicalSlotFutureManually,
 			BiConsumer<AllocationContext, SlotExecutionVertexAssignment> cancelAction) {
-		//if (completePhysicalSlotRequest) {
 		AllocationContext context = AllocationContext
 			.newBuilder()
-			.setGroups(2)
+			.addGroup(EV1, EV2)
 			.completePhysicalSlotFutureManually(completePhysicalSlotFutureManually)
 			.build();
 
-		List<SlotExecutionVertexAssignment> assignments = context.allocateSlotsFor(0, 2);
+		List<SlotExecutionVertexAssignment> assignments = context.allocateSlotsFor(EV1, EV2);
 		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(1));
 
 		// cancel only one sharing logical slots
 		cancelAction.accept(context, assignments.get(0));
-		assignments = context.allocateSlotsFor(0, 2);
+		List<SlotExecutionVertexAssignment> assignmentsAfterOneCancellation = context.allocateSlotsFor(EV1, EV2);
 		// there should be no more physical slot allocations, as the first logical slot reuses the previous shared slot
 		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(1));
 
 		// cancel all sharing logical slots
-		for (SlotExecutionVertexAssignment assignment : assignments) {
+		for (SlotExecutionVertexAssignment assignment : assignmentsAfterOneCancellation) {
 			cancelAction.accept(context, assignment);
 		}
-		SlotRequestId slotRequestId = context.getSlotProvider().getRequests().keySet().stream().findFirst().get();
-		assertThat(context.getSlotProvider().getCancelations().containsKey(slotRequestId), is(true));
+		SlotRequestId slotRequestId = context.getSlotProvider().getFirstRequestOrFail().getSlotRequestId();
+		assertThat(context.getSlotProvider().getCancellations().containsKey(slotRequestId), is(true));
 
-		context.allocateSlotsFor(0, 2);
+		context.allocateSlotsFor(EV1, EV2);
 		// there should be one more physical slot allocation, as the first allocation should be removed after releasing all logical slots
 		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(2));
 	}
 
 	@Test
 	public void testPhysicalSlotReleaseLogicalSlots() throws ExecutionException, InterruptedException {
-		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
-		List<SlotExecutionVertexAssignment> assignments = context.allocateSlotsFor(0, 2);
+		AllocationContext context = AllocationContext.newBuilder().addGroup(EV1, EV2).build();
+		List<SlotExecutionVertexAssignment> assignments = context.allocateSlotsFor(EV1, EV2);
 		List<TestingPayload> payloads = assignments
 			.stream()
 			.map(assignment -> {
@@ -262,7 +266,7 @@ public class SlotSharingExecutionSlotAllocatorTest {
 				return payload;
 			})
 			.collect(Collectors.toList());
-		TestingPhysicalSlot physicalSlot = context.getSlotProvider().getResponses().values().stream().findFirst().get().get();
+		TestingPhysicalSlot physicalSlot = context.getSlotProvider().getFirstResponseOrFail().get();
 
 		assertThat(payloads.stream().allMatch(payload -> payload.getTerminalStateFuture().isDone()), is(false));
 		assertThat(physicalSlot.getPayload(), notNullValue());
@@ -270,44 +274,48 @@ public class SlotSharingExecutionSlotAllocatorTest {
 		assertThat(payloads.stream().allMatch(payload -> payload.getTerminalStateFuture().isDone()), is(true));
 	}
 
+	private static ExecutionVertexID createRandomExecutionVertexId() {
+		return new ExecutionVertexID(new JobVertexID(), 0);
+	}
+
 	private static List<ExecutionVertexID> getAssignIds(Collection<SlotExecutionVertexAssignment> assignments) {
 		return assignments.stream().map(SlotExecutionVertexAssignment::getExecutionVertexId).collect(Collectors.toList());
 	}
 
 	private static class AllocationContext {
-		private final List<ExecutionVertexSchedulingRequirements> requirements;
 		private final TestingPhysicalSlotProvider slotProvider;
 		private final TestingSlotSharingStrategy slotSharingStrategy;
 		private final SlotSharingExecutionSlotAllocator allocator;
 		private final TestingSharedSlotProfileRetrieverFactory slotProfileRetrieverFactory;
 
-		AllocationContext(
-				List<ExecutionVertexSchedulingRequirements> requirements,
+		private AllocationContext(
 				TestingPhysicalSlotProvider slotProvider,
 				TestingSlotSharingStrategy slotSharingStrategy,
 				SlotSharingExecutionSlotAllocator allocator,
 				TestingSharedSlotProfileRetrieverFactory slotProfileRetrieverFactory) {
-			this.requirements = requirements;
 			this.slotProvider = slotProvider;
 			this.slotSharingStrategy = slotSharingStrategy;
 			this.allocator = allocator;
 			this.slotProfileRetrieverFactory = slotProfileRetrieverFactory;
 		}
 
-		public SlotSharingExecutionSlotAllocator getAllocator() {
+		private SlotSharingExecutionSlotAllocator getAllocator() {
 			return allocator;
 		}
 
-		private List<SlotExecutionVertexAssignment> allocateSlotsFor(int start, int end) {
-			return allocator.allocateSlotsFor(requirements.subList(start, end));
+		private List<SlotExecutionVertexAssignment> allocateSlotsFor(ExecutionVertexID... ids) {
+			List<ExecutionVertexSchedulingRequirements> requirements = Stream
+				.of(ids)
+				.map(id -> new ExecutionVertexSchedulingRequirements
+					.Builder()
+					.withExecutionVertexId(id)
+					.build())
+				.collect(Collectors.toList());
+			return allocator.allocateSlotsFor(requirements);
 		}
 
 		private TestingSlotSharingStrategy getSlotSharingStrategy() {
 			return slotSharingStrategy;
-		}
-
-		private List<ExecutionVertexID> getReqIds(int start, int end) {
-			return getReqIds(requirements.subList(start, end));
 		}
 
 		private TestingPhysicalSlotProvider getSlotProvider() {
@@ -318,31 +326,18 @@ public class SlotSharingExecutionSlotAllocatorTest {
 			return slotProfileRetrieverFactory;
 		}
 
-		private static List<ExecutionVertexID> getReqIds(Collection<ExecutionVertexSchedulingRequirements> requirements) {
-			return requirements.stream().map(ExecutionVertexSchedulingRequirements::getExecutionVertexId).collect(Collectors.toList());
-		}
-
-		static Builder newBuilder() {
+		private static Builder newBuilder() {
 			return new Builder();
 		}
 
 		private static class Builder {
-			private int[] groups = { 2, 1 }; // 2 executions in the first group, 1 in the second etc
-			private List<ResourceProfile> resourceProfiles;
-			private boolean completePhysicalSlotFutureManually;
-			private boolean completeSlotProfileFutureManually;
-			private boolean slotWillBeOccupiedIndefinitely;
+			private final Collection<ExecutionVertexID[]> groups = new ArrayList<>();
+			private boolean completePhysicalSlotFutureManually = false;
+			private boolean completeSlotProfileFutureManually = false;
+			private boolean slotWillBeOccupiedIndefinitely = false;
 
-			private Builder setGroups(int... groups) {
-				int reqNumber = IntStream.of(groups).sum();
-				List<ResourceProfile> resourceProfiles = Collections.nCopies(reqNumber, ResourceProfile.UNKNOWN);
-				return setGroupsWithResourceProfiles(resourceProfiles, groups);
-			}
-
-			private Builder setGroupsWithResourceProfiles(List<ResourceProfile> resourceProfiles, int... groups) {
-				Preconditions.checkArgument(resourceProfiles.size() == IntStream.of(groups).sum());
-				this.resourceProfiles = resourceProfiles;
-				this.groups = groups;
+			private Builder addGroup(ExecutionVertexID... group) {
+				groups.add(group);
 				return this;
 			}
 
@@ -367,35 +362,20 @@ public class SlotSharingExecutionSlotAllocatorTest {
 			}
 
 			private AllocationContext build() {
-				List<ExecutionVertexSchedulingRequirements> requirements = createSchedulingRequirements();
 				TestingPhysicalSlotProvider slotProvider = new TestingPhysicalSlotProvider(completePhysicalSlotFutureManually);
 				TestingSharedSlotProfileRetrieverFactory sharedSlotProfileRetrieverFactory =
 					new TestingSharedSlotProfileRetrieverFactory(completeSlotProfileFutureManually);
-				TestingSlotSharingStrategy slotSharingStrategy = TestingSlotSharingStrategy.createWithGroups(getReqIds(requirements), groups);
+				TestingSlotSharingStrategy slotSharingStrategy = TestingSlotSharingStrategy.createWithGroups(groups);
 				SlotSharingExecutionSlotAllocator allocator = new SlotSharingExecutionSlotAllocator(
 					slotProvider,
 					slotWillBeOccupiedIndefinitely,
 					slotSharingStrategy,
 					sharedSlotProfileRetrieverFactory);
 				return new AllocationContext(
-					requirements,
 					slotProvider,
 					slotSharingStrategy,
 					allocator,
 					sharedSlotProfileRetrieverFactory);
-			}
-
-			private List<ExecutionVertexSchedulingRequirements> createSchedulingRequirements() {
-				return resourceProfiles
-					.stream()
-					.map(resourceProfile ->
-						new ExecutionVertexSchedulingRequirements
-							.Builder()
-							.withExecutionVertexId(new ExecutionVertexID(new JobVertexID(), 0))
-							.withTaskResourceProfile(resourceProfile)
-							.withPhysicalSlotResourceProfile(resourceProfile) // not used
-							.build())
-					.collect(Collectors.toList());
 			}
 		}
 	}
@@ -403,14 +383,14 @@ public class SlotSharingExecutionSlotAllocatorTest {
 	private static class TestingPhysicalSlotProvider implements PhysicalSlotProvider {
 		private final Map<SlotRequestId, PhysicalSlotRequest> requests;
 		private final Map<SlotRequestId, CompletableFuture<TestingPhysicalSlot>> responses;
-		private final Map<SlotRequestId, Throwable> cancelations;
+		private final Map<SlotRequestId, Throwable> cancellations;
 		private final boolean completePhysicalSlotFutureManually;
 
 		private TestingPhysicalSlotProvider(boolean completePhysicalSlotFutureManually) {
 			this.completePhysicalSlotFutureManually = completePhysicalSlotFutureManually;
 			this.requests = new HashMap<>();
 			this.responses = new HashMap<>();
-			this.cancelations = new HashMap<>();
+			this.cancellations = new HashMap<>();
 		}
 
 		@Override
@@ -437,19 +417,33 @@ public class SlotSharingExecutionSlotAllocatorTest {
 
 		@Override
 		public void cancelSlotRequest(SlotRequestId slotRequestId, Throwable cause) {
-			cancelations.put(slotRequestId, cause);
+			cancellations.put(slotRequestId, cause);
+		}
+
+		private PhysicalSlotRequest getFirstRequestOrFail() {
+			return getFirstElementOrFail(requests.values());
 		}
 
 		private Map<SlotRequestId, PhysicalSlotRequest> getRequests() {
 			return Collections.unmodifiableMap(requests);
 		}
 
+		private CompletableFuture<TestingPhysicalSlot> getFirstResponseOrFail() {
+			return getFirstElementOrFail(responses.values());
+		}
+
 		private Map<SlotRequestId, CompletableFuture<TestingPhysicalSlot>> getResponses() {
 			return Collections.unmodifiableMap(responses);
 		}
 
-		private Map<SlotRequestId, Throwable> getCancelations() {
-			return Collections.unmodifiableMap(cancelations);
+		private Map<SlotRequestId, Throwable> getCancellations() {
+			return Collections.unmodifiableMap(cancellations);
+		}
+
+		private static <T> T getFirstElementOrFail(Collection<T> collection) {
+			Optional<T> element = collection.stream().findFirst();
+			Preconditions.checkState(element.isPresent());
+			return element.get();
 		}
 	}
 
@@ -467,39 +461,19 @@ public class SlotSharingExecutionSlotAllocatorTest {
 
 		@Override
 		public Set<ExecutionSlotSharingGroup> getExecutionSlotSharingGroups() {
-			Set<ExecutionSlotSharingGroup> groups = new IdentityHashSet<>();
-			groups.addAll(executionSlotSharingGroups.values());
-			return groups;
+			return new HashSet<>(executionSlotSharingGroups.values());
 		}
 
-		private static TestingSlotSharingStrategy createWithGroups(
-				List<ExecutionVertexID> executionVertexIds,
-				int... groupSizes) {
+		private static TestingSlotSharingStrategy createWithGroups(Iterable<ExecutionVertexID[]> groups) {
 			Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroups = new HashMap<>();
-			int startIndex = 0;
-			int nextIndex = 0;
-			for (int groupSize : groupSizes) {
-				nextIndex = startIndex + groupSize;
-				createGroup(executionSlotSharingGroups, executionVertexIds, startIndex, nextIndex);
-				startIndex = nextIndex;
-			}
-			if (nextIndex < executionVertexIds.size()) {
-				createGroup(executionSlotSharingGroups, executionVertexIds, nextIndex, executionVertexIds.size());
+			for (ExecutionVertexID[] group : groups) {
+				ExecutionSlotSharingGroup executionSlotSharingGroup = new ExecutionSlotSharingGroup();
+				for (ExecutionVertexID executionVertexId : group) {
+					executionSlotSharingGroup.addVertex(executionVertexId);
+					executionSlotSharingGroups.put(executionVertexId, executionSlotSharingGroup);
+				}
 			}
 			return new TestingSlotSharingStrategy(executionSlotSharingGroups);
-		}
-
-		private static void createGroup(
-				Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroups,
-				List<ExecutionVertexID> executionVertexIds,
-				int startIndex,
-				int nextIndex) {
-			ExecutionSlotSharingGroup executionSlotSharingGroup = new ExecutionSlotSharingGroup();
-			executionSlotSharingGroup.addVertex(new ExecutionVertexID(new JobVertexID(), 0));
-			executionVertexIds.subList(startIndex, nextIndex).forEach(executionVertexId -> {
-				executionSlotSharingGroup.addVertex(executionVertexId);
-				executionSlotSharingGroups.put(executionVertexId, executionSlotSharingGroup);
-			});
 		}
 	}
 
@@ -550,6 +524,7 @@ public class SlotSharingExecutionSlotAllocatorTest {
 	}
 
 	private static class TestingPhysicalSlot extends SimpleSlotContext implements PhysicalSlot {
+		@Nullable
 		private Payload payload;
 
 		private TestingPhysicalSlot(ResourceProfile resourceProfile) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
@@ -1,0 +1,575 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.TestingPayload;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequest;
+import org.apache.flink.runtime.scheduler.SharedSlotProfileRetriever.SharedSlotProfileRetrieverFactory;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Test;
+import org.powermock.core.IdentityHashSet;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Test suite for {@link SlotSharingExecutionSlotAllocator}.
+ */
+public class SlotSharingExecutionSlotAllocatorTest {
+	@Test
+	public void testSlotProfileRequestAskedBulkAndGroup() {
+		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
+		ExecutionSlotSharingGroup executionSlotSharingGroup =
+			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(context.getReqIds(0, 1).get(0));
+
+		context.allocateSlotsFor(0, 2);
+
+		Set<ExecutionVertexID> ids = new HashSet<>(context.getReqIds(0, 2));
+		assertThat(context.getSlotProfileRetrieverFactory().getAskedBulks(), containsInAnyOrder(ids));
+		assertThat(context.getSlotProfileRetrieverFactory().getAskedGroups(), containsInAnyOrder(executionSlotSharingGroup));
+	}
+
+	@Test
+	public void testSlotRequestCompletionAfterProfileCompletion() {
+		AllocationContext context = AllocationContext.newBuilder().setGroups(2).completeSlotProfileFutureManually().build();
+		ExecutionSlotSharingGroup executionSlotSharingGroup =
+			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(context.getReqIds(0, 1).get(0));
+
+		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(0, 2);
+
+		executionVertexAssignments.forEach(assignment -> assertThat(assignment.getLogicalSlotFuture().isDone(), is(false)));
+		context.getSlotProfileRetrieverFactory().completeSlotProfileFutureFor(executionSlotSharingGroup);
+		executionVertexAssignments.forEach(assignment -> assertThat(assignment.getLogicalSlotFuture().isDone(), is(true)));
+	}
+
+	@Test
+	public void testSlotRequestProfile() {
+		ResourceProfile physicalsSlotResourceProfile = ResourceProfile.fromResources(3, 5);
+		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
+		ExecutionSlotSharingGroup executionSlotSharingGroup =
+			context.getSlotSharingStrategy().getExecutionSlotSharingGroup(context.getReqIds(0, 1).get(0));
+		context.getSlotProfileRetrieverFactory().addGroupResourceProfile(executionSlotSharingGroup, physicalsSlotResourceProfile);
+
+		context.allocateSlotsFor(0, 2);
+
+		Optional<PhysicalSlotRequest> slotRequest = context.getSlotProvider().getRequests().values().stream().findFirst();
+		assertThat(slotRequest.isPresent(), is(true));
+		slotRequest.ifPresent(r -> assertThat(r.getSlotProfile().getPhysicalSlotResourceProfile(), is(physicalsSlotResourceProfile)));
+	}
+
+	@Test
+	public void testNewAllocatePhysicalSlotForSharedSlot() {
+		AllocationContext context = AllocationContext.newBuilder().setGroups(2, 2).build();
+
+		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(0, 4);
+		Collection<ExecutionVertexID> assignIds = getAssignIds(executionVertexAssignments);
+
+		assertThat(assignIds, containsInAnyOrder(context.getReqIds(0, 4).toArray()));
+		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(2));
+	}
+
+	@Test
+	public void testAllocateLogicalSlotFromAvailableSharedSlot() {
+		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
+
+		context.allocateSlotsFor(0, 1);
+		List<SlotExecutionVertexAssignment> executionVertexAssignments = context.allocateSlotsFor(1, 2);
+		Collection<ExecutionVertexID> assignIds = getAssignIds(executionVertexAssignments);
+
+		// execution 0 from the first allocateSlotsFor call and execution 1 from the second allocateSlotsFor call
+		// share a slot, therefore only one physical slot allocation should happen
+		assertThat(assignIds, containsInAnyOrder(context.getReqIds(1, 2).toArray()));
+		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(1));
+	}
+
+	@Test
+	public void testDuplicateAllocationDoesNotRecreateLogicalSlotFuture() throws ExecutionException, InterruptedException {
+		AllocationContext context = AllocationContext.newBuilder().setGroups(1).build();
+
+		SlotExecutionVertexAssignment assignment1 = context.allocateSlotsFor(0, 1).get(0);
+		SlotExecutionVertexAssignment assignment2 = context.allocateSlotsFor(0, 1).get(0);
+
+		assertThat(assignment1.getLogicalSlotFuture().get() == assignment2.getLogicalSlotFuture().get(), is(true));
+	}
+
+	@Test
+	public void testFailedPhysicalSlotRequestFailsLogicalSlotFuturesAndRemovesSharedSlot() {
+		AllocationContext context = AllocationContext
+			.newBuilder()
+			.setGroups(1)
+			.completePhysicalSlotFutureManually()
+			.build();
+		CompletableFuture<LogicalSlot> logicalSlotFuture = context.allocateSlotsFor(0, 1).get(0).getLogicalSlotFuture();
+		SlotRequestId slotRequestId = context.getSlotProvider().getRequests().values().stream().findFirst().get().getSlotRequestId();
+
+		assertThat(logicalSlotFuture.isDone(), is(false));
+		context.getSlotProvider().failPhysicalSlotFutureFor(slotRequestId, new Throwable());
+		assertThat(logicalSlotFuture.isCompletedExceptionally(), is(true));
+
+		// next allocation allocates new shared slot
+		context.allocateSlotsFor(0, 1);
+		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(2));
+	}
+
+	@Test
+	public void testSlotWillBeOccupiedIndefinitelyFalse() throws ExecutionException, InterruptedException {
+		testSlotWillBeOccupiedIndefinitely(false);
+	}
+
+	@Test
+	public void testSlotWillBeOccupiedIndefinitelyTrue() throws ExecutionException, InterruptedException {
+		testSlotWillBeOccupiedIndefinitely(true);
+	}
+
+	private static void testSlotWillBeOccupiedIndefinitely(boolean slotWillBeOccupiedIndefinitely) throws ExecutionException, InterruptedException {
+		AllocationContext context = AllocationContext
+			.newBuilder()
+			.setGroups(1)
+			.setSlotWillBeOccupiedIndefinitely(slotWillBeOccupiedIndefinitely)
+			.build();
+		context.allocateSlotsFor(0, 1);
+
+		PhysicalSlotRequest slotRequest = context.getSlotProvider().getRequests().values().stream().findFirst().get();
+		assertThat(slotRequest.willSlotBeOccupiedIndefinitely(), is(slotWillBeOccupiedIndefinitely));
+
+		TestingPhysicalSlot physicalSlot = context.getSlotProvider().getResponses().get(slotRequest.getSlotRequestId()).get();
+		assertThat(physicalSlot.getPayload(), notNullValue());
+		assertThat(physicalSlot.getPayload().willOccupySlotIndefinitely(), is(slotWillBeOccupiedIndefinitely));
+	}
+
+	@Test
+	public void testReturningLogicalSlotsRemovesSharedSlot() {
+		testLogicalSlotRequestCancellation(
+			false,
+			(context, assignment) -> {
+				try {
+					assignment.getLogicalSlotFuture().get().releaseSlot(null);
+				} catch (InterruptedException | ExecutionException e) {
+					throw new FlinkRuntimeException("Unexpected", e);
+				}
+			});
+	}
+
+	@Test
+	public void testLogicalSlotCancelsPhysicalSlotRequestAndRemovesSharedSlot() {
+		testLogicalSlotRequestCancellation(
+			true,
+			(context, assignment) -> {
+				context.getAllocator().cancel(assignment.getExecutionVertexId());
+				try {
+					assignment.getLogicalSlotFuture().get();
+					fail("THe logical future must finish with the cancellation exception");
+				} catch (InterruptedException | ExecutionException e) {
+					assertThat(e.getCause(), instanceOf(CancellationException.class));
+				}
+			});
+	}
+
+	private static void testLogicalSlotRequestCancellation(
+			boolean completePhysicalSlotFutureManually,
+			BiConsumer<AllocationContext, SlotExecutionVertexAssignment> cancelAction) {
+		//if (completePhysicalSlotRequest) {
+		AllocationContext context = AllocationContext
+			.newBuilder()
+			.setGroups(2)
+			.completePhysicalSlotFutureManually(completePhysicalSlotFutureManually)
+			.build();
+
+		List<SlotExecutionVertexAssignment> assignments = context.allocateSlotsFor(0, 2);
+		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(1));
+
+		// cancel only one sharing logical slots
+		cancelAction.accept(context, assignments.get(0));
+		assignments = context.allocateSlotsFor(0, 2);
+		// there should be no more physical slot allocations, as the first logical slot reuses the previous shared slot
+		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(1));
+
+		// cancel all sharing logical slots
+		for (SlotExecutionVertexAssignment assignment : assignments) {
+			cancelAction.accept(context, assignment);
+		}
+		SlotRequestId slotRequestId = context.getSlotProvider().getRequests().keySet().stream().findFirst().get();
+		assertThat(context.getSlotProvider().getCancelations().containsKey(slotRequestId), is(true));
+
+		context.allocateSlotsFor(0, 2);
+		// there should be one more physical slot allocation, as the first allocation should be removed after releasing all logical slots
+		assertThat(context.getSlotProvider().getRequests().keySet(), hasSize(2));
+	}
+
+	@Test
+	public void testPhysicalSlotReleaseLogicalSlots() throws ExecutionException, InterruptedException {
+		AllocationContext context = AllocationContext.newBuilder().setGroups(2).build();
+		List<SlotExecutionVertexAssignment> assignments = context.allocateSlotsFor(0, 2);
+		List<TestingPayload> payloads = assignments
+			.stream()
+			.map(assignment -> {
+				TestingPayload payload = new TestingPayload();
+				assignment.getLogicalSlotFuture().thenAccept(logicalSlot -> logicalSlot.tryAssignPayload(payload));
+				return payload;
+			})
+			.collect(Collectors.toList());
+		TestingPhysicalSlot physicalSlot = context.getSlotProvider().getResponses().values().stream().findFirst().get().get();
+
+		assertThat(payloads.stream().allMatch(payload -> payload.getTerminalStateFuture().isDone()), is(false));
+		assertThat(physicalSlot.getPayload(), notNullValue());
+		physicalSlot.getPayload().release(new Throwable());
+		assertThat(payloads.stream().allMatch(payload -> payload.getTerminalStateFuture().isDone()), is(true));
+	}
+
+	private static List<ExecutionVertexID> getAssignIds(Collection<SlotExecutionVertexAssignment> assignments) {
+		return assignments.stream().map(SlotExecutionVertexAssignment::getExecutionVertexId).collect(Collectors.toList());
+	}
+
+	private static class AllocationContext {
+		private final List<ExecutionVertexSchedulingRequirements> requirements;
+		private final TestingPhysicalSlotProvider slotProvider;
+		private final TestingSlotSharingStrategy slotSharingStrategy;
+		private final SlotSharingExecutionSlotAllocator allocator;
+		private final TestingSharedSlotProfileRetrieverFactory slotProfileRetrieverFactory;
+
+		AllocationContext(
+				List<ExecutionVertexSchedulingRequirements> requirements,
+				TestingPhysicalSlotProvider slotProvider,
+				TestingSlotSharingStrategy slotSharingStrategy,
+				SlotSharingExecutionSlotAllocator allocator,
+				TestingSharedSlotProfileRetrieverFactory slotProfileRetrieverFactory) {
+			this.requirements = requirements;
+			this.slotProvider = slotProvider;
+			this.slotSharingStrategy = slotSharingStrategy;
+			this.allocator = allocator;
+			this.slotProfileRetrieverFactory = slotProfileRetrieverFactory;
+		}
+
+		public SlotSharingExecutionSlotAllocator getAllocator() {
+			return allocator;
+		}
+
+		private List<SlotExecutionVertexAssignment> allocateSlotsFor(int start, int end) {
+			return allocator.allocateSlotsFor(requirements.subList(start, end));
+		}
+
+		private TestingSlotSharingStrategy getSlotSharingStrategy() {
+			return slotSharingStrategy;
+		}
+
+		private List<ExecutionVertexID> getReqIds(int start, int end) {
+			return getReqIds(requirements.subList(start, end));
+		}
+
+		private TestingPhysicalSlotProvider getSlotProvider() {
+			return slotProvider;
+		}
+
+		private TestingSharedSlotProfileRetrieverFactory getSlotProfileRetrieverFactory() {
+			return slotProfileRetrieverFactory;
+		}
+
+		private static List<ExecutionVertexID> getReqIds(Collection<ExecutionVertexSchedulingRequirements> requirements) {
+			return requirements.stream().map(ExecutionVertexSchedulingRequirements::getExecutionVertexId).collect(Collectors.toList());
+		}
+
+		static Builder newBuilder() {
+			return new Builder();
+		}
+
+		private static class Builder {
+			private int[] groups = { 2, 1 }; // 2 executions in the first group, 1 in the second etc
+			private List<ResourceProfile> resourceProfiles;
+			private boolean completePhysicalSlotFutureManually;
+			private boolean completeSlotProfileFutureManually;
+			private boolean slotWillBeOccupiedIndefinitely;
+
+			private Builder setGroups(int... groups) {
+				int reqNumber = IntStream.of(groups).sum();
+				List<ResourceProfile> resourceProfiles = Collections.nCopies(reqNumber, ResourceProfile.UNKNOWN);
+				return setGroupsWithResourceProfiles(resourceProfiles, groups);
+			}
+
+			private Builder setGroupsWithResourceProfiles(List<ResourceProfile> resourceProfiles, int... groups) {
+				Preconditions.checkArgument(resourceProfiles.size() == IntStream.of(groups).sum());
+				this.resourceProfiles = resourceProfiles;
+				this.groups = groups;
+				return this;
+			}
+
+			private Builder completePhysicalSlotFutureManually() {
+				completePhysicalSlotFutureManually(true);
+				return this;
+			}
+
+			private Builder completePhysicalSlotFutureManually(boolean value) {
+				this.completePhysicalSlotFutureManually = value;
+				return this;
+			}
+
+			private Builder completeSlotProfileFutureManually() {
+				this.completeSlotProfileFutureManually = true;
+				return this;
+			}
+
+			private Builder setSlotWillBeOccupiedIndefinitely(boolean slotWillBeOccupiedIndefinitely) {
+				this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+				return this;
+			}
+
+			private AllocationContext build() {
+				List<ExecutionVertexSchedulingRequirements> requirements = createSchedulingRequirements();
+				TestingPhysicalSlotProvider slotProvider = new TestingPhysicalSlotProvider(completePhysicalSlotFutureManually);
+				TestingSharedSlotProfileRetrieverFactory sharedSlotProfileRetrieverFactory =
+					new TestingSharedSlotProfileRetrieverFactory(completeSlotProfileFutureManually);
+				TestingSlotSharingStrategy slotSharingStrategy = TestingSlotSharingStrategy.createWithGroups(getReqIds(requirements), groups);
+				SlotSharingExecutionSlotAllocator allocator = new SlotSharingExecutionSlotAllocator(
+					slotProvider,
+					slotWillBeOccupiedIndefinitely,
+					slotSharingStrategy,
+					sharedSlotProfileRetrieverFactory);
+				return new AllocationContext(
+					requirements,
+					slotProvider,
+					slotSharingStrategy,
+					allocator,
+					sharedSlotProfileRetrieverFactory);
+			}
+
+			private List<ExecutionVertexSchedulingRequirements> createSchedulingRequirements() {
+				return resourceProfiles
+					.stream()
+					.map(resourceProfile ->
+						new ExecutionVertexSchedulingRequirements
+							.Builder()
+							.withExecutionVertexId(new ExecutionVertexID(new JobVertexID(), 0))
+							.withTaskResourceProfile(resourceProfile)
+							.withPhysicalSlotResourceProfile(resourceProfile) // not used
+							.build())
+					.collect(Collectors.toList());
+			}
+		}
+	}
+
+	private static class TestingPhysicalSlotProvider implements PhysicalSlotProvider {
+		private final Map<SlotRequestId, PhysicalSlotRequest> requests;
+		private final Map<SlotRequestId, CompletableFuture<TestingPhysicalSlot>> responses;
+		private final Map<SlotRequestId, Throwable> cancelations;
+		private final boolean completePhysicalSlotFutureManually;
+
+		private TestingPhysicalSlotProvider(boolean completePhysicalSlotFutureManually) {
+			this.completePhysicalSlotFutureManually = completePhysicalSlotFutureManually;
+			this.requests = new HashMap<>();
+			this.responses = new HashMap<>();
+			this.cancelations = new HashMap<>();
+		}
+
+		@Override
+		public CompletableFuture<PhysicalSlotRequest.Result> allocatePhysicalSlot(PhysicalSlotRequest physicalSlotRequest) {
+			SlotRequestId slotRequestId = physicalSlotRequest.getSlotRequestId();
+			requests.put(slotRequestId, physicalSlotRequest);
+			CompletableFuture<TestingPhysicalSlot> resultFuture = new CompletableFuture<>();
+			responses.put(slotRequestId, resultFuture);
+			if (!completePhysicalSlotFutureManually) {
+				completePhysicalSlotFutureFor(slotRequestId);
+			}
+			return resultFuture.thenApply(physicalSlot -> new PhysicalSlotRequest.Result(slotRequestId, physicalSlot));
+		}
+
+		private void completePhysicalSlotFutureFor(SlotRequestId slotRequestId) {
+			ResourceProfile resourceProfile = requests.get(slotRequestId).getSlotProfile().getPhysicalSlotResourceProfile();
+			TestingPhysicalSlot physicalSlot = new TestingPhysicalSlot(resourceProfile);
+			responses.get(slotRequestId).complete(physicalSlot);
+		}
+
+		private void failPhysicalSlotFutureFor(SlotRequestId slotRequestId, Throwable cause) {
+			responses.get(slotRequestId).completeExceptionally(cause);
+		}
+
+		@Override
+		public void cancelSlotRequest(SlotRequestId slotRequestId, Throwable cause) {
+			cancelations.put(slotRequestId, cause);
+		}
+
+		private Map<SlotRequestId, PhysicalSlotRequest> getRequests() {
+			return Collections.unmodifiableMap(requests);
+		}
+
+		private Map<SlotRequestId, CompletableFuture<TestingPhysicalSlot>> getResponses() {
+			return Collections.unmodifiableMap(responses);
+		}
+
+		private Map<SlotRequestId, Throwable> getCancelations() {
+			return Collections.unmodifiableMap(cancelations);
+		}
+	}
+
+	private static class TestingSlotSharingStrategy implements SlotSharingStrategy {
+		private final Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroups;
+
+		private TestingSlotSharingStrategy(Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroups) {
+			this.executionSlotSharingGroups = executionSlotSharingGroups;
+		}
+
+		@Override
+		public ExecutionSlotSharingGroup getExecutionSlotSharingGroup(ExecutionVertexID executionVertexId) {
+			return executionSlotSharingGroups.get(executionVertexId);
+		}
+
+		@Override
+		public Set<ExecutionSlotSharingGroup> getExecutionSlotSharingGroups() {
+			Set<ExecutionSlotSharingGroup> groups = new IdentityHashSet<>();
+			groups.addAll(executionSlotSharingGroups.values());
+			return groups;
+		}
+
+		private static TestingSlotSharingStrategy createWithGroups(
+				List<ExecutionVertexID> executionVertexIds,
+				int... groupSizes) {
+			Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroups = new HashMap<>();
+			int startIndex = 0;
+			int nextIndex = 0;
+			for (int groupSize : groupSizes) {
+				nextIndex = startIndex + groupSize;
+				createGroup(executionSlotSharingGroups, executionVertexIds, startIndex, nextIndex);
+				startIndex = nextIndex;
+			}
+			if (nextIndex < executionVertexIds.size()) {
+				createGroup(executionSlotSharingGroups, executionVertexIds, nextIndex, executionVertexIds.size());
+			}
+			return new TestingSlotSharingStrategy(executionSlotSharingGroups);
+		}
+
+		private static void createGroup(
+				Map<ExecutionVertexID, ExecutionSlotSharingGroup> executionSlotSharingGroups,
+				List<ExecutionVertexID> executionVertexIds,
+				int startIndex,
+				int nextIndex) {
+			ExecutionSlotSharingGroup executionSlotSharingGroup = new ExecutionSlotSharingGroup();
+			executionSlotSharingGroup.addVertex(new ExecutionVertexID(new JobVertexID(), 0));
+			executionVertexIds.subList(startIndex, nextIndex).forEach(executionVertexId -> {
+				executionSlotSharingGroup.addVertex(executionVertexId);
+				executionSlotSharingGroups.put(executionVertexId, executionSlotSharingGroup);
+			});
+		}
+	}
+
+	private static class TestingSharedSlotProfileRetrieverFactory implements SharedSlotProfileRetrieverFactory {
+		private final List<Set<ExecutionVertexID>> askedBulks;
+		private final List<ExecutionSlotSharingGroup> askedGroups;
+		private final Map<ExecutionSlotSharingGroup, ResourceProfile> resourceProfiles;
+		private final Map<ExecutionSlotSharingGroup, CompletableFuture<SlotProfile>> slotProfileFutures;
+		private final boolean completeSlotProfileFutureManually;
+
+		private TestingSharedSlotProfileRetrieverFactory(boolean completeSlotProfileFutureManually) {
+			this.completeSlotProfileFutureManually = completeSlotProfileFutureManually;
+			this.askedBulks = new ArrayList<>();
+			this.askedGroups = new ArrayList<>();
+			this.resourceProfiles = new IdentityHashMap<>();
+			this.slotProfileFutures = new IdentityHashMap<>();
+		}
+
+		@Override
+		public SharedSlotProfileRetriever createFromBulk(Set<ExecutionVertexID> bulk) {
+			askedBulks.add(bulk);
+			return group -> {
+				askedGroups.add(group);
+				CompletableFuture<SlotProfile> slotProfileFuture =
+					slotProfileFutures.computeIfAbsent(group, g -> new CompletableFuture<>());
+				if (!completeSlotProfileFutureManually) {
+					completeSlotProfileFutureFor(group);
+				}
+				return slotProfileFuture;
+			};
+		}
+
+		private void addGroupResourceProfile(ExecutionSlotSharingGroup group, ResourceProfile resourceProfile) {
+			resourceProfiles.put(group, resourceProfile);
+		}
+
+		private void completeSlotProfileFutureFor(ExecutionSlotSharingGroup group) {
+			slotProfileFutures.get(group).complete(SlotProfile.noLocality(resourceProfiles.getOrDefault(group, ResourceProfile.ANY)));
+		}
+
+		private List<Set<ExecutionVertexID>> getAskedBulks() {
+			return Collections.unmodifiableList(askedBulks);
+		}
+
+		private List<ExecutionSlotSharingGroup> getAskedGroups() {
+			return Collections.unmodifiableList(askedGroups);
+		}
+	}
+
+	private static class TestingPhysicalSlot extends SimpleSlotContext implements PhysicalSlot {
+		private Payload payload;
+
+		private TestingPhysicalSlot(ResourceProfile resourceProfile) {
+			super(
+				new AllocationID(),
+				new LocalTaskManagerLocation(),
+				0,
+				new SimpleAckingTaskManagerGateway(),
+				resourceProfile);
+		}
+
+		@Override
+		public boolean tryAssignPayload(Payload payload) {
+			this.payload = payload;
+			return true;
+		}
+
+		@Nullable
+		private Payload getPayload() {
+			return payload;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/DualKeyLinkedMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/DualKeyLinkedMapTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobmaster.slotpool;
+package org.apache.flink.runtime.util;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.TestLogger;


### PR DESCRIPTION
`SlotSharingExecutionSlotAllocator` maintains a `SharedSlot` for each `ExecutionSlotSharingGroup`. `SlotSharingExecutionSlotAllocator` allocates physical slots for `SharedSlot(s)` and then allocates logical slots from it for scheduled tasks.

The physical slot is lazily allocated for a `SharedSlot`, upon any hosted subtask asking for the `SharedSlot`. Each subsequent sharing subtask allocates a logical slot from the `SharedSlot`. The SharedSlot/physical slot can be released only if all the requested logical slots are released or canceled.

When `SlotSharingExecutionSlotAllocator` receives a set of tasks to allocate slots for, it does the following:
* Map the tasks to ExecutionSlotSharingGroup(s)
* Check which ExecutionSlotSharingGroup(s) already have SharedSlot(s)
* For all involved ExecutionSlotSharingGroup(s) which do not have a SharedSlot yet:
  * Create a SlotProfile future by MergingSharedSlotProfileRetriever and then
  * Allocate a physical slot from the PhysicalSlotProvider
  * Create SharedSlot based on the returned physical slot futures
  * Allocate logical slot futures for the tasks from all corresponding SharedSlot(s).
* If physical slot future fails, cancel its pending logical slot requests within the SharedSlot
* Generates SlotExecutionVertexAssignment(s)  based on the logical slot futures and returns the results.