### PR TITLE
[FLINK-18902][rest] Allow request serving while the REST handlers are shutting down

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -117,13 +117,10 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 
 		FileUploads uploadedFiles = null;
 		try {
-			synchronized (this) {
-				if (terminationFuture != null) {
-					log.debug("The handler instance for {} had already been closed.", untypedResponseMessageHeaders.getTargetRestEndpointURL());
-					ctx.channel().close();
-					return;
-				}
-				inFlightRequestTracker.registerRequest();
+			if (!inFlightRequestTracker.registerRequest()) {
+				log.debug("The handler instance for {} had already been closed.", untypedResponseMessageHeaders.getTargetRestEndpointURL());
+				ctx.channel().close();
+				return;
 			}
 
 			if (!(httpRequest instanceof FullHttpRequest)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
@@ -43,9 +43,12 @@ class InFlightRequestTracker {
 
 	/**
 	 * Registers an in-flight request.
+	 *
+	 * @return {@code true} if the request could be registered; {@code false} if the tracker has already
+	 * been terminated.
 	 */
-	public void registerRequest() {
-		phaser.register();
+	public boolean registerRequest() {
+		return phaser.register() >= 0;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -114,7 +115,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 /**
  * IT cases for {@link RestClient} and {@link RestServerEndpoint}.
@@ -200,7 +200,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
 		RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
 
-		RestfulGateway mockRestfulGateway = mock(RestfulGateway.class);
+		RestfulGateway mockRestfulGateway = new TestingRestfulGateway.Builder().build();
 
 		final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
 			CompletableFuture.completedFuture(mockRestfulGateway);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
@@ -78,4 +78,12 @@ public class InFlightRequestTrackerTest {
 			awaitFuture,
 			inFlightRequestTracker.awaitAsync());
 	}
+
+	@Test
+	public void testShouldNotRegisterNewRequestsAfterTermination() {
+		final CompletableFuture<Void> terminationFuture = inFlightRequestTracker.awaitAsync();
+
+		assertTrue(terminationFuture.isDone());
+		assertFalse(inFlightRequestTracker.registerRequest());
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

In order to serve the job execution result when using the per job mode, the REST
handlers must be able to serve requests while the RestServerEndpoint is being shut
down. Otherwise, it is not possible to serve the asynchronous operation results
such as the job execution result.

This commit solves this problem by checking whether the InFlightRequestTracker
allows to enqueue a new request or not in the AbstractHandler. If it rejects a new
request, this means that the handler has been shut completely shut down and that we
should close the connection to the client. If the InFlightRequestTracker still accepts
requests, then this means that the RestHandler might still want to serve an asynchronous
result.

cc @zentol 

## Verifying this change

- Updated `RestServerEndpointITCase.testShouldWaitForHandlersWhenClosing` and `RestServerEndpointITCase.testRequestsRejectedAfterShutdownOfHandlerIsCompleted`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
