### PR TITLE
[FLINK-18553][table-api-java] Update set operations to new type system

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SetQueryOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SetQueryOperation.java
@@ -38,16 +38,19 @@ public class SetQueryOperation implements QueryOperation {
 
 	private final SetQueryOperationType type;
 	private final boolean all;
+	private final TableSchema tableSchema;
 
 	public SetQueryOperation(
 			QueryOperation leftOperation,
 			QueryOperation rightOperation,
 			SetQueryOperationType type,
-			boolean all) {
+			boolean all,
+			TableSchema tableSchema) {
 		this.leftOperation = leftOperation;
 		this.rightOperation = rightOperation;
 		this.type = type;
 		this.all = all;
+		this.tableSchema = tableSchema;
 	}
 
 	/**
@@ -66,7 +69,7 @@ public class SetQueryOperation implements QueryOperation {
 
 	@Override
 	public TableSchema getTableSchema() {
-		return leftOperation.getTableSchema();
+		return tableSchema;
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/QueryOperationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/QueryOperationTest.java
@@ -51,7 +51,8 @@ public class QueryOperationTest {
 			tableOperation,
 			tableOperation,
 			SetQueryOperation.SetQueryOperationType.UNION,
-			true);
+			true,
+			schema);
 
 		assertEquals("Union: (all: [true])\n" +
 			"    Project: (projections: [a])\n" +

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeMerging.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeMerging.java
@@ -670,12 +670,24 @@ public final class LogicalTypeMerging {
 	private static LogicalType createStringType(LogicalTypeRoot typeRoot, int length) {
 		switch (typeRoot) {
 			case CHAR:
+				if (length == 0) {
+					return CharType.ofEmptyLiteral();
+				}
 				return new CharType(length);
 			case VARCHAR:
+				if (length == 0) {
+					return VarCharType.ofEmptyLiteral();
+				}
 				return new VarCharType(length);
 			case BINARY:
+				if (length == 0) {
+					return BinaryType.ofEmptyLiteral();
+				}
 				return new BinaryType(length);
 			case VARBINARY:
+				if (length == 0) {
+					return VarBinaryType.ofEmptyLiteral();
+				}
 				return new VarBinaryType(length);
 			default:
 				throw new IllegalArgumentException();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalCommonTypeTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalCommonTypeTest.java
@@ -156,6 +156,12 @@ public class LogicalCommonTypeTest {
 					new CharType(2)
 				},
 
+				// CHAR types of length 0
+				{
+					Arrays.asList(CharType.ofEmptyLiteral(), CharType.ofEmptyLiteral()),
+					CharType.ofEmptyLiteral()
+				},
+
 				// CHAR types of different length
 				{
 					Arrays.asList(new CharType(2), new CharType(4)),


### PR DESCRIPTION
## What is the purpose of the change

Updates set operations to the new type system. The result table schema is the common type for each pairwise column types.

## Brief change log

See commit messages.

## Verifying this change

This change added tests and can be verified as follows: `SetOperatorsITCase. testUnionAllWithCommonType`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
