### PR TITLE
[FLINK-18847][docs][python] Add documentation about data types in Python Table API

### DIFF
--- a/docs/dev/table/python/index.md
+++ b/docs/dev/table/python/index.md
@@ -30,6 +30,7 @@ Apache Flink has provided Python Table API support since 1.9.0.
 ## Where to go next?
 
 - [Installation]({{ site.baseurl }}/dev/table/python/installation.html): Introduction of how to set up the Python Table API execution environment.
+- [Python Data Types]({{ site.baseurl }}/dev/table/python/python_types.html): Introduction of Python data types.
 - [User-defined Functions]({{ site.baseurl }}/dev/table/python/python_udfs.html): Explanation of how to define Python user-defined functions.
 - [Vectorized User-defined Functions]({{ site.baseurl }}/dev/table/python/vectorized_python_udfs.html): Explanation of how to define vectorized Python user-defined functions.
 - [Conversions between PyFlink Table and Pandas DataFrame]({{ site.baseurl }}/dev/table/python/conversion_of_pandas.html): Explanation of how to convert between PyFlink Table and Pandas DataFrame.

--- a/docs/dev/table/python/index.zh.md
+++ b/docs/dev/table/python/index.zh.md
@@ -31,6 +31,7 @@ Python Table API允许用户使用Python语言开发[Table API]({{ site.baseurl 
 ## Where to go next?
 
 - [环境安装]({{ site.baseurl }}/zh/dev/table/python/installation.html): 介绍了如何设置Python Table API的执行环境。
+- [Python数据类型]({{ site.baseurl }}/zh/dev/table/python/python_types.html): 介绍Python数据类型。
 - [自定义函数]({{ site.baseurl }}/zh/dev/table/python/python_udfs.html): 有关如何定义Python用户自定义函数的说明。
 - [自定义向量化函数]({{ site.baseurl }}/zh/dev/table/python/vectorized_python_udfs.html): 有关如何定义向量化Python用户自定义函数的说明。
 - [PyFlink Table 和 Pandas DataFrame 互转]({{ site.baseurl }}/zh/dev/table/python/conversion_of_pandas.html): 介绍了PyFlink Table和Pandas DataFrame之间如何互转。

--- a/docs/dev/table/python/python_types.md
+++ b/docs/dev/table/python/python_types.md
@@ -1,0 +1,74 @@
+---
+title: "Python Data Types"
+nav-parent_id: python_tableapi
+nav-pos: 15
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This page describes the data types supported in PyFlink Table API.
+
+* This will be replaced by the TOC
+{:toc}
+
+Data Type
+---------
+
+A *data type* describes the logical type of a value in the table ecosystem. It can be used to declare input and/or
+output types of Python user-defined functions. Users of the Python Table API work with instances of
+`pyflink.table.types.DataType` within the Python Table API or when defining user-defined functions.
+
+A `DataType` instance declares the **logical type** which does not imply a concrete physical representation for transmission
+or storage. All pre-defined data types are available in `pyflink.table.types` and can be instantiated with the utility methods
+defined in `pyflink.table.types.DataTypes`.
+
+A list of all pre-defined data types can be found [below]({{ site.baseurl }}/dev/table/types.html#list-of-data-types).
+
+Data Type and Python type mapping
+------------------
+
+A *data type* can be used to declare input and/or output types of Python user-defined functions. The inputs
+will be converted to Python objects corresponding to the data type and the type of the user-defined functions
+result must also match the defined data type.
+
+For vectorized Python UDF, the input types and output type are `pandas.Series`. The element type
+of the `pandas.Series` corresponds to the specified data type.
+
+| Data Type | Python Type | Pandas Type |
+|:-----------------|:-----------------------|
+| `BOOLEAN` | `bool` | `numpy.bool_` |
+| `TINYINT` | `int` | `numpy.int8` |
+| `SMALLINT` | `int` | `numpy.int16` |
+| `INT` | `int` | `numpy.int32` |
+| `BIGINT` | `int` | `numpy.int64` |
+| `FLOAT` | `float` | `numpy.float32` |
+| `DOUBLE` | `float` | `numpy.float64` |
+| `VARCHAR` | `str` | `str` |
+| `VARBINARY` | `bytes` | `bytes` |
+| `DECIMAL` | `decimal.Decimal` | `decimal.Decimal` |
+| `DATE` | `datetime.date` | `datetime.date` |
+| `TIME` | `datetime.time` | `datetime.time` |
+| `TimestampType` | `datetime.datetime` | `datetime.datetime` |
+| `LocalZonedTimestampType` | `datetime.datetime` | `datetime.datetime` |
+| `INTERVAL YEAR TO MONTH` | `int` | `Not Supported Yet` |
+| `INTERVAL DAY TO SECOND` | `datetime.timedelta` | `Not Supported Yet` |
+| `ARRAY` | `list` | `numpy.ndarray` |
+| `MULTISET` | `list` | `Not Supported Yet` |
+| `MAP` | `dict` | `Not Supported Yet` |
+| `ROW` | `Row` | `dict` |

--- a/docs/dev/table/python/python_types.zh.md
+++ b/docs/dev/table/python/python_types.zh.md
@@ -1,0 +1,74 @@
+---
+title: "Python 数据类型"
+nav-parent_id: python_tableapi
+nav-pos: 15
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This page describes the data types supported in PyFlink Table API.
+
+* This will be replaced by the TOC
+{:toc}
+
+Data Type
+---------
+
+A *data type* describes the logical type of a value in the table ecosystem. It can be used to declare input and/or
+output types of Python user-defined functions. Users of the Python Table API work with instances of
+`pyflink.table.types.DataType` within the Python Table API or when defining user-defined functions.
+
+A `DataType` instance declares the **logical type** which does not imply a concrete physical representation for transmission
+or storage. All pre-defined data types are available in `pyflink.table.types` and can be instantiated with the utility methods
+defined in `pyflink.table.types.DataTypes`.
+
+A list of all pre-defined data types can be found [below]({{ site.baseurl }}/zh/dev/table/types.html#list-of-data-types).
+
+Data Type and Python type mapping
+------------------
+
+A *data type* can be used to declare input and/or output types of Python user-defined functions. The inputs
+will be converted to Python objects corresponding to the data type and the type of the user-defined functions
+result must also match the defined data type.
+
+For vectorized Python UDF, the input types and output type are `pandas.Series`. The element type
+of the `pandas.Series` corresponds to the specified data type.
+
+| Data Type | Python Type | Pandas Type |
+|:-----------------|:-----------------------|
+| `BOOLEAN` | `bool` | `numpy.bool_` |
+| `TINYINT` | `int` | `numpy.int8` |
+| `SMALLINT` | `int` | `numpy.int16` |
+| `INT` | `int` | `numpy.int32` |
+| `BIGINT` | `int` | `numpy.int64` |
+| `FLOAT` | `float` | `numpy.float32` |
+| `DOUBLE` | `float` | `numpy.float64` |
+| `VARCHAR` | `str` | `str` |
+| `VARBINARY` | `bytes` | `bytes` |
+| `DECIMAL` | `decimal.Decimal` | `decimal.Decimal` |
+| `DATE` | `datetime.date` | `datetime.date` |
+| `TIME` | `datetime.time` | `datetime.time` |
+| `TimestampType` | `datetime.datetime` | `datetime.datetime` |
+| `LocalZonedTimestampType` | `datetime.datetime` | `datetime.datetime` |
+| `INTERVAL YEAR TO MONTH` | `int` | `Not Supported` |
+| `INTERVAL DAY TO SECOND` | `datetime.timedelta` | `Not Supported` |
+| `ARRAY` | `list` | `numpy.ndarray` |
+| `MULTISET` | `list` | `Not Supported` |
+| `MAP` | `dict` | `Not Supported` |
+| `ROW` | `Row` | `dict` |

--- a/docs/dev/table/types.md
+++ b/docs/dev/table/types.md
@@ -68,20 +68,23 @@ A list of all pre-defined data types can be found [below](#list-of-data-types).
 ### Data Types in the Table API
 
 Users of the JVM-based API work with instances of `org.apache.flink.table.types.DataType` within the Table API or when
-defining connectors, catalogs, or user-defined functions.
+defining connectors, catalogs, or user-defined functions. Users of the Python API work with instances of
+`pyflink.table.types.DataType` within the Python Table API or when defining Python user-defined functions.
 
 A `DataType` instance has two responsibilities:
 - **Declaration of a logical type** which does not imply a concrete physical representation for transmission
-or storage but defines the boundaries between JVM-based languages and the table ecosystem.
-- *Optional:* **Giving hints about the physical representation of data to the planner** which is useful at the edges to other APIs .
+or storage but defines the boundaries between JVM-based/Python languages and the table ecosystem.
+- *Optional:* **Giving hints about the physical representation of data to the planner** which is useful at the edges to other APIs.
+This is currently only available in the Java/Scalar Table API and still not available in the Python Table API.
 
 For JVM-based languages, all pre-defined data types are available in `org.apache.flink.table.api.DataTypes`.
-
-It is recommended to add a star import to your table programs for having a fluent API:
+For Python language, those types are available in `pyflink.table.types.DataTypes`.
 
 <div class="codetabs" markdown="1">
 
 <div data-lang="Java" markdown="1">
+It is recommended to add a star import to your table programs for having a fluent API:
+
 {% highlight java %}
 import static org.apache.flink.table.api.DataTypes.*;
 
@@ -90,10 +93,21 @@ DataType t = INTERVAL(DAY(), SECOND(3));
 </div>
 
 <div data-lang="Scala" markdown="1">
+It is recommended to add a star import to your table programs for having a fluent API:
+
 {% highlight scala %}
 import org.apache.flink.table.api.DataTypes._
 
 val t: DataType = INTERVAL(DAY(), SECOND(3));
+{% endhighlight %}
+</div>
+
+<div data-lang="Python" markdown="1">
+
+{% highlight python %}
+from pyflink.table.types import DataTypes
+
+t = DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND(3))
 {% endhighlight %}
 </div>
 
@@ -142,6 +156,8 @@ val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[A
 <span class="label label-danger">Attention</span> Please note that physical hints are usually only required if the
 API is extended. Users of predefined sources/sinks/functions do not need to define such hints. Hints within
 a table program (e.g. `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`) are ignored.
+
+<span class="label label-danger">Attention</span> Please note that physical hints are currently not supported in the Python Table API.
 
 Planner Compatibility
 ---------------------
@@ -236,6 +252,7 @@ List of Data Types
 ------------------
 
 This section lists all pre-defined data types. For the JVM-based Table API those types are also available in `org.apache.flink.table.api.DataTypes`.
+For the Python Table API, those types are available in `pyflink.table.types.DataTypes`.
 
 ### Character Strings
 
@@ -258,12 +275,6 @@ CHAR(n)
 {% highlight java %}
 DataTypes.CHAR(n)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `CHAR(n)` where `n` is the number of code points. `n` must have a value between `1`
-and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
 
 **Bridging to JVM Types**
 
@@ -272,6 +283,18 @@ and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to
 |`java.lang.String`                       | X     | X      | *Default*                |
 |`byte[]`                                 | X     | X      | Assumes UTF-8 encoding.  |
 |`org.apache.flink.table.data.StringData` | X     | X      | Internal data structure. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+Not supported.
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `CHAR(n)` where `n` is the number of code points. `n` must have a value between `1`
+and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
 
 #### `VARCHAR` / `STRING`
 
@@ -296,14 +319,6 @@ DataTypes.VARCHAR(n)
 
 DataTypes.STRING()
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `VARCHAR(n)` where `n` is the maximum number of code points. `n` must have a value
-between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
-
-`STRING` is a synonym for `VARCHAR(2147483647)`.
 
 **Bridging to JVM Types**
 
@@ -312,6 +327,24 @@ between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n`
 |`java.lang.String`                       | X     | X      | *Default*                |
 |`byte[]`                                 | X     | X      | Assumes UTF-8 encoding.  |
 |`org.apache.flink.table.data.StringData` | X     | X      | Internal data structure. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.VARCHAR(n)
+
+DataTypes.STRING()
+{% endhighlight %}
+
+<span class="label label-danger">Attention</span> The specified maximum number of code points `n` in `DataTypes.VARCHAR(n)` must be `2,147,483,647` currently.
+</div>
+</div>
+
+The type can be declared using `VARCHAR(n)` where `n` is the maximum number of code points. `n` must have a value
+between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
+
+`STRING` is a synonym for `VARCHAR(2147483647)`.
 
 ### Binary Strings
 
@@ -334,18 +367,24 @@ BINARY(n)
 {% highlight java %}
 DataTypes.BINARY(n)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `BINARY(n)` where `n` is the number of bytes. `n` must have a value
-between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
 
 **Bridging to JVM Types**
 
 | Java Type          | Input | Output | Remarks                 |
 |:-------------------|:-----:|:------:|:------------------------|
 |`byte[]`            | X     | X      | *Default*               |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+Not supported.
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `BINARY(n)` where `n` is the number of bytes. `n` must have a value
+between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
 
 #### `VARBINARY` / `BYTES`
 
@@ -370,8 +409,24 @@ DataTypes.VARBINARY(n)
 
 DataTypes.BYTES()
 {% endhighlight %}
+
+**Bridging to JVM Types**
+
+| Java Type          | Input | Output | Remarks                 |
+|:-------------------|:-----:|:------:|:------------------------|
+|`byte[]`            | X     | X      | *Default*               |
+
 </div>
 
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.VARBINARY(n)
+
+DataTypes.BYTES()
+{% endhighlight %}
+
+<span class="label label-danger">Attention</span> The specified maximum number of bytes `n` in `DataTypes.VARBINARY(n)` must be `2,147,483,647` currently.
+</div>
 </div>
 
 The type can be declared using `VARBINARY(n)` where `n` is the maximum number of bytes. `n` must
@@ -379,12 +434,6 @@ have a value between `1` and `2,147,483,647` (both inclusive). If no length is s
 equal to `1`.
 
 `BYTES` is a synonym for `VARBINARY(2147483647)`.
-
-**Bridging to JVM Types**
-
-| Java Type          | Input | Output | Remarks                 |
-|:-------------------|:-----:|:------:|:------------------------|
-|`byte[]`            | X     | X      | *Default*               |
 
 ### Exact Numerics
 
@@ -416,8 +465,23 @@ NUMERIC(p, s)
 {% highlight java %}
 DataTypes.DECIMAL(p, s)
 {% endhighlight %}
+
+**Bridging to JVM Types**
+
+| Java Type                                | Input | Output | Remarks                  |
+|:-----------------------------------------|:-----:|:------:|:-------------------------|
+|`java.math.BigDecimal`                    | X     | X      | *Default*                |
+|`org.apache.flink.table.data.DecimalData` | X     | X      | Internal data structure. |
+
 </div>
 
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.DECIMAL(p, s)
+{% endhighlight %}
+
+<span class="label label-danger">Attention</span> The `precision` and `scale` specified in `DataTypes.DECIMAL(p, s)` must be `38` and `18` separately currently.
+</div>
 </div>
 
 The type can be declared using `DECIMAL(p, s)` where `p` is the number of digits in a
@@ -427,13 +491,6 @@ must have a value between `0` and `p` (both inclusive). The default value for `p
 The default value for `s` is `0`.
 
 `NUMERIC(p, s)` and `DEC(p, s)` are synonyms for this type.
-
-**Bridging to JVM Types**
-
-| Java Type                                | Input | Output | Remarks                  |
-|:-----------------------------------------|:-----:|:------:|:-------------------------|
-|`java.math.BigDecimal`                    | X     | X      | *Default*                |
-|`org.apache.flink.table.data.DecimalData` | X     | X      | Internal data structure. |
 
 #### `TINYINT`
 
@@ -453,9 +510,6 @@ TINYINT
 {% highlight java %}
 DataTypes.TINYINT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -463,6 +517,15 @@ DataTypes.TINYINT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Byte`    | X     | X      | *Default*                                    |
 |`byte`              | X     | (X)    | Output only if type is not nullable.         |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TINYINT()
+{% endhighlight %}
+</div>
+</div>
 
 #### `SMALLINT`
 
@@ -482,9 +545,6 @@ SMALLINT
 {% highlight java %}
 DataTypes.SMALLINT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -492,6 +552,15 @@ DataTypes.SMALLINT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Short`   | X     | X      | *Default*                                    |
 |`short`             | X     | (X)    | Output only if type is not nullable.         |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.SMALLINT()
+{% endhighlight %}
+</div>
+</div>
 
 #### `INT`
 
@@ -513,11 +582,6 @@ INTEGER
 {% highlight java %}
 DataTypes.INT()
 {% endhighlight %}
-</div>
-
-</div>
-
-`INTEGER` is a synonym for this type.
 
 **Bridging to JVM Types**
 
@@ -525,6 +589,17 @@ DataTypes.INT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Integer` | X     | X      | *Default*                                    |
 |`int`               | X     | (X)    | Output only if type is not nullable.         |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.INT()
+{% endhighlight %}
+</div>
+</div>
+
+`INTEGER` is a synonym for this type.
 
 #### `BIGINT`
 
@@ -545,9 +620,6 @@ BIGINT
 {% highlight java %}
 DataTypes.BIGINT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -555,6 +627,15 @@ DataTypes.BIGINT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Long`    | X     | X      | *Default*                                    |
 |`long`              | X     | (X)    | Output only if type is not nullable.         |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.BIGINT()
+{% endhighlight %}
+</div>
+</div>
 
 ### Approximate Numerics
 
@@ -578,9 +659,6 @@ FLOAT
 {% highlight java %}
 DataTypes.FLOAT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -588,6 +666,15 @@ DataTypes.FLOAT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Float`   | X     | X      | *Default*                                    |
 |`float`             | X     | (X)    | Output only if type is not nullable.         |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.FLOAT()
+{% endhighlight %}
+</div>
+</div>
 
 #### `DOUBLE`
 
@@ -609,11 +696,6 @@ DOUBLE PRECISION
 {% highlight java %}
 DataTypes.DOUBLE()
 {% endhighlight %}
-</div>
-
-</div>
-
-`DOUBLE PRECISION` is a synonym for this type.
 
 **Bridging to JVM Types**
 
@@ -621,6 +703,17 @@ DataTypes.DOUBLE()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Double`  | X     | X      | *Default*                                    |
 |`double`            | X     | (X)    | Output only if type is not nullable.         |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.DOUBLE()
+{% endhighlight %}
+</div>
+</div>
+
+`DOUBLE PRECISION` is a synonym for this type.
 
 ### Date and Time
 
@@ -645,9 +738,6 @@ DATE
 {% highlight java %}
 DataTypes.DATE()
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -657,6 +747,15 @@ DataTypes.DATE()
 |`java.sql.Date`       | X     | X      |                                              |
 |`java.lang.Integer`   | X     | X      | Describes the number of days since epoch.    |
 |`int`                 | X     | (X)    | Describes the number of days since epoch.<br>Output only if type is not nullable. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.DATE()
+{% endhighlight %}
+</div>
+</div>
 
 #### `TIME`
 
@@ -682,13 +781,6 @@ TIME(p)
 {% highlight java %}
 DataTypes.TIME(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `TIME(p)` where `p` is the number of digits of fractional
-seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no
-precision is specified, `p` is equal to `0`.
 
 **Bridging to JVM Types**
 
@@ -700,6 +792,21 @@ precision is specified, `p` is equal to `0`.
 |`int`                 | X     | (X)    | Describes the number of milliseconds of the day.<br>Output only if type is not nullable. |
 |`java.lang.Long`      | X     | X      | Describes the number of nanoseconds of the day.     |
 |`long`                | X     | (X)    | Describes the number of nanoseconds of the day.<br>Output only if type is not nullable. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TIME(p)
+{% endhighlight %}
+
+<span class="label label-danger">Attention</span> The `precision` specified in `DataTypes.TIME(p)` must be `0` currently.
+</div>
+</div>
+
+The type can be declared using `TIME(p)` where `p` is the number of digits of fractional
+seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no
+precision is specified, `p` is equal to `0`.
 
 #### `TIMESTAMP`
 
@@ -732,15 +839,6 @@ TIMESTAMP(p) WITHOUT TIME ZONE
 {% highlight java %}
 DataTypes.TIMESTAMP(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `TIMESTAMP(p)` where `p` is the number of digits of fractional
-seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no precision
-is specified, `p` is equal to `6`.
-
-`TIMESTAMP(p) WITHOUT TIME ZONE` is a synonym for this type.
 
 **Bridging to JVM Types**
 
@@ -749,6 +847,23 @@ is specified, `p` is equal to `6`.
 |`java.time.LocalDateTime`                   | X     | X      | *Default*                |
 |`java.sql.Timestamp`                        | X     | X      |                          |
 |`org.apache.flink.table.data.TimestampData` | X     | X      | Internal data structure. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TIMESTAMP(p)
+{% endhighlight %}
+
+<span class="label label-danger">Attention</span> The `precision` specified in `DataTypes.TIMESTAMP(p)` must be `3` currently.
+</div>
+</div>
+
+The type can be declared using `TIMESTAMP(p)` where `p` is the number of digits of fractional
+seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no precision
+is specified, `p` is equal to `6`.
+
+`TIMESTAMP(p) WITHOUT TIME ZONE` is a synonym for this type.
 
 #### `TIMESTAMP WITH TIME ZONE`
 
@@ -778,13 +893,6 @@ TIMESTAMP(p) WITH TIME ZONE
 {% highlight java %}
 DataTypes.TIMESTAMP_WITH_TIME_ZONE(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `TIMESTAMP(p) WITH TIME ZONE` where `p` is the number of digits of
-fractional seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no
-precision is specified, `p` is equal to `6`.
 
 **Bridging to JVM Types**
 
@@ -792,6 +900,19 @@ precision is specified, `p` is equal to `6`.
 |:--------------------------|:-----:|:------:|:---------------------|
 |`java.time.OffsetDateTime` | X     | X      | *Default*            |
 |`java.time.ZonedDateTime`  | X     |        | Ignores the zone ID. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+Not supported.
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `TIMESTAMP(p) WITH TIME ZONE` where `p` is the number of digits of
+fractional seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no
+precision is specified, `p` is equal to `6`.
 
 #### `TIMESTAMP WITH LOCAL TIME ZONE`
 
@@ -824,13 +945,6 @@ TIMESTAMP(p) WITH LOCAL TIME ZONE
 {% highlight java %}
 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `TIMESTAMP(p) WITH LOCAL TIME ZONE` where `p` is the number
-of digits of fractional seconds (*precision*). `p` must have a value between `0` and `9`
-(both inclusive). If no precision is specified, `p` is equal to `6`.
 
 **Bridging to JVM Types**
 
@@ -842,6 +956,21 @@ of digits of fractional seconds (*precision*). `p` must have a value between `0`
 |`java.lang.Long`    | X     | X      | Describes the number of milliseconds since epoch. |
 |`long`              | X     | (X)    | Describes the number of milliseconds since epoch.<br>Output only if type is not nullable. |
 |`org.apache.flink.table.data.TimestampData` | X     | X      | Internal data structure. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
+{% endhighlight %}
+
+<span class="label label-danger">Attention</span> The `precision` specified in `DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)` must be `3` currently.
+</div>
+</div>
+
+The type can be declared using `TIMESTAMP(p) WITH LOCAL TIME ZONE` where `p` is the number
+of digits of fractional seconds (*precision*). `p` must have a value between `0` and `9`
+(both inclusive). If no precision is specified, `p` is equal to `6`.
 
 #### `INTERVAL YEAR TO MONTH`
 
@@ -879,13 +1008,6 @@ DataTypes.INTERVAL(DataTypes.YEAR(p))
 DataTypes.INTERVAL(DataTypes.YEAR(p), DataTypes.MONTH())
 DataTypes.INTERVAL(DataTypes.MONTH())
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using the above combinations where `p` is the number of digits of years
-(*year precision*). `p` must have a value between `1` and `4` (both inclusive). If no year precision
-is specified, `p` is equal to `2`.
 
 **Bridging to JVM Types**
 
@@ -895,7 +1017,23 @@ is specified, `p` is equal to `2`.
 |`java.lang.Integer` | X     | X      | Describes the number of months.    |
 |`int`               | X     | (X)    | Describes the number of months.<br>Output only if type is not nullable. |
 
-#### `INTERVAL DAY TO MONTH`
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.INTERVAL(DataTypes.YEAR())
+DataTypes.INTERVAL(DataTypes.YEAR(p))
+DataTypes.INTERVAL(DataTypes.YEAR(p), DataTypes.MONTH())
+DataTypes.INTERVAL(DataTypes.MONTH())
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using the above combinations where `p` is the number of digits of years
+(*year precision*). `p` must have a value between `1` and `4` (both inclusive). If no year precision
+is specified, `p` is equal to `2`.
+
+#### `INTERVAL DAY TO SECOND`
 
 Data type for a group of day-time interval types.
 
@@ -952,15 +1090,6 @@ DataTypes.INTERVAL(DataTypes.MINUTE(), DataTypes.SECOND(p2))
 DataTypes.INTERVAL(DataTypes.SECOND())
 DataTypes.INTERVAL(DataTypes.SECOND(p2))
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using the above combinations where `p1` is the number of digits of days
-(*day precision*) and `p2` is the number of digits of fractional seconds (*fractional precision*).
-`p1` must have a value between `1` and `6` (both inclusive). `p2` must have a value between `0`
-and `9` (both inclusive). If no `p1` is specified, it is equal to `2` by default. If no `p2` is
-specified, it is equal to `6` by default.
 
 **Bridging to JVM Types**
 
@@ -969,6 +1098,32 @@ specified, it is equal to `6` by default.
 |`java.time.Duration` | X     | X      | *Default*                             |
 |`java.lang.Long`     | X     | X      | Describes the number of milliseconds. |
 |`long`               | X     | (X)    | Describes the number of milliseconds.<br>Output only if type is not nullable. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.INTERVAL(DataTypes.DAY())
+DataTypes.INTERVAL(DataTypes.DAY(p1))
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.HOUR())
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.HOUR())
+DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.MINUTE(), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.SECOND())
+DataTypes.INTERVAL(DataTypes.SECOND(p2))
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using the above combinations where `p1` is the number of digits of days
+(*day precision*) and `p2` is the number of digits of fractional seconds (*fractional precision*).
+`p1` must have a value between `1` and `6` (both inclusive). `p2` must have a value between `0`
+and `9` (both inclusive). If no `p1` is specified, it is equal to `2` by default. If no `p2` is
+specified, it is equal to `6` by default.
 
 ### Constructured Data Types
 
@@ -994,15 +1149,6 @@ t ARRAY
 {% highlight java %}
 DataTypes.ARRAY(t)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `ARRAY<t>` where `t` is the data type of the contained
-elements.
-
-`t ARRAY` is a synonym for being closer to the SQL standard. For example, `INT ARRAY` is
-equivalent to `ARRAY<INT>`.
 
 **Bridging to JVM Types**
 
@@ -1012,6 +1158,21 @@ equivalent to `ARRAY<INT>`.
 | `java.util.List<t>`                    | X     | X      |                                   |
 | *subclass* of `java.util.List<t>`      | X     |        |                                   |
 |`org.apache.flink.table.data.ArrayData` | X     | X      | Internal data structure.          |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.ARRAY(t)
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `ARRAY<t>` where `t` is the data type of the contained
+elements.
+
+`t ARRAY` is a synonym for being closer to the SQL standard. For example, `INT ARRAY` is
+equivalent to `ARRAY<INT>`.
 
 #### `MAP`
 
@@ -1036,12 +1197,6 @@ MAP<kt, vt>
 {% highlight java %}
 DataTypes.MAP(kt, vt)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `MAP<kt, vt>` where `kt` is the data type of the key elements
-and `vt` is the data type of the value elements.
 
 **Bridging to JVM Types**
 
@@ -1050,6 +1205,18 @@ and `vt` is the data type of the value elements.
 | `java.util.Map<kt, vt>`               | X     | X      | *Default*                |
 | *subclass* of `java.util.Map<kt, vt>` | X     |        |                          |
 |`org.apache.flink.table.data.MapData`  | X     | X      | Internal data structure. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.MAP(kt, vt)
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `MAP<kt, vt>` where `kt` is the data type of the key elements
+and `vt` is the data type of the value elements.
 
 #### `MULTISET`
 
@@ -1073,15 +1240,6 @@ t MULTISET
 {% highlight java %}
 DataTypes.MULTISET(t)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `MULTISET<t>` where `t` is the data type
-of the contained elements.
-
-`t MULTISET` is a synonym for being closer to the SQL standard. For example, `INT MULTISET` is
-equivalent to `MULTISET<INT>`.
 
 **Bridging to JVM Types**
 
@@ -1090,6 +1248,21 @@ equivalent to `MULTISET<INT>`.
 |`java.util.Map<t, java.lang.Integer>`  | X     | X      | Assigns each value to an integer multiplicity. *Default* |
 | *subclass* of `java.util.Map<t, java.lang.Integer>>` | X     |        |                                           |
 |`org.apache.flink.table.data.MapData`  | X     | X      | Internal data structure.                                 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.MULTISET(t)
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `MULTISET<t>` where `t` is the data type
+of the contained elements.
+
+`t MULTISET` is a synonym for being closer to the SQL standard. For example, `INT MULTISET` is
+equivalent to `MULTISET<INT>`.
 
 #### `ROW`
 
@@ -1123,15 +1296,6 @@ ROW(n0 t0 'd0', n1 t1 'd1', ...)
 DataTypes.ROW(DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...)
 DataTypes.ROW(DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `ROW<n0 t0 'd0', n1 t1 'd1', ...>` where `n` is the unique name of
-a field, `t` is the logical type of a field, `d` is the description of a field.
-
-`ROW(...)` is a synonym for being closer to the SQL standard. For example, `ROW(myField INT, myOtherField BOOLEAN)` is
-equivalent to `ROW<myField INT, myOtherField BOOLEAN>`.
 
 **Bridging to JVM Types**
 
@@ -1139,6 +1303,22 @@ equivalent to `ROW<myField INT, myOtherField BOOLEAN>`.
 |:-------------------------------------|:-----:|:------:|:-------------------------|
 |`org.apache.flink.types.Row`          | X     | X      | *Default*                |
 |`org.apache.flink.table.data.RowData` | X     | X      | Internal data structure. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.ROW([DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...])
+DataTypes.ROW([DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...])
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `ROW<n0 t0 'd0', n1 t1 'd1', ...>` where `n` is the unique name of
+a field, `t` is the logical type of a field, `d` is the description of a field.
+
+`ROW(...)` is a synonym for being closer to the SQL standard. For example, `ROW(myField INT, myOtherField BOOLEAN)` is
+equivalent to `ROW<myField INT, myOtherField BOOLEAN>`.
 
 ### User-Defined Data Types
 
@@ -1209,6 +1389,15 @@ class User {
 
 DataTypes.of(User.class);
 {% endhighlight %}
+
+**Bridging to JVM Types**
+
+| Java Type                            | Input | Output | Remarks                                 |
+|:-------------------------------------|:-----:|:------:|:----------------------------------------|
+|*class*                               | X     | X      | Originating class or subclasses (for input) or <br>superclasses (for output). *Default* |
+|`org.apache.flink.types.Row`          | X     | X      | Represent the structured type as a row. |
+|`org.apache.flink.table.data.RowData` | X     | X      | Internal data structure.                |
+
 </div>
 
 <div data-lang="Scala" markdown="1">
@@ -1228,9 +1417,6 @@ case class User(
 
 DataTypes.of(classOf[User])
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -1239,6 +1425,15 @@ DataTypes.of(classOf[User])
 |*class*                               | X     | X      | Originating class or subclasses (for input) or <br>superclasses (for output). *Default* |
 |`org.apache.flink.types.Row`          | X     | X      | Represent the structured type as a row. |
 |`org.apache.flink.table.data.RowData` | X     | X      | Internal data structure.                |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+Not supported.
+{% endhighlight %}
+</div>
+</div>
 
 ### Other Data Types
 
@@ -1260,9 +1455,6 @@ BOOLEAN
 {% highlight java %}
 DataTypes.BOOLEAN()
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -1270,6 +1462,15 @@ DataTypes.BOOLEAN()
 |:-------------------|:-----:|:------:|:-------------------------------------|
 |`java.lang.Boolean` | X     | X      | *Default*                            |
 |`boolean`           | X     | (X)    | Output only if type is not nullable. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.BOOLEAN()
+{% endhighlight %}
+</div>
+</div>
 
 #### `RAW`
 
@@ -1294,16 +1495,6 @@ DataTypes.RAW(class, serializer)
 
 DataTypes.RAW(class)
 {% endhighlight %}
-</div>
-
-</div>
-
-The type can be declared using `RAW('class', 'snapshot')` where `class` is the originating class and
-`snapshot` is the serialized `TypeSerializerSnapshot` in Base64 encoding. Usually, the type string is not
-declared directly but is generated while persisting the type.
-
-In the API, the `RAW` type can be declared either by directly supplying a `Class` + `TypeSerializer` or
-by passing `Class` and letting the framework extract `Class` + `TypeSerializer` from there.
 
 **Bridging to JVM Types**
 
@@ -1312,6 +1503,22 @@ by passing `Class` and letting the framework extract `Class` + `TypeSerializer` 
 |*class*            | X     | X      | Originating class or subclasses (for input) or <br>superclasses (for output). *Default* |
 |`byte[]`           |       | X      |                                      |
 |`org.apache.flink.table.data.RawValueData` | X     | X      | Internal data structure. |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+Not supported.
+{% endhighlight %}
+</div>
+</div>
+
+The type can be declared using `RAW('class', 'snapshot')` where `class` is the originating class and
+`snapshot` is the serialized `TypeSerializerSnapshot` in Base64 encoding. Usually, the type string is not
+declared directly but is generated while persisting the type.
+
+In the API, the `RAW` type can be declared either by directly supplying a `Class` + `TypeSerializer` or
+by passing `Class` and letting the framework extract `Class` + `TypeSerializer` from there.
 
 #### `NULL`
 
@@ -1339,9 +1546,6 @@ NULL
 {% highlight java %}
 DataTypes.NULL()
 {% endhighlight %}
-</div>
-
-</div>
 
 **Bridging to JVM Types**
 
@@ -1349,6 +1553,15 @@ DataTypes.NULL()
 |:------------------|:-----:|:------:|:-------------------------------------|
 |`java.lang.Object` | X     | X      | *Default*                            |
 |*any class*        |       | (X)    | Any non-primitive type.              |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+Not supported.
+{% endhighlight %}
+</div>
+</div>
 
 Data Type Extraction
 --------------------

--- a/docs/dev/table/types.zh.md
+++ b/docs/dev/table/types.zh.md
@@ -54,19 +54,22 @@ Flink 的数据类型和 SQL 标准的 *数据类型* 术语类似，但也包�
 
 ### Table API 的数据类型
 
-JVM API 的用户可以在 Table API 中使用 `org.apache.flink.table.types.DataType` 的实例，以及定义连接器（Connector）、Catalog 或者用户自定义函数（User-Defined Function）。
+JVM API 的用户可以在 Table API 中、定义连接器（Connector）、Catalog 或者用户自定义函数（User-Defined Function）中使用
+`org.apache.flink.table.types.DataType` 的实例。Python API的用户可以在 Python Table API中、Python 用户自定义函数
+（Python User-Defined Function）中使用`pyflink.table.types.DataType` 的实例。
 
 一个 `DataType` 实例有两个作用：
-- **逻辑类型的声明**，它不表达具体物理类型的存储和转换，但是定义了基于 JVM 的语言和 Table 编程环境之间的边界。
-- *可选的：* **向 Planner 提供有关数据的物理表示的提示**，这对于边界 API 很有用。
+- **逻辑类型的声明**，它不表达具体物理类型的存储和转换，但是定义了基于 JVM 的语言或者 Python 语言和 Table 编程环境之间的边界。
+- *可选的：* **向 Planner 提供有关数据的物理表示的提示**，这对于边界 API 很有用。当前只支持在Java／Scala Table API中使用，Python Table API中尚不支持该功能。
 
 对于基于 JVM 的语言，所有预定义的数据类型都在 `org.apache.flink.table.api.DataTypes` 里提供。
-
-建议使用星号将全部的 API 导入到 Table 程序中以便于使用：
+对于 Python 的语言，所有预定义的数据类型都在 `pyflink.table.types.DataTypes` 里提供。
 
 <div class="codetabs" markdown="1">
 
 <div data-lang="Java" markdown="1">
+建议使用星号将全部的 API 导入到 Table 程序中以便于使用：
+
 {% highlight java %}
 import static org.apache.flink.table.api.DataTypes.*;
 
@@ -75,12 +78,22 @@ DataType t = INTERVAL(DAY(), SECOND(3));
 </div>
 
 <div data-lang="Scala" markdown="1">
+建议使用星号将全部的 API 导入到 Table 程序中以便于使用：
+
 {% highlight scala %}
 import org.apache.flink.table.api.DataTypes._
 
 val t: DataType = INTERVAL(DAY(), SECOND(3));
 {% endhighlight %}
 </div>
+
+<div data-lang="Python" markdown="1">
+
+{% highlight python %}
+from pyflink.table.types import DataTypes
+
+t = DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND(3))
+{% endhighlight %}
 
 </div>
 
@@ -122,6 +135,8 @@ val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[A
 
 <span class="label label-danger">注意</span> 请注意，通常只有在扩展 API 时才需要物理提示。
 预定义的 Source、Sink、Function 的用户不需要定义这样的提示。在 Table 编程中（例如 `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`）这些提示将被忽略。
+
+<span class="label label-danger">注意</span> 请注意，物理提示当前在Python Table API中尚不支持。
 
 Planner 兼容性
 ---------------------
@@ -207,6 +222,7 @@ Flink 1.9 之前引入的旧的 Planner 主要支持类型信息（Type Informat
 ------------------
 
 本节列出了所有预定义的数据类型。对于基于 JVM 的 Table API，这些类型也可以从 `org.apache.flink.table.api.DataTypes` 中找到。
+对于Python Table API, 这些类型可以从 `pyflink.table.types.DataTypes` 中找到。
 
 ### 字符串
 
@@ -229,11 +245,6 @@ CHAR(n)
 {% highlight java %}
 DataTypes.CHAR(n)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `CHAR(n)` 声明，其中 `n` 表示字符数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
 
 **JVM 类型**
 
@@ -242,6 +253,17 @@ DataTypes.CHAR(n)
 |`java.lang.String`                       | X     | X      | *缺省*               |
 |`byte[]`                                 | X     | X      | 假设使用 UTF-8 编码。 |
 |`org.apache.flink.table.data.StringData` | X     | X      | 内部数据结构。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+尚不支持
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `CHAR(n)` 声明，其中 `n` 表示字符数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
 
 #### `VARCHAR` / `STRING`
 
@@ -266,13 +288,6 @@ DataTypes.VARCHAR(n)
 
 DataTypes.STRING()
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `VARCHAR(n)` 声明，其中 `n` 表示最大的字符数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
-
-`STRING` 等价于 `VARCHAR(2147483647)`.
 
 **JVM 类型**
 
@@ -281,6 +296,23 @@ DataTypes.STRING()
 |`java.lang.String`                       | X     | X      | *缺省*               |
 |`byte[]`                                 | X     | X      | 假设使用 UTF-8 编码。 |
 |`org.apache.flink.table.data.StringData` | X     | X      | 内部数据结构。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.VARCHAR(n)
+
+DataTypes.STRING()
+{% endhighlight %}
+
+<span class="label label-danger">注意</span> 当前，声明`DataTypes.VARCHAR(n)`中的所指定的最大的字符数量 `n` 必须为 `2,147,483,647`。
+</div>
+</div>
+
+此类型用 `VARCHAR(n)` 声明，其中 `n` 表示最大的字符数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
+
+`STRING` 等价于 `VARCHAR(2147483647)`.
 
 ### 二进制字符串
 
@@ -303,17 +335,23 @@ BINARY(n)
 {% highlight java %}
 DataTypes.BINARY(n)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `BINARY(n)` 声明，其中 `n` 是字节数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
 
 **JVM 类型**
 
 | Java 类型          | 输入 | 输出 | 备注                 |
 |:-------------------|:-----:|:------:|:------------------------|
 |`byte[]`            | X     | X      | *缺省*               |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+尚不支持
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `BINARY(n)` 声明，其中 `n` 是字节数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
 
 #### `VARBINARY` / `BYTES`
 
@@ -338,19 +376,29 @@ DataTypes.VARBINARY(n)
 
 DataTypes.BYTES()
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `VARBINARY(n)` 声明，其中 `n` 是最大的字节数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
-
-`BYTES` 等价于 `VARBINARY(2147483647)`。
 
 **JVM 类型**
 
 | Java 类型          | 输入 | 输出 | 备注                 |
 |:-------------------|:-----:|:------:|:------------------------|
 |`byte[]`            | X     | X      | *缺省*               |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.VARBINARY(n)
+
+DataTypes.BYTES()
+{% endhighlight %}
+
+<span class="label label-danger">注意</span> 当前，声明`DataTypes.VARBINARY(n)`中的所指定的最大的字符数量 `n` 必须为 `2,147,483,647`。
+</div>
+</div>
+
+此类型用 `VARBINARY(n)` 声明，其中 `n` 是最大的字节数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
+
+`BYTES` 等价于 `VARBINARY(2147483647)`。
 
 ### 精确数值
 
@@ -382,13 +430,6 @@ NUMERIC(p, s)
 {% highlight java %}
 DataTypes.DECIMAL(p, s)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `DECIMAL(p, s)` 声明，其中 `p` 是数字的位数（*精度*），`s` 是数字中小数点右边的位数（*尾数*）。`p` 的值必须介于 `1` 和 `38` 之间（含边界值）。`s` 的值必须介于 `0` 和 `p` 之间（含边界值）。其中 `p` 的缺省值是 `10`，`s` 的缺省值是 `0`。
-
-`NUMERIC(p, s)` 和 `DEC(p, s)` 都等价于这个类型。
 
 **JVM 类型**
 
@@ -396,6 +437,21 @@ DataTypes.DECIMAL(p, s)
 |:-----------------------------------------|:-----:|:------:|:------------------------|
 |`java.math.BigDecimal`                    | X     | X      | *缺省*               |
 |`org.apache.flink.table.data.DecimalData` | X     | X      | 内部数据结构。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.DECIMAL(p, s)
+{% endhighlight %}
+
+<span class="label label-danger">注意</span> 当前，声明`DataTypes.DECIMAL(p, s)`中的所指定的精度 `p` 必须为38，尾数 `n` 必须为 `18`。
+</div>
+</div>
+
+此类型用 `DECIMAL(p, s)` 声明，其中 `p` 是数字的位数（*精度*），`s` 是数字中小数点右边的位数（*尾数*）。`p` 的值必须介于 `1` 和 `38` 之间（含边界值）。`s` 的值必须介于 `0` 和 `p` 之间（含边界值）。其中 `p` 的缺省值是 `10`，`s` 的缺省值是 `0`。
+
+`NUMERIC(p, s)` 和 `DEC(p, s)` 都等价于这个类型。
 
 #### `TINYINT`
 
@@ -415,9 +471,6 @@ TINYINT
 {% highlight java %}
 DataTypes.TINYINT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -425,6 +478,15 @@ DataTypes.TINYINT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Byte`    | X     | X      | *缺省*                                    |
 |`byte`              | X     | (X)    | 仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TINYINT()
+{% endhighlight %}
+</div>
+</div>
 
 #### `SMALLINT`
 
@@ -444,9 +506,6 @@ SMALLINT
 {% highlight java %}
 DataTypes.SMALLINT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -454,6 +513,15 @@ DataTypes.SMALLINT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Short`   | X     | X      | *缺省*                                    |
 |`short`             | X     | (X)    | 仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.SMALLINT()
+{% endhighlight %}
+</div>
+</div>
 
 #### `INT`
 
@@ -475,11 +543,6 @@ INTEGER
 {% highlight java %}
 DataTypes.INT()
 {% endhighlight %}
-</div>
-
-</div>
-
-`INTEGER` 等价于此类型。
 
 **JVM 类型**
 
@@ -487,6 +550,17 @@ DataTypes.INT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Integer` | X     | X      | *缺省*                                    |
 |`int`               | X     | (X)    | 仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.INT()
+{% endhighlight %}
+</div>
+</div>
+
+`INTEGER` 等价于此类型。
 
 #### `BIGINT`
 
@@ -506,9 +580,6 @@ BIGINT
 {% highlight java %}
 DataTypes.BIGINT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -516,6 +587,15 @@ DataTypes.BIGINT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Long`    | X     | X      | *缺省*                                    |
 |`long`              | X     | (X)    | 仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.BIGINT()
+{% endhighlight %}
+</div>
+</div>
 
 ### 近似数值
 
@@ -539,9 +619,6 @@ FLOAT
 {% highlight java %}
 DataTypes.FLOAT()
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -549,6 +626,15 @@ DataTypes.FLOAT()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Float`   | X     | X      | *缺省*                                    |
 |`float`             | X     | (X)    | 仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.FLOAT()
+{% endhighlight %}
+</div>
+</div>
 
 #### `DOUBLE`
 
@@ -570,11 +656,6 @@ DOUBLE PRECISION
 {% highlight java %}
 DataTypes.DOUBLE()
 {% endhighlight %}
-</div>
-
-</div>
-
-`DOUBLE PRECISION` 等价于此类型。
 
 **JVM 类型**
 
@@ -582,6 +663,17 @@ DataTypes.DOUBLE()
 |:-------------------|:-----:|:------:|:---------------------------------------------|
 |`java.lang.Double`  | X     | X      | *缺省*                                    |
 |`double`            | X     | (X)    | 仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.DOUBLE()
+{% endhighlight %}
+</div>
+</div>
+
+`DOUBLE PRECISION` 等价于此类型。
 
 ### 日期和时间
 
@@ -605,9 +697,6 @@ DATE
 {% highlight java %}
 DataTypes.DATE()
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -617,6 +706,15 @@ DataTypes.DATE()
 |`java.sql.Date`       | X     | X      |                                              |
 |`java.lang.Integer`   | X     | X      | 描述从 Epoch 算起的天数。    |
 |`int`                 | X     | (X)    | 描述从 Epoch 算起的天数。<br>仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.DATE()
+{% endhighlight %}
+</div>
+</div>
 
 #### `TIME`
 
@@ -639,11 +737,6 @@ TIME(p)
 {% highlight java %}
 DataTypes.TIME(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `TIME(p)` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `0`。
 
 **JVM 类型**
 
@@ -655,6 +748,19 @@ DataTypes.TIME(p)
 |`int`                 | X     | (X)    | 描述自当天以来的毫秒数。<br>仅当类型不可为空时才输出。 |
 |`java.lang.Long`      | X     | X      | 描述自当天以来的纳秒数。     |
 |`long`                | X     | (X)    | 描述自当天以来的纳秒数。<br>仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TIME(p)
+{% endhighlight %}
+
+<span class="label label-danger">注意</span> 当前，声明`DataTypes.TIME(p)`中的所指定的精度 `p` 必须为0。
+</div>
+</div>
+
+此类型用 `TIME(p)` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `0`。
 
 #### `TIMESTAMP`
 
@@ -682,13 +788,6 @@ TIMESTAMP(p) WITHOUT TIME ZONE
 {% highlight java %}
 DataTypes.TIMESTAMP(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `TIMESTAMP(p)` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `6`。
-
-`TIMESTAMP(p) WITHOUT TIME ZONE` 等价于此类型。
 
 **JVM 类型**
 
@@ -697,6 +796,21 @@ DataTypes.TIMESTAMP(p)
 |`java.time.LocalDateTime`                   | X     | X      | *缺省*                            |
 |`java.sql.Timestamp`                        | X     | X      |                                   |
 |`org.apache.flink.table.data.TimestampData` | X     | X      | 内部数据结构。                      |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TIMESTAMP(p)
+{% endhighlight %}
+
+<span class="label label-danger">注意</span> 当前，声明`DataTypes.TIMESTAMP(p)`中的所指定的精度 `p` 必须为3。
+</div>
+</div>
+
+此类型用 `TIMESTAMP(p)` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `6`。
+
+`TIMESTAMP(p) WITHOUT TIME ZONE` 等价于此类型。
 
 #### `TIMESTAMP WITH TIME ZONE`
 
@@ -722,11 +836,6 @@ TIMESTAMP(p) WITH TIME ZONE
 {% highlight java %}
 DataTypes.TIMESTAMP_WITH_TIME_ZONE(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `TIMESTAMP(p) WITH TIME ZONE` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `6`。
 
 **JVM 类型**
 
@@ -734,6 +843,17 @@ DataTypes.TIMESTAMP_WITH_TIME_ZONE(p)
 |:--------------------------|:-----:|:------:|:---------------------|
 |`java.time.OffsetDateTime` | X     | X      | *缺省*            |
 |`java.time.ZonedDateTime`  | X     |        | 忽略时区 ID。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+尚不支持
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `TIMESTAMP(p) WITH TIME ZONE` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `6`。
 
 #### `TIMESTAMP WITH LOCAL TIME ZONE`
 
@@ -761,11 +881,6 @@ TIMESTAMP(p) WITH LOCAL TIME ZONE
 {% highlight java %}
 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `TIMESTAMP(p) WITH LOCAL TIME ZONE` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `6`。
 
 **JVM 类型**
 
@@ -777,6 +892,19 @@ DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 |`java.lang.Long`                            | X     | X      | 描述从 Epoch 算起的毫秒数。                          |
 |`long`                                      | X     | (X)    | 描述从 Epoch 算起的毫秒数。<br>仅当类型不可为空时才输出 |
 |`org.apache.flink.table.data.TimestampData` | X     | X      | 内部数据结构。                                       |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
+{% endhighlight %}
+
+<span class="label label-danger">注意</span> 当前，声明`DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)`中的所指定的精度 `p` 必须为3。
+</div>
+</div>
+
+此类型用 `TIMESTAMP(p) WITH LOCAL TIME ZONE` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `6`。
 
 #### `INTERVAL YEAR TO MONTH`
 
@@ -811,11 +939,6 @@ DataTypes.INTERVAL(DataTypes.YEAR(p))
 DataTypes.INTERVAL(DataTypes.YEAR(p), DataTypes.MONTH())
 DataTypes.INTERVAL(DataTypes.MONTH())
 {% endhighlight %}
-</div>
-
-</div>
-
-可以使用以上组合来声明类型，其中 `p` 是年数（*年精度*）的位数。`p` 的值必须介于 `1` 和 `4` 之间（含边界值）。如果未指定年精度，`p` 则等于 `2`。
 
 **JVM 类型**
 
@@ -825,7 +948,21 @@ DataTypes.INTERVAL(DataTypes.MONTH())
 |`java.lang.Integer` | X     | X      | 描述月的数量。    |
 |`int`               | X     | (X)    | 描述月的数量。<br>仅当类型不可为空时才输出。 |
 
-#### `INTERVAL DAY TO MONTH`
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.INTERVAL(DataTypes.YEAR())
+DataTypes.INTERVAL(DataTypes.YEAR(p))
+DataTypes.INTERVAL(DataTypes.YEAR(p), DataTypes.MONTH())
+DataTypes.INTERVAL(DataTypes.MONTH())
+{% endhighlight %}
+</div>
+</div>
+
+可以使用以上组合来声明类型，其中 `p` 是年数（*年精度*）的位数。`p` 的值必须介于 `1` 和 `4` 之间（含边界值）。如果未指定年精度，`p` 则等于 `2`。
+
+#### `INTERVAL DAY TO SECOND`
 
 一组 Day-Time Interval 数据类型。
 
@@ -881,11 +1018,6 @@ DataTypes.INTERVAL(DataTypes.MINUTE(), DataTypes.SECOND(p2))
 DataTypes.INTERVAL(DataTypes.SECOND())
 DataTypes.INTERVAL(DataTypes.SECOND(p2))
 {% endhighlight %}
-</div>
-
-</div>
-
-可以使用以上组合来声明类型，其中 `p1` 是天数（*天精度*）的位数，`p2` 是秒的小数部分的位数（*小数精度*）。`p1` 的值必须介于 `1` 和之间 `6`（含边界值），`p2` 的值必须介于 `0` 和之间 `9`（含边界值）。如果 `p1` 未指定值，则缺省等于 `2`，如果 `p2` 未指定值，则缺省等于 `6`。
 
 **JVM 类型**
 
@@ -894,6 +1026,28 @@ DataTypes.INTERVAL(DataTypes.SECOND(p2))
 |`java.time.Duration` | X     | X      | *缺省*                             |
 |`java.lang.Long`     | X     | X      | 描述毫秒数。 |
 |`long`               | X     | (X)    | 描述毫秒数。<br>仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.INTERVAL(DataTypes.DAY())
+DataTypes.INTERVAL(DataTypes.DAY(p1))
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.HOUR())
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.DAY(p1), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.HOUR())
+DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.MINUTE())
+DataTypes.INTERVAL(DataTypes.MINUTE(), DataTypes.SECOND(p2))
+DataTypes.INTERVAL(DataTypes.SECOND())
+DataTypes.INTERVAL(DataTypes.SECOND(p2))
+{% endhighlight %}
+</div>
+</div>
+
+可以使用以上组合来声明类型，其中 `p1` 是天数（*天精度*）的位数，`p2` 是秒的小数部分的位数（*小数精度*）。`p1` 的值必须介于 `1` 和之间 `6`（含边界值），`p2` 的值必须介于 `0` 和之间 `9`（含边界值）。如果 `p1` 未指定值，则缺省等于 `2`，如果 `p2` 未指定值，则缺省等于 `6`。
 
 ### 结构化的数据类型
 
@@ -918,13 +1072,6 @@ t ARRAY
 {% highlight java %}
 DataTypes.ARRAY(t)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `ARRAY<t>` 声明，其中 `t` 是所包含元素的数据类型。
-
-`t ARRAY` 接近等价于 SQL 标准。例如，`INT ARRAY` 等价于 `ARRAY<INT>`。
 
 **JVM 类型**
 
@@ -934,6 +1081,19 @@ DataTypes.ARRAY(t)
 | `java.util.List<t>`                    | X     | X      |                                   |
 | `java.util.List<t>` 的*子类型*          | X     |        |                                   |
 |`org.apache.flink.table.data.ArrayData` | X     | X      | 内部数据结构。                    |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.ARRAY(t)
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `ARRAY<t>` 声明，其中 `t` 是所包含元素的数据类型。
+
+`t ARRAY` 接近等价于 SQL 标准。例如，`INT ARRAY` 等价于 `ARRAY<INT>`。
 
 #### `MAP`
 
@@ -957,11 +1117,6 @@ MAP<kt, vt>
 {% highlight java %}
 DataTypes.MAP(kt, vt)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `MAP<kt, vt>` 声明，其中 `kt` 是键的数据类型，`vt` 是值的数据类型。
 
 **JVM 类型**
 
@@ -970,6 +1125,17 @@ DataTypes.MAP(kt, vt)
 | `java.util.Map<kt, vt>`               | X     | X      | *缺省*         |
 | `java.util.Map<kt, vt>` 的*子类型*    | X     |        |                |
 |`org.apache.flink.table.data.MapData`  | X     | X      | 内部数据结构。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.MAP(kt, vt)
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `MAP<kt, vt>` 声明，其中 `kt` 是键的数据类型，`vt` 是值的数据类型。
 
 #### `MULTISET`
 
@@ -992,13 +1158,6 @@ t MULTISET
 {% highlight java %}
 DataTypes.MULTISET(t)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `MULTISET<t>` 声明，其中 `t` 是所包含元素的数据类型。
-
-`t MULTISET` 接近等价于 SQL 标准。例如，`INT MULTISET` 等价于 `MULTISET<INT>`。
 
 **JVM 类型**
 
@@ -1007,6 +1166,19 @@ DataTypes.MULTISET(t)
 |`java.util.Map<t, java.lang.Integer>`             | X     | X      | 将每个值可多重地分配给一个整数 *缺省*                 |
 | `java.util.Map<t, java.lang.Integer>` 的*子类型* | X     |        |                                                       |
 |`org.apache.flink.table.data.MapData`             | X     | X      | 内部数据结构。                                        |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.MULTISET(t)
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `MULTISET<t>` 声明，其中 `t` 是所包含元素的数据类型。
+
+`t MULTISET` 接近等价于 SQL 标准。例如，`INT MULTISET` 等价于 `MULTISET<INT>`。
 
 #### `ROW`
 
@@ -1037,13 +1209,6 @@ ROW(n0 t0 'd0', n1 t1 'd1', ...)
 DataTypes.ROW(DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...)
 DataTypes.ROW(DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `ROW<n0 t0 'd0', n1 t1 'd1', ...>` 声明，其中 `n` 是唯一的字段名称，`t` 是字段的逻辑类型，`d` 是字段的描述。
-
-`ROW(...)` 接近等价于 SQL 标准。例如，`ROW(myField INT, myOtherField BOOLEAN)` 等价于 `ROW<myField INT, myOtherField BOOLEAN>`。
 
 **JVM 类型**
 
@@ -1051,6 +1216,20 @@ DataTypes.ROW(DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...)
 |:-------------------------------------|:-----:|:------:|:------------------------|
 |`org.apache.flink.types.Row`          | X     | X      | *缺省*                  |
 |`org.apache.flink.table.data.RowData` | X     | X      | 内部数据结构。          |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.ROW([DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...])
+DataTypes.ROW([DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...])
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `ROW<n0 t0 'd0', n1 t1 'd1', ...>` 声明，其中 `n` 是唯一的字段名称，`t` 是字段的逻辑类型，`d` 是字段的描述。
+
+`ROW(...)` 接近等价于 SQL 标准。例如，`ROW(myField INT, myOtherField BOOLEAN)` 等价于 `ROW<myField INT, myOtherField BOOLEAN>`。
 
 ### 用户自定义数据类型
 
@@ -1107,6 +1286,15 @@ class User {
 
 DataTypes.of(User.class);
 {% endhighlight %}
+
+**JVM 类型**
+
+| Java 类型                            | 输入  | 输出   | 备注                                                  |
+|:-------------------------------------|:-----:|:------:|:------------------------------------------------------|
+|*类型*                               | X     | X      | 原始类或子类（用于输入）或超类（用于输出）*缺省*      |
+|`org.apache.flink.types.Row`          | X     | X      | 代表一行数据的结构化类型。                            |
+|`org.apache.flink.table.data.RowData` | X     | X      | 内部数据结构。                                        |
+
 </div>
 
 <div data-lang="Scala" markdown="1">
@@ -1126,9 +1314,6 @@ case class User(
 
 DataTypes.of(classOf[User])
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -1137,6 +1322,10 @@ DataTypes.of(classOf[User])
 |*类型*                               | X     | X      | 原始类或子类（用于输入）或超类（用于输出）*缺省*      |
 |`org.apache.flink.types.Row`          | X     | X      | 代表一行数据的结构化类型。                            |
 |`org.apache.flink.table.data.RowData` | X     | X      | 内部数据结构。                                        |
+
+</div>
+
+</div>
 
 ### 其他数据类型
 
@@ -1158,9 +1347,6 @@ BOOLEAN
 {% highlight java %}
 DataTypes.BOOLEAN()
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -1168,6 +1354,15 @@ DataTypes.BOOLEAN()
 |:-------------------|:-----:|:------:|:-------------------------------------|
 |`java.lang.Boolean` | X     | X      | *缺省*                            |
 |`boolean`           | X     | (X)    | 仅当类型不可为空时才输出。 |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+DataTypes.BOOLEAN()
+{% endhighlight %}
+</div>
+</div>
 
 #### `RAW`
 
@@ -1191,13 +1386,6 @@ DataTypes.RAW(class, serializer)
 
 DataTypes.RAW(class)
 {% endhighlight %}
-</div>
-
-</div>
-
-此类型用 `RAW('class', 'snapshot')` 声明，其中 `class` 是原始类，`snapshot` 是 Base64 编码的序列化的 `TypeSerializerSnapshot`。通常，类型字符串不是直接声明的，而是在持久化类型时生成的。
-
-在 API 中，可以通过直接提供 `Class` + `TypeSerializer` 或通过传递 `TypeInformation` 并让框架从那里提取 `Class` + `TypeSerializer` 来声明 `RAW` 类型。
 
 **JVM 类型**
 
@@ -1206,6 +1394,19 @@ DataTypes.RAW(class)
 |*类型*                                     | X     | X      | 原始类或子类（用于输入）或超类（用于输出）。 *缺省* |
 |`byte[]`                                   |       | X      |                                                     |
 |`org.apache.flink.table.data.RawValueData` | X     | X      | 内部数据结构。                                      |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+尚不支持
+{% endhighlight %}
+</div>
+</div>
+
+此类型用 `RAW('class', 'snapshot')` 声明，其中 `class` 是原始类，`snapshot` 是 Base64 编码的序列化的 `TypeSerializerSnapshot`。通常，类型字符串不是直接声明的，而是在持久化类型时生成的。
+
+在 API 中，可以通过直接提供 `Class` + `TypeSerializer` 或通过传递 `TypeInformation` 并让框架从那里提取 `Class` + `TypeSerializer` 来声明 `RAW` 类型。
 
 #### `NULL`
 
@@ -1231,9 +1432,6 @@ NULL
 {% highlight java %}
 DataTypes.NULL()
 {% endhighlight %}
-</div>
-
-</div>
 
 **JVM 类型**
 
@@ -1241,6 +1439,15 @@ DataTypes.NULL()
 |:------------------|:-----:|:------:|:-------------------------------------|
 |`java.lang.Object` | X     | X      | *缺省*                            |
 |*任何类型*        |       | (X)    | 任何非基本数据类型              |
+
+</div>
+
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+尚不支持
+{% endhighlight %}
+</div>
+</div>
 
 数据类型注解
 ---------------------


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add documentation about data types in Python Table API*

## Brief change log

  - *Add documentation about data types in Python Table API*


## Verifying this change

This change is a documentation rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
