### PR TITLE
[FLINK-18949][python] Support Streaming File Sink for Python DataStream API

### DIFF
--- a/flink-python/pyflink/common/serialization.py
+++ b/flink-python/pyflink/common/serialization.py
@@ -365,3 +365,27 @@ class AvroRowSerializationSchema(SerializationSchema):
             j_serialization_schema = JAvroRowSerializationSchema(avro_schema_string)
 
         super(AvroRowSerializationSchema, self).__init__(j_serialization_schema)
+
+
+class Encoder(object):
+    """
+    A `Encoder` is used by the streaming file sink to perform the actual writing
+    of the incoming elements to the files in a bucket.
+    """
+
+    def __init__(self, j_encoder):
+        self.j_encoder = j_encoder
+
+    def get_java_encoder(self):
+        return self.j_encoder
+
+
+class SimpleStringEncoder(Encoder):
+    """
+    A simple `Encoder` that uses `toString()` on the input elements and
+    writes them to the output bucket file separated by newline.
+    """
+    def __init__(self, charset_name: str = "UTF-8"):
+        j_encoder = get_gateway().\
+            jvm.org.apache.flink.api.common.serialization.SimpleStringEncoder(charset_name)
+        super(SimpleStringEncoder, self).__init__(j_encoder)

--- a/flink-python/pyflink/common/serialization.py
+++ b/flink-python/pyflink/common/serialization.py
@@ -15,12 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from py4j.java_gateway import java_import
+from py4j.java_gateway import java_import, JavaObject
 from pyflink.common.typeinfo import TypeInformation, WrapperTypeInfo
 
 from pyflink.util.utils import load_java_class
 
 from pyflink.java_gateway import get_gateway
+from typing import Union
 
 
 class SerializationSchema(object):
