### PR TITLE
[FLINK-18809][table] Update all built-in aggregate functions to the new type system

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRawValueData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRawValueData.java
@@ -78,12 +78,25 @@ public final class BinaryRawValueData<T> extends LazyBinaryFormat<T> implements 
 
 	@Override
 	public boolean equals(Object o) {
-		throw new UnsupportedOperationException("BinaryRawValueData cannot be compared");
+		if (o instanceof BinaryRawValueData) {
+			BinaryRawValueData<?> other = (BinaryRawValueData<?>) o;
+			if (binarySection != null && other.binarySection != null) {
+				return binarySection.equals(other.binarySection);
+			}
+			throw new UnsupportedOperationException(
+				"Unmaterialized BinaryRawValueData cannot be compared.");
+		} else {
+			return false;
+		}
 	}
 
 	@Override
 	public int hashCode() {
-		throw new UnsupportedOperationException("BinaryRawValueData does not have a hashCode");
+		if (binarySection != null) {
+			return binarySection.hashCode();
+		}
+		throw new UnsupportedOperationException(
+			"Unmaterialized BinaryRawValueData does not have a hashCode.");
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
@@ -432,6 +432,20 @@ public final class BinaryRowData extends BinarySection implements RowData, Typed
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		// both BinaryRowData and NestedRowData have the same memory format
+		if (!(o instanceof BinaryRowData || o instanceof NestedRowData)) {
+			return false;
+		}
+		final BinarySection that = (BinarySection) o;
+		return sizeInBytes == that.sizeInBytes &&
+			BinarySegmentUtils.equals(segments, offset, that.segments, that.offset, sizeInBytes);
+	}
+
+	@Override
 	public int hashCode() {
 		return BinarySegmentUtils.hashByWords(segments, offset, sizeInBytes);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinarySection.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinarySection.java
@@ -62,10 +62,15 @@ public class BinarySection implements BinaryFormat {
 
 	@Override
 	public boolean equals(Object o) {
-		return this == o || o != null &&
-			getClass() == o.getClass() &&
-			sizeInBytes == ((BinarySection) o).sizeInBytes &&
-			BinarySegmentUtils.equals(segments, offset, ((BinarySection) o).segments, ((BinarySection) o).offset, sizeInBytes);
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final BinarySection that = (BinarySection) o;
+		return sizeInBytes == that.sizeInBytes &&
+			BinarySegmentUtils.equals(segments, offset, that.segments, that.offset, sizeInBytes);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NestedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NestedRowData.java
@@ -328,6 +328,20 @@ public final class NestedRowData extends BinarySection implements RowData, Typed
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		// both BinaryRowData and NestedRowData have the same memory format
+		if (!(o instanceof NestedRowData || o instanceof BinaryRowData)) {
+			return false;
+		}
+		final BinarySection that = (BinarySection) o;
+		return sizeInBytes == that.sizeInBytes &&
+			BinarySegmentUtils.equals(segments, offset, that.segments, that.offset, sizeInBytes);
+	}
+
+	@Override
 	public int hashCode() {
 		return BinarySegmentUtils.hashByWords(segments, offset, sizeInBytes);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -99,7 +99,7 @@ public final class LogicalTypeChecks {
 	public static boolean hasLegacyTypes(LogicalType logicalType) {
 		return hasNested(
 			logicalType,
-			t -> t instanceof LegacyTypeInformationType || t instanceof TypeInformationRawType
+			t -> t instanceof LegacyTypeInformationType
 		);
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CollectAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CollectAggFunction.java
@@ -18,41 +18,62 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.MapTypeInfo;
-import org.apache.flink.api.java.typeutils.PojoField;
-import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.MapView;
-import org.apache.flink.table.dataview.MapViewTypeInfo;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.util.WrappingRuntimeException;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
+
 /**
- * Aggregate function for COLLECT.
- * @param <T> type of collect element.
+ * Built-in COLLECT aggregate function.
  */
-public class CollectAggFunction<T>
-	extends AggregateFunction<Map<T, Integer>, CollectAggFunction.CollectAccumulator<T>> {
+@Internal
+public final class CollectAggFunction<T>
+		extends InternalAggregateFunction<MapData, CollectAggFunction.CollectAccumulator<T>> {
 
 	private static final long serialVersionUID = -5860934997657147836L;
 
-	private final TypeInformation<T> elementType;
+	private transient DataType elementDataType;
 
-	public CollectAggFunction(TypeInformation<T> elementType) {
-		this.elementType = elementType;
+	public CollectAggFunction(LogicalType elementType) {
+		this.elementDataType = toInternalDataType(elementType);
 	}
 
-	/** The initial accumulator for Collect aggregate function. */
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{elementDataType};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.STRUCTURED(
+			CollectAccumulator.class,
+			DataTypes.FIELD("map", MapView.newMapViewDataType(elementDataType.notNull(), DataTypes.INT())));
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return DataTypes.MULTISET(elementDataType).bridgedTo(MapData.class);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
+	/** Accumulator for COLLECT. */
 	public static class CollectAccumulator<T> {
-		public MapView<T, Integer> map = null;
+		public MapView<T, Integer> map;
 
 		@Override
 		public boolean equals(Object o) {
@@ -68,8 +89,8 @@ public class CollectAggFunction<T>
 	}
 
 	public CollectAccumulator<T> createAccumulator() {
-		CollectAccumulator<T> acc = new CollectAccumulator<>();
-		acc.map = new MapView<>(elementType, Types.INT);
+		final CollectAccumulator<T> acc = new CollectAccumulator<>();
+		acc.map = new MapView<>();
 		return acc;
 	}
 
@@ -119,35 +140,7 @@ public class CollectAggFunction<T>
 	}
 
 	@Override
-	public Map<T, Integer> getValue(CollectAccumulator<T> accumulator) {
-		Map<T, Integer> result = new HashMap<>();
-		try {
-			for (Map.Entry<T, Integer> entry : accumulator.map.entries()) {
-				result.put(entry.getKey(), entry.getValue());
-			}
-			return result;
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@Override
-	public TypeInformation<Map<T, Integer>> getResultType() {
-		return new MapTypeInfo<>(elementType, Types.INT);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public TypeInformation<CollectAccumulator<T>> getAccumulatorType() {
-		try {
-			Class<CollectAccumulator<T>> clazz = (Class<CollectAccumulator<T>>) (Class) CollectAccumulator.class;
-			List<PojoField> pojoFields = new ArrayList<>();
-			pojoFields.add(new PojoField(
-				clazz.getDeclaredField("map"),
-				new MapViewTypeInfo<>(elementType, BasicTypeInfo.INT_TYPE_INFO)));
-			return new PojoTypeInfo<>(clazz, pojoFields);
-		} catch (NoSuchFieldException e) {
-			throw new WrappingRuntimeException(e);
-		}
+	public MapData getValue(CollectAccumulator<T> accumulator) {
+		return new GenericMapData(accumulator.map.getMap());
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunction.java
@@ -18,37 +18,61 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
-import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
-import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType;
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
 
 /**
- * built-in FirstValue aggregate function.
+ * Built-in FIRST_VALUE aggregate function.
  */
-public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, RowData> {
+@Internal
+public final class FirstValueAggFunction<T> extends InternalAggregateFunction<T, RowData> {
+
+	private transient DataType valueDataType;
+
+	public FirstValueAggFunction(LogicalType valueType) {
+		this.valueDataType = toInternalDataType(valueType);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{valueDataType};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.ROW(
+			DataTypes.FIELD("firstValue", valueDataType.nullable()),
+			DataTypes.FIELD("firstOrder", DataTypes.BIGINT())).bridgedTo(RowData.class);
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return valueDataType;
+	}
 
 	@Override
 	public boolean isDeterministic() {
 		return false;
 	}
 
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
 	@Override
 	public RowData createAccumulator() {
-		// The accumulator schema:
-		// firstValue: T
-		// firstOrder: Long
 		GenericRowData acc = new GenericRowData(2);
 		acc.setField(0, null);
 		acc.setField(1, Long.MAX_VALUE);
@@ -71,6 +95,18 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, RowD
 		}
 	}
 
+	public void accumulate(RowData rowData, StringData value) {
+		if (value != null) {
+			accumulate(rowData, (Object) ((BinaryStringData) value).copy());
+		}
+	}
+
+	public void accumulate(RowData rowData, StringData value, Long order) {
+		if (value != null) {
+			accumulate(rowData, (Object) ((BinaryStringData) value).copy(), order);
+		}
+	}
+
 	public void resetAccumulator(RowData rowData) {
 		GenericRowData acc = (GenericRowData) rowData;
 		acc.setField(0, null);
@@ -82,146 +118,5 @@ public abstract class FirstValueAggFunction<T> extends AggregateFunction<T, RowD
 	public T getValue(RowData acc) {
 		GenericRowData genericAcc = (GenericRowData) acc;
 		return (T) genericAcc.getField(0);
-	}
-
-	@Override
-	public TypeInformation<RowData> getAccumulatorType() {
-		LogicalType[] fieldTypes = new LogicalType[] {
-				fromTypeInfoToLogicalType(getResultType()),
-				new BigIntType()
-		};
-
-		String[] fieldNames = new String[] {
-				"value",
-				"time"
-		};
-
-		return InternalTypeInfo.ofFields(fieldTypes, fieldNames);
-	}
-
-	/**
-	 * Built-in Byte FirstValue aggregate function.
-	 */
-	public static class ByteFirstValueAggFunction extends FirstValueAggFunction<Byte> {
-
-		@Override
-		public TypeInformation<Byte> getResultType() {
-			return Types.BYTE;
-		}
-	}
-
-	/**
-	 * Built-in Short FirstValue aggregate function.
-	 */
-	public static class ShortFirstValueAggFunction extends FirstValueAggFunction<Short> {
-
-		@Override
-		public TypeInformation<Short> getResultType() {
-			return Types.SHORT;
-		}
-	}
-
-	/**
-	 * Built-in Int FirstValue aggregate function.
-	 */
-	public static class IntFirstValueAggFunction extends FirstValueAggFunction<Integer> {
-
-		@Override
-		public TypeInformation<Integer> getResultType() {
-			return Types.INT;
-		}
-	}
-
-	/**
-	 * Built-in Long FirstValue aggregate function.
-	 */
-	public static class LongFirstValueAggFunction extends FirstValueAggFunction<Long> {
-
-		@Override
-		public TypeInformation<Long> getResultType() {
-			return Types.LONG;
-		}
-	}
-
-	/**
-	 * Built-in Float FirstValue aggregate function.
-	 */
-	public static class FloatFirstValueAggFunction extends FirstValueAggFunction<Float> {
-
-		@Override
-		public TypeInformation<Float> getResultType() {
-			return Types.FLOAT;
-		}
-	}
-
-	/**
-	 * Built-in Double FirstValue aggregate function.
-	 */
-	public static class DoubleFirstValueAggFunction extends FirstValueAggFunction<Double> {
-
-		@Override
-		public TypeInformation<Double> getResultType() {
-			return Types.DOUBLE;
-		}
-	}
-
-	/**
-	 * Built-in Boolean FirstValue aggregate function.
-	 */
-	public static class BooleanFirstValueAggFunction extends FirstValueAggFunction<Boolean> {
-
-		@Override
-		public TypeInformation<Boolean> getResultType() {
-			return Types.BOOLEAN;
-		}
-	}
-
-	/**
-	 * Built-in DecimalData FirstValue aggregate function.
-	 */
-	public static class DecimalFirstValueAggFunction extends FirstValueAggFunction<DecimalData> {
-
-		private DecimalDataTypeInfo decimalTypeInfo;
-
-		public DecimalFirstValueAggFunction(DecimalDataTypeInfo decimalTypeInfo) {
-			this.decimalTypeInfo = decimalTypeInfo;
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value) {
-			super.accumulate(acc, value);
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value, Long order) {
-			super.accumulate(acc, value, order);
-		}
-
-		@Override
-		public TypeInformation<DecimalData> getResultType() {
-			return decimalTypeInfo;
-		}
-	}
-
-	/**
-	 * Built-in String FirstValue aggregate function.
-	 */
-	public static class StringFirstValueAggFunction extends FirstValueAggFunction<StringData> {
-
-		@Override
-		public TypeInformation<StringData> getResultType() {
-			return StringDataTypeInfo.INSTANCE;
-		}
-
-		public void accumulate(GenericRowData acc, StringData value) {
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy());
-			}
-		}
-
-		public void accumulate(GenericRowData acc, StringData value, Long order) {
-			// just ignore nulls values and orders
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy(), order);
-			}
-		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunction.java
@@ -18,127 +18,182 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
-import org.apache.flink.api.common.typeutils.base.ByteSerializer;
-import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
-import org.apache.flink.api.common.typeutils.base.FloatSerializer;
-import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.common.typeutils.base.ListSerializer;
-import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.api.common.typeutils.base.MapSerializer;
-import org.apache.flink.api.common.typeutils.base.ShortSerializer;
-import org.apache.flink.api.java.typeutils.ListTypeInfo;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.MapView;
-import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.RawValueData;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
-import org.apache.flink.table.dataview.MapViewSerializer;
-import org.apache.flink.table.dataview.MapViewTypeInfo;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataSerializer;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.runtime.typeutils.StringDataSerializer;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
-import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.TypeInformationRawType;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
-import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType;
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
 
 /**
- * built-in FirstValue with retraction aggregate function.
+ * Built-in FIRST_VALUE with retraction aggregate function.
  */
-public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunction<T, RowData> {
+@Internal
+public final class FirstValueWithRetractAggFunction<T>
+		extends InternalAggregateFunction<T, FirstValueWithRetractAggFunction.FirstValueWithRetractAccumulator<T>> {
+
+	private transient DataType valueDataType;
+
+	public FirstValueWithRetractAggFunction(LogicalType valueType) {
+		this.valueDataType = toInternalDataType(valueType);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public RowData createAccumulator() {
-		// The accumulator schema:
-		// firstValue: T
-		// fistOrder: Long
-		// valueToOrderMap: RawValueData<MapView<T, List<Long>>>
-		// orderToValueMap: RawValueData<MapView<Long, List<T>>>
-		GenericRowData acc = new GenericRowData(4);
-		acc.setField(0, null);
-		acc.setField(1, null);
-		acc.setField(2, RawValueData.fromObject(
-			new MapView<>(getResultType(), new ListTypeInfo<>(Types.LONG))));
-		acc.setField(3, RawValueData.fromObject(
-			new MapView<>(Types.LONG, new ListTypeInfo<>(getResultType()))));
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{valueDataType};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.STRUCTURED(
+			FirstValueWithRetractAccumulator.class,
+			DataTypes.FIELD(
+				"firstValue",
+				valueDataType.nullable()),
+			DataTypes.FIELD(
+				"firstOrder",
+				DataTypes.BIGINT()),
+			DataTypes.FIELD(
+				"valueToOrderMap",
+				MapView.newMapViewDataType(
+					valueDataType.notNull(),
+					DataTypes.ARRAY(DataTypes.BIGINT()).bridgedTo(List.class))),
+			DataTypes.FIELD(
+				"orderToValueMap",
+				MapView.newMapViewDataType(
+					DataTypes.BIGINT(),
+					DataTypes.ARRAY(valueDataType.notNull()).bridgedTo(List.class)))
+		);
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return valueDataType;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
+	/** Accumulator for FIRST_VALUE. */
+	public static class FirstValueWithRetractAccumulator<T> {
+		public T firstValue;
+		public Long firstOrder;
+		public MapView<T, List<Long>> valueToOrderMap;
+		public MapView<Long, List<T>> orderToValueMap;
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof FirstValueWithRetractAccumulator)) {
+				return false;
+			}
+			FirstValueWithRetractAccumulator<?> that = (FirstValueWithRetractAccumulator<?>) o;
+			return Objects.equals(firstValue, that.firstValue) &&
+				Objects.equals(firstOrder, that.firstOrder) &&
+				Objects.equals(valueToOrderMap, that.valueToOrderMap) &&
+				Objects.equals(orderToValueMap, that.orderToValueMap);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(firstValue, firstOrder, valueToOrderMap, orderToValueMap);
+		}
+	}
+
+	@Override
+	public FirstValueWithRetractAccumulator<T> createAccumulator() {
+		final FirstValueWithRetractAccumulator<T> acc = new FirstValueWithRetractAccumulator<>();
+		acc.firstValue = null;
+		acc.firstOrder = null;
+		acc.valueToOrderMap = new MapView<>();
+		acc.orderToValueMap = new MapView<>();
 		return acc;
 	}
 
-	public void accumulate(RowData rowData, Object value) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	@SuppressWarnings("unchecked")
+	public void accumulate(FirstValueWithRetractAccumulator<T> acc, Object value) throws Exception {
 		if (value != null) {
 			T v = (T) value;
 			Long order = System.currentTimeMillis();
-			MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
-			List<Long> orderList = valueToOrderMapView.get(v);
+			List<Long> orderList = acc.valueToOrderMap.get(v);
 			if (orderList == null) {
 				orderList = new ArrayList<>();
 			}
 			orderList.add(order);
-			valueToOrderMapView.put(v, orderList);
-			accumulate(acc, value, order);
+			acc.valueToOrderMap.put(v, orderList);
+			accumulate(acc, v, order);
 		}
 	}
 
-	public void accumulate(RowData rowData, Object value, Long order) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	@SuppressWarnings("unchecked")
+	public void accumulate(FirstValueWithRetractAccumulator<T> acc, Object value, Long order) throws Exception {
 		if (value != null) {
 			T v = (T) value;
-			Long prevOrder = (Long) acc.getField(1);
+			Long prevOrder = acc.firstOrder;
 			if (prevOrder == null || prevOrder > order) {
-				acc.setField(0, v); // acc.firstValue = v
-				acc.setField(1, order); // acc.firstOrder = order
+				acc.firstValue = v;
+				acc.firstOrder = order;
 			}
 
-			MapView<Long, List<T>> orderToValueMapView = getOrderToValueMapViewFromAcc(acc);
-			List<T> valueList = orderToValueMapView.get(order);
+			List<T> valueList = acc.orderToValueMap.get(order);
 			if (valueList == null) {
 				valueList = new ArrayList<>();
 			}
 			valueList.add(v);
-			orderToValueMapView.put(order, valueList);
+			acc.orderToValueMap.put(order, valueList);
 		}
 	}
 
-	public void retract(RowData rowData, Object value) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	public void accumulate(FirstValueWithRetractAccumulator<T> acc, StringData value) throws Exception {
+		if (value != null) {
+			accumulate(acc, (Object) ((BinaryStringData) value).copy());
+		}
+	}
+
+	public void accumulate(FirstValueWithRetractAccumulator<T> acc, StringData value, Long order) throws Exception {
+		if (value != null) {
+			accumulate(acc, (Object) ((BinaryStringData) value).copy(), order);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public void retract(FirstValueWithRetractAccumulator<T> acc, Object value) throws Exception {
 		if (value != null) {
 			T v = (T) value;
-			MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
-			List<Long> orderList = valueToOrderMapView.get(v);
+			List<Long> orderList = acc.valueToOrderMap.get(v);
 			if (orderList != null && orderList.size() > 0) {
 				Long order = orderList.get(0);
 				orderList.remove(0);
 				if (orderList.isEmpty()) {
-					valueToOrderMapView.remove(v);
+					acc.valueToOrderMap.remove(v);
 				} else {
-					valueToOrderMapView.put(v, orderList);
+					acc.valueToOrderMap.put(v, orderList);
 				}
-				retract(acc, value, order);
+				retract(acc, v, order);
 			}
 		}
 	}
 
-	public void retract(RowData rowData, Object value, Long order) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	@SuppressWarnings("unchecked")
+	public void retract(FirstValueWithRetractAccumulator<T> acc, Object value, Long order) throws Exception {
 		if (value != null) {
 			T v = (T) value;
-			MapView<Long, List<T>> orderToValueMapView = getOrderToValueMapViewFromAcc(acc);
-			List<T> valueList = orderToValueMapView.get(order);
+			List<T> valueList = acc.orderToValueMap.get(order);
 			if (valueList == null) {
 				return;
 			}
@@ -146,14 +201,14 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 			if (index >= 0) {
 				valueList.remove(index);
 				if (valueList.isEmpty()) {
-					orderToValueMapView.remove(order);
+					acc.orderToValueMap.remove(order);
 				} else {
-					orderToValueMapView.put(order, valueList);
+					acc.orderToValueMap.put(order, valueList);
 				}
 			}
-			if (v.equals(acc.getField(0))) { // v == acc.firstValue
-				Long startKey = (Long) acc.getField(1);
-				Iterator<Long> iter = orderToValueMapView.keys().iterator();
+			if (v.equals(acc.firstValue)) {
+				Long startKey = acc.firstOrder;
+				Iterator<Long> iter = acc.orderToValueMap.keys().iterator();
 				// find the minimal order which is greater than or equal to `startKey`
 				Long nextKey = Long.MAX_VALUE;
 				while (iter.hasNext()) {
@@ -164,252 +219,25 @@ public abstract class FirstValueWithRetractAggFunction<T> extends AggregateFunct
 				}
 
 				if (nextKey != Long.MAX_VALUE) {
-					acc.setField(0, orderToValueMapView.get(nextKey).get(0));
-					acc.setField(1, nextKey);
+					acc.firstValue = acc.orderToValueMap.get(nextKey).get(0);
+					acc.firstOrder = nextKey;
 				} else {
-					acc.setField(0, null);
-					acc.setField(1, null);
+					acc.firstValue = null;
+					acc.firstOrder = null;
 				}
 			}
 		}
 	}
 
-	public void resetAccumulator(RowData rowData) {
-		GenericRowData acc = (GenericRowData) rowData;
-		acc.setField(0, null);
-		acc.setField(1, null);
-		MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
-		valueToOrderMapView.clear();
-		MapView<Long, List<T>> orderToValueMapView = getOrderToValueMapViewFromAcc(acc);
-		orderToValueMapView.clear();
+	public void resetAccumulator(FirstValueWithRetractAccumulator<T> acc) {
+		acc.firstValue = null;
+		acc.firstOrder = null;
+		acc.valueToOrderMap.clear();
+		acc.orderToValueMap.clear();
 	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public T getValue(RowData rowData) {
-		GenericRowData acc = (GenericRowData) rowData;
-		return (T) acc.getField(0);
-	}
-
-	protected abstract TypeSerializer<T> createValueSerializer();
 
 	@Override
-	public TypeInformation<RowData> getAccumulatorType() {
-		LogicalType[] fieldTypes = new LogicalType[] {
-				fromTypeInfoToLogicalType(getResultType()),
-				new BigIntType(),
-				new TypeInformationRawType<>(new MapViewTypeInfo<>(getResultType(), new ListTypeInfo<>(Types.LONG), false, false)),
-				new TypeInformationRawType<>(new MapViewTypeInfo<>(Types.LONG, new ListTypeInfo<>(getResultType()), false, false))
-		};
-
-		String[] fieldNames = new String[] {
-				"firstValue",
-				"firstOrder",
-				"valueToOrderMapView",
-				"orderToValueMapView"
-		};
-
-		return InternalTypeInfo.ofFields(fieldTypes, fieldNames);
-	}
-
-	@SuppressWarnings("unchecked")
-	private MapView<T, List<Long>> getValueToOrderMapViewFromAcc(GenericRowData acc) {
-		RawValueData<MapView<T, List<Long>>> rawValue =
-				(RawValueData<MapView<T, List<Long>>>) acc.getField(2);
-		return rawValue.toObject(getValueToOrderMapViewSerializer());
-	}
-
-	@SuppressWarnings("unchecked")
-	private MapView<Long, List<T>> getOrderToValueMapViewFromAcc(GenericRowData acc) {
-		RawValueData<MapView<Long, List<T>>> rawValue =
-				(RawValueData<MapView<Long, List<T>>>) acc.getField(3);
-		return rawValue.toObject(getOrderToValueMapViewSerializer());
-	}
-
-	// MapView<T, List<Long>>
-	private MapViewSerializer<T, List<Long>> getValueToOrderMapViewSerializer() {
-		return new MapViewSerializer<>(
-				new MapSerializer<>(
-						createValueSerializer(),
-						new ListSerializer<>(LongSerializer.INSTANCE)));
-	}
-
-	// MapView<Long, List<T>>
-	private MapViewSerializer<Long, List<T>> getOrderToValueMapViewSerializer() {
-		return new MapViewSerializer<>(
-				new MapSerializer<>(
-						LongSerializer.INSTANCE,
-						new ListSerializer<>(createValueSerializer())));
-	}
-
-	/**
-	 * Built-in Byte FirstValue with retract aggregate function.
-	 */
-	public static class ByteFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Byte> {
-
-		@Override
-		public TypeInformation<Byte> getResultType() {
-			return Types.BYTE;
-		}
-
-		@Override
-		protected TypeSerializer<Byte> createValueSerializer() {
-			return ByteSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Short FirstValue with retract aggregate function.
-	 */
-	public static class ShortFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Short> {
-
-		@Override
-		public TypeInformation<Short> getResultType() {
-			return Types.SHORT;
-		}
-
-		@Override
-		protected TypeSerializer<Short> createValueSerializer() {
-			return ShortSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Int FirstValue with retract aggregate function.
-	 */
-	public static class IntFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Integer> {
-
-		@Override
-		public TypeInformation<Integer> getResultType() {
-			return Types.INT;
-		}
-
-		@Override
-		protected TypeSerializer<Integer> createValueSerializer() {
-			return IntSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Long FirstValue with retract aggregate function.
-	 */
-	public static class LongFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Long> {
-
-		@Override
-		public TypeInformation<Long> getResultType() {
-			return Types.LONG;
-		}
-
-		@Override
-		protected TypeSerializer<Long> createValueSerializer() {
-			return LongSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Float FirstValue with retract aggregate function.
-	 */
-	public static class FloatFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Float> {
-
-		@Override
-		public TypeInformation<Float> getResultType() {
-			return Types.FLOAT;
-		}
-
-		@Override
-		protected TypeSerializer<Float> createValueSerializer() {
-			return FloatSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Double FirstValue with retract aggregate function.
-	 */
-	public static class DoubleFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Double> {
-
-		@Override
-		public TypeInformation<Double> getResultType() {
-			return Types.DOUBLE;
-		}
-
-		@Override
-		protected TypeSerializer<Double> createValueSerializer() {
-			return DoubleSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Boolean FirstValue with retract aggregate function.
-	 */
-	public static class BooleanFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<Boolean> {
-
-		@Override
-		public TypeInformation<Boolean> getResultType() {
-			return Types.BOOLEAN;
-		}
-
-		@Override
-		protected TypeSerializer<Boolean> createValueSerializer() {
-			return BooleanSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in DecimalData FirstValue with retract aggregate function.
-	 */
-	public static class DecimalFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<DecimalData> {
-
-		private DecimalDataTypeInfo decimalTypeInfo;
-
-		public DecimalFirstValueWithRetractAggFunction(DecimalDataTypeInfo decimalTypeInfo) {
-			this.decimalTypeInfo = decimalTypeInfo;
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value, Long order) throws Exception {
-			super.accumulate(acc, value, order);
-		}
-
-		@Override
-		public TypeInformation<DecimalData> getResultType() {
-			return decimalTypeInfo;
-		}
-
-		@Override
-		protected TypeSerializer<DecimalData> createValueSerializer() {
-			return new DecimalDataSerializer(decimalTypeInfo.precision(), decimalTypeInfo.scale());
-		}
-	}
-
-	/**
-	 * Built-in String FirstValue with retract aggregate function.
-	 */
-	public static class StringFirstValueWithRetractAggFunction extends FirstValueWithRetractAggFunction<StringData> {
-
-		@Override
-		public TypeInformation<StringData> getResultType() {
-			return StringDataTypeInfo.INSTANCE;
-		}
-
-		public void accumulate(GenericRowData acc, StringData value) throws Exception {
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy());
-			}
-		}
-
-		public void accumulate(GenericRowData acc, StringData value, Long order) throws Exception {
-			// just ignore nulls values and orders
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy(), order);
-			}
-		}
-
-		@Override
-		protected TypeSerializer<StringData> createValueSerializer() {
-			return StringDataSerializer.INSTANCE;
-		}
+	public T getValue(FirstValueWithRetractAccumulator<T> acc) {
+		return acc.firstValue;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/InternalAggregateFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/InternalAggregateFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.planner.plan.utils.AggFunctionFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.TypeInference;
+
+import static org.apache.flink.table.types.inference.TypeStrategies.explicit;
+
+/**
+ * Base class for fully resolved and strongly typed {@link AggregateFunction}s provided by {@link AggFunctionFactory}.
+ *
+ * <p>We override {@link #getTypeInference(DataTypeFactory)} in case the internal function is used
+ * externally for testing.
+ */
+@Internal
+public abstract class InternalAggregateFunction<T, ACC> extends AggregateFunction<T, ACC> {
+
+	public abstract DataType[] getInputDataTypes();
+
+	public abstract DataType getAccumulatorDataType();
+
+	public abstract DataType getOutputDataType();
+
+	@Override
+	public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+		return TypeInference.newBuilder()
+			.typedArguments(getInputDataTypes())
+			.accumulatorTypeStrategy(explicit(getAccumulatorDataType()))
+			.outputTypeStrategy(explicit(getOutputDataType()))
+			.build();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
@@ -18,37 +18,61 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
-import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
-import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType;
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
 
 /**
- * built-in LastValue aggregate function.
+ * Built-in LAST_VALUE aggregate function.
  */
-public class LastValueAggFunction<T> extends AggregateFunction<T, RowData> {
+@Internal
+public final class LastValueAggFunction<T> extends InternalAggregateFunction<T, RowData> {
+
+	private transient DataType valueDataType;
+
+	public LastValueAggFunction(LogicalType valueType) {
+		this.valueDataType = toInternalDataType(valueType);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{valueDataType};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.ROW(
+			DataTypes.FIELD("lastValue", valueDataType.nullable()),
+			DataTypes.FIELD("lastOrder", DataTypes.BIGINT())).bridgedTo(RowData.class);
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return valueDataType;
+	}
 
 	@Override
 	public boolean isDeterministic() {
 		return false;
 	}
 
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
 	@Override
 	public RowData createAccumulator() {
-		// The accumulator schema:
-		// lastValue: T
-		// lastOrder: Long
 		GenericRowData acc = new GenericRowData(2);
 		acc.setField(0, null);
 		acc.setField(1, Long.MIN_VALUE);
@@ -70,6 +94,18 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, RowData> {
 		}
 	}
 
+	public void accumulate(GenericRowData acc, StringData value) {
+		if (value != null) {
+			accumulate(acc, (Object) ((BinaryStringData) value).copy());
+		}
+	}
+
+	public void accumulate(GenericRowData acc, StringData value, Long order) {
+		if (value != null) {
+			accumulate(acc, (Object) ((BinaryStringData) value).copy(), order);
+		}
+	}
+
 	public void resetAccumulator(RowData rowData) {
 		GenericRowData acc = (GenericRowData) rowData;
 		acc.setField(0, null);
@@ -81,146 +117,5 @@ public class LastValueAggFunction<T> extends AggregateFunction<T, RowData> {
 	public T getValue(RowData rowData) {
 		GenericRowData acc = (GenericRowData) rowData;
 		return (T) acc.getField(0);
-	}
-
-	@Override
-	public TypeInformation<RowData> getAccumulatorType() {
-		LogicalType[] fieldTypes = new LogicalType[] {
-				fromTypeInfoToLogicalType(getResultType()),
-				new BigIntType()
-		};
-
-		String[] fieldNames = new String[] {
-				"value",
-				"time"
-		};
-
-		return InternalTypeInfo.ofFields(fieldTypes, fieldNames);
-	}
-
-	/**
-	 * Built-in Byte LastValue aggregate function.
-	 */
-	public static class ByteLastValueAggFunction extends LastValueAggFunction<Byte> {
-
-		@Override
-		public TypeInformation<Byte> getResultType() {
-			return Types.BYTE;
-		}
-	}
-
-	/**
-	 * Built-in Short LastValue aggregate function.
-	 */
-	public static class ShortLastValueAggFunction extends LastValueAggFunction<Short> {
-
-		@Override
-		public TypeInformation<Short> getResultType() {
-			return Types.SHORT;
-		}
-	}
-
-	/**
-	 * Built-in Int LastValue aggregate function.
-	 */
-	public static class IntLastValueAggFunction extends LastValueAggFunction<Integer> {
-
-		@Override
-		public TypeInformation<Integer> getResultType() {
-			return Types.INT;
-		}
-	}
-
-	/**
-	 * Built-in Long LastValue aggregate function.
-	 */
-	public static class LongLastValueAggFunction extends LastValueAggFunction<Long> {
-
-		@Override
-		public TypeInformation<Long> getResultType() {
-			return Types.LONG;
-		}
-	}
-
-	/**
-	 * Built-in Float LastValue aggregate function.
-	 */
-	public static class FloatLastValueAggFunction extends LastValueAggFunction<Float> {
-
-		@Override
-		public TypeInformation<Float> getResultType() {
-			return Types.FLOAT;
-		}
-	}
-
-	/**
-	 * Built-in Double LastValue aggregate function.
-	 */
-	public static class DoubleLastValueAggFunction extends LastValueAggFunction<Double> {
-
-		@Override
-		public TypeInformation<Double> getResultType() {
-			return Types.DOUBLE;
-		}
-	}
-
-	/**
-	 * Built-in Boolean LastValue aggregate function.
-	 */
-	public static class BooleanLastValueAggFunction extends LastValueAggFunction<Boolean> {
-
-		@Override
-		public TypeInformation<Boolean> getResultType() {
-			return Types.BOOLEAN;
-		}
-	}
-
-	/**
-	 * Built-in DecimalData LastValue aggregate function.
-	 */
-	public static class DecimalLastValueAggFunction extends LastValueAggFunction<DecimalData> {
-
-		private DecimalDataTypeInfo decimalTypeInfo;
-
-		public DecimalLastValueAggFunction(DecimalDataTypeInfo decimalTypeInfo) {
-			this.decimalTypeInfo = decimalTypeInfo;
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value) {
-			super.accumulate(acc, value);
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value, Long order) {
-			super.accumulate(acc, value, order);
-		}
-
-		@Override
-		public TypeInformation<DecimalData> getResultType() {
-			return decimalTypeInfo;
-		}
-	}
-
-	/**
-	 * Built-in String LastValue aggregate function.
-	 */
-	public static class StringLastValueAggFunction extends LastValueAggFunction<StringData> {
-
-		@Override
-		public TypeInformation<StringData> getResultType() {
-			return StringDataTypeInfo.INSTANCE;
-		}
-
-		public void accumulate(GenericRowData acc, StringData value) {
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy());
-			}
-		}
-
-		public void accumulate(GenericRowData acc, StringData value, Long order) {
-			// just ignore nulls values and orders
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy(), order);
-			}
-		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
@@ -18,127 +18,177 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
-import org.apache.flink.api.common.typeutils.base.ByteSerializer;
-import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
-import org.apache.flink.api.common.typeutils.base.FloatSerializer;
-import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.common.typeutils.base.ListSerializer;
-import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.api.common.typeutils.base.MapSerializer;
-import org.apache.flink.api.common.typeutils.base.ShortSerializer;
-import org.apache.flink.api.java.typeutils.ListTypeInfo;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.MapView;
-import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.RawValueData;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
-import org.apache.flink.table.dataview.MapViewSerializer;
-import org.apache.flink.table.dataview.MapViewTypeInfo;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataSerializer;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.runtime.typeutils.StringDataSerializer;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
-import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.TypeInformationRawType;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
-import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType;
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
 
 /**
- * built-in LastValue with retraction aggregate function.
+ * Built-in LAST_VALUE with retraction aggregate function.
  */
-public abstract class LastValueWithRetractAggFunction<T> extends AggregateFunction<T, RowData> {
+@Internal
+public final class LastValueWithRetractAggFunction<T>
+		extends InternalAggregateFunction<T, LastValueWithRetractAggFunction.LastValueWithRetractAccumulator<T>> {
 
-	@Override
-	public RowData createAccumulator() {
-		// The accumulator schema:
-		// lastValue: T
-		// lastOrder: Long
-		// valueToOrderMap: RawValueData<MapView<T, List<Long>>>
-		// orderToValueMap: RawValueData<MapView<Long, List<T>>>
-		GenericRowData acc = new GenericRowData(4);
-		acc.setField(0, null);
-		acc.setField(1, null);
-		acc.setField(2, RawValueData.fromObject(
-				new MapView<>(getResultType(), new ListTypeInfo<>(Types.LONG))));
-		acc.setField(3, RawValueData.fromObject(
-				new MapView<>(Types.LONG, new ListTypeInfo<>(getResultType()))));
-		return acc;
+	private transient DataType valueDataType;
+
+	public LastValueWithRetractAggFunction(LogicalType valueType) {
+		this.valueDataType = toInternalDataType(valueType);
 	}
 
-	public void accumulate(RowData rowData, Object value) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{valueDataType};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.STRUCTURED(
+			LastValueWithRetractAccumulator.class,
+			DataTypes.FIELD(
+				"lastValue",
+				valueDataType.nullable()),
+			DataTypes.FIELD(
+				"lastOrder",
+				DataTypes.BIGINT()),
+			DataTypes.FIELD(
+				"valueToOrderMap",
+				MapView.newMapViewDataType(
+					valueDataType.notNull(),
+					DataTypes.ARRAY(DataTypes.BIGINT()).bridgedTo(List.class))),
+			DataTypes.FIELD(
+				"orderToValueMap",
+				MapView.newMapViewDataType(
+					DataTypes.BIGINT(),
+					DataTypes.ARRAY(valueDataType.notNull()).bridgedTo(List.class)))
+		);
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return valueDataType;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
+	/** Accumulator for LAST_VALUE with retraction. */
+	public static class LastValueWithRetractAccumulator<T> {
+		public T lastValue = null;
+		public Long lastOrder = null;
+		public MapView<T, List<Long>> valueToOrderMap = new MapView<>();
+		public MapView<Long, List<T>> orderToValueMap = new MapView<>();
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof LastValueWithRetractAccumulator)) {
+				return false;
+			}
+			LastValueWithRetractAccumulator<?> that = (LastValueWithRetractAccumulator<?>) o;
+			return Objects.equals(lastValue, that.lastValue) &&
+				Objects.equals(lastOrder, that.lastOrder) &&
+				valueToOrderMap.equals(that.valueToOrderMap) &&
+				orderToValueMap.equals(that.orderToValueMap);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(lastValue, lastOrder, valueToOrderMap, orderToValueMap);
+		}
+	}
+
+	@Override
+	public LastValueWithRetractAccumulator<T> createAccumulator() {
+		return new LastValueWithRetractAccumulator<>();
+	}
+
+	@SuppressWarnings("unchecked")
+	public void accumulate(LastValueWithRetractAccumulator<T> acc, Object value) throws Exception {
 		if (value != null) {
 			T v = (T) value;
 			Long order = System.currentTimeMillis();
-			MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
-			List<Long> orderList = valueToOrderMapView.get(v);
+			List<Long> orderList = acc.valueToOrderMap.get(v);
 			if (orderList == null) {
 				orderList = new ArrayList<>();
 			}
 			orderList.add(order);
-			valueToOrderMapView.put(v, orderList);
+			acc.valueToOrderMap.put(v, orderList);
 			accumulate(acc, value, order);
 		}
 	}
 
-	public void accumulate(RowData rowData, Object value, Long order) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	@SuppressWarnings("unchecked")
+	public void accumulate(LastValueWithRetractAccumulator<T> acc, Object value, Long order) throws Exception {
 		if (value != null) {
 			T v = (T) value;
-			Long prevOrder = (Long) acc.getField(1);
+			Long prevOrder = acc.lastOrder;
 			if (prevOrder == null || prevOrder <= order) {
-				acc.setField(0, v); // acc.lastValue = v
-				acc.setField(1, order); // acc.lastOrder = order
+				acc.lastValue = v;
+				acc.lastOrder = order;
 			}
 
-			MapView<Long, List<T>> orderToValueMapView = getOrderToValueMapViewFromAcc(acc);
-			List<T> valueList = orderToValueMapView.get(order);
+			List<T> valueList = acc.orderToValueMap.get(order);
 			if (valueList == null) {
 				valueList = new ArrayList<>();
 			}
 			valueList.add(v);
-			orderToValueMapView.put(order, valueList);
+			acc.orderToValueMap.put(order, valueList);
 		}
 	}
 
-	public void retract(RowData rowData, Object value) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	public void accumulate(LastValueWithRetractAccumulator<T> acc, StringData value) throws Exception {
+		if (value != null) {
+			accumulate(acc, (Object) ((BinaryStringData) value).copy());
+		}
+	}
+
+	public void accumulate(LastValueWithRetractAccumulator<T> acc, StringData value, Long order) throws Exception {
+		if (value != null) {
+			accumulate(acc, (Object) ((BinaryStringData) value).copy(), order);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public void retract(LastValueWithRetractAccumulator<T> acc, Object value) throws Exception {
 		if (value != null) {
 			T v = (T) value;
-			MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
-			List<Long> orderList = valueToOrderMapView.get(v);
+			List<Long> orderList = acc.valueToOrderMap.get(v);
 			if (orderList != null && orderList.size() > 0) {
 				Long order = orderList.get(0);
 				orderList.remove(0);
 				if (orderList.isEmpty()) {
-					valueToOrderMapView.remove(v);
+					acc.valueToOrderMap.remove(v);
 				} else {
-					valueToOrderMapView.put(v, orderList);
+					acc.valueToOrderMap.put(v, orderList);
 				}
 				retract(acc, value, order);
 			}
 		}
 	}
 
-	public void retract(RowData rowData, Object value, Long order) throws Exception {
-		GenericRowData acc = (GenericRowData) rowData;
+	@SuppressWarnings("unchecked")
+	public void retract(LastValueWithRetractAccumulator<T> acc, Object value, Long order) throws Exception {
 		if (value != null) {
 			T v = (T) value;
-			MapView<Long, List<T>> orderToValueMapView = getOrderToValueMapViewFromAcc(acc);
-			List<T> valueList = orderToValueMapView.get(order);
+			List<T> valueList = acc.orderToValueMap.get(order);
 			if (valueList == null) {
 				return;
 			}
@@ -146,14 +196,14 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 			if (index >= 0) {
 				valueList.remove(index);
 				if (valueList.isEmpty()) {
-					orderToValueMapView.remove(order);
+					acc.orderToValueMap.remove(order);
 				} else {
-					orderToValueMapView.put(order, valueList);
+					acc.orderToValueMap.put(order, valueList);
 				}
 			}
-			if (v.equals(acc.getField(0))) { // v == acc.firstValue
-				Long startKey = (Long) acc.getField(1);
-				Iterator<Long> iter = orderToValueMapView.keys().iterator();
+			if (v.equals(acc.lastValue)) {
+				Long startKey = acc.lastOrder;
+				Iterator<Long> iter = acc.orderToValueMap.keys().iterator();
 				// find the maximal order which is less than or equal to `startKey`
 				Long nextKey = Long.MIN_VALUE;
 				while (iter.hasNext()) {
@@ -164,252 +214,26 @@ public abstract class LastValueWithRetractAggFunction<T> extends AggregateFuncti
 				}
 
 				if (nextKey != Long.MIN_VALUE) {
-					List<T> values = orderToValueMapView.get(nextKey);
-					acc.setField(0, values.get(values.size() - 1));
-					acc.setField(1, nextKey);
+					List<T> values = acc.orderToValueMap.get(nextKey);
+					acc.lastValue = values.get(values.size() - 1);
+					acc.lastOrder = nextKey;
 				} else {
-					acc.setField(0, null);
-					acc.setField(1, null);
+					acc.lastValue = null;
+					acc.lastOrder = null;
 				}
 			}
 		}
 	}
 
-	public void resetAccumulator(RowData rowData) {
-		GenericRowData acc = (GenericRowData) rowData;
-		acc.setField(0, null);
-		acc.setField(1, null);
-		MapView<T, List<Long>> valueToOrderMapView = getValueToOrderMapViewFromAcc(acc);
-		valueToOrderMapView.clear();
-		MapView<Long, List<T>> orderToValueMapView = getOrderToValueMapViewFromAcc(acc);
-		orderToValueMapView.clear();
+	public void resetAccumulator(LastValueWithRetractAccumulator<T> acc) {
+		acc.lastValue = null;
+		acc.lastOrder = null;
+		acc.valueToOrderMap.clear();
+		acc.orderToValueMap.clear();
 	}
 
 	@Override
-	public T getValue(RowData rowData) {
-		GenericRowData acc = (GenericRowData) rowData;
-		return (T) acc.getField(0);
-	}
-
-	protected abstract TypeSerializer<T> createValueSerializer();
-
-	@Override
-	public TypeInformation<RowData> getAccumulatorType() {
-		LogicalType[] fieldTypes = new LogicalType[] {
-				fromTypeInfoToLogicalType(getResultType()),
-				new BigIntType(),
-				new TypeInformationRawType<>(new MapViewTypeInfo<>(getResultType(), new ListTypeInfo<>(Types.LONG), false, false)),
-				new TypeInformationRawType<>(new MapViewTypeInfo<>(Types.LONG, new ListTypeInfo<>(getResultType()), false, false))
-		};
-
-		String[] fieldNames = new String[] {
-				"lastValue",
-				"lastOrder",
-				"valueToOrderMapView",
-				"orderToValueMapView"
-		};
-
-		return InternalTypeInfo.ofFields(fieldTypes, fieldNames);
-	}
-
-	@SuppressWarnings("unchecked")
-	private MapView<T, List<Long>> getValueToOrderMapViewFromAcc(GenericRowData acc) {
-		RawValueData<MapView<T, List<Long>>> rawValue =
-				(RawValueData<MapView<T, List<Long>>>) acc.getField(2);
-		return rawValue.toObject(getValueToOrderMapViewSerializer());
-	}
-
-	@SuppressWarnings("unchecked")
-	private MapView<Long, List<T>> getOrderToValueMapViewFromAcc(GenericRowData acc) {
-		RawValueData<MapView<Long, List<T>>> rawValue =
-				(RawValueData<MapView<Long, List<T>>>) acc.getField(3);
-		return rawValue.toObject(getOrderToValueMapViewSerializer());
-	}
-
-	// MapView<T, List<Long>>
-	private MapViewSerializer<T, List<Long>> getValueToOrderMapViewSerializer() {
-		return new MapViewSerializer<>(
-				new MapSerializer<>(
-						createValueSerializer(),
-						new ListSerializer<>(LongSerializer.INSTANCE)));
-	}
-
-	// MapView<Long, List<T>>
-	private MapViewSerializer<Long, List<T>> getOrderToValueMapViewSerializer() {
-		return new MapViewSerializer<>(
-				new MapSerializer<>(
-						LongSerializer.INSTANCE,
-						new ListSerializer<>(createValueSerializer())));
-	}
-
-	/**
-	 * Built-in Byte LastValue with retract aggregate function.
-	 */
-	public static class ByteLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Byte> {
-
-		@Override
-		public TypeInformation<Byte> getResultType() {
-			return Types.BYTE;
-		}
-
-		@Override
-		protected TypeSerializer<Byte> createValueSerializer() {
-			return ByteSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Short LastValue with retract aggregate function.
-	 */
-	public static class ShortLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Short> {
-
-		@Override
-		public TypeInformation<Short> getResultType() {
-			return Types.SHORT;
-		}
-
-		@Override
-		protected TypeSerializer<Short> createValueSerializer() {
-			return ShortSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Int LastValue with retract aggregate function.
-	 */
-	public static class IntLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Integer> {
-
-		@Override
-		public TypeInformation<Integer> getResultType() {
-			return Types.INT;
-		}
-
-		@Override
-		protected TypeSerializer<Integer> createValueSerializer() {
-			return IntSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Long LastValue with retract aggregate function.
-	 */
-	public static class LongLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Long> {
-
-		@Override
-		public TypeInformation<Long> getResultType() {
-			return Types.LONG;
-		}
-
-		@Override
-		protected TypeSerializer<Long> createValueSerializer() {
-			return LongSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Float LastValue with retract aggregate function.
-	 */
-	public static class FloatLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Float> {
-
-		@Override
-		public TypeInformation<Float> getResultType() {
-			return Types.FLOAT;
-		}
-
-		@Override
-		protected TypeSerializer<Float> createValueSerializer() {
-			return FloatSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Double LastValue with retract aggregate function.
-	 */
-	public static class DoubleLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Double> {
-
-		@Override
-		public TypeInformation<Double> getResultType() {
-			return Types.DOUBLE;
-		}
-
-		@Override
-		protected TypeSerializer<Double> createValueSerializer() {
-			return DoubleSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Boolean LastValue with retract aggregate function.
-	 */
-	public static class BooleanLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<Boolean> {
-
-		@Override
-		public TypeInformation<Boolean> getResultType() {
-			return Types.BOOLEAN;
-		}
-
-		@Override
-		protected TypeSerializer<Boolean> createValueSerializer() {
-			return BooleanSerializer.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in DecimalData LastValue with retract aggregate function.
-	 */
-	public static class DecimalLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<DecimalData> {
-
-		private DecimalDataTypeInfo decimalTypeInfo;
-
-		public DecimalLastValueWithRetractAggFunction(DecimalDataTypeInfo decimalTypeInfo) {
-			this.decimalTypeInfo = decimalTypeInfo;
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void accumulate(GenericRowData acc, DecimalData value, Long order) throws Exception {
-			super.accumulate(acc, value, order);
-		}
-
-		@Override
-		public TypeInformation<DecimalData> getResultType() {
-			return decimalTypeInfo;
-		}
-
-		@Override
-		protected TypeSerializer<DecimalData> createValueSerializer() {
-			return new DecimalDataSerializer(decimalTypeInfo.precision(), decimalTypeInfo.scale());
-		}
-	}
-
-	/**
-	 * Built-in String LastValue with retract aggregate function.
-	 */
-	public static class StringLastValueWithRetractAggFunction extends LastValueWithRetractAggFunction<StringData> {
-
-		@Override
-		public TypeInformation<StringData> getResultType() {
-			return StringDataTypeInfo.INSTANCE;
-		}
-
-		public void accumulate(GenericRowData acc, StringData value) throws Exception {
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy());
-			}
-		}
-
-		public void accumulate(GenericRowData acc, StringData value, Long order) throws Exception {
-			// just ignore nulls values and orders
-			if (value != null) {
-				super.accumulate(acc, ((BinaryStringData) value).copy(), order);
-			}
-		}
-
-		@Override
-		protected TypeSerializer<StringData> createValueSerializer() {
-			return StringDataSerializer.INSTANCE;
-		}
+	public T getValue(LastValueWithRetractAccumulator<T> acc) {
+		return acc.lastValue;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWithRetractAggFunction.java
@@ -18,46 +18,65 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.typeutils.PojoField;
-import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.ListView;
-import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.data.binary.BinaryStringDataUtil;
-import org.apache.flink.table.dataview.ListViewTypeInfo;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
-import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.FlinkRuntimeException;
-import org.apache.flink.util.WrappingRuntimeException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static org.apache.flink.table.types.inference.TypeStrategies.explicit;
-
 /**
- * built-in listagg with retraction aggregate function.
+ * Built-in LISTAGG with retraction aggregate function.
  */
+@Internal
 public final class ListAggWithRetractAggFunction
-	extends AggregateFunction<StringData, ListAggWithRetractAggFunction.ListAggWithRetractAccumulator> {
+		extends InternalAggregateFunction<StringData, ListAggWithRetractAggFunction.ListAggWithRetractAccumulator> {
 
 	private static final long serialVersionUID = -2836795091288790955L;
+
 	private static final BinaryStringData lineDelimiter = BinaryStringData.fromString(",");
 
-	/**
-	 * The initial accumulator for listagg with retraction aggregate function.
-	 */
-	public static class ListAggWithRetractAccumulator {
-		public ListView<StringData> list = new ListView<>(StringDataTypeInfo.INSTANCE);
-		public ListView<StringData> retractList = new ListView<>(StringDataTypeInfo.INSTANCE);
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
 
-		@VisibleForTesting
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{DataTypes.STRING().bridgedTo(StringData.class)};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.STRUCTURED(
+			ListAggWithRetractAccumulator.class,
+			DataTypes.FIELD(
+				"list",
+				ListView.newListViewDataType(DataTypes.STRING().notNull().bridgedTo(StringData.class))),
+			DataTypes.FIELD(
+				"retractList",
+				ListView.newListViewDataType(DataTypes.STRING().notNull().bridgedTo(StringData.class))));
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return DataTypes.STRING().bridgedTo(StringData.class);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
+	/** Accumulator for LISTAGG with retraction. */
+	public static class ListAggWithRetractAccumulator {
+		public ListView<StringData> list;
+		public ListView<StringData> retractList;
+
 		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
@@ -70,59 +89,22 @@ public final class ListAggWithRetractAggFunction
 			return Objects.equals(list, that.list) &&
 				Objects.equals(retractList, that.retractList);
 		}
-	}
 
-	@Override
-	public TypeInformation<StringData> getResultType() {
-		return StringDataTypeInfo.INSTANCE;
-	}
-
-	@Override
-	public TypeInformation<ListAggWithRetractAccumulator> getAccumulatorType() {
-		try {
-			Class<ListAggWithRetractAccumulator> clazz = ListAggWithRetractAccumulator.class;
-			List<PojoField> pojoFields = new ArrayList<>();
-			pojoFields.add(new PojoField(
-				clazz.getDeclaredField("list"),
-				new ListViewTypeInfo<>(StringDataTypeInfo.INSTANCE)));
-			pojoFields.add(new PojoField(
-				clazz.getDeclaredField("retractList"),
-				new ListViewTypeInfo<>(StringDataTypeInfo.INSTANCE)));
-			return new PojoTypeInfo<>(clazz, pojoFields);
-		} catch (NoSuchFieldException e) {
-			throw new WrappingRuntimeException(e);
+		@Override
+		public int hashCode() {
+			return Objects.hash(list, retractList);
 		}
-	}
-
-	// updated to new type system for testing
-	@Override
-	public TypeInference getTypeInference(DataTypeFactory typeFactory) {
-		return TypeInference.newBuilder()
-			.typedArguments(DataTypes.STRING().bridgedTo(StringData.class))
-			.accumulatorTypeStrategy(
-				explicit(
-					DataTypes.STRUCTURED(
-						ListAggWithRetractAccumulator.class,
-						DataTypes.FIELD(
-							"list",
-							ListView.newListViewDataType(DataTypes.STRING().bridgedTo(StringData.class))),
-						DataTypes.FIELD(
-							"retractList",
-							ListView.newListViewDataType(DataTypes.STRING().bridgedTo(StringData.class)))
-					)
-				)
-			)
-			.outputTypeStrategy(explicit(DataTypes.STRING().bridgedTo(StringData.class)))
-			.build();
 	}
 
 	@Override
 	public ListAggWithRetractAccumulator createAccumulator() {
-		return new ListAggWithRetractAccumulator();
+		final ListAggWithRetractAccumulator acc = new ListAggWithRetractAccumulator();
+		acc.list = new ListView<>();
+		acc.retractList = new ListView<>();
+		return acc;
 	}
 
 	public void accumulate(ListAggWithRetractAccumulator acc, StringData value) throws Exception {
-		// ignore null value
 		if (value != null) {
 			acc.list.add(value);
 		}
@@ -175,9 +157,8 @@ public final class ListAggWithRetractAggFunction
 	@Override
 	public StringData getValue(ListAggWithRetractAccumulator acc) {
 		try {
-			// we removed the element type to make the compile pass,
 			// the element must be BinaryStringData because it's the only implementation.
-			Iterable accList = acc.list.get();
+			Iterable<BinaryStringData> accList = (Iterable) acc.list.get();
 			if (accList == null || !accList.iterator().hasNext()) {
 				// return null when the list is empty
 				return null;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunction.java
@@ -18,41 +18,69 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.typeutils.PojoField;
-import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.ListView;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.data.binary.BinaryStringDataUtil;
-import org.apache.flink.table.dataview.ListViewTypeInfo;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.FlinkRuntimeException;
-import org.apache.flink.util.WrappingRuntimeException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 /**
- * built-in listAggWs with retraction aggregate function.
+ * Built-in LISTAGGWS with retraction aggregate function.
  */
+@Internal
 public final class ListAggWsWithRetractAggFunction
-	extends AggregateFunction<StringData, ListAggWsWithRetractAggFunction.ListAggWsWithRetractAccumulator> {
+		extends InternalAggregateFunction<StringData, ListAggWsWithRetractAggFunction.ListAggWsWithRetractAccumulator> {
 
 	private static final long serialVersionUID = -8627988150350160473L;
 
-	/**
-	 * The initial accumulator for concat with retraction aggregate function.
-	 */
-	public static class ListAggWsWithRetractAccumulator {
-		public ListView<StringData> list = new ListView<>(StringDataTypeInfo.INSTANCE);
-		public ListView<StringData> retractList = new ListView<>(StringDataTypeInfo.INSTANCE);
-		public StringData delimiter = StringData.fromString(",");
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
 
-		@VisibleForTesting
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{
+			DataTypes.STRING().bridgedTo(StringData.class),
+			DataTypes.STRING().bridgedTo(StringData.class)};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.STRUCTURED(
+			ListAggWsWithRetractAccumulator.class,
+			DataTypes.FIELD(
+				"list",
+				ListView.newListViewDataType(DataTypes.STRING().notNull().bridgedTo(StringData.class))),
+			DataTypes.FIELD(
+				"retractList",
+				ListView.newListViewDataType(DataTypes.STRING().notNull().bridgedTo(StringData.class))),
+			DataTypes.FIELD(
+				"delimiter",
+				DataTypes.STRING().bridgedTo(StringData.class)));
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return DataTypes.STRING().bridgedTo(StringData.class);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
+	/** Accumulator for LISTAGGWS with retraction. */
+	public static class ListAggWsWithRetractAccumulator {
+		public ListView<StringData> list;
+		public ListView<StringData> retractList;
+		public StringData delimiter;
+
 		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
@@ -63,43 +91,25 @@ public final class ListAggWsWithRetractAggFunction
 			}
 			ListAggWsWithRetractAccumulator that = (ListAggWsWithRetractAccumulator) o;
 			return Objects.equals(list, that.list) &&
-				Objects.equals(retractList, that.retractList) &&
-				Objects.equals(delimiter, that.delimiter);
+				Objects.equals(retractList, that.retractList);
 		}
-	}
 
-	@Override
-	public TypeInformation<StringData> getResultType() {
-		return StringDataTypeInfo.INSTANCE;
-	}
-
-	@Override
-	public TypeInformation<ListAggWsWithRetractAccumulator> getAccumulatorType() {
-		try {
-			Class<ListAggWsWithRetractAccumulator> clazz = ListAggWsWithRetractAccumulator.class;
-			List<PojoField> pojoFields = new ArrayList<>();
-			pojoFields.add(new PojoField(
-				clazz.getDeclaredField("list"),
-				new ListViewTypeInfo<>(StringDataTypeInfo.INSTANCE)));
-			pojoFields.add(new PojoField(
-				clazz.getDeclaredField("retractList"),
-				new ListViewTypeInfo<>(StringDataTypeInfo.INSTANCE)));
-			pojoFields.add(new PojoField(
-				clazz.getDeclaredField("delimiter"),
-				StringDataTypeInfo.INSTANCE));
-			return new PojoTypeInfo<>(clazz, pojoFields);
-		} catch (NoSuchFieldException e) {
-			throw new WrappingRuntimeException(e);
+		@Override
+		public int hashCode() {
+			return Objects.hash(list, retractList);
 		}
 	}
 
 	@Override
 	public ListAggWsWithRetractAccumulator createAccumulator() {
-		return new ListAggWsWithRetractAccumulator();
+		final ListAggWsWithRetractAccumulator acc = new ListAggWsWithRetractAccumulator();
+		acc.list = new ListView<>();
+		acc.retractList = new ListView<>();
+		acc.delimiter = StringData.fromString(",");
+		return acc;
 	}
 
 	public void accumulate(ListAggWsWithRetractAccumulator acc, StringData value, StringData lineDelimiter) throws Exception {
-		// ignore null value
 		if (value != null) {
 			acc.delimiter = lineDelimiter;
 			acc.list.add(value);
@@ -161,9 +171,8 @@ public final class ListAggWsWithRetractAggFunction
 	@Override
 	public StringData getValue(ListAggWsWithRetractAccumulator acc) {
 		try {
-			// we removed the element type to make the compile pass,
 			// the element must be BinaryStringData because it's the only implementation.
-			Iterable accList = acc.list.get();
+			Iterable<BinaryStringData> accList = (Iterable) acc.list.get();
 			if (accList == null || !accList.iterator().hasNext()) {
 				// return null when the list is empty
 				return null;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
@@ -18,71 +18,111 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.PojoField;
-import org.apache.flink.api.java.typeutils.PojoTypeInfo;
-import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.MapView;
-import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.data.TimestampData;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.TimestampDataTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
-import java.sql.Date;
-import java.sql.Time;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
 
 /**
- * built-in Max with retraction aggregate function.
+ * Built-in MAX with retraction aggregate function.
  */
-public abstract class MaxWithRetractAggFunction<T extends Comparable>
-		extends AggregateFunction<T, MaxWithRetractAggFunction.MaxWithRetractAccumulator<T>> {
+@Internal
+public final class MaxWithRetractAggFunction<T extends Comparable<T>>
+		extends InternalAggregateFunction<T, MaxWithRetractAggFunction.MaxWithRetractAccumulator<T>> {
 
 	private static final long serialVersionUID = -5860934997657147836L;
 
-	/** The initial accumulator for Max with retraction aggregate function. */
+	private transient DataType valueDataType;
+
+	public MaxWithRetractAggFunction(LogicalType valueType) {
+		this.valueDataType = toInternalDataType(valueType);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{valueDataType};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.STRUCTURED(
+			MaxWithRetractAccumulator.class,
+			DataTypes.FIELD("max", valueDataType.nullable()),
+			DataTypes.FIELD("mapSize", DataTypes.BIGINT()),
+			DataTypes.FIELD("map", MapView.newMapViewDataType(valueDataType.notNull(), DataTypes.BIGINT())));
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return valueDataType;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
+	/** Accumulator for MAX with retraction. */
 	public static class MaxWithRetractAccumulator<T> {
 		public T max;
 		public Long mapSize;
 		public MapView<T, Long> map;
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof MaxWithRetractAccumulator)) {
+				return false;
+			}
+			MaxWithRetractAccumulator<?> that = (MaxWithRetractAccumulator<?>) o;
+			return Objects.equals(max, that.max) &&
+				Objects.equals(mapSize, that.mapSize) &&
+				Objects.equals(map, that.map);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(max, mapSize, map);
+		}
 	}
 
 	@Override
 	public MaxWithRetractAccumulator<T> createAccumulator() {
-		MaxWithRetractAccumulator<T> acc = new MaxWithRetractAccumulator<>();
-		acc.max = null; // max
+		final MaxWithRetractAccumulator<T> acc = new MaxWithRetractAccumulator<>();
+		acc.max = null;
 		acc.mapSize = 0L;
-		// store the count for each value
-		acc.map = new MapView<>(getValueTypeInfo(), BasicTypeInfo.LONG_TYPE_INFO);
+		acc.map = new MapView<>();
 		return acc;
 	}
 
-	public void accumulate(MaxWithRetractAccumulator<T> acc, Object value) throws Exception {
+	public void accumulate(MaxWithRetractAccumulator<T> acc, T value) throws Exception {
 		if (value != null) {
-			T v = (T) value;
-
-			if (acc.mapSize == 0L || acc.max.compareTo(v) < 0) {
-				acc.max = v;
+			if (acc.mapSize == 0L || acc.max.compareTo(value) < 0) {
+				acc.max = value;
 			}
 
-			Long count = acc.map.get(v);
+			Long count = acc.map.get(value);
 			if (count == null) {
 				count = 0L;
 			}
 			count += 1L;
 			if (count == 0) {
 				// remove it when count is increased from -1 to 0
-				acc.map.remove(v);
+				acc.map.remove(value);
 			} else {
 				// store it when count is NOT zero
-				acc.map.put(v, count);
+				acc.map.put(value, count);
 			}
 			if (count == 1L) {
 				// previous count is zero, this is the first time to see the key
@@ -91,18 +131,16 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 		}
 	}
 
-	public void retract(MaxWithRetractAccumulator<T> acc, Object value) throws Exception {
+	public void retract(MaxWithRetractAccumulator<T> acc, T value) throws Exception {
 		if (value != null) {
-			T v = (T) value;
-
-			Long count = acc.map.get(v);
+			Long count = acc.map.get(value);
 			if (count == null) {
 				count = 0L;
 			}
 			count -= 1;
 			if (count == 0) {
 				// remove it when count is decreased from 1 to 0
-				acc.map.remove(v);
+				acc.map.remove(value);
 				acc.mapSize -= 1L;
 
 				//if the total count is 0, we could just simply set the f0(max) to the initial value
@@ -112,12 +150,12 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 				}
 				//if v is the current max value, we have to iterate the map to find the 2nd biggest
 				// value to replace v as the max value
-				if (v.equals(acc.max)) {
+				if (value.equals(acc.max)) {
 					updateMax(acc);
 				}
 			} else {
 				// store it when count is NOT zero
-				acc.map.put(v, count);
+				acc.map.put(value, count);
 				// we do not take negative number account into mapSize
 			}
 		}
@@ -149,9 +187,9 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 				acc.max = a.max;
 			}
 			// merge the count for each key
-			for (Map.Entry entry : a.map.entries()) {
-				T key = (T) entry.getKey();
-				Long otherCount = (Long) entry.getValue(); // non-null
+			for (Map.Entry<T, Long> entry : a.map.entries()) {
+				T key = entry.getKey();
+				Long otherCount = entry.getValue(); // non-null
 				Long thisCount = acc.map.get(key);
 				if (thisCount == null) {
 					thisCount = 0L;
@@ -202,219 +240,6 @@ public abstract class MaxWithRetractAggFunction<T extends Comparable>
 			return acc.max;
 		} else {
 			return null;
-		}
-	}
-
-	@Override
-	public TypeInformation<MaxWithRetractAccumulator<T>> getAccumulatorType() {
-		PojoTypeInfo pojoType = (PojoTypeInfo) TypeExtractor.createTypeInfo(MaxWithRetractAccumulator.class);
-		List<PojoField> pojoFields = new ArrayList<>();
-		for (int i = 0; i < pojoType.getTotalFields(); i++) {
-			PojoField field = pojoType.getPojoFieldAt(i);
-			if (field.getField().getName().equals("max")) {
-				pojoFields.add(new PojoField(field.getField(), getValueTypeInfo()));
-			} else {
-				pojoFields.add(field);
-			}
-		}
-		//noinspection unchecked
-		return new PojoTypeInfo(pojoType.getTypeClass(), pojoFields);
-	}
-
-	@Override
-	public TypeInformation<T> getResultType() {
-		return getValueTypeInfo();
-	}
-
-	protected abstract TypeInformation<T> getValueTypeInfo();
-
-	/**
-	 * Built-in Byte Max with retraction aggregate function.
-	 */
-	public static class ByteMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Byte> {
-
-		private static final long serialVersionUID = 7383980948808353819L;
-
-		@Override
-		protected TypeInformation<Byte> getValueTypeInfo() {
-			return BasicTypeInfo.BYTE_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Short Max with retraction aggregate function.
-	 */
-	public static class ShortMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Short> {
-
-		private static final long serialVersionUID = 7579072678911328694L;
-
-		@Override
-		protected TypeInformation<Short> getValueTypeInfo() {
-			return BasicTypeInfo.SHORT_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Int Max with retraction aggregate function.
-	 */
-	public static class IntMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Integer> {
-
-		private static final long serialVersionUID = 3833976566544263072L;
-
-		@Override
-		protected TypeInformation<Integer> getValueTypeInfo() {
-			return BasicTypeInfo.INT_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Long Max with retraction aggregate function.
-	 */
-	public static class LongMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Long> {
-
-		private static final long serialVersionUID = 8585384188523017375L;
-
-		@Override
-		protected TypeInformation<Long> getValueTypeInfo() {
-			return BasicTypeInfo.LONG_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Float Max with retraction aggregate function.
-	 */
-	public static class FloatMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Float> {
-
-		private static final long serialVersionUID = -1433882434794024584L;
-
-		@Override
-		protected TypeInformation<Float> getValueTypeInfo() {
-			return BasicTypeInfo.FLOAT_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Double Max with retraction aggregate function.
-	 */
-	public static class DoubleMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Double> {
-
-		private static final long serialVersionUID = -1525221057708740308L;
-
-		@Override
-		protected TypeInformation<Double> getValueTypeInfo() {
-			return BasicTypeInfo.DOUBLE_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Boolean Max with retraction aggregate function.
-	 */
-	public static class BooleanMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Boolean> {
-
-		private static final long serialVersionUID = -8408715018822625309L;
-
-		@Override
-		protected TypeInformation<Boolean> getValueTypeInfo() {
-			return BasicTypeInfo.BOOLEAN_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Big Decimal Max with retraction aggregate function.
-	 */
-	public static class DecimalMaxWithRetractAggFunction extends MaxWithRetractAggFunction<DecimalData> {
-		private static final long serialVersionUID = 5301860581297042635L;
-		private DecimalDataTypeInfo decimalType;
-
-		public DecimalMaxWithRetractAggFunction(DecimalDataTypeInfo decimalType) {
-			this.decimalType = decimalType;
-		}
-
-		public void accumulate(MaxWithRetractAccumulator<DecimalData> acc, DecimalData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void retract(MaxWithRetractAccumulator<DecimalData> acc, DecimalData value) throws Exception {
-			super.retract(acc, value);
-		}
-
-		@Override
-		protected TypeInformation<DecimalData> getValueTypeInfo() {
-			return decimalType;
-		}
-	}
-
-	/**
-	 * Built-in String Max with retraction aggregate function.
-	 */
-	public static class StringMaxWithRetractAggFunction extends MaxWithRetractAggFunction<StringData> {
-
-		private static final long serialVersionUID = 787528574867514796L;
-
-		public void accumulate(MaxWithRetractAccumulator<StringData> acc, StringData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void retract(MaxWithRetractAccumulator<StringData> acc, StringData value) throws Exception {
-			super.retract(acc, value);
-		}
-
-		@Override
-		protected TypeInformation<StringData> getValueTypeInfo() {
-			return StringDataTypeInfo.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Timestamp Max with retraction aggregate function.
-	 */
-	public static class TimestampMaxWithRetractAggFunction extends MaxWithRetractAggFunction<TimestampData> {
-
-		private static final long serialVersionUID = -7096481949093142944L;
-
-		private final int precision;
-
-		public TimestampMaxWithRetractAggFunction(int precision) {
-			this.precision = precision;
-		}
-
-		public void accumulate(MaxWithRetractAccumulator<TimestampData> acc, TimestampData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void retract(MaxWithRetractAccumulator<TimestampData> acc, TimestampData value) throws Exception {
-			super.retract(acc, value);
-		}
-
-		@Override
-		protected TypeInformation<TimestampData> getValueTypeInfo() {
-			return new TimestampDataTypeInfo(precision);
-		}
-	}
-
-	/**
-	 * Built-in Date Max with retraction aggregate function.
-	 */
-	public static class DateMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Date> {
-
-		private static final long serialVersionUID = 7452698503075473023L;
-
-		@Override
-		protected TypeInformation<Date> getValueTypeInfo() {
-			return Types.SQL_DATE;
-		}
-	}
-
-	/**
-	 * Built-in Time Max with retraction aggregate function.
-	 */
-	public static class TimeMaxWithRetractAggFunction extends MaxWithRetractAggFunction<Time> {
-
-		private static final long serialVersionUID = 3578216747876121493L;
-
-		@Override
-		protected TypeInformation<Time> getValueTypeInfo() {
-			return Types.SQL_TIME;
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
@@ -18,71 +18,111 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.PojoField;
-import org.apache.flink.api.java.typeutils.PojoTypeInfo;
-import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.MapView;
-import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.data.TimestampData;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
-import org.apache.flink.table.runtime.typeutils.TimestampDataTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
-import java.sql.Date;
-import java.sql.Time;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
 
 /**
- * built-in Min with retraction aggregate function.
+ * Built-in MIN with retraction aggregate function.
  */
-public abstract class MinWithRetractAggFunction<T extends Comparable>
-		extends AggregateFunction<T, MinWithRetractAggFunction.MinWithRetractAccumulator<T>> {
+@Internal
+public final class MinWithRetractAggFunction<T extends Comparable<T>>
+		extends InternalAggregateFunction<T, MinWithRetractAggFunction.MinWithRetractAccumulator<T>> {
 
 	private static final long serialVersionUID = 4253774292802374843L;
 
-	/** The initial accumulator for Min with retraction aggregate function. */
+	private transient DataType valueDataType;
+
+	public MinWithRetractAggFunction(LogicalType valueType) {
+		this.valueDataType = toInternalDataType(valueType);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Planning
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DataType[] getInputDataTypes() {
+		return new DataType[]{valueDataType};
+	}
+
+	@Override
+	public DataType getAccumulatorDataType() {
+		return DataTypes.STRUCTURED(
+			MinWithRetractAccumulator.class,
+			DataTypes.FIELD("min", valueDataType.nullable()),
+			DataTypes.FIELD("mapSize", DataTypes.BIGINT()),
+			DataTypes.FIELD("map", MapView.newMapViewDataType(valueDataType.notNull(), DataTypes.BIGINT())));
+	}
+
+	@Override
+	public DataType getOutputDataType() {
+		return valueDataType;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Runtime
+	// --------------------------------------------------------------------------------------------
+
+	/** Accumulator for MIN with retraction. */
 	public static class MinWithRetractAccumulator<T> {
 		public T min;
 		public Long mapSize;
 		public MapView<T, Long> map;
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof MinWithRetractAccumulator)) {
+				return false;
+			}
+			MinWithRetractAccumulator<?> that = (MinWithRetractAccumulator<?>) o;
+			return Objects.equals(min, that.min) &&
+				Objects.equals(mapSize, that.mapSize) &&
+				Objects.equals(map, that.map);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(min, mapSize, map);
+		}
 	}
 
 	@Override
 	public MinWithRetractAccumulator<T> createAccumulator() {
-		MinWithRetractAccumulator<T> acc = new MinWithRetractAccumulator<>();
-		acc.min = null; // min
+		final MinWithRetractAccumulator<T> acc = new MinWithRetractAccumulator<>();
+		acc.min = null;
 		acc.mapSize = 0L;
-		// store the count for each value
-		acc.map = new MapView<>(getValueTypeInfo(), BasicTypeInfo.LONG_TYPE_INFO);
+		acc.map = new MapView<>();
 		return acc;
 	}
 
-	public void accumulate(MinWithRetractAccumulator<T> acc, Object value) throws Exception {
+	public void accumulate(MinWithRetractAccumulator<T> acc, T value) throws Exception {
 		if (value != null) {
-			T v = (T) value;
-
-			if (acc.mapSize == 0L || acc.min.compareTo(v) > 0) {
-				acc.min = v;
+			if (acc.mapSize == 0L || acc.min.compareTo(value) > 0) {
+				acc.min = value;
 			}
 
-			Long count = acc.map.get(v);
+			Long count = acc.map.get(value);
 			if (count == null) {
 				count = 0L;
 			}
 			count += 1L;
 			if (count == 0) {
 				// remove it when count is increased from -1 to 0
-				acc.map.remove(v);
+				acc.map.remove(value);
 			} else {
 				// store it when count is NOT zero
-				acc.map.put(v, count);
+				acc.map.put(value, count);
 			}
 			if (count == 1L) {
 				// previous count is zero, this is the first time to see the key
@@ -91,18 +131,16 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 		}
 	}
 
-	public void retract(MinWithRetractAccumulator<T> acc, Object value) throws Exception {
+	public void retract(MinWithRetractAccumulator<T> acc, T value) throws Exception {
 		if (value != null) {
-			T v = (T) value;
-
-			Long count = acc.map.get(v);
+			Long count = acc.map.get(value);
 			if (count == null) {
 				count = 0L;
 			}
 			count -= 1;
 			if (count == 0) {
 				// remove it when count is decreased from 1 to 0
-				acc.map.remove(v);
+				acc.map.remove(value);
 				acc.mapSize -= 1L;
 
 				//if the total count is 0, we could just simply set the f0(min) to the initial value
@@ -112,12 +150,12 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 				}
 				//if v is the current min value, we have to iterate the map to find the 2nd biggest
 				// value to replace v as the min value
-				if (v.equals(acc.min)) {
+				if (value.equals(acc.min)) {
 					updateMin(acc);
 				}
 			} else {
 				// store it when count is NOT zero
-				acc.map.put(v, count);
+				acc.map.put(value, count);
 				// we do not take negative number account into mapSize
 			}
 		}
@@ -149,9 +187,9 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 				acc.min = a.min;
 			}
 			// merge the count for each key
-			for (Map.Entry entry : a.map.entries()) {
-				T key = (T) entry.getKey();
-				Long otherCount = (Long) entry.getValue(); // non-null
+			for (Map.Entry<T, Long> entry : a.map.entries()) {
+				T key = entry.getKey();
+				Long otherCount = entry.getValue(); // non-null
 				Long thisCount = acc.map.get(key);
 				if (thisCount == null) {
 					thisCount = 0L;
@@ -202,219 +240,6 @@ public abstract class MinWithRetractAggFunction<T extends Comparable>
 			return acc.min;
 		} else {
 			return null;
-		}
-	}
-
-	@Override
-	public TypeInformation<MinWithRetractAccumulator<T>> getAccumulatorType() {
-		PojoTypeInfo pojoType = (PojoTypeInfo) TypeExtractor.createTypeInfo(MinWithRetractAccumulator.class);
-		List<PojoField> pojoFields = new ArrayList<>();
-		for (int i = 0; i < pojoType.getTotalFields(); i++) {
-			PojoField field = pojoType.getPojoFieldAt(i);
-			if (field.getField().getName().equals("min")) {
-				pojoFields.add(new PojoField(field.getField(), getValueTypeInfo()));
-			} else {
-				pojoFields.add(field);
-			}
-		}
-		//noinspection unchecked
-		return new PojoTypeInfo(pojoType.getTypeClass(), pojoFields);
-	}
-
-	@Override
-	public TypeInformation<T> getResultType() {
-		return getValueTypeInfo();
-	}
-
-	protected abstract TypeInformation<T> getValueTypeInfo();
-
-	/**
-	 * Built-in Byte Min with retraction aggregate function.
-	 */
-	public static class ByteMinWithRetractAggFunction extends MinWithRetractAggFunction<Byte> {
-
-		private static final long serialVersionUID = 3170462557144510063L;
-
-		@Override
-		protected TypeInformation<Byte> getValueTypeInfo() {
-			return BasicTypeInfo.BYTE_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Short Min with retraction aggregate function.
-	 */
-	public static class ShortMinWithRetractAggFunction extends MinWithRetractAggFunction<Short> {
-
-		private static final long serialVersionUID = -4877567451203730974L;
-
-		@Override
-		protected TypeInformation<Short> getValueTypeInfo() {
-			return BasicTypeInfo.SHORT_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Int Min with retraction aggregate function.
-	 */
-	public static class IntMinWithRetractAggFunction extends MinWithRetractAggFunction<Integer> {
-
-		private static final long serialVersionUID = -3187801696860321834L;
-
-		@Override
-		protected TypeInformation<Integer> getValueTypeInfo() {
-			return BasicTypeInfo.INT_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Long Min with retraction aggregate function.
-	 */
-	public static class LongMinWithRetractAggFunction extends MinWithRetractAggFunction<Long> {
-
-		private static final long serialVersionUID = -3224670103852172282L;
-
-		@Override
-		protected TypeInformation<Long> getValueTypeInfo() {
-			return BasicTypeInfo.LONG_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Float Min with retraction aggregate function.
-	 */
-	public static class FloatMinWithRetractAggFunction extends MinWithRetractAggFunction<Float> {
-
-		private static final long serialVersionUID = 6683867851550125554L;
-
-		@Override
-		protected TypeInformation<Float> getValueTypeInfo() {
-			return BasicTypeInfo.FLOAT_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Double Min with retraction aggregate function.
-	 */
-	public static class DoubleMinWithRetractAggFunction extends MinWithRetractAggFunction<Double> {
-
-		private static final long serialVersionUID = -9107897474595423074L;
-
-		@Override
-		protected TypeInformation<Double> getValueTypeInfo() {
-			return BasicTypeInfo.DOUBLE_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Boolean Min with retraction aggregate function.
-	 */
-	public static class BooleanMinWithRetractAggFunction extends MinWithRetractAggFunction<Boolean> {
-
-		private static final long serialVersionUID = -4667566512148979776L;
-
-		@Override
-		protected TypeInformation<Boolean> getValueTypeInfo() {
-			return BasicTypeInfo.BOOLEAN_TYPE_INFO;
-		}
-	}
-
-	/**
-	 * Built-in Big DecimalData Min with retraction aggregate function.
-	 */
-	public static class DecimalMinWithRetractAggFunction extends MinWithRetractAggFunction<DecimalData> {
-		private static final long serialVersionUID = -7984016112363017960L;
-		private DecimalDataTypeInfo decimalType;
-
-		public DecimalMinWithRetractAggFunction(DecimalDataTypeInfo decimalType) {
-			this.decimalType = decimalType;
-		}
-
-		public void accumulate(MinWithRetractAccumulator<DecimalData> acc, DecimalData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void retract(MinWithRetractAccumulator<DecimalData> acc, DecimalData value) throws Exception {
-			super.retract(acc, value);
-		}
-
-		@Override
-		protected TypeInformation<DecimalData> getValueTypeInfo() {
-			return decimalType;
-		}
-	}
-
-	/**
-	 * Built-in String Min with retraction aggregate function.
-	 */
-	public static class StringMinWithRetractAggFunction extends MinWithRetractAggFunction<StringData> {
-
-		private static final long serialVersionUID = -6402993104400269468L;
-
-		public void accumulate(MinWithRetractAccumulator<StringData> acc, StringData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void retract(MinWithRetractAccumulator<StringData> acc, StringData value) throws Exception {
-			super.retract(acc, value);
-		}
-
-		@Override
-		protected TypeInformation<StringData> getValueTypeInfo() {
-			return StringDataTypeInfo.INSTANCE;
-		}
-	}
-
-	/**
-	 * Built-in Timestamp Min with retraction aggregate function.
-	 */
-	public static class TimestampMinWithRetractAggFunction extends MinWithRetractAggFunction<TimestampData> {
-
-		private static final long serialVersionUID = -7494198823345305907L;
-
-		private final int precision;
-
-		public TimestampMinWithRetractAggFunction(int precision) {
-			this.precision = precision;
-		}
-
-		public void accumulate(MinWithRetractAccumulator<TimestampData> acc, TimestampData value) throws Exception {
-			super.accumulate(acc, value);
-		}
-
-		public void retract(MinWithRetractAccumulator<TimestampData> acc, TimestampData value) throws Exception {
-			super.retract(acc, value);
-		}
-
-		@Override
-		protected TypeInformation<TimestampData> getValueTypeInfo() {
-			return new TimestampDataTypeInfo(precision);
-		}
-	}
-
-	/**
-	 * Built-in Date Min with retraction aggregate function.
-	 */
-	public static class DateMinWithRetractAggFunction extends MinWithRetractAggFunction<Date> {
-
-		private static final long serialVersionUID = 604406649989470870L;
-
-		@Override
-		protected TypeInformation<Date> getValueTypeInfo() {
-			return Types.SQL_DATE;
-		}
-	}
-
-	/**
-	 * Built-in Time Min with retraction aggregate function.
-	 */
-	public static class TimeMinWithRetractAggFunction extends MinWithRetractAggFunction<Time> {
-
-		private static final long serialVersionUID = -6908371577415696291L;
-
-		@Override
-		protected TypeInformation<Time> getValueTypeInfo() {
-			return Types.SQL_TIME;
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
@@ -29,7 +29,6 @@ import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator._
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, ExprCodeGenerator, GeneratedExpression}
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter
 import org.apache.flink.table.planner.plan.utils.DistinctInfo
-import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.types.logical.{LogicalType, RowType}
@@ -83,9 +82,9 @@ class DistinctAggCodeGen(
 
   val aggCount: Int = innerAggCodeGens.length
   val externalAccType: DataType = distinctInfo.accType
-  val internalAccType: LogicalType = fromDataTypeToLogicalType(externalAccType)
+  val internalAccType: LogicalType = externalAccType.getLogicalType
   val keyType: DataType = distinctInfo.keyType
-  val internalKeyType: LogicalType = fromDataTypeToLogicalType(keyType)
+  val internalKeyType: LogicalType = keyType.getLogicalType
   val keyTypeTerm: String = keyType.getConversionClass.getCanonicalName
   val distinctAccTerm: String = s"distinct_view_$distinctIndex"
   val distinctBackupAccTerm: String = s"distinct_backup_view_$distinctIndex"
@@ -124,14 +123,14 @@ class DistinctAggCodeGen(
       ctx.addReusableMember(s"private $MAP_VIEW $distinctBackupAccTerm;")
     }
 
-    // when dataview works on state, assign the stateDataView to accTerm in open method
+    // when data view works on state, assign it to distinctAccTerm in open method
     distinctInfo.dataViewSpec match {
       case Some(spec) =>
-        val dataviewTerm = createDataViewTerm(spec)
-        ctx.addReusableOpenStatement(s"$distinctAccTerm = $dataviewTerm;")
+        val dataViewTerm = createDataViewTerm(spec)
+        ctx.addReusableOpenStatement(s"$distinctAccTerm = $dataViewTerm;")
         if (enableBackupDataView) {
-          val dataviewBackupTerm = createDataViewBackupTerm(spec)
-          ctx.addReusableOpenStatement(s"$distinctBackupAccTerm = $dataviewBackupTerm;")
+          val dataViewBackupTerm = createDataViewBackupTerm(spec)
+          ctx.addReusableOpenStatement(s"$distinctBackupAccTerm = $dataViewBackupTerm;")
         }
       case None => // do nothing
     }
@@ -143,11 +142,12 @@ class DistinctAggCodeGen(
       Seq()
     } else {
       val Seq(mapViewTerm, accTerm) = newNames("mapview", "distinct_acc")
+      val accTypeTerm = boxedTypeTermForType(internalAccType)
       val code =
         s"""
            |$MAP_VIEW $mapViewTerm = new $MAP_VIEW();
-           |$BINARY_RAW_VALUE $accTerm = ${genToInternalConverter(
-              ctx, externalAccType, mapViewTerm)};
+           |$accTypeTerm $accTerm =
+           |  ${genToInternalConverter(ctx, externalAccType, mapViewTerm)};
          """.stripMargin
 
       Seq(GeneratedExpression(accTerm, NEVER_NULL, code, internalAccType))
@@ -180,10 +180,11 @@ class DistinctAggCodeGen(
       Seq()
     } else {
       val accTerm = newName("distinct_acc")
+      val accTypeTerm = boxedTypeTermForType(internalAccType)
       val code =
         s"""
-           |$BINARY_RAW_VALUE $accTerm = ${genToInternalConverter(
-              ctx, externalAccType, distinctAccTerm)};
+           |$accTypeTerm $accTerm =
+           |  ${genToInternalConverter(ctx, externalAccType, distinctAccTerm)};
          """.stripMargin
 
       Seq(GeneratedExpression(
@@ -425,10 +426,6 @@ class DistinctAggCodeGen(
     }
   }
 
-  /**
-    * This method is mainly the same as CodeGenUtils.generateFieldAccess(), the only difference is
-    * that this method using UpdatableRow to wrap RowData to handle DataViews.
-    */
   private def generateAccumulatorAccess(
     ctx: CodeGeneratorContext,
     inputType: LogicalType,
@@ -437,6 +434,8 @@ class DistinctAggCodeGen(
     useStateDataView: Boolean,
     useBackupDataView: Boolean,
     nullableInput: Boolean = false): GeneratedExpression = {
+
+    val distinctSpec = distinctInfo.dataViewSpec
 
     // if input has been used before, we can reuse the code that
     // has already been generated
@@ -447,14 +446,14 @@ class DistinctAggCodeGen(
       // generate input access and unboxing if necessary
       case None =>
 
-        val expr = if (distinctInfo.dataViewSpec.nonEmpty && useStateDataView) {
-          val spec = distinctInfo.dataViewSpec.get
+        val expr = if (distinctSpec.nonEmpty && useStateDataView) {
+          val spec = distinctSpec.get
           val dataViewTerm = if (useBackupDataView) {
             createDataViewBackupTerm(spec)
           } else {
             createDataViewTerm(spec)
           }
-          val resultTerm = if (useBackupDataView) {
+          val accTerm = if (useBackupDataView) {
             distinctBackupAccTerm
           } else {
             distinctAccTerm
@@ -466,19 +465,26 @@ class DistinctAggCodeGen(
                |// when namespace is null, the dataview is used in heap, no key and namespace set
                |if ($NAMESPACE_TERM != null) {
                |  $dataViewTerm.setCurrentNamespace($NAMESPACE_TERM);
-               |  $resultTerm = $dataViewTerm;
+               |  $accTerm = $dataViewTerm;
                |} else {
                |  ${expr.code}
-               |  $resultTerm = ($MAP_VIEW) ${expr.resultTerm}.getJavaObject();
+               |  $accTerm = ($MAP_VIEW) ${expr.resultTerm}.getJavaObject();
                |}
             """.stripMargin
           } else {
             s"""
-               |$resultTerm = $dataViewTerm;
+               |$accTerm = $dataViewTerm;
             """.stripMargin
           }
-          GeneratedExpression(resultTerm, NEVER_NULL, code, internalAccType)
+          GeneratedExpression(accTerm, NEVER_NULL, code, internalAccType)
         } else {
+          val accDataType = if (distinctSpec.nonEmpty && !useStateDataView) {
+            // externalAccType represents "null" for state backed views
+            // but we don't want to use state here
+            distinctSpec.get.getDistinctViewDataType
+          } else {
+            externalAccType
+          }
           val expr = generateFieldAccess(ctx, inputType, inputTerm, index)
           if (useBackupDataView) {
             // this is called in the merge method
@@ -489,18 +495,19 @@ class DistinctAggCodeGen(
                  |${expr.code}
                  |$otherMapViewTerm = null;
                  |if (!${expr.nullTerm}) {
-                 | $otherMapViewTerm = ${genToExternalConverter(
-                      ctx, externalAccType, expr.resultTerm)};
+                 | $otherMapViewTerm =
+                 |   ${genToExternalConverter(ctx, accDataType, expr.resultTerm)};
                  |}
                """.stripMargin
-            GeneratedExpression(otherMapViewTerm, expr.nullTerm, code, internalAccType)
+            GeneratedExpression(otherMapViewTerm, expr.nullTerm, code, accDataType.getLogicalType)
           } else {
             val code =
               s"""
                  |${expr.code}
-                 |$distinctAccTerm = ($MAP_VIEW) ${expr.resultTerm}.getJavaObject();
+                 |$distinctAccTerm =
+                 |  ${genToExternalConverter(ctx, accDataType, expr.resultTerm)};
               """.stripMargin
-            GeneratedExpression(distinctAccTerm, NEVER_NULL, code, internalAccType)
+            GeneratedExpression(distinctAccTerm, NEVER_NULL, code, accDataType.getLogicalType)
           }
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -286,35 +286,14 @@ class AggFunctionFactory(
 
   private def createMinAggFunction(
       argTypes: Array[LogicalType],
-      index: Int): UserDefinedFunction = {
+      index: Int)
+    : UserDefinedFunction = {
+    val valueType = argTypes(0)
     if (needRetraction(index)) {
-      argTypes(0).getTypeRoot match {
-        case TINYINT =>
-          new ByteMinWithRetractAggFunction
-        case SMALLINT =>
-          new ShortMinWithRetractAggFunction
-        case INTEGER =>
-          new IntMinWithRetractAggFunction
-        case BIGINT =>
-          new LongMinWithRetractAggFunction
-        case FLOAT =>
-          new FloatMinWithRetractAggFunction
-        case DOUBLE =>
-          new DoubleMinWithRetractAggFunction
-        case BOOLEAN =>
-          new BooleanMinWithRetractAggFunction
-        case VARCHAR | CHAR =>
-          new StringMinWithRetractAggFunction
-        case DECIMAL =>
-          val d = argTypes(0).asInstanceOf[DecimalType]
-          new DecimalMinWithRetractAggFunction(DecimalDataTypeInfo.of(d.getPrecision, d.getScale))
-        case TIME_WITHOUT_TIME_ZONE =>
-          new TimeMinWithRetractAggFunction
-        case DATE =>
-          new DateMinWithRetractAggFunction
-        case TIMESTAMP_WITHOUT_TIME_ZONE =>
-          val d = argTypes(0).asInstanceOf[TimestampType]
-          new TimestampMinWithRetractAggFunction(d.getPrecision)
+      valueType.getTypeRoot match {
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
+          new MinWithRetractAggFunction(argTypes(0))
         case t =>
           throw new TableException(s"Min with retract aggregate function does not " +
             s"support type: ''$t''.\nPlease re-check the data type.")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -475,54 +475,21 @@ class AggFunctionFactory(
 
   private def createFirstValueAggFunction(
       argTypes: Array[LogicalType],
-      index: Int): UserDefinedFunction = {
+      index: Int)
+    : UserDefinedFunction = {
+    val valueType = argTypes(0)
     if (needRetraction(index)) {
-      argTypes(0).getTypeRoot match {
-        case TINYINT =>
-          new ByteFirstValueWithRetractAggFunction
-        case SMALLINT =>
-          new ShortFirstValueWithRetractAggFunction
-        case INTEGER =>
-          new IntFirstValueWithRetractAggFunction
-        case BIGINT =>
-          new LongFirstValueWithRetractAggFunction
-        case FLOAT =>
-          new FloatFirstValueWithRetractAggFunction
-        case DOUBLE =>
-          new DoubleFirstValueWithRetractAggFunction
-        case BOOLEAN =>
-          new BooleanFirstValueWithRetractAggFunction
-        case VARCHAR =>
-          new StringFirstValueWithRetractAggFunction
-        case DECIMAL =>
-          val d = argTypes(0).asInstanceOf[DecimalType]
-          new DecimalFirstValueWithRetractAggFunction(
-            DecimalDataTypeInfo.of(d.getPrecision, d.getScale))
+      valueType.getTypeRoot match {
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+          new FirstValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(s"FIRST_VALUE with retract aggregate function does not " +
             s"support type: ''$t''.\nPlease re-check the data type.")
       }
     } else {
-      argTypes(0).getTypeRoot match {
-        case TINYINT =>
-          new ByteFirstValueAggFunction
-        case SMALLINT =>
-          new ShortFirstValueAggFunction
-        case INTEGER =>
-          new IntFirstValueAggFunction
-        case BIGINT =>
-          new LongFirstValueAggFunction
-        case FLOAT =>
-          new FloatFirstValueAggFunction
-        case DOUBLE =>
-          new DoubleFirstValueAggFunction
-        case BOOLEAN =>
-          new BooleanFirstValueAggFunction
-        case VARCHAR =>
-          new StringFirstValueAggFunction
-        case DECIMAL =>
-          val d = argTypes(0).asInstanceOf[DecimalType]
-          new DecimalFirstValueAggFunction(DecimalDataTypeInfo.of(d.getPrecision, d.getScale))
+      valueType.getTypeRoot match {
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+          new FirstValueAggFunction(valueType)
         case t =>
           throw new TableException(s"FIRST_VALUE aggregate function does not support " +
             s"type: ''$t''.\nPlease re-check the data type.")
@@ -532,54 +499,21 @@ class AggFunctionFactory(
 
   private def createLastValueAggFunction(
       argTypes: Array[LogicalType],
-      index: Int): UserDefinedFunction = {
+      index: Int)
+    : UserDefinedFunction = {
+    val valueType = argTypes(0)
     if (needRetraction(index)) {
-      argTypes(0).getTypeRoot match {
-        case TINYINT =>
-          new ByteLastValueWithRetractAggFunction
-        case SMALLINT =>
-          new ShortLastValueWithRetractAggFunction
-        case INTEGER =>
-          new IntLastValueWithRetractAggFunction
-        case BIGINT =>
-          new LongLastValueWithRetractAggFunction
-        case FLOAT =>
-          new FloatLastValueWithRetractAggFunction
-        case DOUBLE =>
-          new DoubleLastValueWithRetractAggFunction
-        case BOOLEAN =>
-          new BooleanLastValueWithRetractAggFunction
-        case VARCHAR =>
-          new StringLastValueWithRetractAggFunction
-        case DECIMAL =>
-          val d = argTypes(0).asInstanceOf[DecimalType]
-          new DecimalLastValueWithRetractAggFunction(
-            DecimalDataTypeInfo.of(d.getPrecision, d.getScale))
+      valueType.getTypeRoot match {
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+          new LastValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(s"LAST_VALUE with retract aggregate function does not " +
             s"support type: ''$t''.\nPlease re-check the data type.")
       }
     } else {
-      argTypes(0).getTypeRoot match {
-        case TINYINT =>
-          new ByteLastValueAggFunction
-        case SMALLINT =>
-          new ShortLastValueAggFunction
-        case INTEGER =>
-          new IntLastValueAggFunction
-        case BIGINT =>
-          new LongLastValueAggFunction
-        case FLOAT =>
-          new FloatLastValueAggFunction
-        case DOUBLE =>
-          new DoubleLastValueAggFunction
-        case BOOLEAN =>
-          new BooleanLastValueAggFunction
-        case VARCHAR =>
-          new StringLastValueAggFunction
-        case DECIMAL =>
-          val d = argTypes(0).asInstanceOf[DecimalType]
-          new DecimalLastValueAggFunction(DecimalDataTypeInfo.of(d.getPrecision, d.getScale))
+      valueType.getTypeRoot match {
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+          new LastValueAggFunction(valueType)
         case t =>
           throw new TableException(s"LAST_VALUE aggregate function does not support " +
             s"type: ''$t''.\nPlease re-check the data type.")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -390,41 +390,21 @@ class AggFunctionFactory(
   }
 
   private def createMaxAggFunction(
-      argTypes: Array[LogicalType], index: Int): UserDefinedFunction = {
+        argTypes: Array[LogicalType],
+        index: Int)
+    : UserDefinedFunction = {
+    val valueType = argTypes(0)
     if (needRetraction(index)) {
-      argTypes(0).getTypeRoot match {
-        case TINYINT =>
-          new ByteMaxWithRetractAggFunction
-        case SMALLINT =>
-          new ShortMaxWithRetractAggFunction
-        case INTEGER =>
-          new IntMaxWithRetractAggFunction
-        case BIGINT =>
-          new LongMaxWithRetractAggFunction
-        case FLOAT =>
-          new FloatMaxWithRetractAggFunction
-        case DOUBLE =>
-          new DoubleMaxWithRetractAggFunction
-        case BOOLEAN =>
-          new BooleanMaxWithRetractAggFunction
-        case VARCHAR =>
-          new StringMaxWithRetractAggFunction
-        case DECIMAL =>
-          val d = argTypes(0).asInstanceOf[DecimalType]
-          new DecimalMaxWithRetractAggFunction(DecimalDataTypeInfo.of(d.getPrecision, d.getScale))
-        case TIME_WITHOUT_TIME_ZONE =>
-          new TimeMaxWithRetractAggFunction
-        case DATE =>
-          new DateMaxWithRetractAggFunction
-        case TIMESTAMP_WITHOUT_TIME_ZONE =>
-          val d = argTypes(0).asInstanceOf[TimestampType]
-          new TimestampMaxWithRetractAggFunction(d.getPrecision)
+      valueType.getTypeRoot match {
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
+          new MaxWithRetractAggFunction(argTypes(0))
         case t =>
           throw new TableException(s"Max with retract aggregate function does not " +
             s"support type: ''$t''.\nPlease re-check the data type.")
       }
     } else {
-      argTypes(0).getTypeRoot match {
+      valueType.getTypeRoot match {
         case TINYINT =>
           new MaxAggFunction.ByteMaxAggFunction
         case SMALLINT =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -26,15 +26,12 @@ import org.apache.flink.table.planner.functions.aggfunctions.IncrSumAggFunction.
 import org.apache.flink.table.planner.functions.aggfunctions.IncrSumWithRetractAggFunction._
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction._
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction._
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction._
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction._
 import org.apache.flink.table.planner.functions.aggfunctions.SingleValueAggFunction._
 import org.apache.flink.table.planner.functions.aggfunctions.SumWithRetractAggFunction._
 import org.apache.flink.table.planner.functions.aggfunctions._
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction
 import org.apache.flink.table.planner.functions.sql.{SqlFirstLastValueAggFunction, SqlListAggFunction}
 import org.apache.flink.table.planner.functions.utils.AggSqlFunction
-import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
@@ -611,10 +608,6 @@ class AggFunctionFactory(
   }
 
   private def createCollectAggFunction(argTypes: Array[LogicalType]): UserDefinedFunction = {
-    val elementTypeInfo = argTypes(0) match {
-      case gt: TypeInformationRawType[_] => gt.getTypeInformation
-      case t => TypeInfoLogicalTypeConverter.fromLogicalTypeToTypeInfo(t)
-    }
-    new CollectAggFunction(elementTypeInfo)
+    new CollectAggFunction(argTypes(0))
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -346,10 +346,7 @@ object AggregateUtil extends Enumeration {
         hasStateBackedDataViews,
         needsRetraction)
 
-    case _: AggSqlFunction |
-          // TODO remove once all agg functions are internal functions
-          _: SqlAggFunction if !udf.isInstanceOf[InternalAggregateFunction[_, _]] &&
-            udf.isInstanceOf[ImperativeAggregateFunction[_, _]] =>
+    case _: AggSqlFunction =>
       createAggregateInfoFromLegacyFunction(
         inputRowRelDataType,
         call,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/aggregation.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/aggregation.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.table.functions.UserDefinedFunction
-import org.apache.flink.table.planner.typeutils.DataViewUtils.DataViewSpec
+import org.apache.flink.table.planner.typeutils.DataViewUtils.{DataViewSpec, DistinctViewSpec}
 import org.apache.flink.table.types.DataType
 
 import org.apache.calcite.rel.core.AggregateCall
@@ -70,7 +70,7 @@ case class DistinctInfo(
     keyType: DataType,
     accType: DataType,
     excludeAcc: Boolean,
-    dataViewSpec: Option[DataViewSpec],
+    dataViewSpec: Option[DistinctViewSpec],
     consumeRetraction: Boolean,
     filterArgs: ArrayBuffer[Int],
     aggIndexes: ArrayBuffer[Int])

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.MaxWithRetractAccumulator;
 import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.MinWithRetractAccumulator;
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -228,12 +227,6 @@ public abstract class AggFunctionTestBase<T, ACC> {
 			MinWithRetractAccumulator e = (MinWithRetractAccumulator) expected;
 			MinWithRetractAccumulator r = (MinWithRetractAccumulator) result;
 			assertEquals(e.min, r.min);
-			assertEquals(e.mapSize, r.mapSize);
-		} else if (expected instanceof MaxWithRetractAccumulator &&
-				result instanceof MaxWithRetractAccumulator) {
-			MaxWithRetractAccumulator e = (MaxWithRetractAccumulator) expected;
-			MaxWithRetractAccumulator r = (MaxWithRetractAccumulator) result;
-			assertEquals(e.max, r.max);
 			assertEquals(e.mapSize, r.mapSize);
 		} else if (expected instanceof RawValueData && result instanceof RawValueData) {
 			TypeSerializer<?> serializer = typeInfo.createSerializer(new ExecutionConfig());

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
@@ -18,33 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.RawValueData;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.runtime.typeutils.RawValueDataSerializer;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromLogicalTypeToTypeInfo;
-import static org.apache.flink.table.utils.RawValueDataAsserter.equivalent;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * Base class for aggregate function test.
@@ -86,13 +74,13 @@ public abstract class AggFunctionTestBase<T, ACC> {
 			T expected = expectedResults.get(i);
 			ACC acc = accumulateValues(inputValues);
 			T result = aggregator.getValue(acc);
-			validateResult(expected, result, aggregator.getAccumulatorType());
+			validateResult(expected, result);
 
 			if (UserDefinedFunctionUtils.ifMethodExistInFunction("retract", aggregator)) {
 				retractValues(acc, inputValues);
 				ACC expectedAcc = aggregator.createAccumulator();
 				// The two accumulators should be exactly same
-				validateResult(expectedAcc, acc, aggregator.getAccumulatorType());
+				validateResult(expectedAcc, acc);
 			}
 		}
 	}
@@ -121,17 +109,17 @@ public abstract class AggFunctionTestBase<T, ACC> {
 
 				ACC acc = accumulateValues(firstValues);
 
-				mergeFunc.invoke(aggregator, (Object) acc, accumulators);
+				mergeFunc.invoke(aggregator, acc, accumulators);
 
 				T result = aggregator.getValue(acc);
-				validateResult(expected, result, aggregator.getResultType());
+				validateResult(expected, result);
 
 				// 2. verify merge with accumulate & retract
 				if (UserDefinedFunctionUtils.ifMethodExistInFunction("retract", aggregator)) {
 					retractValues(acc, inputValues);
 					ACC expectedAcc = aggregator.createAccumulator();
 					// The two accumulators should be exactly same
-					validateResult(expectedAcc, acc, aggregator.getAccumulatorType());
+					validateResult(expectedAcc, acc);
 				}
 			}
 
@@ -144,10 +132,10 @@ public abstract class AggFunctionTestBase<T, ACC> {
 				accumulators.add(aggregator.createAccumulator());
 
 				ACC acc = accumulateValues(inputValues);
-				mergeFunc.invoke(aggregator, (Object) acc, accumulators);
+				mergeFunc.invoke(aggregator, acc, accumulators);
 
 				T result = aggregator.getValue(acc);
-				validateResult(expected, result, aggregator.getResultType());
+				validateResult(expected, result);
 			}
 		}
 	}
@@ -190,7 +178,7 @@ public abstract class AggFunctionTestBase<T, ACC> {
 
 			// getValue
 			T result = aggregator.getValue(accWithSubset);
-			validateResult(expectedValue, result, aggregator.getResultType());
+			validateResult(expectedValue, result);
 		}
 	}
 
@@ -207,40 +195,17 @@ public abstract class AggFunctionTestBase<T, ACC> {
 			// iterate over input sets
 			for (int i = 0; i < size; ++i) {
 				List<T> inputValues = inputValueSets.get(i);
-				T expected = expectedResults.get(i);
 				ACC acc = accumulateValues(inputValues);
-				resetAccFunc.invoke(aggregator, (Object) acc);
+				resetAccFunc.invoke(aggregator, acc);
 				ACC expectedAcc = aggregator.createAccumulator();
 				//The accumulator after reset should be exactly same as the new accumulator
-				validateResult(expectedAcc, acc, aggregator.getAccumulatorType());
+				validateResult(expectedAcc, acc);
 			}
 		}
 	}
 
-	protected <E> void validateResult(E expected, E result, TypeInformation<?> typeInfo) {
-		if (expected instanceof BigDecimal && result instanceof BigDecimal) {
-			// BigDecimal.equals() value and scale but we are only interested in value.
-			assertEquals(0, ((BigDecimal) expected).compareTo((BigDecimal) result));
-		} else if (expected instanceof RawValueData && result instanceof RawValueData) {
-			TypeSerializer<?> serializer = typeInfo.createSerializer(new ExecutionConfig());
-			assertThat(
-					(RawValueData) result,
-					equivalent((RawValueData<?>) expected, new RawValueDataSerializer<>(serializer)));
-		} else if (expected instanceof GenericRowData && result instanceof GenericRowData) {
-			validateGenericRow((GenericRowData) expected, (GenericRowData) result, (InternalTypeInfo<RowData>) typeInfo);
-		} else {
-			assertEquals(expected, result);
-		}
-	}
-
-	private void validateGenericRow(GenericRowData expected, GenericRowData result, InternalTypeInfo<RowData> typeInfo) {
-		assertEquals(expected.getArity(), result.getArity());
-
-		for (int i = 0; i < expected.getArity(); ++i) {
-			Object expectedObj = expected.getField(i);
-			Object resultObj = result.getField(i);
-			validateResult(expectedObj, resultObj, fromLogicalTypeToTypeInfo(typeInfo.toRowFieldTypes()[i]));
-		}
+	protected <E> void validateResult(E expected, E result) {
+		assertEquals(expected, result);
 	}
 
 	protected ACC accumulateValues(List<T> values)
@@ -250,9 +215,9 @@ public abstract class AggFunctionTestBase<T, ACC> {
 		Method accumulateFunc = getAccumulateFunc();
 		for (T value : values) {
 			if (accumulateFunc.getParameterCount() == 1) {
-				accumulateFunc.invoke(aggregator, (Object) accumulator);
+				accumulateFunc.invoke(aggregator, accumulator);
 			} else if (accumulateFunc.getParameterCount() == 2) {
-				accumulateFunc.invoke(aggregator, (Object) accumulator, (Object) value);
+				accumulateFunc.invoke(aggregator, accumulator, value);
 			} else {
 				throw new TableException("Unsupported now");
 			}
@@ -266,9 +231,9 @@ public abstract class AggFunctionTestBase<T, ACC> {
 		Method retractFunc = getRetractFunc();
 		for (T value : values) {
 			if (retractFunc.getParameterCount() == 1) {
-				retractFunc.invoke(aggregator, (Object) accumulator);
+				retractFunc.invoke(aggregator, accumulator);
 			} else if (retractFunc.getParameterCount() == 2) {
-				retractFunc.invoke(aggregator, (Object) accumulator, (Object) value);
+				retractFunc.invoke(aggregator, accumulator, value);
 			} else {
 				throw new TableException("Unsupported now");
 			}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/AggFunctionTestBase.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.MinWithRetractAccumulator;
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.RawValueDataSerializer;
@@ -222,12 +221,6 @@ public abstract class AggFunctionTestBase<T, ACC> {
 		if (expected instanceof BigDecimal && result instanceof BigDecimal) {
 			// BigDecimal.equals() value and scale but we are only interested in value.
 			assertEquals(0, ((BigDecimal) expected).compareTo((BigDecimal) result));
-		} else if (expected instanceof MinWithRetractAccumulator &&
-				result instanceof MinWithRetractAccumulator) {
-			MinWithRetractAccumulator e = (MinWithRetractAccumulator) expected;
-			MinWithRetractAccumulator r = (MinWithRetractAccumulator) result;
-			assertEquals(e.min, r.min);
-			assertEquals(e.mapSize, r.mapSize);
 		} else if (expected instanceof RawValueData && result instanceof RawValueData) {
 			TypeSerializer<?> serializer = typeInfo.createSerializer(new ExecutionConfig());
 			assertThat(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.BooleanFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.ByteFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.DecimalFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.DoubleFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.FloatFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.IntFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.LongFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.ShortFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.StringFirstValueAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -41,7 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in FirstValue aggregate function.
+ * Test case for built-in FIRST_VALUE aggregate function.
  * This class tests `accumulate` method with order argument.
  */
 @RunWith(Enclosed.class)
@@ -56,7 +56,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteFirstValueAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteFirstValueAggFunctionWithOrderTest
 			extends NumberFirstValueAggFunctionWithOrderTestBase<Byte> {
@@ -68,12 +68,12 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortFirstValueAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortFirstValueAggFunctionWithOrderTest
 			extends NumberFirstValueAggFunctionWithOrderTestBase<Short> {
@@ -85,12 +85,12 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntFirstValueAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntFirstValueAggFunctionWithOrderTest
 			extends NumberFirstValueAggFunctionWithOrderTestBase<Integer> {
@@ -102,12 +102,12 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongFirstValueAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongFirstValueAggFunctionWithOrderTest
 			extends NumberFirstValueAggFunctionWithOrderTestBase<Long> {
@@ -119,12 +119,12 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatFirstValueAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatFirstValueAggFunctionWithOrderTest
 			extends NumberFirstValueAggFunctionWithOrderTestBase<Float> {
@@ -136,12 +136,12 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleFirstValueAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleFirstValueAggFunctionWithOrderTest
 			extends NumberFirstValueAggFunctionWithOrderTestBase<Double> {
@@ -153,15 +153,15 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanFirstValueAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
 	public static final class BooleanFirstValueAggFunctionWithOrderTest
-			extends FirstLastValueAggFunctionWithOrderTestBase<Boolean> {
+			extends FirstValueAggFunctionWithOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -243,15 +243,15 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalFirstValueAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
 	public static final class DecimalFirstValueAggFunctionWithOrderTest
-			extends FirstLastValueAggFunctionWithOrderTestBase<DecimalData> {
+			extends FirstValueAggFunctionWithOrderTestBase<DecimalData> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -323,15 +323,15 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalFirstValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
+			return new FirstValueAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringFirstValueAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
 	public static final class StringFirstValueAggFunctionWithOrderTest
-			extends FirstLastValueAggFunctionWithOrderTestBase<StringData> {
+			extends FirstValueAggFunctionWithOrderTestBase<StringData> {
 
 		@Override
 		protected List<List<StringData>> getInputValueSets() {
@@ -401,7 +401,7 @@ public final class FirstValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -412,10 +412,23 @@ public final class FirstValueAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test FirstValueAggFunction for number type.
+	 * Test base for {@link FirstValueAggFunction}.
+	 */
+	public abstract static class FirstValueAggFunctionWithOrderTestBase<T>
+			extends FirstLastValueAggFunctionWithOrderTestBase<T, RowData> {
+
+		@Override
+		protected Class<?> getAccClass() {
+			return RowData.class;
+		}
+	}
+
+	/**
+	 * Test base for {@link FirstValueAggFunction} with number types.
 	 */
 	public abstract static class NumberFirstValueAggFunctionWithOrderTestBase<T>
-		extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+			extends FirstValueAggFunctionWithOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.BooleanFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.ByteFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.DecimalFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.DoubleFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.FloatFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.IntFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.LongFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.ShortFirstValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.StringFirstValueAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -41,7 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in FirstValue aggregate function.
+ * Test case for built-in FIRST_VALUE aggregate function.
  * This class tests `accumulate` method without order argument.
  */
 @RunWith(Enclosed.class)
@@ -55,7 +55,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteFirstValueAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteFirstValueAggFunctionWithoutOrderTest
 			extends NumberFirstValueAggFunctionWithoutOrderTest<Byte> {
@@ -67,12 +67,12 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortFirstValueAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortFirstValueAggFunctionWithoutOrderTest
 			extends NumberFirstValueAggFunctionWithoutOrderTest<Short> {
@@ -84,12 +84,12 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntFirstValueAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntFirstValueAggFunctionWithoutOrderTest
 			extends NumberFirstValueAggFunctionWithoutOrderTest<Integer> {
@@ -101,12 +101,12 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongFirstValueAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongFirstValueAggFunctionWithoutOrderTest
 			extends NumberFirstValueAggFunctionWithoutOrderTest<Long> {
@@ -118,12 +118,12 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatFirstValueAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatFirstValueAggFunctionWithoutOrderTest
 			extends NumberFirstValueAggFunctionWithoutOrderTest<Float> {
@@ -135,12 +135,12 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleFirstValueAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleFirstValueAggFunctionWithoutOrderTest
 			extends NumberFirstValueAggFunctionWithoutOrderTest<Double> {
@@ -152,15 +152,15 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanFirstValueAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
-	public static final class BooleanFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTestBase<Boolean> {
+	public static final class BooleanFirstValueAggFunctionWithoutOrderTest
+			extends FirstValueAggFunctionWithoutOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -208,15 +208,15 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalFirstValueAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
-	public static final class DecimalFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTestBase<DecimalData> {
+	public static final class DecimalFirstValueAggFunctionWithoutOrderTest
+			extends FirstValueAggFunctionWithoutOrderTestBase<DecimalData> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -260,15 +260,15 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalFirstValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
+			return new FirstValueAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringFirstValueAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
-	public static final class StringFirstValueAggFunctionWithoutOrderTest extends
-			FirstValueAggFunctionWithoutOrderTestBase<StringData> {
+	public static final class StringFirstValueAggFunctionWithoutOrderTest
+			extends FirstValueAggFunctionWithoutOrderTestBase<StringData> {
 
 		@Override
 		protected List<List<StringData>> getInputValueSets() {
@@ -310,7 +310,7 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringFirstValueAggFunction();
+			return new FirstValueAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -322,10 +322,11 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * The base test class for FirstValueAggFunction without order.
+	 * Test base for {@link FirstValueAggFunction} without order.
 	 */
 	public abstract static class FirstValueAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, RowData> {
+			extends AggFunctionTestBase<T, RowData> {
+
 		@Override
 		protected Class<?> getAccClass() {
 			return RowData.class;
@@ -333,10 +334,11 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 	}
 
 	/**
-	 * Test FirstValueAggFunction for number type.
+	 * Test base for {@link FirstValueAggFunction} with number types.
 	 */
 	public abstract static class NumberFirstValueAggFunctionWithoutOrderTest<T>
-		extends FirstValueAggFunctionWithoutOrderTestBase<T> {
+			extends FirstValueAggFunctionWithoutOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.BooleanFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.ByteFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.DecimalFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.DoubleFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.FloatFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.IntFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.LongFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.ShortFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.StringFirstValueWithRetractAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.FirstValueWithRetractAccumulator;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -42,7 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in FirstValue with retract aggregate function.
+ * Test case for built-in FIRST_VALUE with retract aggregate function.
  * This class tests `accumulate` method with order argument.
  */
 @RunWith(Enclosed.class)
@@ -57,7 +57,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteFirstValueWithRetractAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteFirstValueWithRetractAggFunctionWithOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Byte> {
@@ -68,13 +68,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Byte, FirstValueWithRetractAccumulator<Byte>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortFirstValueWithRetractAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortFirstValueWithRetractAggFunctionWithOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Short> {
@@ -85,13 +85,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Short, FirstValueWithRetractAccumulator<Short>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntFirstValueWithRetractAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntFirstValueWithRetractAggFunctionWithOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Integer> {
@@ -102,13 +102,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Integer, FirstValueWithRetractAccumulator<Integer>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongFirstValueWithRetractAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongFirstValueWithRetractAggFunctionWithOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Long> {
@@ -119,13 +119,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Long, FirstValueWithRetractAccumulator<Long>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatFirstValueWithRetractAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatFirstValueWithRetractAggFunctionWithOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Float> {
@@ -136,13 +136,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Float, FirstValueWithRetractAccumulator<Float>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleFirstValueWithRetractAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleFirstValueWithRetractAggFunctionWithOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithOrderTestBase<Double> {
@@ -153,13 +153,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Double, FirstValueWithRetractAccumulator<Double>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanFirstValueWithRetractAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
 	public static final class BooleanFirstValueWithRetractAggFunctionWithOrderTest
 			extends FirstValueWithRetractAggFunctionWithOrderTestBase<Boolean> {
@@ -243,13 +243,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Boolean, FirstValueWithRetractAccumulator<Boolean>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalFirstValueWithRetractAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
 	public static final class DecimalFirstValueWithRetractAggFunctionWithOrderTest
 			extends FirstValueWithRetractAggFunctionWithOrderTestBase<DecimalData> {
@@ -323,13 +323,13 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalFirstValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
+		protected AggregateFunction<DecimalData, FirstValueWithRetractAccumulator<DecimalData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringFirstValueWithRetractAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
 	public static final class StringFirstValueWithRetractAggFunctionWithOrderTest
 			extends FirstValueWithRetractAggFunctionWithOrderTestBase<StringData> {
@@ -401,20 +401,8 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringFirstValueWithRetractAggFunction();
-		}
-	}
-
-	/**
-	 * The base test class for FirstValueWithRetractAggFunction with order.
-	 */
-	public abstract static class FirstValueWithRetractAggFunctionWithOrderTestBase<T>
-		extends FirstLastValueAggFunctionWithOrderTestBase<T> {
-
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
+		protected AggregateFunction<StringData, FirstValueWithRetractAccumulator<StringData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -423,10 +411,28 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test FirstValueWithRetractAggFunction for number type.
+	 * Test base for {@link FirstValueWithRetractAggFunction} with order.
+	 */
+	public abstract static class FirstValueWithRetractAggFunctionWithOrderTestBase<T>
+			extends FirstLastValueAggFunctionWithOrderTestBase<T, FirstValueWithRetractAccumulator<T>> {
+
+		@Override
+		protected Class<?> getAccClass() {
+			return FirstValueWithRetractAccumulator.class;
+		}
+
+		@Override
+		protected Method getRetractFunc() throws NoSuchMethodException {
+			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class, Long.class);
+		}
+	}
+
+	/**
+	 * Test base for {@link FirstValueWithRetractAggFunction} with number types.
 	 */
 	public abstract static class NumberFirstValueWithRetractAggFunctionWithOrderTestBase<T>
-		extends FirstValueWithRetractAggFunctionWithOrderTestBase<T> {
+			extends FirstValueWithRetractAggFunctionWithOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override
@@ -494,5 +500,4 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 			);
 		}
 	}
-
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.BooleanFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.ByteFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.DecimalFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.DoubleFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.FloatFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.IntFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.LongFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.ShortFirstValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.StringFirstValueWithRetractAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.FirstValueWithRetractAccumulator;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -56,7 +56,7 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteFirstValueWithRetractAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteFirstValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Byte> {
@@ -67,13 +67,13 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Byte, FirstValueWithRetractAccumulator<Byte>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortFirstValueWithRetractAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortFirstValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Short> {
@@ -84,13 +84,13 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Short, FirstValueWithRetractAccumulator<Short>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntFirstValueWithRetractAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntFirstValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Integer> {
@@ -101,13 +101,13 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Integer, FirstValueWithRetractAccumulator<Integer>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongFirstValueWithRetractAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongFirstValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Long> {
@@ -118,13 +118,13 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Long, FirstValueWithRetractAccumulator<Long>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatFirstValueWithRetractAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatFirstValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Float> {
@@ -135,13 +135,13 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Float, FirstValueWithRetractAccumulator<Float>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleFirstValueWithRetractAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleFirstValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<Double> {
@@ -152,16 +152,16 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Double, FirstValueWithRetractAccumulator<Double>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanFirstValueWithRetractAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
-	public static final class BooleanFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
+	public static final class BooleanFirstValueWithRetractAggFunctionWithoutOrderTest
+			extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -208,16 +208,16 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanFirstValueWithRetractAggFunction();
+		protected AggregateFunction<Boolean, FirstValueWithRetractAccumulator<Boolean>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalFirstValueWithRetractAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
-	public static final class DecimalFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTestBase<DecimalData> {
+	public static final class DecimalFirstValueWithRetractAggFunctionWithoutOrderTest
+			extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<DecimalData> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -260,16 +260,16 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalFirstValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
+		protected AggregateFunction<DecimalData, FirstValueWithRetractAccumulator<DecimalData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringFirstValueWithRetractAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
-	public static final class StringFirstValueWithRetractAggFunctionWithoutOrderTest extends
-			FirstValueWithRetractAggFunctionWithoutOrderTestBase<StringData> {
+	public static final class StringFirstValueWithRetractAggFunctionWithoutOrderTest
+			extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<StringData> {
 
 		@Override
 		protected List<List<StringData>> getInputValueSets() {
@@ -310,8 +310,8 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringFirstValueWithRetractAggFunction();
+		protected AggregateFunction<StringData, FirstValueWithRetractAccumulator<StringData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -324,14 +324,14 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * The base test class for FirstValueWithRetractAggFunction without order.
+	 * Test base for {@link FirstValueWithRetractAggFunction} without order.
 	 */
 	public abstract static class FirstValueWithRetractAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, RowData> {
+			extends AggFunctionTestBase<T, FirstValueWithRetractAccumulator<T>> {
 
 		@Override
 		protected Class<?> getAccClass() {
-			return RowData.class;
+			return FirstValueWithRetractAccumulator.class;
 		}
 
 		@Override
@@ -341,10 +341,11 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 	}
 
 	/**
-	 * Test FirstValueWithRetractAggFunction for number type.
+	 * Test base for {@link FirstValueWithRetractAggFunction} with number types.
 	 */
 	public abstract static class NumberFirstValueWithRetractAggFunctionWithoutOrderTestBase<T>
-		extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<T> {
+			extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.BooleanLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.ByteLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.DecimalLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.DoubleLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.FloatLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.IntLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.LongLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.ShortLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.StringLastValueAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -56,7 +56,7 @@ public final class LastValueAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteLastValueAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteLastValueAggFunctionWithOrderTest
 			extends NumberLastValueAggFunctionWithOrderTestBase<Byte> {
@@ -68,12 +68,12 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortLastValueAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortLastValueAggFunctionWithOrderTest
 			extends NumberLastValueAggFunctionWithOrderTestBase<Short> {
@@ -85,12 +85,12 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntLastValueAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntLastValueAggFunctionWithOrderTest
 			extends NumberLastValueAggFunctionWithOrderTestBase<Integer> {
@@ -102,12 +102,12 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongLastValueAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongLastValueAggFunctionWithOrderTest
 			extends NumberLastValueAggFunctionWithOrderTestBase<Long> {
@@ -119,12 +119,12 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatLastValueAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatLastValueAggFunctionWithOrderTest
 			extends NumberLastValueAggFunctionWithOrderTestBase<Float> {
@@ -136,12 +136,12 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleLastValueAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleLastValueAggFunctionWithOrderTest
 			extends NumberLastValueAggFunctionWithOrderTestBase<Double> {
@@ -153,15 +153,15 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanLastValueAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
 	public static final class BooleanLastValueAggFunctionWithOrderTest
-			extends FirstLastValueAggFunctionWithOrderTestBase<Boolean> {
+			extends LastValueAggFunctionWithOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -243,15 +243,15 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalLastValueAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
 	public static final class DecimalLastValueAggFunctionWithOrderTest
-			extends FirstLastValueAggFunctionWithOrderTestBase<DecimalData> {
+			extends LastValueAggFunctionWithOrderTestBase<DecimalData> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -323,15 +323,15 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalLastValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
+			return new LastValueAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringLastValueAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
 	public static final class StringLastValueAggFunctionWithOrderTest
-			extends FirstLastValueAggFunctionWithOrderTestBase<StringData> {
+			extends LastValueAggFunctionWithOrderTestBase<StringData> {
 
 		@Override
 		protected List<List<StringData>> getInputValueSets() {
@@ -401,7 +401,7 @@ public final class LastValueAggFunctionWithOrderTest {
 
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -410,10 +410,23 @@ public final class LastValueAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test LastValueAggFunction for number type.
+	 * Test base for {@link LastValueAggFunction}.
+	 */
+	public abstract static class LastValueAggFunctionWithOrderTestBase<T>
+			extends FirstLastValueAggFunctionWithOrderTestBase<T, RowData> {
+
+		@Override
+		protected Class<?> getAccClass() {
+			return RowData.class;
+		}
+	}
+
+	/**
+	 * Test base for {@link LastValueAggFunction} with number types.
 	 */
 	public abstract static class NumberLastValueAggFunctionWithOrderTestBase<T>
-		extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+			extends LastValueAggFunctionWithOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.BooleanLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.ByteLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.DecimalLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.DoubleLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.FloatLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.IntLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.LongLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.ShortLastValueAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.StringLastValueAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -41,7 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in LastValue aggregate function.
+ * Test case for built-in LAST_VALUE aggregate function.
  * This class tests `accumulate` method without order argument.
  */
 @RunWith(Enclosed.class)
@@ -55,7 +55,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteLastValueAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteLastValueAggFunctionWithoutOrderTest
 			extends NumberLastValueAggFunctionWithoutOrderTestBase<Byte> {
@@ -67,12 +67,12 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortLastValueAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortLastValueAggFunctionWithoutOrderTest
 			extends NumberLastValueAggFunctionWithoutOrderTestBase<Short> {
@@ -84,12 +84,12 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntLastValueAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntLastValueAggFunctionWithoutOrderTest
 			extends NumberLastValueAggFunctionWithoutOrderTestBase<Integer> {
@@ -101,12 +101,12 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongLastValueAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongLastValueAggFunctionWithoutOrderTest
 			extends NumberLastValueAggFunctionWithoutOrderTestBase<Long> {
@@ -118,12 +118,12 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatLastValueAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatLastValueAggFunctionWithoutOrderTest
 			extends NumberLastValueAggFunctionWithoutOrderTestBase<Float> {
@@ -135,12 +135,12 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleLastValueAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleLastValueAggFunctionWithoutOrderTest
 			extends NumberLastValueAggFunctionWithoutOrderTestBase<Double> {
@@ -152,12 +152,12 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanLastValueAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
 	public static final class BooleanLastValueAggFunctionWithoutOrderTest extends
 			LastValueAggFunctionWithoutOrderTestBase<Boolean> {
@@ -208,15 +208,15 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalLastValueAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
-	public static final class DecimalLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTestBase<DecimalData> {
+	public static final class DecimalLastValueAggFunctionWithoutOrderTest
+			extends LastValueAggFunctionWithoutOrderTestBase<DecimalData> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -260,15 +260,15 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalLastValueAggFunction(DecimalDataTypeInfo.of(precision, scale));
+			return new LastValueAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringLastValueAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
-	public static final class StringLastValueAggFunctionWithoutOrderTest extends
-			LastValueAggFunctionWithoutOrderTestBase<StringData> {
+	public static final class StringLastValueAggFunctionWithoutOrderTest
+			extends LastValueAggFunctionWithoutOrderTestBase<StringData> {
 
 		@Override
 		protected List<List<StringData>> getInputValueSets() {
@@ -311,7 +311,7 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringLastValueAggFunction();
+			return new LastValueAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -321,10 +321,10 @@ public final class LastValueAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * The base test class for LastValueAggFunction without order.
+	 * Test base for {@link LastValueAggFunction} without order.
 	 */
 	public abstract static class LastValueAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, RowData> {
+			extends AggFunctionTestBase<T, RowData> {
 
 		@Override
 		protected Class<?> getAccClass() {
@@ -333,10 +333,11 @@ public final class LastValueAggFunctionWithoutOrderTest {
 	}
 
 	/**
-	 * Test LastValueAggFunction for number type.
+	 * Test base for {@link LastValueAggFunction} with number types.
 	 */
 	public abstract static class NumberLastValueAggFunctionWithoutOrderTestBase<T>
-		extends LastValueAggFunctionWithoutOrderTestBase<T> {
+			extends LastValueAggFunctionWithoutOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.BooleanLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.ByteLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.DecimalLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.DoubleLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.FloatLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.IntLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.LongLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.ShortLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.StringLastValueWithRetractAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.LastValueWithRetractAccumulator;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -42,7 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in LastValue with retract aggregate function.
+ * Test case for built-in LAST_VALUE with retract aggregate function.
  * This class tests `accumulate` method with order argument.
  */
 @RunWith(Enclosed.class)
@@ -57,7 +57,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteLastValueWithRetractAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteLastValueWithRetractAggFunctionWithOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Byte> {
@@ -68,13 +68,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteLastValueWithRetractAggFunction();
+		protected AggregateFunction<Byte, LastValueWithRetractAccumulator<Byte>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortLastValueWithRetractAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortLastValueWithRetractAggFunctionWithOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Short> {
@@ -85,13 +85,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortLastValueWithRetractAggFunction();
+		protected AggregateFunction<Short, LastValueWithRetractAccumulator<Short>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntLastValueWithRetractAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntLastValueWithRetractAggFunctionWithOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Integer> {
@@ -102,13 +102,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntLastValueWithRetractAggFunction();
+		protected AggregateFunction<Integer, LastValueWithRetractAccumulator<Integer>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongLastValueWithRetractAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongLastValueWithRetractAggFunctionWithOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Long> {
@@ -119,13 +119,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongLastValueWithRetractAggFunction();
+		protected AggregateFunction<Long, LastValueWithRetractAccumulator<Long>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatLastValueWithRetractAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatLastValueWithRetractAggFunctionWithOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Float> {
@@ -136,13 +136,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatLastValueWithRetractAggFunction();
+		protected AggregateFunction<Float, LastValueWithRetractAccumulator<Float>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleLastValueWithRetractAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleLastValueWithRetractAggFunctionWithOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithOrderTestBase<Double> {
@@ -153,13 +153,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleLastValueWithRetractAggFunction();
+		protected AggregateFunction<Double, LastValueWithRetractAccumulator<Double>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanLastValueWithRetractAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
 	public static final class BooleanLastValueWithRetractAggFunctionWithOrderTest
 			extends LastValueWithRetractAggFunctionWithOrderTestBase<Boolean> {
@@ -243,13 +243,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanLastValueWithRetractAggFunction();
+		protected AggregateFunction<Boolean, LastValueWithRetractAccumulator<Boolean>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalLastValueWithRetractAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
 	public static final class DecimalLastValueWithRetractAggFunctionWithOrderTest
 			extends LastValueWithRetractAggFunctionWithOrderTestBase<DecimalData> {
@@ -323,13 +323,13 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalLastValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
+		protected AggregateFunction<DecimalData, LastValueWithRetractAccumulator<DecimalData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringLastValueWithRetractAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
 	public static final class StringLastValueWithRetractAggFunctionWithOrderTest
 			extends LastValueWithRetractAggFunctionWithOrderTestBase<StringData> {
@@ -407,8 +407,8 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringLastValueWithRetractAggFunction();
+		protected AggregateFunction<StringData, LastValueWithRetractAccumulator<StringData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -418,10 +418,15 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * The base test class for LastValueWithRetractAggFunction with order.
+	 * Test base for {@link LastValueWithRetractAggFunction} with order.
 	 */
 	public abstract static class LastValueWithRetractAggFunctionWithOrderTestBase<T>
-		extends FirstLastValueAggFunctionWithOrderTestBase<T> {
+		extends FirstLastValueAggFunctionWithOrderTestBase<T, LastValueWithRetractAccumulator<T>> {
+
+		@Override
+		protected Class<?> getAccClass() {
+			return LastValueWithRetractAccumulator.class;
+		}
 
 		@Override
 		protected Method getRetractFunc() throws NoSuchMethodException {
@@ -430,10 +435,11 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 	}
 
 	/**
-	 * Test LastValueWithRetractAggFunction for number type.
+	 * Test base for {@link LastValueWithRetractAggFunction} with number types.
 	 */
 	public abstract static class NumberLastValueWithRetractAggFunctionWithOrderTestBase<T>
-		extends LastValueWithRetractAggFunctionWithOrderTestBase<T> {
+			extends LastValueWithRetractAggFunctionWithOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.BooleanLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.ByteLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.DecimalLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.DoubleLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.FloatLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.IntLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.LongLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.ShortLastValueWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.StringLastValueWithRetractAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.LastValueWithRetractAccumulator;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.serialization.types.ShortType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -42,7 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in LastValue with retract aggregate function.
+ * Test case for built-in LAST_VALUE with retract aggregate function.
  * This class tests `accumulate` method without order argument.
  */
 @RunWith(Enclosed.class)
@@ -56,7 +56,7 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteLastValueWithRetractAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteLastValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Byte> {
@@ -67,13 +67,13 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Byte, RowData> getAggregator() {
-			return new ByteLastValueWithRetractAggFunction();
+		protected AggregateFunction<Byte, LastValueWithRetractAccumulator<Byte>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortLastValueWithRetractAggFunction.
+	 * Test for {@link ShortType}.
 	 */
 	public static final class ShortLastValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Short> {
@@ -84,13 +84,13 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Short, RowData> getAggregator() {
-			return new ShortLastValueWithRetractAggFunction();
+		protected AggregateFunction<Short, LastValueWithRetractAccumulator<Short>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntLastValueWithRetractAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntLastValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Integer> {
@@ -101,13 +101,13 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Integer, RowData> getAggregator() {
-			return new IntLastValueWithRetractAggFunction();
+		protected AggregateFunction<Integer, LastValueWithRetractAccumulator<Integer>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongLastValueWithRetractAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongLastValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Long> {
@@ -118,13 +118,13 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Long, RowData> getAggregator() {
-			return new LongLastValueWithRetractAggFunction();
+		protected AggregateFunction<Long, LastValueWithRetractAccumulator<Long>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatLastValueWithRetractAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatLastValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Float> {
@@ -135,13 +135,13 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Float, RowData> getAggregator() {
-			return new FloatLastValueWithRetractAggFunction();
+		protected AggregateFunction<Float, LastValueWithRetractAccumulator<Float>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleLastValueWithRetractAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleLastValueWithRetractAggFunctionWithoutOrderTest
 			extends NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<Double> {
@@ -152,16 +152,16 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Double, RowData> getAggregator() {
-			return new DoubleLastValueWithRetractAggFunction();
+		protected AggregateFunction<Double, LastValueWithRetractAccumulator<Double>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanLastValueWithRetractAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
-	public static final class BooleanLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
+	public static final class BooleanLastValueWithRetractAggFunctionWithoutOrderTest
+			extends LastValueWithRetractAggFunctionWithoutOrderTestBase<Boolean> {
 
 		@Override
 		protected List<List<Boolean>> getInputValueSets() {
@@ -208,16 +208,16 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<Boolean, RowData> getAggregator() {
-			return new BooleanLastValueWithRetractAggFunction();
+		protected AggregateFunction<Boolean, LastValueWithRetractAccumulator<Boolean>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalLastValueWithRetractAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
-	public static final class DecimalLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTestBase<DecimalData> {
+	public static final class DecimalLastValueWithRetractAggFunctionWithoutOrderTest
+			extends LastValueWithRetractAggFunctionWithoutOrderTestBase<DecimalData> {
 
 		private int precision = 20;
 		private int scale = 6;
@@ -260,16 +260,16 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<DecimalData, RowData> getAggregator() {
-			return new DecimalLastValueWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
+		protected AggregateFunction<DecimalData, LastValueWithRetractAccumulator<DecimalData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringLastValueWithRetractAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
-	public static final class StringLastValueWithRetractAggFunctionWithoutOrderTest extends
-			LastValueWithRetractAggFunctionWithoutOrderTestBase<StringData> {
+	public static final class StringLastValueWithRetractAggFunctionWithoutOrderTest
+			extends LastValueWithRetractAggFunctionWithoutOrderTestBase<StringData> {
 
 		@Override
 		protected List<List<StringData>> getInputValueSets() {
@@ -310,8 +310,8 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		}
 
 		@Override
-		protected AggregateFunction<StringData, RowData> getAggregator() {
-			return new StringLastValueWithRetractAggFunction();
+		protected AggregateFunction<StringData, LastValueWithRetractAccumulator<StringData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
@@ -324,14 +324,14 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * The base test class for LastValueWithRetractAggFunction without order.
+	 * Test base for {@link LastValueWithRetractAggFunction} without order.
 	 */
 	public abstract static class LastValueWithRetractAggFunctionWithoutOrderTestBase<T>
-		extends AggFunctionTestBase<T, RowData> {
+			extends AggFunctionTestBase<T, LastValueWithRetractAccumulator<T>> {
 
 		@Override
 		protected Class<?> getAccClass() {
-			return RowData.class;
+			return LastValueWithRetractAccumulator.class;
 		}
 
 		@Override
@@ -341,10 +341,11 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 	}
 
 	/**
-	 * Test LastValueWithRetractAggFunction for number type.
+	 * Test base for {@link LastValueWithRetractAggFunction} with number types.
 	 */
 	public abstract static class NumberLastValueWithRetractAggFunctionWithoutOrderTestBase<T>
-		extends LastValueWithRetractAggFunctionWithoutOrderTestBase<T> {
+			extends LastValueWithRetractAggFunctionWithoutOrderTestBase<T> {
+
 		protected abstract T getValue(String v);
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunctionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
@@ -29,8 +28,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test case for built-in ListAggWs with retraction aggregate function.
@@ -103,18 +100,6 @@ public final class ListAggWsWithRetractAggFunctionTest
 	@Override
 	protected Class<?> getAccClass() {
 		return ListAggWsWithRetractAccumulator.class;
-	}
-
-	@Override
-	protected <E> void validateResult(E expected, E result, TypeInformation<?> typeInfo) {
-		if (expected instanceof ListAggWsWithRetractAccumulator && result instanceof ListAggWsWithRetractAccumulator) {
-			ListAggWsWithRetractAccumulator e = (ListAggWsWithRetractAccumulator) expected;
-			ListAggWsWithRetractAccumulator r = (ListAggWsWithRetractAccumulator) result;
-			assertEquals(e.list, r.list);
-			assertEquals(e.list, r.list);
-		} else {
-			super.validateResult(expected, result, typeInfo);
-		}
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunctionTest.java
@@ -18,32 +18,31 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.BooleanMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.ByteMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.DateMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.DecimalMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.DoubleMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.FloatMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.IntMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.LongMaxWithRetractAggFunction;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.MaxWithRetractAccumulator;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.ShortMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.StringMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.TimeMaxWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MaxWithRetractAggFunction.TimestampMaxWithRetractAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
-import java.sql.Date;
-import java.sql.Time;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,7 +60,7 @@ public final class MaxWithRetractAggFunctionTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteMaxWithRetractAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Byte> {
 
@@ -82,12 +81,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Byte, MaxWithRetractAccumulator<Byte>> getAggregator() {
-			return new ByteMaxWithRetractAggFunction();
+			return new MaxWithRetractAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortMaxWithRetractAggFunction.
+	 * Test for {@link SmallIntType}.
 	 */
 	public static final class ShortMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Short> {
 
@@ -108,12 +107,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Short, MaxWithRetractAccumulator<Short>> getAggregator() {
-			return new ShortMaxWithRetractAggFunction();
+			return new MaxWithRetractAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntMaxWithRetractAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Integer> {
 
@@ -134,12 +133,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Integer, MaxWithRetractAccumulator<Integer>> getAggregator() {
-			return new IntMaxWithRetractAggFunction();
+			return new MaxWithRetractAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongMaxWithRetractAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Long> {
 
@@ -160,12 +159,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Long, MaxWithRetractAccumulator<Long>> getAggregator() {
-			return new LongMaxWithRetractAggFunction();
+			return new MaxWithRetractAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatMaxWithRetractAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Float> {
 
@@ -186,12 +185,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Float, MaxWithRetractAccumulator<Float>> getAggregator() {
-			return new FloatMaxWithRetractAggFunction();
+			return new MaxWithRetractAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleMaxWithRetractAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleMaxWithRetractAggFunctionTest extends NumberMaxWithRetractAggFunctionTest<Double> {
 
@@ -212,12 +211,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Double, MaxWithRetractAccumulator<Double>> getAggregator() {
-			return new DoubleMaxWithRetractAggFunction();
+			return new MaxWithRetractAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanMaxWithRetractAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
 	public static final class BooleanMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Boolean> {
 
@@ -267,22 +266,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Boolean, MaxWithRetractAccumulator<Boolean>> getAggregator() {
-			return new BooleanMaxWithRetractAggFunction();
-		}
-
-		@Override
-		protected Class<?> getAccClass() {
-			return MaxWithRetractAccumulator.class;
-		}
-
-		@Override
-		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+			return new MaxWithRetractAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalMaxWithRetractAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
 	public static final class DecimalMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<DecimalData> {
 
@@ -328,12 +317,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<DecimalData, MaxWithRetractAccumulator<DecimalData>> getAggregator() {
-			return new DecimalMaxWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
+			return new MaxWithRetractAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringMaxWithRetractAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
 	public static final class StringMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<StringData> {
 
@@ -377,12 +366,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<StringData, MaxWithRetractAccumulator<StringData>> getAggregator() {
-			return new StringMaxWithRetractAggFunction();
+			return new MaxWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for TimestampMaxWithRetractAggFunction.
+	 * Test for {@link TimestampType}.
 	 */
 	public static final class TimestampMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<TimestampData> {
 
@@ -421,12 +410,12 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<TimestampData, MaxWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new TimestampMaxWithRetractAggFunction(3);
+			return new MaxWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for TimestampMaxWithRetractAggFunction, precision is 9.
+	 * Test for {@link TimestampType} with precision 9.
 	 */
 	public static final class Timestamp9MaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<TimestampData> {
 
@@ -467,24 +456,24 @@ public final class MaxWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<TimestampData, MaxWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new TimestampMaxWithRetractAggFunction(9);
+			return new MaxWithRetractAggFunction<>(DataTypes.TIMESTAMP(9).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DateMaxWithRetractAggFunction.
+	 * Test for {@link DateType}.
 	 */
-	public static final class DateMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Date> {
+	public static final class DateMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Integer> {
 
 		@Override
-		protected List<List<Date>> getInputValueSets() {
+		protected List<List<Integer>> getInputValueSets() {
 			return Arrays.asList(
 					Arrays.asList(
-							new Date(0),
-							new Date(1000),
-							new Date(100),
+							0,
+							1000,
+							100,
 							null,
-							new Date(10)
+							10
 					),
 					Arrays.asList(
 							null,
@@ -495,40 +484,40 @@ public final class MaxWithRetractAggFunctionTest {
 					),
 					Arrays.asList(
 							null,
-							new Date(1)
+							1
 					)
 			);
 		}
 
 		@Override
-		protected List<Date> getExpectedResults() {
+		protected List<Integer> getExpectedResults() {
 			return Arrays.asList(
-					new Date(1000),
+					1000,
 					null,
-					new Date(1)
+					1
 			);
 		}
 
 		@Override
-		protected AggregateFunction<Date, MaxWithRetractAccumulator<Date>> getAggregator() {
-			return new DateMaxWithRetractAggFunction();
+		protected AggregateFunction<Integer, MaxWithRetractAccumulator<Integer>> getAggregator() {
+			return new MaxWithRetractAggFunction<>(DataTypes.DATE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for TimeMaxWithRetractAggFunction.
+	 * Test for {@link TimeType}.
 	 */
-	public static final class TimeMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Time> {
+	public static final class TimeMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTestBase<Integer> {
 
 		@Override
-		protected List<List<Time>> getInputValueSets() {
+		protected List<List<Integer>> getInputValueSets() {
 			return Arrays.asList(
 					Arrays.asList(
-							new Time(0),
-							new Time(1000),
-							new Time(100),
+							0,
+							1000,
+							100,
 							null,
-							new Time(10)
+							10
 					),
 					Arrays.asList(
 							null,
@@ -539,23 +528,23 @@ public final class MaxWithRetractAggFunctionTest {
 					),
 					Arrays.asList(
 							null,
-							new Time(1)
+							1
 					)
 			);
 		}
 
 		@Override
-		protected List<Time> getExpectedResults() {
+		protected List<Integer> getExpectedResults() {
 			return Arrays.asList(
-					new Time(1000),
+					1000,
 					null,
-					new Time(1)
+					1
 			);
 		}
 
 		@Override
-		protected AggregateFunction<Time, MaxWithRetractAccumulator<Time>> getAggregator() {
-			return new TimeMaxWithRetractAggFunction();
+		protected AggregateFunction<Integer, MaxWithRetractAccumulator<Integer>> getAggregator() {
+			return new MaxWithRetractAggFunction<>(DataTypes.TIME(0).getLogicalType());
 		}
 	}
 
@@ -568,7 +557,7 @@ public final class MaxWithRetractAggFunctionTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * The base test class for MaxWithRetractAggFunction.
+	 * Test base for {@link MaxWithRetractAggFunction}.
 	 */
 	public abstract static class MaxWithRetractAggFunctionTestBase<T>
 		extends AggFunctionTestBase<T, MaxWithRetractAccumulator<T>> {
@@ -579,13 +568,28 @@ public final class MaxWithRetractAggFunctionTest {
 		}
 
 		@Override
+		protected Method getAccumulateFunc() throws NoSuchMethodException {
+			return getAggregator()
+				.getClass()
+				.getMethod(
+					UserDefinedFunctionHelper.AGGREGATE_ACCUMULATE,
+					getAccClass(),
+					Comparable.class);
+		}
+
+		@Override
 		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+			return getAggregator()
+				.getClass()
+				.getMethod(
+					UserDefinedFunctionHelper.AGGREGATE_RETRACT,
+					getAccClass(),
+					Comparable.class);
 		}
 	}
 
 	/**
-	 * Test MaxWithRetractAggFunction for number type.
+	 * Test base for {@link MaxWithRetractAggFunction} and numeric types.
 	 */
 	public abstract static class NumberMaxWithRetractAggFunctionTest<T> extends MaxWithRetractAggFunctionTestBase<T> {
 		protected abstract T getMinValue();

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunctionTest.java
@@ -18,32 +18,31 @@
 
 package org.apache.flink.table.planner.functions.aggfunctions;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.BooleanMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.ByteMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.DateMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.DecimalMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.DoubleMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.FloatMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.IntMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.LongMinWithRetractAggFunction;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.MinWithRetractAccumulator;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.ShortMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.StringMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.TimeMinWithRetractAggFunction;
-import org.apache.flink.table.planner.functions.aggfunctions.MinWithRetractAggFunction.TimestampMinWithRetractAggFunction;
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
-import java.sql.Date;
-import java.sql.Time;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,7 +60,7 @@ public final class MinWithRetractAggFunctionTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test for ByteMinWithRetractAggFunction.
+	 * Test for {@link TinyIntType}.
 	 */
 	public static final class ByteMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Byte> {
 
@@ -82,12 +81,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Byte, MinWithRetractAccumulator<Byte>> getAggregator() {
-			return new ByteMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.TINYINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for ShortMinWithRetractAggFunction.
+	 * Test for {@link SmallIntType}.
 	 */
 	public static final class ShortMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Short> {
 
@@ -108,12 +107,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Short, MinWithRetractAccumulator<Short>> getAggregator() {
-			return new ShortMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.SMALLINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for IntMinWithRetractAggFunction.
+	 * Test for {@link IntType}.
 	 */
 	public static final class IntMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Integer> {
 
@@ -134,12 +133,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Integer, MinWithRetractAccumulator<Integer>> getAggregator() {
-			return new IntMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.INT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for LongMinWithRetractAggFunction.
+	 * Test for {@link BigIntType}.
 	 */
 	public static final class LongMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Long> {
 
@@ -160,12 +159,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Long, MinWithRetractAccumulator<Long>> getAggregator() {
-			return new LongMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.BIGINT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for FloatMinWithRetractAggFunction.
+	 * Test for {@link FloatType}.
 	 */
 	public static final class FloatMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Float> {
 
@@ -186,12 +185,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Float, MinWithRetractAccumulator<Float>> getAggregator() {
-			return new FloatMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.FLOAT().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DoubleMinWithRetractAggFunction.
+	 * Test for {@link DoubleType}.
 	 */
 	public static final class DoubleMinWithRetractAggFunctionTest extends NumberMinWithRetractAggFunctionTestBase<Double> {
 
@@ -212,12 +211,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Double, MinWithRetractAccumulator<Double>> getAggregator() {
-			return new DoubleMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.DOUBLE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for BooleanMinWithRetractAggFunction.
+	 * Test for {@link BooleanType}.
 	 */
 	public static final class BooleanMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Boolean> {
 
@@ -267,12 +266,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<Boolean, MinWithRetractAccumulator<Boolean>> getAggregator() {
-			return new BooleanMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DecimalMinWithRetractAggFunction.
+	 * Test for {@link DecimalType}.
 	 */
 	public static final class DecimalMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<DecimalData> {
 
@@ -318,12 +317,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<DecimalData, MinWithRetractAccumulator<DecimalData>> getAggregator() {
-			return new DecimalMinWithRetractAggFunction(DecimalDataTypeInfo.of(precision, scale));
+			return new MinWithRetractAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for StringMinWithRetractAggFunction.
+	 * Test for {@link VarCharType}.
 	 */
 	public static final class StringMinWithRetractAggFunctionTest
 			extends MinWithRetractAggFunctionTestBase<StringData> {
@@ -368,12 +367,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<StringData, MinWithRetractAccumulator<StringData>> getAggregator() {
-			return new StringMinWithRetractAggFunction();
+			return new MinWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for TimestampMinWithRetractAggFunction.
+	 * Test for {@link TimestampType}.
 	 */
 	public static final class TimestampMinWithRetractAggFunctionTest
 			extends MinWithRetractAggFunctionTestBase<TimestampData> {
@@ -413,12 +412,12 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<TimestampData, MinWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new TimestampMinWithRetractAggFunction(3);
+			return new MinWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for TimestampMinWithRetractAggFunction, precision is 9.
+	 * Test for {@link TimestampType} with precision 9.
 	 */
 	public static final class Timestamp9MinWithRetractAggFunctionTest
 			extends MinWithRetractAggFunctionTestBase<TimestampData> {
@@ -460,24 +459,24 @@ public final class MinWithRetractAggFunctionTest {
 
 		@Override
 		protected AggregateFunction<TimestampData, MinWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new TimestampMinWithRetractAggFunction(9);
+			return new MinWithRetractAggFunction<>(DataTypes.TIMESTAMP(9).getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for DateMinWithRetractAggFunction.
+	 * Test for {@link DateType}.
 	 */
-	public static final class DateMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Date> {
+	public static final class DateMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Integer> {
 
 		@Override
-		protected List<List<Date>> getInputValueSets() {
+		protected List<List<Integer>> getInputValueSets() {
 			return Arrays.asList(
 					Arrays.asList(
-							new Date(0),
-							new Date(1000),
-							new Date(100),
+							0,
+							1000,
+							100,
 							null,
-							new Date(10)
+							10
 					),
 					Arrays.asList(
 							null,
@@ -488,40 +487,40 @@ public final class MinWithRetractAggFunctionTest {
 					),
 					Arrays.asList(
 							null,
-							new Date(1)
+							1
 					)
 			);
 		}
 
 		@Override
-		protected List<Date> getExpectedResults() {
+		protected List<Integer> getExpectedResults() {
 			return Arrays.asList(
-					new Date(0),
+					0,
 					null,
-					new Date(1)
+					1
 			);
 		}
 
 		@Override
-		protected AggregateFunction<Date, MinWithRetractAccumulator<Date>> getAggregator() {
-			return new DateMinWithRetractAggFunction();
+		protected AggregateFunction<Integer, MinWithRetractAccumulator<Integer>> getAggregator() {
+			return new MinWithRetractAggFunction<>(DataTypes.DATE().getLogicalType());
 		}
 	}
 
 	/**
-	 * Test for TimeMinWithRetractAggFunction.
+	 * Test for {@link TimeType}.
 	 */
-	public static final class TimeMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Time> {
+	public static final class TimeMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTestBase<Integer> {
 
 		@Override
-		protected List<List<Time>> getInputValueSets() {
+		protected List<List<Integer>> getInputValueSets() {
 			return Arrays.asList(
 					Arrays.asList(
-							new Time(0),
-							new Time(1000),
-							new Time(100),
+							0,
+							1000,
+							100,
 							null,
-							new Time(10)
+							10
 					),
 					Arrays.asList(
 							null,
@@ -532,23 +531,23 @@ public final class MinWithRetractAggFunctionTest {
 					),
 					Arrays.asList(
 							null,
-							new Time(1)
+							1
 					)
 			);
 		}
 
 		@Override
-		protected List<Time> getExpectedResults() {
+		protected List<Integer> getExpectedResults() {
 			return Arrays.asList(
-					new Time(0),
+					0,
 					null,
-					new Time(1)
+					1
 			);
 		}
 
 		@Override
-		protected AggregateFunction<Time, MinWithRetractAccumulator<Time>> getAggregator() {
-			return new TimeMinWithRetractAggFunction();
+		protected AggregateFunction<Integer, MinWithRetractAccumulator<Integer>> getAggregator() {
+			return new MinWithRetractAggFunction<>(DataTypes.TIME(0).getLogicalType());
 		}
 	}
 
@@ -561,7 +560,7 @@ public final class MinWithRetractAggFunctionTest {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * The base test class for MinWithRetractAggFunction.
+	 * Test base for {@link MinWithRetractAggFunction}.
 	 */
 	public abstract static class MinWithRetractAggFunctionTestBase<T>
 		extends AggFunctionTestBase<T, MinWithRetractAccumulator<T>> {
@@ -572,13 +571,28 @@ public final class MinWithRetractAggFunctionTest {
 		}
 
 		@Override
+		protected Method getAccumulateFunc() throws NoSuchMethodException {
+			return getAggregator()
+				.getClass()
+				.getMethod(
+					UserDefinedFunctionHelper.AGGREGATE_ACCUMULATE,
+					getAccClass(),
+					Comparable.class);
+		}
+
+		@Override
 		protected Method getRetractFunc() throws NoSuchMethodException {
-			return getAggregator().getClass().getMethod("retract", getAccClass(), Object.class);
+			return getAggregator()
+				.getClass()
+				.getMethod(
+					UserDefinedFunctionHelper.AGGREGATE_RETRACT,
+					getAccClass(),
+					Comparable.class);
 		}
 	}
 
 	/**
-	 * Test MinWithRetractAggFunction for number type.
+	 * Test base for {@link MinWithRetractAggFunction} and numeric types.
 	 */
 	public abstract static class NumberMinWithRetractAggFunctionTestBase<T> extends MinWithRetractAggFunctionTestBase<T> {
 		protected abstract T getMinValue();

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
@@ -21,8 +21,7 @@ package org.apache.flink.table.planner.plan.batch.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.IntFirstValueAggFunction
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.LongLastValueAggFunction
+import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecSortMergeJoinRule
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecSortRule.TABLE_EXEC_SORT_RANGE_ENABLED
 import org.apache.flink.table.planner.plan.utils.OperatorType
@@ -205,9 +204,13 @@ class SubplanReuseTest extends TableTestBase {
 
   @Test
   def testSubplanReuseOnAggregateWithNonDeterministicAggCall(): Unit = {
-    // IntFirstValueAggFunction and LongLastValueAggFunction are deterministic
-    util.addFunction("MyFirst", new IntFirstValueAggFunction)
-    util.addFunction("MyLast", new LongLastValueAggFunction)
+    // FirstValueAggFunction and LastValueAggFunction are not deterministic
+    util.addTemporarySystemFunction(
+      "MyFirst",
+      new FirstValueAggFunction(DataTypes.INT().getLogicalType))
+        util.addTemporarySystemFunction(
+      "MyLast",
+      new FirstValueAggFunction(DataTypes.BIGINT().getLogicalType))
 
     val sqlQuery =
       """
@@ -333,8 +336,10 @@ class SubplanReuseTest extends TableTestBase {
 
   @Test
   def testSubplanReuseOnOverWindowWithNonDeterministicAggCall(): Unit = {
-    // IntFirstValueAggFunction is deterministic
-    util.addFunction("MyFirst", new IntFirstValueAggFunction)
+    // FirstValueAggFunction is not deterministic
+    util.addTemporarySystemFunction(
+      "MyFirst",
+      new FirstValueAggFunction(DataTypes.STRING().getLogicalType))
 
     val sqlQuery =
       """

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
@@ -21,8 +21,7 @@ package org.apache.flink.table.planner.plan.stream.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
-import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction.IntFirstValueAggFunction
-import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunction.LongLastValueAggFunction
+import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.NonDeterministicUdf
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.{NonDeterministicTableFunc, StringSplit}
 import org.apache.flink.table.planner.utils.TableTestBase
@@ -157,9 +156,13 @@ class SubplanReuseTest extends TableTestBase {
 
   @Test
   def testSubplanReuseOnAggregateWithNonDeterministicAggCall(): Unit = {
-    // IntFirstValueAggFunction and LongLastValueAggFunction are deterministic
-    util.addFunction("MyFirst", new IntFirstValueAggFunction)
-    util.addFunction("MyLast", new LongLastValueAggFunction)
+    // FirstValueAggFunction and LastValueAggFunction are not deterministic
+    util.addTemporarySystemFunction(
+      "MyFirst",
+      new FirstValueAggFunction(DataTypes.INT().getLogicalType))
+    util.addTemporarySystemFunction(
+      "MyLast",
+      new FirstValueAggFunction(DataTypes.BIGINT().getLogicalType))
 
     val sqlQuery =
       """
@@ -248,9 +251,10 @@ class SubplanReuseTest extends TableTestBase {
 
   @Test
   def testSubplanReuseOnOverWindowWithNonDeterministicAggCall(): Unit = {
-    // IntFirstValueAggFunction is deterministic
-    util.addFunction("MyFirst", new IntFirstValueAggFunction)
-
+    // FirstValueAggFunction is not deterministic
+    util.addTemporarySystemFunction(
+      "MyFirst",
+      new FirstValueAggFunction(DataTypes.STRING().getLogicalType))
     val sqlQuery =
       """
         |WITH r AS (SELECT a, b, MyFirst(c) OVER (PARTITION BY c ORDER BY c DESC) FROM x)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1057,13 +1057,13 @@ class AggregateITCase(
     val view1 = tEnv.sqlQuery(sql)
     tEnv.registerTable("v1", view1)
 
-    val toCompositeObj = ToCompositeObj
-    tEnv.registerFunction("toCompObj", toCompositeObj)
+    tEnv.createTemporarySystemFunction("toCompObj", ToCompositeObj)
+    tEnv.createTemporarySystemFunction("anyToString", AnyToStringFunction)
 
     val sql1 =
       s"""
          |SELECT
-         |  a, b, COLLECT(toCompObj(t.sid, 'a', 100, t.point)) as info
+         |  a, b, anyToString(COLLECT(toCompObj(t.sid, 'a', 100, t.point)))
          |from (
          | select
          |  a, b, uuid() as u, V.sid, V.point

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1089,8 +1089,12 @@ class AggregateITCase(
   /** Test LISTAGG **/
   @Test
   def testListAgg(): Unit = {
-    tEnv.createTemporarySystemFunction("listagg_retract", classOf[ListAggWithRetractAggFunction])
-    tEnv.registerFunction("listagg_ws_retract", new ListAggWsWithRetractAggFunction)
+    tEnv.createTemporarySystemFunction(
+      "listagg_retract",
+      classOf[ListAggWithRetractAggFunction])
+    tEnv.createTemporarySystemFunction(
+      "listagg_ws_retract",
+      classOf[ListAggWsWithRetractAggFunction])
     val sqlQuery =
       s"""
          |SELECT

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -25,9 +25,10 @@ import org.apache.flink.api.scala.ExecutionEnvironment
 import org.apache.flink.api.scala.typeutils.Types
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.annotation.{DataTypeHint, InputGroup}
 import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.functions.{AggregateFunction, FunctionContext, ScalarFunction}
-import org.apache.flink.table.planner.JLong
+import org.apache.flink.table.planner.{JInt, JLong}
 import org.apache.flink.types.Row
 
 import com.google.common.base.Charsets
@@ -198,6 +199,11 @@ object UserDefinedFunctionTestUtils {
   }
 
   @SerialVersionUID(1L)
+  object AnyToStringFunction extends ScalarFunction {
+    def eval(@DataTypeHint(inputGroup = InputGroup.ANY) any: AnyRef): String = any.toString
+  }
+
+  @SerialVersionUID(1L)
   object MyStringFunc extends ScalarFunction {
     def eval(s: String): String = s + "haha"
   }
@@ -298,11 +304,11 @@ object UserDefinedFunctionTestUtils {
 
   @SerialVersionUID(1L)
   object ToCompositeObj extends ScalarFunction {
-    def eval(id: Int, name: String, age: Int): CompositeObj = {
+    def eval(id: JInt, name: String, age: JInt): CompositeObj = {
       CompositeObj(id, name, age, "0.0")
     }
 
-    def eval(id: Int, name: String, age: Int, point: String): CompositeObj = {
+    def eval(id: JInt, name: String, age: JInt, point: String): CompositeObj = {
       CompositeObj(id, name, age, point)
     }
   }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/RawByteArrayConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/RawByteArrayConverter.java
@@ -19,10 +19,13 @@
 package org.apache.flink.table.data.conversion;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RawType;
+import org.apache.flink.table.types.logical.TypeInformationRawType;
 
 /**
  * Converter for {@link RawType} of {@code byte[]} external type.
@@ -53,7 +56,16 @@ public class RawByteArrayConverter<T> implements DataStructureConverter<RawValue
 	// --------------------------------------------------------------------------------------------
 
 	public static RawByteArrayConverter<?> create(DataType dataType) {
-		final TypeSerializer<?> serializer = ((RawType<?>) dataType.getLogicalType()).getTypeSerializer();
+		final LogicalType logicalType = dataType.getLogicalType();
+		final TypeSerializer<?> serializer;
+		if (logicalType instanceof TypeInformationRawType) {
+			serializer = ((TypeInformationRawType<?>) logicalType)
+				.getTypeInformation()
+				.createSerializer(new ExecutionConfig());
+		} else {
+			serializer = ((RawType<?>) dataType.getLogicalType())
+				.getTypeSerializer();
+		}
 		return new RawByteArrayConverter<>(serializer);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/RawObjectConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/RawObjectConverter.java
@@ -19,10 +19,13 @@
 package org.apache.flink.table.data.conversion;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RawType;
+import org.apache.flink.table.types.logical.TypeInformationRawType;
 
 /**
  * Converter for {@link RawType} of object external type.
@@ -53,7 +56,16 @@ public class RawObjectConverter<T> implements DataStructureConverter<RawValueDat
 	// --------------------------------------------------------------------------------------------
 
 	public static RawObjectConverter<?> create(DataType dataType) {
-		final TypeSerializer<?> serializer = ((RawType<?>) dataType.getLogicalType()).getTypeSerializer();
+		final LogicalType logicalType = dataType.getLogicalType();
+		final TypeSerializer<?> serializer;
+		if (logicalType instanceof TypeInformationRawType) {
+			serializer = ((TypeInformationRawType<?>) logicalType)
+				.getTypeInformation()
+				.createSerializer(new ExecutionConfig());
+		} else {
+			serializer = ((RawType<?>) dataType.getLogicalType())
+				.getTypeSerializer();
+		}
 		return new RawObjectConverter<>(serializer);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
@@ -30,6 +30,7 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.BOOLEAN;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.MAP;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.MULTISET;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.RAW;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
@@ -111,6 +112,10 @@ public class TypeCheckUtils {
 		return type.getTypeRoot() == MAP;
 	}
 
+	public static boolean isMultiset(LogicalType type) {
+		return type.getTypeRoot() == MULTISET;
+	}
+
 	public static boolean isRaw(LogicalType type) {
 		return type.getTypeRoot() == RAW;
 	}
@@ -120,7 +125,7 @@ public class TypeCheckUtils {
 	}
 
 	public static boolean isComparable(LogicalType type) {
-		return !isRaw(type) && !isMap(type) && !isRow(type) && !isArray(type);
+		return !isRaw(type) && !isMap(type) && !isMultiset(type) && !isRow(type) && !isArray(type);
 	}
 
 	public static boolean isMutable(LogicalType type) {


### PR DESCRIPTION
## What is the purpose of the change

Updates all built-in aggregate functions to the new type system. The functions extend from `InternalAggregateFunction` for easier translation but can also be used as external functions (e.g. for testing). 

## Brief change log

- Introduce `InternalAggregateFunction`
- Update all functions including `DISTINCT`
- Fix various issues around types and their data structures

## Verifying this change

This change is already covered by existing tests, such as `AggregateITCase` or tests that extend from `AggFunctionTestBase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
