### PR TITLE
[FLINK-18821][network] Fix indefinite wait in PartitionRequestClientFactory.createPartitionRequestClient - 1.11

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -45,12 +45,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Ignore
 public class PartitionRequestClientFactoryTest {
 
 	private final static int SERVER_PORT = NetUtils.getAvailablePort();
 
 	@Test
+	@Ignore
 	public void testResourceReleaseAfterInterruptedConnect() throws Exception {
 
 		// Latch to synchronize on the connect call.


### PR DESCRIPTION
## What is the purpose of the change

Fix of FLINK-18821 for FLINK-1.11 release (similar to #13067 for 1.12).

Currently, an exception in `PartitionRequestClientFactory` is propagated to the client directly. 
The future in the internal `PartitionRequestClientFactory` map is not completed exceptionally.
This causes subsequent calls to wait indefinitely for the future to complete (see FLINK-18821).

This PR fixes it by completing the future exceptionally in case of error.

## Verifying this change

Added unit test: `PartitionRequestClientFactoryTest.testFailureReportedToSubsequentRequests`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
