### PR TITLE
[FLINK-18936][docs] Update documentation around aggregate functions

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AggregateFunction.java
@@ -61,7 +61,6 @@ import org.apache.flink.table.types.inference.TypeInference;
  * <ul>
  *     <li>{@code retract}</li>
  *     <li>{@code merge}</li>
- *     <li>{@code resetAccumulator}</li>
  * </ul>
  *
  * <p>All these methods must be declared publicly, not static, and named exactly as the names
@@ -88,7 +87,7 @@ import org.apache.flink.table.types.inference.TypeInference;
  * Retracts the input values from the accumulator instance. The current design assumes the
  * inputs are the values that have been previously accumulated. The method retract can be
  * overloaded with different custom types and arguments. This method must be implemented for
- * unbounded OVER aggregates.
+ * bounded OVER aggregates over unbounded tables.
  *
  * param: accumulator           the accumulator which contains the current aggregated results
  * param: [user defined inputs] the input value (usually obtained from new arrived data).
@@ -106,26 +105,15 @@ import org.apache.flink.table.types.inference.TypeInference;
  *                    be noted that the accumulator may contain the previous aggregated
  *                    results. Therefore user should not replace or clean this instance in the
  *                    custom merge method.
- * param: its         an java.lang.Iterable pointed to a group of accumulators that will be
+ * param: iterable    an java.lang.Iterable pointed to a group of accumulators that will be
  *                    merged.
  *
  * public void merge(ACC accumulator, java.lang.Iterable<ACC> iterable)
  * }
  * </pre>
  *
