### PR TITLE
[FLINK-18918][python][docs] Add dedicated connector documentation for Python Table API

### DIFF
--- a/docs/dev/python/user-guide/table/python_table_api_connectors.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.md
@@ -23,7 +23,7 @@ under the License.
 -->
 
 
-This page describes how to use connectors in PyFlink and highlights the different parts between using connectors in PyFlink vs Java/Scala. 
+This page describes how to use connectors in PyFlink and highlights the details to be aware of when using Flink connectors in Python programs.
 
 * This will be replaced by the TOC
 {:toc}
@@ -32,7 +32,7 @@ This page describes how to use connectors in PyFlink and highlights the differen
 
 ## Download connector and format jars
 
-For both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html).
+Since Flink is a Java/Scala-based project, for both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html).
 
 {% highlight python %}
 
@@ -76,12 +76,12 @@ sink_ddl = """
 t_env.execute_sql(source_ddl)
 t_env.execute_sql(sink_ddl)
 
-t_env.sql_query("select a from source_table") \
+t_env.sql_query("SELECT a FROM source_table") \
     .insert_into("sink_table")
     
 {% endhighlight %}
 
-Below is a complete example of how to use the Kafka and Json format in PyFlink.
+Below is a complete example of how to use a Kafka source/sink and the JSON format in PyFlink.
 
 {% highlight python %}
 
@@ -127,7 +127,7 @@ def log_processing():
     t_env.execute_sql(source_ddl)
     t_env.execute_sql(sink_ddl)
 
-    t_env.sql_query("select a from source_table") \
+    t_env.sql_query("SELECT a FROM source_table") \
         .insert_into("sink_table")
 
     t_env.execute("payment_demo")
@@ -140,7 +140,7 @@ if __name__ == '__main__':
 
 ## Predefined Sources and Sinks
 
-A few basic data sources and sinks are built into Flink and are always available. The predefined data sources include reading from Pandas DataFrame, or ingesting data from collections. The predefined data sinks support writing to Pandas DataFrame.
+Some data sources and sinks are built into Flink and are available out-of-the-box. These predefined data sources include reading from Pandas DataFrame, or ingesting data from collections. The predefined data sinks support writing to Pandas DataFrame.
 
 ### from/to Pandas
 
@@ -161,7 +161,7 @@ pdf = table.to_pandas()
 
 ### from_elements()
 
-`from_elements()` is used to creates a table from a collection of elements. The elements types must be acceptable atomic types or acceptable composite types. 
+`from_elements()` is used to create a table from a collection of elements. The element types must be acceptable atomic types or acceptable composite types.
 
 {% highlight python %}
 
@@ -170,7 +170,7 @@ table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
 # use the second parameter to specify custom field names
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['a', 'b'])
 
-# use the second parameter to specify custom table schema
+# use the second parameter to specify a custom table schema
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
                         DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
                                        DataTypes.FIELD("b", DataTypes.STRING())]))
@@ -190,5 +190,5 @@ The above query returns a Table like:
 
 ## User-defined sources & sinks
 
-In some cases, you may want to define custom sources and sinks. Currently, sources and sinks must be implemented in Java/Scala but you can define a TableFactory to support their use via DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/dev/table/sourceSinks.html).
+In some cases, you may want to define custom sources and sinks. Currently, sources and sinks must be implemented in Java/Scala, but you can define a `TableFactory` to support their use via DDL. More details can be found in the [Java/Scala documentation]({{ site.baseurl }}/dev/table/sourceSinks.html).
 

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.md
@@ -23,16 +23,16 @@ under the License.
 -->
 
 
+This page describes how to use connectors in PyFlink and highlights the different parts between using connectors in PyFlink vs Java/Scala. 
+
 * This will be replaced by the TOC
 {:toc}
 
-This page describes how to use connectors in PyFlink. The main purpose of this page is to highlight the different parts between using connectors in PyFlink and Java/Scala. Below, we will guide you how to use connectors through an explicit example in which Kafka and Json format are used.
-
-<span class="label label-info">Note</span> For the common parts of using connectors between PyFlink and Java/Scala, you can refer to the [Java/Scala document]({{ site.baseurl }}/dev/table/connectors/index.html) for more details. 
+<span class="label label-info">Note</span>For general connector information and common configuration, please refer to the corresponding [Java/Scala documentation]({{ site.baseurl }}/dev/table/connectors/index.html). 
 
 ## Download connector and format jars
 
-Suppose you are using Kafka connector and Json format, you need first download the [Kafka]({{ site.baseurl }}/dev/table/connectors/kafka.html) and [Json](https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/) jars. Once the connector and format jars are downloaded to local, specify them with the [Dependency Management]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html) APIs.
+For both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html).
 
 {% highlight python %}
 
@@ -42,7 +42,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 
 ## How to use connectors
 
-In the Table API of PyFlink, DDL is recommended to define source and sink. You can use the `execute_sql()` method on `TableEnvironment` to register source and sink with DDL. After that, you can select from the source table and insert into the sink table.
+In PyFink's Table API, DDL is the recommended way to define sources and sinks, executed via the `execute_sql()` method on the `TableEnvironment`. This makes the table available for use by the application.
 
 {% highlight python %}
 
@@ -144,7 +144,7 @@ A few basic data sources and sinks are built into Flink and are always available
 
 ### from/to Pandas
 
-It supports to convert between PyFlink Table and Pandas DataFrame.
+PyFlink Tables support conversion to and from Pandas DataFrame.
 
 {% highlight python %}
 
@@ -190,5 +190,5 @@ The above query returns a Table like:
 
 ## User-defined sources & sinks
 
-In some cases, you may want to defined your own sources and sinks. Currently, Python sources and sinks are not supported. However, you can write Java/Scala TableFactory and use your own sources and sinks in DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/dev/table/sourceSinks.html).
+In some cases, you may want to define custom sources and sinks. Currently, sources and sinks must be implemented in Java/Scala but you can define a TableFactory to support their use via DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/dev/table/sourceSinks.html).
 

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.md
@@ -1,0 +1,194 @@
+---
+title: "Connectors"
+nav-parent_id: python_tableapi
+nav-pos: 130
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+* This will be replaced by the TOC
+{:toc}
+
+This page describes how to use connectors in PyFlink. The main purpose of this page is to highlight the different parts between using connectors in PyFlink and Java/Scala. Below, we will guide you how to use connectors through an explicit example in which Kafka and Json format are used.
+
+<span class="label label-info">Note</span> For the common parts of using connectors between PyFlink and Java/Scala, you can refer to the [Java/Scala document]({{ site.baseurl }}/dev/table/connectors/index.html) for more details. 
+
+## Download connector and format jars
+
+Suppose you are using Kafka connector and Json format, you need first download the [Kafka]({{ site.baseurl }}/dev/table/connectors/kafka.html) and [Json](https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/) jars. Once the connector and format jars are downloaded to local, specify them with the [Dependency Management]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html) APIs.
+
+{% highlight python %}
+
+table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+
+{% endhighlight %}
+
+## How to use connectors
+
+In the Table API of PyFlink, DDL is recommended to define source and sink. You can use the `execute_sql()` method on `TableEnvironment` to register source and sink with DDL. After that, you can select from the source table and insert into the sink table.
+
+{% highlight python %}
+
+source_ddl = """
+        CREATE TABLE source_table(
+            a VARCHAR,
+            b INT
+        ) WITH (
+          'connector.type' = 'kafka',
+          'connector.version' = 'universal',
+          'connector.topic' = 'source_topic',
+          'connector.properties.bootstrap.servers' = 'kafka:9092',
+          'connector.properties.group.id' = 'test_3',
+          'connector.startup-mode' = 'latest-offset',
+          'format.type' = 'json'
+        )
+        """
+
+sink_ddl = """
+        CREATE TABLE sink_table(
+            a VARCHAR
+        ) WITH (
+          'connector.type' = 'kafka',
+          'connector.version' = 'universal',
+          'connector.topic' = 'sink_topic',
+          'connector.properties.bootstrap.servers' = 'kafka:9092',
+          'format.type' = 'json'
+        )
+        """
+
+t_env.execute_sql(source_ddl)
+t_env.execute_sql(sink_ddl)
+
+t_env.sql_query("select a from source_table") \
+    .insert_into("sink_table")
+    
+{% endhighlight %}
+
+Below is a complete example of how to use the Kafka and Json format in PyFlink.
+
+{% highlight python %}
+
+from pyflink.datastream import StreamExecutionEnvironment, TimeCharacteristic
+from pyflink.table import StreamTableEnvironment, EnvironmentSettings
+
+
+def log_processing():
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env_settings = EnvironmentSettings.Builder().use_blink_planner().build()
+    t_env = StreamTableEnvironment.create(stream_execution_environment=env, environment_settings=env_settings)
+    t_env.get_config().get_configuration().set_boolean("python.fn-execution.memory.managed", True)
+    # specify connector and format jars
+    t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+    
+    source_ddl = """
+            CREATE TABLE source_table(
+                a VARCHAR,
+                b INT
+            ) WITH (
+              'connector.type' = 'kafka',
+              'connector.version' = 'universal',
+              'connector.topic' = 'source_topic',
+              'connector.properties.bootstrap.servers' = 'kafka:9092',
+              'connector.properties.group.id' = 'test_3',
+              'connector.startup-mode' = 'latest-offset',
+              'format.type' = 'json'
+            )
+            """
+
+    sink_ddl = """
+            CREATE TABLE sink_table(
+                a VARCHAR
+            ) WITH (
+              'connector.type' = 'kafka',
+              'connector.version' = 'universal',
+              'connector.topic' = 'sink_topic',
+              'connector.properties.bootstrap.servers' = 'kafka:9092',
+              'format.type' = 'json'
+            )
+            """
+
+    t_env.execute_sql(source_ddl)
+    t_env.execute_sql(sink_ddl)
+
+    t_env.sql_query("select a from source_table") \
+        .insert_into("sink_table")
+
+    t_env.execute("payment_demo")
+
+
+if __name__ == '__main__':
+    log_processing()
+{% endhighlight %}
+
+
+## Predefined Sources and Sinks
+
+A few basic data sources and sinks are built into Flink and are always available. The predefined data sources include reading from Pandas DataFrame, or ingesting data from collections. The predefined data sinks support writing to Pandas DataFrame.
+
+### from/to Pandas
+
+It supports to convert between PyFlink Table and Pandas DataFrame.
+
+{% highlight python %}
+
+import pandas as pd
+import numpy as np
+
+# Create a PyFlink Table
+pdf = pd.DataFrame(np.random.rand(1000, 2))
+table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
+
+# Convert the PyFlink Table to a Pandas DataFrame
+pdf = table.to_pandas()
+{% endhighlight %}
+
+### from_elements()
+
+`from_elements()` is used to creates a table from a collection of elements. The elements types must be acceptable atomic types or acceptable composite types. 
+
+{% highlight python %}
+
+table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
+
+# use the second parameter to specify custom field names
+table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['a', 'b'])
+
+# use the second parameter to specify custom table schema
+table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
+                        DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
+                                       DataTypes.FIELD("b", DataTypes.STRING())]))
+{% endhighlight %}
+
+The above query returns a Table like:
+
+{% highlight python %}
++----+-------+
+| a  |   b   |
++====+=======+
+| 1  |  Hi   |
++----+-------+
+| 2  | Hello |
++----+-------+
+{% endhighlight %}
+
+## User-defined sources & sinks
+
+In some cases, you may want to defined your own sources and sinks. Currently, Python sources and sinks are not supported. However, you can write Java/Scala TableFactory and use your own sources and sinks in DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/dev/table/sourceSinks.html).
+

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.md
@@ -28,7 +28,7 @@ This page describes how to use connectors in PyFlink and highlights the details 
 * This will be replaced by the TOC
 {:toc}
 
-<span class="label label-info">Note</span>For general connector information and common configuration, please refer to the corresponding [Java/Scala documentation]({{ site.baseurl }}/dev/table/connectors/index.html). 
+<span class="label label-info">Note</span> For general connector information and common configuration, please refer to the corresponding [Java/Scala documentation]({{ site.baseurl }}/dev/table/connectors/index.html). 
 
 ## Download connector and format jars
 
@@ -51,13 +51,12 @@ source_ddl = """
             a VARCHAR,
             b INT
         ) WITH (
-          'connector.type' = 'kafka',
-          'connector.version' = 'universal',
-          'connector.topic' = 'source_topic',
-          'connector.properties.bootstrap.servers' = 'kafka:9092',
-          'connector.properties.group.id' = 'test_3',
-          'connector.startup-mode' = 'latest-offset',
-          'format.type' = 'json'
+          'type' = 'kafka',
+          'topic' = 'source_topic',
+          'properties.bootstrap.servers' = 'kafka:9092',
+          'properties.group.id' = 'test_3',
+          'scan.startup.mode' = 'latest-offset',
+          'format' = 'json'
         )
         """
 
@@ -65,11 +64,10 @@ sink_ddl = """
         CREATE TABLE sink_table(
             a VARCHAR
         ) WITH (
-          'connector.type' = 'kafka',
-          'connector.version' = 'universal',
-          'connector.topic' = 'sink_topic',
-          'connector.properties.bootstrap.servers' = 'kafka:9092',
-          'format.type' = 'json'
+          'type' = 'kafka',
+          'topic' = 'sink_topic',
+          'properties.bootstrap.servers' = 'kafka:9092',
+          'format' = 'json'
         )
         """
 
@@ -78,7 +76,6 @@ t_env.execute_sql(sink_ddl)
 
 t_env.sql_query("SELECT a FROM source_table") \
     .insert_into("sink_table")
-    
 {% endhighlight %}
 
 Below is a complete example of how to use a Kafka source/sink and the JSON format in PyFlink.
@@ -102,13 +99,12 @@ def log_processing():
                 a VARCHAR,
                 b INT
             ) WITH (
-              'connector.type' = 'kafka',
-              'connector.version' = 'universal',
-              'connector.topic' = 'source_topic',
-              'connector.properties.bootstrap.servers' = 'kafka:9092',
-              'connector.properties.group.id' = 'test_3',
-              'connector.startup-mode' = 'latest-offset',
-              'format.type' = 'json'
+              'type' = 'kafka',
+              'topic' = 'source_topic',
+              'properties.bootstrap.servers' = 'kafka:9092',
+              'properties.group.id' = 'test_3',
+              'scan.startup.mode' = 'latest-offset',
+              'format' = 'json'
             )
             """
 
