### PR TITLE
[FLINK-18986][kubernetes] Create ClusterClient only for attached deployments

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -51,10 +51,7 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 	@Override
 	public KubernetesClusterDescriptor createClusterDescriptor(Configuration configuration) {
 		checkNotNull(configuration);
-		if (!configuration.contains(KubernetesConfigOptions.CLUSTER_ID)) {
-			final String clusterId = generateClusterId();
-			configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
-		}
+		ensureClusterIdIsSet(configuration);
 		return new KubernetesClusterDescriptor(configuration, KubeClientFactory.fromConfiguration(configuration));
 	}
 
@@ -65,7 +62,14 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 		return configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
 	}
 
-	private String generateClusterId() {
+	public static void ensureClusterIdIsSet(Configuration configuration) {
+		if (!configuration.contains(KubernetesConfigOptions.CLUSTER_ID)) {
+			final String clusterId = generateClusterId();
+			configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+		}
+	}
+
+	private static String generateClusterId() {
 		final String randomID = new AbstractID().toString();
 		return (CLUSTER_ID_PREFIX + randomID).substring(0, Constants.MAXIMUM_CHARACTERS_OF_CLUSTER_ID);
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -34,6 +34,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
+import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
@@ -89,6 +90,7 @@ public class KubernetesSessionCli {
 
 	private int run(String[] args) throws FlinkException, CliArgsException {
 		final Configuration configuration = getEffectiveConfiguration(args);
+		KubernetesClusterClientFactory.ensureClusterIdIsSet(configuration);
 
 		final ClusterClientFactory<String> kubernetesClusterClientFactory =
 			clusterClientServiceLoader.getClusterClientFactory(configuration);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -28,8 +28,6 @@ import org.apache.flink.client.deployment.ClusterClientFactory;
 import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
-import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -99,35 +97,26 @@ public class KubernetesSessionCli {
 			kubernetesClusterClientFactory.createClusterDescriptor(configuration);
 
 		try {
-			final ClusterClientProvider<String> clusterClientProvider;
-			String clusterId = kubernetesClusterClientFactory.getClusterId(configuration);
+			final String clusterId = kubernetesClusterClientFactory.getClusterId(configuration);
 			final boolean detached = !configuration.get(DeploymentOptions.ATTACHED);
 
 			boolean connectToExistingCluster = false;
 			try (final FlinkKubeClient kubeClient = KubeClientFactory.fromConfiguration(configuration)) {
-				connectToExistingCluster = clusterId != null && kubeClient.getRestService(clusterId).isPresent();
+				connectToExistingCluster = kubeClient.getRestService(clusterId).isPresent();
 			} catch (Exception e) {
 				LOG.info("Could not properly shutdown cluster client.", e);
 			}
 
 			// Retrieve or create a session cluster.
 			if (connectToExistingCluster) {
-				clusterClientProvider = kubernetesClusterDescriptor.retrieve(clusterId);
+				kubernetesClusterDescriptor.retrieve(clusterId);
 			} else {
-				clusterClientProvider = kubernetesClusterDescriptor
+				kubernetesClusterDescriptor
 						.deploySessionCluster(
 								kubernetesClusterClientFactory.getClusterSpecification(configuration));
 			}
 
 			if (!detached) {
-				if (!connectToExistingCluster) {
-					try (ClusterClient<String> clusterClient = clusterClientProvider.getClusterClient()) {
-						clusterId = clusterClient.getClusterId();
-					} catch (Exception e) {
-						LOG.info("Could not properly shutdown cluster client.", e);
-					}
-				}
-
 				Tuple2<Boolean, Boolean> continueRepl = new Tuple2<>(true, false);
 				try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
 					while (continueRepl.f0) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -102,6 +102,9 @@ public interface FlinkKubeClient extends AutoCloseable {
 	 */
 	KubernetesWatch watchPodsAndDoCallback(Map<String, String> labels, PodCallbackHandler podCallbackHandler);
 
+	@Override
+	void close();
+
 	/**
 	 * Callback handler for kubernetes pods.
 	 */


### PR DESCRIPTION
Only create a ClusterClient for attached deployments.

The client is not necessary for detached deployments, and the creation results in error messages if the REST API is not accessible from the outside.

I would like to add a test for this, but this requires mocking of several classes, and I only wanted to do that once I have approval of the change in general.