### PR TITLE
[FLINK-18220][runtime] Extended OutOfMemoryError message.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -147,12 +147,12 @@ public final class MemorySegmentFactory {
 			// once we find a common way to handle OOM errors in netty threads.
 			// Here we enrich it to propagate better OOM message to the receiver
 			// if it happens in a netty thread.
-			Throwable enrichedOutOfMemoryError = TaskManagerExceptionUtils.tryEnrichTaskManagerError(outOfMemoryError);
+			TaskManagerExceptionUtils.tryEnrichTaskManagerError(outOfMemoryError);
 			if (ExceptionUtils.isDirectOutOfMemoryError(outOfMemoryError)) {
-				LOG.error("Cannot allocate direct memory segment", enrichedOutOfMemoryError);
+				LOG.error("Cannot allocate direct memory segment", outOfMemoryError);
 			}
 
-			ExceptionUtils.rethrow(enrichedOutOfMemoryError);
+			ExceptionUtils.rethrow(outOfMemoryError);
 			return null;
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/TaskManagerExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TaskManagerExceptionUtils.java
@@ -53,17 +53,14 @@ public class TaskManagerExceptionUtils {
 	}
 
 	/**
-	 * Tries to enrich the passed exception with additional information.
+	 * Tries to enrich the passed exception or its causes with additional information.
 	 *
-	 * <p>This method improves error message for direct and metaspace {@link OutOfMemoryError}.
-	 * It adds description of possible causes and ways of resolution.
+	 * <p>This method improves error messages for direct and metaspace {@link OutOfMemoryError}.
+	 * It adds descriptions about possible causes and ways of resolution.
 	 *
-	 * @param exception exception to enrich if not {@code null}
-	 * @return the enriched exception or the original if no additional information could be added;
-	 * {@code null} if the argument was {@code null}
+	 * @param root The Throwable of which the cause tree shall be traversed.
 	 */
-	@Nullable
-	public static Throwable tryEnrichTaskManagerError(@Nullable Throwable exception) {
-		return tryEnrichOutOfMemoryError(exception, TM_METASPACE_OOM_ERROR_MESSAGE, TM_DIRECT_OOM_ERROR_MESSAGE);
+	public static void tryEnrichTaskManagerError(@Nullable Throwable root) {
+		tryEnrichOutOfMemoryError(root, TM_METASPACE_OOM_ERROR_MESSAGE, TM_DIRECT_OOM_ERROR_MESSAGE, null);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.entrypoint.ClusterEntryPointExceptionUtils;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -338,6 +339,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 			if (throwable != null) {
 				cleanUpJobData(jobGraph.getJobID(), true);
 
+				ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(throwable);
 				final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(throwable);
 				log.error("Failed to submit job {}.", jobGraph.getJobID(), strippedThrowable);
 				throw new CompletionException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -399,8 +399,8 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
 	@Override
 	public void onFatalError(Throwable exception) {
-		Throwable enrichedException = ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(exception);
-		LOG.error("Fatal error occurred in the cluster entrypoint.", enrichedException);
+		ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(exception);
+		LOG.error("Fatal error occurred in the cluster entrypoint.", exception);
 
 		System.exit(RUNTIME_FAILURE_RETURN_CODE);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
+import org.apache.flink.runtime.entrypoint.ClusterEntryPointExceptionUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
@@ -1296,6 +1297,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				}
 				catch (Throwable t) {
 					ExceptionUtils.rethrowIfFatalError(t);
+					ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(t);
 					failGlobal(new Exception("Failed to finalize execution on master", t));
 					return;
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/InputOutputFormatVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/InputOutputFormatVertex.java
@@ -99,7 +99,6 @@ public class InputOutputFormatVertex extends JobVertex {
 					((InitializeOnMaster) outputFormat).initializeGlobal(getParallelism());
 				}
 			}
-
 		} finally {
 			// restore original classloader
 			Thread.currentThread().setContextClassLoader(original);
@@ -132,7 +131,6 @@ public class InputOutputFormatVertex extends JobVertex {
 					((FinalizeOnMaster) outputFormat).finalizeGlobal(getParallelism());
 				}
 			}
-
 		} finally {
 			// restore original classloader
 			Thread.currentThread().setContextClassLoader(original);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -68,6 +68,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.TaskManagerExceptionUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -267,13 +268,13 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 	@Override
 	public void onFatalError(Throwable exception) {
-		Throwable enrichedException = TaskManagerExceptionUtils.tryEnrichTaskManagerError(exception);
-		LOG.error("Fatal error occurred while executing the TaskManager. Shutting it down...", enrichedException);
+		TaskManagerExceptionUtils.tryEnrichTaskManagerError(exception);
+		LOG.error("Fatal error occurred while executing the TaskManager. Shutting it down...", exception);
 
 		// In case of the Metaspace OutOfMemoryError, we expect that the graceful shutdown is possible,
 		// as it does not usually require more class loading to fail again with the Metaspace OutOfMemoryError.
-		if (ExceptionUtils.isJvmFatalOrOutOfMemoryError(enrichedException) &&
-				!ExceptionUtils.isMetaspaceOutOfMemoryError(enrichedException)) {
+		if (ExceptionUtils.isJvmFatalOrOutOfMemoryError(exception) &&
+				!ExceptionUtils.isMetaspaceOutOfMemoryError(exception)) {
 			terminateJVM();
 		} else {
 			closeAsync();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -755,7 +755,7 @@ public class Task implements Runnable, TaskSlotPayload, TaskActions, PartitionPr
 			// an exception was thrown as a side effect of cancelling
 			// ----------------------------------------------------------------
 
-			t = TaskManagerExceptionUtils.tryEnrichTaskManagerError(t);
+			TaskManagerExceptionUtils.tryEnrichTaskManagerError(t);
 
 			try {
 				// check if the exception is unrecoverable

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntryPointExceptionUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntryPointExceptionUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * ClusterEntryPointExceptionUtilsTest checks whether the OOM message enrichment works as expected.
+ */
+public class ClusterEntryPointExceptionUtilsTest extends TestLogger {
+
+	@Test
+	public void testDirectMemoryOOMHandling() {
+		OutOfMemoryError error = new OutOfMemoryError("Direct buffer memory");
+		ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(error);
+
+		assertThat(error.getMessage(), is(ClusterEntryPointExceptionUtils.JM_DIRECT_OOM_ERROR_MESSAGE));
+	}
+
+	@Test
+	public void testMetaspaceOOMHandling() {
+		OutOfMemoryError error = new OutOfMemoryError("Metaspace");
+		ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(error);
+
+		assertThat(error.getMessage(), is(ClusterEntryPointExceptionUtils.JM_METASPACE_OOM_ERROR_MESSAGE));
+	}
+
+	@Test
+	public void testHeapSpaceOOMHandling() {
+		OutOfMemoryError error = new OutOfMemoryError("Java heap space");
+		ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(error);
+
+		assertThat(error.getMessage(), is(ClusterEntryPointExceptionUtils.JM_HEAP_SPACE_OOM_ERROR_MESSAGE));
+	}
+
+	@Test
+	public void testAnyOtherOOMHandling() {
+		String message = "Any other message won't be changed.";
+		OutOfMemoryError error = new OutOfMemoryError(message);
+		ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(error);
+
+		assertThat(error.getMessage(), is(message));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -52,10 +52,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -572,6 +575,86 @@ public class MiniClusterITCase extends TestLogger {
 			jobResultFuture.get().toJobExecutionResult(getClass().getClassLoader());
 
 			assertTrue(sink.finalizedOnMaster.get());
+		}
+	}
+
+	@Test
+	public void testOutOfMemoryErrorMessageEnrichmentInJobVertexFinalization() throws Exception {
+		final int parallelism = 1;
+
+		final MiniClusterConfiguration cfg = new MiniClusterConfiguration.Builder()
+				.setNumTaskManagers(1)
+				.setNumSlotsPerTaskManager(parallelism)
+				.setConfiguration(getDefaultConfiguration())
+				.build();
+
+		try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
+			miniCluster.start();
+
+			final JobVertex failingJobVertex = new JobVertex("FailingInFinalization") {
+
+				@Override
+				public void finalizeOnMaster(ClassLoader loader) {
+					throw new OutOfMemoryError("Java heap space");
+				}
+			};
+			failingJobVertex.setInvokableClass(NoOpInvokable.class);
+			failingJobVertex.setParallelism(parallelism);
+
+			final JobGraph jobGraph = new JobGraph("JobGraphWithFailingJobVertex", failingJobVertex);
+
+			final CompletableFuture<JobSubmissionResult> submissionFuture = miniCluster.submitJob(jobGraph);
+
+			final CompletableFuture<JobResult> jobResultFuture = submissionFuture.thenCompose(
+					(JobSubmissionResult ignored) -> miniCluster.requestJobResult(jobGraph.getJobID()));
+
+			try {
+				jobResultFuture.get().toJobExecutionResult(getClass().getClassLoader());
+			} catch (JobExecutionException e) {
+				assertTrue(findThrowable(e, OutOfMemoryError.class).isPresent());
+				assertThat(findThrowable(e, OutOfMemoryError.class).map(OutOfMemoryError::getMessage).get(),
+						startsWith("Java heap space. A heap space-related out-of-memory error has occurred."));
+			}
+		}
+	}
+
+	@Test
+	public void testOutOfMemoryErrorMessageEnrichmentInJobVertexInitialization() throws Exception {
+		final int parallelism = 1;
+
+		final MiniClusterConfiguration cfg = new MiniClusterConfiguration.Builder()
+				.setNumTaskManagers(1)
+				.setNumSlotsPerTaskManager(parallelism)
+				.setConfiguration(getDefaultConfiguration())
+				.build();
+
+		try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
+			miniCluster.start();
+
+			final JobVertex failingJobVertex = new JobVertex("FailingInFinalization") {
+
+				@Override
+				public void initializeOnMaster(ClassLoader loader) {
+					throw new OutOfMemoryError("Java heap space");
+				}
+			};
+			failingJobVertex.setInvokableClass(NoOpInvokable.class);
+			failingJobVertex.setParallelism(parallelism);
+
+			final JobGraph jobGraph = new JobGraph("JobGraphWithFailingJobVertex", failingJobVertex);
+
+			final CompletableFuture<JobSubmissionResult> submissionFuture = miniCluster.submitJob(jobGraph);
+
+			final CompletableFuture<JobResult> jobResultFuture = submissionFuture.thenCompose(
+					(JobSubmissionResult ignored) -> miniCluster.requestJobResult(jobGraph.getJobID()));
+
+			try {
+				jobResultFuture.get();
+			} catch (ExecutionException e) {
+				assertTrue(findThrowable(e, OutOfMemoryError.class).isPresent());
+				assertThat(findThrowable(e, OutOfMemoryError.class).map(OutOfMemoryError::getMessage).get(),
+						startsWith("Java heap space. A heap space-related out-of-memory error has occurred."));
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

* Adding meaningful information to the error message of an OutOfMemoryError that happens while initializing or finalizing the an OutputFormat on the master.

## Brief change log

* Added OOM-enrichment to InputOutputFormatVertex.initializeOnMaster and InputOutputFormatVertex.finalizeOnMaster
* Adapted signature of JobVertex.finalizeOnMaster and JobVertex.initializeOnMaster to indicate that not only Exceptions might occur.
* ClusterEntrypointExceptionUtils and its method was made public
* JavaDoc was fixed.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
