### PR TITLE
[FLINK-17621][e2e] Use default akka.ask.timeout in TPC-DS e2e test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -57,7 +57,6 @@ echo "[INFO]Preparing Flink cluster..."
 set_config_key "taskmanager.memory.process.size" "4096m"
 set_config_key "taskmanager.numberOfTaskSlots" "4"
 set_config_key "parallelism.default" "4"
-set_config_key "akka.ask.timeout" "20 s"
 start_cluster
 
 


### PR DESCRIPTION
This E2E test has been modified temporarily. 
The underlying issue has been fixed, so we can revert the change.
