### PR TITLE
[FLINK-18997][python] Rename type_info to result_type to make it more clear

### DIFF
--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -212,7 +212,7 @@ class DataStream(object):
         self._j_data_stream.slotSharingGroup(slot_sharing_group)
         return self
 
-    def map(self, func: Union[Callable, MapFunction], type_info: TypeInformation = None) \
+    def map(self, func: Union[Callable, MapFunction], output_type: TypeInformation = None) \
             -> 'DataStream':
         """
         Applies a Map transformation on a DataStream. The transformation calls a MapFunction for
@@ -224,7 +224,7 @@ class DataStream(object):
         as pickle primitive byte array.
 
         :param func: The MapFunction that is called for each element of the DataStream.
-        :param type_info: The type information of the MapFunction output data.
+        :param output_type: The type information of the MapFunction output data.
         :return: The transformed DataStream.
         """
         if not isinstance(func, MapFunction):
@@ -236,7 +236,7 @@ class DataStream(object):
         from pyflink.fn_execution import flink_fn_execution_pb2
         j_python_data_stream_scalar_function_operator, j_output_type_info = \
             self._get_java_python_function_operator(func,
-                                                    type_info,
+                                                    output_type,
                                                     func_name,
                                                     flink_fn_execution_pb2
                                                     .UserDefinedDataStreamFunction.MAP)
@@ -302,7 +302,7 @@ class DataStream(object):
             is_key_pickled_byte_array = True
 
         intermediate_map_stream = self.map(lambda x: (key_selector.get_key(x), x),
-                                           type_info=Types.ROW([key_type_info, output_type_info]))
+                                           output_type=Types.ROW([key_type_info, output_type_info]))
         intermediate_map_stream.name(gateway.jvm.org.apache.flink.python.util.PythonConfigUtil
                                      .STREAM_KEY_BY_MAP_OPERATOR_NAME)
         generated_key_stream = KeyedStream(intermediate_map_stream._j_data_stream
@@ -500,7 +500,7 @@ class DataStream(object):
 
         original_type_info = self.get_type()
         intermediate_map_stream = self.map(PartitionCustomMapFunction(),
-                                           type_info=Types.ROW([Types.INT(), original_type_info]))
+                                           output_type=Types.ROW([Types.INT(), original_type_info]))
         intermediate_map_stream.name(
             gateway.jvm.org.apache.flink.python.util.PythonConfigUtil
             .STREAM_PARTITION_CUSTOM_MAP_OPERATOR_NAME)
@@ -634,8 +634,9 @@ class DataStream(object):
                     value = str(value)
                 return value
 
-            transformed_data_stream = DataStream(self.map(python_obj_to_str_map_func,
-                                                          type_info=Types.STRING())._j_data_stream)
+            transformed_data_stream = DataStream(
+                self.map(python_obj_to_str_map_func,
+                         output_type=Types.STRING())._j_data_stream)
             return transformed_data_stream
         else:
             return self
@@ -764,9 +765,9 @@ class KeyedStream(DataStream):
         self._original_data_type_info = None
         self._origin_stream = origin_stream
 
-    def map(self, func: Union[Callable, MapFunction], type_info: TypeInformation = None) \
+    def map(self, func: Union[Callable, MapFunction], output_type: TypeInformation = None) \
             -> 'DataStream':
-        return self._values().map(func, type_info)
+        return self._values().map(func, output_type)
 
     def flat_map(self, func: Union[Callable, FlatMapFunction], type_info: TypeInformation = None)\
             -> 'DataStream':
@@ -849,7 +850,7 @@ class KeyedStream(DataStream):
         Since python KeyedStream is in the format of Row(key_value, original_data), it is used for
         getting the original_data.
         """
-        transformed_stream = super().map(lambda x: x[1], type_info=self._original_data_type_info)
+        transformed_stream = super().map(lambda x: x[1], output_type=self._original_data_type_info)
         transformed_stream.name(get_gateway().jvm.org.apache.flink.python.util.PythonConfigUtil
                                 .KEYED_STREAM_VALUE_OPERATOR_NAME)
         return DataStream(transformed_stream._j_data_stream)
@@ -941,7 +942,7 @@ class ConnectedStreams(object):
         call returns exactly one element.
 
         :param func: The CoMapFunction used to jointly transform the two input DataStreams
-        :param type_info: `TypeInformation` for the result type of the function.
+        :param output_type: `TypeInformation` for the result type of the function.
         :return: The transformed `DataStream`
         """
         if not isinstance(func, CoMapFunction):

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -246,8 +246,8 @@ class DataStream(object):
             j_python_data_stream_scalar_function_operator
         ))
 
