### PR TITLE
[FLINK-18834][doc] Fix the bug of wrong link of rocks db html in config doc

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -253,7 +253,7 @@ The metrics here are scoped to the operators and then further broken down by col
   <strong>Note:</strong> Enabling RocksDB's native metrics may cause degraded performance and should be set carefully. 
 </div>
 
-{% include generated/rocks_db_native_metric_configuration.html %}
+{% include generated/rocksdb_native_metric_configuration.html %}
 
 ----
 ----
@@ -316,7 +316,7 @@ Advanced options to tune RocksDB and RocksDB checkpoints.
 These options give fine-grained control over the behavior and resoures of ColumnFamilies.
 With the introduction of `state.backend.rocksdb.memory.managed` and `state.backend.rocksdb.memory.fixed-per-slot` (Apache Flink 1.10), it should be only necessary to use the options here for advanced performance tuning. These options here can also be specified in the application program via `RocksDBStateBackend.setOptions(PptionsFactory)`.
 
-{% include generated/rocks_db_configurable_configuration.html %}
+{% include generated/rocksdb_configurable_configuration.html %}
 
 ### Advanced Fault Tolerance Options
 

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -253,7 +253,7 @@ The metrics here are scoped to the operators and then further broken down by col
   <strong>Note:</strong> Enabling RocksDB's native metrics may cause degraded performance and should be set carefully. 
 </div>
 
-{% include generated/rocks_db_native_metric_configuration.html %}
+{% include generated/rocksdb_native_metric_configuration.html %}
 
 ----
 ----
@@ -316,7 +316,7 @@ Advanced options to tune RocksDB and RocksDB checkpoints.
 These options give fine-grained control over the behavior and resoures of ColumnFamilies.
 With the introduction of `state.backend.rocksdb.memory.managed` and `state.backend.rocksdb.memory.fixed-per-slot` (Apache Flink 1.10), it should be only necessary to use the options here for advanced performance tuning. These options here can also be specified in the application program via `RocksDBStateBackend.setOptions(PptionsFactory)`.
 
-{% include generated/rocks_db_configurable_configuration.html %}
+{% include generated/rocksdb_configurable_configuration.html %}
 
 ### Advanced Fault Tolerance Options
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of wrong link of rocks db html in config doc*


## Brief change log

  - *change the link in config.md and config.zh.md*


## Verifying this change

 execute the script ./build_docs.sh

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