@@ -116,11 +112,10 @@ def log_processing():
             CREATE TABLE sink_table(
                 a VARCHAR
             ) WITH (
-              'connector.type' = 'kafka',
-              'connector.version' = 'universal',
-              'connector.topic' = 'sink_topic',
-              'connector.properties.bootstrap.servers' = 'kafka:9092',
-              'format.type' = 'json'
+              'type' = 'kafka',
+              'topic' = 'sink_topic',
+              'properties.bootstrap.servers' = 'kafka:9092',
+              'format' = 'json'
             )
             """
 

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -1,0 +1,194 @@
+---
+title: "Connectors"
+nav-parent_id: python_tableapi
+nav-pos: 130
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+* This will be replaced by the TOC
+{:toc}
+
+This page describes how to use connectors in PyFlink Tale API. The main purpose of this page is to highlight the different parts between using connectors in PyFlink and Java/Scala. Below, we will guide you how to use connectors through an explicit example in which Kafka and Json format are used.
+
+<span class="label label-info">Note</span> For the common parts of using connectors between PyFlink and Java/Scala, you can refer to the [Java/Scala document]({{ site.baseurl }}/zh/dev/table/connectors/index.html) for more details. 
+
+## Download connector and format jars
+
+Suppose you are using Kafka connector and Json format, you need first download the [Kafka]({{ site.baseurl }}/zh/dev/table/connectors/kafka.html) and [Json](https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/) jars. Once the connector and format jars are downloaded to local, specify them with the [Dependency Management]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html) APIs.
+
+{% highlight python %}
+
+table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+
+{% endhighlight %}
+
+## How to use connectors
+
+In the Table API of PyFlink, DDL is recommended to define source and sink. You can use the `execute_sql()` method on `TableEnvironment` to register source and sink with DDL. After that, you can select from the source table and insert into the sink table.
+
+{% highlight python %}
+
+source_ddl = """
+        CREATE TABLE source_table(
+            a VARCHAR,
+            b INT
+        ) WITH (
+          'connector.type' = 'kafka',
+          'connector.version' = 'universal',
+          'connector.topic' = 'source_topic',
+          'connector.properties.bootstrap.servers' = 'kafka:9092',
+          'connector.properties.group.id' = 'test_3',
+          'connector.startup-mode' = 'latest-offset',
+          'format.type' = 'json'
+        )
+        """
+
+sink_ddl = """
+        CREATE TABLE sink_table(
+            a VARCHAR
+        ) WITH (
+          'connector.type' = 'kafka',
+          'connector.version' = 'universal',
+          'connector.topic' = 'sink_topic',
+          'connector.properties.bootstrap.servers' = 'kafka:9092',
+          'format.type' = 'json'
+        )
+        """
+
+t_env.execute_sql(source_ddl)
+t_env.execute_sql(sink_ddl)
+
+t_env.sql_query("select a from source_table") \
+    .insert_into("sink_table")
+    
+{% endhighlight %}
+
+Below is a complete example of how to use the Kafka and Json format in PyFlink.
+
+{% highlight python %}
+
+from pyflink.datastream import StreamExecutionEnvironment, TimeCharacteristic
+from pyflink.table import StreamTableEnvironment, EnvironmentSettings
+
+
+def log_processing():
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env_settings = EnvironmentSettings.Builder().use_blink_planner().build()
+    t_env = StreamTableEnvironment.create(stream_execution_environment=env, environment_settings=env_settings)
+    t_env.get_config().get_configuration().set_boolean("python.fn-execution.memory.managed", True)
+    # specify connector and format jars
+    t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+    
+    source_ddl = """
+            CREATE TABLE source_table(
+                a VARCHAR,
+                b INT
+            ) WITH (
+              'connector.type' = 'kafka',
+              'connector.version' = 'universal',
+              'connector.topic' = 'source_topic',
+              'connector.properties.bootstrap.servers' = 'kafka:9092',
+              'connector.properties.group.id' = 'test_3',
+              'connector.startup-mode' = 'latest-offset',
+              'format.type' = 'json'
+            )
+            """
+
+    sink_ddl = """
+            CREATE TABLE sink_table(
+                a VARCHAR
+            ) WITH (
+              'connector.type' = 'kafka',
+              'connector.version' = 'universal',
+              'connector.topic' = 'sink_topic',
+              'connector.properties.bootstrap.servers' = 'kafka:9092',
+              'format.type' = 'json'
+            )
+            """
+
+    t_env.execute_sql(source_ddl)
+    t_env.execute_sql(sink_ddl)
+
+    t_env.sql_query("select a from source_table") \
+        .insert_into("sink_table")
+
+    t_env.execute("payment_demo")
+
+
+if __name__ == '__main__':
+    log_processing()
+{% endhighlight %}
+
+
+## Predefined Sources and Sinks
+
+A few basic data sources and sinks are built into Flink and are always available. The predefined data sources include reading from Pandas DataFrame, or ingesting data from collections. The predefined data sinks support writing to Pandas DataFrame.
+
+### from/to Pandas
+
+It supports to convert between PyFlink Table and Pandas DataFrame.
+
+{% highlight python %}
+
+import pandas as pd
+import numpy as np
+
+# Create a PyFlink Table
+pdf = pd.DataFrame(np.random.rand(1000, 2))
+table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
+
+# Convert the PyFlink Table to a Pandas DataFrame
+pdf = table.to_pandas()
+{% endhighlight %}
+
+### from_elements()
+
+`from_elements()` is used to creates a table from a collection of elements. The elements types must be acceptable atomic types or acceptable composite types. 
+
+{% highlight python %}
+
+table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
+
+# use the second parameter to specify custom field names
+table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['a', 'b'])
+
+# use the second parameter to specify custom table schema
+table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
+                        DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
+                                       DataTypes.FIELD("b", DataTypes.STRING())]))
+{% endhighlight %}
+
+The above query returns a Table like:
+
+{% highlight python %}
++----+-------+
+| a  |   b   |
++====+=======+
+| 1  |  Hi   |
++----+-------+
+| 2  | Hello |
++----+-------+
+{% endhighlight %}
+
+## User-defined sources & sinks
+
+In some cases, you may want to defined your own sources and sinks. Currently, Python sources and sinks are not supported. However, you can write Java/Scala TableFactory and use your own sources and sinks in DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/zh/dev/table/sourceSinks.html).
+

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -23,7 +23,7 @@ under the License.
 -->
 
 
-This page describes how to use connectors in PyFlink and highlights the different parts between using connectors in PyFlink vs Java/Scala. 
+This page describes how to use connectors in PyFlink and highlights the details to be aware of when using Flink connectors in Python programs.
 
 * This will be replaced by the TOC
 {:toc}
@@ -32,7 +32,7 @@ This page describes how to use connectors in PyFlink and highlights the differen
 
 ## Download connector and format jars
 
-For both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html).
+Since Flink is a Java/Scala-based project, for both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html).
 
 {% highlight python %}
 
@@ -76,12 +76,12 @@ sink_ddl = """
 t_env.execute_sql(source_ddl)
 t_env.execute_sql(sink_ddl)
 
