### PR TITLE
[FLINK-16789][runtime] Support JMX RMI random port assign 

### DIFF
--- a/docs/_includes/generated/expert_debugging_and_tuning_section.html
+++ b/docs/_includes/generated/expert_debugging_and_tuning_section.html
@@ -12,7 +12,7 @@
             <td><h5>jmx.server.port</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The port range for the JMX server to start the registry. The port config can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234". <br />A random port number will be acquired if port config is set to "0". <br />This option overrides metrics.reporter.*.port option.</td>
+            <td>The port range for the JMX server to start the registry. The port config can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234". <br />A random port between 10000-65000 will be acquired if port config is set to "0". <br />This option overrides metrics.reporter.*.port option.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/expert_debugging_and_tuning_section.html
+++ b/docs/_includes/generated/expert_debugging_and_tuning_section.html
@@ -12,7 +12,7 @@
             <td><h5>jmx.server.port</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The port range for the JMX server to start the registry. The port config can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234". <br />This option overrides metrics.reporter.*.port option.</td>
+            <td>The port range for the JMX server to start the registry. The port config can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234". <br />A random port number will be acquired if port config is set to "0". <br />This option overrides metrics.reporter.*.port option.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JMXServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JMXServerOptions.java
@@ -41,7 +41,7 @@ public class JMXServerOptions {
 					"port config can be a single port: \"9123\", a range of ports: \"50100-50200\", " +
 					"or a list of ranges and ports: \"50100-50200,50300-50400,51234\". ")
 				.linebreak()
-				.text("A random port number will be acquired if port config is set to \"0\". ")
+				.text("A random port between 10000-65000 will be acquired if port config is set to \"0\". ")
 				.linebreak()
 				.text("This option overrides metrics.reporter.*.port option.")
 				.build());

--- a/flink-core/src/main/java/org/apache/flink/configuration/JMXServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JMXServerOptions.java
@@ -41,6 +41,8 @@ public class JMXServerOptions {
 					"port config can be a single port: \"9123\", a range of ports: \"50100-50200\", " +
 					"or a list of ranges and ports: \"50100-50200,50300-50400,51234\". ")
 				.linebreak()
+				.text("A random port number will be acquired if port config is set to \"0\". ")
+				.linebreak()
 				.text("This option overrides metrics.reporter.*.port option.")
 				.build());
 

