### PR TITLE
[FLINK-18683][table-common] Support @DataTypeHint for table/aggregate function output types

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/DataTypeHint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/DataTypeHint.java
@@ -67,6 +67,9 @@ import java.lang.annotation.Target;
  * class is annotated with {@code @DataTypeHint(defaultDecimalPrecision = 12, defaultDecimalScale = 2)}. Individual
  * field annotations allow to deviate from those default values.
  *
+ * <p>A data type hint on top of a table or aggregate function is similar to defining {@link FunctionHint#output()}
+ * for the output type of the function.
+ *
  * @see FunctionHint
  */
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionTemplate.java
@@ -74,6 +74,28 @@ final class FunctionTemplate {
 		);
 	}
 
+	/**
+	 * Creates an instance of {@link FunctionResultTemplate} from a {@link DataTypeHint}.
+	 */
+	static @Nullable FunctionResultTemplate createResultTemplate(
+			DataTypeFactory typeFactory,
+			@Nullable DataTypeHint hint) {
+		if (hint == null) {
+			return null;
+		}
+		final DataTypeTemplate template;
+		try {
+			template = DataTypeTemplate.fromAnnotation(typeFactory, hint);
+		} catch (Throwable t) {
+			throw extractionError(t, "Error in data type hint annotation.");
+		}
+		if (template.dataType != null) {
+			return FunctionResultTemplate.of(template.dataType);
+		}
+		throw extractionError(
+			"Data type hint does not specify a data type for use as function result.");
+	}
+
 	@Nullable FunctionSignatureTemplate getSignatureTemplate() {
 		return signatureTemplate;
 	}
@@ -139,25 +161,6 @@ final class FunctionTemplate {
 				.collect(Collectors.toList()),
 			isVarArg,
 			argumentNames);
-	}
-
-	private static @Nullable FunctionResultTemplate createResultTemplate(
-			DataTypeFactory typeFactory,
-			@Nullable DataTypeHint hint) {
-		if (hint == null) {
-			return null;
-		}
-		final DataTypeTemplate template;
-		try {
-			template = DataTypeTemplate.fromAnnotation(typeFactory, hint);
-		} catch (Throwable t) {
-			throw extractionError(t, "Error in data type hint annotation.");
-		}
-		if (template.dataType != null) {
-			return FunctionResultTemplate.of(template.dataType);
-		}
-		throw extractionError(
-			"Data type hint does not specify a data type for use as function result.");
 	}
 
 	private static FunctionArgumentTemplate createArgumentTemplate(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
@@ -96,8 +96,8 @@ public final class TypeInferenceExtractor {
 			function,
 			UserDefinedFunctionHelper.AGGREGATE_ACCUMULATE,
 			createParameterSignatureExtraction(1),
-			createGenericResultExtraction(AggregateFunction.class, 1),
-			createGenericResultExtraction(AggregateFunction.class, 0),
+			createGenericResultExtraction(AggregateFunction.class, 1, false),
+			createGenericResultExtraction(AggregateFunction.class, 0, true),
 			createParameterWithAccumulatorVerification());
 		return extractTypeInference(mappingExtractor);
 	}
@@ -114,7 +114,7 @@ public final class TypeInferenceExtractor {
 			UserDefinedFunctionHelper.TABLE_EVAL,
 			createParameterSignatureExtraction(0),
 			null,
-			createGenericResultExtraction(TableFunction.class, 0),
+			createGenericResultExtraction(TableFunction.class, 0, true),
 			createParameterVerification());
 		return extractTypeInference(mappingExtractor);
 	}
@@ -130,8 +130,8 @@ public final class TypeInferenceExtractor {
 			function,
 			UserDefinedFunctionHelper.TABLE_AGGREGATE_ACCUMULATE,
 			createParameterSignatureExtraction(1),
-			createGenericResultExtraction(TableAggregateFunction.class, 1),
-			createGenericResultExtraction(TableAggregateFunction.class, 0),
+			createGenericResultExtraction(TableAggregateFunction.class, 1, false),
+			createGenericResultExtraction(TableAggregateFunction.class, 0, true),
 			createParameterWithAccumulatorVerification());
 		return extractTypeInference(mappingExtractor);
 	}
