### PR TITLE
[FLINK-18962][checkpointing] Improve logging when checkpoint declined

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -387,6 +387,7 @@ function check_logs_for_exceptions {
    | grep -v  "WARN  org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline" \
    | grep -v 'INFO.*AWSErrorCode' \
    | grep -v "RejectedExecutionException" \
+   | grep -v "CancellationException" \
    | grep -v "An exception was thrown by an exception handler" \
    | grep -v "Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.yarn.exceptions.YarnException" \
    | grep -v "Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.conf.Configuration" \

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -367,7 +367,7 @@ function check_logs_for_errors {
       | grep -ic "error" || true)
   if [[ ${error_count} -gt 0 ]]; then
     echo "Found error in log files; printing first 500 lines; see full logs for details:"
-    find $FLINK_DIR/log/ -exec head -n 500 {} \;
+    find $FLINK_DIR/log/ -type f -exec head -n 500 {} \;
     EXIT_CODE=1
   else
     echo "No errors in log files."
@@ -404,7 +404,7 @@ function check_logs_for_exceptions {
    | grep -ic "exception" || true)
   if [[ ${exception_count} -gt 0 ]]; then
     echo "Found exception in log files; printing first 500 lines; see full logs for details:"
-    find $FLINK_DIR/log/ -exec head -n 500 {} \;
+    find $FLINK_DIR/log/ -type f -exec head -n 500 {} \;
     EXIT_CODE=1
   else
     echo "No exceptions in log files."
@@ -426,7 +426,7 @@ function check_logs_for_non_empty_out_files {
    | grep "." \
    > /dev/null; then
     echo "Found non-empty .out files; printing first 500 lines; see full logs for details:"
-    find $FLINK_DIR/log/ -name '*.out' -exec head -n 500 {} \;
+    find $FLINK_DIR/log/ -type f -name '*.out' -exec head -n 500 {} \;
     EXIT_CODE=1
   else
     echo "No non-empty .out files."

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -887,7 +887,8 @@ public class CheckpointCoordinator {
 					checkpointId,
 					message.getTaskExecutionId(),
 					job,
-					taskManagerLocationInfo);
+					taskManagerLocationInfo,
+					message.getReason());
 				final CheckpointException checkpointException;
 				if (message.getReason() == null) {
 					checkpointException =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -129,12 +129,10 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
 					checkpointMetaData.getCheckpointId());
 			}
 		} catch (Exception e) {
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("{} - asynchronous part of checkpoint {} could not be completed.",
-					taskName,
-					checkpointMetaData.getCheckpointId(),
-					e);
-			}
+			LOG.info("{} - asynchronous part of checkpoint {} could not be completed.",
+				taskName,
+				checkpointMetaData.getCheckpointId(),
+				e);
 			handleExecutionException(e);
 		} finally {
 			unregisterConsumer.accept(this);


### PR DESCRIPTION

## What is the purpose of the change

*Improve logging when a checkpoint is declined (e.g. target directory is not writable).*

## Verifying this change

Tested manually on a local cluster.

### Job Manager ###

```
2020-08-17 18:06:47,238 INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator    [] - Decline checkpoint 4 by task 5271c210329e73bd743f3227edfb3b71_0_0 of job 815316dcc17ceea916d2a4da019aca13 at 127.0.1.1:44861-e3cf2c @ roman-ThinkPad-L380 (dataPort=33273).
org.apache.flink.util.SerializedThrowable: Could not materialize checkpoint 4 for operator ArtificalKeyedStateMapper_Kryo_and_Custom_Stateful (1/2).
Caused by: org.apache.flink.util.SerializedThrowable: com.esotericsoftware.kryo.KryoException: java.io.IOException: Could not open output stream for state backend
	... 
Caused by: org.apache.flink.util.SerializedThrowable: java.io.IOException: Could not open output stream for state backend
	...
Caused by: org.apache.flink.util.SerializedThrowable: Could not open output stream for state backend
	... 
Caused by: org.apache.flink.util.SerializedThrowable: Mkdirs failed to create file:/tmp/forbidden/savepoint-e2e-test-chckpt-dir/815316dcc17ceea916d2a4da019aca13/chk-4
	...
```

### Task Manager ###

```
2020-08-17 18:06:45,239 INFO  org.apache.flink.streaming.runtime.tasks.AsyncCheckpointRunnable [] - ArtificalKeyedStateMapper_Kryo_and_Custom_Stateful (2/2) - asynchronous part of checkpoint 2 could not be completed.
java.util.concurrent.ExecutionException: com.esotericsoftware.kryo.KryoException: java.io.IOException: Could not open output stream for state backend
Caused by: com.esotericsoftware.kryo.KryoException: java.io.IOException: Could not open output stream for state backend
	... 
Caused by: java.io.IOException: Could not open output stream for state backend
	...
Caused by: java.io.IOException: Mkdirs failed to create file:/tmp/forbidden/savepoint-e2e-test-chckpt-dir/815316dcc17ceea916d2a4da019aca13/chk-2
	... 
```

cc: @NicoK 