### PR TITLE
[FLINK-18938][tableSQL/API] Throw better exception message for quering sink-only connector

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -35,6 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,8 @@ import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link FactoryUtil}.
@@ -62,9 +65,9 @@ public class FactoryUtilTest {
 	public void testInvalidConnector() {
 		expectError(
 			"Could not find any factory for identifier 'FAIL' that implements '" +
-				DynamicTableSourceFactory.class.getName() + "' in the classpath.\n\n" +
+				DynamicTableFactory.class.getName() + "' in the classpath.\n\n" +
 			"Available factory identifiers are:\n\n" +
-			"test-connector");
+			"sink-only\nsource-only\ntest-connector");
 		testError(options -> options.put("connector", "FAIL"));
 	}
 
@@ -205,6 +208,25 @@ public class FactoryUtilTest {
 			new EncodingFormatMock(","),
 			new EncodingFormatMock(";"));
 		assertEquals(expectedSink, actualSink);
+	}
+
+	@Test
+	public void testAvailableFactoryTipsDependencyJarForConnector() {
+		try {
+			createTableSource(Collections.singletonMap("connector", "sink-only"));
+			fail();
+		} catch (Exception e) {
+			String errorMsg = "Connector 'sink-only' only supports to be used as sink, can't be used as source.";
+			assertThat(e, containsCause(new ValidationException(errorMsg)));
+		}
+
+		try {
+			createTableSink(Collections.singletonMap("connector", "source-only"));
+			fail();
+		} catch (Exception e) {
+			String errorMsg = "Connector 'source-only' only supports to be used as source, can't be used as sink.";
+			assertThat(e, containsCause(new ValidationException(errorMsg)));
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSinkOnlyFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSinkOnlyFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Test implementations for {@link DynamicTableSinkFactory} which only supports to be used as sink.
+ */
+public final class TestDynamicTableSinkOnlyFactory implements  DynamicTableSinkFactory {
+
+	public static final String IDENTIFIER = "sink-only";
+
+	@Override
+	public DynamicTableSink createDynamicTableSink(Context context) {
+		return null;
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		return Collections.emptySet();
+	}
+
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSourceOnlyFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSourceOnlyFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Test implementations for {@link DynamicTableSourceFactory} which only supports to be used as source.
+ */
+public final class TestDynamicTableSourceOnlyFactory implements DynamicTableSourceFactory {
+
+	public static final String IDENTIFIER = "source-only";
+
+	@Override
+	public DynamicTableSource createDynamicTableSource(Context context) {
+		return null;
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		return Collections.emptySet();
+	}
+}

--- a/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -15,3 +15,5 @@
 
 org.apache.flink.table.factories.TestDynamicTableFactory
 org.apache.flink.table.factories.TestFormatFactory
+org.apache.flink.table.factories.TestDynamicTableSinkOnlyFactory
+org.apache.flink.table.factories.TestDynamicTableSourceOnlyFactory


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

1.Throw better exception message for quering sink-only(source-only) connector.
2.Add tips(support as source or sink) following the identifier when 1 heppens.

## Brief change log

- Throw better exception message for quering sink-only(source-only) connector.
For example, when we are quering a sink-only connector ,if we have a dependency jar in the classpath ,return the following excception message: 
before:
`Caused by: org.apache.flink.table.api.ValidationException: Could not find any factory for identifier 'elasticsearch-7' that implements 'org.apache.flink.table.factories.DynamicTableSourceFactory' in the classpath.`
now:
`Caused by: org.apache.flink.table.api.ValidationException: The connector named 'elasticsearch-7' is only supported as sink,can n't be used as a source.`
- Add tips follow the identifier when 1 heppens.
before:
`Available factory identifiers are:`
 `datagen`
now:
`Available factory identifiers are: `
`datagen (DynamicTableSourceFactory,DynamicTableSinkFactory)`
`elasticsearch-7 (DynamicTableSinkFactory)`
`test-connector (DynamicTableSourceFactory)`


## Verifying this change

This change added tests and can be verified by  running unit test :
testAvailableFactoryTipsNoDependencyJarForFormat()
testAvailableFactoryTipsDependencyJarForFormat()
testAvailableFactoryTipsNoDependencyJarForConnector()
testAvailableFactoryTipsDependencyJarForConnector()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
