### PR TITLE
[FLINK-18853][sql-client] Supports properties from flink-conf.yaml for SET command in sql client

### DIFF
--- a/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
@@ -100,18 +100,10 @@ execution:
   planner: blink
   # 'batch' or 'streaming' execution
   type: streaming
-  # allow 'event-time' or only 'processing-time' in sources
-  time-characteristic: event-time
-  # interval in ms for emitting periodic watermarks
-  periodic-watermarks-interval: 200
   # 'changelog', 'table' or 'tableau' presentation of results
   result-mode: table
   # maximum number of maintained rows in 'table' presentation of results
   max-table-result-rows: 1000000
-  # parallelism of the program
-  # parallelism: 1
-  # maximum parallelism
-  max-parallelism: 128
   # minimum idle state retention in ms
   min-idle-state-retention: 0
   # maximum idle state retention in ms
@@ -120,11 +112,6 @@ execution:
   current-catalog: default_catalog
   # current database of the current catalog (default database of the catalog by default)
   current-database: default_database
-  # controls how table programs are restarted in case of a failures
-  # restart-strategy:
-    # strategy type
-    # possible values are "fixed-delay", "failure-rate", "none", or "fallback" (default)
-    # type: fallback
 
 #==============================================================================
 # Configuration options
@@ -137,6 +124,18 @@ execution:
 
 # A configuration can look like:
 # configuration:
