### PR TITLE
[FLINK-18878][python] Support dependency management for Python Stream…

### DIFF
--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -258,10 +258,12 @@ class DataStream(object):
         if key_type_info is None:
             key_type_info = Types.PICKLED_BYTE_ARRAY()
             is_key_pickled_byte_array = True
-        generated_key_stream = KeyedStream(self.map(lambda x: (key_selector.get_key(x), x),
-                                                    type_info=Types.ROW([key_type_info,
-                                                                         output_type_info]))
-                                           ._j_data_stream
+
+        intermediate_map_stream = self.map(lambda x: (key_selector.get_key(x), x),
+                                           type_info=Types.ROW([key_type_info, output_type_info]))
+        intermediate_map_stream.name(gateway.jvm.org.apache.flink.python.util.PythonConfigUtil
+                                     .STREAM_KEY_BY_MAP_OPERATOR_NAME)
+        generated_key_stream = KeyedStream(intermediate_map_stream._j_data_stream
                                            .keyBy(PickledKeySelector(is_key_pickled_byte_array),
                                                   key_type_info.get_java_type_info()), self)
         generated_key_stream._original_data_type_info = output_type_info
@@ -438,7 +440,7 @@ class DataStream(object):
 
         j_env = self._j_data_stream.getExecutionEnvironment()
         PythonConfigUtil = gateway.jvm.org.apache.flink.python.util.PythonConfigUtil
-        j_conf = PythonConfigUtil.getMergedConfig(j_env)
+        j_conf = PythonConfigUtil.getEnvConfigWithDependencies(j_env)
 
         # set max bundle size to 1 to force synchronize process for reduce function.
         from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
@@ -686,9 +688,10 @@ class KeyedStream(DataStream):
         Since python KeyedStream is in the format of Row(key_value, original_data), it is used for
         getting the original_data.
         """
-        j_transformed_stream = super().map(lambda x: x[1],
-                                           type_info=self._original_data_type_info)._j_data_stream
-        return DataStream(j_transformed_stream)
+        transformed_stream = super().map(lambda x: x[1], type_info=self._original_data_type_info)
+        transformed_stream.name(get_gateway().jvm.org.apache.flink.python.util.PythonConfigUtil
+                                .KEYED_STREAM_VALUE_OPERATOR_NAME)
+        return DataStream(transformed_stream._j_data_stream)
 
     def set_parallelism(self, parallelism: int):
         raise Exception("Set parallelism for KeyedStream is not supported.")

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -438,9 +438,7 @@ class DataStream(object):
             j_python_data_stream_scalar_function,
             func_type)
 
-        j_env = self._j_data_stream.getExecutionEnvironment()
-        PythonConfigUtil = gateway.jvm.org.apache.flink.python.util.PythonConfigUtil
-        j_conf = PythonConfigUtil.getEnvConfigWithDependencies(j_env)
+        j_conf = gateway.jvm.org.apache.flink.configuration.Configuration()
 
         # set max bundle size to 1 to force synchronize process for reduce function.
         from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -389,6 +389,174 @@ class StreamExecutionEnvironment(object):
         j_characteristic = self._j_stream_execution_environment.getStreamTimeCharacteristic()
         return TimeCharacteristic._from_j_time_characteristic(j_characteristic)
 
+    def add_python_file(self, file_path: str):
+        """
+        Adds a python dependency which could be python files, python packages or
+        local directories. They will be added to the PYTHONPATH of the python UDF worker.
+        Please make sure that these dependencies can be imported.
+
+        :param file_path: The path of the python dependency.
+        :type file_path: str
+        """
+        jvm = get_gateway().jvm
+        env_config = jvm.org.apache.flink.python.util.PythonConfigUtil\
+            .getEnvironmentConfig(self._j_stream_execution_environment)
+        python_files = env_config.getString(jvm.PythonOptions.PYTHON_FILES.key(), None)
+        if python_files is not None:
+            python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join([python_files, file_path])
+        else:
+            python_files = file_path
+        env_config.setString(jvm.PythonOptions.PYTHON_FILES.key(), python_files)
+
+    def set_python_requirements(self, requirements_file_path: str,
+                                requirements_cache_dir: str = None):
+        """
+        Specifies a requirements.txt file which defines the third-party dependencies.
+        These dependencies will be installed to a temporary directory and added to the
+        PYTHONPATH of the python UDF worker.
+
+        For the dependencies which could not be accessed in the cluster, a directory which contains
+        the installation packages of these dependencies could be specified using the parameter
+        "requirements_cached_dir". It will be uploaded to the cluster to support offline
+        installation.
+
+        Example:
+        ::
+
+            # commands executed in shell
+            $ echo numpy==1.16.5 > requirements.txt
+            $ pip download -d cached_dir -r requirements.txt --no-binary :all:
+
+            # python code
+            >>> stream_env.set_python_requirements("requirements.txt", "cached_dir")
+
+        .. note::
+
+            Please make sure the installation packages matches the platform of the cluster
+            and the python version used. These packages will be installed using pip,
+            so also make sure the version of Pip (version >= 7.1.0) and the version of
+            SetupTools (version >= 37.0.0).
+
+        :param requirements_file_path: The path of "requirements.txt" file.
+        :type requirements_file_path: str
+        :param requirements_cache_dir: The path of the local directory which contains the
+                                       installation packages.
+        :type requirements_cache_dir: str
+        """
+        jvm = get_gateway().jvm
+        python_requirements = requirements_file_path
+        if requirements_cache_dir is not None:
+            python_requirements = jvm.PythonDependencyUtils.PARAM_DELIMITER.join(
+                [python_requirements, requirements_cache_dir])
+        env_config = jvm.org.apache.flink.python.util.PythonConfigUtil \
+            .getEnvironmentConfig(self._j_stream_execution_environment)
+        env_config.setString(jvm.PythonOptions.PYTHON_REQUIREMENTS.key(), python_requirements)
+
+    def add_python_archive(self, archive_path: str, target_dir: str = None):
+        """
+        Adds a python archive file. The file will be extracted to the working directory of
+        python UDF worker.
+
+        If the parameter "target_dir" is specified, the archive file will be extracted to a
+        directory named ${target_dir}. Otherwise, the archive file will be extracted to a
+        directory with the same name of the archive file.
+
+        If python UDF depends on a specific python version which does not exist in the cluster,
+        this method can be used to upload the virtual environment.
+        Note that the path of the python interpreter contained in the uploaded environment
+        should be specified via the method :func:`pyflink.table.TableConfig.set_python_executable`.
+
+        The files uploaded via this method are also accessible in UDFs via relative path.
+
+        Example:
+        ::
+
+            # command executed in shell
+            # assert the relative path of python interpreter is py_env/bin/python
+            $ zip -r py_env.zip py_env
+
+            # python code
+            >>> stream_env.add_python_archive("py_env.zip")
+            >>> stream_env.set_python_executable("py_env.zip/py_env/bin/python")
+
+            # or
+            >>> stream_env.add_python_archive("py_env.zip", "myenv")
+            >>> stream_env.set_python_executable("myenv/py_env/bin/python")
+
+            # the files contained in the archive file can be accessed in UDF
+            >>> def my_udf():
+            ...     with open("myenv/py_env/data/data.txt") as f:
+            ...         ...
+
+        .. note::
+
+            Please make sure the uploaded python environment matches the platform that the cluster
+            is running on and that the python version must be 3.5 or higher.
+
+        .. note::
+
+            Currently only zip-format is supported. i.e. zip, jar, whl, egg, etc.
+            The other archive formats such as tar, tar.gz, 7z, rar, etc are not supported.
+
+        :param archive_path: The archive file path.
+        :type archive_path: str
+        :param target_dir: Optional, the target dir name that the archive file extracted to.
+        :type target_dir: str
+        """
+        jvm = get_gateway().jvm
+        if target_dir is not None:
+            archive_path = jvm.PythonDependencyUtils.PARAM_DELIMITER.join(
+                [archive_path, target_dir])
+        env_config = jvm.org.apache.flink.python.util.PythonConfigUtil \
+            .getEnvironmentConfig(self._j_stream_execution_environment)
+        python_archives = env_config.getString(jvm.PythonOptions.PYTHON_ARCHIVES.key(), None)
+        if python_archives is not None:
+            python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join(
+                [python_archives, archive_path])
+        else:
+            python_files = archive_path
+        env_config.setString(jvm.PythonOptions.PYTHON_ARCHIVES.key(), python_files)
+
+    def set_python_executable(self, python_exec: str):
+        """
+        Sets the path of the python interpreter which is used to execute the python udf workers.
+
+        e.g. "/usr/local/bin/python3".
+
+        If python UDF depends on a specific python version which does not exist in the cluster,
+        the method :func:`pyflink.datastream.StreamExecutionEnvironment.add_python_archive` can be
+        used to upload a virtual environment. The path of the python interpreter contained in the
+        uploaded environment can be specified via this method.
+
+        Example:
+        ::
+
+            # command executed in shell
+            # assume that the relative path of python interpreter is py_env/bin/python
+            $ zip -r py_env.zip py_env
+
+            # python code
+            >>> stream_env.add_python_archive("py_env.zip")
+            >>> stream_env.set_python_executable("py_env.zip/py_env/bin/python")
+
+        .. note::
+
+            Please make sure the uploaded python environment matches the platform that the cluster
+            is running on and that the python version must be 3.5 or higher.
+
+        .. note::
+
+            The python udf worker depends on Apache Beam (version == 2.19.0).
+            Please ensure that the specified environment meets the above requirements.
+
+        :param python_exec: The path of python interpreter.
+        :type python_exec: str
+        """
+        jvm = get_gateway().jvm
+        env_config = jvm.org.apache.flink.python.util.PythonConfigUtil \
+            .getEnvironmentConfig(self._j_stream_execution_environment)
+        env_config.setString(jvm.PythonOptions.PYTHON_EXECUTABLE.key(), python_exec)
+
     def get_default_local_parallelism(self):
         """
         Gets the default parallelism that will be used for the local execution environment.
@@ -416,10 +584,14 @@ class StreamExecutionEnvironment(object):
         :param job_name: Desired name of the job, optional.
         :return: The result of the job execution, containing elapsed time and accumulators.
         """
-        if job_name is None:
-            return JobExecutionResult(self._j_stream_execution_environment.execute())
-        else:
-            return JobExecutionResult(self._j_stream_execution_environment.execute(job_name))
+        j_stream_graph = get_gateway().jvm \
+            .org.apache.flink.python.util.PythonConfigUtil.generateStreamGraphWithDependencies(
+            self._j_stream_execution_environment, True)
+
+        if job_name is not None:
+            j_stream_graph.setJobName(job_name)
+
+        return JobExecutionResult(self._j_stream_execution_environment.execute(j_stream_graph))
 
     def execute_async(self, job_name: str = 'Flink Streaming Job') -> JobClient:
         """
@@ -432,7 +604,12 @@ class StreamExecutionEnvironment(object):
         :return: A JobClient that can be used to communicate with the submitted job, completed on
                  submission succeeded.
         """
-        j_job_client = self._j_stream_execution_environment.executeAsync(job_name)
+        j_stream_graph = get_gateway().jvm \
+            .org.apache.flink.python.util.PythonConfigUtil.generateStreamGraphWithDependencies(
+            self._j_stream_execution_environment, True)
+        j_stream_graph.setJobName(job_name)
+
+        j_job_client = self._j_stream_execution_environment.executeAsync(j_stream_graph)
         return JobClient(j_job_client=j_job_client)
 
     def get_execution_plan(self):
@@ -447,7 +624,11 @@ class StreamExecutionEnvironment(object):
 
         :return: The execution plan of the program, as a JSON String.
         """
-        return self._j_stream_execution_environment.getExecutionPlan()
+        j_stream_graph = get_gateway().jvm\
+            .org.apache.flink.python.util.PythonConfigUtil.generateStreamGraphWithDependencies(
+            self._j_stream_execution_environment, False)
+
+        return j_stream_graph.getStreamingPlanAsJSON()
 
     @staticmethod
     def get_execution_environment():

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -409,19 +409,8 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
             assert os.environ["python"] == python_exec_link_path
             return i
 
-        def check_pyflink_gateway_disabled(i):
-            try:
-                from pyflink.java_gateway import get_gateway
-                get_gateway()
-            except Exception as e:
-                assert str(e).startswith("It's launching the PythonGatewayServer during Python UDF"
-                                         " execution which is unexpected.")
-            else:
-                raise Exception("The gateway server is not disabled!")
-            return i
-
         ds = self.env.from_collection([1, 2, 3, 4, 5])
-        ds.map(check_python_exec).map(check_pyflink_gateway_disabled).add_sink(self.test_sink)
+        ds.map(check_python_exec).add_sink(self.test_sink)
         self.env.execute("test set python executable")
         result = self.test_sink.get_results(True)
         expected = ['1', '2', '3', '4', '5']

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -16,11 +16,13 @@
 # limitations under the License.
 ################################################################################
 import os
+import shutil
 import tempfile
 import json
 import time
 
 import unittest
+import uuid
 
 from pyflink.common import ExecutionConfig, RestartStrategies
 from pyflink.common.typeinfo import Types
@@ -28,6 +30,7 @@ from pyflink.datastream import (StreamExecutionEnvironment, CheckpointConfig,
                                 CheckpointingMode, MemoryStateBackend, TimeCharacteristic)
 from pyflink.datastream.functions import SourceFunction
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
+from pyflink.java_gateway import get_gateway
 from pyflink.table import DataTypes, CsvTableSource, CsvTableSink, StreamTableEnvironment
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
@@ -279,6 +282,223 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         self.assertIsNotNone(job_id)
         execution_result = job_client.get_job_execution_result().result()
         self.assertEqual(str(job_id), str(execution_result.get_job_id()))
+
+    def test_add_python_file(self):
+        import uuid
+        python_file_dir = os.path.join(self.tempdir, "python_file_dir_" + str(uuid.uuid4()))
+        os.mkdir(python_file_dir)
+        python_file_path = os.path.join(python_file_dir, "test_stream_dependency_manage_lib.py")
+        with open(python_file_path, 'w') as f:
+            f.write("def add_two(a):\n    return a + 2")
+
+        def plus_two_map(value):
+            from test_stream_dependency_manage_lib import add_two
+            return add_two(value)
+
+        self.env.add_python_file(python_file_path)
+        ds = self.env.from_collection([1, 2, 3, 4, 5])
+        ds.map(plus_two_map).add_sink(self.test_sink)
+        self.env.execute("test add python file")
+        result = self.test_sink.get_results(True)
+        expected = ['3', '4', '5', '6', '7']
+        result.sort()
+        expected.sort()
+        self.assertEqual(expected, result)
+
+    def test_set_requirements_without_cached_directory(self):
+        import uuid
+        requirements_txt_path = os.path.join(self.tempdir, str(uuid.uuid4()))
+        with open(requirements_txt_path, 'w') as f:
+            f.write("cloudpickle==1.2.2")
+        self.env.set_python_requirements(requirements_txt_path)
+
+        def check_requirements(i):
+            import cloudpickle
+            assert os.path.abspath(cloudpickle.__file__).startswith(
+                os.environ['_PYTHON_REQUIREMENTS_INSTALL_DIR'])
+            return i
+
+        ds = self.env.from_collection([1, 2, 3, 4, 5])
+        ds.map(check_requirements).add_sink(self.test_sink)
+        self.env.execute("test set requirements without cache dir")
+        result = self.test_sink.get_results(True)
+        expected = ['1', '2', '3', '4', '5']
+        result.sort()
+        expected.sort()
+        self.assertEqual(expected, result)
+
+    def test_set_requirements_with_cached_directory(self):
+        import uuid
+        tmp_dir = self.tempdir
+        requirements_txt_path = os.path.join(tmp_dir, "requirements_txt_" + str(uuid.uuid4()))
+        with open(requirements_txt_path, 'w') as f:
+            f.write("python-package1==0.0.0")
+
+        requirements_dir_path = os.path.join(tmp_dir, "requirements_dir_" + str(uuid.uuid4()))
+        os.mkdir(requirements_dir_path)
+        package_file_name = "python-package1-0.0.0.tar.gz"
+        with open(os.path.join(requirements_dir_path, package_file_name), 'wb') as f:
+            import base64
+            # This base64 data is encoded from a python package file which includes a
+            # "python_package1" module. The module contains a "plus(a, b)" function.
+            # The base64 can be recomputed by following code:
+            # base64.b64encode(open("python-package1-0.0.0.tar.gz", "rb").read()).decode("utf-8")
+            f.write(base64.b64decode(
+                "H4sICNefrV0C/2Rpc3QvcHl0aG9uLXBhY2thZ2UxLTAuMC4wLnRhcgDtmVtv2jAYhnPtX2H1CrRCY+ckI"
+                "XEx7axuUA11u5imyICTRc1JiVnHfv1MKKWjYxwKEdPehws7xkmUfH5f+3PyqfqWpa1cjG5EKFnLbOvfhX"
+                "FQTI3nOPPSdavS5Pa8nGMwy3Esi3ke9wyTObbnGNQxamBSKlFQavzUryG8ldG6frpbEGx4yNmDLMp/hPy"
+                "P8b+6fNN613vdP1z8XdteG3+ug/17/F3Hcw1qIv5H54NUYiyUaH2SRRllaYeytkl6IpEdujI2yH2XapCQ"
+                "wSRJRDHt0OveZa//uUfeZonUvUO5bHo+0ZcoVo9bMhFRvGx9H41kWj447aUsR0WUq+pui8arWKggK5Jli"
+                "wGOo/95q79ovXi6/nfyf246Dof/n078fT9KI+X77Xx6BP83bX4Xf5NxT7dz7toO/L8OxjKgeTwpG+KcDp"
+                "sdQjWFVJMipYI+o0MCk4X/t2UYtqI0yPabCHb3f861XcD/Ty/+Y5nLdCzT0dSPo/SmbKsf6un+b7KV+Ls"
+                "W4/D/OoC9w/930P9eGwM75//csrD+Q/6P/P/k9D/oX3988Wqw1bS/tf6tR+s/m3EG/ddBqXO9XKf15C8p"
+                "P9k4HZBtBgzZaVW5vrfKcj+W32W82ygEB9D/Xu9+4/qfP9L/rBv0X1v87yONKRX61/qfzwqjIDzIPTbv/"
+                "7or3/88i0H/tfBFW7s/s/avRInQH06ieEy7tDrQeYHUdRN7wP+n/vf62LOH/pld7f9xz7a5Pfufedy0oP"
+                "86iJI8KxStAq6yLC4JWdbbVbWRikR2z1ZGytk5vauW3QdnBFE6XqwmykazCesAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAOBw/AJw5CHBAFAAAA=="))
+        self.env.set_python_requirements(requirements_txt_path, requirements_dir_path)
+
+        def add_one(i):
+            from python_package1 import plus
+            return plus(i, 1)
+
+        ds = self.env.from_collection([1, 2, 3, 4, 5])
+        ds.map(add_one).add_sink(self.test_sink)
+        self.env.execute("test set requirements with cachd dir")
+        result = self.test_sink.get_results(True)
+        expected = ['2', '3', '4', '5', '6']
+        result.sort()
+        expected.sort()
+        self.assertEqual(expected, result)
+
+    def test_add_python_archive(self):
+        import uuid
+        import shutil
+        tmp_dir = self.tempdir
+        archive_dir_path = os.path.join(tmp_dir, "archive_" + str(uuid.uuid4()))
+        os.mkdir(archive_dir_path)
+        with open(os.path.join(archive_dir_path, "data.txt"), 'w') as f:
+            f.write("2")
+        archive_file_path = \
+            shutil.make_archive(os.path.dirname(archive_dir_path), 'zip', archive_dir_path)
+        self.env.add_python_archive(archive_file_path, "data")
+
+        def add_from_file(i):
+            with open("data/data.txt", 'r') as f:
+                return i + int(f.read())
+
+        ds = self.env.from_collection([1, 2, 3, 4, 5])
+        ds.map(add_from_file).add_sink(self.test_sink)
+        self.env.execute("test set python archive")
+        result = self.test_sink.get_results(True)
+        expected = ['3', '4', '5', '6', '7']
+        result.sort()
+        expected.sort()
+        self.assertEqual(expected, result)
+
+    def test_set_stream_env(self):
+        import sys
+        python_exec = sys.executable
+        tmp_dir = self.tempdir
+        python_exec_link_path = os.path.join(tmp_dir, "py_exec")
+        os.symlink(python_exec, python_exec_link_path)
+        self.env.set_python_executable(python_exec_link_path)
+
+        def check_python_exec(i):
+            import os
+            assert os.environ["python"] == python_exec_link_path
+            return i
+
+        def check_pyflink_gateway_disabled(i):
+            try:
+                from pyflink.java_gateway import get_gateway
+                get_gateway()
+            except Exception as e:
+                assert str(e).startswith("It's launching the PythonGatewayServer during Python UDF"
+                                         " execution which is unexpected.")
+            else:
+                raise Exception("The gateway server is not disabled!")
+            return i
+
+        ds = self.env.from_collection([1, 2, 3, 4, 5])
+        ds.map(check_python_exec).map(check_pyflink_gateway_disabled).add_sink(self.test_sink)
+        self.env.execute("test set python executable")
+        result = self.test_sink.get_results(True)
+        expected = ['1', '2', '3', '4', '5']
+        result.sort()
+        expected.sort()
+        self.assertEqual(expected, result)
+
+    def test_generate_stream_graph_with_dependencies(self):
+
+        python_file_dir = os.path.join(self.tempdir, "python_file_dir_" + str(uuid.uuid4()))
+        os.mkdir(python_file_dir)
+        python_file_path = os.path.join(python_file_dir, "test_stream_dependency_manage_lib.py")
+        with open(python_file_path, 'w') as f:
+            f.write("def add_two(a):\n    return a + 2")
+        self.env.add_python_file(python_file_path)
+
+        def plus_two_map(value):
+            from test_stream_dependency_manage_lib import add_two
+            return value[0], add_two(value[1])
+
+        def add_from_file(i):
+            with open("data/data.txt", 'r') as f:
+                return i[0], i[1] + int(f.read())
+
+        from_collection_source = self.env.from_collection([('a', 0), ('b', 0), ('c', 1), ('d', 1),
+                                                           ('e', 2)],
+                                                          type_info=Types.ROW([Types.STRING(),
+                                                                               Types.INT()]))
+        from_collection_source.name("From Collection")
+        keyed_stream = from_collection_source.key_by(lambda x: x[1], key_type_info=Types.INT())
+
+        plus_two_map_stream = keyed_stream.map(plus_two_map).name("Plus Two Map").set_parallelism(3)
+
+        add_from_file_map = plus_two_map_stream.map(add_from_file).name("Add From File Map")
+
+        test_stream_sink = add_from_file_map.add_sink(self.test_sink).name("Test Sink")
+        test_stream_sink.set_parallelism(4)
+
+        archive_dir_path = os.path.join(self.tempdir, "archive_" + str(uuid.uuid4()))
+        os.mkdir(archive_dir_path)
+        with open(os.path.join(archive_dir_path, "data.txt"), 'w') as f:
+            f.write("3")
+        archive_file_path = \
+            shutil.make_archive(os.path.dirname(archive_dir_path), 'zip', archive_dir_path)
+        self.env.add_python_archive(archive_file_path, "data")
+
+        nodes = eval(self.env.get_execution_plan())['nodes']
+
+        # The StreamGraph should be as bellow:
+        # Source: From Collection -> _stream_key_by_map_operator -> _keyed_stream_values_operator ->
+        # Plus Two Map -> Add From File Map -> Sink: Test Sink.
+
+        # Source: From Collection and _stream_key_by_map_operator should have same parallelism.
+        self.assertEqual(nodes[0]['parallelism'], nodes[1]['parallelism'])
+
+        # _keyed_stream_values_operator and Plus Two Map should have same parallisim.
+        self.assertEqual(nodes[3]['parallelism'], 3)
+        self.assertEqual(nodes[2]['parallelism'], nodes[3]['parallelism'])
+
+        # The ship_strategy for Source: From Collection and _stream_key_by_map_operator shoule be
+        # FORWARD
+        self.assertEqual(nodes[1]['predecessors'][0]['ship_strategy'], "FORWARD")
+
+        # The ship_strategy for _keyed_stream_values_operator and Plus Two Map shoule be
+        # FORWARD
+        self.assertEqual(nodes[3]['predecessors'][0]['ship_strategy'], "FORWARD")
+
+        # The parallelism of Sink: Test Sink should be 4
+        self.assertEqual(nodes[5]['parallelism'], 4)
+
+        env_config_with_dependencies = dict(get_gateway().jvm.org.apache.flink.python.util
+                                            .PythonConfigUtil.getEnvConfigWithDependencies(
+            self.env._j_stream_execution_environment).toMap())
+
+        # Make sure that user specified files and archives are correctly added.
+        self.assertIsNotNone(env_config_with_dependencies['python.files'])
+        self.assertIsNotNone(env_config_with_dependencies['python.archives'])
 
     def tearDown(self) -> None:
         self.test_sink.clear()

--- a/flink-python/src/main/java/org/apache/flink/datastream/runtime/operators/python/DataStreamPythonStatelessFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/datastream/runtime/operators/python/DataStreamPythonStatelessFunctionOperator.java
@@ -75,8 +75,6 @@ public class DataStreamPythonStatelessFunctionOperator<IN, OUT> extends Abstract
 
 	protected transient StreamRecordCollector streamRecordCollector;
 
-	private Configuration mergedEnvConfig;
-
 	public DataStreamPythonStatelessFunctionOperator(
 		Configuration config,
 		TypeInformation<IN> inputTypeInfo,
@@ -87,7 +85,6 @@ public class DataStreamPythonStatelessFunctionOperator<IN, OUT> extends Abstract
 		jobOptions = config.toMap();
 		this.inputTypeInfo = inputTypeInfo;
 		this.outputTypeInfo = outputTypeInfo;
-		this.mergedEnvConfig = config;
 	}
 
 	@Override
@@ -151,10 +148,6 @@ public class DataStreamPythonStatelessFunctionOperator<IN, OUT> extends Abstract
 		baos.reset();
 		checkInvokeFinishBundleByCount();
 		emitResults();
-	}
-
-	public Configuration getMergedEnvConfig(){
-		return this.mergedEnvConfig;
 	}
 
 	protected FlinkFnApi.UserDefinedDataStreamFunctions getUserDefinedDataStreamFunctionsProto() {

--- a/flink-python/src/main/java/org/apache/flink/datastream/runtime/operators/python/DataStreamPythonStatelessFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/datastream/runtime/operators/python/DataStreamPythonStatelessFunctionOperator.java
@@ -75,6 +75,8 @@ public class DataStreamPythonStatelessFunctionOperator<IN, OUT> extends Abstract
 
 	protected transient StreamRecordCollector streamRecordCollector;
 
+	private Configuration mergedEnvConfig;
+
 	public DataStreamPythonStatelessFunctionOperator(
 		Configuration config,
 		TypeInformation<IN> inputTypeInfo,
@@ -85,6 +87,7 @@ public class DataStreamPythonStatelessFunctionOperator<IN, OUT> extends Abstract
 		jobOptions = config.toMap();
 		this.inputTypeInfo = inputTypeInfo;
 		this.outputTypeInfo = outputTypeInfo;
+		this.mergedEnvConfig = config;
 	}
 
 	@Override
@@ -148,6 +151,10 @@ public class DataStreamPythonStatelessFunctionOperator<IN, OUT> extends Abstract
 		baos.reset();
 		checkInvokeFinishBundleByCount();
 		emitResults();
+	}
+
+	public Configuration getMergedEnvConfig(){
+		return this.mergedEnvConfig;
 	}
 
 	protected FlinkFnApi.UserDefinedDataStreamFunctions getUserDefinedDataStreamFunctionsProto() {

--- a/flink-python/src/main/java/org/apache/flink/python/PythonConfig.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonConfig.java
@@ -107,7 +107,13 @@ public class PythonConfig implements Serializable {
 	 */
 	private final boolean isUsingManagedMemory;
 
+	/**
+	 * The Configuration that contains execution configs and dependencies info.
+	 * */
+	private final Configuration mergedConfig;
+
 	public PythonConfig(Configuration config) {
+		mergedConfig = config;
 		maxBundleSize = config.get(PythonOptions.MAX_BUNDLE_SIZE);
 		maxBundleTimeMills = config.get(PythonOptions.MAX_BUNDLE_TIME_MILLS);
 		maxArrowBatchSize = config.get(PythonOptions.MAX_ARROW_BATCH_SIZE);
@@ -172,5 +178,9 @@ public class PythonConfig implements Serializable {
 
 	public boolean isUsingManagedMemory() {
 		return isUsingManagedMemory;
+	}
+
+	public Configuration getMergedConfig() {
+		return mergedConfig;
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -17,11 +17,25 @@
 
 package org.apache.flink.python.util;
 
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.datastream.runtime.operators.python.DataStreamPythonStatelessFunctionOperator;
+import org.apache.flink.python.PythonConfig;
+import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A Util class to get the {@link StreamExecutionEnvironment} configuration and merged configuration with environment
@@ -29,14 +43,18 @@ import java.lang.reflect.Method;
  */
 public class PythonConfigUtil {
 
+	public static final String KEYED_STREAM_VALUE_OPERATOR_NAME = "_keyed_stream_values_operator";
+	public static final String STREAM_KEY_BY_MAP_OPERATOR_NAME = "_stream_key_by_map_operator";
+
 	/**
 	 * A static method to get the {@link StreamExecutionEnvironment} configuration merged with python dependency
 	 * management configurations.
 	 */
-	public static Configuration getMergedConfig(StreamExecutionEnvironment env) throws InvocationTargetException,
+	public static Configuration getEnvConfigWithDependencies(StreamExecutionEnvironment env) throws InvocationTargetException,
 		IllegalAccessException, NoSuchMethodException {
 		Configuration envConfiguration = getEnvironmentConfig(env);
-		Configuration config = PythonDependencyUtils.configurePythonDependencies(env.getCachedFiles(), envConfiguration);
+		Configuration config = PythonDependencyUtils.configurePythonDependencies(env.getCachedFiles(),
+			envConfiguration);
 		return config;
 	}
 
@@ -63,5 +81,104 @@ public class PythonConfigUtil {
 		getConfigurationMethod.setAccessible(true);
 		Configuration envConfiguration = (Configuration) getConfigurationMethod.invoke(env);
 		return envConfiguration;
+	}
+
+	/**
+	 * Configure the {@link DataStreamPythonStatelessFunctionOperator} to be chained with the upstream/downstream
+	 * operator by setting their parallelism, slot sharing group, co-location group to be the same, and applying a
+	 * {@link ForwardPartitioner}.
+	 * 1. operator with name "_keyed_stream_values_operator" should align with its downstream operator.
+	 * 2. operator with name "_stream_key_by_map_operator" should align with its upstream operator.
+	 */
+	private static void alignStreamNode(StreamNode streamNode, StreamGraph streamGraph) {
+		if (streamNode.getOperatorName().equals(KEYED_STREAM_VALUE_OPERATOR_NAME)) {
+			StreamEdge downStreamEdge = streamNode.getOutEdges().get(0);
+			StreamNode downStreamNode = streamGraph.getStreamNode(downStreamEdge.getTargetId());
+			downStreamEdge.setPartitioner(new ForwardPartitioner());
+			streamNode.setParallelism(downStreamNode.getParallelism());
+			streamNode.setCoLocationGroup(downStreamNode.getCoLocationGroup());
+			streamNode.setSlotSharingGroup(downStreamNode.getSlotSharingGroup());
+		}
+
+		if (streamNode.getOperatorName().equals(STREAM_KEY_BY_MAP_OPERATOR_NAME)) {
+			StreamEdge upStreamEdge = streamNode.getInEdges().get(0);
+			StreamNode upStreamNode = streamGraph.getStreamNode(upStreamEdge.getSourceId());
+			upStreamEdge.setPartitioner(new ForwardPartitioner<>());
+			streamNode.setParallelism(upStreamNode.getParallelism());
+			streamNode.setSlotSharingGroup(upStreamNode.getSlotSharingGroup());
+			streamNode.setCoLocationGroup(upStreamNode.getCoLocationGroup());
+		}
+	}
+
+	/**
+	 * Generate a {@link StreamGraph} for transformations maintained by current {@link StreamExecutionEnvironment}, and
+	 * reset the merged env configurations with dependencies to every {@link DataStreamPythonStatelessFunctionOperator}.
+	 * It is an idempotent operation that can be call multiple times. Remember that only when need to execute the
+	 * StreamGraph can we set the clearTransformations to be True.
+	 */
+	public static StreamGraph generateStreamGraphWithDependencies(
+		StreamExecutionEnvironment env, boolean clearTransformations) throws IllegalAccessException,
+		NoSuchMethodException, InvocationTargetException {
+
+		Configuration mergedConfig = getEnvConfigWithDependencies(env);
+		StreamGraph streamGraph = env.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, clearTransformations);
+		Collection<StreamNode> streamNodes = streamGraph.getStreamNodes();
+		for (StreamNode streamNode : streamNodes) {
+
+			alignStreamNode(streamNode, streamGraph);
+
+			StreamOperatorFactory streamOperatorFactory = streamNode.getOperatorFactory();
+			if (streamOperatorFactory instanceof SimpleOperatorFactory) {
+				StreamOperator streamOperator = ((SimpleOperatorFactory) streamOperatorFactory).getOperator();
+				if (streamOperator instanceof DataStreamPythonStatelessFunctionOperator) {
+					DataStreamPythonStatelessFunctionOperator dataStreamPythonStatelessFunctionOperator =
+						(DataStreamPythonStatelessFunctionOperator) streamOperator;
+					Configuration oldConfig = dataStreamPythonStatelessFunctionOperator.getMergedEnvConfig();
+					dataStreamPythonStatelessFunctionOperator.setPythonConfig(generateNewPythonConfig(oldConfig,
+						mergedConfig));
+				}
+			}
+		}
+		return streamGraph;
+	}
+
+	/**
+	 * Generator a new {@link  PythonConfig} with the combined config which is derived from oldConfig.
+	 */
+	private static PythonConfig generateNewPythonConfig(Configuration oldConfig, Configuration newConfig) {
+		setIfNotExist(PythonOptions.MAX_BUNDLE_SIZE, oldConfig, newConfig);
+		setIfNotExist(PythonOptions.MAX_BUNDLE_TIME_MILLS, oldConfig, newConfig);
+		setIfNotExist(PythonOptions.MAX_BUNDLE_TIME_MILLS, oldConfig, newConfig);
+		setIfNotExist(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE, oldConfig, newConfig);
+		setIfNotExist(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE, oldConfig, newConfig);
+		setIfNotExist(PythonOptions.PYTHON_EXECUTABLE, oldConfig, newConfig);
+		setIfNotExist(PythonOptions.PYTHON_METRIC_ENABLED, oldConfig, newConfig);
+		setIfNotExist(PythonOptions.USE_MANAGED_MEMORY, oldConfig, newConfig);
+
+		combineConfigValue(PythonDependencyUtils.PYTHON_FILES, oldConfig, newConfig);
+		combineConfigValue(PythonDependencyUtils.PYTHON_REQUIREMENTS_FILE, oldConfig, newConfig);
+		combineConfigValue(PythonDependencyUtils.PYTHON_ARCHIVES, oldConfig, newConfig);
+
+		return new PythonConfig(oldConfig);
+	}
+
+	/**
+	 * Make sure new configuration not overriding the previously configured value. For example, the MAX_BUNDLE_SIZE of
+	 * {@link org.apache.flink.datastream.runtime.operators.python.DataStreamPythonReduceFunctionOperator} is
+	 * pre-configured to be 1, we must not to change it.
+	 */
+	private static void setIfNotExist(ConfigOption configOption, Configuration oldConfig, Configuration newConfig) {
+		if (!oldConfig.containsKey(configOption.key())) {
+			oldConfig.set(configOption, newConfig.get(configOption));
+		}
+	}
+
+	/**
+	 * Dependency file information maintained by a Map in old config can be combined with new config.
+	 */
+	private static void combineConfigValue(ConfigOption<Map<String, String>> configOption, Configuration oldConfig, Configuration newConfig) {
+		Map<String, String> oldConfigValue = oldConfig.getOptional(configOption).orElse(new HashMap<>());
+		oldConfigValue.putAll(newConfig.getOptional(configOption).orElse(new HashMap<>()));
+		oldConfig.set(configOption, oldConfigValue);
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -95,7 +95,7 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 	/**
 	 * The python config.
 	 */
-	private final PythonConfig config;
+	private PythonConfig config;
 
 	public AbstractPythonFunctionOperator(Configuration config) {
 		this.config = new PythonConfig(Preconditions.checkNotNull(config));
@@ -238,6 +238,14 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 					}
 				};
 		}
+	}
+
+	/**
+	 * Reset the {@link PythonConfig} if needed.
+	 * */
+	@Internal
+	public void setPythonConfig(PythonConfig pythonConfig) {
+		this.config = pythonConfig;
 	}
 
 	/**

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -243,9 +243,15 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 	/**
 	 * Reset the {@link PythonConfig} if needed.
 	 * */
-	@Internal
 	public void setPythonConfig(PythonConfig pythonConfig) {
 		this.config = pythonConfig;
+	}
+
+	/**
+	 * Returns the {@link PythonConfig}.
+	 * */
+	public PythonConfig getConfig() {
+		return config;
 	}
 
 	/**

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
@@ -34,7 +34,7 @@ public class PythonConfigUtilTest {
 	@Test
 	public void testGetEnvironmentConfig() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		StreamExecutionEnvironment executionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
-		Configuration envConfig = PythonConfigUtil.getMergedConfig(executionEnvironment);
+		Configuration envConfig = PythonConfigUtil.getEnvConfigWithDependencies(executionEnvironment);
 		assertNotNull(envConfig);
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add dependency management for StreamExecutionEnvironment when Users need to specified third party dependencies in their DataStream Job. We purpose to add the following interfaces forPython StreamExecutionEnvironment:
- add_python_file()
- set_python_requirements()
- add_python_archive()
- set_python_executable()

And user might apply those interfaces arbitrarily, we must configure those dependencies to operators that depend on them correctly before executing the job.

Further more, some operation might consist of multiple operations,  take key_by() for instance:

```
>>> source_stream = env.from_collection(...)
>>> keyed_stream = upstream.key_by(...)
>>> mapped_stream = keyed_stream.map(...)
```

The implementation of key_by() is consist of a _stream_key_by_map operator and a _keyed_stream_values_map operator.
we need to make sure the _stream_key_by_map operator is chained with the source_stream operator,   the _keyed_stream_values_map operator chained with mapped_stream operator that they have the same parallelism, slot sharing group, co-location group and the ship_strategy should be FORWARD.

All this task should be accomplished before submitting the job by a PythonConfigUtil.


## Brief change log

Add the following interfaces forPython StreamExecutionEnvironment:
- add_python_file()
- set_python_requirements()
- add_python_archive()
- set_python_executable()

Add util method getEnvConfigWithDependencies() to get StreamExecutionEnvironment configuration with dependencies.
Add a util method generateStreamGraphWithDependencies() to generate a StreamGraph with all operators have dependencies configured.

## Verifying this change

This change has test cases covered as followed:
- test_add_python_file()
- test_set_requirements_without_cached_directory()
- test_set_requirements_with_cached_directory()
- test_add_python_archive()
- test_set_stream_env()
- test_generate_stream_graph_with_dependencies()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
