### PR TITLE
[FLINK-18953][python][docs] Add documentation for DataTypes in Python DataStream API

### DIFF
--- a/docs/dev/python/user-guide/datastream/data_types.md
+++ b/docs/dev/python/user-guide/datastream/data_types.md
@@ -30,6 +30,7 @@ It can be used to declare input and output types of operations and informs the s
 
 
 ## Pickle Serialization
+
 If the type has not been declared, data would be serialized or deserialized using Pickle. 
 For example, the program below specifies no data types.
 

--- a/docs/dev/python/user-guide/datastream/data_types.md
+++ b/docs/dev/python/user-guide/datastream/data_types.md
@@ -22,15 +22,14 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+In Apache Flink's Python DataStream API, a data type describes the type of a value in the DataStream ecosystem. 
+It can be used to declare input and output types of operations and informs the system how to serailize elements. 
+
 * This will be replaced by the TOC
 {:toc}
 
 
-## Why need Data Types
-
-In Python DataStream, a data type describes the type of a value in the DataStream ecosystem. 
-It can be used to declare input and/or output types of operations. 
-Similar to Python, you don't require to specify types for the parameters of a Function in Python DataStream. 
+## Pickle Serialization
 If the type has not been declared, data would be serialized or deserialized using Pickle. 
 For example, the program below specifies no data types.
 
@@ -59,9 +58,8 @@ However, types need to be specified when:
 
 ### Passing Python records to Java operations
 
-Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python data to Java data for processing.
-For example, types need to be provided if you want to output data from the map into the StreamingFileSink. 
-The StreamingFileSink is actually implemented by Java for the runtime part. 
+Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python types to Java types for processing.
+For example, types need to be provided if you want to output data using the StreamingFileSink which is implemented in Java.
 
 {% highlight python %}
 from pyflink.common.serialization import SimpleStringEncoder
@@ -90,8 +88,8 @@ if __name__ == '__main__':
 
 ### Improve serialization and deserialization performance
 
-Even though data can be serialized and deserialized through Pickle, the performance should be better if types are provided. 
-This is because PyFlink can use more efficient serializers and deserializers to serialize and deserialize data.
+Even though data can be serialized and deserialized through Pickle, performance will be better if types are provided.
+Explicit types allow PyFlink to use efficient serializers when moving records through the pipeline.
 
 ## Supported Data Types
 

--- a/docs/dev/python/user-guide/datastream/data_types.md
+++ b/docs/dev/python/user-guide/datastream/data_types.md
@@ -1,0 +1,116 @@
+---
+title: "Data Types"
+nav-parent_id: python_datastream_api
+nav-pos: 10
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+
+## Why need Data Types
+
+In Python DataStream, a data type describes the type of a value in the DataStream ecosystem. 
+It can be used to declare input and/or output types of operations. 
+Similar to Python, you don't require to specify types for the parameters of a Function in Python DataStream. 
+If the type has not been declared, data would be serialized or deserialized using Pickle. 
+For example, the program below specifies no data types.
+
+{% highlight python %}
+from pyflink.datastream import StreamExecutionEnvironment
+
+
+def processing():
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+    env.from_collection(collection=[(1, 'aaa'), (2, 'bbb')]) \
+        .map(lambda record: (record[0]+1, record[1].upper())) \
+        .print()  # note: print to stdout on the worker machine
+
+    env.execute()
+
+
+if __name__ == '__main__':
+    processing()
+{% endhighlight %}
+
+However, types need to be specified when:
+
+- Passing Python records to Java operations.
+- Improve serialization and deserialization performance.
+
+### Passing Python records to Java operations
+
+Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python data to Java data for processing.
+For example, types need to be provided if you want to output data from the map into the StreamingFileSink. 
+The StreamingFileSink is actually implemented by Java for the runtime part. 
+
+{% highlight python %}
+from pyflink.common.serialization import SimpleStringEncoder
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.connectors import StreamingFileSink
+
+
+def streaming_file_sink():
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+    env.from_collection(collection=[(1, 'aaa'), (2, 'bbb')]) \
+        .map(lambda record: (record[0]+1, record[1].upper()),
+             result_type=Types.ROW([Types.INT(), Types.STRING()])) \
+        .add_sink(StreamingFileSink
+                  .for_row_format('/tmp/output', SimpleStringEncoder())
+                  .build())
+
+    env.execute()
+
+
+if __name__ == '__main__':
+    streaming_file_sink()
+
+{% endhighlight %}
+
+### Improve serialization and deserialization performance
+
+Even though data can be serialized and deserialized through Pickle, the performance should be better if types are provided. 
+This is because PyFlink can use more efficient serializers and deserializers to serialize and deserialize data.
+
+## Supported Data Types
+
+You can use `pyflink.common.typeinfo.Types` to specify types in Python DataStream API. 
+The table below shows the type supported now and how to define them:
+
+| PyFlink Type | Usage |  Corresponding Python Type |
+|:-----------------|:-----------------------|:-----------------------|
+| `BOOLEAN` | `Types.BOOLEAN()` | `bool` |
+| `SHORT` | `Types.SHORT()` | `int` |
+| `INT` | `Types.INT()` | `int` |
+| `LONG` | `Types.LONG()` | `int` |
+| `FLOAT` | `Types.FLOAT()` | `float` |
+| `DOUBLE` | `Types.DOUBLE()` | `float` |
+| `CHAR` | `Types.CHAR()` | `str` |
+| `BIG_INT` | `Types.BIG_INT()` | `bytes` |
+| `BIG_DEC` | `Types.BIG_DEC()` | `decimal.Decimal` |
+| `STRING` | `Types.STRING()` | `str` |
+| `BYTE` | `Types.BYTE()` | `int` |
+| `TUPLE` | `Types.TUPLE()` | `tuple` |
+| `PRIMITIVE_ARRAY` | `Types.PRIMITIVE_ARRAY()` | `list` |
+| `ROW` | `Types.ROW()` | `dict` |

