### PR TITLE
[FLINK-18676] [FileSystem] Bump s3 aws version

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<fs.s3.aws.version>1.11.754</fs.s3.aws.version>
+		<fs.s3.aws.version>1.11.788</fs.s3.aws.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What is the purpose of the change

This pull request bumps AWS SDK version to minimal version supported WebIdentityTokenCredentialsProvider in s3-fs-package, which is described in an issue.

## Brief change log

- flink-s3-fs-base - bumped aws dependency

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
