### PR TITLE
[docs] Replaced outdated 'RocksDBStateBackend.setOptions(..)'

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -314,7 +314,7 @@ Advanced options to tune RocksDB and RocksDB checkpoints.
 **RocksDB Configurable Options**
 
 These options give fine-grained control over the behavior and resoures of ColumnFamilies.
-With the introduction of `state.backend.rocksdb.memory.managed` and `state.backend.rocksdb.memory.fixed-per-slot` (Apache Flink 1.10), it should be only necessary to use the options here for advanced performance tuning. These options here can also be specified in the application program via `RocksDBStateBackend.setOptions(PptionsFactory)`.
+With the introduction of `state.backend.rocksdb.memory.managed` and `state.backend.rocksdb.memory.fixed-per-slot` (Apache Flink 1.10), it should be only necessary to use the options here for advanced performance tuning. These options here can also be specified in the application program via `RocksDBStateBackend.setRocksDBOptions(RocksDBOptionsFactory)`.
 
 {% include generated/rocksdb_configurable_configuration.html %}
 

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -314,7 +314,7 @@ Advanced options to tune RocksDB and RocksDB checkpoints.
 **RocksDB Configurable Options**
 
 These options give fine-grained control over the behavior and resoures of ColumnFamilies.
-With the introduction of `state.backend.rocksdb.memory.managed` and `state.backend.rocksdb.memory.fixed-per-slot` (Apache Flink 1.10), it should be only necessary to use the options here for advanced performance tuning. These options here can also be specified in the application program via `RocksDBStateBackend.setOptions(PptionsFactory)`.
+With the introduction of `state.backend.rocksdb.memory.managed` and `state.backend.rocksdb.memory.fixed-per-slot` (Apache Flink 1.10), it should be only necessary to use the options here for advanced performance tuning. These options here can also be specified in the application program via `RocksDBStateBackend.setRocksDBOptions(RocksDBOptionsFactory)`.
 
 {% include generated/rocksdb_configurable_configuration.html %}
 

--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -290,7 +290,7 @@ There are two ways to pass a RocksDBOptionsFactory to the RocksDB State Backend:
 
   - Configure options factory class name in the `flink-conf.yaml` via `state.backend.rocksdb.options-factory`.
   
-  - Set the options factory programmatically, e.g. `RocksDBStateBackend.setOptions(new MyOptionsFactory());`
+  - Set the options factory programmatically, e.g. `RocksDBStateBackend.setRocksDBOptions(new MyOptionsFactory());`
 
 <span class="label label-info">Note</span> Options factory which set programmatically would override the one configured via `flink-conf.yaml`,
 and options factory has a higher priority over the predefined options if ever configured or set.

--- a/docs/ops/state/state_backends.zh.md
+++ b/docs/ops/state/state_backends.zh.md
@@ -280,7 +280,7 @@ Flink还提供了两个参数来控制*写路径*（MemTable）和*读路径*（
 
   - 通过 `state.backend.rocksdb.options-factory` 选项将工厂实现类的名称设置到`flink-conf.yaml` 。
   
-  - 通过程序设置，例如 `RocksDBStateBackend.setOptions(new MyOptionsFactory());` 。
+  - 通过程序设置，例如 `RocksDBStateBackend.setRocksDBOptions(new MyOptionsFactory());` 。
   
 <span class="label label-info">注意</span> 通过程序设置的 `RocksDBOptionsFactory` 将覆盖 `flink-conf.yaml` 配置文件的设置，且 `RocksDBOptionsFactory` 设置的优先级高于预定义选项（`PredefinedOptions`）。
 


### PR DESCRIPTION
…by RocksDBStateBackend.setRocksDBOptions(..)' and fixed typo in parameter list (PptionsFactory -> RocksDBOptionsFactory).

## What is the purpose of the change

This was a doc fix requested by @NicoK .

## Brief change log
The outdated field `RocksDBStateBackend.setOptions(..)` was replaced by `RocksDBStateBackend.setRocksDBOptions(..)`.
As part of this change, another typo got fixed: `PptionsFactory -> RocksDBOptionsFactory`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
