### PR TITLE
[FLINK-18917][doc][python] Add a "Built-in Functions" link (linked to dev/table/functions/systemFunctions.md) under the "Python API" -> "User Guide" -> "Table API" section.

### DIFF
--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -85,6 +85,9 @@ under the License.
       </div>
     </div><!-- /.container -->
 
+    <!-- default code tab -->
+    <script>var defaultCodeTab = "{{ page.code_tab }}";</script>
+
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="{{ site.baseurl }}/page/js/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->

--- a/docs/_plugins/include_without_header.rb
+++ b/docs/_plugins/include_without_header.rb
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Jekyll
+  module Tags
+
+    class IncludeWithoutHeaderTag < Liquid::Tag
+
+      def initialize(tag_name, text, tokens)
+        super
+        @file = text.strip
+      end
+
+      def render(context)
+        source = File.expand_path(context.registers[:site].config['source']).freeze
+        path = File.join(source, @file)
+        content = File.read(path)
+        content = content.split(/<!--[^>]*LICENSE-2.0[^>]*-->/, 2)[1]
+        partial = Liquid::Template.parse(content)
+
+        context.stack do
+          begin
+            partial.render!(context)
+          rescue Liquid::Error => e
+            e.template_name = path
+            e.markup_context = "included " if e.markup_context.nil?
+            raise e
+          end
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("include_without_header", Jekyll::Tags::IncludeWithoutHeaderTag)

--- a/docs/_plugins/include_without_header.rb
+++ b/docs/_plugins/include_without_header.rb
@@ -31,16 +31,7 @@ module Jekyll
         content = File.read(path)
         content = content.split(/<!--[^>]*LICENSE-2.0[^>]*-->/, 2)[1]
         partial = Liquid::Template.parse(content)
-
-        context.stack do
-          begin
-            partial.render!(context)
-          rescue Liquid::Error => e
-            e.template_name = path
-            e.markup_context = "included " if e.markup_context.nil?
-            raise e
-          end
-        end
+        partial.render!(context)
       end
     end
   end

--- a/docs/_plugins/include_without_header.rb
+++ b/docs/_plugins/include_without_header.rb
@@ -26,7 +26,7 @@ module Jekyll
       end
 
       def render(context)
-        source = File.expand_path(context.registers[:site].config['source']).freeze
+        source = File.expand_path(context.registers[:site].config['source'])
         path = File.join(source, @file)
         content = File.read(path)
         content = content.split(/<!--[^>]*LICENSE-2.0[^>]*-->/, 2)[1]

--- a/docs/dev/python/user-guide/table/built_in_functions.md
+++ b/docs/dev/python/user-guide/table/built_in_functions.md
@@ -1,0 +1,25 @@
+---
+title: "System (Built-in) Functions"
+nav-parent_id: python_tableapi
+nav-pos: 31
+code_tab: python
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+{% include_without_header dev/table/functions/systemFunctions.md %}

--- a/docs/dev/python/user-guide/table/built_in_functions.zh.md
+++ b/docs/dev/python/user-guide/table/built_in_functions.zh.md
@@ -1,0 +1,25 @@
+---
+title: "系统（内置）函数"
+nav-parent_id: python_tableapi
+nav-pos: 31
+code_tab: python
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+{% include_without_header dev/table/functions/systemFunctions.zh.md %}

--- a/docs/page/js/flink.js
+++ b/docs/page/js/flink.js
@@ -40,8 +40,9 @@ function codeTabs() {
     "python": "img/python-sm.png",
     "java": "img/java-sm.png"
   };
+  var codeTabParam = null;
   if (typeof window.defaultCodeTab !== "undefined" && window.defaultCodeTab !== "") {
-    var codeTabParam = window.defaultCodeTab
+    codeTabParam = window.defaultCodeTab
   }
   codeTabParam = getUrlParameter("code_tab") == null ? codeTabParam : getUrlParameter("code_tab").toLowerCase();
   // Processing duplicated tabs, e.g. if the data-lang="Java/Scala",

--- a/docs/page/js/flink.js
+++ b/docs/page/js/flink.js
@@ -40,7 +40,10 @@ function codeTabs() {
     "python": "img/python-sm.png",
     "java": "img/java-sm.png"
   };
-  var codeTabParam = getUrlParameter("code_tab") == null ? null : getUrlParameter("code_tab").toLowerCase();
+  if (typeof window.defaultCodeTab !== "undefined" && window.defaultCodeTab !== "") {
+    var codeTabParam = window.defaultCodeTab
+  }
+  codeTabParam = getUrlParameter("code_tab") == null ? codeTabParam : getUrlParameter("code_tab").toLowerCase();
   // Processing duplicated tabs, e.g. if the data-lang="Java/Scala",
   // it will be copied to 2 elements, the "data-lang" value of them would be "Java" and "Scala".
   function splitDataLang() {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add a "Built-in Functions" link (linked to dev/table/functions/systemFunctions.md) under the "Python API" -> "User Guide" -> "Table API" section.*


## Brief change log

  - *Add a new "include_without_header" tag to reuse the content of other .md files.*
  - *Add a new param "code_tab" to specify the default code tab to display.*
  - *Add a "Built-in Functions" link (linked to dev/table/functions/systemFunctions.md) under the "Python API" -> "User Guide" -> "Table API" section.*


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
