### PR TITLE
[FLINK-19031] Remove deprecated StreamExecutionEnvironment#setStateBackend(AbstactStateBackend)

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -59,7 +59,6 @@ import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
@@ -559,16 +558,6 @@ public class StreamExecutionEnvironment {
 	 */
 	@PublicEvolving
 	public StreamExecutionEnvironment setStateBackend(StateBackend backend) {
-		this.defaultStateBackend = Preconditions.checkNotNull(backend);
-		return this;
-	}
-
-	/**
-	 * @deprecated Use {@link #setStateBackend(StateBackend)} instead.
-	 */
-	@Deprecated
-	@PublicEvolving
-	public StreamExecutionEnvironment setStateBackend(AbstractStateBackend backend) {
 		this.defaultStateBackend = Preconditions.checkNotNull(backend);
 		return this;
 	}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.api.scala
 
-import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.annotation.{Experimental, Internal, Public, PublicEvolving}
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
@@ -30,16 +29,17 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
 import org.apache.flink.configuration.{Configuration, ReadableConfig}
 import org.apache.flink.core.execution.{JobClient, JobListener}
-import org.apache.flink.runtime.state.AbstractStateBackend
 import org.apache.flink.runtime.state.StateBackend
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
-import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.{CheckpointingMode, TimeCharacteristic}
 import org.apache.flink.util.SplittableIterator
 
-import scala.collection.JavaConverters._
+import com.esotericsoftware.kryo.Serializer
+
 import _root_.scala.language.implicitConversions
+import scala.collection.JavaConverters._
 
 @Public
 class StreamExecutionEnvironment(javaEnv: JavaEnv) {
@@ -258,15 +258,6 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def setStateBackend(backend: StateBackend): StreamExecutionEnvironment = {
     javaEnv.setStateBackend(backend)
     this
-  }
-
-  /**
-   * @deprecated Use [[StreamExecutionEnvironment.setStateBackend(StateBackend)]] instead.
-   */
-  @Deprecated
-  @PublicEvolving
-  def setStateBackend(backend: AbstractStateBackend): StreamExecutionEnvironment = {
-    setStateBackend(backend.asInstanceOf[StateBackend])
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -175,12 +174,6 @@ public class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment 
 
 	@Override
 	public StreamExecutionEnvironment setStateBackend(StateBackend backend) {
-		throw new UnsupportedOperationException(
-				"This is a dummy StreamExecutionEnvironment, setStateBackend method is unsupported.");
-	}
-
-	@Override
-	public StreamExecutionEnvironment setStateBackend(AbstractStateBackend backend) {
 		throw new UnsupportedOperationException(
 				"This is a dummy StreamExecutionEnvironment, setStateBackend method is unsupported.");
 	}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/util/DummyStreamExecutionEnvironment.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/util/DummyStreamExecutionEnvironment.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -175,12 +174,6 @@ public class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment 
 
 	@Override
 	public StreamExecutionEnvironment setStateBackend(StateBackend backend) {
-		throw new UnsupportedOperationException(
-			"This is a dummy StreamExecutionEnvironment, setStateBackend method is unsupported.");
-	}
-
-	@Override
-	public StreamExecutionEnvironment setStateBackend(AbstractStateBackend backend) {
 		throw new UnsupportedOperationException(
 			"This is a dummy StreamExecutionEnvironment, setStateBackend method is unsupported.");
 	}


### PR DESCRIPTION
## What is the purpose of the change

Remove long deprecated `StreamExecutionEnvironment#setStateBackend(AbstactStateBackend)`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