--- a/docs/dev/python/user-guide/datastream/data_types.zh.md
+++ b/docs/dev/python/user-guide/datastream/data_types.zh.md
@@ -30,6 +30,7 @@ It can be used to declare input and output types of operations and informs the s
 
 
 ## Pickle Serialization
+
 If the type has not been declared, data would be serialized or deserialized using Pickle. 
 For example, the program below specifies no data types.
 

--- a/docs/dev/python/user-guide/datastream/data_types.zh.md
+++ b/docs/dev/python/user-guide/datastream/data_types.zh.md
@@ -22,15 +22,14 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+In Apache Flink's Python DataStream API, a data type describes the type of a value in the DataStream ecosystem. 
+It can be used to declare input and output types of operations and informs the system how to serailize elements. 
+
 * This will be replaced by the TOC
 {:toc}
 
 
-## Why need Data Types
-
-In Python DataStream, a data type describes the type of a value in the DataStream ecosystem. 
-It can be used to declare input and/or output types of operations. 
-Similar to Python, you don't require to specify types for the parameters of a Function in Python DataStream. 
+## Pickle Serialization
 If the type has not been declared, data would be serialized or deserialized using Pickle. 
 For example, the program below specifies no data types.
 
@@ -59,9 +58,8 @@ However, types need to be specified when:
 
 ### Passing Python records to Java operations
 
-Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python data to Java data for processing.
-For example, types need to be provided if you want to output data from the map into the StreamingFileSink. 
-The StreamingFileSink is actually implemented by Java for the runtime part. 
+Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python types to Java types for processing.
+For example, types need to be provided if you want to output data using the StreamingFileSink which is implemented in Java.
 
 {% highlight python %}
 from pyflink.common.serialization import SimpleStringEncoder
@@ -90,8 +88,8 @@ if __name__ == '__main__':
 
 ### Improve serialization and deserialization performance
 
-Even though data can be serialized and deserialized through Pickle, the performance should be better if types are provided. 
-This is because PyFlink can use more efficient serializers and deserializers to serialize and deserialize data.
+Even though data can be serialized and deserialized through Pickle, performance will be better if types are provided.
+Explicit types allow PyFlink to use efficient serializers when moving records through the pipeline.
 
 ## Supported Data Types
 

--- a/docs/dev/python/user-guide/datastream/data_types.zh.md
+++ b/docs/dev/python/user-guide/datastream/data_types.zh.md
@@ -1,0 +1,116 @@
+---
+title: "Data Types"
+nav-parent_id: python_datastream_api
+nav-pos: 10
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+
+## Why need Data Types
+
+In Python DataStream, a data type describes the type of a value in the DataStream ecosystem. 
+It can be used to declare input and/or output types of operations. 
+Similar to Python, you don't require to specify types for the parameters of a Function in Python DataStream. 
+If the type has not been declared, data would be serialized or deserialized using Pickle. 
+For example, the program below specifies no data types.
+
+{% highlight python %}
+from pyflink.datastream import StreamExecutionEnvironment
+
+
+def processing():
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+    env.from_collection(collection=[(1, 'aaa'), (2, 'bbb')]) \
+        .map(lambda record: (record[0]+1, record[1].upper())) \
+        .print()  # note: print to stdout on the worker machine
+
+    env.execute()
+
+
+if __name__ == '__main__':
+    processing()
+{% endhighlight %}
+
+However, types need to be specified when:
+
+- Passing Python records to Java operations.
+- Improve serialization and deserialization performance.
+
+### Passing Python records to Java operations
+
+Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python data to Java data for processing.
+For example, types need to be provided if you want to output data from the map into the StreamingFileSink. 
+The StreamingFileSink is actually implemented by Java for the runtime part. 
+
+{% highlight python %}
+from pyflink.common.serialization import SimpleStringEncoder
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.connectors import StreamingFileSink
+
+
+def streaming_file_sink():
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+    env.from_collection(collection=[(1, 'aaa'), (2, 'bbb')]) \
+        .map(lambda record: (record[0]+1, record[1].upper()),
+             result_type=Types.ROW([Types.INT(), Types.STRING()])) \
+        .add_sink(StreamingFileSink
+                  .for_row_format('/tmp/output', SimpleStringEncoder())
+                  .build())
+
+    env.execute()
+
+
+if __name__ == '__main__':
+    streaming_file_sink()
+
+{% endhighlight %}
+
+### Improve serialization and deserialization performance
+
+Even though data can be serialized and deserialized through Pickle, the performance should be better if types are provided. 
+This is because PyFlink can use more efficient serializers and deserializers to serialize and deserialize data.
+
+## Supported Data Types
+
+You can use `pyflink.common.typeinfo.Types` to specify types in Python DataStream API. 
+The table below shows the type supported now and how to define them:
+
+| PyFlink Type | Usage |  Corresponding Python Type |
+|:-----------------|:-----------------------|:-----------------------|
+| `BOOLEAN` | `Types.BOOLEAN()` | `bool` |
+| `SHORT` | `Types.SHORT()` | `int` |
+| `INT` | `Types.INT()` | `int` |
+| `LONG` | `Types.LONG()` | `int` |
+| `FLOAT` | `Types.FLOAT()` | `float` |
+| `DOUBLE` | `Types.DOUBLE()` | `float` |
+| `CHAR` | `Types.CHAR()` | `str` |
+| `BIG_INT` | `Types.BIG_INT()` | `bytes` |
+| `BIG_DEC` | `Types.BIG_DEC()` | `decimal.Decimal` |
+| `STRING` | `Types.STRING()` | `str` |
+| `BYTE` | `Types.BYTE()` | `int` |
+| `TUPLE` | `Types.TUPLE()` | `tuple` |
+| `PRIMITIVE_ARRAY` | `Types.PRIMITIVE_ARRAY()` | `list` |
+| `ROW` | `Types.ROW()` | `dict` |

