### PR TITLE
[FLINK-18963][docs] Introduced IntelliJ subsection about adding a Copyright Profile for the Apache license.                  

### DIFF
--- a/docs/flinkDev/ide_setup.md
+++ b/docs/flinkDev/ide_setup.md
@@ -117,6 +117,32 @@ Nevertheless please make sure that code you add/modify in these modules still co
 
 Enable scalastyle in Intellij by selecting Settings -> Editor -> Inspections, then searching for "Scala style inspections". Also Place `"tools/maven/scalastyle-config.xml"` in the `"<root>/.idea"` or `"<root>/project"` directory.
 
+### Copyright Profile
+
+Each file needs to include the Apache license as a header. This can be automated in IntelliJ by adding a Copyright profile:
+1. Open settings
+2. Go to Editor -> Copyright -> Copyright Profiles
+3. Add a new profile naming it `Apache`
+4. Add the following text as the license text:
+```
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+   
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and 
+limitations under the License.
+```
+5. Apply the changes.
+
 ### FAQ
 
 This section lists issues that developers have run into in the past when working with IntelliJ:

--- a/docs/flinkDev/ide_setup.zh.md
+++ b/docs/flinkDev/ide_setup.zh.md
@@ -117,6 +117,32 @@ Nevertheless please make sure that code you add/modify in these modules still co
 
 Enable scalastyle in Intellij by selecting Settings -> Editor -> Inspections, then searching for "Scala style inspections". Also Place `"tools/maven/scalastyle-config.xml"` in the `"<root>/.idea"` or `"<root>/project"` directory.
 
+### Copyright Profile
+
+Each file needs to include the Apache license as a header. This can be automated in IntelliJ by adding a Copyright profile:
+1. Open settings
+2. Go to Editor -> Copyright -> Copyright Profiles
+3. Add a new profile naming it `Apache`
+4. Add the following text as the license text:
+```
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+   
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and 
+limitations under the License.
+```
+5. Apply the changes.
+
 ### FAQ
 
 This section lists issues that developers have run into in the past when working with IntelliJ:


### PR DESCRIPTION
## What is the purpose of the change

Instruction were added on how to add the Copyright Profile for the Apache license to IntelliJ.

## Brief change log

- Added a subsection to `docs/flinkDev/ide_setup.md` and `docs/flinkDev/idea_setup.zh.md`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
