### PR TITLE
[FLINK-18849][docs] Improve the code tabs of the Flink documents.

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2737,86 +2737,27 @@ Table table = input
   .window([OverWindow w].as("w"))           // define over window with alias w
   .select($("a"), $("b").sum().over($("w")), $("c").min().over($("w"))); // aggregate over the over window w
 {% endhighlight %}
-
-The `OverWindow` defines a range of rows over which aggregates are computed. `OverWindow` is not an interface that users can implement. Instead, the Table API provides the `Over` class to configure the properties of the over window. Over windows can be defined on event-time or processing-time and on ranges specified as time interval or row-count. The supported over window definitions are exposed as methods on `Over` (and other classes) and are listed below:
-
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Required</th>
-      <th class="text-left">Description</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td><code>partitionBy</code></td>
-      <td>Optional</td>
-      <td>
-        <p>Defines a partitioning of the input on one or more attributes. Each partition is individually sorted and aggregate functions are applied to each partition separately.</p>
-
-        <p><b>Note:</b> In streaming environments, over window aggregates can only be computed in parallel if the window includes a partition by clause. Without <code>partitionBy(...)</code> the stream is processed by a single, non-parallel task.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>orderBy</code></td>
-      <td>Required</td>
-      <td>
-        <p>Defines the order of rows within each partition and thereby the order in which the aggregate functions are applied to rows.</p>
-
-        <p><b>Note:</b> For streaming queries this must be a <a href="streaming/time_attributes.html">declared event-time or processing-time time attribute</a>. Currently, only a single sort attribute is supported.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>preceding</code></td>
-      <td>Optional</td>
-      <td>
-        <p>Defines the interval of rows that are included in the window and precede the current row. The interval can either be specified as time or row-count interval.</p>
-
-        <p><a href="tableApi.html#bounded-over-windows">Bounded over windows</a> are specified with the size of the interval, e.g., <code>10.minutes</code> for a time interval or <code>10.rows</code> for a row-count interval.</p>
-
-        <p><a href="tableApi.html#unbounded-over-windows">Unbounded over windows</a> are specified using a constant, i.e., <code>UNBOUNDED_RANGE</code> for a time interval or <code>UNBOUNDED_ROW</code> for a row-count interval. Unbounded over windows start with the first row of a partition.</p>
-
-        <p>If the <code>preceding</code> clause is omitted, <code>UNBOUNDED_RANGE</code> and <code>CURRENT_RANGE</code> are used as the default <code>preceding</code> and <code>following</code> for the window.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>following</code></td>
-      <td>Optional</td>
-      <td>
-        <p>Defines the window interval of rows that are included in the window and follow the current row. The interval must be specified in the same unit as the preceding interval (time or row-count).</p>
-
-        <p>At the moment, over windows with rows following the current row are not supported. Instead you can specify one of two constants:</p>
-
-        <ul>
-          <li><code>CURRENT_ROW</code> sets the upper bound of the window to the current row.</li>
-          <li><code>CURRENT_RANGE</code> sets the upper bound of the window to sort key of the current row, i.e., all rows with the same sort key as the current row are included in the window.</li>
-        </ul>
-
-        <p>If the <code>following</code> clause is omitted, the upper bound of a time interval window is defined as <code>CURRENT_RANGE</code> and the upper bound of a row-count interval window is defined as <code>CURRENT_ROW</code>.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>as</code></td>
-      <td>Required</td>
-      <td>
-        <p>Assigns an alias to the over window. The alias is used to reference the over window in the following <code>select()</code> clause.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
 </div>
-
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 val table = input
   .window([w: OverWindow] as $"w")              // define over window with alias w
   .select($"a", $"b".sum over $"w", $"c".min over $"w") // aggregate over the over window w
 {% endhighlight %}
+</div>
+<div data-lang="python" markdown="1">
+{% highlight python %}
+# define over window with alias w and aggregate over the over window w
+table = input.over_window([w: OverWindow].alias("w")) \
+    .select("a, b.sum over w, c.min over w")
+{% endhighlight %}
+</div>
+</div>
 
 The `OverWindow` defines a range of rows over which aggregates are computed. `OverWindow` is not an interface that users can implement. Instead, the Table API provides the `Over` class to configure the properties of the over window. Over windows can be defined on event-time or processing-time and on ranges specified as time interval or row-count. The supported over window definitions are exposed as methods on `Over` (and other classes) and are listed below:
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="java/scala" markdown="1">
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -2886,15 +2827,6 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
 </div>
 
 <div data-lang="python" markdown="1">
-{% highlight python %}
-# define over window with alias w and aggregate over the over window w
-table = input.over_window([w: OverWindow].alias("w")) \
-    .select("a, b.sum over w, c.min over w")
-{% endhighlight %}
-</div>
-
-The `OverWindow` defines a range of rows over which aggregates are computed. `OverWindow` is not an interface that users can implement. Instead, the Table API provides the `Over` class to configure the properties of the over window. Over windows can be defined on event-time or processing-time and on ranges specified as time interval or row-count. The supported over window definitions are exposed as methods on `Over` (and other classes) and are listed below:
-
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -2961,6 +2893,7 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
     </tr>
   </tbody>
 </table>
+</div>
 </div>
 
 **Note:** Currently, all aggregation functions in the same `select()` call must be computed of the same over window.

--- a/docs/dev/table/tableApi.zh.md
+++ b/docs/dev/table/tableApi.zh.md
@@ -2734,86 +2734,27 @@ Table table = input
   .window([OverWindow w].as("w"))           // define over window with alias w
   .select($("a"), $("b").sum().over($("w")), $("c").min().over($("w"))); // aggregate over the over window w
 {% endhighlight %}
