### PR TITLE
[FLINK-18808][runtime/metrics] Include side outputs in numRecordsOut metric.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/CopyingDirectedOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/CopyingDirectedOutput.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.collector.selector;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -35,8 +36,9 @@ public class CopyingDirectedOutput<OUT> extends DirectedOutput<OUT> {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public CopyingDirectedOutput(
 			List<OutputSelector<OUT>> outputSelectors,
-			List<? extends Tuple2<? extends Output<StreamRecord<OUT>>, StreamEdge>> outputs) {
-		super(outputSelectors, outputs);
+			List<? extends Tuple2<? extends Output<StreamRecord<OUT>>, StreamEdge>> outputs,
+			Counter numRecordsOutForTask) {
+		super(outputSelectors, outputs, numRecordsOutForTask);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutputsCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutputsCollector.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.collector.selector;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Map;
+
+/**
+ * The selected outputs collector will send records to the default output,
+ * and output matching outputNames.
+ *
+ * @param <T> The type of the elements that can be emitted.
+ */
+public class DirectedOutputsCollector<T> implements SelectedOutputsCollector<T> {
+
+	private final Output<StreamRecord<T>>[] selectAllOutputs;
+	private final Map<String, Output<StreamRecord<T>>[]> outputMap;
+
+	public DirectedOutputsCollector(
+			Output<StreamRecord<T>>[] selectAllOutputs,
+			Map<String, Output<StreamRecord<T>>[]> outputMap) {
+		this.selectAllOutputs = selectAllOutputs;
+		this.outputMap = outputMap;
+	}
+
+	@Override
+	public boolean collect(Iterable<String> outputNames, StreamRecord<T> record) {
+		boolean emitted = false;
+
+		if (selectAllOutputs.length > 0) {
+			collect(selectAllOutputs, record);
+			emitted = true;
+		}
+
+		for (String outputName : outputNames) {
+			Output<StreamRecord<T>>[] outputList = outputMap.get(outputName);
+			if (outputList != null && outputList.length > 0) {
+				collect(outputList, record);
+				emitted = true;
+			}
+		}
+		return emitted;
+	}
+
+	protected void collect(Output<StreamRecord<T>>[] outputs, StreamRecord<T> record) {
+		for (Output<StreamRecord<T>> output : outputs) {
+			output.collect(record);
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/SelectedOutputsCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/SelectedOutputsCollector.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.collector.selector;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * Used to define an interface for {@link SelectedOutputsCollector}, which is
+ * provided to {@link OutputSelector}.
+ *
+ * @param <T> The type of the elements that can be emitted.
+ */
+public interface SelectedOutputsCollector<T> {
+	boolean collect(Iterable<String> outputNames, StreamRecord<T> record);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -156,12 +156,13 @@ public abstract class AbstractStreamOperator<OUT>
 		this.config = config;
 		try {
 			OperatorMetricGroup operatorMetricGroup = environment.getMetricGroup().getOrAddOperator(config.getOperatorID(), config.getOperatorName());
-			this.output = new CountingOutput<>(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+			if (output instanceof CountingOutput) {
+				this.output = output;
+			} else {
+				this.output = new CountingOutput<>(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+			}
 			if (config.isChainStart()) {
 				operatorMetricGroup.getIOMetricGroup().reuseInputMetricsForTask();
-			}
-			if (config.isChainEnd()) {
-				operatorMetricGroup.getIOMetricGroup().reuseOutputMetricsForTask();
 			}
 			this.metrics = operatorMetricGroup;
 		} catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -106,12 +106,13 @@ public abstract class AbstractStreamOperatorV2<OUT> implements StreamOperator<OU
 		OperatorMetricGroup operatorMetricGroup;
 		try {
 			operatorMetricGroup = environment.getMetricGroup().getOrAddOperator(config.getOperatorID(), config.getOperatorName());
-			countingOutput = new CountingOutput(parameters.getOutput(), operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+			if (parameters.getOutput() instanceof CountingOutput) {
+				countingOutput = (CountingOutput<OUT>) parameters.getOutput();
+			} else {
+				countingOutput = new CountingOutput<>(parameters.getOutput(), operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+			}
 			if (config.isChainStart()) {
 				operatorMetricGroup.getIOMetricGroup().reuseInputMetricsForTask();
-			}
-			if (config.isChainEnd()) {
-				operatorMetricGroup.getIOMetricGroup().reuseOutputMetricsForTask();
 			}
 		} catch (Exception e) {
 			LOG.warn("An error occurred while instantiating task metrics.", e);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -89,7 +90,7 @@ public class OperatorChainTest {
 			// initial output goes to nowhere
 			@SuppressWarnings({"unchecked", "rawtypes"})
 			WatermarkGaugeExposingOutput<StreamRecord<T>> lastWriter = new BroadcastingOutputCollector<>(
-					new Output[0], statusProvider);
+					new Output[0], statusProvider, new SimpleCounter());
 
 			// build the reverse operators array
 			for (int i = 0; i < operators.length; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
@@ -31,13 +34,17 @@ import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+import org.apache.flink.util.OutputTag;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -53,6 +60,9 @@ public class StreamConfigChainer<OWNER> {
 
 	private StreamConfig tailConfig;
 	private int chainIndex = MAIN_NODE_ID;
+
+	private final List<List<StreamEdge>> outEdgesInOrder = new LinkedList<>();
+	private boolean setTailNonChainedOutputs = true;
 
 	StreamConfigChainer(OperatorID headOperatorID, StreamConfig headConfig, OWNER owner) {
 		this.owner = checkNotNull(owner);
@@ -70,6 +80,7 @@ public class StreamConfigChainer<OWNER> {
 		headConfig.setBufferTimeout(bufferTimeout);
 	}
 
+	@Deprecated
 	public <T> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperator<T, T> operator,
@@ -78,12 +89,14 @@ public class StreamConfigChainer<OWNER> {
 		return chain(operatorID, operator, typeSerializer, typeSerializer, createKeyedStateBackend);
 	}
 
+	@Deprecated
 	public <T> StreamConfigChainer<OWNER> chain(
 			OneInputStreamOperator<T, T> operator,
 			TypeSerializer<T> typeSerializer) {
 		return chain(new OperatorID(), operator, typeSerializer);
 	}
 
+	@Deprecated
 	public <T> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperator<T, T> operator,
@@ -91,12 +104,14 @@ public class StreamConfigChainer<OWNER> {
 		return chain(operatorID, operator, typeSerializer, typeSerializer, false);
 	}
 
+	@Deprecated
 	public <T> StreamConfigChainer<OWNER> chain(
 			OneInputStreamOperatorFactory<T, T> operatorFactory,
 			TypeSerializer<T> typeSerializer) {
 		return chain(new OperatorID(), operatorFactory, typeSerializer);
 	}
 
+	@Deprecated
 	public <T> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperatorFactory<T, T> operatorFactory,
@@ -104,6 +119,7 @@ public class StreamConfigChainer<OWNER> {
 		return chain(operatorID, operatorFactory, typeSerializer, typeSerializer, false);
 	}
 
+	@Deprecated
 	private <IN, OUT> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperator<IN, OUT> operator,
@@ -118,6 +134,7 @@ public class StreamConfigChainer<OWNER> {
 			createKeyedStateBackend);
 	}
 
+	@Deprecated
 	public <IN, OUT> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			StreamOperatorFactory<OUT> operatorFactory,
@@ -152,25 +169,39 @@ public class StreamConfigChainer<OWNER> {
 		return this;
 	}
 
+	public <T> StreamConfigEdgeChainer<OWNER, T, T> chain(
+			TypeSerializer<T> typeSerializer) {
+		return chain(typeSerializer, typeSerializer);
+	}
+
+	public <IN, OUT> StreamConfigEdgeChainer<OWNER, IN, OUT> chain(
+			TypeSerializer<IN> inputSerializer,
+			TypeSerializer<OUT> outputSerializer) {
+		return new StreamConfigEdgeChainer<>(this, inputSerializer, outputSerializer);
+	}
+
 	public OWNER finish() {
-		checkState(chainIndex > 0, "Use finishForSingletonOperatorChain");
-		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
-		outEdgesInOrder.add(
-			new StreamEdge(
+		if (setTailNonChainedOutputs) {
+			List<StreamEdge> nonChainedOutputs = Collections.singletonList(new StreamEdge(
 				new StreamNode(chainIndex, null, null, (StreamOperator<?>) null, null, null, null),
 				new StreamNode(chainIndex , null, null, (StreamOperator<?>) null, null, null, null),
 				0,
 				Collections.<String>emptyList(),
 				new BroadcastPartitioner<Object>(),
 				null));
+			outEdgesInOrder.add(nonChainedOutputs);
+			tailConfig.setNumberOfOutputs(1);
+			tailConfig.setNonChainedOutputs(nonChainedOutputs);
+		}
+
+		Collections.reverse(outEdgesInOrder);
+		List<StreamEdge> allOutEdgesInOrder = outEdgesInOrder.stream()
+			.flatMap(List::stream)
+			.collect(Collectors.toList());
 
 		tailConfig.setChainEnd();
-		tailConfig.setOutputSelectors(Collections.emptyList());
-		tailConfig.setNumberOfOutputs(1);
-		tailConfig.setOutEdgesInOrder(outEdgesInOrder);
-		tailConfig.setNonChainedOutputs(outEdgesInOrder);
 		headConfig.setTransitiveChainedTaskConfigs(chainedConfigs);
-		headConfig.setOutEdgesInOrder(outEdgesInOrder);
+		headConfig.setOutEdgesInOrder(allOutEdgesInOrder);
 
 		return owner;
 	}
@@ -218,5 +249,129 @@ public class StreamConfigChainer<OWNER> {
 		headConfig.setTypeSerializerOut(outputSerializer);
 
 		return owner;
+	}
+
+	/**
+	 * Helper class to build operator node.
+	 */
+	public static class StreamConfigEdgeChainer<OWNER, IN, OUT> {
+		private final OutputTag<Void> placeHolderTag;
+		private StreamConfigChainer<OWNER> parent;
+		private OperatorID operatorID;
+
+		private final TypeSerializer<IN> inputSerializer;
+		private final TypeSerializer<OUT> outputSerializer;
+
+		private StreamOperatorFactory<OUT> operatorFactory;
+		private List<OutputSelector<?>> outputSelectors = new ArrayList<>();
+
+		private Map<OutputTag<?>, Tuple2<Integer, List<String>>> nonChainedOutPuts;
+		private boolean createKeyedStateBackend;
+
+		private int nonChainIndex = -1;
+
+		private StreamConfigEdgeChainer(
+				StreamConfigChainer<OWNER> parent,
+				TypeSerializer<IN> inputSerializer,
+				TypeSerializer<OUT> outputSerializer) {
+			this.parent = parent;
+			this.parent.setTailNonChainedOutputs = true;
+
+			this.inputSerializer = inputSerializer;
+			this.outputSerializer = outputSerializer;
+			this.placeHolderTag = new OutputTag<>("FLINK_PLACEHOLDER", BasicTypeInfo.VOID_TYPE_INFO);
+			this.nonChainedOutPuts = new HashMap<>(4);
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> setOperatorID(OperatorID operatorID) {
+			this.operatorID = operatorID;
+			return this;
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> setOperatorFactory(StreamOperatorFactory operatorFactory) {
+			this.operatorFactory = operatorFactory;
+			return this;
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> setOutputSelectors(List<OutputSelector<?>> outputSelectors) {
+			this.outputSelectors = outputSelectors;
+			return this;
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> addNonChainedOutputsCount(int nonChainedOutputsCount) {
+			return addNonChainedOutputsCount(nonChainedOutputsCount, Collections.emptyList());
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> addNonChainedOutputsCount(int nonChainedOutputsCount, List<String> selectedNames) {
+			return addNonChainedOutputsCount(placeHolderTag, nonChainedOutputsCount, selectedNames);
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> addNonChainedOutputsCount(OutputTag<?> outputTag, int nonChainedOutputsCount) {
+			return addNonChainedOutputsCount(outputTag, nonChainedOutputsCount, Collections.emptyList());
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> addNonChainedOutputsCount(OutputTag<?> outputTag, int nonChainedOutputsCount, List<String> selectedNames) {
+			checkArgument(nonChainedOutputsCount >= 0 && outputTag != null);
+			this.nonChainedOutPuts.put(outputTag, Tuple2.of(nonChainedOutputsCount, selectedNames));
+			return this;
+		}
+
+		public StreamConfigEdgeChainer<OWNER, IN, OUT> setCreateKeyedStateBackend(boolean createKeyedStateBackend) {
+			this.createKeyedStateBackend = createKeyedStateBackend;
+			return this;
+		}
+
+		public StreamConfigChainer<OWNER> build() {
+			parent.chainIndex++;
+
+			parent.tailConfig.setChainedOutputs(Collections.singletonList(
+				new StreamEdge(
+					new StreamNode(parent.tailConfig.getChainIndex(), null, null, (StreamOperator<?>) null, null, null, null),
+					new StreamNode(parent.chainIndex, null, null, (StreamOperator<?>) null, null, null, null),
+					0,
+					Collections.<String>emptyList(),
+					null,
+					null)));
+			parent.tailConfig = new StreamConfig(new Configuration());
+			parent.tailConfig.setStreamOperatorFactory(checkNotNull(operatorFactory));
+			parent.tailConfig.setOperatorID(operatorID == null ? new OperatorID() : operatorID);
+			parent.tailConfig.setTypeSerializersIn(checkNotNull(inputSerializer));
+			parent.tailConfig.setTypeSerializerOut(checkNotNull(outputSerializer));
+			parent.tailConfig.setOutputSelectors(outputSelectors == null ? Collections.emptyList() : outputSelectors);
+			if (createKeyedStateBackend) {
+				// used to test multiple stateful operators chained in a single task.
+				parent.tailConfig.setStateKeySerializer(inputSerializer);
+			}
+			parent.tailConfig.setChainIndex(parent.chainIndex);
+			parent.tailConfig.setBufferTimeout(parent.bufferTimeout);
+			if (!nonChainedOutPuts.isEmpty()) {
+				List<StreamEdge> nonChainedOutputs = createNonChainedOutputs(nonChainedOutPuts);
+				parent.tailConfig.setNonChainedOutputs(nonChainedOutputs);
+				parent.tailConfig.setNumberOfOutputs(nonChainedOutputs.size());
+				parent.outEdgesInOrder.add(nonChainedOutputs);
+				parent.setTailNonChainedOutputs = false;
+			}
+			parent.chainedConfigs.put(parent.chainIndex, parent.tailConfig);
+			return parent;
+		}
+
+		private List<StreamEdge> createNonChainedOutputs(Map<OutputTag<?>, Tuple2<Integer, List<String>>> nonChainedOutputsCount) {
+			List<StreamEdge> nonChainedOutputs = new ArrayList<>();
+			nonChainedOutputsCount.forEach((outputTag, value) -> {
+				for (int i = 0; i < value.f0; i++) {
+					nonChainedOutputs.add(new StreamEdge(
+						new StreamNode(parent.tailConfig.getChainIndex(), null, null, (StreamOperator<?>) null, null, null, null),
+						new StreamNode(nonChainIndex--, null, null, (StreamOperator<?>) null, null, null, null),
+						0,
+						value.f1,
+						new BroadcastPartitioner<Object>(),
+						placeHolderTag.equals(outputTag) ? null : outputTag));
+					if (!placeHolderTag.equals(outputTag)) {
+						parent.tailConfig.setTypeSerializerSideOut(outputTag, outputSerializer);
+					}
+				}
+			});
+			return nonChainedOutputs;
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -150,7 +150,10 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
 		StreamElementSerializer<OUT> outputStreamRecordSerializer = new StreamElementSerializer<>(outputSerializer);
 
 		Queue<Object> outputList = new ArrayDeque<>();
-		streamMockEnvironment.addOutput(outputList, outputStreamRecordSerializer);
+		// set up multiple outputs
+		for (int i = 0; i < streamConfig.getOutEdgesInOrder(streamMockEnvironment.getUserClassLoader()).size(); i++) {
+			streamMockEnvironment.addOutput(outputList, outputStreamRecordSerializer);
+		}
 		streamMockEnvironment.setTaskMetricGroup(taskMetricGroup);
 
 		StreamTask<OUT, ?> task = taskFactory.apply(streamMockEnvironment);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -187,7 +187,10 @@ public class StreamTaskTestHarness<OUT> {
 
 	private void initializeOutput() {
 		outputList = new LinkedBlockingQueue<>();
-		mockEnv.addOutput(outputList, outputStreamRecordSerializer);
+		// set up multiple outputs
+		for (int i = 0; i < streamConfig.getOutEdgesInOrder(mockEnv.getUserClassLoader()).size(); i++) {
+			mockEnv.addOutput(outputList, outputStreamRecordSerializer);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*If an operator has nonChainedOutputs, then its corresponding output should be counted in the task-level numRecordsOut metric.*

## Brief change log

* Include side outputs in numRecordsOut metric.*


## Verifying this change

This change modified tests and can be verified as follows:

  - *OneInputStreamTaskTest#testOperatorMetricReuse*
  - *TwoInputStreamTaskTest#testOperatorMetricReuse*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
