### PR TITLE
[FLINK-18704][table] Add DECIMAL type in datagen

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
 
+import java.math.BigDecimal;
+
 /**
  * Random generator.
  */
@@ -95,6 +97,15 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
 			@Override
 			public Double next() {
 				return random.nextUniform(min, max);
+			}
+		};
+	}
+
+	public static RandomGenerator<BigDecimal> decimalGenerator(BigDecimal min, BigDecimal max) {
+		return new RandomGenerator<BigDecimal>() {
+			@Override
+			public BigDecimal next() {
+				return BigDecimal.valueOf(random.nextUniform(min.doubleValue(), max.doubleValue()));
 			}
 		};
 	}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenTableSourceFactory.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -202,6 +203,14 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
 						RandomGenerator.doubleGenerator(
 								config.get(min), config.get(max)),
 						min, max);
+			}
+			case DECIMAL: {
+				ConfigOption<Double> min = minKey.doubleType().defaultValue(Double.MIN_VALUE);
+				ConfigOption<Double> max = maxKey.doubleType().defaultValue(Double.MAX_VALUE);
+				return DataGeneratorContainer.of(
+					RandomGenerator.decimalGenerator(
+						BigDecimal.valueOf(config.get(min)), BigDecimal.valueOf(config.get(max))),
+					min, max);
 			}
 			default:
 				throw new ValidationException("Unsupported type: " + type);

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -68,6 +68,7 @@ public class DataGenTableSourceFactoryTest {
 		.field("f0", DataTypes.STRING())
 		.field("f1", DataTypes.BIGINT())
 		.field("f2", DataTypes.BIGINT())
+		.field("f3", DataTypes.DECIMAL(3, 3))
 		.build();
 
 	@Test
@@ -86,6 +87,10 @@ public class DataGenTableSourceFactoryTest {
 		descriptor.putString(FIELDS + ".f2." + KIND, SEQUENCE);
 		descriptor.putLong(FIELDS + ".f2." + START, 50);
 		descriptor.putLong(FIELDS + ".f2." + END, 60);
+
+		descriptor.putString(FIELDS + ".f3." + KIND, RANDOM);
+		descriptor.putLong(FIELDS + ".f3." + MIN, 100000);
+		descriptor.putLong(FIELDS + ".f3." + MAX, 1000000);
 
 		DynamicTableSource source = createSource(
 				TEST_SCHEMA, descriptor.asMap());


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds DECIMAL type (using BigDecimal) to the datagen Table source connector.

## Brief change log

  - Added decimalGenerator using BigDecimal
  - Added DECIMAL type in DataGenTableSourceFactory
  - Modified unit test to use DECIMAL

## Verifying this change

This change added tests and can be verified as follows:

  - Modified tests to use DECIMAL

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
