### PR TITLE
[FLINK-18797][docs][examples] Update deprecated forms of keyBy in docs and examples

### DIFF
--- a/docs/dev/connectors/cassandra.md
+++ b/docs/dev/connectors/cassandra.md
@@ -160,7 +160,7 @@ DataStream<Tuple2<String, Long>> result = text
                 }
             }
         })
-        .keyBy(0)
+        .keyBy(value -> value.f0)
         .timeWindow(Time.seconds(5))
         .sum(1);
 
@@ -185,7 +185,7 @@ val result: DataStream[(String, Long)] = text
   .filter(_.nonEmpty)
   .map((_, 1L))
   // group by the tuple field "0" and sum up tuple field "1"
-  .keyBy(0)
+  .keyBy(_._1)
   .timeWindow(Time.seconds(5))
   .sum(1)
 
@@ -231,7 +231,7 @@ DataStream<WordCount> result = text
                 }
             }
         })
-        .keyBy("word")
+        .keyBy(WordCount :: getWord)
         .timeWindow(Time.seconds(5))
 
         .reduce(new ReduceFunction<WordCount>() {

--- a/docs/dev/connectors/cassandra.zh.md
+++ b/docs/dev/connectors/cassandra.zh.md
@@ -160,7 +160,7 @@ DataStream<Tuple2<String, Long>> result = text
                 }
             }
         })
-        .keyBy(0)
+        .keyBy(value -> value.f0)
         .timeWindow(Time.seconds(5))
         .sum(1);
 
@@ -185,7 +185,7 @@ val result: DataStream[(String, Long)] = text
   .filter(_.nonEmpty)
   .map((_, 1L))
   // group by the tuple field "0" and sum up tuple field "1"
-  .keyBy(0)
+  .keyBy(_._1)
   .timeWindow(Time.seconds(5))
   .sum(1)
 
@@ -231,7 +231,7 @@ DataStream<WordCount> result = text
                 }
             }
         })
