### PR TITLE
[FLINK-18802][formats] Package uber jar including all dependencies for flink-avro

### DIFF
--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -55,11 +55,6 @@ under the License.
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<!-- managed version -->
-			<scope>provided</scope>
-			<!-- Avro records can contain JodaTime fields when using logical fields.
-				In order to handle them, we need to add an optional dependency.
-				Users with those Avro records need to add this dependency themselves. -->
-			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -186,6 +181,16 @@ under the License.
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<executions>
+					<execution>
+						<id>build-uber-jar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<descriptorRefs>jar-with-dependencies</descriptorRefs>
+						</configuration>
+					</execution>
 					<execution>
 						<id>create-test-dependency</id>
 						<phase>process-test-classes</phase>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -188,7 +188,9 @@ under the License.
 							<goal>single</goal>
 						</goals>
 						<configuration>
-							<descriptorRefs>jar-with-dependencies</descriptorRefs>
+							<descriptorRefs>
+								<descriptorRef>jar-with-dependencies</descriptorRef>
+							</descriptorRefs>
 						</configuration>
 					</execution>
 					<execution>


### PR DESCRIPTION
## What is the purpose of the change

This pull request changes the pom.xml of flink-avro module in order to create a uber jar in packaging phase, including dependencies such as avro, jackson-core-asl, jackson-mapper-asl and joda-time. 


## Brief change log

- Add another execution in maven-assembly-plugin to create a jar-with-dependencies
- Remove the "provided" scope and "optional" tag of joda-time dependency to include it in the uber jar


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