-
-The `OverWindow` defines a range of rows over which aggregates are computed. `OverWindow` is not an interface that users can implement. Instead, the Table API provides the `Over` class to configure the properties of the over window. Over windows can be defined on event-time or processing-time and on ranges specified as time interval or row-count. The supported over window definitions are exposed as methods on `Over` (and other classes) and are listed below:
-
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Required</th>
-      <th class="text-left">Description</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td><code>partitionBy</code></td>
-      <td>Optional</td>
-      <td>
-        <p>Defines a partitioning of the input on one or more attributes. Each partition is individually sorted and aggregate functions are applied to each partition separately.</p>
-
-        <p><b>Note:</b> In streaming environments, over window aggregates can only be computed in parallel if the window includes a partition by clause. Without <code>partitionBy(...)</code> the stream is processed by a single, non-parallel task.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>orderBy</code></td>
-      <td>Required</td>
-      <td>
-        <p>Defines the order of rows within each partition and thereby the order in which the aggregate functions are applied to rows.</p>
-
-        <p><b>Note:</b> For streaming queries this must be a <a href="streaming/time_attributes.html">declared event-time or processing-time time attribute</a>. Currently, only a single sort attribute is supported.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>preceding</code></td>
-      <td>Optional</td>
-      <td>
-        <p>Defines the interval of rows that are included in the window and precede the current row. The interval can either be specified as time or row-count interval.</p>
-
-        <p><a href="tableApi.html#bounded-over-windows">Bounded over windows</a> are specified with the size of the interval, e.g., <code>10.minutes</code> for a time interval or <code>10.rows</code> for a row-count interval.</p>
-
-        <p><a href="tableApi.html#unbounded-over-windows">Unbounded over windows</a> are specified using a constant, i.e., <code>UNBOUNDED_RANGE</code> for a time interval or <code>UNBOUNDED_ROW</code> for a row-count interval. Unbounded over windows start with the first row of a partition.</p>
-
-        <p>If the <code>preceding</code> clause is omitted, <code>UNBOUNDED_RANGE</code> and <code>CURRENT_RANGE</code> are used as the default <code>preceding</code> and <code>following</code> for the window.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>following</code></td>
-      <td>Optional</td>
-      <td>
-        <p>Defines the window interval of rows that are included in the window and follow the current row. The interval must be specified in the same unit as the preceding interval (time or row-count).</p>
-
-        <p>At the moment, over windows with rows following the current row are not supported. Instead you can specify one of two constants:</p>
-
-        <ul>
-          <li><code>CURRENT_ROW</code> sets the upper bound of the window to the current row.</li>
-          <li><code>CURRENT_RANGE</code> sets the upper bound of the window to sort key of the current row, i.e., all rows with the same sort key as the current row are included in the window.</li>
-        </ul>
-
-        <p>If the <code>following</code> clause is omitted, the upper bound of a time interval window is defined as <code>CURRENT_RANGE</code> and the upper bound of a row-count interval window is defined as <code>CURRENT_ROW</code>.</p>
-      </td>
-    </tr>
-    <tr>
-      <td><code>as</code></td>
-      <td>Required</td>
-      <td>
-        <p>Assigns an alias to the over window. The alias is used to reference the over window in the following <code>select()</code> clause.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
 </div>
-
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 val table = input
   .window([w: OverWindow] as $"w")              // define over window with alias w
   .select($"a", $"b".sum over $"w", $"c".min over $"w") // aggregate over the over window w
 {% endhighlight %}
+</div>
+<div data-lang="python" markdown="1">
+{% highlight python %}
+# define over window with alias w and aggregate over the over window w
+table = input.over_window([w: OverWindow].alias("w")) \
+    .select("a, b.sum over w, c.min over w")
+{% endhighlight %}
+</div>
+</div>
 
 The `OverWindow` defines a range of rows over which aggregates are computed. `OverWindow` is not an interface that users can implement. Instead, the Table API provides the `Over` class to configure the properties of the over window. Over windows can be defined on event-time or processing-time and on ranges specified as time interval or row-count. The supported over window definitions are exposed as methods on `Over` (and other classes) and are listed below:
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="java/scala" markdown="1">
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -2883,14 +2824,6 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
 </div>
 
 <div data-lang="python" markdown="1">
-{% highlight python %}
-# define over window with alias w and aggregate over the over window w
-table = input.over_window([w: OverWindow].alias("w")) \
-    .select("a, b.sum over w, c.min over w")
-{% endhighlight %}
-
-The `OverWindow` defines a range of rows over which aggregates are computed. `OverWindow` is not an interface that users can implement. Instead, the Table API provides the `Over` class to configure the properties of the over window. Over windows can be defined on event-time or processing-time and on ranges specified as time interval or row-count. The supported over window definitions are exposed as methods on `Over` (and other classes) and are listed below:
-
 <table class="table table-bordered">
   <thead>
     <tr>

