### PR TITLE
[FLINK-17330[runtime] Merge cyclic dependent pipelined regions into one region

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
@@ -45,7 +45,7 @@ public final class PipelinedRegionComputeUtil {
 		// currently we let a job with co-location constraints fail as one region
 		// putting co-located vertices in the same region with each other can be a future improvement
 		if (topology.containsCoLocationConstraints()) {
-			return uniqueRegions(buildOneRegionForAllVertices(topology));
+			return Collections.singleton(buildOneRegionForAllVertices(topology));
 		}
 
 		final Map<V, Set<V>> vertexToRegion = new IdentityHashMap<>();
@@ -94,20 +94,17 @@ public final class PipelinedRegionComputeUtil {
 		return uniqueRegions(vertexToRegion);
 	}
 
-	private static <V extends Vertex<?, ?, V, ?>> Map<V, Set<V>> buildOneRegionForAllVertices(
+	private static <V extends Vertex<?, ?, V, ?>> Set<V> buildOneRegionForAllVertices(
 			final BaseTopology<?, ?, V, ?> topology) {
 
 		LOG.warn("Cannot decompose the topology into individual failover regions due to use of " +
 			"Co-Location constraints (iterations). Job will fail over as one holistic unit.");
 
-		final Map<V, Set<V>> vertexToRegion = new IdentityHashMap<>();
-
-		final Set<V> allVertices = new HashSet<>();
+		final Set<V> allVertices = Collections.newSetFromMap(new IdentityHashMap<>());
 		for (V vertex : topology.getVertices()) {
 			allVertices.add(vertex);
-			vertexToRegion.put(vertex, allVertices);
 		}
-		return vertexToRegion;
+		return allVertices;
 	}
 
 	private static <V extends Vertex<?, ?, V, ?>> Set<Set<V>> uniqueRegions(final Map<V, Set<V>> vertexToRegion) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
@@ -26,11 +26,16 @@ import org.apache.flink.runtime.topology.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Utility for computing pipelined regions.
@@ -50,7 +55,7 @@ public final class PipelinedRegionComputeUtil {
 
 		final Map<V, Set<V>> vertexToRegion = buildRawRegions(topology);
 
-		return uniqueRegions(vertexToRegion);
+		return mergeRegionsOnCycles(vertexToRegion);
 	}
 
 	private static <V extends Vertex<?, ?, V, R>, R extends Result<?, ?, V, R>> Map<V, Set<V>> buildRawRegions(
@@ -126,6 +131,60 @@ public final class PipelinedRegionComputeUtil {
 		final Set<Set<V>> distinctRegions = Collections.newSetFromMap(new IdentityHashMap<>());
 		distinctRegions.addAll(vertexToRegion.values());
 		return distinctRegions;
+	}
+
+	private static <V extends Vertex<?, ?, V, R>, R extends Result<?, ?, V, R>> Set<Set<V>> mergeRegionsOnCycles(
+			final Map<V, Set<V>> vertexToRegion) {
+
+		final List<Set<V>> regionList = uniqueRegions(vertexToRegion).stream().collect(Collectors.toList());
+		final List<List<Integer>> outEdges = buildOutEdgesDesc(vertexToRegion, regionList);
+		final Set<Set<Integer>> sccs = StronglyConnectedComponentsComputeUtils.computeStronglyConnectedComponents(
+			outEdges.size(),
+			outEdges);
+
+		final Set<Set<V>> mergedRegions = Collections.newSetFromMap(new IdentityHashMap<>());
+		for (Set<Integer> scc : sccs) {
+			checkState(scc.size() > 0);
+
+			Set<V> mergedRegion = new HashSet<>();
+			for (int regionIndex : scc) {
+				mergedRegion = mergeRegions(mergedRegion, regionList.get(regionIndex), vertexToRegion);
+			}
+			mergedRegions.add(mergedRegion);
+		}
+
+		return mergedRegions;
+	}
+
+	private static <V extends Vertex<?, ?, V, R>, R extends Result<?, ?, V, R>> List<List<Integer>> buildOutEdgesDesc(
+			final Map<V, Set<V>> vertexToRegion,
+			final List<Set<V>> regionList) {
+
+		final Map<Set<V>, Integer> regionIndices = new IdentityHashMap<>();
+		for (int i = 0; i < regionList.size(); i++) {
+			regionIndices.put(regionList.get(i), i);
+		}
+
+		final List<List<Integer>> outEdges = new ArrayList<>(regionList.size());
+		for (int i = 0; i < regionList.size(); i++) {
+			final List<Integer> currentRegionOutEdges = new ArrayList<>();
+			final Set<V> currentRegion = regionList.get(i);
+			for (V vertex : currentRegion) {
+				for (R producedResult : vertex.getProducedResults()) {
+					if (producedResult.getResultType().isPipelined()) {
+						continue;
+					}
+					for (V consumerVertex : producedResult.getConsumers()) {
+						if (!currentRegion.contains(consumerVertex)) {
+							currentRegionOutEdges.add(regionIndices.get(vertexToRegion.get(consumerVertex)));
+						}
+					}
+				}
+			}
+			outEdges.add(currentRegionOutEdges);
+		}
+
+		return outEdges;
 	}
 
 	private PipelinedRegionComputeUtil() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/StronglyConnectedComponentsComputeUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/StronglyConnectedComponentsComputeUtils.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Utility for computing strongly connected components.
+ *
+ * <p>The computation is an implementation of Tarjan's algorithm.
+ *
+ * <p>Ref: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm.
+ */
+public final class StronglyConnectedComponentsComputeUtils {
+
+	private StronglyConnectedComponentsComputeUtils() {
+	}
+
+	static Set<Set<Integer>> computeStronglyConnectedComponents(final int numVertex, final List<List<Integer>> outEdges) {
+		final Set<Set<Integer>> stronglyConnectedComponents = new HashSet<>();
+
+		// a vertex will be added into this stack when it is visited for the first time
+		final Deque<Integer> visitingStack = new ArrayDeque<>(numVertex);
+		final boolean[] onVisitingStack = new boolean[numVertex];
+
+		// stores the order that a vertex is visited for the first time, -1 indicates it is not visited yet
+		final int[] vertexIndices = new int[numVertex];
+		Arrays.fill(vertexIndices, -1);
+
+		final AtomicInteger indexCounter = new AtomicInteger(0);
+
+		final int[] vertexLowLinks = new int[numVertex];
+
+		for (int vertex = 0; vertex < numVertex; vertex++) {
+			if (!isVisited(vertex, vertexIndices)) {
+				dfs(vertex, outEdges, vertexIndices, vertexLowLinks, visitingStack, onVisitingStack, indexCounter, stronglyConnectedComponents);
+			}
+		}
+
+		return stronglyConnectedComponents;
+	}
+
+	private static boolean isVisited(final int vertex, final int[] vertexIndices) {
+		return vertexIndices[vertex] != -1;
+	}
+
+	private static void dfs(
+			final int rootVertex,
+			final List<List<Integer>> outEdges,
+			final int[] vertexIndices,
+			final int[] vertexLowLinks,
+			final Deque<Integer> visitingStack,
+			final boolean[] onVisitingStack,
+			final AtomicInteger indexCounter,
+			final Set<Set<Integer>> stronglyConnectedComponents) {
+
+		final Deque<Tuple2<Integer, Integer>> dfsLoopStack = new ArrayDeque<>();
+		dfsLoopStack.add(new Tuple2<>(rootVertex, 0));
+
+		while (!dfsLoopStack.isEmpty()) {
+			Tuple2<Integer, Integer> tuple = dfsLoopStack.pollLast();
+			final int currentVertex = tuple.f0;
+			final int vertexOutEdgeIndex = tuple.f1;
+
+			if (vertexOutEdgeIndex == 0) {
+				startTraversingVertex(currentVertex, vertexIndices, vertexLowLinks, visitingStack, onVisitingStack, indexCounter);
+			} else if (vertexOutEdgeIndex > 0) {
+				finishTraversingOutEdge(currentVertex, vertexOutEdgeIndex - 1, outEdges, vertexLowLinks);
+			}
+
+			if (traverseOutEdges(currentVertex, vertexOutEdgeIndex, outEdges, vertexIndices, vertexLowLinks, onVisitingStack, dfsLoopStack)) {
+				continue;
+			}
+
+			if (vertexLowLinks[currentVertex] == vertexIndices[currentVertex]) {
+				stronglyConnectedComponents.add(createConnectedComponent(currentVertex, visitingStack, onVisitingStack));
+			}
+		}
+	}
+
+	private static void startTraversingVertex(
+			final int currentVertex,
+			final int[] vertexIndices,
+			final int[] vertexLowLinks,
+			final Deque<Integer> visitingStack,
+			final boolean[] onVisitingStack,
+			final AtomicInteger indexCounter) {
+
+		vertexIndices[currentVertex] = indexCounter.get();
+		vertexLowLinks[currentVertex] = indexCounter.getAndIncrement();
+		visitingStack.add(currentVertex);
+		onVisitingStack[currentVertex] = true;
+	}
+
+	private static void finishTraversingOutEdge(
+			final int currentVertex,
+			final int vertexOutEdgeIndex,
+			final List<List<Integer>> outEdges,
+			final int[] vertexLowLinks) {
+
+		final int successorVertex = outEdges.get(currentVertex).get(vertexOutEdgeIndex);
+		vertexLowLinks[currentVertex] = Math.min(vertexLowLinks[currentVertex], vertexLowLinks[successorVertex]);
+	}
+
+	private static boolean traverseOutEdges(
+			final int currentVertex,
+			final int vertexOutEdgeIndex,
+			final List<List<Integer>> outEdges,
+			final int[] vertexIndices,
+			final int[] vertexLowLinks,
+			final boolean[] onVisitingStack,
+			final Deque<Tuple2<Integer, Integer>> dfsLoopStack) {
+
+		for (int i = vertexOutEdgeIndex; i < outEdges.get(currentVertex).size(); i++) {
+			final int successorVertex = outEdges.get(currentVertex).get(i);
+			if (!isVisited(successorVertex, vertexIndices)) {
+				dfsLoopStack.add(new Tuple2<>(currentVertex, i + 1));
+				dfsLoopStack.add(new Tuple2<>(successorVertex, 0));
+				return true;
+			} else if (onVisitingStack[successorVertex]) {
+				// this is deliberate and the proof can be found in Tarjan's paper
+				vertexLowLinks[currentVertex] = Math.min(vertexLowLinks[currentVertex], vertexIndices[successorVertex]);
+			}
+		}
+		return false;
+	}
+
+	private static Set<Integer> createConnectedComponent(
+			final int currentVertex,
+			final Deque<Integer> visitingStack,
+			final boolean[] onVisitingStack) {
+
+		final Set<Integer> scc = new HashSet<>();
+		while (onVisitingStack[currentVertex]) {
+			final int v = visitingStack.pollLast();
+			onVisitingStack[v] = false;
+			scc.add(v);
+
+		}
+		return scc;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtilTest.java
@@ -508,6 +508,44 @@ public class PipelinedRegionComputeUtilTest extends TestLogger {
 		assertSameRegion(ra1, ra2, rb1, rb2);
 	}
 
+	/**
+	 * This test checks that cyclic dependent regions will be merged into one.
+	 * <pre>
+	 *       (blocking)(blocking)
+	 *           |      |
+	 *           v      v
+	 *          +|-(v2)-|+
+	 *          |        |
+	 *     (v1)--+       +--(v4)
+	 *          |        |
+	 *          +--(v3)--+
+	 * </pre>
+	 */
+	@Test
+	public void testCyclicDependentRegionsAreMerged() {
+		TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex();
+
+		topology
+			.connect(v1, v2, ResultPartitionType.BLOCKING)
+			.connect(v1, v3, ResultPartitionType.PIPELINED)
+			.connect(v2, v4, ResultPartitionType.BLOCKING)
+			.connect(v3, v4, ResultPartitionType.PIPELINED);
+
+		Map<ExecutionVertexID, Set<SchedulingExecutionVertex>> pipelinedRegionByVertex = computePipelinedRegionByVertex(topology);
+
+		Set<SchedulingExecutionVertex> r1 = pipelinedRegionByVertex.get(v1.getId());
+		Set<SchedulingExecutionVertex> r2 = pipelinedRegionByVertex.get(v2.getId());
+		Set<SchedulingExecutionVertex> r3 = pipelinedRegionByVertex.get(v3.getId());
+		Set<SchedulingExecutionVertex> r4 = pipelinedRegionByVertex.get(v4.getId());
+
+		assertSameRegion(r1, r2, r3, r4);
+	}
+
 	// ------------------------------------------------------------------------
 	//  utilities
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/StronglyConnectedComponentsComputeUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/StronglyConnectedComponentsComputeUtilsTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.runtime.executiongraph.failover.flip1.StronglyConnectedComponentsComputeUtils.computeStronglyConnectedComponents;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests for {@link StronglyConnectedComponentsComputeUtils}.
+ */
+public class StronglyConnectedComponentsComputeUtilsTest extends TestLogger {
+
+	@Test
+	public void testWithCycles() {
+		final List<List<Integer>> edges = Arrays.asList(
+			Arrays.asList(2, 3),
+			Arrays.asList(0),
+			Arrays.asList(1),
+			Arrays.asList(4),
+			Collections.emptyList());
+
+		final Set<Set<Integer>> result = computeStronglyConnectedComponents(5, edges);
+
+		final Set<Set<Integer>> expected = new HashSet<>();
+		expected.add(new HashSet<>(Arrays.asList(0, 1, 2)));
+		expected.add(Collections.singleton(3));
+		expected.add(Collections.singleton(4));
+
+		assertThat(result, is(expected));
+	}
+
+	@Test
+	public void testWithMultipleCycles() {
+		final List<List<Integer>> edges = Arrays.asList(
+			Arrays.asList(1),
+			Arrays.asList(2),
+			Arrays.asList(0),
+			Arrays.asList(1, 2, 4),
+			Arrays.asList(3, 5),
+			Arrays.asList(2, 6),
+			Arrays.asList(5),
+			Arrays.asList(4, 6, 7));
+
+		final Set<Set<Integer>> result = computeStronglyConnectedComponents(8, edges);
+
+		final Set<Set<Integer>> expected = new HashSet<>();
+		expected.add(new HashSet<>(Arrays.asList(0, 1, 2)));
+		expected.add(new HashSet<>(Arrays.asList(3, 4)));
+		expected.add(new HashSet<>(Arrays.asList(5, 6)));
+		expected.add(Collections.singleton(7));
+
+		assertThat(result, is(expected));
+	}
+
+	@Test
+	public void testWithConnectedCycles() {
+		final List<List<Integer>> edges = Arrays.asList(
+			Arrays.asList(1),
+			Arrays.asList(2, 4, 5),
+			Arrays.asList(3, 6),
+			Arrays.asList(2, 7),
+			Arrays.asList(0, 5),
+			Arrays.asList(6),
+			Arrays.asList(5),
+			Arrays.asList(3, 6));
+
+		final Set<Set<Integer>> result = computeStronglyConnectedComponents(8, edges);
+
+		final Set<Set<Integer>> expected = new HashSet<>();
+		expected.add(new HashSet<>(Arrays.asList(0, 1, 4)));
+		expected.add(new HashSet<>(Arrays.asList(2, 3, 7)));
+		expected.add(new HashSet<>(Arrays.asList(5, 6)));
+
+		assertThat(result, is(expected));
+	}
+
+	@Test
+	public void testWithNoEdge() {
+		final List<List<Integer>> edges = Arrays.asList(
+			Collections.emptyList(),
+			Collections.emptyList(),
+			Collections.emptyList(),
+			Collections.emptyList(),
+			Collections.emptyList());
+
+		final Set<Set<Integer>> result = computeStronglyConnectedComponents(5, edges);
+
+		final Set<Set<Integer>> expected = new HashSet<>();
+		expected.add(Collections.singleton(0));
+		expected.add(Collections.singleton(1));
+		expected.add(Collections.singleton(2));
+		expected.add(Collections.singleton(3));
+		expected.add(Collections.singleton(4));
+
+		assertThat(result, is(expected));
+	}
+
+	@Test
+	public void testWithNoCycle() {
+		final List<List<Integer>> edges = Arrays.asList(
+			Arrays.asList(1),
+			Arrays.asList(2),
+			Arrays.asList(3),
+			Arrays.asList(4),
+			Collections.emptyList());
+
+		final Set<Set<Integer>> result = computeStronglyConnectedComponents(5, edges);
+
+		final Set<Set<Integer>> expected = new HashSet<>();
+		expected.add(Collections.singleton(0));
+		expected.add(Collections.singleton(1));
+		expected.add(Collections.singleton(2));
+		expected.add(Collections.singleton(3));
+		expected.add(Collections.singleton(4));
+
+		assertThat(result, is(expected));
+	}
+
+	@Test
+	public void testLargeGraph() {
+		final int n = 100000;
+		final List<List<Integer>> edges = new ArrayList<>();
+		for (int i = 0; i < n; i++) {
+			edges.add(Collections.singletonList((i + 1) % n));
+		}
+
+		final Set<Set<Integer>> result = computeStronglyConnectedComponents(n, edges);
+
+		final Set<Integer> singleComponent = IntStream.range(0, n).boxed().collect(Collectors.toSet());
+
+		assertThat(result, is(Collections.singleton(singleComponent)));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR changes regions building to merge cyclic dependent pipelined regions into one region.
This is to avoid scheduling deadlocks due to cyclic dependencies.
More details see FLINK-17330.

## Brief change log

  - *Added StronglyConnectedComponentsComputeUtils to find out cyclic dependent regions*
  - *Changed PipelinedRegionComputeUtil to merge cyclic dependent pipelined regions into one region*

## Verifying this change

  - *Added UT StronglyConnectedComponentsComputeUtilsTest*
  - *Added test case in PipelinedRegionComputeUtilTest to verify regions on the same cycles are merged*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