-        .keyBy("word")
+        .keyBy(WordCount :: getWord)
         .timeWindow(Time.seconds(5))
 
         .reduce(new ReduceFunction<WordCount>() {

--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -274,7 +274,7 @@ public class WindowWordCount {
         DataStream<Tuple2<String, Integer>> dataStream = env
                 .socketTextStream("localhost", 9999)
                 .flatMap(new Splitter())
-                .keyBy(0)
+                .keyBy(value -> value.f0)
                 .timeWindow(Time.seconds(5))
                 .sum(1);
 
@@ -311,7 +311,7 @@ object WindowWordCount {
 
     val counts = text.flatMap { _.toLowerCase.split("\\W+") filter { _.nonEmpty } }
       .map { (_, 1) }
-      .keyBy(0)
+      .keyBy(_._1)
       .timeWindow(Time.seconds(5))
       .sum(1)
 

--- a/docs/dev/datastream_api.zh.md
+++ b/docs/dev/datastream_api.zh.md
@@ -274,7 +274,7 @@ public class WindowWordCount {
         DataStream<Tuple2<String, Integer>> dataStream = env
                 .socketTextStream("localhost", 9999)
                 .flatMap(new Splitter())
-                .keyBy(0)
+                .keyBy(value -> value.f0)
                 .timeWindow(Time.seconds(5))
                 .sum(1);
 
@@ -311,7 +311,7 @@ object WindowWordCount {
 
     val counts = text.flatMap { _.toLowerCase.split("\\W+") filter { _.nonEmpty } }
       .map { (_, 1) }
-      .keyBy(0)
+      .keyBy(_._1)
       .timeWindow(Time.seconds(5))
       .sum(1)
 

--- a/docs/dev/parallel.md
+++ b/docs/dev/parallel.md
@@ -54,7 +54,7 @@ final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEn
 DataStream<String> text = [...]
 DataStream<Tuple2<String, Integer>> wordCounts = text
     .flatMap(new LineSplitter())
-    .keyBy(0)
+    .keyBy(value -> value.f0)
     .timeWindow(Time.seconds(5))
     .sum(1).setParallelism(5);
 
@@ -70,7 +70,7 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment
 val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
-    .keyBy(0)
+    .keyBy(_._1)
     .timeWindow(Time.seconds(5))
     .sum(1).setParallelism(5)
 wordCounts.print()
@@ -113,7 +113,7 @@ env.setParallelism(3)
 val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
-    .keyBy(0)
+    .keyBy(_._1)
     .timeWindow(Time.seconds(5))
     .sum(1)
 wordCounts.print()

--- a/docs/dev/parallel.zh.md
+++ b/docs/dev/parallel.zh.md
@@ -45,7 +45,7 @@ final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEn
 DataStream<String> text = [...]
 DataStream<Tuple2<String, Integer>> wordCounts = text
     .flatMap(new LineSplitter())
-    .keyBy(0)
+    .keyBy(value -> value.f0)
     .timeWindow(Time.seconds(5))
     .sum(1).setParallelism(5);
 
@@ -61,7 +61,7 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment
 val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
-    .keyBy(0)
+    .keyBy(_._1)
     .timeWindow(Time.seconds(5))
     .sum(1).setParallelism(5)
 wordCounts.print()
@@ -98,7 +98,7 @@ env.setParallelism(3)
 val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
-    .keyBy(0)
+    .keyBy(_._1)
     .timeWindow(Time.seconds(5))
     .sum(1)
 wordCounts.print()

--- a/docs/dev/stream/operators/index.md
+++ b/docs/dev/stream/operators/index.md
@@ -104,8 +104,8 @@ dataStream.filter(new FilterFunction<Integer>() {
             <p>
             This transformation returns a <em>KeyedStream</em>, which is, among other things, required to use <a href="{{ site.baseurl }}/dev/stream/state/state.html#keyed-state">keyed state</a>. </p>
 {% highlight java %}
-dataStream.keyBy("someKey") // Key by field "someKey"
-dataStream.keyBy(0) // Key by the first element of a Tuple
+dataStream.keyBy(value -> value.getSomeKey()) // Key by field "someKey"
+dataStream.keyBy(value -> value.f0) // Key by the first element of a Tuple
 {% endhighlight %}
             <p>
             <span class="label label-danger">Attention</span>
@@ -187,7 +187,7 @@ keyedStream.maxBy("key");
             key according to some characteristic (e.g., the data that arrived within the last 5 seconds).
             See <a href="windows.html">windows</a> for a complete description of windows.
 {% highlight java %}
-dataStream.keyBy(0).window(TumblingEventTimeWindows.of(Time.seconds(5))); // Last 5 seconds of data
+dataStream.keyBy(value -> value.f0).window(TumblingEventTimeWindows.of(Time.seconds(5))); // Last 5 seconds of data
 {% endhighlight %}
         </p>
           </td>
@@ -503,8 +503,8 @@ dataStream.filter { _ != 0 }
             Internally, this is implemented with hash partitioning. See <a href="{{ site.baseurl }}/dev/stream/state/state.html#keyed-state">keys</a> on how to specify keys.
             This transformation returns a KeyedStream.</p>
 {% highlight scala %}
-dataStream.keyBy("someKey") // Key by field "someKey"
-dataStream.keyBy(0) // Key by the first element of a Tuple
+dataStream.keyBy(_.someKey) // Key by field "someKey"
+dataStream.keyBy(_._1) // Key by the first element of a Tuple
 {% endhighlight %}
           </td>
         </tr>
@@ -566,7 +566,7 @@ keyedStream.maxBy("key")
             key according to some characteristic (e.g., the data that arrived within the last 5 seconds).
             See <a href="windows.html">windows</a> for a description of windows.
 {% highlight scala %}
-dataStream.keyBy(0).window(TumblingEventTimeWindows.of(Time.seconds(5))) // Last 5 seconds of data
+dataStream.keyBy(_._1).window(TumblingEventTimeWindows.of(Time.seconds(5))) // Last 5 seconds of data
 {% endhighlight %}
         </p>
           </td>

--- a/docs/dev/stream/operators/index.zh.md
+++ b/docs/dev/stream/operators/index.zh.md
@@ -104,8 +104,8 @@ dataStream.filter(new FilterFunction<Integer>() {
             <p>
             This transformation returns a <em>KeyedStream</em>, which is, among other things, required to use <a href="{{ site.baseurl }}/dev/stream/state/state.html#keyed-state">keyed state</a>. </p>
 {% highlight java %}
-dataStream.keyBy("someKey") // Key by field "someKey"
-dataStream.keyBy(0) // Key by the first element of a Tuple
+dataStream.keyBy(value -> value.getSomeKey()) // Key by field "someKey"
+dataStream.keyBy(value -> value.f0) // Key by the first element of a Tuple
 {% endhighlight %}
             <p>
             <span class="label label-danger">Attention</span>
@@ -187,7 +187,7 @@ keyedStream.maxBy("key");
             key according to some characteristic (e.g., the data that arrived within the last 5 seconds).
             See <a href="windows.html">windows</a> for a complete description of windows.
 {% highlight java %}
-dataStream.keyBy(0).window(TumblingEventTimeWindows.of(Time.seconds(5))); // Last 5 seconds of data
+dataStream.keyBy(value -> value.f0).window(TumblingEventTimeWindows.of(Time.seconds(5))); // Last 5 seconds of data
 {% endhighlight %}
         </p>
           </td>
@@ -503,8 +503,8 @@ dataStream.filter { _ != 0 }
             Internally, this is implemented with hash partitioning. See <a href="{{ site.baseurl }}/dev/stream/state/state.html#keyed-state">keys</a> on how to specify keys.
             This transformation returns a KeyedStream.</p>
 {% highlight scala %}
-dataStream.keyBy("someKey") // Key by field "someKey"
-dataStream.keyBy(0) // Key by the first element of a Tuple
+dataStream.keyBy(_.someKey) // Key by field "someKey"
+dataStream.keyBy(_._1) // Key by the first element of a Tuple
 {% endhighlight %}
           </td>
         </tr>
@@ -566,7 +566,7 @@ keyedStream.maxBy("key")
             key according to some characteristic (e.g., the data that arrived within the last 5 seconds).
             See <a href="windows.html">windows</a> for a description of windows.
 {% highlight scala %}
-dataStream.keyBy(0).window(TumblingEventTimeWindows.of(Time.seconds(5))) // Last 5 seconds of data
+dataStream.keyBy(_._1).window(TumblingEventTimeWindows.of(Time.seconds(5))) // Last 5 seconds of data
 {% endhighlight %}
         </p>
           </td>

--- a/docs/dev/stream/operators/process_function.md
+++ b/docs/dev/stream/operators/process_function.md
@@ -107,7 +107,7 @@ DataStream<Tuple2<String, String>> stream = ...;
 
 // apply the process function onto a keyed stream
 DataStream<Tuple2<String, Long>> result = stream
-    .keyBy(0)
+    .keyBy(value -> value.f0)
     .process(new CountWithTimeoutFunction());
 
 /**
@@ -192,7 +192,7 @@ val stream: DataStream[Tuple2[String, String]] = ...
 
 // apply the process function onto a keyed stream
 val result: DataStream[Tuple2[String, Long]] = stream
-  .keyBy(0)
+  .keyBy(_._1)
   .process(new CountWithTimeoutFunction())
 
 /**

--- a/docs/dev/stream/operators/process_function.zh.md
+++ b/docs/dev/stream/operators/process_function.zh.md
@@ -107,7 +107,7 @@ DataStream<Tuple2<String, String>> stream = ...;
 
 // apply the process function onto a keyed stream
 DataStream<Tuple2<String, Long>> result = stream
-    .keyBy(0)
+    .keyBy(value -> value.f0)
     .process(new CountWithTimeoutFunction());
 
 /**
@@ -192,7 +192,7 @@ val stream: DataStream[Tuple2[String, String]] = ...
 
 // apply the process function onto a keyed stream
 val result: DataStream[Tuple2[String, Long]] = stream
-  .keyBy(0)
+  .keyBy(_._1)
   .process(new CountWithTimeoutFunction())
 
 /**

--- a/docs/dev/stream/state/queryable_state.md
+++ b/docs/dev/stream/state/queryable_state.md
@@ -130,7 +130,7 @@ In a program like the following, all records of the keyed stream will be used to
 `ValueState.update(value)`:
 
 {% highlight java %}
-stream.keyBy(0).asQueryableState("query-name")
+stream.keyBy(value -> value.f0).asQueryableState("query-name")
 {% endhighlight %}
 
 This acts like the Scala API's `flatMapWithState`.

--- a/docs/dev/stream/state/queryable_state.zh.md
+++ b/docs/dev/stream/state/queryable_state.zh.md
@@ -102,7 +102,7 @@ QueryableStateStream asQueryableState(
 返回的 `QueryableStateStream` 可以被视作一个sink，而且**不能再**被进一步转换。在内部实现上，一个 `QueryableStateStream` 被转换成一个 operator，使用输入的数据来更新 queryable state。state 如何更新是由 `asQueryableState` 提供的 `StateDescriptor` 来决定的。在下面的代码中, keyed stream 的所有数据将会通过 `ValueState.update(value)` 来更新状态：
 
 {% highlight java %}
-stream.keyBy(0).asQueryableState("query-name")
+stream.keyBy(value -> value.f0).asQueryableState("query-name")
 {% endhighlight %}
 
 这个行为类似于 Scala API 中的 `flatMapWithState`。

--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -195,7 +195,7 @@ public class CountWindowAverage extends RichFlatMapFunction<Tuple2<Long, Long>, 
 
 // this can be used in a streaming program like this (assuming we have a StreamExecutionEnvironment env)
 env.fromElements(Tuple2.of(1L, 3L), Tuple2.of(1L, 5L), Tuple2.of(1L, 7L), Tuple2.of(1L, 4L), Tuple2.of(1L, 2L))
-        .keyBy(0)
+        .keyBy(value -> value.f0)
         .flatMap(new CountWindowAverage())
         .print();
 

--- a/docs/dev/stream/state/state.zh.md
+++ b/docs/dev/stream/state/state.zh.md
@@ -175,7 +175,7 @@ public class CountWindowAverage extends RichFlatMapFunction<Tuple2<Long, Long>, 
 
 // this can be used in a streaming program like this (assuming we have a StreamExecutionEnvironment env)
 env.fromElements(Tuple2.of(1L, 3L), Tuple2.of(1L, 5L), Tuple2.of(1L, 7L), Tuple2.of(1L, 4L), Tuple2.of(1L, 2L))
-        .keyBy(0)
+        .keyBy(value -> value.f0)
         .flatMap(new CountWindowAverage())
         .print();
 

--- a/docs/dev/types_serialization.md
+++ b/docs/dev/types_serialization.md
@@ -70,7 +70,7 @@ wordCounts.map(new MapFunction<Tuple2<String, Integer>, Integer>() {
     }
 });
 
-wordCounts.keyBy(0); // also valid .keyBy("f0")
+wordCounts.keyBy(value -> value.f0);
 
 
 {% endhighlight %}
@@ -86,11 +86,11 @@ val input = env.fromElements(
     WordCount("hello", 1),
     WordCount("world", 2)) // Case Class Data Set
 
-input.keyBy("word")// key by field expression "word"
+input.keyBy(_.word)
 
 val input2 = env.fromElements(("hello", 1), ("world", 2)) // Tuple2 Data Set
 
-input2.keyBy(0, 1) // key by field positions 0 and 1
+input2.keyBy(value => (value._1, value._2))
 {% endhighlight %}
 
 </div>
@@ -137,7 +137,7 @@ DataStream<WordWithCount> wordCounts = env.fromElements(
     new WordWithCount("hello", 1),
     new WordWithCount("world", 2));
 
-wordCounts.keyBy("word"); // key by field expression "word"
+wordCounts.keyBy(value -> value.word);
 
 {% endhighlight %}
 </div>
@@ -153,7 +153,7 @@ val input = env.fromElements(
     new WordWithCount("hello", 1),
     new WordWithCount("world", 2)) // Case Class Data Set
 
-input.keyBy("word")// key by field expression "word"
+input.keyBy(_.word)
 
 {% endhighlight %}
 </div>
@@ -237,9 +237,6 @@ usually be inferred by the result types of the previous operations.
 Flink tries to infer a lot of information about the data types that are exchanged and stored during the distributed computation.
 Think about it like a database that infers the schema of tables. In most cases, Flink infers all necessary information seamlessly
 by itself. Having the type information allows Flink to do some cool things:
-
-* Using POJOs types and grouping / joining / aggregating them by referring to field names (like `dataSet.keyBy("username")`).
-  The type information allows Flink to check (for typos and type compatibility) early rather than failing later at runtime.
 
 * The more Flink knows about data types, the better the serialization and data layout schemes are.
   That is quite important for the memory usage paradigm in Flink (work on serialized data inside/outside the heap where ever possible

--- a/docs/dev/types_serialization.zh.md
+++ b/docs/dev/types_serialization.zh.md
@@ -70,7 +70,7 @@ wordCounts.map(new MapFunction<Tuple2<String, Integer>, Integer>() {
     }
 });
 
-wordCounts.keyBy(0); // also valid .keyBy("f0")
+wordCounts.keyBy(value -> value.f0);
 
 
 {% endhighlight %}
@@ -86,11 +86,11 @@ val input = env.fromElements(
     WordCount("hello", 1),
     WordCount("world", 2)) // Case Class Data Set
 
-input.keyBy("word")// key by field expression "word"
+input.keyBy(_.word)
 
 val input2 = env.fromElements(("hello", 1), ("world", 2)) // Tuple2 Data Set
 
-input2.keyBy(0, 1) // key by field positions 0 and 1
+input2.keyBy(value => (value._1, value._2))
 {% endhighlight %}
 
 </div>
@@ -137,7 +137,7 @@ DataStream<WordWithCount> wordCounts = env.fromElements(
     new WordWithCount("hello", 1),
     new WordWithCount("world", 2));
 
-wordCounts.keyBy("word"); // key by field expression "word"
+wordCounts.keyBy(value -> value.word);
 
 {% endhighlight %}
 </div>
@@ -153,7 +153,7 @@ val input = env.fromElements(
     new WordWithCount("hello", 1),
     new WordWithCount("world", 2)) // Case Class Data Set
 
-input.keyBy("word")// key by field expression "word"
+input.keyBy(_.word)
 
 {% endhighlight %}
 </div>
@@ -236,9 +236,6 @@ usually be inferred by the result types of the previous operations.
 Flink 会尽力推断有关数据类型的大量信息，这些数据会在分布式计算期间被网络交换或存储。
 可以把它想象成一个推断表结构的数据库。在大多数情况下，Flink 可以依赖自身透明的推断出所有需要的类型信息。
 掌握这些类型信息可以帮助 Flink 实现很多意想不到的特性：
-
-* 对于使用 POJOs 类型的数据，可以通过指定字段名（比如 `dataSet.keyBy("username")` ）进行 grouping 、joining、aggregating 操作。
-  类型信息可以帮助 Flink 在运行前做一些拼写错误以及类型兼容方面的检查，而不是等到运行时才暴露这些问题。
 
 * Flink 对数据类型了解的越多，序列化和数据布局方案就越好。
   这对 Flink 中的内存使用范式尤为重要（可以尽可能处理堆上或者堆外的序列化数据并且使序列化操作很廉价）。

--- a/docs/learn-flink/etl.md
+++ b/docs/learn-flink/etl.md
@@ -149,7 +149,7 @@ this would mean doing some sort of GROUP BY with the `startCell`, while in Flink
 {% highlight java %}
 rides
     .flatMap(new NYCEnrichment())
-    .keyBy("startCell")
+    .keyBy(value -> value.startCell)
 {% endhighlight %}
 
 Every `keyBy` causes a network shuffle that repartitions the stream. In general this is pretty
@@ -241,7 +241,7 @@ specify the key.
 
 {% highlight java %}
 minutesByStartCell
-  .keyBy(0) // startCell
+  .keyBy(value -> value.f0) // .keyBy(value -> value.startCell)
   .maxBy(1) // duration
   .print();
 {% endhighlight %}

--- a/docs/learn-flink/etl.zh.md
+++ b/docs/learn-flink/etl.zh.md
@@ -130,7 +130,7 @@ public static class NYCEnrichment implements FlatMapFunction<TaxiRide, EnrichedR
 {% highlight java %}
 rides
     .flatMap(new NYCEnrichment())
-    .keyBy("startCell")
+    .keyBy(value -> value.startCell)
 {% endhighlight %}
 
 每个 `keyBy` 会通过 shuffle 来为数据流进行重新分区。总体来说这个开销是很大的，它涉及网络通信、序列化和反序列化。
@@ -206,7 +206,7 @@ DataStream<Tuple2<Integer, Minutes>> minutesByStartCell = enrichedNYCRides
 
 {% highlight java %}
 minutesByStartCell
-  .keyBy(0) // startCell
+  .keyBy(value -> value.f0) // .keyBy(value -> value.startCell)
   .maxBy(1) // duration
   .print();
 {% endhighlight %}

--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -77,7 +77,7 @@ Scala-Flink> val textStreaming = senv.fromElements(
   "Or to take arms against a sea of troubles,")
 Scala-Flink> val countsStreaming = textStreaming
     .flatMap { _.toLowerCase.split("\\W+") }
-    .map { (_, 1) }.keyBy(0).sum(1)
+    .map { (_, 1) }.keyBy(_._1).sum(1)
 Scala-Flink> countsStreaming.print()
 Scala-Flink> senv.execute("Streaming Wordcount")
 {% endhighlight %}

--- a/docs/ops/scala_shell.zh.md
+++ b/docs/ops/scala_shell.zh.md
@@ -77,7 +77,7 @@ Scala-Flink> val textStreaming = senv.fromElements(
   "Or to take arms against a sea of troubles,")
 Scala-Flink> val countsStreaming = textStreaming
     .flatMap { _.toLowerCase.split("\\W+") }
-    .map { (_, 1) }.keyBy(0).sum(1)
+    .map { (_, 1) }.keyBy(_._1).sum(1)
 Scala-Flink> countsStreaming.print()
 Scala-Flink> senv.execute("Streaming Wordcount")
 {% endhighlight %}

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/async/AsyncIOExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/async/AsyncIOExample.java
@@ -304,7 +304,7 @@ public class AsyncIOExample {
 			public void flatMap(String value, Collector<Tuple2<String, Integer>> out) throws Exception {
 				out.collect(new Tuple2<>(value, 1));
 			}
-		}).keyBy(0).sum(1).print();
+		}).keyBy(value -> value.f0).sum(1).print();
 
 		// execute the program
 		env.execute("Async IO Example");

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/sideoutput/SideOutputExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/sideoutput/SideOutputExample.java
@@ -95,7 +95,7 @@ public class SideOutputExample {
 				});
 
 		DataStream<Tuple2<String, Integer>> counts = tokenized
-				.keyBy(0)
+				.keyBy(value -> value.f0)
 				.window(TumblingEventTimeWindows.of(Time.seconds(5)))
 				// group by the tuple field "0" and sum up tuple field "1"
 				.sum(1);

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/socket/SocketWindowWordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/socket/SocketWindowWordCount.java
@@ -76,7 +76,7 @@ public class SocketWindowWordCount {
 					}
 				})
 
-				.keyBy("word")
+				.keyBy(value -> value.word)
 				.timeWindow(Time.seconds(5))
 
 				.reduce(new ReduceFunction<WordWithCount>() {

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/twitter/TwitterExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/twitter/TwitterExample.java
@@ -91,7 +91,7 @@ public class TwitterExample {
 				// selecting English tweets and splitting to (word, 1)
 				.flatMap(new SelectEnglishAndTokenizeFlatMap())
 				// group by words and sum their occurrences
-				.keyBy(0).sum(1);
+				.keyBy(value -> value.f0).sum(1);
 
 		// emit result
 		if (params.has("output")) {

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
@@ -47,7 +47,7 @@ public class GroupedProcessingTimeWindowExample {
 		DataStream<Tuple2<Long, Long>> stream = env.addSource(new DataSource());
 
 		stream
-			.keyBy(0)
+			.keyBy(value -> value.f0)
 			.timeWindow(Time.of(2500, MILLISECONDS), Time.of(500, MILLISECONDS))
 			.reduce(new SummingReducer())
 

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
@@ -81,7 +81,7 @@ public class SessionWindowing {
 
 		// We create sessions for each id with max timeout of 3 time units
 		DataStream<Tuple3<String, Long, Integer>> aggregated = source
-				.keyBy(0)
+				.keyBy(value -> value.f0)
 				.window(EventTimeSessionWindows.withGap(Time.milliseconds(3L)))
 				.sum(2);
 

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
@@ -70,7 +70,7 @@ public class TopSpeedWindowing {
 		double triggerMeters = 50;
 		DataStream<Tuple4<Integer, Integer, Double, Long>> topSpeeds = carData
 				.assignTimestampsAndWatermarks(new CarTimestamp())
-				.keyBy(0)
+				.keyBy(value -> value.f0)
 				.window(GlobalWindows.create())
 				.evictor(TimeEvictor.of(Time.of(evictionSec, TimeUnit.SECONDS)))
 				.trigger(DeltaTrigger.of(triggerMeters,

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/WindowWordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/WindowWordCount.java
@@ -75,7 +75,7 @@ public class WindowWordCount {
 		// split up the lines in pairs (2-tuples) containing: (word,1)
 		text.flatMap(new WordCount.Tokenizer())
 				// create windows of windowSize records slided every slideSize records
-				.keyBy(0)
+				.keyBy(value -> value.f0)
 				.countWindow(windowSize, slideSize)
 				// group by the tuple field "0" and sum up tuple field "1"
 				.sum(1);

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
@@ -83,7 +83,7 @@ public class WordCount {
 			// split up the lines in pairs (2-tuples) containing: (word,1)
 			text.flatMap(new Tokenizer())
 			// group by the tuple field "0" and sum up tuple field "1"
-			.keyBy(0).sum(1);
+			.keyBy(value -> value.f0).sum(1);
 
 		// emit result
 		if (params.has("output")) {

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/socket/SocketWindowWordCount.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/socket/SocketWindowWordCount.scala
@@ -67,7 +67,7 @@ object SocketWindowWordCount {
     val windowCounts = text
           .flatMap { w => w.split("\\s") }
           .map { w => WordWithCount(w, 1) }
-          .keyBy("word")
+          .keyBy(_.word)
           .timeWindow(Time.seconds(5))
           .sum("count")
 

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/twitter/TwitterExample.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/twitter/TwitterExample.scala
@@ -98,7 +98,7 @@ object TwitterExample {
       // selecting English tweets and splitting to (word, 1)
       .flatMap(new SelectEnglishAndTokenizeFlatMap)
       // group by words and sum their occurrences
-      .keyBy(0).sum(1)
+      .keyBy(_._1).sum(1)
 
     // emit result
     if (params.has("output")) {

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/GroupedProcessingTimeWindowExample.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/GroupedProcessingTimeWindowExample.scala
@@ -41,7 +41,7 @@ object GroupedProcessingTimeWindowExample {
     val stream: DataStream[(Long, Long)] = env.addSource(new DataSource)
 
     stream
-      .keyBy(0)
+      .keyBy(_._1)
       .timeWindow(Time.of(2500, MILLISECONDS), Time.of(500, MILLISECONDS))
       .reduce((value1, value2) => (value1._1, value1._2 + value2._2))
       .addSink(new SinkFunction[(Long, Long)]() {

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/SessionWindowing.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/SessionWindowing.scala
@@ -75,7 +75,7 @@ object SessionWindowing {
 
     // We create sessions for each id with max timeout of 3 time units
     val aggregated: DataStream[(String, Long, Int)] = source
-      .keyBy(0)
+      .keyBy(_._1)
       .window(EventTimeSessionWindows.withGap(Time.milliseconds(3L)))
       .sum(2)
 

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/TopSpeedWindowing.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/TopSpeedWindowing.scala
@@ -103,7 +103,7 @@ object TopSpeedWindowing {
 
     val topSpeeds = cars
       .assignAscendingTimestamps( _.time )
-      .keyBy("carId")
+      .keyBy(_.carId)
       .window(GlobalWindows.create)
       .evictor(TimeEvictor.of(Time.of(evictionSec * 1000, TimeUnit.MILLISECONDS)))
       .trigger(DeltaTrigger.of(triggerMeters, new DeltaFunction[CarEvent] {

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/WindowWordCount.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/windowing/WindowWordCount.scala
@@ -79,7 +79,7 @@ object WindowWordCount {
       .flatMap(_.toLowerCase.split("\\W+"))
       .filter(_.nonEmpty)
       .map((_, 1))
-      .keyBy(0)
+      .keyBy(_._1)
       // create windows of windowSize records slided every slideSize records
       .countWindow(windowSize, slideSize)
       // group by the tuple field "0" and sum up tuple field "1"

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/wordcount/WordCount.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/wordcount/WordCount.scala
@@ -74,7 +74,7 @@ object WordCount {
       .filter(_.nonEmpty)
       .map((_, 1))
       // group by the tuple field "0" and sum up tuple field "1"
-      .keyBy(0)
+      .keyBy(_._1)
       .sum(1)
 
     // emit result


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The `keyBy` usage of the examples and documents is no longer recommended, so update to the latest usage. This PR only updates docs and examples.


## Brief change log

[a2a8717](https://github.com/apache/flink/commit/a2a8717c3738c883d0dfadf3f4b59289302bca21) : In the examples module, if it is java class, update '.keyBy("word")' to '.keyBy(value -> value.word)', update '.keyBy(0)' to '.keyBy(value -> value.f0)'; if it is scala class, update '.keyBy("word")' to '.keyBy(_.word)', update '.keyBy(0)' to '.keyBy(_._1)';
[30d841e](https://github.com/apache/flink/commit/30d841ee0c5df64c98e1e572937427ccbac592b0) : update docs module like examples module
[3b2c0da](https://github.com/apache/flink/commit/3b2c0da11cb0ec78cf24b14c0b70a88df7fff745) : adjust `etl.md` code comment

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