--- a/docs/dev/table/types.md
+++ b/docs/dev/table/types.md
@@ -181,15 +181,29 @@ val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[A
 API is extended. Users of predefined sources/sinks/functions do not need to define such hints. Hints within
 a table program (e.g. `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`) are ignored.
 
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 Planner Compatibility
 ---------------------
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 As mentioned in the introduction, reworking the type system will span multiple releases, and the support of each data
 type depends on the used planner. This section aims to summarize the most significant differences.
+</div>
+<div data-lang="Python" markdown="1">
+This part is for Java/Scala users.
+There are no known similiar planner compatibility issues on the data types of Python Table API currently. 
+</div>
+</div>
 
 ### Old Planner
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 Flink's old planner, introduced before Flink 1.9, primarily supports type information. It has only limited
 support for data types. It is possible to declare data types that can be translated into type information such that the
 old planner understands them.
@@ -228,9 +242,16 @@ For the *Data Type Representation* column the table omits the prefix `org.apache
 
 <span class="label label-danger">Attention</span> If there is a problem with the new type system. Users
 can fallback to type information defined in `org.apache.flink.table.api.Types` at any time.
+</div>
+<div data-lang="Python" markdown="1">
+N/A
+</div>
+</div>
 
 ### New Blink Planner
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 The new Blink planner supports all of types of the old planner. This includes in particular
 the listed Java expression strings and type information.
 
@@ -261,18 +282,26 @@ The following data types are supported:
 | `ROW` | |
 | `RAW` | |
 | stuctured types | Only exposed in user-defined functions yet. |
+</div>
+<div data-lang="Python" markdown="1">
+N/A
+</div>
+</div>
 
 Limitations
 -----------
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 **Java Expression String**: Java expression strings in the Table API such as `table.select("field.cast(STRING)")`
 have not been updated to the new type system yet. Use the string representations declared in
 the [old planner section](#old-planner).
 
 **User-defined Functions**: User-defined aggregate functions cannot declare a data type yet. Scalar and table functions fully support data types.
-
 </div>
 <div data-lang="Python" markdown="1">
+This part is for Java/Scala users.
+There are no known similiar limitations on the data types of Python Table API currently.
 </div>
 </div>
 
@@ -932,22 +961,23 @@ is specified, `p` is equal to `6`.
 
 #### `TIMESTAMP WITH TIME ZONE`
 
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="SQL/Java/Scala" markdown="1">
 Data type of a timestamp *with* time zone consisting of `year-month-day hour:minute:second[.fractional] zone`
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
 `9999-12-31 23:59:59.999999999 -14:59`.
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as the semantics
 are closer to `java.time.OffsetDateTime`.
+</div>
+<div data-lang="Python" markdown="1">
+Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported.
+</div>
+</div>
 
 Compared to `TIMESTAMP WITH LOCAL TIME ZONE`, the time zone offset information is physically
 stored in every datum. It is used individually for every computation, visualization, or communication
 to external systems.
-</div>
-<div data-lang="Python" markdown="1">
-</div>
-</div>
 
 **Declaration**
 
@@ -1568,16 +1598,10 @@ DataTypes.BOOLEAN()
 
 #### `RAW`
 
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="SQL/Java/Scala" markdown="1">
 Data type of an arbitrary serialized type. This type is a black box within the table ecosystem
 and is only deserialized at the edges.
 
 The raw type is an extension to the SQL standard.
-</div>
-<div data-lang="Python" markdown="1">
-</div>
-</div>
 
 **Declaration**
 
@@ -1628,8 +1652,6 @@ by passing `Class` and letting the framework extract `Class` + `TypeSerializer` 
 
 #### `NULL`
 
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="SQL/Java/Scala" markdown="1">
 Data type for representing untyped `NULL` values.
 
 The null type is an extension to the SQL standard. A null type has no other value
@@ -1639,10 +1661,6 @@ This type helps in representing unknown types in API calls that use a `NULL` lit
 as well as bridging to formats such as JSON or Avro that define such a type as well.
 
 This type is not very useful in practice and is just mentioned here for completeness.
-</div>
-<div data-lang="Python" markdown="1">
-</div>
-</div>
 
 **Declaration**
 

--- a/docs/dev/table/types.md
+++ b/docs/dev/table/types.md
@@ -22,6 +22,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 Due to historical reasons, before Flink 1.9, Flink's Table & SQL API data types were
 tightly coupled to Flink's `TypeInformation`. `TypeInformation` is used in the DataStream
 and DataSet API and is sufficient to describe all information needed to serialize and
@@ -31,7 +33,10 @@ However, `TypeInformation` was not designed to represent logical types independe
 an actual JVM class. In the past, it was difficult to map SQL standard types to this
 abstraction. Furthermore, some types were not SQL-compliant and introduced without a
 bigger picture in mind.
-
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 Starting with Flink 1.9, the Table & SQL API will receive a new type system that serves as a long-term
 solution for API stability and standard compliance.
 
@@ -42,8 +47,14 @@ Due to the simultaneous addition of a new planner for table programs (see [FLINK
 not every combination of planner and data type is supported. Furthermore, planners might not support every
 data type with the desired precision or parameter.
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 <span class="label label-danger">Attention</span> Please see the planner compatibility table and limitations
 section before using a data type.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 * This will be replaced by the TOC
 {:toc}
@@ -67,18 +78,29 @@ A list of all pre-defined data types can be found [below](#list-of-data-types).
 
 ### Data Types in the Table API
 
+<div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 Users of the JVM-based API work with instances of `org.apache.flink.table.types.DataType` within the Table API or when
-defining connectors, catalogs, or user-defined functions. Users of the Python API work with instances of
-`pyflink.table.types.DataType` within the Python Table API or when defining Python user-defined functions.
+defining connectors, catalogs, or user-defined functions. 
 
 A `DataType` instance has two responsibilities:
 - **Declaration of a logical type** which does not imply a concrete physical representation for transmission
 or storage but defines the boundaries between JVM-based/Python languages and the table ecosystem.
 - *Optional:* **Giving hints about the physical representation of data to the planner** which is useful at the edges to other APIs.
-This is currently only available in the Java/Scalar Table API and still not available in the Python Table API.
 
 For JVM-based languages, all pre-defined data types are available in `org.apache.flink.table.api.DataTypes`.
+</div>
+<div data-lang="Python" markdown="1">
+Users of the Python API work with instances of `pyflink.table.types.DataType` within the Python Table API or when 
+defining Python user-defined functions.
+
+A `DataType` instance has such a responsibility:
+- **Declaration of a logical type** which does not imply a concrete physical representation for transmission
+or storage but defines the boundaries between Python languages and the table ecosystem.
+
 For Python language, those types are available in `pyflink.table.types.DataTypes`.
+</div>
+</div>
 
 <div class="codetabs" markdown="1">
 
@@ -113,6 +135,8 @@ t = DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND(3))
 
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 #### Physical Hints
 
 Physical hints are required at the edges of the table ecosystem where the SQL-based type system ends and
@@ -125,7 +149,7 @@ the produced class into its internal data format. In return, a data sink can dec
 
 Here are some examples of how to declare a bridging conversion class:
 
-<div class="codetabs" markdown="1">
+<div class="codetabs" data-hide-tabs="1"  markdown="1">
 
 <div data-lang="Java" markdown="1">
 {% highlight java %}
@@ -157,7 +181,6 @@ val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[A
 API is extended. Users of predefined sources/sinks/functions do not need to define such hints. Hints within
 a table program (e.g. `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`) are ignored.
 
-<span class="label label-danger">Attention</span> Please note that physical hints are currently not supported in the Python Table API.
 
 Planner Compatibility
 ---------------------
@@ -248,11 +271,23 @@ the [old planner section](#old-planner).
 
 **User-defined Functions**: User-defined aggregate functions cannot declare a data type yet. Scalar and table functions fully support data types.
 
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
+
 List of Data Types
 ------------------
 
-This section lists all pre-defined data types. For the JVM-based Table API those types are also available in `org.apache.flink.table.api.DataTypes`.
+This section lists all pre-defined data types.
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+For the JVM-based Table API those types are also available in `org.apache.flink.table.api.DataTypes`.
+</div>
+<div data-lang="Python" markdown="1">
 For the Python Table API, those types are available in `pyflink.table.types.DataTypes`.
+</div>
+</div>
 
 ### Character Strings
 
@@ -293,8 +328,14 @@ Not supported.
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 The type can be declared using `CHAR(n)` where `n` is the number of code points. `n` must have a value between `1`
 and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `VARCHAR` / `STRING`
 
@@ -383,8 +424,14 @@ Not supported.
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 The type can be declared using `BINARY(n)` where `n` is the number of bytes. `n` must have a value
 between `1` and `2,147,483,647` (both inclusive). If no length is specified, `n` is equal to `1`.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `VARBINARY` / `BYTES`
 
@@ -763,8 +810,16 @@ Data type of a time *without* time zone consisting of `hour:minute:second[.fract
 up to nanosecond precision and values ranging from `00:00:00.000000000` to
 `23:59:59.999999999`.
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as
 the semantics are closer to `java.time.LocalTime`. A time *with* time zone is not provided.
+</div>
+<div data-lang="Python" markdown="1">
+Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported.
+A time *with* time zone is not provided.
+</div>
+</div>
 
 **Declaration**
 
@@ -814,12 +869,22 @@ Data type of a timestamp *without* time zone consisting of `year-month-day hour:
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000` to
 `9999-12-31 23:59:59.999999999`.
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as
 the semantics are closer to `java.time.LocalDateTime`.
 
 A conversion from and to `BIGINT` (a JVM `long` type) is not supported as this would imply a time
 zone. However, this type is time zone free. For more `java.time.Instant`-like semantics use
 `TIMESTAMP WITH LOCAL TIME ZONE`.
+</div>
+<div data-lang="Python" markdown="1">
+Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported.
+
+A conversion from and to `BIGINT` is not supported as this would imply a time zone.
+However, this type is time zone free. If you have such a requirement please use `TIMESTAMP WITH LOCAL TIME ZONE`.
+</div>
+</div>
 
 **Declaration**
 
@@ -867,6 +932,8 @@ is specified, `p` is equal to `6`.
 
 #### `TIMESTAMP WITH TIME ZONE`
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 Data type of a timestamp *with* time zone consisting of `year-month-day hour:minute:second[.fractional] zone`
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
 `9999-12-31 23:59:59.999999999 -14:59`.
@@ -877,6 +944,10 @@ are closer to `java.time.OffsetDateTime`.
 Compared to `TIMESTAMP WITH LOCAL TIME ZONE`, the time zone offset information is physically
 stored in every datum. It is used individually for every computation, visualization, or communication
 to external systems.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **Declaration**
 
@@ -910,9 +981,15 @@ Not supported.
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 The type can be declared using `TIMESTAMP(p) WITH TIME ZONE` where `p` is the number of digits of
 fractional seconds (*precision*). `p` must have a value between `0` and `9` (both inclusive). If no
 precision is specified, `p` is equal to `6`.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `TIMESTAMP WITH LOCAL TIME ZONE`
 
@@ -920,12 +997,23 @@ Data type of a timestamp *with local* time zone consisting of `year-month-day ho
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
 `9999-12-31 23:59:59.999999999 -14:59`.
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 Leap seconds (`23:59:60` and `23:59:61`) are not supported as the semantics are closer to `java.time.OffsetDateTime`.
 
 Compared to `TIMESTAMP WITH TIME ZONE`, the time zone offset information is not stored physically
 in every datum. Instead, the type assumes `java.time.Instant` semantics in UTC time zone at
 the edges of the table ecosystem. Every datum is interpreted in the local time zone configured in
 the current session for computation and visualization.
+</div>
+<div data-lang="Python" markdown="1">
+Leap seconds (`23:59:60` and `23:59:61`) are not supported.
+
+Compared to `TIMESTAMP WITH TIME ZONE`, the time zone offset information is not stored physically
+in every datum. 
+Every datum is interpreted in the local time zone configured in the current session for computation and visualization.
+</div>
+</div>
 
 This type fills the gap between time zone free and time zone mandatory timestamp types by allowing
 the interpretation of UTC timestamps according to the configured session time zone.
@@ -1322,6 +1410,8 @@ equivalent to `ROW<myField INT, myOtherField BOOLEAN>`.
 
 ### User-Defined Data Types
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 <span class="label label-danger">Attention</span> User-defined data types are not fully supported yet. They are
 currently (as of Flink 1.11) only exposed as unregistered structured types in parameters and return types of functions.
 
@@ -1367,6 +1457,10 @@ bridging classes defined for every data type in this document (e.g. `java.lang.I
 
 For some classes an annotation is required in order to map the class to a data type (e.g. `@DataTypeHint("DECIMAL(10, 2)")`
 to assign a fixed precision and scale for `java.math.BigDecimal`).
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **Declaration**
 
@@ -1474,10 +1568,16 @@ DataTypes.BOOLEAN()
 
 #### `RAW`
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 Data type of an arbitrary serialized type. This type is a black box within the table ecosystem
 and is only deserialized at the edges.
 
 The raw type is an extension to the SQL standard.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **Declaration**
 
@@ -1513,15 +1613,23 @@ Not supported.
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 The type can be declared using `RAW('class', 'snapshot')` where `class` is the originating class and
 `snapshot` is the serialized `TypeSerializerSnapshot` in Base64 encoding. Usually, the type string is not
 declared directly but is generated while persisting the type.
 
 In the API, the `RAW` type can be declared either by directly supplying a `Class` + `TypeSerializer` or
 by passing `Class` and letting the framework extract `Class` + `TypeSerializer` from there.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `NULL`
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 Data type for representing untyped `NULL` values.
 
 The null type is an extension to the SQL standard. A null type has no other value
@@ -1531,6 +1639,10 @@ This type helps in representing unknown types in API calls that use a `NULL` lit
 as well as bridging to formats such as JSON or Avro that define such a type as well.
 
 This type is not very useful in practice and is just mentioned here for completeness.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **Declaration**
 
@@ -1566,6 +1678,8 @@ Not supported.
 Data Type Extraction
 --------------------
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 At many locations in the API, Flink tries to automatically extract data type from class information using
 reflection to avoid repetitive manual schema work. However, extracting a data type reflectively is not always
 successful because logical information might be missing. Therefore, it might be necessary to add additional
@@ -1619,6 +1733,10 @@ extent the default extraction logic should be modified by declaring a `@DataType
 
 The `@DataTypeHint` annotation provides a set of optional hint parameters. Some of those parameters are shown in the
 following example. More information can be found in the documentation of the annotation class.
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 <div class="codetabs" markdown="1">
 
@@ -1678,7 +1796,11 @@ class User {
 }
 {% endhighlight %}
 </div>
-
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+Not supported.
+{% endhighlight %}
+</div>
 </div>
 
 {% top %}

--- a/docs/dev/table/types.zh.md
+++ b/docs/dev/table/types.zh.md
@@ -161,13 +161,28 @@ val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[A
 <span class="label label-danger">注意</span> 请注意，通常只有在扩展 API 时才需要物理提示。
 预定义的 Source、Sink、Function 的用户不需要定义这样的提示。在 Table 编程中（例如 `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`）这些提示将被忽略。
 
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
+
 Planner 兼容性
 ---------------------
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 正如简介里提到的，重新开发类型系统将跨越多个版本，每个数据类型的支持取决于使用的 Planner。本节旨在总结最重要的差异。
+</div>
+<div data-lang="Python" markdown="1">
+本节仅适用于Java/Scala用户。
+目前Python Table API的类型系统上还未发现类似的Planner兼容性问题。
+</div>
+</div>
 
 ### 旧的 Planner
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 Flink 1.9 之前引入的旧的 Planner 主要支持类型信息（Type Information），它只对数据类型提供有限的支持，可以声明能够转换为类型信息的数据类型，以便旧的 Planner 能够理解它们。
 
 下表总结了数据类型和类型信息之间的区别。大多数简单类型以及 Row 类型保持不变。Time 类型、 Array 类型和 Decimal 类型需要特别注意。不允许使用其他的类型提示。
@@ -201,9 +216,16 @@ Flink 1.9 之前引入的旧的 Planner 主要支持类型信息（Type Informat
 | 其他通用类型 | | `RAW(...)` | |
 
 <span class="label label-danger">注意</span> 如果对于新的类型系统有任何疑问，用户可以随时切换到 `org.apache.flink.table.api.Types` 中定义的 type information。
+</div>
+<div data-lang="Python" markdown="1">
+N/A
+</div>
+</div>
 
 ### 新的 Blink Planner
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 新的 Blink Planner 支持旧的 Planner 的全部类型，尤其包括列出的 Java 表达式字符串和类型信息。
 
 支持以下数据类型：
@@ -233,16 +255,25 @@ Flink 1.9 之前引入的旧的 Planner 主要支持类型信息（Type Informat
 | `ROW` | |
 | `RAW` | |
 | stuctured types | 暂只能在用户自定义函数里使用。 |
+</div>
+<div data-lang="Python" markdown="1">
+N/A
+</div>
+</div>
 
 局限性
 -----------
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 **Java 表达式字符串**：Table API 中的 Java 表达式字符串，例如 `table.select("field.cast(STRING)")`，尚未被更新到新的类型系统中，使用[旧的 Planner 章节](#旧的-planner)中声明的字符串来表示。
 
 **用户自定义函数**：用户自定义聚合函数尚不能声明数据类型，标量函数和表函数充分支持数据类型。
 
 </div>
 <div data-lang="Python" markdown="1">
+本节仅适用于Java/Scala用户。
+目前Python Table API的类型系统上还未发现类似的局限性。
 </div>
 </div>
 
@@ -877,18 +908,19 @@ DataTypes.TIMESTAMP(p)
 
 #### `TIMESTAMP WITH TIME ZONE`
 
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="SQL/Java/Scala" markdown="1">
 *带有*时区的时间戳数据类型，由 `year-month-day hour:minute:second[.fractional] zone` 组成，精度达到纳秒，范围从 `0000-01-01 00:00:00.000000000 +14:59` 到
 `9999-12-31 23:59:59.999999999 -14:59`。
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 与 SQL 标准相比，不支持闰秒（`23:59:60` 和 `23:59:61`），语义上更接近于 `java.time.OffsetDateTime`。
-
-与 `TIMESTAMP WITH LOCAL TIME ZONE` 相比，时区偏移信息物理存储在每个数据中。它单独用于每次计算、可视化或者与外部系统的通信。
 </div>
 <div data-lang="Python" markdown="1">
+与 SQL 标准相比，不支持闰秒（`23:59:60` 和 `23:59:61`）。
 </div>
 </div>
+
+与 `TIMESTAMP WITH LOCAL TIME ZONE` 相比，时区偏移信息物理存储在每个数据中。它单独用于每次计算、可视化或者与外部系统的通信。
 
 **声明**
 
@@ -1460,15 +1492,9 @@ DataTypes.BOOLEAN()
 
 #### `RAW`
 
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="SQL/Java/Scala" markdown="1">
 任意序列化类型的数据类型。此类型对于 Flink Table 来讲是一个黑盒子，仅在跟外部交互时被反序列化。
 
 Raw 类型是 SQL 标准的扩展。
-</div>
-<div data-lang="Python" markdown="1">
-</div>
-</div>
 
 **声明**
 
@@ -1516,8 +1542,6 @@ DataTypes.RAW(class)
 
 #### `NULL`
 
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="SQL/Java/Scala" markdown="1">
 表示空类型 `NULL` 值的数据类型。
 
 NULL 类型是 SQL 标准的扩展。NULL 类型除 `NULL` 值以外没有其他值，因此可以将其强制转换为 JVM 里的任何可空类型。
@@ -1525,10 +1549,6 @@ NULL 类型是 SQL 标准的扩展。NULL 类型除 `NULL` 值以外没有其他
 此类型有助于使用 `NULL` 字面量表示 `API` 调用中的未知类型，以及桥接到定义该类型的 JSON 或 Avro 等格式。
 
 这种类型在实践中不是很有用，为完整起见仅在此提及。
-</div>
-<div data-lang="Python" markdown="1">
-</div>
-</div>
 
 **声明**
 

--- a/docs/dev/table/types.zh.md
+++ b/docs/dev/table/types.zh.md
@@ -22,17 +22,28 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<div class="codetabs" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 由于历史原因，在 Flink 1.9 之前，Flink Table & SQL API 的数据类型与 Flink 的 `TypeInformation` 耦合紧密。`TypeInformation` 在 DataStream 和 DataSet API 中被使用，并且足以用来用于描述分布式环境中 JVM 对象的序列化和反序列化操作所需的全部信息。
 
 然而,`TypeInformation` 并不是为独立于 JVM class 的逻辑类型而设计的。之前很难将 SQL 的标准类型映射到 `TypeInformation` 抽象。此外，有一些类型并不是兼容 SQL 的并且引入的时候没有长远规划过。
-
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 从 Flink 1.9 开始，Table & SQL API 开始启用一种新的类型系统作为长期解决方案，用来保持 API 稳定性和 SQL 标准的兼容性。
 
 重新设计类型系统是一项涉及几乎所有的面向用户接口的重大工作。因此，它的引入跨越多个版本，社区的目标是在 Flink 1.12 完成这项工作。
 
 同时由于为 Table 编程添加了新的 Planner 详见（[FLINK-11439](https://issues.apache.org/jira/browse/FLINK-11439)）, 并不是每种 Planner 都支持所有的数据类型。此外,Planner 对于数据类型的精度和参数化支持也可能是不完整的。
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 <span class="label label-danger">注意</span> 在使用数据类型之前请参阅 Planner 的兼容性表和局限性章节。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 * This will be replaced by the TOC
 {:toc}
@@ -54,16 +65,27 @@ Flink 的数据类型和 SQL 标准的 *数据类型* 术语类似，但也包�
 
 ### Table API 的数据类型
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 JVM API 的用户可以在 Table API 中、定义连接器（Connector）、Catalog 或者用户自定义函数（User-Defined Function）中使用
-`org.apache.flink.table.types.DataType` 的实例。Python API的用户可以在 Python Table API中、Python 用户自定义函数
-（Python User-Defined Function）中使用`pyflink.table.types.DataType` 的实例。
+`org.apache.flink.table.types.DataType` 的实例。
 
 一个 `DataType` 实例有两个作用：
 - **逻辑类型的声明**，它不表达具体物理类型的存储和转换，但是定义了基于 JVM 的语言或者 Python 语言和 Table 编程环境之间的边界。
-- *可选的：* **向 Planner 提供有关数据的物理表示的提示**，这对于边界 API 很有用。当前只支持在Java／Scala Table API中使用，Python Table API中尚不支持该功能。
+- *可选的：* **向 Planner 提供有关数据的物理表示的提示**，这对于边界 API 很有用。
 
 对于基于 JVM 的语言，所有预定义的数据类型都在 `org.apache.flink.table.api.DataTypes` 里提供。
+</div>
+<div data-lang="Python" markdown="1">
+Python API的用户可以在 Python Table API中、Python 用户自定义函数（Python User-Defined Function）中使用
+`pyflink.table.types.DataType` 的实例。
+
+`DataType` 实例的作用：
+- **逻辑类型的声明**，它不表达具体物理类型的存储和转换，但是定义了基于 JVM 的语言或者 Python 语言和 Table 编程环境之间的边界。
+
 对于 Python 的语言，所有预定义的数据类型都在 `pyflink.table.types.DataTypes` 里提供。
+</div>
+</div>
 
 <div class="codetabs" markdown="1">
 
@@ -96,7 +118,10 @@ t = DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND(3))
 {% endhighlight %}
 
 </div>
+</div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 #### 物理提示
 
 在 Table 编程环境中，基于 SQL 的类型系统与程序指定的数据类型之间需要物理提示。该提示指出了实现预期的数据格式。
@@ -105,7 +130,7 @@ t = DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND(3))
 
 下面是一些如何声明桥接转换类的示例：
 
-<div class="codetabs" markdown="1">
+<div class="codetabs" data-hide-tabs="1" markdown="1">
 
 <div data-lang="Java" markdown="1">
 {% highlight java %}
@@ -135,8 +160,6 @@ val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[A
 
 <span class="label label-danger">注意</span> 请注意，通常只有在扩展 API 时才需要物理提示。
 预定义的 Source、Sink、Function 的用户不需要定义这样的提示。在 Table 编程中（例如 `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`）这些提示将被忽略。
-
-<span class="label label-danger">注意</span> 请注意，物理提示当前在Python Table API中尚不支持。
 
 Planner 兼容性
 ---------------------
@@ -218,11 +241,23 @@ Flink 1.9 之前引入的旧的 Planner 主要支持类型信息（Type Informat
 
 **用户自定义函数**：用户自定义聚合函数尚不能声明数据类型，标量函数和表函数充分支持数据类型。
 
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
+
 数据类型列表
 ------------------
 
-本节列出了所有预定义的数据类型。对于基于 JVM 的 Table API，这些类型也可以从 `org.apache.flink.table.api.DataTypes` 中找到。
+本节列出了所有预定义的数据类型。
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+对于基于 JVM 的 Table API，这些类型也可以从 `org.apache.flink.table.api.DataTypes` 中找到。
+</div>
+<div data-lang="Python" markdown="1">
 对于Python Table API, 这些类型可以从 `pyflink.table.types.DataTypes` 中找到。
+</div>
+</div>
 
 ### 字符串
 
@@ -263,7 +298,13 @@ DataTypes.CHAR(n)
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 此类型用 `CHAR(n)` 声明，其中 `n` 表示字符数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `VARCHAR` / `STRING`
 
@@ -351,7 +392,13 @@ DataTypes.BINARY(n)
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 此类型用 `BINARY(n)` 声明，其中 `n` 是字节数量。`n` 的值必须在 `1` 和 `2,147,483,647` 之间（含边界值）。如果未指定长度，`n` 等于 `1`。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `VARBINARY` / `BYTES`
 
@@ -720,7 +767,14 @@ DataTypes.DATE()
 
 *不带*时区的时间数据类型，由 `hour:minute:second[.fractional]` 组成，精度达到纳秒，范围从 `00:00:00.000000000` 到 `23:59:59.999999999`。
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 与 SQL 标准相比，不支持闰秒（`23:59:60` 和 `23:59:61`），语义上更接近于 `java.time.LocalTime`。没有提供*带有*时区的时间。
+</div>
+<div data-lang="Python" markdown="1">
+与 SQL 标准相比，不支持闰秒（`23:59:60` 和 `23:59:61`）。没有提供*带有*时区的时间。
+</div>
+</div>
 
 **声明**
 
@@ -766,9 +820,18 @@ DataTypes.TIME(p)
 
 *不带*时区的时间戳数据类型，由 `year-month-day hour:minute:second[.fractional]` 组成，精度达到纳秒，范围从 `0000-01-01 00:00:00.000000000` 到 `9999-12-31 23:59:59.999999999`。
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 与 SQL 标准相比，不支持闰秒（`23:59:60` 和 `23:59:61`），语义上更接近于 `java.time.LocalDateTime`。
 
 不支持和 `BIGINT`（JVM `long` 类型）互相转换，因为这意味着有时区，然而此类型是无时区的。对于语义上更接近于 `java.time.Instant` 的需求请使用 `TIMESTAMP WITH LOCAL TIME ZONE`。
+</div>
+<div data-lang="Python" markdown="1">
+与 SQL 标准相比，不支持闰秒（`23:59:60` 和 `23:59:61`）。
+
+不支持和 `BIGINT`（JVM `long` 类型）互相转换，因为这意味着有时区，然而此类型是无时区的。有此需求请使用 `TIMESTAMP WITH LOCAL TIME ZONE`。
+</div>
+</div>
 
 **声明**
 
@@ -814,12 +877,18 @@ DataTypes.TIMESTAMP(p)
 
 #### `TIMESTAMP WITH TIME ZONE`
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 *带有*时区的时间戳数据类型，由 `year-month-day hour:minute:second[.fractional] zone` 组成，精度达到纳秒，范围从 `0000-01-01 00:00:00.000000000 +14:59` 到
 `9999-12-31 23:59:59.999999999 -14:59`。
 
 与 SQL 标准相比，不支持闰秒（`23:59:60` 和 `23:59:61`），语义上更接近于 `java.time.OffsetDateTime`。
 
 与 `TIMESTAMP WITH LOCAL TIME ZONE` 相比，时区偏移信息物理存储在每个数据中。它单独用于每次计算、可视化或者与外部系统的通信。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **声明**
 
@@ -853,16 +922,31 @@ DataTypes.TIMESTAMP_WITH_TIME_ZONE(p)
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 此类型用 `TIMESTAMP(p) WITH TIME ZONE` 声明，其中 `p` 是秒的小数部分的位数（*精度*）。`p` 的值必须介于 `0` 和 `9` 之间（含边界值）。如果未指定精度，则 `p` 等于 `6`。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `TIMESTAMP WITH LOCAL TIME ZONE`
 
 *带有本地*时区的时间戳数据类型，由 `year-month-day hour:minute:second[.fractional] zone` 组成，精度达到纳秒，范围从 `0000-01-01 00:00:00.000000000 +14:59` 到
 `9999-12-31 23:59:59.999999999 -14:59`。
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 不支持闰秒（`23:59:60` 和 `23:59:61`），语义上更接近于 `java.time.OffsetDateTime`。
 
 与 `TIMESTAMP WITH TIME ZONE` 相比，时区偏移信息并非物理存储在每个数据中。相反，此类型在 Table 编程环境的 UTC 时区中采用 `java.time.Instant` 语义。每个数据都在当前会话中配置的本地时区中进行解释，以便用于计算和可视化。
+</div>
+<div data-lang="Python" markdown="1">
+不支持闰秒（`23:59:60` 和 `23:59:61`）。
+
+与 `TIMESTAMP WITH TIME ZONE` 相比，时区偏移信息并非物理存储在每个数据中。每个数据都在当前会话中配置的本地时区中进行解释，以便用于计算和可视化。
+</div>
+</div>
 
 此类型允许根据配置的会话时区来解释 UTC 时间戳，从而填补了时区无关和时区相关的时间戳类型之间的鸿沟。
 
@@ -1233,6 +1317,8 @@ DataTypes.ROW([DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...])
 
 ### 用户自定义数据类型
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 <span class="label label-danger">注意</span> 还未完全支持用户自定义数据类型，当前（从 Flink 1.11 开始）它们仅可作为函数参数和返回值的未注册的结构化类型。
 
 结构化类型类似于面向对象编程语言中的对象，可包含零个、一个或多个属性，每个属性都包含一个名称和一个类型。
@@ -1264,6 +1350,10 @@ DataTypes.ROW([DataTypes.FIELD(n0, t0, d0), DataTypes.FIELD(n1, t1, d1), ...])
 成员变量（比如 `public int age;`）的类型必须包含在本文为每种数据类型定义的受支持的 JVM 类型列表里（例如，`java.lang.Integer` 或 `int` 对应 `INT`）。
 
 对于某些类，需要有注解才能将类映射到数据类型（例如， `@DataTypeHint("DECIMAL(10, 2)")` 为 `java.math.BigDecimal` 分配固定的精度和小数位）。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **声明**
 
@@ -1324,7 +1414,11 @@ DataTypes.of(classOf[User])
 |`org.apache.flink.table.data.RowData` | X     | X      | 内部数据结构。                                        |
 
 </div>
-
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+尚不支持
+{% endhighlight %}
+</div>
 </div>
 
 ### 其他数据类型
@@ -1366,9 +1460,15 @@ DataTypes.BOOLEAN()
 
 #### `RAW`
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 任意序列化类型的数据类型。此类型对于 Flink Table 来讲是一个黑盒子，仅在跟外部交互时被反序列化。
 
 Raw 类型是 SQL 标准的扩展。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **声明**
 
@@ -1404,12 +1504,20 @@ DataTypes.RAW(class)
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 此类型用 `RAW('class', 'snapshot')` 声明，其中 `class` 是原始类，`snapshot` 是 Base64 编码的序列化的 `TypeSerializerSnapshot`。通常，类型字符串不是直接声明的，而是在持久化类型时生成的。
 
 在 API 中，可以通过直接提供 `Class` + `TypeSerializer` 或通过传递 `TypeInformation` 并让框架从那里提取 `Class` + `TypeSerializer` 来声明 `RAW` 类型。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 #### `NULL`
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="SQL/Java/Scala" markdown="1">
 表示空类型 `NULL` 值的数据类型。
 
 NULL 类型是 SQL 标准的扩展。NULL 类型除 `NULL` 值以外没有其他值，因此可以将其强制转换为 JVM 里的任何可空类型。
@@ -1417,6 +1525,10 @@ NULL 类型是 SQL 标准的扩展。NULL 类型除 `NULL` 值以外没有其他
 此类型有助于使用 `NULL` 字面量表示 `API` 调用中的未知类型，以及桥接到定义该类型的 JSON 或 Avro 等格式。
 
 这种类型在实践中不是很有用，为完整起见仅在此提及。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 **声明**
 
@@ -1452,6 +1564,8 @@ DataTypes.NULL()
 数据类型注解
 ---------------------
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
 Flink API 经常尝试使用反射自动从类信息中提取数据类型，以避免重复的手动定义模式工作。然而以反射方式提取数据类型并不总是成功的，因为可能会丢失逻辑信息。因此，可能有必要在类或字段声明附近添加额外信息以支持提取逻辑。
 
 下表列出了可以隐式映射到数据类型而无需额外信息的类。
@@ -1500,6 +1614,10 @@ information similar to `java.lang.Map[java.lang.Object, java.lang.Object]`.
 _数据类型提示_ 可以参数化或替换函数参数和返回值、结构化类或结构化类字段的默认提取逻辑，实现者可以通过声明 `@DataTypeHint` 注解来选择默认提取逻辑应修改的程度。
 
 `@DataTypeHint` 注解提供了一组可选的提示参数，以下示例显示了其中一些参数，可以在注解类的文档中找到更多信息。
+</div>
+<div data-lang="Python" markdown="1">
+</div>
+</div>
 
 <div class="codetabs" markdown="1">
 
@@ -1559,7 +1677,11 @@ class User {
 }
 {% endhighlight %}
 </div>
-
+<div data-lang="Python" markdown="1">
+{% highlight python %}
+尚不支持
+{% endhighlight %}
+</div>
 </div>
 
 {% top %}

--- a/docs/page/js/flink.js
+++ b/docs/page/js/flink.js
@@ -109,7 +109,7 @@ function codeTabs() {
       tabBar.children("li").first().addClass("active");
     }
     if (hideTabs != null) {
-        tabBar.hide()
+        tabBar.hide();
     }
     counter++;
   });

--- a/docs/page/js/flink.js
+++ b/docs/page/js/flink.js
@@ -18,6 +18,19 @@
 /* Note: This file is originally from the Apache Spark project. */
 
 /* Custom JavaScript code in the MarkDown docs */
+function getUrlParameter(sParam) {
+  var sPageURL = window.location.search.substring(1),
+    sURLVariables = sPageURL.split('&'),
+    sParameterName,
+    i;
+
+  for (i = 0; i < sURLVariables.length; i++) {
+    sParameterName = sURLVariables[i].split('=');
+    if (sParameterName[0] === sParam) {
+      return sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
+    }
+  }
+}
 
 // Enable language-specific code tabs
 function codeTabs() {
@@ -27,15 +40,42 @@ function codeTabs() {
     "python": "img/python-sm.png",
     "java": "img/java-sm.png"
   };
+  var codeTabParam = getUrlParameter("code_tab") == null ? null : getUrlParameter("code_tab").toLowerCase();
+  // Processing duplicated tabs, e.g. if the data-lang="Java/Scala",
+  // it will be copied to 2 elements, the "data-lang" value of them would be "Java" and "Scala".
+  function splitDataLang() {
+    var codeSamples = $(this).children("div");
+    codeSamples.each(function() {
+      var langData = $(this).data("lang");
+      if (langData != null) {
+        var langs = langData.split("/");
+        if (langs.length > 1) {
+          var last = $(this);
+          for (let lang of langs) {
+            var cloned = $(this).clone();
+            cloned.attr("data-lang", lang);
+            last.after(cloned);
+            last = cloned;
+            // process recursively
+            $("div.codetabs", cloned).each(splitDataLang);
+          }
+          $(this).remove();
+        }
+      }
+    });
+  }
+  $("div.codetabs").each(splitDataLang);
   $("div.codetabs").each(function() {
     $(this).addClass("tab-content");
+    var hideTabs = $(this).data("hide-tabs");
 
     // Insert the tab bar
     var tabBar = $('<ul class="nav nav-tabs" data-tabs="tabs"></ul>');
     $(this).before(tabBar);
 
+    var hasActivedTab = false;
     // Add each code sample to the tab bar:
-    var codeSamples = $(this).children("div");
+    codeSamples = $(this).children("div");
     codeSamples.each(function() {
       $(this).addClass("tab-pane");
       var lang = $(this).data("lang");
@@ -43,6 +83,8 @@ function codeTabs() {
       var notabs = $(this).data("notabs");
       var capitalizedLang = lang.substr(0, 1).toUpperCase() + lang.substr(1);
       lang = lang.replace(/[^a-zA-Z0-9]/g, "_");
+      // let the first character upper case
+      lang = lang.charAt(0).toUpperCase() + lang.slice(1);
       var id = "tab_" + lang + "_" + counter;
       $(this).attr("id", id);
       if (image != null && langImages[lang]) {
@@ -55,10 +97,20 @@ function codeTabs() {
       tabBar.append(
         '<li><a class="tab_' + lang + '" href="#' + id + '">' + buttonLabel + '</a></li>'
       );
+      if (codeTabParam === lang.toLowerCase()) {
+        $(this).addClass("active");
+        tabBar.children("li").last().addClass("active");
+        hasActivedTab = true;
+      }
     });
 
-    codeSamples.first().addClass("active");
-    tabBar.children("li").first().addClass("active");
+    if (!hasActivedTab) {
+      codeSamples.first().addClass("active");
+      tabBar.children("li").first().addClass("active");
+    }
+    if (hideTabs != null) {
+        tabBar.hide()
+    }
     counter++;
   });
   $("ul.nav-tabs a").click(function (e) {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request modifies the `flink.js` to improve the code tabs of the Flink documents.*

## Brief change log

  - *Split the code tab label like "Java/Scala" to 2 labels.*
  - *Let the first character of the code tab label always upper case.*
  - *Add a new attribute "data-hide-tabs" used to hide the code tab headers.*
  - *Add a new url parameter "code_tab" to set the default code tab displayed when entering the page.*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
