### PR TITLE
[FLINK-18993][Runtime]Invoke sanityCheckTotalFlinkMemory method incorrectly in JobManagerFlinkMemoryUtils.java

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/jobmanager/JobManagerFlinkMemoryUtils.java
@@ -46,7 +46,7 @@ public class JobManagerFlinkMemoryUtils implements FlinkMemoryUtils<JobManagerFl
 			MemorySize totalFlinkMemorySize = ProcessMemoryUtils.getMemorySizeFromConfig(config, JobManagerOptions.TOTAL_FLINK_MEMORY);
 			if (config.contains(JobManagerOptions.OFF_HEAP_MEMORY)) {
 				// off-heap memory is explicitly set by user
-				sanityCheckTotalFlinkMemory(totalFlinkMemorySize, jvmHeapMemorySize, totalFlinkMemorySize);
+				sanityCheckTotalFlinkMemory(totalFlinkMemorySize, jvmHeapMemorySize, offHeapMemorySize);
 			} else {
 				// off-heap memory is not explicitly set by user, derive it from Total Flink Memory and JVM Heap
 				offHeapMemorySize = deriveOffHeapMemory(jvmHeapMemorySize, totalFlinkMemorySize, offHeapMemorySize);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtilsTest.java
@@ -145,6 +145,22 @@ public class JobManagerProcessUtilsTest extends ProcessMemoryUtilsTestBase<JobMa
 				defaultOffHeap.toHumanReadableString()))));
 	}
 
+	@Test
+	public void testDeriveFromRequiredFineGrainedOptions() {
+		MemorySize jvmHeap = MemorySize.ofMebiBytes(150);
+		MemorySize offHeap = MemorySize.ofMebiBytes(50);
+		MemorySize totalFlinkMemory = MemorySize.ofMebiBytes(200);
+		MemorySize expectedOffHeap = MemorySize.ofMebiBytes(50);
+
+		Configuration conf = new Configuration();
+		conf.set(JobManagerOptions.TOTAL_FLINK_MEMORY, totalFlinkMemory);
+		conf.set(JobManagerOptions.OFF_HEAP_MEMORY, offHeap);
+		conf.set(JobManagerOptions.JVM_HEAP_MEMORY, jvmHeap);
+
+		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfig(conf);
+		assertThat(jobManagerProcessSpec.getJvmDirectMemorySize(), is(expectedOffHeap));
+	}
+
 	@Override
 	protected JobManagerProcessSpec processSpecFromConfig(Configuration config) {
 		return JobManagerProcessUtils.processSpecFromConfig(config);


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes checking jobmanager off-heap memory size incorrectly when off-heap memory is explicitly set by user.


## Brief change log

When call sanityCheckTotalFlinkMemory method, change its third argument to offHeapMemorySize.


## Verifying this change

Add new test case in JobManagerProcessUtilsTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components) (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
