### PR TITLE
[FLINK-18863][python] Support read_text_file() and print() interface …

### DIFF
--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -465,6 +465,21 @@ class StreamExecutionEnvironment(object):
                                                                        j_type_info)
         return DataStream(j_data_stream=j_data_stream)
 
+    def read_text_file(self, file_path: str, charset_name: str = "UTF-8") -> DataStream:
+        """
+        Reads the given file line-by-line and creates a DataStream that contains a string with the
+        contents of each such line. The charset with the given name will be used to read the files.
+
+        Note that this interface is not fault tolerant that is supposed to be used for test purpose.
+
+        :param file_path: The path of the file, as a URI (e.g., "file:///some/local/file" or
+                          "hdfs://host:port/file/path")
+        :param charset_name: The name of the character set used to read the file.
+        :return: The DataStream that represents the data read from the given file as text lines.
+        """
+        return DataStream(self._j_stream_execution_environment
+                          .readTextFile(file_path, charset_name))
+
     def from_collection(self, collection: List[Any],
                         type_info: TypeInformation = None) -> DataStream:
         """

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -225,6 +225,23 @@ class DataStreamTests(PyFlinkTestCase):
         expected.sort()
         self.assertEqual(expected, results)
 
+    def test_print_without_align_output(self):
+        # No need to align output typeinfo since we have specified the type info of the DataStream.
+        self.env.set_parallelism(1)
+        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        ds.print()
+        plan = eval(str(self.env.get_execution_plan()))
+        self.assertEqual("Sink: Print to Std. Out", plan['nodes'][1]['type'])
+
+    def test_print_with_align_output(self):
+        # need to align output type before print, therefore the plan will contain three nodes
+        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)])
+        ds.print()
+        plan = eval(str(self.env.get_execution_plan()))
+        self.assertEqual(3, len(plan['nodes']))
+        self.assertEqual("Sink: Print to Std. Out", plan['nodes'][2]['type'])
+
     def tearDown(self) -> None:
         self.test_sink.get_results()
 

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -254,3 +254,20 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         results.sort()
         expected.sort()
         self.assertEqual(expected, results)
+
+    def test_read_text_file(self):
+        texts = ["Mike", "Marry", "Ted", "Jack", "Bob", "Henry"]
+        text_file_path = self.tempdir + '/text_file'
+        with open(text_file_path, 'a') as f:
+            for text in texts:
+                f.write(text)
+                f.write('\n')
+
+        ds = self.env.read_text_file(text_file_path)
+        test_sink = DataStreamTestSinkFunction()
+        ds.add_sink(test_sink)
+        self.env.execute("test read text file")
+        results = test_sink.get_results()
+        results.sort()
+        texts.sort()
+        self.assertEqual(texts, results)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add read_text_file() and print() interface for Python DataStream API. It would be of benefit for ease of use and debug purpose. Further more, Users can play with Flink out of box through these simple source/sink API.

## Brief change log

- Add print() for Python DataStream API.
- Add read_text_file for StreamExecutionEnvironment to get a DataStream.


## Verifying this change

This change has test cases covered by test_print() in test_data_stream.py and test_read_text_file() in test_stream_execution_environment.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