@@ -373,7 +374,10 @@ class Encoder(object):
     of the incoming elements to the files in a bucket.
     """
 
-    def __init__(self, j_encoder):
+    def __init__(self, j_encoder: Union[str, JavaObject]):
+        if isinstance(j_encoder, str):
+            j_encoder_class = get_gateway().jvm.__getattr__(j_encoder)
+            j_encoder = j_encoder_class()
         self.j_encoder = j_encoder
 
     def get_java_encoder(self):

--- a/flink-python/pyflink/common/tests/test_serialization_schemas.py
+++ b/flink-python/pyflink/common/tests/test_serialization_schemas.py
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from pyflink.common.serialization_schemas import JsonRowSerializationSchema, \
+from pyflink.common.serialization import JsonRowSerializationSchema, \
     JsonRowDeserializationSchema, CsvRowSerializationSchema, CsvRowDeserializationSchema, \
     SimpleStringSchema
 from pyflink.common.typeinfo import Types

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -17,13 +17,15 @@
 ################################################################################
 
 from pyflink.common import typeinfo
-from pyflink.common.serialization_schemas import JsonRowDeserializationSchema, \
-    JsonRowSerializationSchema
+from pyflink.common.serialization import JsonRowDeserializationSchema, \
+    JsonRowSerializationSchema, SimpleStringEncoder
 from pyflink.common.typeinfo import Types
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.datastream.connectors import FlinkKafkaConsumer010, FlinkKafkaProducer010, \
     FlinkKafkaConsumer011, FlinkKafkaProducer011, FlinkKafkaConsumer, FlinkKafkaProducer, JdbcSink,\
-    JdbcConnectionOptions, JdbcExecutionOptions
+    JdbcConnectionOptions, JdbcExecutionOptions, StreamingFileSink, DefaultRollingPolicy, \
+    OutputFileConfig
+from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkTestCase, _load_specific_flink_module_jars, \
     get_private_field, invoke_java_object_method
@@ -150,3 +152,48 @@ class FlinkJdbcSinkTest(PyFlinkTestCase):
     def tearDown(self):
         if self._cxt_clz_loader is not None:
             get_gateway().jvm.Thread.currentThread().setContextClassLoader(self._cxt_clz_loader)
+
+
+class ConnectorTests(PyFlinkTestCase):
+
+    def setUp(self) -> None:
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        self.test_sink = DataStreamTestSinkFunction()
+
+    def test_stream_file_sink(self):
+        self.env.set_parallelism(2)
+        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        ds.map(
+            lambda a: a[0],
+            Types.STRING()).add_sink(
+            StreamingFileSink.for_row_format(self.tempdir, SimpleStringEncoder())
+                .with_rolling_policy(
+                    DefaultRollingPolicy.builder().with_rollover_interval(15 * 60 * 1000)
+                .with_inactivity_interval(5 * 60 * 1000)
+                .with_max_part_size(1024 * 1024 * 1024).build())
+                .with_output_file_config(
+                    OutputFileConfig.OutputFileConfigBuilder()
+                    .with_part_prefix("prefix")
+                    .with_part_suffix("suffix").build()).build())
+
+        self.env.execute("test_streaming_file_sink")
+
+        results = []
+        import os
+        for root, dirs, files in os.walk(self.tempdir, topdown=True):
+            for file in files:
+                self.assertTrue(file.startswith('.prefix'))
+                self.assertTrue('suffix' in file)
+                path = root + "/" + file
+                with open(path) as infile:
+                    for line in infile:
+                        results.append(line)
+
+        expected = ['deeefg\n', 'bdc\n', 'ab\n', 'cfgs\n']
+        results.sort()
+        expected.sort()
+        self.assertEqual(expected, results)
+
+    def tearDown(self) -> None:
+        self.test_sink.clear()

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -17,10 +17,8 @@
 ################################################################################
 import decimal
 
-from pyflink.common.serialization import SimpleStringEncoder
 from pyflink.common.typeinfo import Types
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.datastream.connectors import StreamingFileSink, DefaultRollingPolicy, OutputFileConfig
 from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.functions import FilterFunction
 from pyflink.datastream.functions import KeySelector
@@ -529,41 +527,6 @@ class DataStreamTests(PyFlinkTestCase):
         # We disable chaining for map_operator_1, therefore, it cannot be chained with
         # upstream and downstream operators.
         assert_chainable(j_generated_stream_graph, False, False)
-
-    def test_stream_file_sink(self):
-        self.env.set_parallelism(2)
-        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
-                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
-        ds.map(
-            lambda a: a[0],
-            Types.STRING()).add_sink(
-            StreamingFileSink.for_row_format(self.tempdir, SimpleStringEncoder())
-                .with_rolling_policy(
-                    DefaultRollingPolicy.builder().with_rollover_interval(15 * 60 * 1000)
-                .with_inactivity_interval(5 * 60 * 1000)
-                .with_max_part_size(1024 * 1024 * 1024).build())
-                .with_output_file_config(
-                    OutputFileConfig.OutputFileConfigBuilder()
-                    .with_part_prefix("prefix")
-                    .with_part_suffix("suffix").build()).build())
-
-        self.env.execute("test_streaming_file_sink")
-
-        results = []
-        import os
-        for root, dirs, files in os.walk(self.tempdir, topdown=True):
-            for file in files:
-                self.assertTrue(file.startswith('.prefix'))
-                self.assertTrue('suffix' in file)
-                path = root + "/" + file
-                with open(path) as infile:
-                    for line in infile:
-                        results.append(line)
-
-        expected = ['deeefg\n', 'bdc\n', 'ab\n', 'cfgs\n']
-        results.sort()
-        expected.sort()
-        self.assertEqual(expected, results)
 
     def tearDown(self) -> None:
         self.test_sink.clear()


### PR DESCRIPTION
## What is the purpose of the change

This pull request supports StreamingFileSink on Python DataStream API. Row-encoded Formats is only supported in this PR, i.e., Bulk-encoded Formats are not supported.

## Brief change log

  - Add StreamingFileSink on Python API.
  - Add Row-encoded Formats related APIs.


## Verifying this change

This change added tests and can be verified as follows:

  - Added `test_stream_file_sink` integration tests in test_data_stream

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (PythonDocs)