-t_env.sql_query("select a from source_table") \
+t_env.sql_query("SELECT a FROM source_table") \
     .insert_into("sink_table")
     
 {% endhighlight %}
 
-Below is a complete example of how to use the Kafka and Json format in PyFlink.
+Below is a complete example of how to use a Kafka source/sink and the JSON format in PyFlink.
 
 {% highlight python %}
 
@@ -127,7 +127,7 @@ def log_processing():
     t_env.execute_sql(source_ddl)
     t_env.execute_sql(sink_ddl)
 
-    t_env.sql_query("select a from source_table") \
+    t_env.sql_query("SELECT a FROM source_table") \
         .insert_into("sink_table")
 
     t_env.execute("payment_demo")
@@ -140,7 +140,7 @@ if __name__ == '__main__':
 
 ## Predefined Sources and Sinks
 
-A few basic data sources and sinks are built into Flink and are always available. The predefined data sources include reading from Pandas DataFrame, or ingesting data from collections. The predefined data sinks support writing to Pandas DataFrame.
+Some data sources and sinks are built into Flink and are available out-of-the-box. These predefined data sources include reading from Pandas DataFrame, or ingesting data from collections. The predefined data sinks support writing to Pandas DataFrame.
 
 ### from/to Pandas
 
@@ -161,7 +161,7 @@ pdf = table.to_pandas()
 
 ### from_elements()
 