--- a/docs/dev/python/user-guide/datastream/index.md
+++ b/docs/dev/python/user-guide/datastream/index.md
@@ -3,7 +3,6 @@ title: "DataStream API"
 nav-id: python_datastream_api
 nav-parent_id: python_user_guide
 nav-pos: 30
-nav-show_overview: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -23,10 +22,3 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-Python DataStream API allows users to develop [DataStream API]({{ site.baseurl }}/dev/datastream_api.html) programs using the Python language.
-Apache Flink has provided Python DataStream API support since 1.12.0.
-
-## Where to go next?
-
-- [Data Types]({{ site.baseurl }}/dev/python/user-guide/datastream/data_types.html): Lists the supported data types in Python DataStream API.

--- a/docs/dev/python/user-guide/datastream/index.md
+++ b/docs/dev/python/user-guide/datastream/index.md
@@ -1,0 +1,32 @@
+---
+title: "DataStream API"
+nav-id: python_datastream_api
+nav-parent_id: python_user_guide
+nav-pos: 30
+nav-show_overview: true
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Python DataStream API allows users to develop [DataStream API]({{ site.baseurl }}/dev/datastream_api.html) programs using the Python language.
+Apache Flink has provided Python DataStream API support since 1.12.0.
+
+## Where to go next?
+
+- [Data Types]({{ site.baseurl }}/dev/python/user-guide/datastream/data_types.html): Lists the supported data types in Python DataStream API.

--- a/docs/dev/python/user-guide/datastream/index.zh.md
+++ b/docs/dev/python/user-guide/datastream/index.zh.md
@@ -3,7 +3,6 @@ title: "DataStream API"
 nav-id: python_datastream_api
 nav-parent_id: python_user_guide
 nav-pos: 30
-nav-show_overview: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -24,11 +23,4 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Python DataStream API允许用户使用Python语言开发[DataStream API]({{ site.baseurl }}/zh/dev/datastream_api.html)程序。
-
-自1.12.0起，Apache Flink就提供了Python DataStream API支持。
-
-## Where to go next?
-
-- [数据类型]({{ site.baseurl }}/zh/dev/python/user-guide/datastream/data_types.html): 介绍Python数据类型。
 

--- a/docs/dev/python/user-guide/datastream/index.zh.md
+++ b/docs/dev/python/user-guide/datastream/index.zh.md
@@ -1,0 +1,34 @@
+---
+title: "DataStream API"
+nav-id: python_datastream_api
+nav-parent_id: python_user_guide
+nav-pos: 30
+nav-show_overview: true
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Python DataStream API允许用户使用Python语言开发[DataStream API]({{ site.baseurl }}/zh/dev/datastream_api.html)程序。
+
+自1.12.0起，Apache Flink就提供了Python DataStream API支持。
+
+## Where to go next?
+
+- [数据类型]({{ site.baseurl }}/zh/dev/python/user-guide/datastream/data_types.html): 介绍Python数据类型。
+


### PR DESCRIPTION

## What is the purpose of the change

This pull request adds documentation for DataTypes in Python DataStream API


## Brief change log

  - Add index page for the Python DataStream Doc.
  - Add documentation for DataTypes under the index page of Python DataStream Doc.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

