### PR TITLE
[FLINK-19050][Documentation]Doc of MAX_DECIMAL_PRECISION should be DECIMAL

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/PostgresDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/PostgresDialect.java
@@ -40,7 +40,7 @@ public class PostgresDialect extends AbstractDialect {
 	private static final int MAX_TIMESTAMP_PRECISION = 6;
 	private static final int MIN_TIMESTAMP_PRECISION = 1;
 
-	// Define MAX/MIN precision of TIMESTAMP type according to PostgreSQL docs:
+	// Define MAX/MIN precision of DECIMAL type according to PostgreSQL docs:
 	// https://www.postgresql.org/docs/12/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL
 	private static final int MAX_DECIMAL_PRECISION = 1000;
 	private static final int MIN_DECIMAL_PRECISION = 1;


### PR DESCRIPTION
## What is the purpose of the change

fix mistake of java doc of decimal presision constants definition in PostgresDialect.java#L43 



## Brief change log

-fix mistake of java doc of decimal presision constants definition in PostgresDialect.java#L43 


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (no)