--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -34,9 +34,7 @@ import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Random;
@@ -470,10 +468,10 @@ public class NetUtils {
 		public Integer next() {
 			int port = start + shift + multiple * seed;
 			if (shift + (multiple + 1) * seed > end - start) {
-				shift ++;
+				shift++;
 				multiple = 0;
 			} else {
-				multiple ++;
+				multiple++;
 			}
 			return port;
 		}

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -140,7 +140,7 @@ public class NetUtilsTest extends TestLogger {
 		while (portsIter.hasNext()) {
 			Assert.assertTrue("Duplicate element", ports.add(portsIter.next()));
 		}
-		Assert.assertEquals(65000-10000+1, ports.size());
+		Assert.assertEquals(65000 - 10000 + 1, ports.size());
 
 		// check first range
 		Assert.assertThat(ports, hasItems(50000, 50001, 50002, 50050));

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -121,15 +121,27 @@ public class NetUtilsTest extends TestLogger {
 
 	@Test
 	public void testFreePortRangeUtility() {
+		Iterator<Integer> portsIter;
+		Set<Integer> ports;
+
 		// inspired by Hadoop's example for "yarn.app.mapreduce.am.job.client.port-range"
 		String rangeDefinition = "50000-50050, 50100-50200,51234 "; // this also contains some whitespaces
-		Iterator<Integer> portsIter = NetUtils.getPortRangeFromString(rangeDefinition);
-		Set<Integer> ports = new HashSet<>();
+		portsIter = NetUtils.getPortRangeFromString(rangeDefinition);
+		ports = new HashSet<>();
 		while (portsIter.hasNext()) {
 			Assert.assertTrue("Duplicate element", ports.add(portsIter.next()));
 		}
-
 		Assert.assertEquals(51 + 101 + 1, ports.size());
+
+		// test random port assignment should match NetUtils.DEFAULT_RANDOMIZE_PORT_RANGE
+		String randomDef = "0";
+		portsIter = NetUtils.getPortRangeFromString(randomDef);
+		ports = new HashSet<>();
+		while (portsIter.hasNext()) {
+			Assert.assertTrue("Duplicate element", ports.add(portsIter.next()));
+		}
+		Assert.assertEquals(65000-10000+1, ports.size());
+
 		// check first range
 		Assert.assertThat(ports, hasItems(50000, 50001, 50002, 50050));
 		// check second range and last point

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/management/JMXServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/management/JMXServer.java
@@ -41,9 +41,9 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * JMX Server implementation that JMX clients can connect to.
  *
- * <p>Heavily based on j256 simplejmx project
+ * <p>This implementation is heavily based on j256/simplejmx project.
  *
- * <p>https://github.com/j256/simplejmx/blob/master/src/main/java/com/j256/simplejmx/server/JmxServer.java
+ * @see <a href="https://github.com/j256/simplejmx/blob/master/src/main/java/com/j256/simplejmx/server/JmxServer.java">j256/simplejmx project</a>
  */
 class JMXServer {
 	private static final Logger LOG = LoggerFactory.getLogger(JMXServer.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/management/JMXService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/management/JMXService.java
@@ -25,9 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -106,6 +104,7 @@ public class JMXService {
 		}
 		return successfullyStartedServer;
 	}
+
 	/**
 	 * This method tries to poke for a new port number, then releases it.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/management/JMXService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/management/JMXService.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Iterator;
 import java.util.Optional;
 
@@ -86,9 +85,6 @@ public class JMXService {
 		while (ports.hasNext() && successfullyStartedServer == null) {
 			JMXServer server = new JMXServer();
 			int port = ports.next();
-			if (port == 0) { // try poke with a random port when port is set to zero
-				port = tryPokeForNewPort();
-			}
 			try {
 				server.start(port);
 				LOG.info("Started JMX server on port " + port + ".");
@@ -103,29 +99,5 @@ public class JMXService {
 			}
 		}
 		return successfullyStartedServer;
-	}
-
-	/**
-	 * This method tries to poke for a new port number, then releases it.
-	 *
-	 * @return a successful poked port number.
-	 */
-	private static int tryPokeForNewPort() {
-		ServerSocket serverSocket = null;
-		try {
-			serverSocket = new ServerSocket(0);
-			return serverSocket.getLocalPort();
-		} catch (IOException e) {
-			LOG.warn("Unable to allocate new Server Socket!", e);
-			return -1;
-		} finally {
-			if (serverSocket != null) {
-				try {
-					serverSocket.close();
-				} catch (IOException e) {
-					LOG.warn("Unable to close allocated new Server Socket!", e);
-				}
-			}
-		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/management/JMXServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/management/JMXServiceTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.management;
 
 import org.junit.Test;
 
-import javax.management.JMX;
 import java.net.ServerSocket;
 
 import static org.junit.Assert.assertFalse;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/management/JMXServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/management/JMXServiceTest.java
@@ -20,9 +20,11 @@ package org.apache.flink.runtime.management;
 
 import org.junit.Test;
 
+import javax.management.JMX;
 import java.net.ServerSocket;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -38,6 +40,17 @@ public class JMXServiceTest {
 		try {
 			JMXService.startInstance("23456-23466");
 			assertTrue(JMXService.getPort().isPresent());
+		} finally {
+			JMXService.stopInstance();
+		}
+	}
+
+	@Test
+	public void testJMXServiceInitWithRandomPort() throws Exception {
+		try {
+			JMXService.startInstance("0");
+			assertTrue(JMXService.getPort().isPresent());
+			assertNotEquals(0, JMXService.getPort().get().intValue());
 		} finally {
 			JMXService.stopInstance();
 		}


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes adds support for acquiring random port when JMX server setting is explicitly set to 0.


## Brief change log

  - incorporate random port logic in JMXService.
  - added random port poking utility.


## Verifying this change

- added additional unit-test in JMXServiceTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs.