- * <pre>
- * {@code
- * Resets the accumulator for this aggregate function. This method must be implemented for
- * bounded grouping aggregates.
- *
- * param: accumulator the accumulator which needs to be reset
- *
- * public void resetAccumulator(ACC accumulator)
- * }
- * </pre>
- *
- * <p>If this aggregate function can only be applied in an OVER window, this can be declared using the
- * requirement {@link FunctionRequirement#OVER_WINDOW_ONLY} in {@link #getRequirements()}.
+ * <p>If this aggregate function can only be applied in an OVER window, this can be declared by returning
+ * the requirement {@link FunctionRequirement#OVER_WINDOW_ONLY} in {@link #getRequirements()}.
  *
  * <p>If an accumulator needs to store large amounts of data, {@link ListView} and {@link MapView}
  * provide advanced features for leveraging Flink's state backends in unbounded data scenarios.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
@@ -32,9 +32,9 @@ import org.apache.flink.util.Collector;
 
 /**
  * Base class for a user-defined table function. A user-defined table function maps zero, one, or
- * multiple scalar values to zero, one, or multiple rows. If an output row consists of only one field,
- * the row can be omitted and a scalar value can be emitted. It will be wrapped into an implicit row
- * by the runtime.
+ * multiple scalar values to zero, one, or multiple rows (or structured types). If an output record
+ * consists of only one field, the structured record can be omitted, and a scalar value can be emitted
+ * that will be implicitly wrapped into a row by the runtime.
  *
  * <p>The behavior of a {@link TableFunction} can be defined by implementing a custom evaluation
  * method. An evaluation method must be declared publicly, not static, and named <code>eval</code>.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
@@ -66,11 +66,11 @@ public final class UserDefinedFunctionHelper {
 
 	public static final String AGGREGATE_MERGE = "merge";
 
-	public static final String AGGREGATE_RESET = "resetAccumulator";
-
 	public static final String TABLE_AGGREGATE_ACCUMULATE = "accumulate";
 
 	public static final String TABLE_AGGREGATE_RETRACT = "retract";
+
+	public static final String TABLE_AGGREGATE_MERGE = "merge";
 
 	public static final String TABLE_AGGREGATE_EMIT = "emitValue";
 
@@ -328,10 +328,10 @@ public final class UserDefinedFunctionHelper {
 			validateImplementationMethod(functionClass, true, false, AGGREGATE_ACCUMULATE);
 			validateImplementationMethod(functionClass, true, true, AGGREGATE_RETRACT);
 			validateImplementationMethod(functionClass, true, true, AGGREGATE_MERGE);
-			validateImplementationMethod(functionClass, true, true, AGGREGATE_RESET);
 		} else if (TableAggregateFunction.class.isAssignableFrom(functionClass)) {
 			validateImplementationMethod(functionClass, true, false, TABLE_AGGREGATE_ACCUMULATE);
 			validateImplementationMethod(functionClass, true, true, TABLE_AGGREGATE_RETRACT);
+			validateImplementationMethod(functionClass, true, true, TABLE_AGGREGATE_MERGE);
 			validateImplementationMethod(functionClass, true, false, TABLE_AGGREGATE_EMIT, TABLE_AGGREGATE_EMIT_RETRACT);
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
@@ -470,16 +470,6 @@ class ImperativeAggCodeGen(
       )
     }
 
-    if (needReset) {
-      UserDefinedFunctionHelper.validateClassForRuntime(
-        function.getClass,
-        UserDefinedFunctionHelper.AGGREGATE_RESET,
-        accumulatorClass,
-        classOf[Unit],
-        functionName
-      )
-    }
-
     if (needEmitValue) {
       UserDefinedFunctionHelper.validateClassForRuntime(
         function.getClass,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
@@ -2583,10 +2583,6 @@ class CountAggFunction extends AggregateFunction[JLong, CountAccumulator] {
     new CountAccumulator
   }
 
-  def resetAccumulator(acc: CountAccumulator): Unit = {
-    acc.f0 = 0L
-  }
-
   override def getAccumulatorType: TypeInformation[CountAccumulator] = {
     new TupleTypeInfo(classOf[CountAccumulator], Types.LONG)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
@@ -347,10 +347,6 @@ class MyPojoAggFunction extends AggregateFunction[MyPojo, CountAccumulator] {
     new CountAccumulator
   }
 
-  def resetAccumulator(acc: CountAccumulator): Unit = {
-    acc.f0 = 0L
-  }
-
   override def getAccumulatorType: TypeInformation[CountAccumulator] = {
     new TupleTypeInfo[CountAccumulator](classOf[CountAccumulator], Types.LONG)
   }
@@ -385,10 +381,6 @@ class VarArgsAggFunction extends AggregateFunction[JLong, CountAccumulator] {
 
   override def createAccumulator(): CountAccumulator = {
     new CountAccumulator
-  }
-
-  def resetAccumulator(acc: CountAccumulator): Unit = {
-    acc.f0 = 0L
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/AggregationITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/AggregationITCase.scala
@@ -440,10 +440,6 @@ class Top10 extends AggregateFunction[Array[JTuple2[JInt, JFloat]], Array[JTuple
 
   override def getValue(acc: Array[JTuple2[JInt, JFloat]]): Array[JTuple2[JInt, JFloat]] = acc
 
-  def resetAccumulator(acc: Array[JTuple2[JInt, JFloat]]): Unit = {
-    java.util.Arrays.fill(acc.asInstanceOf[Array[Object]], null)
-  }
-
   def merge(
       acc: Array[JTuple2[JInt, JFloat]],
       its: java.lang.Iterable[Array[JTuple2[JInt, JFloat]]]): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -78,10 +78,6 @@ object UserDefinedFunctionTestUtils {
     override def createAccumulator(): CountAccumulator = {
       new CountAccumulator
     }
-
-    def resetAccumulator(acc: CountAccumulator): Unit = {
-      acc.f0 = 0L
-    }
   }
 
   /** The initial accumulator for count aggregate function */
@@ -117,10 +113,6 @@ object UserDefinedFunctionTestUtils {
 
     override def createAccumulator(): CountAccumulator = {
       new CountAccumulator
-    }
-
-    def resetAccumulator(acc: CountAccumulator): Unit = {
-      acc.f0 = 0L
     }
   }
 
@@ -477,9 +469,5 @@ class GenericAggregateFunction extends AggregateFunction[java.lang.Integer, Rand
 
   def retract(acc: RandomClass, value: Int): Unit = {
     acc.i = value
-  }
-
-  def resetAccumulator(acc: RandomClass): Unit = {
-    acc.i = 0
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/AvgAggFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/AvgAggFunction.scala
@@ -82,11 +82,6 @@ abstract class IntegralAvgAggFunction[T] extends AggregateFunction[T, IntegralAv
     }
   }
 
-  def resetAccumulator(acc: IntegralAvgAccumulator): Unit = {
-    acc.f0 = 0L
-    acc.f1 = 0L
-  }
-
   override def getAccumulatorType: TypeInformation[IntegralAvgAccumulator] = {
     new TupleTypeInfo(classOf[IntegralAvgAccumulator], Types.LONG, Types.LONG)
   }
@@ -174,11 +169,6 @@ abstract class BigIntegralAvgAggFunction[T]
     }
   }
 
-  def resetAccumulator(acc: BigIntegralAvgAccumulator): Unit = {
-    acc.f0 = BigInteger.ZERO
-    acc.f1 = 0
-  }
-
   override def getAccumulatorType: TypeInformation[BigIntegralAvgAccumulator] = {
     new TupleTypeInfo(classOf[BigIntegralAvgAccumulator], Types.INT, Types.LONG)
   }
@@ -249,11 +239,6 @@ abstract class FloatingAvgAggFunction[T] extends AggregateFunction[T, FloatingAv
       acc.f1 += a.f1
       acc.f0 += a.f0
     }
-  }
-
-  def resetAccumulator(acc: FloatingAvgAccumulator): Unit = {
-    acc.f0 = 0
-    acc.f1 = 0L
   }
 
   override def getAccumulatorType: TypeInformation[FloatingAvgAccumulator] = {
@@ -331,11 +316,6 @@ class DecimalAvgAggFunction(argType: DecimalType)
       acc.f0 = acc.f0.add(a.f0)
       acc.f1 += a.f1
     }
