### PR TITLE
[FLINK-18859][tests] Increase timeout of ExecutionGraphNotEnoughResourceTest#testRestartWithSlotSharingAndNotEnoughResources to make it more stable

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphNotEnoughResourceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphNotEnoughResourceTest.java
@@ -129,7 +129,7 @@ public class ExecutionGraphNotEnoughResourceTest extends TestLogger {
 
 			CommonTestUtils.waitUntilCondition(
 				() -> CompletableFuture.supplyAsync(eg::getState, mainThreadExecutor).join() == JobStatus.FAILED,
-				Deadline.fromNow(Duration.ofMillis(2000)));
+				Deadline.fromNow(Duration.ofSeconds(10)));
 
 			// the last suppressed restart is also counted
 			assertEquals(numRestarts + 1, CompletableFuture.supplyAsync(eg::getNumberOfRestarts, mainThreadExecutor).join().longValue());


### PR DESCRIPTION
## What is the purpose of the change

Fix unstable test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
