### PR TITLE
[FLINK-18900][hive] HiveCatalog should error out when listing partitions with an invalid spec

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -772,16 +772,14 @@ public class HiveCatalog extends AbstractCatalog {
 		Table hiveTable = getHiveTable(tablePath);
 
 		ensurePartitionedTable(tablePath, hiveTable);
+		checkValidPartitionSpec(partitionSpec, getFieldNames(hiveTable.getPartitionKeys()), tablePath);
 
 		try {
 			// partition spec can be partial
 			List<String> partialVals = HiveReflectionUtils.getPvals(hiveShim, hiveTable.getPartitionKeys(),
 				partitionSpec.getPartitionSpec());
-			checkValidPartitionSpec(partitionSpec, getFieldNames(hiveTable.getPartitionKeys()), tablePath);
 			return client.listPartitionNames(tablePath.getDatabaseName(), tablePath.getObjectName(), partialVals,
 				(short) -1).stream().map(HiveCatalog::createPartitionSpec).collect(Collectors.toList());
-		} catch (PartitionSpecInvalidException e) {
-			throw new PartitionSpecInvalidException(getName(), getFieldNames(hiveTable.getPartitionKeys()), tablePath, partitionSpec, e);
 		} catch (TException e) {
 			throw new CatalogException(
 				String.format("Failed to list partitions of table %s", tablePath), e);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -468,35 +468,13 @@ public class HiveDialectITCase {
 
 	@Test
 	public void testShowPartitions() throws Exception {
-		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (country string)");
-		tableEnv.executeSql("alter table tbl add partition (country='china') partition (country='us')");
+		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt date, country string)");
+		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30',country='china') partition (dt='2020-04-30',country='us')");
 
 		ObjectPath tablePath = new ObjectPath("default", "tbl");
 		assertEquals(2, hiveCatalog.listPartitions(tablePath).size());
 
 		List<Row> partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
-		assertEquals(2, partitions.size());
-		assertTrue(partitions.toString().contains("country=china"));
-		assertTrue(partitions.toString().contains("country=us"));
-		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (country='china')").collect());
-		assertEquals(1, partitions.size());
-		assertTrue(partitions.toString().contains("country=china"));
-		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (country='japan')").collect());
-		assertEquals(0, partitions.size());
-		try {
-			Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (city='china')").collect());
-		} catch (TableException e) {
-			assertEquals(String.format("Could not execute SHOW PARTITIONS %s.%s PARTITION (city=china)", hiveCatalog.getName(), tablePath), e.getMessage());
-		}
-
-		tableEnv.executeSql("alter table tbl drop partition (country='china'),partition (country='us')");
-		assertEquals(0, hiveCatalog.listPartitions(tablePath).size());
-
-		tableEnv.executeSql("drop table tbl");
-		tableEnv.executeSql("create table tbl (x int,y binary) partitioned by (dt date, country string)");
-		tableEnv.executeSql("alter table tbl add partition (dt='2020-04-30',country='china') partition (dt='2020-04-30',country='us')");
-
-		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl").collect());
 		assertEquals(2, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=us"));
@@ -510,6 +488,13 @@ public class HiveDialectITCase {
 		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-04-30',country='china')").collect());
 		assertEquals(1, partitions.size());
 		assertTrue(partitions.toString().contains("dt=2020-04-30/country=china"));
+		partitions = Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (dt='2020-05-01',country='japan')").collect());
+		assertEquals(0, partitions.size());
+		try {
+			Lists.newArrayList(tableEnv.executeSql("show partitions tbl partition (de='2020-04-30',city='china')").collect());
+		} catch (TableException e) {
+			assertEquals(String.format("Could not execute SHOW PARTITIONS %s.%s PARTITION (de=2020-04-30, city=china)", hiveCatalog.getName(), tablePath), e.getMessage());
+		}
 
 		tableEnv.executeSql("alter table tbl drop partition (dt='2020-04-30',country='china'),partition (dt='2020-04-30',country='us')");
 		assertEquals(0, hiveCatalog.listPartitions(tablePath).size());

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -215,7 +215,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws TableNotExistException, TableNotPartitionedException, CatalogException {
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws TableNotExistException, TableNotPartitionedException, PartitionNotExistException, CatalogException {
 		return Collections.emptyList();
 	}
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -215,7 +215,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
 	}
 
 	@Override
-	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws TableNotExistException, TableNotPartitionedException, PartitionNotExistException, CatalogException {
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, CatalogException {
 		return Collections.emptyList();
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -533,7 +533,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 
 	@Override
 	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-			throws TableNotExistException, TableNotPartitionedException, CatalogException {
+			throws TableNotExistException, TableNotPartitionedException, PartitionNotExistException, CatalogException {
 		checkNotNull(tablePath);
 		checkNotNull(partitionSpec);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -533,7 +533,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 
 	@Override
 	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-			throws TableNotExistException, TableNotPartitionedException, PartitionNotExistException, CatalogException {
+			throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, CatalogException {
 		checkNotNull(tablePath);
 		checkNotNull(partitionSpec);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -327,7 +327,7 @@ public interface Catalog {
 	 * @throws CatalogException in case of any runtime exception
 	 */
 	List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-		throws TableNotExistException, TableNotPartitionedException, PartitionNotExistException, CatalogException;
+		throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, CatalogException;
 
 	/**
 	 * Get CatalogPartitionSpec of partitions by expression filters in the table.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -327,7 +327,7 @@ public interface Catalog {
 	 * @throws CatalogException in case of any runtime exception
 	 */
 	List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-		throws TableNotExistException, TableNotPartitionedException, CatalogException;
+		throws TableNotExistException, TableNotPartitionedException, PartitionNotExistException, CatalogException;
 
 	/**
 	 * Get CatalogPartitionSpec of partitions by expression filters in the table.


### PR DESCRIPTION
## What is the purpose of the change

*Currently `HiveCatalog` could return all partitions of table for `SHOW PARTITIONS` with an invalid spec, which is wrong. `HiveCatalog` should error out when listing partitions with an invalid spec.*

## Brief change log

  - *`HiveCatalog` throws `PartitionNotExistException ` after calling `HiveReflectionUtils.getPvals` with an invalid spec.*

## Verifying this change

  - *Method `testShowPartitions` of `HiveDialectITCase` add case for executing `SHOW PARTITIONS` with an invalid spec.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)