@@ -148,7 +148,7 @@ public final class TypeInferenceExtractor {
 			UserDefinedFunctionHelper.ASYNC_TABLE_EVAL,
 			createParameterSignatureExtraction(1),
 			null,
-			createGenericResultExtraction(AsyncTableFunction.class, 0),
+			createGenericResultExtraction(AsyncTableFunction.class, 0, true),
 			createParameterWithArgumentVerification(CompletableFuture.class));
 		return extractTypeInference(mappingExtractor);
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.annotation.InputGroup;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
@@ -379,7 +380,52 @@ public class TypeInferenceExtractorTest {
 					TypeStrategies.explicit(DataTypes.BIGINT()))
 				.expectOutputMapping(
 					InputTypeStrategies.sequence(InputTypeStrategies.explicit(DataTypes.INT())),
-					TypeStrategies.explicit(DataTypes.INT()))
+					TypeStrategies.explicit(DataTypes.INT())),
+
+			TestSpec
+				.forTableFunction(
+					"A data type hint on the class is used instead of a function output hint",
+					DataTypeHintOnTableFunction.class)
+				.expectNamedArguments()
+				.expectTypedArguments()
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{},
+						new ArgumentTypeStrategy[]{}),
+					TypeStrategies.explicit(DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT())))),
+
+			TestSpec
+				.forTableFunction(
+					"A data type hint on the method is used instead of a function output hint",
+					DataTypeHintOnTableFunction2.class)
+				.expectNamedArguments("i")
+				.expectTypedArguments(DataTypes.INT())
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"i"},
+						new ArgumentTypeStrategy[]{InputTypeStrategies.explicit(DataTypes.INT())}),
+					TypeStrategies.explicit(DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT())))),
+
+			TestSpec
+				.forTableFunction(
+					"Invalid data type hint on top of method and class",
+					InvalidDataTypeHintOnTableFunction.class)
+				.expectErrorMessage(
+					"More than one data type hint found for output of function. " +
+						"Please use a function hint instead."),
+
+			TestSpec
+				.forScalarFunction(
+					"A data type hint on the method is used for enriching (not a function output hint)",
+					DataTypeHintOnScalarFunction.class)
+				.expectNamedArguments()
+				.expectTypedArguments()
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{},
+						new ArgumentTypeStrategy[]{}),
+					TypeStrategies.explicit(
+						DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT())).bridgedTo(RowData.class)))
 		);
 	}
 
@@ -859,6 +905,34 @@ public class TypeInferenceExtractorTest {
 		@FunctionHint(input = @DataTypeHint("INT"), output = @DataTypeHint("INT"))
 		public Number eval(Number n) {
 			return n;
+		}
+	}
+
+	@DataTypeHint("ROW<i INT>")
+	private static class DataTypeHintOnTableFunction extends TableFunction<Row> {
+		public void eval() {
+			// nothing to do
+		}
+	}
+
+	private static class DataTypeHintOnTableFunction2 extends TableFunction<Row> {
+		@DataTypeHint("ROW<i INT>")
+		public void eval(Integer i) {
+			// nothing to do
+		}
+	}
+
+	@DataTypeHint("ROW<i BOOLEAN>")
+	private static class InvalidDataTypeHintOnTableFunction extends TableFunction<Row> {
+		@DataTypeHint("ROW<i INT>")
+		public void eval(Integer i) {
+			// nothing to do
+		}
+	}
+
+	private static class DataTypeHintOnScalarFunction extends ScalarFunction {
+		public @DataTypeHint("ROW<i INT>") RowData eval() {
+			return null;
 		}
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -385,7 +385,7 @@ public class TypeInferenceExtractorTest {
 			TestSpec
 				.forTableFunction(
 					"A data type hint on the class is used instead of a function output hint",
-					DataTypeHintOnTableFunction.class)
+					DataTypeHintOnTableFunctionClass.class)
 				.expectNamedArguments()
 				.expectTypedArguments()
 				.expectOutputMapping(
@@ -397,7 +397,7 @@ public class TypeInferenceExtractorTest {
 			TestSpec
 				.forTableFunction(
 					"A data type hint on the method is used instead of a function output hint",
-					DataTypeHintOnTableFunction2.class)
+					DataTypeHintOnTableFunctionMethod.class)
 				.expectNamedArguments("i")
 				.expectTypedArguments(DataTypes.INT())
 				.expectOutputMapping(
@@ -909,13 +909,13 @@ public class TypeInferenceExtractorTest {
 	}
 
 	@DataTypeHint("ROW<i INT>")
-	private static class DataTypeHintOnTableFunction extends TableFunction<Row> {
+	private static class DataTypeHintOnTableFunctionClass extends TableFunction<Row> {
 		public void eval() {
 			// nothing to do
 		}
 	}
 
-	private static class DataTypeHintOnTableFunction2 extends TableFunction<Row> {
+	private static class DataTypeHintOnTableFunctionMethod extends TableFunction<Row> {
 		@DataTypeHint("ROW<i INT>")
 		public void eval(Integer i) {
 			// nothing to do


### PR DESCRIPTION
## What is the purpose of the change

Allows to use `@DataTypeHint(...)` as a synonym `@FunctionHint(output = @DataTypeHint(...))` for table and aggregate functions.

## Brief change log

Search for a single `@DataTypeHint(...)` on top of method/class if reflection extraction is used.

## Verifying this change

This change added tests and can be verified as follows: `TypeInferenceExtractorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
