### PR TITLE
[FLINK-18838][python] Support JdbcCatalog in Python Table API

### DIFF
--- a/docs/dev/table/catalogs.md
+++ b/docs/dev/table/catalogs.md
@@ -265,7 +265,7 @@ table_properties = Kafka() \
     .to_properties()
 
 catalog_table = CatalogBaseTable.create_table(
-    schema=table_schema, properties=table_properties, "my comment")
+    schema=table_schema, properties=table_properties, comment="my comment")
 
 catalog.create_table(
     ObjectPath("mydb", "mytable"),

--- a/docs/dev/table/catalogs.md
+++ b/docs/dev/table/catalogs.md
@@ -249,15 +249,8 @@ catalog = HiveCatalog("myhive", None, "<path_of_hive_conf>")
 # Register the catalog
 t_env.register_catalog("myhive", catalog)
 
-from pyflink.java_gateway import get_gateway
-gateway = get_gateway()
-database_properties = {"k1": "v1"}
-database_comment = None
-j_database = gateway.jvm.org.apache.flink.table.catalog.CatalogDatabaseImpl(
-    database_properties, database_comment)
-database = CatalogDatabase(j_database)
-
 # Create a catalog database
+database = CatalogDatabase.create_instance({"k1": "v1"}, None)
 catalog.create_database("mydb", database)
 
 # Create a catalog table
@@ -271,11 +264,8 @@ table_properties = Kafka() \
     .start_from_earlist() \
     .to_properties()
 
-j_catalog_table = gateway.jvm.org.apache.flink.table.catalog.CatalogTableImpl(
-    table_schema._j_table_schema,
-    table_properties,
-    "my comment")
-catalog_table = CatalogBaseTable(j_catalog_table)
+catalog_table = CatalogBaseTable.create_table(
+    schema=table_schema, properties=table_properties, "my comment")
 
 catalog.create_table(
     ObjectPath("mydb", "mytable"),
@@ -322,15 +312,9 @@ catalog.listDatabases();
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table.catalog import CatalogDatabase
-from pyflink.java_gateway import get_gateway
-gateway = get_gateway()
 
 # create database
-database_properties = {"k1": "v1"}
-database_comment = None
-j_catalog_database = gateway.jvm.org.apache.flink.table.catalog.CatalogDatabaseImpl(
-    database_properties, database_comment)
-catalog_database = CatalogDatabase(j_catalog_database)
+catalog_database = CatalogDatabase.create_instance({"k1": "v1"}, None)
 catalog.create_database("mydb", catalog_database, False)
 
 # drop database
@@ -381,7 +365,6 @@ catalog.listTables("mydb");
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table import *
-from pyflink.java_gateway import get_gateway
 from pyflink.table.catalog import CatalogBaseTable, ObjectPath
 from pyflink.table.descriptors import Kafka
 
@@ -395,12 +378,7 @@ table_properties = Kafka() \
     .start_from_earlist() \
     .to_properties()
 
-gateway = get_gateway()
-j_catalog_table = gateway.jvm.org.apache.flink.table.catalog.CatalogTableImpl(
-    table_schema._j_table_schema,
-    table_properties,
-    "my comment")
-catalog_table = CatalogBaseTable(j_catalog_table)
+catalog_table = CatalogBaseTable.create_table(schema=table_schema, properties=table_properties, comment="my comment")
 
 # create table
 catalog.create_table(ObjectPath("mydb", "mytable"), catalog_table, False)
@@ -457,21 +435,19 @@ catalog.listViews("mydb");
 {% highlight python %}
 from pyflink.table import *
 from pyflink.table.catalog import CatalogBaseTable, ObjectPath
-from pyflink.java_gateway import get_gateway
 
 table_schema = TableSchema.builder() \
     .field("name", DataTypes.STRING()) \
     .field("age", DataTypes.INT()) \
     .build()
 
-gateway = get_gateway()
-j_view = gateway.jvm.org.apache.flink.table.catalog.CatalogViewImpl(
-            "select * from t1",
-            "select * from test-catalog.db1.t1",
-            table_schema._j_table_schema,
-            {},
-            "This is a view")
-catalog_table = CatalogBaseTable(j_view)
+catalog_table = CatalogBaseTable.create_view(
+    original_query="select * from t1",
+    expanded_query="select * from test-catalog.db1.t1",
+    schema=table_schema,
+    properties={},
+    comment="This is a view"
+)
 
 catalog.create_table(ObjectPath("mydb", "myview"), catalog_table, False)
 
@@ -538,14 +514,8 @@ catalog.listPartitionsByFilter(new ObjectPath("mydb", "mytable"), Arrays.asList(
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table.catalog import ObjectPath, CatalogPartitionSpec, CatalogPartition
-from pyflink.java_gateway import get_gateway
 
-gateway = get_gateway()
-partition_properties = {}
-partition_comments = "my partition"
-j_partition = gateway.jvm.org.apache.flink.table.catalog.CatalogPartitionImpl(
-    partition_properties, partition_comments)
-catalog_partition = CatalogPartition(j_partition)
+catalog_partition = CatalogPartition.create_instance({}, "my partition")
 
 catalog_partition_spec = CatalogPartitionSpec({"third": "2010", "second": "bob"})
 catalog.create_partition(
@@ -607,13 +577,8 @@ catalog.listFunctions("mydb");
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table.catalog import ObjectPath, CatalogFunction
-from pyflink.java_gateway import get_gateway
 
-gateway = get_gateway()
-j_function = gateway.jvm.org.apache.flink.table.catalog.CatalogFunctionImpl(
-    "my.python.udf",
-    gateway.jvm.org.apache.flink.table.catalog.FunctionLanguage.PYTHON)
-catalog_function = CatalogFunction(j_function)
+catalog_function = CatalogFunction.create_instance(class_name="my.python.udf")
 
 # create function
 catalog.create_function(ObjectPath("mydb", "myfunc"), catalog_function, False)

--- a/docs/dev/table/catalogs.zh.md
+++ b/docs/dev/table/catalogs.zh.md
@@ -262,7 +262,7 @@ table_properties = Kafka() \
     .to_properties()
 
 catalog_table = CatalogBaseTable.create_table(
-    schema=table_schema, properties=table_properties, "my comment")
+    schema=table_schema, properties=table_properties, comment="my comment")
 
 catalog.create_table(
     ObjectPath("mydb", "mytable"),

--- a/docs/dev/table/catalogs.zh.md
+++ b/docs/dev/table/catalogs.zh.md
@@ -246,15 +246,8 @@ catalog = HiveCatalog("myhive", None, "<path_of_hive_conf>")
 # Register the catalog
 t_env.register_catalog("myhive", catalog)
 
-from pyflink.java_gateway import get_gateway
-gateway = get_gateway()
-database_properties = {"k1": "v1"}
-database_comment = None
-j_database = gateway.jvm.org.apache.flink.table.catalog.CatalogDatabaseImpl(
-database_properties, database_comment)
-database = CatalogDatabase(j_database)
-
 # Create a catalog database
+database = CatalogDatabase.create_instance({"k1": "v1"}, None)
 catalog.create_database("mydb", database)
 
 # Create a catalog table
@@ -268,11 +261,8 @@ table_properties = Kafka() \
     .start_from_earlist() \
     .to_properties()
 
-j_catalog_table = gateway.jvm.org.apache.flink.table.catalog.CatalogTableImpl(
-    table_schema._j_table_schema,
-    table_properties,
-    "my comment")
-catalog_table = CatalogBaseTable(j_catalog_table)
+catalog_table = CatalogBaseTable.create_table(
+    schema=table_schema, properties=table_properties, "my comment")
 
 catalog.create_table(
     ObjectPath("mydb", "mytable"),
@@ -319,15 +309,9 @@ catalog.listDatabases("mycatalog");
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table.catalog import CatalogDatabase
-from pyflink.java_gateway import get_gateway
-gateway = get_gateway()
 
 # create database
-database_properties = {"k1": "v1"}
-database_comment = None
-j_catalog_database = gateway.jvm.org.apache.flink.table.catalog.CatalogDatabaseImpl(
-    database_properties, database_comment)
-catalog_database = CatalogDatabase(j_catalog_database)
+catalog_database = CatalogDatabase.create_instance({"k1": "v1"}, None)
 catalog.create_database("mydb", catalog_database, False)
 
 # drop database
@@ -378,7 +362,6 @@ catalog.listTables("mydb");
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table import *
-from pyflink.java_gateway import get_gateway
 from pyflink.table.catalog import CatalogBaseTable, ObjectPath
 from pyflink.table.descriptors import Kafka
 
@@ -392,12 +375,7 @@ table_properties = Kafka() \
     .start_from_earlist() \
     .to_properties()
 
-gateway = get_gateway()
-j_catalog_table = gateway.jvm.org.apache.flink.table.catalog.CatalogTableImpl(
-    table_schema._j_table_schema,
-    table_properties,
-    "my comment")
-catalog_table = CatalogBaseTable(j_catalog_table)
+catalog_table = CatalogBaseTable.create_table(schema=table_schema, properties=table_properties, comment="my comment")
 
 # create table
 catalog.create_table(ObjectPath("mydb", "mytable"), catalog_table, False)
@@ -454,21 +432,19 @@ catalog.listViews("mydb");
 {% highlight python %}
 from pyflink.table import *
 from pyflink.table.catalog import CatalogBaseTable, ObjectPath
-from pyflink.java_gateway import get_gateway
 
 table_schema = TableSchema.builder() \
     .field("name", DataTypes.STRING()) \
     .field("age", DataTypes.INT()) \
     .build()
 
-gateway = get_gateway()
-j_view = gateway.jvm.org.apache.flink.table.catalog.CatalogViewImpl(
-            "select * from t1",
-            "select * from test-catalog.db1.t1",
-            table_schema._j_table_schema,
-            {},
-            "This is a view")
-catalog_table = CatalogBaseTable(j_view)
+catalog_table = CatalogBaseTable.create_view(
+    original_query="select * from t1",
+    expanded_query="select * from test-catalog.db1.t1",
+    schema=table_schema,
+    properties={},
+    comment="This is a view"
+)
 
 catalog.create_table(ObjectPath("mydb", "myview"), catalog_table, False)
 
@@ -535,14 +511,8 @@ catalog.listPartitions(new ObjectPath("mydb", "mytable"), Arrays.asList(epr1, ..
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table.catalog import ObjectPath, CatalogPartitionSpec, CatalogPartition
-from pyflink.java_gateway import get_gateway
 
-gateway = get_gateway()
-partition_properties = {}
-partition_comments = "my partition"
-j_partition = gateway.jvm.org.apache.flink.table.catalog.CatalogPartitionImpl(
-    partition_properties, partition_comments)
-catalog_partition = CatalogPartition(j_partition)
+catalog_partition = CatalogPartition.create_instance({}, "my partition")
 
 catalog_partition_spec = CatalogPartitionSpec({"third": "2010", "second": "bob"})
 catalog.create_partition(
@@ -604,13 +574,8 @@ catalog.listFunctions("mydb");
 <div data-lang="Python" markdown="1">
 {% highlight python %}
 from pyflink.table.catalog import ObjectPath, CatalogFunction
-from pyflink.java_gateway import get_gateway
 
-gateway = get_gateway()
-j_function = gateway.jvm.org.apache.flink.table.catalog.CatalogFunctionImpl(
-    "my.python.udf",
-    gateway.jvm.org.apache.flink.table.catalog.FunctionLanguage.PYTHON)
-catalog_function = CatalogFunction(j_function)
+catalog_function = CatalogFunction.create_instance(class_name="my.python.udf")
 
 # create function
 catalog.create_function(ObjectPath("mydb", "myfunc"), catalog_function, False)

--- a/docs/dev/table/connectors/jdbc.md
+++ b/docs/dev/table/connectors/jdbc.md
@@ -377,19 +377,7 @@ tableEnv.useCatalog("mypg")
 </div>
 <div data-lang="Python" markdown="1">
 {% highlight python %}
-from pyflink.table.catalog import Catalog
-
-class JdbcCatalog(Catalog):
-    """
-    A catalog implementation for Jdbc.
-    """
-    def __init__(self, catalog_name, default_database, username, pwd, base_url):
-        from pyflink.java_gateway import get_gateway
-        gateway = get_gateway()
-
-        j_jdbc_catalog = gateway.jvm.org.apache.flink.connector.jdbc.catalog.JdbcCatalog(
-            catalog_name, default_database, username, pwd, base_url)
-        super(JdbcCatalog, self).__init__(j_jdbc_catalog)
+from pyflink.table.catalog import JdbcCatalog
 
 environment_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 t_env = StreamTableEnvironment.create(environment_settings=environment_settings)

--- a/docs/dev/table/connectors/jdbc.zh.md
+++ b/docs/dev/table/connectors/jdbc.zh.md
@@ -377,19 +377,7 @@ tableEnv.useCatalog("mypg")
 </div>
 <div data-lang="Python" markdown="1">
 {% highlight python %}
-from pyflink.table.catalog import Catalog
-
-class JdbcCatalog(Catalog):
-    """
-    A catalog implementation for Jdbc.
-    """
-    def __init__(self, catalog_name, default_database, username, pwd, base_url):
-        from pyflink.java_gateway import get_gateway
-        gateway = get_gateway()
-
-        j_jdbc_catalog = gateway.jvm.org.apache.flink.connector.jdbc.catalog.JdbcCatalog(
-            catalog_name, default_database, username, pwd, base_url)
-        super(JdbcCatalog, self).__init__(j_jdbc_catalog)
+from pyflink.table.catalog import JdbcCatalog
 
 environment_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 t_env = StreamTableEnvironment.create(environment_settings=environment_settings)

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -37,13 +37,6 @@ class Catalog(object):
     def __init__(self, j_catalog):
         self._j_catalog = j_catalog
 
-    @staticmethod
-    def _get(j_catalog):
-        if j_catalog.getClass().getName() == "org.apache.flink.table.catalog.hive.HiveCatalog":
-            return HiveCatalog(j_hive_catalog=j_catalog)
-        else:
-            return Catalog(j_catalog)
-
     def get_default_database(self):
         """
         Get the name of the default database for this catalog. The default database will be the
@@ -1106,13 +1099,13 @@ class HiveCatalog(Catalog):
     A catalog implementation for Hive.
     """
 
-    def __init__(self, catalog_name=None, default_database="default", hive_conf_dir=None,
-                 j_hive_catalog=None):
+    def __init__(self, catalog_name: str, default_database: str = None, hive_conf_dir: str = None):
+        assert catalog_name is not None
+
         gateway = get_gateway()
 
-        if j_hive_catalog is None:
-            j_hive_catalog = gateway.jvm.org.apache.flink.table.catalog.hive.HiveCatalog(
-                catalog_name, default_database, hive_conf_dir)
+        j_hive_catalog = gateway.jvm.org.apache.flink.table.catalog.hive.HiveCatalog(
+            catalog_name, default_database, hive_conf_dir)
         super(HiveCatalog, self).__init__(j_hive_catalog)
 
 
@@ -1120,7 +1113,14 @@ class JdbcCatalog(Catalog):
     """
     A catalog implementation for Jdbc.
     """
-    def __init__(self, catalog_name, default_database, username, pwd, base_url):
+    def __init__(self, catalog_name: str, default_database: str, username: str, pwd: str,
+                 base_url: str):
+        assert catalog_name is not None
+        assert default_database is not None
+        assert username is not None
+        assert pwd is not None
+        assert base_url is not None
+
         from pyflink.java_gateway import get_gateway
         gateway = get_gateway()
 

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 import warnings
+from typing import Dict, List
 
 from py4j.java_gateway import java_import
 
@@ -556,6 +557,23 @@ class CatalogDatabase(object):
         self._j_catalog_database = j_catalog_database
 
     @staticmethod
+    def create_instance(
+        properties: Dict[str, str],
+        comment: str = None
+    ) -> "CatalogDatabase":
+        """
+        Creates an instance of CatalogDatabase.
+
+        :param properties: Property of the database
+        :param comment: Comment of the database
+        """
+        assert properties is not None
+
+        gateway = get_gateway()
+        return CatalogDatabase(gateway.jvm.org.apache.flink.table.catalog.CatalogDatabaseImpl(
+            properties, comment))
+
+    @staticmethod
     def _get(j_catalog_database):
         return CatalogDatabase(j_catalog_database)
 
@@ -614,6 +632,60 @@ class CatalogBaseTable(object):
 
     def __init__(self, j_catalog_base_table):
         self._j_catalog_base_table = j_catalog_base_table
+
+    @staticmethod
+    def create_table(
+        schema: TableSchema,
+        partition_keys: List[str] = [],
+        properties: Dict[str, str] = {},
+        comment: str = None
+    ) -> "CatalogBaseTable":
+        """
+        Create an instance of CatalogBaseTable for the catalog table.
+
+        :param schema: the table schema
+        :param partition_keys: the partition keys, default empty
+        :param properties: the properties of the catalog table
+        :param comment: the comment of the catalog table
+        """
+        assert schema is not None
+        assert partition_keys is not None
+        assert properties is not None
+
+        gateway = get_gateway()
+        return CatalogBaseTable(
+            gateway.jvm.org.apache.flink.table.catalog.CatalogTableImpl(
+                schema._j_table_schema, partition_keys, properties, comment))
+
+    @staticmethod
+    def create_view(
+        original_query: str,
+        expanded_query: str,
+        schema: TableSchema,
+        properties: Dict[str, str],
+        comment: str = None
+    ) -> "CatalogBaseTable":
+        """
+        Create an instance of CatalogBaseTable for the catalog view.
+
+        :param original_query: the original text of the view definition
+        :param expanded_query: the expanded text of the original view definition, this is needed
+                               because the context such as current DB is lost after the session,
+                               in which view is defined, is gone. Expanded query text takes care
+                               of the this, as an example.
+        :param schema: the table schema
+        :param properties: the properties of the catalog view
+        :param comment: the comment of the catalog view
+        """
+        assert original_query is not None
+        assert expanded_query is not None
+        assert schema is not None
+        assert properties is not None
+
+        gateway = get_gateway()
+        return CatalogBaseTable(
+            gateway.jvm.org.apache.flink.table.catalog.CatalogViewImpl(
+                original_query, expanded_query, schema._j_table_schema, properties, comment))
 
     @staticmethod
     def _get(j_catalog_base_table):
@@ -703,6 +775,24 @@ class CatalogPartition(object):
         self._j_catalog_partition = j_catalog_partition
 
     @staticmethod
+    def create_instance(
+        properties: Dict[str, str],
+        comment: str = None
+    ) -> "CatalogPartition":
+        """
+        Creates an instance of CatalogPartition.
+
+        :param properties: Property of the partition
+        :param comment: Comment of the partition
+        """
+        assert properties is not None
+
+        gateway = get_gateway()
+        return CatalogPartition(
+            gateway.jvm.org.apache.flink.table.catalog.CatalogPartitionImpl(
+                properties, comment))
+
+    @staticmethod
     def _get(j_catalog_partition):
         return CatalogPartition(j_catalog_partition)
 
@@ -763,6 +853,34 @@ class CatalogFunction(object):
 
     def __init__(self, j_catalog_function):
         self._j_catalog_function = j_catalog_function
+
+    @staticmethod
+    def create_instance(
+        class_name: str,
+        function_language: str = 'Python'
+    ) -> "CatalogFunction":
+        """
+        Creates an instance of CatalogDatabase.
+
+        :param class_name: full qualified path of the class name
+        :param function_language: language of the function, must be one of
+                                  'Python', 'Java' or 'Scala'. (default Python)
+        """
+        assert class_name is not None
+
+        gateway = get_gateway()
+        FunctionLanguage = gateway.jvm.org.apache.flink.table.catalog.FunctionLanguage
+        if function_language.lower() == 'python':
+            function_language = FunctionLanguage.PYTHON
+        elif function_language.lower() == 'java':
+            function_language = FunctionLanguage.JAVA
+        elif function_language.lower() == 'scala':
+            function_language = FunctionLanguage.SCALA
+        else:
+            raise ValueError("function_language must be one of 'Python', 'Java' or 'Scala'")
+        return CatalogFunction(
+            gateway.jvm.org.apache.flink.table.catalog.CatalogFunctionImpl(
+                class_name, function_language))
 
     @staticmethod
     def _get(j_catalog_function):
@@ -996,3 +1114,16 @@ class HiveCatalog(Catalog):
             j_hive_catalog = gateway.jvm.org.apache.flink.table.catalog.hive.HiveCatalog(
                 catalog_name, default_database, hive_conf_dir)
         super(HiveCatalog, self).__init__(j_hive_catalog)
+
+
+class JdbcCatalog(Catalog):
+    """
+    A catalog implementation for Jdbc.
+    """
+    def __init__(self, catalog_name, default_database, username, pwd, base_url):
+        from pyflink.java_gateway import get_gateway
+        gateway = get_gateway()
+
+        j_jdbc_catalog = gateway.jvm.org.apache.flink.connector.jdbc.catalog.JdbcCatalog(
+            catalog_name, default_database, username, pwd, base_url)
+        super(JdbcCatalog, self).__init__(j_jdbc_catalog)

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -144,7 +144,7 @@ class TableEnvironment(object):
         """
         catalog = self._j_tenv.getCatalog(catalog_name)
         if catalog.isPresent():
-            return Catalog._get(catalog.get())
+            return Catalog(catalog.get())
         else:
             return None
 

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -75,15 +75,11 @@ class CatalogTestBase(PyFlinkTestCase):
 
     @staticmethod
     def create_db():
-        gateway = get_gateway()
-        j_database = gateway.jvm.CatalogDatabaseImpl({"k1": "v1"}, CatalogTestBase.test_comment)
-        return CatalogDatabase(j_database)
+        return CatalogDatabase.create_instance({"k1": "v1"}, CatalogTestBase.test_comment)
 
     @staticmethod
     def create_another_db():
-        gateway = get_gateway()
-        j_database = gateway.jvm.CatalogDatabaseImpl({"k2": "v2"}, "this is another database.")
-        return CatalogDatabase(j_database)
+        return CatalogDatabase.create_instance({"k2": "v2"}, "this is another database.")
 
     @staticmethod
     def create_table_schema():
@@ -109,125 +105,95 @@ class CatalogTestBase(PyFlinkTestCase):
 
     @staticmethod
     def create_table():
-        gateway = get_gateway()
-        table_schema = CatalogTestBase.create_table_schema()
-        j_table = gateway.jvm.CatalogTableImpl(
-            table_schema._j_table_schema, CatalogTestBase.get_batch_table_properties(),
-            CatalogTestBase.test_comment)
-        return CatalogBaseTable(j_table)
+        return CatalogBaseTable.create_table(
+            schema=CatalogTestBase.create_table_schema(),
+            properties=CatalogTestBase.get_batch_table_properties(),
+            comment=CatalogTestBase.test_comment)
 
     @staticmethod
     def create_another_table():
-        gateway = get_gateway()
-        table_schema = CatalogTestBase.create_another_table_schema()
-        j_table = gateway.jvm.CatalogTableImpl(
-            table_schema._j_table_schema, CatalogTestBase.get_batch_table_properties(),
-            CatalogTestBase.test_comment)
-        return CatalogBaseTable(j_table)
+        return CatalogBaseTable.create_table(
+            schema=CatalogTestBase.create_another_table_schema(),
+            properties=CatalogTestBase.get_batch_table_properties(),
+            comment=CatalogTestBase.test_comment)
 
     @staticmethod
     def create_stream_table():
-        gateway = get_gateway()
-        table_schema = CatalogTestBase.create_table_schema()
-        j_table = gateway.jvm.CatalogTableImpl(
-            table_schema._j_table_schema, CatalogTestBase.get_streaming_table_properties(),
-            CatalogTestBase.test_comment)
-        return CatalogBaseTable(j_table)
+        return CatalogBaseTable.create_table(
+            schema=CatalogTestBase.create_table_schema(),
+            properties=CatalogTestBase.get_streaming_table_properties(),
+            comment=CatalogTestBase.test_comment)
 
     @staticmethod
     def create_partitioned_table():
-        gateway = get_gateway()
-        table_schema = CatalogTestBase.create_table_schema()
-        j_table = gateway.jvm.CatalogTableImpl(
-            table_schema._j_table_schema, CatalogTestBase.create_partition_keys(),
-            CatalogTestBase.get_batch_table_properties(), CatalogTestBase.test_comment)
-        return CatalogBaseTable(j_table)
+        return CatalogBaseTable.create_table(
+            schema=CatalogTestBase.create_table_schema(),
+            partition_keys=CatalogTestBase.create_partition_keys(),
+            properties=CatalogTestBase.get_batch_table_properties(),
+            comment=CatalogTestBase.test_comment)
 
     @staticmethod
     def create_another_partitioned_table():
-        gateway = get_gateway()
-        table_schema = CatalogTestBase.create_another_table_schema()
-        j_table = gateway.jvm.CatalogTableImpl(
-            table_schema._j_table_schema, CatalogTestBase.create_partition_keys(),
-            CatalogTestBase.get_batch_table_properties(), CatalogTestBase.test_comment)
-        return CatalogBaseTable(j_table)
+        return CatalogBaseTable.create_table(
+            schema=CatalogTestBase.create_another_table_schema(),
+            partition_keys=CatalogTestBase.create_partition_keys(),
+            properties=CatalogTestBase.get_batch_table_properties(),
+            comment=CatalogTestBase.test_comment)
 
     @staticmethod
     def create_view():
-        gateway = get_gateway()
         table_schema = CatalogTestBase.create_table_schema()
-        j_view = gateway.jvm.CatalogViewImpl(
+        return CatalogBaseTable.create_view(
             "select * from t1",
             "select * from test-catalog.db1.t1",
-            table_schema._j_table_schema,
+            table_schema,
             {},
             "This is a view")
-        return CatalogBaseTable(j_view)
 
     @staticmethod
     def create_another_view():
-        gateway = get_gateway()
         table_schema = CatalogTestBase.create_another_table_schema()
-        j_view = gateway.jvm.CatalogViewImpl(
+        return CatalogBaseTable.create_view(
             "select * from t2",
             "select * from test-catalog.db2.t2",
-            table_schema._j_table_schema,
+            table_schema,
             {},
             "This is another view")
-        return CatalogBaseTable(j_view)
 
     @staticmethod
     def create_function():
-        gateway = get_gateway()
-        j_function = gateway.jvm.CatalogFunctionImpl(
-            "org.apache.flink.table.functions.python.PythonScalarFunction")
-        return CatalogFunction(j_function)
+        return CatalogFunction.create_instance(
+            "org.apache.flink.table.functions.python.PythonScalarFunction", "Java")
 
     @staticmethod
     def create_another_function():
-        gateway = get_gateway()
-        j_function = gateway.jvm.CatalogFunctionImpl(
-            "org.apache.flink.table.functions.ScalarFunction")
-        return CatalogFunction(j_function)
+        return CatalogFunction.create_instance(
+            "org.apache.flink.table.functions.ScalarFunction", "Java")
 
     @staticmethod
     def create_partition_spec():
-        gateway = get_gateway()
-        j_partition_spec = gateway.jvm.CatalogPartitionSpec(
-            {"third": "2000", "second": "bob"})
-        return CatalogPartitionSpec(j_partition_spec)
+        return CatalogPartitionSpec({"third": "2000", "second": "bob"})
 
     @staticmethod
     def create_another_partition_spec():
-        gateway = get_gateway()
-        j_partition_spec = gateway.jvm.CatalogPartitionSpec(
-            {"third": "2010", "second": "bob"})
-        return CatalogPartitionSpec(j_partition_spec)
+        return CatalogPartitionSpec({"third": "2010", "second": "bob"})
 
     @staticmethod
     def create_partition():
-        gateway = get_gateway()
-        j_partition = gateway.jvm.CatalogPartitionImpl(
+        return CatalogPartition.create_instance(
             CatalogTestBase.get_batch_table_properties(), "catalog partition tests")
-        return CatalogPartition(j_partition)
 
     @staticmethod
     def create_partition_spec_subset():
-        gateway = get_gateway()
-        j_partition_spec = gateway.jvm.CatalogPartitionSpec({"second": "bob"})
-        return CatalogPartitionSpec(j_partition_spec)
+        return CatalogPartitionSpec({"second": "bob"})
 
     @staticmethod
     def create_another_partition_spec_subset():
-        gateway = get_gateway()
-        j_partition_spec = gateway.jvm.CatalogPartitionSpec({"third": "2000"})
-        return CatalogPartitionSpec(j_partition_spec)
+        return CatalogPartitionSpec({"third": "2000"})
 
     @staticmethod
     def create_invalid_partition_spec_subset():
-        gateway = get_gateway()
-        j_partition_spec = gateway.jvm.CatalogPartitionSpec({"third": "2010"})
-        return CatalogPartitionSpec(j_partition_spec)
+        return CatalogPartitionSpec({"third": "2010"})
 
     def test_create_db(self):
         self.assertFalse(self.catalog.database_exists(self.db1))
@@ -810,10 +776,8 @@ class CatalogTestBase(PyFlinkTestCase):
         self.check_catalog_partition_equals(self.create_partition(), cp)
         self.assertIsNone(cp.get_properties().get("k"))
 
-        gateway = get_gateway()
-        j_partition = gateway.jvm.CatalogPartitionImpl(
+        another = CatalogPartition.create_instance(
             {"is_streaming": "false", "k": "v"}, "catalog partition")
-        another = CatalogPartition(j_partition)
         self.catalog.alter_partition(self.path1, self.create_partition_spec(), another, False)
 
         cp = self.catalog.get_partition(self.path1, self.create_partition_spec())


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add support JdbcCatalog in Python Table API. It also add a few static methods used for creating CatalogFunction, CatalogDatabase, CatalogTable, etc*

## Brief change log

  - *Introduce JdbcCatalog*
  - *Add a few static methods used for creating CatalogFunction, CatalogDatabase, CatalogTable*

## Verifying this change

This change is already covered by existing tests in test_catalog.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
