### PR TITLE
[FLINK-18856][checkpointing] Don't ignore minPauseBetweenCheckpoints

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
@@ -66,7 +66,6 @@ public class CheckpointRequestDeciderTest {
 		assertEquals(Optional.of(request), decider.chooseQueuedRequestToExecute(isTriggering, 0));
 	}
 
-
 	@Test
 	public void testNonForcedEnqueueOnTooManyPending() {
 		final int maxPending = 1;
@@ -99,7 +98,6 @@ public class CheckpointRequestDeciderTest {
 				new CheckpointTriggerRequest[]{savepoint, checkpoint});
 	}
 
-
 	@Test
 	public void testNonForcedUserSubmittedPrioritized() {
 		CheckpointTriggerRequest userSubmitted = nonForcedSavepoint();
@@ -117,8 +115,6 @@ public class CheckpointRequestDeciderTest {
 			new CheckpointTriggerRequest[]{checkpoint, savepoint},
 			new CheckpointTriggerRequest[]{savepoint, checkpoint});
 	}
-
-
 
 	@Test
 	public void testQueueSizeLimit() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
@@ -169,7 +169,7 @@ public class CheckpointRequestDeciderTest {
 	private void testTiming(CheckpointTriggerRequest request, TriggerExpectation expectation) {
 		final long pause = 10;
 		final ManualClock clock = new ManualClock();
-		final CheckpointRequestDecider decider = new CheckpointRequestDecider(1, NO_OP, clock, pause, () -> 0, new Object(), Integer.MAX_VALUE);
+		final CheckpointRequestDecider decider = new CheckpointRequestDecider(1, NO_OP, clock, pause, () -> 0, Integer.MAX_VALUE);
 
 		final long lastCompletionMs = clock.relativeTimeMillis();
 		final boolean isTriggering = false;
@@ -220,7 +220,7 @@ public class CheckpointRequestDeciderTest {
 	private CheckpointRequestDecider decider(int maxQueued, int maxPending, int minPause, AtomicInteger currentPending) {
 		ManualClock clock = new ManualClock();
 		clock.advanceTime(1, TimeUnit.DAYS);
-		return new CheckpointRequestDecider(maxPending, NO_OP, clock, minPause, currentPending::get, new Object(), maxQueued);
+		return new CheckpointRequestDecider(maxPending, NO_OP, clock, minPause, currentPending::get, maxQueued);
 	}
 
 	private static final Consumer<Long> NO_OP = unused -> {


### PR DESCRIPTION
## What is the purpose of the change

`CheckpointRequestDecider` uses lastCheckpointCompletionTime and pendingRequests.size to make a decision.
While latter is currently checked under a lock, the former is not.

So it can see "no pending checkpoints" (fresh value of `pendingRequests.size`) and "last checkpoint completed long time ago" (stale value of `lastCheckpointCompletionTime`).
Therefore, it decides to execute request, effictevely ignoring minPauseBetweenCheckpoint setting.

This increases checkpoint frequency, and in some cases decreases throughput (see ML thread).

This PR replaces function argument for `lastCheckpointCompletionTime` with a supplier, which is called under lock (similar to `pendingRequests.size()`).

## Verifying this change

Added unit test: `CheckpointCoordinatorTest.testMinCheckpointPause`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes, Checkpointing
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
