### PR TITLE
[FLINK-17159] Harden ElasticsearchSinkITCase

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/ElasticsearchResource.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/ElasticsearchResource.java
@@ -21,11 +21,20 @@ package org.apache.flink.streaming.connectors.elasticsearch.testutils;
 import org.apache.flink.streaming.connectors.elasticsearch.EmbeddedElasticsearchNodeEnvironment;
 import org.apache.flink.util.InstantiationUtil;
 
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ClusterAdminClient;
+import org.elasticsearch.common.unit.TimeValue;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertThat;
 
 /**
  * A resource that starts an embedded elasticsearch cluster.
@@ -55,6 +64,27 @@ public class ElasticsearchResource extends ExternalResource {
 
 		tempFolder.create();
 		embeddedNodeEnv.start(tempFolder.newFolder(), clusterName);
+
+		waitForCluster();
+	}
+
+	/**
+	 * Blocks until the cluster is ready and data nodes/nodes are live.
+	 */
+	private void waitForCluster() {
+		AdminClient adminClient = embeddedNodeEnv.getClient().admin();
+		ClusterAdminClient clusterAdminClient = adminClient.cluster();
+
+		ClusterHealthRequestBuilder requestBuilder = clusterAdminClient.prepareHealth("_all");
+		requestBuilder = requestBuilder.setTimeout(TimeValue.timeValueSeconds(120));
+
+		ActionFuture<ClusterHealthResponse> healthFuture =
+				clusterAdminClient.health(requestBuilder.request());
+
+		ClusterHealthResponse health = healthFuture.actionGet(TimeValue.timeValueSeconds(120));
+
+		assertThat(health.getNumberOfNodes(), greaterThanOrEqualTo(1));
+		assertThat(health.getNumberOfDataNodes(), greaterThanOrEqualTo(1));
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Before, it could happen that the embedded node is not ready. Now we set
a restart strategy and enable checkpointing for the test job to allow it
to recover from failures that result from this.

## Verifying this change

- covered by the test that we're hardening