### PR TITLE
[FLINK-18815][test-stability] Close safety net guarded closeable iff it is still registered

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetCloseableRegistry.java
@@ -175,8 +175,13 @@ public class SafetyNetCloseableRegistry extends
 
 		@Override
 		public void close() throws IOException {
-			closeableRegistry.removeCloseableInternal(innerCloseable);
-			innerCloseable.close();
+			// Mark sure the inner closeable is still registered and thus unclosed to
+			// prevent duplicated and concurrent closing from registry closing. This could
+			// happen if registry is closing after this phantom reference was enqueued.
+			if (closeableRegistry.removeCloseableInternal(innerCloseable, this)) {
+				LOG.warn("Closing unclosed resource via safety-net: {}", getDebugString());
+				innerCloseable.close();
+			}
 		}
 	}
 
@@ -205,7 +210,6 @@ public class SafetyNetCloseableRegistry extends
 
 					if (toClose != null) {
 						try {
-							LOG.warn("Closing unclosed resource via safety-net: {}", toClose.getDebugString());
 							toClose.close();
 						}
 						catch (Throwable t) {

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetCloseableRegistry.java
@@ -178,7 +178,7 @@ public class SafetyNetCloseableRegistry extends
 			// Mark sure the inner closeable is still registered and thus unclosed to
 			// prevent duplicated and concurrent closing from registry closing. This could
 			// happen if registry is closing after this phantom reference was enqueued.
-			if (closeableRegistry.removeCloseableInternal(innerCloseable, this)) {
+			if (closeableRegistry.removeCloseableInternal(innerCloseable)) {
 				LOG.warn("Closing unclosed resource via safety-net: {}", getDebugString());
 				innerCloseable.close();
 			}

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
@@ -163,9 +163,9 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 	/**
 	 * Removes a mapping from the registry map, respecting locking.
 	 */
-	protected final boolean removeCloseableInternal(Closeable closeable, T object) {
+	protected final boolean removeCloseableInternal(Closeable closeable) {
 		synchronized (getSynchronizationLock()) {
-			return closeableToRef.remove(closeable, object);
+			return closeableToRef.remove(closeable) != null;
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
@@ -163,9 +163,9 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 	/**
 	 * Removes a mapping from the registry map, respecting locking.
 	 */
-	protected final void removeCloseableInternal(Closeable closeable) {
+	protected final boolean removeCloseableInternal(Closeable closeable, T object) {
 		synchronized (getSynchronizationLock()) {
-			closeableToRef.remove(closeable);
+			return closeableToRef.remove(closeable, object);
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
@@ -164,7 +164,7 @@ public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 					createAndRegisterStream();
 
 					try {
-						Thread.sleep(2);
+						Thread.sleep(0);
 					} catch (InterruptedException ignored) {}
 
 					if (maxStreams != Integer.MAX_VALUE) {


### PR DESCRIPTION
## What is the purpose of the change

Guard safety net closeable concurrenting closing between `SafetyNetCloseableRegistry#close` and `SafetyNetCloseableRegistry.PhantomDelegatingCloseableRef#close`.

## Brief change log

- Change test code to fail `SafetyNetCloseableRegistryTest#testClose` more often
- Close safety net guarded closeable iff it is still registered


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
* `SafetyNetCloseableRegistryTest#testClose`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
