### PR TITLE
[FLINK-19040][task] Close SourceReader in SourceOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -162,6 +162,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 
 	@Override
 	public void close() throws Exception {
+		sourceReader.close();
 		eventTimeLogic.stopPeriodicWatermarkEmits();
 		super.close();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -85,38 +85,54 @@ public class SourceOperatorTest {
 		operator.initializeState(getStateContext());
 		// Open the operator.
 		operator.open();
+		try {
+			// The source reader should have been assigned a split.
+			assertEquals(Collections.singletonList(MOCK_SPLIT), mockSourceReader.getAssignedSplits());
+			// The source reader should have started.
+			assertTrue(mockSourceReader.isStarted());
 
-		// The source reader should have been assigned a split.
-		assertEquals(Collections.singletonList(MOCK_SPLIT), mockSourceReader.getAssignedSplits());
-		// The source reader should have started.
-		assertTrue(mockSourceReader.isStarted());
+			// A ReaderRegistrationRequest should have been sent.
+			assertEquals(1, mockGateway.getEventsSent().size());
+			OperatorEvent operatorEvent = mockGateway.getEventsSent().get(0);
+			assertTrue(operatorEvent instanceof ReaderRegistrationEvent);
+			assertEquals(SUBTASK_INDEX, ((ReaderRegistrationEvent) operatorEvent).subtaskId());
 
-		// A ReaderRegistrationRequest should have been sent.
-		assertEquals(1, mockGateway.getEventsSent().size());
-		OperatorEvent operatorEvent = mockGateway.getEventsSent().get(0);
-		assertTrue(operatorEvent instanceof ReaderRegistrationEvent);
-		assertEquals(SUBTASK_INDEX, ((ReaderRegistrationEvent) operatorEvent).subtaskId());
+		}
+		finally {
+			operator.close();
+		}
 	}
 
 	@Test
 	public void testHandleAddSplitsEvent() throws Exception {
 		operator.initializeState(getStateContext());
 		operator.open();
-		MockSourceSplit newSplit = new MockSourceSplit((2));
-		operator.handleOperatorEvent(new AddSplitEvent<>(
+		try {
+			MockSourceSplit newSplit = new MockSourceSplit((2));
+			operator.handleOperatorEvent(new AddSplitEvent<>(
 				Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
-		// The source reader should have been assigned two splits.
-		assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), mockSourceReader.getAssignedSplits());
+			// The source reader should have been assigned two splits.
+			assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), mockSourceReader.getAssignedSplits());
+		}
+		finally {
+			operator.close();
+		}
 	}
 
 	@Test
 	public void testHandleAddSourceEvent() throws Exception {
 		operator.initializeState(getStateContext());
 		operator.open();
-		SourceEvent event = new SourceEvent() {};
-		operator.handleOperatorEvent(new SourceEventWrapper(event));
-		// The source reader should have been assigned two splits.
-		assertEquals(Collections.singletonList(event), mockSourceReader.getReceivedSourceEvents());
+		try {
+			SourceEvent event = new SourceEvent() {
+			};
+			operator.handleOperatorEvent(new SourceEventWrapper(event));
+			// The source reader should have been assigned two splits.
+			assertEquals(Collections.singletonList(event), mockSourceReader.getReceivedSourceEvents());
+		}
+		finally {
+			operator.close();
+		}
 	}
 
 	@Test
@@ -124,14 +140,19 @@ public class SourceOperatorTest {
 		StateInitializationContext stateContext = getStateContext();
 		operator.initializeState(stateContext);
 		operator.open();
-		MockSourceSplit newSplit = new MockSourceSplit((2));
-		operator.handleOperatorEvent(new AddSplitEvent<>(
+		try {
+			MockSourceSplit newSplit = new MockSourceSplit((2));
+			operator.handleOperatorEvent(new AddSplitEvent<>(
 				Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
-		operator.snapshotState(new StateSnapshotContextSynchronousImpl(100L, 100L));
+			operator.snapshotState(new StateSnapshotContextSynchronousImpl(100L, 100L));
 
-		// Verify the splits in state.
-		List<MockSourceSplit> splitsInState = CollectionUtil.iterableToList(operator.getReaderState().get());
-		assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), splitsInState);
+			// Verify the splits in state.
+			List<MockSourceSplit> splitsInState = CollectionUtil.iterableToList(operator.getReaderState().get());
+			assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), splitsInState);
+		}
+		finally {
+			operator.close();
+		}
 	}
 
 	// ---------------- helper methods -------------------------
@@ -139,21 +160,21 @@ public class SourceOperatorTest {
 	private StateInitializationContext getStateContext() throws Exception {
 		// Create a mock split.
 		byte[] serializedSplitWithVersion = SimpleVersionedSerialization
-				.writeVersionAndSerialize(new MockSourceSplitSerializer(), MOCK_SPLIT);
+			.writeVersionAndSerialize(new MockSourceSplitSerializer(), MOCK_SPLIT);
 
 		// Crate the state context.
 		OperatorStateStore operatorStateStore = createOperatorStateStore();
 		StateInitializationContext stateContext = new StateInitializationContextImpl(
-				false,
-				operatorStateStore,
-				null,
-				null,
-				null);
+			false,
+			operatorStateStore,
+			null,
+			null,
+			null);
 
 		// Update the context.
 		stateContext.getOperatorStateStore()
-					.getListState(SourceOperator.SPLITS_STATE_DESC)
-					.update(Collections.singletonList(serializedSplitWithVersion));
+			.getListState(SourceOperator.SPLITS_STATE_DESC)
+			.update(Collections.singletonList(serializedSplitWithVersion));
 
 		return stateContext;
 	}
@@ -163,6 +184,6 @@ public class SourceOperatorTest {
 		final AbstractStateBackend abstractStateBackend = new MemoryStateBackend();
 		CloseableRegistry cancelStreamRegistry = new CloseableRegistry();
 		return abstractStateBackend.createOperatorStateBackend(
-				env, "test-operator", Collections.emptyList(), cancelStreamRegistry);
+			env, "test-operator", Collections.emptyList(), cancelStreamRegistry);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -101,6 +101,7 @@ public class SourceOperatorTest {
 		finally {
 			operator.close();
 		}
+		assertTrue(mockSourceReader.isClosed());
 	}
 
 	@Test


### PR DESCRIPTION
Also properly close operator in the SourceOperatorTest unit tests

## Verifying this change

This change added tests an extra assertion to the `SourceOperatorTest#testOpen` unit test, to add test coverage for the bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