-`from_elements()` is used to creates a table from a collection of elements. The elements types must be acceptable atomic types or acceptable composite types. 
+`from_elements()` is used to create a table from a collection of elements. The element types must be acceptable atomic types or acceptable composite types.
 
 {% highlight python %}
 
@@ -170,7 +170,7 @@ table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
 # use the second parameter to specify custom field names
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['a', 'b'])
 
-# use the second parameter to specify custom table schema
+# use the second parameter to specify a custom table schema
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
                         DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
                                        DataTypes.FIELD("b", DataTypes.STRING())]))
@@ -190,5 +190,5 @@ The above query returns a Table like:
 
 ## User-defined sources & sinks
 
-In some cases, you may want to define custom sources and sinks. Currently, sources and sinks must be implemented in Java/Scala but you can define a TableFactory to support their use via DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/zh/dev/table/sourceSinks.html).
+In some cases, you may want to define custom sources and sinks. Currently, sources and sinks must be implemented in Java/Scala, but you can define a `TableFactory` to support their use via DDL. More details can be found in the [Java/Scala documentation]({{ site.baseurl }}/zh/dev/table/sourceSinks.html).
 

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -28,11 +28,11 @@ This page describes how to use connectors in PyFlink and highlights the details 
 * This will be replaced by the TOC
 {:toc}
 
