### PR TITLE
[FLINK-18956][task] StreamTask.invoke should catch Throwable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -543,7 +543,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			afterInvoke();
 		}
-		catch (Exception invokeException) {
+		catch (Throwable invokeException) {
 			failing = !canceled;
 			try {
 				cleanUpInvoke();
@@ -551,9 +551,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// TODO: investigate why Throwable instead of Exception is used here.
 			catch (Throwable cleanUpException) {
 				Throwable throwable = ExceptionUtils.firstOrSuppressed(cleanUpException, invokeException);
-				throw (throwable instanceof Exception ? (Exception) throwable : new Exception(throwable));
+				ExceptionUtils.rethrowException(throwable);
 			}
-			throw invokeException;
+			ExceptionUtils.rethrowException(invokeException);
 		}
 		cleanUpInvoke();
 	}


### PR DESCRIPTION

## What is the purpose of the change

*Currently, StreamTask.invoke only handles Exception. This pull request makes sure that all kinds of exceptions and handled.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
