### PR TITLE
[FLINK-18955][Checkpointing] Add checkpoint path to job startup/restore message

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1293,7 +1293,7 @@ public class CheckpointCoordinator {
 				}
 			}
 
-			LOG.info("Restoring job {} from latest valid checkpoint: {}.", job, latest);
+			LOG.info("Restoring job {} from {}.", job, latest);
 
 			// re-assign the task states
 			final Map<OperatorID, OperatorState> operatorStates = latest.getOperatorStates();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
@@ -24,24 +24,28 @@ package org.apache.flink.runtime.checkpoint;
 public enum CheckpointType {
 
 	/** A checkpoint, full or incremental. */
-	CHECKPOINT(false, false),
+	CHECKPOINT(false, false, "Checkpoint"),
 
 	/** A regular savepoint. */
-	SAVEPOINT(true, false),
+	SAVEPOINT(true, false, "Savepoint"),
 
 	/** A savepoint taken while suspending/terminating the job. */
-	SYNC_SAVEPOINT(true, true);
+	SYNC_SAVEPOINT(true, true, "Synchronous Savepoint");
 
 	private final boolean isSavepoint;
 
 	private final boolean isSynchronous;
 
+	private final String name;
+
 	CheckpointType(
 			final boolean isSavepoint,
-			final boolean isSynchronous) {
+			final boolean isSynchronous,
+			final String name) {
 
 		this.isSavepoint = isSavepoint;
 		this.isSynchronous = isSynchronous;
+		this.name = name;
 	}
 
 	public boolean isSavepoint() {
@@ -50,5 +54,9 @@ public enum CheckpointType {
 
 	public boolean isSynchronous() {
 		return isSynchronous;
+	}
+
+	public String getName() {
+		return name;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -320,6 +320,12 @@ public class CompletedCheckpoint implements Serializable {
 
 	@Override
 	public String toString() {
-		return String.format("Checkpoint %d @ %d for %s", checkpointID, timestamp, job);
+		return String.format(
+			"%s %d @ %d for %s located at %s",
+			props.getCheckpointType().getName(),
+			checkpointID,
+			timestamp,
+			job,
+			externalPointer);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Add checkpoint path to job startup/restore message to help users identify which checkpoint is used for restoring.

## Brief change log
- add `externalPointer` to the message


## Verifying this change

Test Msg like this:
Test:

It produces something similar to:

```
8366 [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator [] - Restoring job 7aec7905c64fcf38ceb2b86e6193638d from CHECKPOINT 1 @ 1597898260536 for 7aec7905c64fcf38ceb2b86e6193638d located at file:/var/folders/dm/5xn_h6n9135dwy4j27sr65zh0000gp/T/junit495383509976337357/junit8019506371853310216/checkpoints/7aec7905c64fcf38ceb2b86e6193638d/chk-1.
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)