-<span class="label label-info">Note</span>For general connector information and common configuration, please refer to the corresponding [Java/Scala documentation]({{ site.baseurl }}/zh/dev/table/connectors/index.html). 
+<span class="label label-info">Note</span> For general connector information and common configuration, please refer to the corresponding [Java/Scala documentation]({{ site.baseurl }}/zh/dev/table/connectors/index.html). 
 
 ## Download connector and format jars
 
-Since Flink is a Java/Scala-based project, for both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html).
+Since Flink is a Java/Scala-based project, for both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html).
 
 {% highlight python %}
 
@@ -51,13 +51,12 @@ source_ddl = """
             a VARCHAR,
             b INT
         ) WITH (
-          'connector.type' = 'kafka',
-          'connector.version' = 'universal',
-          'connector.topic' = 'source_topic',
-          'connector.properties.bootstrap.servers' = 'kafka:9092',
-          'connector.properties.group.id' = 'test_3',
-          'connector.startup-mode' = 'latest-offset',
-          'format.type' = 'json'
+          'type' = 'kafka',
+          'topic' = 'source_topic',
+          'properties.bootstrap.servers' = 'kafka:9092',
+          'properties.group.id' = 'test_3',
+          'scan.startup.mode' = 'latest-offset',
+          'format' = 'json'
         )
         """
 
