### PR TITLE
[FLINK-18972][runtime] BulkSlotProviderImpl disables batch slot request timeout check only if it is really in use

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImpl.java
@@ -73,8 +73,6 @@ class BulkSlotProviderImpl implements BulkSlotProvider {
 	@Override
 	public void start(final ComponentMainThreadExecutor mainThreadExecutor) {
 		this.componentMainThreadExecutor = mainThreadExecutor;
-
-		slotPool.disableBatchSlotRequestTimeoutCheck();
 	}
 
 	@Override
@@ -166,6 +164,7 @@ class BulkSlotProviderImpl implements BulkSlotProvider {
 		if (willSlotBeOccupiedIndefinitely) {
 			return slotPool.requestNewAllocatedSlot(slotRequestId, resourceProfile, null);
 		} else {
+			slotPool.disableBatchSlotRequestTimeoutCheck();
 			return slotPool.requestNewAllocatedBatchSlot(slotRequestId, resourceProfile);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotProviderImplTest.java
@@ -185,8 +185,19 @@ public class BulkSlotProviderImplTest extends TestLogger {
 	}
 
 	@Test
-	public void testIndividualBatchSlotRequestTimeoutCheckIsDisabled() {
+	public void testIndividualBatchSlotRequestTimeoutCheckIsDisabledOnAllocatingNewSlots() {
+		assertThat(slotPool.isBatchSlotRequestTimeoutCheckEnabled(), is(true));
+
+		allocateSlots(Collections.singletonList(createPhysicalSlotRequest()));
+
+		// drain the main thread tasks to ensure BulkSlotProviderImpl#requestNewSlot() to have been invoked
+		drainMainThreadExecutorTasks();
+
 		assertThat(slotPool.isBatchSlotRequestTimeoutCheckEnabled(), is(false));
+	}
+
+	private static void drainMainThreadExecutorTasks() {
+		CompletableFuture.runAsync(() -> {}, mainThreadExecutor).join();
 	}
 
 	private void addSlotToSlotPool() {
@@ -209,6 +220,6 @@ public class BulkSlotProviderImplTest extends TestLogger {
 		return new PhysicalSlotRequest(
 			new SlotRequestId(),
 			SlotProfile.noLocality(ResourceProfile.UNKNOWN),
-			true);
+			false);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The unfulfillability check of batch slot requests are unconditionally disabled in SchedulerImpl#start() -> BulkSlotProviderImpl#start().
This means slot allocation timeout will not be triggered if a Blink planner batch job cannot obtain any slot.
This PR changed BulkSlotProviderImpl to disable batch slot request timeout check only if it is really in use.

## Verifying this change

  - *Added unit tests BulkSlotProviderImplTest#testIndividualBatchSlotRequestTimeoutCheckIsDisabledOnAllocatingNewSlots*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