-    def flat_map(self, func: Union[Callable, FlatMapFunction], type_info: TypeInformation = None) \
-            -> 'DataStream':
+    def flat_map(self, func: Union[Callable, FlatMapFunction],
+                 result_type: TypeInformation = None) -> 'DataStream':
         """
         Applies a FlatMap transformation on a DataStream. The transformation calls a FlatMapFunction
         for each element of the DataStream. Each FlatMapFunction call can return any number of
@@ -255,7 +255,7 @@ class DataStream(object):
         other features provided by the RichFUnction.
 
         :param func: The FlatMapFunction that is called for each element of the DataStream.
-        :param type_info: The type information of output data.
+        :param result_type: The type information of output data.
         :return: The transformed DataStream.
         """
         if not isinstance(func, FlatMapFunction):
@@ -267,7 +267,7 @@ class DataStream(object):
         from pyflink.fn_execution import flink_fn_execution_pb2
         j_python_data_stream_scalar_function_operator, j_output_type_info = \
             self._get_java_python_function_operator(func,
-                                                    type_info,
+                                                    result_type,
                                                     func_name,
                                                     flink_fn_execution_pb2
                                                     .UserDefinedDataStreamFunction.FLAT_MAP)
@@ -337,7 +337,7 @@ class DataStream(object):
 
         j_input_type = self._j_data_stream.getTransformation().getOutputType()
         type_info = typeinfo._from_java_type(j_input_type)
-        j_data_stream = self.flat_map(FilterFlatMap(func), type_info=type_info)._j_data_stream
+        j_data_stream = self.flat_map(FilterFlatMap(func), result_type=type_info)._j_data_stream
         filtered_stream = DataStream(j_data_stream)
         filtered_stream.name("Filter")
         return filtered_stream
@@ -769,9 +769,9 @@ class KeyedStream(DataStream):
             -> 'DataStream':
         return self._values().map(func, output_type)
 
-    def flat_map(self, func: Union[Callable, FlatMapFunction], type_info: TypeInformation = None)\
+    def flat_map(self, func: Union[Callable, FlatMapFunction], result_type: TypeInformation = None)\
             -> 'DataStream':
-        return self._values().flat_map(func, type_info)
+        return self._values().flat_map(func, result_type)
 
     def reduce(self, func: Union[Callable, ReduceFunction]) -> 'DataStream':
         """

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -98,7 +98,7 @@ class DataStreamTests(PyFlinkTestCase):
             result = (value[0], len(value[0]), value[1])
             return result
 
-        ds.map(map_func, type_info=Types.ROW([Types.STRING(), Types.INT(), Types.INT()]))\
+        ds.map(map_func, output_type=Types.ROW([Types.STRING(), Types.INT(), Types.INT()]))\
             .add_sink(self.test_sink)
         self.env.execute('map_function_test')
         results = self.test_sink.get_results(False)
@@ -181,7 +181,7 @@ class DataStreamTests(PyFlinkTestCase):
         ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
                                       type_info=Types.ROW([Types.STRING(), Types.INT()]))
 
-        ds.map(MyMapFunction(), type_info=Types.ROW([Types.STRING(), Types.INT(), Types.INT()]))\
+        ds.map(MyMapFunction(), output_type=Types.ROW([Types.STRING(), Types.INT(), Types.INT()]))\
             .add_sink(self.test_sink)
         self.env.execute('map_function_test')
         results = self.test_sink.get_results(False)
@@ -416,8 +416,8 @@ class DataStreamTests(PyFlinkTestCase):
             assert expected_num_partitions, num_partitions
             return key % num_partitions
 
-        partitioned_stream = ds.map(lambda x: x, type_info=Types.ROW([Types.STRING(),
-                                                                      Types.INT()]))\
+        partitioned_stream = ds.map(lambda x: x, output_type=Types.ROW([Types.STRING(),
+                                                                        Types.INT()]))\
             .set_parallelism(4).partition_custom(my_partitioner, lambda x: x[1])
 
         JPartitionCustomTestMapFunction = get_gateway().jvm\

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -193,7 +193,7 @@ class DataStreamTests(PyFlinkTestCase):
     def test_flat_map_function(self):
         ds = self.env.from_collection([('a', 0), ('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
                                       type_info=Types.ROW([Types.STRING(), Types.INT()]))
-        ds.flat_map(MyFlatMapFunction(), type_info=Types.ROW([Types.STRING(), Types.INT()]))\
+        ds.flat_map(MyFlatMapFunction(), result_type=Types.ROW([Types.STRING(), Types.INT()]))\
             .add_sink(self.test_sink)
 
         self.env.execute('flat_map_test')
@@ -212,7 +212,7 @@ class DataStreamTests(PyFlinkTestCase):
             if value[1] % 2 == 0:
                 yield value
 
-        ds.flat_map(flat_map, type_info=Types.ROW([Types.STRING(), Types.INT()]))\
+        ds.flat_map(flat_map, result_type=Types.ROW([Types.STRING(), Types.INT()]))\
             .add_sink(self.test_sink)
         self.env.execute('flat_map_test')
         results = self.test_sink.get_results(False)


### PR DESCRIPTION

## What is the purpose of the change

This pull request renames type_info to result_type to make it more clear.


## Brief change log

  - Rename parameter name type_info to result_type for DataStream.map()
  - Rename parameter name type_info to result_type for DataStream.flat_map()


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
