### PR TITLE
[BP-1.11][FLINK-18862][table-planner-blink] Fix LISTAGG throws BinaryRawValueData cannot be cast to StringData exception during runtime

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWithRetractAggFunction.java
@@ -19,13 +19,18 @@
 package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.PojoField;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.table.api.dataview.ListView;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.dataview.ListViewTypeInfo;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.WrappingRuntimeException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +64,28 @@ public final class ListAggWithRetractAggFunction
 			ListAggWithRetractAccumulator that = (ListAggWithRetractAccumulator) o;
 			return Objects.equals(list, that.list) &&
 				Objects.equals(retractList, that.retractList);
+		}
+	}
+
+	@Override
+	public TypeInformation<StringData> getResultType() {
+		return StringDataTypeInfo.INSTANCE;
+	}
+
+	@Override
+	public TypeInformation<ListAggWithRetractAccumulator> getAccumulatorType() {
+		try {
+			Class<ListAggWithRetractAccumulator> clazz = ListAggWithRetractAccumulator.class;
+			List<PojoField> pojoFields = new ArrayList<>();
+			pojoFields.add(new PojoField(
+				clazz.getDeclaredField("list"),
+				new ListViewTypeInfo<>(StringDataTypeInfo.INSTANCE)));
+			pojoFields.add(new PojoField(
+				clazz.getDeclaredField("retractList"),
+				new ListViewTypeInfo<>(StringDataTypeInfo.INSTANCE)));
+			return new PojoTypeInfo<>(clazz, pojoFields);
+		} catch (NoSuchFieldException e) {
+			throw new WrappingRuntimeException(e);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
@@ -41,7 +41,6 @@ import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataTy
 import org.apache.flink.table.typeutils.FieldInfoUtils
 import org.apache.flink.types.Row
 import org.apache.flink.util.InstantiationUtil
-
 import com.google.common.primitives.Primitives
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.calcite.rex.{RexLiteral, RexNode}


### PR DESCRIPTION
This is a backport to release-1.11 branch. 