### PR TITLE
[FLINK-19032] Remove deprecated RuntimeContext#getAllAcumullators

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -42,7 +42,6 @@ import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -142,15 +141,6 @@ public interface RuntimeContext {
 	 * accumulator exists, but with different type.
 	 */
 	<V, A extends Serializable> Accumulator<V, A> getAccumulator(String name);
-
-	/**
-	 * Returns a map of all registered accumulators for this task.
-	 * The returned map must not be modified.
-	 * @deprecated Use getAccumulator(..) to obtain the value of an accumulator.
-	 */
-	@Deprecated
-	@PublicEvolving
-	Map<String, Accumulator<?, ?>> getAllAccumulators();
 
 	/**
 	 * Convenience function to create a counter object for integers.

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -45,7 +45,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -156,11 +155,6 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 	@Override
 	public <V, A extends Serializable> Accumulator<V, A> getAccumulator(String name) {
 		return (Accumulator<V, A>) accumulators.get(name);
-	}
-
-	@Override
-	public Map<String, Accumulator<?, ?>> getAllAccumulators() {
-		return Collections.unmodifiableMap(this.accumulators);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
@@ -43,7 +43,6 @@ import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -133,11 +132,6 @@ class CepRuntimeContext implements RuntimeContext {
 
 	@Override
 	public <V, A extends Serializable> Accumulator<V, A> getAccumulator(final String name) {
-		throw new UnsupportedOperationException("Accumulators are not supported.");
-	}
-
-	@Override
-	public Map<String, Accumulator<?, ?>> getAllAccumulators() {
 		throw new UnsupportedOperationException("Accumulators are not supported.");
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepRuntimeContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepRuntimeContextTest.java
@@ -198,13 +198,6 @@ public class CepRuntimeContextTest extends TestLogger {
 		}
 
 		try {
-			runtimeContext.getAllAccumulators();
-			fail("Expected getAllAccumulators to fail with unsupported operation exception.");
-		} catch (UnsupportedOperationException e) {
-			// expected
-		}
-
-		try {
 			runtimeContext.getIntCounter("foobar");
 			fail("Expected getIntCounter to fail with unsupported operation exception.");
 		} catch (UnsupportedOperationException e) {

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
@@ -48,7 +48,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -133,12 +132,6 @@ public final class SavepointRuntimeContext implements RuntimeContext {
 	@Override
 	public <V, A extends Serializable> Accumulator<V, A> getAccumulator(String name) {
 		return ctx.getAccumulator(name);
-	}
-
-	@Override
-	@Deprecated
-	public Map<String, Accumulator<?, ?>> getAllAccumulators() {
-		return ctx.getAllAccumulators();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -49,7 +49,6 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -195,11 +194,6 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction im
 
 		@Override
 		public <V, A extends Serializable> Accumulator<V, A> getAccumulator(String name) {
-			throw new UnsupportedOperationException("Accumulators are not supported in rich async functions.");
-		}
-
-		@Override
-		public Map<String, Accumulator<?, ?>> getAllAccumulators() {
 			throw new UnsupportedOperationException("Accumulators are not supported in rich async functions.");
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunctionTest.java
@@ -242,13 +242,6 @@ public class RichAsyncFunctionTest {
 		}
 
 		try {
-			runtimeContext.getAllAccumulators();
-			fail("Expected getAllAccumulators to fail with unsupported operation exception.");
-		} catch (UnsupportedOperationException e) {
-			// expected
-		}
-
-		try {
 			runtimeContext.getIntCounter("foobar");
 			fail("Expected getIntCounter to fail with unsupported operation exception.");
 		} catch (UnsupportedOperationException e) {


### PR DESCRIPTION

## What is the purpose of the change

Remove long deprecated RuntimeContext#getAllAcumullators method


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