+    # parallelism of the program
+    parallelism.default: 1
+    # maximum parallelism
+    pipeline.max-parallelism: 128
+    # possible values are "EventTime", "ProcessingTime" or "IngestionTime"
+    pipeline.time-characteristic: EventTime
+    # interval in ms for emitting periodic watermarks
+    pipeline.auto-watermark-interval: 200
+    # controls how table programs are restarted in case of a failures, default is fallback strategy
+    # possible values are "fixed-delay", "failure-rate", "none"
+    # restart-strategy: failure-rate
+
 #   table.exec.spill-compression.enabled: true
 #   table.exec.spill-compression.block-size: 128kb
 #   table.optimizer.join-reorder-enabled: true

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigurationEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigurationEntry.java
@@ -22,12 +22,15 @@ import org.apache.flink.table.client.config.ConfigUtil;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
-
-import static org.apache.flink.table.client.config.Environment.CONFIGURATION_ENTRY;
 
 /**
  * Configuration for configuring {@link org.apache.flink.table.api.TableConfig}.
+ * This class parses the `configuring` section in an environment file.
+ *
+ * <p>The configuration describes properties that would usually be defined in
+ * the flink-conf.yaml file or user defined properties.
  */
 public class ConfigurationEntry extends ConfigEntry {
 
@@ -63,15 +66,17 @@ public class ConfigurationEntry extends ConfigEntry {
 		return new ConfigurationEntry(properties);
 	}
 
-	public static ConfigurationEntry enrich(ConfigurationEntry configuration, Map<String, String> prefixedProperties) {
+	public static ConfigurationEntry enrich(
+			ConfigurationEntry configuration,
+			Map<String, String> remainingPrefixedProperties) {
 		final Map<String, String> enrichedProperties = new HashMap<>(configuration.asMap());
 
-		prefixedProperties.forEach((k, v) -> {
-			final String normalizedKey = k.toLowerCase();
-			if (k.startsWith(CONFIGURATION_ENTRY + ".")) {
-				enrichedProperties.put(normalizedKey, v);
-			}
-		});
+		Iterator<Map.Entry<String, String>> it = remainingPrefixedProperties.entrySet().iterator();
+		while (it.hasNext()) {
+			Map.Entry<String, String> entry = it.next();
+			enrichedProperties.put(entry.getKey().toLowerCase(), entry.getValue());
+			it.remove();
+		}
 
 		final DescriptorProperties properties = new DescriptorProperties(true);
 		properties.putProperties(enrichedProperties);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/DeploymentEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/DeploymentEntry.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -150,15 +151,18 @@ public class DeploymentEntry extends ConfigEntry {
 	 * Creates a new deployment entry enriched with additional properties that are prefixed with
 	 * {@link Environment#DEPLOYMENT_ENTRY}.
 	 */
-	public static DeploymentEntry enrich(DeploymentEntry deployment, Map<String, String> prefixedProperties) {
+	public static DeploymentEntry enrich(DeploymentEntry deployment, Map<String, String> remainingPrefixedProperties) {
 		final Map<String, String> enrichedProperties = new HashMap<>(deployment.asMap());
 
-		prefixedProperties.forEach((k, v) -> {
-			final String normalizedKey = k.toLowerCase();
-			if (k.startsWith(DEPLOYMENT_ENTRY + '.')) {
-				enrichedProperties.put(normalizedKey.substring(DEPLOYMENT_ENTRY.length() + 1), v);
+		Iterator<Map.Entry<String, String>> it = remainingPrefixedProperties.entrySet().iterator();
+		while (it.hasNext()) {
+			Map.Entry<String, String> entry = it.next();
+			final String normalizedKey = entry.getKey().toLowerCase();
+			if (normalizedKey.startsWith(DEPLOYMENT_ENTRY + '.')) {
+				enrichedProperties.put(normalizedKey.substring(DEPLOYMENT_ENTRY.length() + 1), entry.getValue());
+				it.remove();
 			}
-		});
+		}
 
 		final DescriptorProperties properties = new DescriptorProperties(true);
 		properties.putProperties(enrichedProperties);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -543,7 +543,6 @@ public class ExecutionContext<ClusterID> {
 		final TableConfig config = new TableConfig();
 		config.addConfiguration(flinkConfig);
 		Configuration conf = config.getConfiguration();
-		environment.getConfiguration().asMap().forEach(conf::setString);
 		ExecutionEntry execution = environment.getExecution();
 		config.setIdleStateRetentionTime(
 				Time.milliseconds(execution.getMinStateRetention()),
@@ -560,6 +559,7 @@ public class ExecutionContext<ClusterID> {
 		}
 
 		setRestartStrategy(conf);
+		environment.getConfiguration().asMap().forEach(conf::setString);
 		return config;
 	}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -76,6 +76,7 @@ import static org.junit.Assert.assertTrue;
 public class ExecutionContextTest {
 
 	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-client-defaults.yaml";
+	private static final String DEPRECATED_KEY_ENVIRONMENT_FILE = "test-sql-client-defaults-with-deprecated-key.yaml";
 	private static final String MODULES_ENVIRONMENT_FILE = "test-sql-client-modules.yaml";
 	public static final String CATALOGS_ENVIRONMENT_FILE = "test-sql-client-catalogs.yaml";
 	private static final String STREAMING_ENVIRONMENT_FILE = "test-sql-client-streaming.yaml";
@@ -84,8 +85,18 @@ public class ExecutionContextTest {
 	private static final String EXECUTION_ENVIRONMENT_FILE = "test-sql-client-execution.yaml";
 
 	@Test
+	public void testExecutionConfigWithDeprecatedKey() throws Exception {
+		final Map<String, String> replaceVars = createDefaultReplaceVars();
+		final ExecutionContext<?> context = createExecutionContext(DEPRECATED_KEY_ENVIRONMENT_FILE, replaceVars);
+		testExecutionConfig(context);
+	}
+
+	@Test
 	public void testExecutionConfig() throws Exception {
-		final ExecutionContext<?> context = createDefaultExecutionContext();
+		testExecutionConfig(createDefaultExecutionContext());
+	}
+
+	private void testExecutionConfig(ExecutionContext<?> context) throws Exception {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
 		final TableConfig tableConfig = tableEnv.getConfig();
 
@@ -358,6 +369,7 @@ public class ExecutionContextTest {
 		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
 		replaceVars.put("$VAR_MAX_ROWS", "100");
 		replaceVars.put("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
+
 		return replaceVars;
 	}
 

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults-with-deprecated-key.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults-with-deprecated-key.yaml
@@ -32,6 +32,8 @@ tables:
         type: INT
       - name: StringField1
         type: VARCHAR
+      - name: TimestampField1
+        type: TIMESTAMP
     connector:
       type: filesystem
       path: "$VAR_SOURCE_PATH1"
@@ -42,11 +44,13 @@ tables:
           type: INT
         - name: StringField1
           type: VARCHAR
+        - name: TimestampField1
+          type: TIMESTAMP
       line-delimiter: "\n"
       comment-prefix: "#"
   - name: TestView1
     type: view
-    query: SELECT scalarUDF(IntegerField1) FROM default_catalog.default_database.TableNumber1
+    query: SELECT scalarUDF(IntegerField1) FROM TableNumber1
   - name: TableNumber2
     # Test backwards compatibility ("source" -> "source-table")
     type: source
@@ -56,7 +60,7 @@ tables:
         type: INT
       - name: StringField2
         type: VARCHAR
-      - name: TimestampField3
+      - name: TimestampField2
         type: TIMESTAMP
     connector:
       type: filesystem
@@ -68,33 +72,35 @@ tables:
           type: INT
         - name: StringField2
           type: VARCHAR
-        - name: TimestampField3
+        - name: TimestampField2
           type: TIMESTAMP
       line-delimiter: "\n"
       comment-prefix: "#"
-  - name: TestView2
-    type: view
-    query: SELECT * FROM default_catalog.default_database.TestView1
-  - name: TableNumber3
-    type: source-table
+  - name: TableSourceSink
+    type: source-sink-table
     $VAR_UPDATE_MODE
     schema:
-      - name: DecimalField
-        type: DECIMAL
+      - name: BooleanField
+        type: BOOLEAN
       - name: StringField
         type: VARCHAR
+      - name: TimestampField
+        type: TIMESTAMP
     connector:
       type: filesystem
-      path: "$VAR_SOURCE_PATH2"
+      path: "$VAR_SOURCE_SINK_PATH"
     format:
       type: csv
       fields:
-        - name: DecimalField
-          type: DECIMAL
+        - name: BooleanField
+          type: BOOLEAN
         - name: StringField
           type: VARCHAR
-      line-delimiter: "\n"
-      comment-prefix: "#"
+        - name: TimestampField
+          type: TIMESTAMP
+  - name: TestView2
+    type: view
+    query: SELECT * FROM TestView1
 
 functions:
   - name: scalarUDF
@@ -121,42 +127,32 @@ functions:
       - type: LONG
         value: 5
 
-execution:
-  planner: "$VAR_PLANNER"
-  type: "$VAR_EXECUTION_TYPE"
-  min-idle-state-retention: 0
-  max-idle-state-retention: 0
-  result-mode: "$VAR_RESULT_MODE"
-  max-table-result-rows: "$VAR_MAX_ROWS"
-  current-catalog: inmemorycatalog
-  current-database: mydatabase
-
-configuration:
-  parallelism.default: 1
-  pipeline.max-parallelism: 16
-  pipeline.time-characteristic: EventTime
-  pipeline.auto-watermark-interval: 99
-  restart-strategy: failure-rate
-  restart-strategy.failure-rate.max-failures-per-interval: 10
-  restart-strategy.failure-rate.failure-rate-interval: 99000
-  restart-strategy.failure-rate.delay: 1000
-
-deployment:
-  response-timeout: 5000
-
 catalogs:
   - name: catalog1
     type: DependencyTest
-  - name: catalog2
-    type: DependencyTest
-    default-database: mydatabase
-  - name: inmemorycatalog
-    type: generic_in_memory
-    default-database: mydatabase
-  - name: hivecatalog
-    type: hive
-    test: test
-    hive-version: 2.3.4
-  - name: hivedefaultversion
-    type: hive
-    test: test
+  - name: simple-catalog
+    type: simple-catalog
+    test-table: test-table
+
+execution:
+  planner: "$VAR_PLANNER"
+  type: "$VAR_EXECUTION_TYPE"
+  time-characteristic: event-time
+  periodic-watermarks-interval: 99
+  parallelism: 1
+  max-parallelism: 16
+  min-idle-state-retention: 1000
+  max-idle-state-retention: 600000
+  result-mode: "$VAR_RESULT_MODE"
+  max-table-result-rows: "$VAR_MAX_ROWS"
+  restart-strategy:
+    type: "$VAR_RESTART_STRATEGY_TYPE"
+    max-failures-per-interval: 10
+    failure-rate-interval: 99000
+    delay: 1000
+
+configuration:
+  table.optimizer.join-reorder-enabled: false
+
+deployment:
+  response-timeout: 5000

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -137,21 +137,20 @@ catalogs:
 execution:
   planner: "$VAR_PLANNER"
   type: "$VAR_EXECUTION_TYPE"
-  time-characteristic: event-time
-  periodic-watermarks-interval: 99
-  parallelism: 1
-  max-parallelism: 16
   min-idle-state-retention: 1000
   max-idle-state-retention: 600000
   result-mode: "$VAR_RESULT_MODE"
   max-table-result-rows: "$VAR_MAX_ROWS"
-  restart-strategy:
-    type: "$VAR_RESTART_STRATEGY_TYPE"
-    max-failures-per-interval: 10
-    failure-rate-interval: 99000
-    delay: 1000
 
 configuration:
+  parallelism.default: 1
+  pipeline.max-parallelism: 16
+  pipeline.time-characteristic: EventTime
+  pipeline.auto-watermark-interval: 99
+  restart-strategy: "$VAR_RESTART_STRATEGY_TYPE"
+  restart-strategy.failure-rate.max-failures-per-interval: 10
+  restart-strategy.failure-rate.failure-rate-interval: 99000
+  restart-strategy.failure-rate.delay: 1000
   table.optimizer.join-reorder-enabled: false
 
 deployment:

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
@@ -46,9 +46,9 @@ tables:
 
 execution:
   type: streaming
-  parallelism: 1
 
 configuration:
+  parallelism.default: 1
   table.optimizer.join-reorder-enabled: true
 
 deployment:

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
@@ -26,19 +26,20 @@
 execution:
   planner: "$VAR_PLANNER"
   type: "$VAR_EXECUTION_TYPE"
-  time-characteristic: event-time
-  periodic-watermarks-interval: 99
-  parallelism: 1
-  max-parallelism: 16
   min-idle-state-retention: 0
   max-idle-state-retention: 0
   result-mode: "$VAR_RESULT_MODE"
   max-table-result-rows: "$VAR_MAX_ROWS"
-  restart-strategy:
-    type: failure-rate
-    max-failures-per-interval: 10
-    failure-rate-interval: 99000
-    delay: 1000
+
+configuration:
+  parallelism.default: 1
+  pipeline.max-parallelism: 16
+  pipeline.time-characteristic: EventTime
+  pipeline.auto-watermark-interval: 99
+  restart-strategy: failure-rate
+  restart-strategy.failure-rate.max-failures-per-interval: 10
+  restart-strategy.failure-rate.failure-rate-interval: 99000
+  restart-strategy.failure-rate.delay: 1000
 
 deployment:
   response-timeout: 5000

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-streaming.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-streaming.yaml
@@ -84,5 +84,7 @@ tables:
 
 execution:
   type: streaming
-  time-characteristic: event-time
-  parallelism: 1
+
+configuration:
+  parallelism.default: 1
+  pipeline.time-characteristic: EventTime


### PR DESCRIPTION


## What is the purpose of the change

*Many specific properties for sql client can be replace with config options from flink-conf.yaml. such as: execution.parallelism can be replaced with parallelism.default.
Sql client does not support many properties from flink-conf.yaml for SET command, such as `state.backend`.
As discussed in [FLINK-18161](https://issues.apache.org/jira/browse/FLINK-18161), we can deprecate sql client specific properties and support all properties from flink-conf.yaml. If there is a conflict between deprecate property and new property, just throws exception.*


## Brief change log

  - *Let ConfigurationEntry accept all properties, and let ExecutionEntry accept properties which are defined*
  - *add property conflict check when merging environment file and calling SET command*
  - *update environment file and document*


## Verifying this change



This change added tests and can be verified as follows:

  - *Extended EnvironmentTest to verify the property conflict*
  - *Extended LocalExecutorITCase to verify SET command*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
