### PR TITLE
[FLINK-17503][runtime] [logs] Refactored log output.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -132,9 +132,10 @@ public class TaskExecutorResourceUtils {
 	public static Configuration adjustForLocalExecution(Configuration config) {
 		UNUSED_CONFIG_OPTIONS.forEach(option -> warnOptionHasNoEffectIfSet(config, option));
 
-		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
-		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.MAX_VALUE);
-		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.TASK_OFF_HEAP_MEMORY, MemorySize.MAX_VALUE);
+		setConfigOptionToPassedMaxIfNotSet(config, TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
+		setConfigOptionToPassedMaxIfNotSet(config, TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.MAX_VALUE);
+		setConfigOptionToPassedMaxIfNotSet(config, TaskManagerOptions.TASK_OFF_HEAP_MEMORY, MemorySize.MAX_VALUE);
+
 		adjustNetworkMemoryForLocalExecution(config);
 		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
 
@@ -168,11 +169,26 @@ public class TaskExecutorResourceUtils {
 			Configuration config,
 			ConfigOption<T> option,
 			T defaultValue) {
+		setConfigOptionToDefaultIfNotSet(config, option, defaultValue, "its default value " + defaultValue);
+	}
+
+	private static <T> void setConfigOptionToPassedMaxIfNotSet(
+			Configuration config,
+			ConfigOption<T> option,
+			T maxValue) {
+		setConfigOptionToDefaultIfNotSet(config, option, maxValue, "the maximal possible value");
+	}
+
+	private static <T> void setConfigOptionToDefaultIfNotSet(
+			Configuration config,
+			ConfigOption<T> option,
+			T defaultValue,
+			String defaultValueLogExt) {
 		if (!config.contains(option)) {
 			LOG.info(
-				"The configuration option {} required for local execution is not set, setting it to its default value {}",
-				option,
-				defaultValue);
+				"The configuration option {} required for local execution is not set, setting it to {}.",
+				option.key(),
+				defaultValueLogExt);
 			config.set(option, defaultValue);
 		}
 	}


### PR DESCRIPTION
The log output was cleaned up:
 - Only the key of the option is logged out instead of the whole
   instance's toString() method.
 - A new utility method was introduce that adapts the log output in a
   way that an adapted extension is used for maximum values instead of
   logging the actual max value.


## Contribution Checklist

## What is the purpose of the change

The PR improves the log output in terms of readability.

## Brief change log
 - A new utility method was introduced to handle the max value log output.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
