### PR TITLE
[FLINK-18852] Fix StreamScan doesn't inherit parallelism from input in legacy planner

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
@@ -66,7 +66,7 @@ trait StreamScan extends CommonScan[CRow] with DataStreamRel {
           outCRow.row = v
           outCRow
         }
-      }).returns(cRowType)
+      }).returns(cRowType).setParallelism(input.getParallelism)
 
     } else {
       // input needs to be converted and wrapped as CRow or time indicators need to be generated
@@ -88,7 +88,11 @@ trait StreamScan extends CommonScan[CRow] with DataStreamRel {
 
       val opName = s"from: (${schema.fieldNames.mkString(", ")})"
 
-      input.process(processFunc).name(opName).returns(cRowType)
+      input
+        .process(processFunc)
+        .name(opName)
+        .returns(cRowType)
+        .setParallelism(input.getParallelism)
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/resources/testFilterStream0.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testFilterStream0.out
@@ -12,7 +12,7 @@ Stage 1 : Data Source
 
 	Stage 2 : Operator
 		content : from: (a, b)
-		ship_strategy : REBALANCE
+		ship_strategy : FORWARD
 
 		Stage 3 : Operator
 			content : where: (=(MOD(a, 2), 0)), select: (a, b)

--- a/flink-table/flink-table-planner/src/test/scala/resources/testUnionStream0.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testUnionStream0.out
@@ -17,9 +17,9 @@ Stage 2 : Data Source
 
 	Stage 3 : Operator
 		content : from: (count, word)
-		ship_strategy : REBALANCE
+		ship_strategy : FORWARD
 
 		Stage 4 : Operator
 			content : from: (count, word)
-			ship_strategy : REBALANCE
+			ship_strategy : FORWARD
 


### PR DESCRIPTION
…legacy planner


## What is the purpose of the change

Currently in legacy planner, StreamScan don't inherit parallelism from input, which is unexpected.
This PR will fix it.


## Brief change log

Fix StreamScan parallelism


## Verifying this change


This change is verified through UT (TableSourceITCase#testStreamScanParallelism)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