-  }
-
-  def resetAccumulator(acc: DecimalAvgAccumulator): Unit = {
-    acc.f0 = BigDecimal.ZERO
-    acc.f1 = 0L
   }
 
   override def getAccumulatorType: TypeInformation[DecimalAvgAccumulator] = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/CountAggFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/CountAggFunction.scala
@@ -70,10 +70,6 @@ class CountAggFunction extends AggregateFunction[JLong, CountAccumulator] {
     new CountAccumulator
   }
 
-  def resetAccumulator(acc: CountAccumulator): Unit = {
-    acc.f0 = 0L
-  }
-
   override def getAccumulatorType: TypeInformation[CountAccumulator] = {
     new TupleTypeInfo(classOf[CountAccumulator], BasicTypeInfo.LONG_TYPE_INFO)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/SumAggFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/SumAggFunction.scala
@@ -71,11 +71,6 @@ abstract class SumAggFunction[T: Numeric] extends AggregateFunction[T, SumAccumu
     }
   }
 
-  def resetAccumulator(acc: SumAccumulator[T]): Unit = {
-    acc.f0 = numeric.zero
-    acc.f1 = false
-  }
-
   override def getAccumulatorType: TypeInformation[SumAccumulator[T]] = {
     new TupleTypeInfo(
       classOf[SumAccumulator[T]],
@@ -168,11 +163,6 @@ class DecimalSumAggFunction extends AggregateFunction[BigDecimal, DecimalSumAccu
         acc.f1 = true
       }
     }
-  }
-
-  def resetAccumulator(acc: DecimalSumAccumulator): Unit = {
-    acc.f0 = BigDecimal.ZERO
-    acc.f1 = false
   }
 
   override def getAccumulatorType: TypeInformation[DecimalSumAccumulator] = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedAggFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedAggFunctions.scala
@@ -82,10 +82,6 @@ class Top10 extends AggregateFunction[Array[JTuple2[JInt, JFloat]], Array[JTuple
 
   override def getValue(acc: Array[JTuple2[JInt, JFloat]]): Array[JTuple2[JInt, JFloat]] = acc
 
-  def resetAccumulator(acc: Array[JTuple2[JInt, JFloat]]): Unit = {
-    util.Arrays.fill(acc.asInstanceOf[Array[Object]], null)
-  }
-
   def merge(
       acc: Array[JTuple2[JInt, JFloat]],
       its: java.lang.Iterable[Array[JTuple2[JInt, JFloat]]]): Unit = {
@@ -135,10 +131,6 @@ class NonMergableCount extends AggregateFunction[Long, NonMergableCountAcc] {
     }
   }
 
-  def resetAccumulator(acc: NonMergableCountAcc): Unit = {
-    acc.count = 0
-  }
-
   override def createAccumulator(): NonMergableCountAcc = NonMergableCountAcc(0)
 
   override def getValue(acc: NonMergableCountAcc): Long = acc.count
@@ -156,12 +148,6 @@ class CountMinMax extends AggregateFunction[Row, CountMinMaxAcc] {
       acc.max = value
     }
     acc.count += 1
-  }
-
-  def resetAccumulator(acc: CountMinMaxAcc): Unit = {
-    acc.count = 0
-    acc.min = 0
-    acc.max = 0
   }
 
   override def createAccumulator(): CountMinMaxAcc = CountMinMaxAcc(0L, 0, 0)


### PR DESCRIPTION
## What is the purpose of the change

Ensures that all documentation about aggregate functions is correct and consistent.

## Brief change log

- Removes mentioning of `resetAccumulator`
- Updates JavaDocs and website docs for `AggregateFunction` and `TableAggregateFunction`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