@@ -65,11 +64,10 @@ sink_ddl = """
         CREATE TABLE sink_table(
             a VARCHAR
         ) WITH (
-          'connector.type' = 'kafka',
-          'connector.version' = 'universal',
-          'connector.topic' = 'sink_topic',
-          'connector.properties.bootstrap.servers' = 'kafka:9092',
-          'format.type' = 'json'
+          'type' = 'kafka',
+          'topic' = 'sink_topic',
+          'properties.bootstrap.servers' = 'kafka:9092',
+          'format' = 'json'
         )
         """
 
@@ -78,7 +76,6 @@ t_env.execute_sql(sink_ddl)
 
 t_env.sql_query("SELECT a FROM source_table") \
     .insert_into("sink_table")
-    
 {% endhighlight %}
 
 Below is a complete example of how to use a Kafka source/sink and the JSON format in PyFlink.
@@ -102,13 +99,12 @@ def log_processing():
                 a VARCHAR,
                 b INT
             ) WITH (
-              'connector.type' = 'kafka',
-              'connector.version' = 'universal',
-              'connector.topic' = 'source_topic',
-              'connector.properties.bootstrap.servers' = 'kafka:9092',
-              'connector.properties.group.id' = 'test_3',
-              'connector.startup-mode' = 'latest-offset',
-              'format.type' = 'json'
+              'type' = 'kafka',
+              'topic' = 'source_topic',
+              'properties.bootstrap.servers' = 'kafka:9092',
+              'properties.group.id' = 'test_3',
+              'scan.startup.mode' = 'latest-offset',
+              'format' = 'json'
             )
             """
 
@@ -116,11 +112,10 @@ def log_processing():
             CREATE TABLE sink_table(
                 a VARCHAR
             ) WITH (
-              'connector.type' = 'kafka',
-              'connector.version' = 'universal',
-              'connector.topic' = 'sink_topic',
-              'connector.properties.bootstrap.servers' = 'kafka:9092',
-              'format.type' = 'json'
+              'type' = 'kafka',
+              'topic' = 'sink_topic',
+              'properties.bootstrap.servers' = 'kafka:9092',
+              'format' = 'json'
             )
             """
 

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -23,16 +23,16 @@ under the License.
 -->
 
 
