### PR TITLE
[FLINK-18945][python] Support CoFlatMap for Python DataStream API

### DIFF
--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -63,7 +63,7 @@ class CoMapFunction(Function):
     The same instance of the transformation function is used to transform both of
     the connected streams. That way, the stream transformations can share state.
 
-    The basic syntax for using a MapFunction is as follows:
+    The basic syntax for using a CoMapFunction is as follows:
     ::
         >>> ds1 = ...
         >>> ds2 = ...
@@ -114,6 +114,57 @@ class FlatMapFunction(Function):
                 >>>     def flat_map(self, value):
                 >>>         for i in range(value):
                 >>>             yield i
+
+        :param value: The input value.
+        :return: A genertaor
+        """
+        pass
+
+
+class CoFlatMapFunction(Function):
+    """
+    A CoFlatMapFunction implements a flat-map transformation over two connected streams.
+
+    The same instance of the transformation function is used to transform both of the
+    connected streams. That way, the stream transformations can share state.
+
+    An example for the use of connected streams would be to apply rules that change over time
+    onto elements of a stream. One of the connected streams has the rules, the other stream the
+    elements to apply the rules to. The operation on the connected stream maintains the
+    current set of rules in the state. It may receive either a rule update (from the first stream)
+    and update the state, or a data element (from the second stream) and apply the rules in the
+    state to the element. The result of applying the rules would be emitted.
+
+    The basic syntax for using a CoFlatMapFunction is as follows:
+    ::
+        >>> ds1 = ...
+        >>> ds2 = ...
+
+        >>> class MyCoFlatMapFunction(CoFlatMapFunction):
+        >>>     def flat_map1(self, value):
+        >>>         for i in range(value):
+        >>>             yield i
+        >>>     def flat_map2(self, value):
+        >>>         for i in range(value):
+        >>>             yield i
+
+        >>> new_ds = ds1.connect(ds2).flat_map(MyCoFlatMapFunction())
+    """
+
+    @abc.abstractmethod
+    def flat_map1(self, value):
+        """
+        This method is called for each element in the first of the connected streams.
+
+        :param value: The input value.
+        :return: A genertaor
+        """
+        pass
+
+    @abc.abstractmethod
+    def flat_map2(self, value):
+        """
+        This method is called for each element in the second of the connected streams.
 
         :param value: The input value.
         :return: A genertaor

--- a/flink-python/pyflink/fn_execution/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/operation_utils.py
@@ -114,6 +114,14 @@ def extract_data_stream_stateless_funcs(udfs):
         def wrap_func(value):
             return co_map_func.map1(value[1]) if value[0] else co_map_func.map2(value[2])
         func = wrap_func
+    elif func_type == udf.CO_FLAT_MAP:
+        co_flat_map_func = cloudpickle.loads(udfs[0].payload)
+
+        def wrap_func(value):
+            return co_flat_map_func.flat_map1(
+                value[1]) if value[0] else co_flat_map_func.flat_map2(
+                value[2])
+        func = wrap_func
     return func
 
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds CoFlatMapFunction for Python DataStream API.


## Brief change log

  - Add CoFlatMapFunction on DataStream.


## Verifying this change

This change added tests and can be verified as follows:

  - Added `test_co_flat_map_function_without_data_types` and `test_co_flat_map_function_with_data_types` integration tests in test_data_stream

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (PythonDocs)
