### PR TITLE
[FLINK-18820] SourceOperator should send MAX_WATERMARK to downstream operator when closed

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -190,6 +191,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 	public void close() throws Exception {
 		sourceReader.close();
 		eventTimeLogic.stopPeriodicWatermarkEmits();
+		currentMainOutput.emitWatermark(Watermark.MAX_WATERMARK);
 		super.close();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -42,6 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T, ?>> {
+	private AsyncDataOutputToOutput<T> output;
 
 	public SourceOperatorStreamTask(Environment env) throws Exception {
 		super(env);
@@ -54,7 +55,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 		 * {@link SourceOperatorStreamTask} doesn't have any inputs, so there is no need for
 		 * {@link WatermarkGauge} on the input.
 		 */
-		DataOutput<T> output = new AsyncDataOutputToOutput<>(
+		output = new AsyncDataOutputToOutput<>(
 			operatorChain.getMainOperatorOutput(),
 			getStreamStatusMaintainer(),
 			null);
@@ -63,6 +64,11 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 			input,
 			output,
 			operatorChain);
+	}
+
+	@Override
+	protected void advanceToEndOfEventTime() {
+		output.emitWatermark(Watermark.MAX_WATERMARK);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -141,12 +141,12 @@ public class SourceOperatorTest {
 
 	@Test
 	public void testCloseWillSendMaxWatermark() throws Exception {
-		operator.initializeState(getStateContext());
+		MockSourceSplit mockSplit = new MockSourceSplit(1, 0, 0);
+		operator.initializeState(getStateContext(mockSplit));
 		PushingAsyncDataInput.DataOutput<Integer> dataOutput =
 			Mockito.mock(PushingAsyncDataInput.DataOutput.class);
 		operator.open();
 		operator.emitNext(dataOutput);
-		operator.close();
 		Mockito.verify(dataOutput, Mockito.times(1)).emitWatermark(Watermark.MAX_WATERMARK);
 	}
 
@@ -173,9 +173,13 @@ public class SourceOperatorTest {
 	// ---------------- helper methods -------------------------
 
 	private StateInitializationContext getStateContext() throws Exception {
+		return getStateContext(MOCK_SPLIT);
+	}
+
+	private StateInitializationContext getStateContext(MockSourceSplit mockSplit) throws Exception {
 		// Create a mock split.
 		byte[] serializedSplitWithVersion = SimpleVersionedSerialization
-			.writeVersionAndSerialize(new MockSourceSplitSerializer(), MOCK_SPLIT);
+			.writeVersionAndSerialize(new MockSourceSplitSerializer(), mockSplit);
 
 		// Crate the state context.
 		OperatorStateStore operatorStateStore = createOperatorStateStore();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
@@ -68,7 +68,8 @@ public class SourceOperatorEventTimeTest {
 
 		assertThat(result, contains(
 			new Watermark(100L),
-			new Watermark(120L)
+			new Watermark(120L),
+				Watermark.MAX_WATERMARK
 		));
 	}
 
@@ -86,7 +87,8 @@ public class SourceOperatorEventTimeTest {
 
 		assertThat(result, contains(
 			new Watermark(100L),
-			new Watermark(120L)
+			new Watermark(120L),
+				Watermark.MAX_WATERMARK
 		));
 	}
 
@@ -111,7 +113,8 @@ public class SourceOperatorEventTimeTest {
 		assertThat(result, contains(
 			new Watermark(100L),
 			new Watermark(150L),
-			new Watermark(200L)
+			new Watermark(200L),
+				Watermark.MAX_WATERMARK
 		));
 	}
 
@@ -136,7 +139,8 @@ public class SourceOperatorEventTimeTest {
 		assertThat(result, contains(
 			new Watermark(100L),
 			new Watermark(150L),
-			new Watermark(200L)
+			new Watermark(200L),
+				Watermark.MAX_WATERMARK
 		));
 	}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request make the SourceOperator send the Watermark.MAX_VALUE to the downstream when closing.*


## Brief change log

- *Send the Watermark.MAX_VALUE in the close method of SourceOperator


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates that Watermark.MAX_VALUE is sent when closing*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