+This page describes how to use connectors in PyFlink and highlights the different parts between using connectors in PyFlink vs Java/Scala. 
+
 * This will be replaced by the TOC
 {:toc}
 
-This page describes how to use connectors in PyFlink Tale API. The main purpose of this page is to highlight the different parts between using connectors in PyFlink and Java/Scala. Below, we will guide you how to use connectors through an explicit example in which Kafka and Json format are used.
-
-<span class="label label-info">Note</span> For the common parts of using connectors between PyFlink and Java/Scala, you can refer to the [Java/Scala document]({{ site.baseurl }}/zh/dev/table/connectors/index.html) for more details. 
+<span class="label label-info">Note</span>For general connector information and common configuration, please refer to the corresponding [Java/Scala documentation]({{ site.baseurl }}/zh/dev/table/connectors/index.html). 
 
 ## Download connector and format jars
 
-Suppose you are using Kafka connector and Json format, you need first download the [Kafka]({{ site.baseurl }}/zh/dev/table/connectors/kafka.html) and [Json](https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/) jars. Once the connector and format jars are downloaded to local, specify them with the [Dependency Management]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html) APIs.
+For both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html).
 
 {% highlight python %}
 
@@ -42,7 +42,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 
 ## How to use connectors
 
-In the Table API of PyFlink, DDL is recommended to define source and sink. You can use the `execute_sql()` method on `TableEnvironment` to register source and sink with DDL. After that, you can select from the source table and insert into the sink table.
+In PyFink's Table API, DDL is the recommended way to define sources and sinks, executed via the `execute_sql()` method on the `TableEnvironment`. This makes the table available for use by the application.
 
 {% highlight python %}
 
@@ -144,7 +144,7 @@ A few basic data sources and sinks are built into Flink and are always available
 
 ### from/to Pandas
 
-It supports to convert between PyFlink Table and Pandas DataFrame.
+PyFlink Tables support conversion to and from Pandas DataFrame.
 
 {% highlight python %}
 
@@ -190,5 +190,5 @@ The above query returns a Table like:
 
 ## User-defined sources & sinks
 
-In some cases, you may want to defined your own sources and sinks. Currently, Python sources and sinks are not supported. However, you can write Java/Scala TableFactory and use your own sources and sinks in DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/zh/dev/table/sourceSinks.html).
+In some cases, you may want to define custom sources and sinks. Currently, sources and sinks must be implemented in Java/Scala but you can define a TableFactory to support their use via DDL. More details can be found in the [Java/Scala document]({{ site.baseurl }}/zh/dev/table/sourceSinks.html).
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds dedicated connector documentation for Python Table API.

The reason for writing connectors documentation for Python users separately is that using connectors on PyFlink is a little different from using them on Java/Scala, e.g. how to add the connector jars in Python program. These documents will only introduce the Python-only part of connectors usage. 


## Brief change log

  - Adds dedicated connector documentation for Python Table API

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

