### PR TITLE
[FLINK-18977][datastream] Extract WindowOperator construction into a builder class

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -24,56 +24,27 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.FoldFunction;
-import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichFunction;
-import org.apache.flink.api.common.state.AggregatingStateDescriptor;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.Utils;
-import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
 import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
 import org.apache.flink.streaming.api.functions.aggregation.SumAggregator;
-import org.apache.flink.streaming.api.functions.windowing.AggregateApplyWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.FoldApplyProcessWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.FoldApplyWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.PassThroughWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.ReduceApplyProcessWindowFunction;
-import org.apache.flink.streaming.api.functions.windowing.ReduceApplyWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.api.windowing.assigners.BaseAlignedWindowAssigner;
-import org.apache.flink.streaming.api.windowing.assigners.MergingWindowAssigner;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.evictors.Evictor;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.Trigger;
 import org.apache.flink.streaming.api.windowing.windows.Window;
-import org.apache.flink.streaming.runtime.operators.windowing.EvictingWindowOperator;
-import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalAggregateProcessWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableProcessWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueProcessWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueWindowFunction;
-import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
-import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorBuilder;
 import org.apache.flink.util.OutputTag;
-import org.apache.flink.util.Preconditions;
 
-import javax.annotation.Nullable;
-
-import java.lang.reflect.Type;
-
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -104,30 +75,23 @@ public class WindowedStream<T, K, W extends Window> {
 	/** The keyed data stream that is windowed by this stream. */
 	private final KeyedStream<T, K> input;
 
-	/** The window assigner. */
-	private final WindowAssigner<? super T, W> windowAssigner;
-
-	/** The trigger that is used for window evaluation/emission. */
-	private Trigger<? super T, ? super W> trigger;
-
-	/** The evictor that is used for evicting elements before window evaluation. */
-	private Evictor<? super T, ? super W> evictor;
-
-	/** The user-specified allowed lateness. */
-	private long allowedLateness = 0L;
-
-	/**
-	 * Side output {@code OutputTag} for late data. If no tag is set late data will simply be
-	 * dropped.
- 	 */
-	private OutputTag<T> lateDataOutputTag;
+	private final WindowOperatorBuilder<T, K, W> builder;
 
 	@PublicEvolving
-	public WindowedStream(KeyedStream<T, K> input,
-			WindowAssigner<? super T, W> windowAssigner) {
+	public WindowedStream(
+		KeyedStream<T, K> input,
+		WindowAssigner<? super T, W> windowAssigner) {
+
 		this.input = input;
-		this.windowAssigner = windowAssigner;
-		this.trigger = windowAssigner.getDefaultTrigger(input.getExecutionEnvironment());
+
+		this.builder = new WindowOperatorBuilder<>(
+			windowAssigner,
+			windowAssigner.getDefaultTrigger(input.getExecutionEnvironment()),
+			input.getExecutionConfig(),
+			input.getType(),
+			input.getKeySelector(),
+			input.getKeyType()
+		);
 	}
 
 	/**
@@ -135,15 +99,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> trigger(Trigger<? super T, ? super W> trigger) {
-		if (windowAssigner instanceof MergingWindowAssigner && !trigger.canMerge()) {
-			throw new UnsupportedOperationException("A merging window assigner cannot be used with a trigger that does not support merging.");
-		}
-
-		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
-			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with a custom trigger.");
-		}
-
-		this.trigger = trigger;
+		builder.trigger(trigger);
 		return this;
 	}
 
@@ -156,10 +112,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> allowedLateness(Time lateness) {
-		final long millis = lateness.toMilliseconds();
-		checkArgument(millis >= 0, "The allowed lateness cannot be negative.");
-
-		this.allowedLateness = millis;
+		builder.allowedLateness(lateness);
 		return this;
 	}
 
@@ -175,8 +128,8 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> sideOutputLateData(OutputTag<T> outputTag) {
-		Preconditions.checkNotNull(outputTag, "Side output tag must not be null.");
-		this.lateDataOutputTag = input.getExecutionEnvironment().clean(outputTag);
+		outputTag = input.getExecutionEnvironment().clean(outputTag);
+		builder.sideOutputLateData(outputTag);
 		return this;
 	}
 
@@ -188,10 +141,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> evictor(Evictor<? super T, ? super W> evictor) {
-		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
-			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with an Evictor.");
-		}
-		this.evictor = evictor;
+		builder.evictor(evictor);
 		return this;
 	}
 
@@ -224,7 +174,7 @@ public class WindowedStream<T, K, W extends Window> {
 
 		//clean the closure
 		function = input.getExecutionEnvironment().clean(function);
-		return reduce(function, new PassThroughWindowFunction<K, W, T>());
+		return reduce(function, new PassThroughWindowFunction<>());
 	}
 
 	/**
@@ -239,8 +189,8 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
 	public <R> SingleOutputStreamOperator<R> reduce(
-			ReduceFunction<T> reduceFunction,
-			WindowFunction<T, R, K, W> function) {
+		ReduceFunction<T> reduceFunction,
+		WindowFunction<T, R, K, W> function) {
 
 		TypeInformation<T> inType = input.getType();
 		TypeInformation<R> resultType = getWindowFunctionReturnType(function, inType);
@@ -260,60 +210,17 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
 	public <R> SingleOutputStreamOperator<R> reduce(
-			ReduceFunction<T> reduceFunction,
-			WindowFunction<T, R, K, W> function,
-			TypeInformation<R> resultType) {
-
-		if (reduceFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("ReduceFunction of reduce can not be a RichFunction.");
-		}
+		ReduceFunction<T> reduceFunction,
+		WindowFunction<T, R, K, W> function,
+		TypeInformation<R> resultType) {
 
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, reduceFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(reduceFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-				(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-				new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-				new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
-				reduceFunction,
-				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-				new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueWindowFunction<>(function),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
-
+		OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 		return input.transform(opName, resultType, operator);
 	}
 
@@ -351,54 +258,12 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@Internal
 	public <R> SingleOutputStreamOperator<R> reduce(ReduceFunction<T> reduceFunction, ProcessWindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
-		if (reduceFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
-		}
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, reduceFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
-
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-					new EvictingWindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalIterableProcessWindowFunction<>(new ReduceApplyProcessWindowFunction<>(reduceFunction, function)),
-							trigger,
-							evictor,
-							allowedLateness,
-							lateDataOutputTag);
-
-		} else {
-			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
-					reduceFunction,
-					input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-					new WindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalSingleValueProcessWindowFunction<>(function),
-							trigger,
-							allowedLateness,
-							lateDataOutputTag);
-		}
+		final String opName = builder.generateOperatorName(reduceFunction, function);
+		OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -425,7 +290,7 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		TypeInformation<R> resultType = TypeExtractor.getFoldReturnTypes(function, input.getType(),
-				Utils.getCallLocationName(), true);
+			Utils.getCallLocationName(), true);
 
 		return fold(initialValue, function, resultType);
 	}
@@ -447,7 +312,7 @@ public class WindowedStream<T, K, W extends Window> {
 				"Please use fold(FoldFunction, WindowFunction) instead.");
 		}
 
-		return fold(initialValue, function, new PassThroughWindowFunction<K, W, R>(), resultType, resultType);
+		return fold(initialValue, function, new PassThroughWindowFunction<>(), resultType, resultType);
 	}
 
 	/**
@@ -494,65 +359,20 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	@Deprecated
-	public <ACC, R> SingleOutputStreamOperator<R> fold(ACC initialValue,
-			FoldFunction<T, ACC> foldFunction,
-			WindowFunction<ACC, R, K, W> function,
-			TypeInformation<ACC> foldAccumulatorType,
-			TypeInformation<R> resultType) {
-		if (foldFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("FoldFunction of fold can not be a RichFunction.");
-		}
-		if (windowAssigner instanceof MergingWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
-		}
-
-		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a " +
-				windowAssigner.getClass().getSimpleName() + " assigner.");
-		}
+	public <ACC, R> SingleOutputStreamOperator<R> fold(
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		WindowFunction<ACC, R, K, W> function,
+		TypeInformation<ACC> foldAccumulatorType,
+		TypeInformation<R> resultType) {
 
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		foldFunction = input.getExecutionEnvironment().clean(foldFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, foldFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(foldFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-				(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-				new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, foldAccumulatorType)),
-				trigger,
-				evictor,
-				allowedLateness,
-				lateDataOutputTag);
-
-		} else {
-			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>("window-contents",
-				initialValue, foldFunction, foldAccumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalSingleValueWindowFunction<>(function),
-				trigger,
-				allowedLateness,
-				lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.fold(initialValue, foldFunction, function, foldAccumulatorType);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -580,7 +400,7 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		TypeInformation<ACC> foldResultType = TypeExtractor.getFoldReturnTypes(foldFunction, input.getType(),
-				Utils.getCallLocationName(), true);
+			Utils.getCallLocationName(), true);
 
 		TypeInformation<R> windowResultType = getProcessWindowFunctionReturnType(windowFunction, foldResultType, Utils.getCallLocationName());
 
@@ -606,64 +426,18 @@ public class WindowedStream<T, K, W extends Window> {
 	@Deprecated
 	@Internal
 	public <R, ACC> SingleOutputStreamOperator<R> fold(
-			ACC initialValue,
-			FoldFunction<T, ACC> foldFunction,
-			ProcessWindowFunction<ACC, R, K, W> windowFunction,
-			TypeInformation<ACC> foldResultType,
-			TypeInformation<R> windowResultType) {
-		if (foldFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("FoldFunction can not be a RichFunction.");
-		}
-		if (windowAssigner instanceof MergingWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
-		}
-
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		ProcessWindowFunction<ACC, R, K, W> windowFunction,
+		TypeInformation<ACC> foldResultType,
+		TypeInformation<R> windowResultType) {
 		//clean the closures
 		windowFunction = input.getExecutionEnvironment().clean(windowFunction);
 		foldFunction = input.getExecutionEnvironment().clean(foldFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, foldFunction, windowFunction);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(foldFunction, windowFunction);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-					new EvictingWindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalIterableProcessWindowFunction<>(new FoldApplyProcessWindowFunction<>(initialValue, foldFunction, windowFunction, foldResultType)),
-							trigger,
-							evictor,
-							allowedLateness,
-							lateDataOutputTag);
-
-		} else {
-			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>("window-contents",
-					initialValue,
-					foldFunction,
-					foldResultType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-					new WindowOperator<>(windowAssigner,
-							windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-							keySel,
-							input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-							stateDesc,
-							new InternalSingleValueProcessWindowFunction<>(windowFunction),
-							trigger,
-							allowedLateness,
-							lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.fold(initialValue, foldFunction, windowFunction, foldResultType);
 
 		return input.transform(opName, windowResultType, operator);
 	}
@@ -693,10 +467,10 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
-				function, input.getType(), null, false);
+			function, input.getType(), null, false);
 
 		TypeInformation<R> resultType = TypeExtractor.getAggregateFunctionReturnType(
-				function, input.getType(), null, false);
+			function, input.getType(), null, false);
 
 		return aggregate(function, accumulatorType, resultType);
 	}
@@ -715,9 +489,9 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, R> function,
-			TypeInformation<ACC> accumulatorType,
-			TypeInformation<R> resultType) {
+		AggregateFunction<T, ACC, R> function,
+		TypeInformation<ACC> accumulatorType,
+		TypeInformation<R> resultType) {
 
 		checkNotNull(function, "function");
 		checkNotNull(accumulatorType, "accumulatorType");
@@ -727,7 +501,7 @@ public class WindowedStream<T, K, W extends Window> {
 			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
 		}
 
-		return aggregate(function, new PassThroughWindowFunction<K, W, R>(),
+		return aggregate(function, new PassThroughWindowFunction<>(),
 			accumulatorType, resultType);
 	}
 
@@ -751,17 +525,17 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggFunction,
-			WindowFunction<V, R, K, W> windowFunction) {
+		AggregateFunction<T, ACC, V> aggFunction,
+		WindowFunction<V, R, K, W> windowFunction) {
 
 		checkNotNull(aggFunction, "aggFunction");
 		checkNotNull(windowFunction, "windowFunction");
 
 		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<V> aggResultType = TypeExtractor.getAggregateFunctionReturnType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<R> resultType = getWindowFunctionReturnType(windowFunction, aggResultType);
 
@@ -790,10 +564,10 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggregateFunction,
-			WindowFunction<V, R, K, W> windowFunction,
-			TypeInformation<ACC> accumulatorType,
-			TypeInformation<R> resultType) {
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		WindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType,
+		TypeInformation<R> resultType) {
 
 		checkNotNull(aggregateFunction, "aggregateFunction");
 		checkNotNull(windowFunction, "windowFunction");
@@ -808,44 +582,9 @@ public class WindowedStream<T, K, W extends Window> {
 		windowFunction = input.getExecutionEnvironment().clean(windowFunction);
 		aggregateFunction = input.getExecutionEnvironment().clean(aggregateFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, aggregateFunction, windowFunction);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(aggregateFunction, windowFunction);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalIterableWindowFunction<>(new AggregateApplyWindowFunction<>(aggregateFunction, windowFunction)),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
-					aggregateFunction, accumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueWindowFunction<>(windowFunction),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -870,17 +609,17 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggFunction,
-			ProcessWindowFunction<V, R, K, W> windowFunction) {
+		AggregateFunction<T, ACC, V> aggFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction) {
 
 		checkNotNull(aggFunction, "aggFunction");
 		checkNotNull(windowFunction, "windowFunction");
 
 		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<V> aggResultType = TypeExtractor.getAggregateFunctionReturnType(
-				aggFunction, input.getType(), null, false);
+			aggFunction, input.getType(), null, false);
 
 		TypeInformation<R> resultType = getProcessWindowFunctionReturnType(windowFunction, aggResultType, null);
 
@@ -902,9 +641,9 @@ public class WindowedStream<T, K, W extends Window> {
 	}
 
 	private static <IN, OUT, KEY> TypeInformation<OUT> getProcessWindowFunctionReturnType(
-			ProcessWindowFunction<IN, OUT, KEY, ?> function,
-			TypeInformation<IN> inType,
-			String functionName) {
+		ProcessWindowFunction<IN, OUT, KEY, ?> function,
+		TypeInformation<IN> inType,
+		String functionName) {
 		return TypeExtractor.getUnaryOperatorReturnType(
 			function,
 			ProcessWindowFunction.class,
@@ -938,11 +677,11 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@PublicEvolving
 	public <ACC, V, R> SingleOutputStreamOperator<R> aggregate(
-			AggregateFunction<T, ACC, V> aggregateFunction,
-			ProcessWindowFunction<V, R, K, W> windowFunction,
-			TypeInformation<ACC> accumulatorType,
-			TypeInformation<V> aggregateResultType,
-			TypeInformation<R> resultType) {
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType,
+		TypeInformation<V> aggregateResultType,
+		TypeInformation<R> resultType) {
 
 		checkNotNull(aggregateFunction, "aggregateFunction");
 		checkNotNull(windowFunction, "windowFunction");
@@ -958,44 +697,9 @@ public class WindowedStream<T, K, W extends Window> {
 		windowFunction = input.getExecutionEnvironment().clean(windowFunction);
 		aggregateFunction = input.getExecutionEnvironment().clean(aggregateFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, aggregateFunction, windowFunction);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(aggregateFunction, windowFunction);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalAggregateProcessWindowFunction<>(aggregateFunction, windowFunction),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
-					aggregateFunction, accumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueProcessWindowFunction<>(windowFunction),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -1035,7 +739,11 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	public <R> SingleOutputStreamOperator<R> apply(WindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
 		function = input.getExecutionEnvironment().clean(function);
-		return apply(new InternalIterableWindowFunction<>(function), resultType, function);
+
+		final String opName = builder.generateOperatorName(function, null);
+		OneInputStreamOperator<T, R> operator = builder.apply(function);
+
+		return input.transform(opName, resultType, operator);
 	}
 
 	/**
@@ -1071,51 +779,10 @@ public class WindowedStream<T, K, W extends Window> {
 	@Internal
 	public <R> SingleOutputStreamOperator<R> process(ProcessWindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
 		function = input.getExecutionEnvironment().clean(function);
-		return apply(new InternalIterableProcessWindowFunction<>(function), resultType, function);
-	}
 
-	private <R> SingleOutputStreamOperator<R> apply(InternalWindowFunction<Iterable<T>, R, K, W> function, TypeInformation<R> resultType, Function originalFunction) {
+		final String opName = builder.generateOperatorName(function, null);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, originalFunction, null);
-		KeySelector<T, K> keySel = input.getKeySelector();
-
-		WindowOperator<K, T, Iterable<T>, R, W> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-				new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					function,
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>("window-contents",
-				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-				new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					function,
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.process(function);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -1157,55 +824,13 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@Deprecated
 	public <R> SingleOutputStreamOperator<R> apply(ReduceFunction<T> reduceFunction, WindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
-		if (reduceFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
-		}
-
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, reduceFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(reduceFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator =
-				new EvictingWindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)),
-					trigger,
-					evictor,
-					allowedLateness,
-					lateDataOutputTag);
-
-		} else {
-			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
-				reduceFunction,
-				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator =
-				new WindowOperator<>(windowAssigner,
-					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-					keySel,
-					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-					stateDesc,
-					new InternalSingleValueWindowFunction<>(function),
-					trigger,
-					allowedLateness,
-					lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 
 		return input.transform(opName, resultType, operator);
 	}
@@ -1250,91 +875,15 @@ public class WindowedStream<T, K, W extends Window> {
 	 */
 	@Deprecated
 	public <R> SingleOutputStreamOperator<R> apply(R initialValue, FoldFunction<T, R> foldFunction, WindowFunction<R, R, K, W> function, TypeInformation<R> resultType) {
-		if (foldFunction instanceof RichFunction) {
-			throw new UnsupportedOperationException("FoldFunction of apply can not be a RichFunction.");
-		}
-		if (windowAssigner instanceof MergingWindowAssigner) {
-			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
-		}
-
 		//clean the closures
 		function = input.getExecutionEnvironment().clean(function);
 		foldFunction = input.getExecutionEnvironment().clean(foldFunction);
 
-		final String opName = generateOperatorName(windowAssigner, trigger, evictor, foldFunction, function);
-		KeySelector<T, K> keySel = input.getKeySelector();
+		final String opName = builder.generateOperatorName(foldFunction, function);
 
-		OneInputStreamOperator<T, R> operator;
-
-		if (evictor != null) {
-			@SuppressWarnings({"unchecked", "rawtypes"})
-			TypeSerializer<StreamRecord<T>> streamRecordSerializer =
-					(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			ListStateDescriptor<StreamRecord<T>> stateDesc =
-					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			operator = new EvictingWindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, resultType)),
-				trigger,
-				evictor,
-				allowedLateness,
-				lateDataOutputTag);
-
-		} else {
-			FoldingStateDescriptor<T, R> stateDesc = new FoldingStateDescriptor<>("window-contents",
-				initialValue, foldFunction, resultType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			operator = new WindowOperator<>(windowAssigner,
-				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
-				keySel,
-				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
-				stateDesc,
-				new InternalSingleValueWindowFunction<>(function),
-				trigger,
-				allowedLateness,
-				lateDataOutputTag);
-		}
+		OneInputStreamOperator<T, R> operator = builder.fold(initialValue, foldFunction, function, resultType);
 
 		return input.transform(opName, resultType, operator);
-	}
-
-	private static String generateFunctionName(Function function) {
-		Class<? extends Function> functionClass = function.getClass();
-		if (functionClass.isAnonymousClass()) {
-			// getSimpleName returns an empty String for anonymous classes
-			Type[] interfaces = functionClass.getInterfaces();
-			if (interfaces.length == 0) {
-				// extends an existing class (like RichMapFunction)
-				Class<?> functionSuperClass = functionClass.getSuperclass();
-				return functionSuperClass.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
-			} else {
-				// implements a Function interface
-				Class<?> functionInterface = functionClass.getInterfaces()[0];
-				return functionInterface.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
-			}
-		} else {
-			return functionClass.getSimpleName();
-		}
-	}
-
-	private static String generateOperatorName(
-			WindowAssigner<?, ?> assigner,
-			Trigger<?, ?> trigger,
-			@Nullable Evictor<?, ?> evictor,
-			Function function1,
-			@Nullable Function function2) {
-		return "Window(" +
-			assigner + ", " +
-			trigger.getClass().getSimpleName() + ", " +
-			(evictor == null ? "" : (evictor.getClass().getSimpleName() + ", ")) +
-			generateFunctionName(function1) +
-			(function2 == null ? "" : (", " + generateFunctionName(function2))) +
-			")";
 	}
 
 	// ------------------------------------------------------------------------
@@ -1543,6 +1092,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 	@VisibleForTesting
 	long getAllowedLateness() {
-		return allowedLateness;
+		return builder.getAllowedLateness();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorBuilder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorBuilder.java
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.functions.windowing.AggregateApplyWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.FoldApplyProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.FoldApplyWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ReduceApplyProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ReduceApplyWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.BaseAlignedWindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.MergingWindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalAggregateProcessWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableProcessWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueProcessWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Type;
+
+/**
+ * A builder for creating {@code WindowOperator}'s.
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <T> The type of the incoming elements.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public class WindowOperatorBuilder<T, K, W extends Window> {
+
+	private static final String WINDOW_STATE_NAME = "window-contents";
+
+	private final ExecutionConfig config;
+
+	private final WindowAssigner<? super T, W> windowAssigner;
+
+	private final TypeInformation<T> inputType;
+
+	private final KeySelector<T, K> keySelector;
+
+	private final TypeInformation<K> keyType;
+
+	private Trigger<? super T, ? super W> trigger;
+
+	@Nullable
+	private Evictor<? super T, ? super W> evictor;
+
+	private long allowedLateness = 0L;
+
+	@Nullable
+	private OutputTag<T> lateDataOutputTag;
+
+	public WindowOperatorBuilder(
+		WindowAssigner<? super T, W> windowAssigner,
+		Trigger<? super T, ? super W> trigger,
+		ExecutionConfig config,
+		TypeInformation<T> inputType,
+		KeySelector<T, K> keySelector,
+		TypeInformation<K> keyType) {
+		this.windowAssigner = windowAssigner;
+		this.config = config;
+		this.inputType = inputType;
+		this.keySelector = keySelector;
+		this.keyType = keyType;
+		this.trigger = trigger;
+	}
+
+	public void trigger(Trigger<? super T, ? super W> trigger) {
+		Preconditions.checkNotNull(trigger, "Window triggers cannot be null");
+
+		if (windowAssigner instanceof MergingWindowAssigner && !trigger.canMerge()) {
+			throw new UnsupportedOperationException("A merging window assigner cannot be used with a trigger that does not support merging.");
+		}
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with a custom trigger.");
+		}
+
+		this.trigger = trigger;
+	}
+
+	public void allowedLateness(Time lateness) {
+		Preconditions.checkNotNull(lateness, "Allowed lateness cannot be null");
+
+		final long millis = lateness.toMilliseconds();
+		Preconditions.checkArgument(millis >= 0, "The allowed lateness cannot be negative.");
+
+		this.allowedLateness = millis;
+	}
+
+	public void sideOutputLateData(OutputTag<T> outputTag) {
+		Preconditions.checkNotNull(outputTag, "Side output tag must not be null.");
+		this.lateDataOutputTag = outputTag;
+	}
+
+	public void evictor(Evictor<? super T, ? super W> evictor) {
+		Preconditions.checkNotNull(evictor, "Evictor cannot be null");
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Cannot use a " + windowAssigner.getClass().getSimpleName() + " with an Evictor.");
+		}
+		this.evictor = evictor;
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> reduce(ReduceFunction<T> reduceFunction, WindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(reduceFunction, "ReduceFunction cannot be null");
+		Preconditions.checkNotNull(function, "WindowFunction cannot be null");
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)));
+		} else {
+			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>(WINDOW_STATE_NAME, reduceFunction, inputType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueWindowFunction<>(function));
+		}
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> reduce(ReduceFunction<T> reduceFunction, ProcessWindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(reduceFunction, "ReduceFunction cannot be null");
+		Preconditions.checkNotNull(function, "ProcessWindowFunction cannot be null");
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of apply can not be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableProcessWindowFunction<>(new ReduceApplyProcessWindowFunction<>(reduceFunction, function)));
+		} else {
+			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>(WINDOW_STATE_NAME, reduceFunction, inputType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueProcessWindowFunction<>(function));
+		}
+	}
+
+	@Deprecated
+	public <ACC, R> WindowOperator<K, T, ?, R, W> fold(
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		WindowFunction<ACC, R, K, W> function,
+		TypeInformation<ACC> foldAccumulatorType) {
+
+		Preconditions.checkNotNull(foldAccumulatorType, "FoldFunction cannot be null");
+		Preconditions.checkNotNull(function, "WindowFunction cannot be null");
+
+		if (foldFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("FoldFunction of fold can not be a RichFunction.");
+		}
+		if (windowAssigner instanceof MergingWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
+		}
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a " +
+				windowAssigner.getClass().getSimpleName() + " assigner.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, foldAccumulatorType)));
+		} else {
+			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>(WINDOW_STATE_NAME,
+				initialValue, foldFunction, foldAccumulatorType.createSerializer(config));
+			return buildWindowOperator(stateDesc, new InternalSingleValueWindowFunction<>(function));
+		}
+	}
+
+	@Deprecated
+	public <ACC, R> WindowOperator<K, T, ?, R, W> fold(
+		ACC initialValue,
+		FoldFunction<T, ACC> foldFunction,
+		ProcessWindowFunction<ACC, R, K, W> windowFunction,
+		TypeInformation<ACC> foldAccumulatorType) {
+
+		Preconditions.checkNotNull(foldAccumulatorType, "FoldFunction cannot be null");
+		Preconditions.checkNotNull(windowFunction, "ProcessWindowFunction cannot be null");
+
+		if (foldFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("FoldFunction of fold can not be a RichFunction.");
+		}
+		if (windowAssigner instanceof MergingWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a merging WindowAssigner.");
+		}
+
+		if (windowAssigner instanceof BaseAlignedWindowAssigner) {
+			throw new UnsupportedOperationException("Fold cannot be used with a " +
+				windowAssigner.getClass().getSimpleName() + " assigner.");
+		}
+
+		if (evictor != null) {
+			InternalIterableProcessWindowFunction<T, R, K, W> internalFunction = new InternalIterableProcessWindowFunction<>(
+				new FoldApplyProcessWindowFunction<>(initialValue, foldFunction, windowFunction, foldAccumulatorType));
+			return buildEvictingWindowOperator(internalFunction);
+		} else {
+			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>(WINDOW_STATE_NAME,
+				initialValue, foldFunction, foldAccumulatorType.createSerializer(config));
+			return buildWindowOperator(stateDesc, new InternalSingleValueProcessWindowFunction<>(windowFunction));
+		}
+	}
+
+	public <ACC, V, R> WindowOperator<K, T, ?, R, W> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		WindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		Preconditions.checkNotNull(aggregateFunction, "AggregateFunction cannot be null");
+		Preconditions.checkNotNull(windowFunction, "WindowFunction cannot be null");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalIterableWindowFunction<>(new AggregateApplyWindowFunction<>(aggregateFunction, windowFunction)));
+		} else {
+			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>(WINDOW_STATE_NAME,
+				aggregateFunction, accumulatorType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueWindowFunction<>(windowFunction));
+		}
+	}
+
+	public <ACC, V, R> WindowOperator<K, T, ?, R, W> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		Preconditions.checkNotNull(aggregateFunction, "AggregateFunction cannot be null");
+		Preconditions.checkNotNull(windowFunction, "ProcessWindowFunction cannot be null");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		if (evictor != null) {
+			return buildEvictingWindowOperator(new InternalAggregateProcessWindowFunction<>(aggregateFunction, windowFunction));
+		} else {
+			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>(WINDOW_STATE_NAME,
+				aggregateFunction, accumulatorType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, new InternalSingleValueProcessWindowFunction<>(windowFunction));
+		}
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> apply(WindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(function, "WindowFunction cannot be null");
+		return apply(new InternalIterableWindowFunction<>(function));
+	}
+
+	public <R> WindowOperator<K, T, ?, R, W> process(ProcessWindowFunction<T, R, K, W> function) {
+		Preconditions.checkNotNull(function, "ProcessWindowFunction cannot be null");
+		return apply(new InternalIterableProcessWindowFunction<>(function));
+	}
+
+	private  <R> WindowOperator<K, T, ?, R, W> apply(InternalWindowFunction<Iterable<T>, R, K, W> function) {
+		if (evictor != null) {
+			return buildEvictingWindowOperator(function);
+		} else {
+			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>(WINDOW_STATE_NAME, inputType.createSerializer(config));
+
+			return buildWindowOperator(stateDesc, function);
+		}
+	}
+
+	private <ACC, R> WindowOperator<K, T, ACC, R, W> buildWindowOperator(
+		StateDescriptor<? extends AppendingState<T, ACC>, ?> stateDesc,
+		InternalWindowFunction<ACC, R, K, W> function) {
+
+		return new WindowOperator<>(
+			windowAssigner,
+			windowAssigner.getWindowSerializer(config),
+			keySelector,
+			keyType.createSerializer(config),
+			stateDesc,
+			function,
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+	}
+
+	private <R> WindowOperator<K, T, Iterable<T>, R, W> buildEvictingWindowOperator(InternalWindowFunction<Iterable<T>, R, K, W> function) {
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<T>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(inputType.createSerializer(config));
+
+		ListStateDescriptor<StreamRecord<T>> stateDesc = new ListStateDescriptor<>(WINDOW_STATE_NAME, streamRecordSerializer);
+
+		return new EvictingWindowOperator<>(windowAssigner,
+			windowAssigner.getWindowSerializer(config),
+			keySelector,
+			keyType.createSerializer(config),
+			stateDesc,
+			function,
+			trigger,
+			evictor,
+			allowedLateness,
+			lateDataOutputTag);
+	}
+
+	private static String generateFunctionName(Function function) {
+		Class<? extends Function> functionClass = function.getClass();
+		if (functionClass.isAnonymousClass()) {
+			// getSimpleName returns an empty String for anonymous classes
+			Type[] interfaces = functionClass.getInterfaces();
+			if (interfaces.length == 0) {
+				// extends an existing class (like RichMapFunction)
+				Class<?> functionSuperClass = functionClass.getSuperclass();
+				return functionSuperClass.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
+			} else {
+				// implements a Function interface
+				Class<?> functionInterface = functionClass.getInterfaces()[0];
+				return functionInterface.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
+			}
+		} else {
+			return functionClass.getSimpleName();
+		}
+	}
+
+	public String generateOperatorName(Function function1, @Nullable Function function2) {
+		return "Window(" +
+			windowAssigner + ", " +
+			trigger.getClass().getSimpleName() + ", " +
+			(evictor == null ? "" : (evictor.getClass().getSimpleName() + ", ")) +
+			generateFunctionName(function1) +
+			(function2 == null ? "" : (", " + generateFunctionName(function2))) +
+			")";
+	}
+
+	@VisibleForTesting
+	public long getAllowedLateness() {
+		return allowedLateness;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Extracts the logic from WindowedStream into a builder class so that there is one definitive way to create and configure the window operator. This is a pre-requisite to supporting the window operator in the state processor api. 

## Verifying this change

This change is a trivial rework / code cleanup without any new test coverage, however, I did execute the end 2 end tests as additional verification. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
