### PR TITLE
[FLINK-19009][metrics] Fixed the downtime metric issue and updated the comment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/DownTimeGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/DownTimeGauge.java
@@ -28,16 +28,16 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A gauge that returns (in milliseconds) how long a job has not been not running any
  * more, in case it is in a failing/recovering situation. Running jobs return naturally
  * a value of zero.
- * 
- * <p>For jobs that have never run (new not yet scheduled jobs), this gauge returns
- * {@value NOT_YET_RUNNING}, and for jobs that are not running any more, it returns
- * {@value NO_LONGER_RUNNING}. 
+ *
+ * <p>For jobs that have never run (new not yet scheduled jobs) or jobs that
+ * have run again after failing, this gauge returns {@value EXPIRED_FAILING},
+ * and for jobs that are not running any more, it returns {@value NO_LONGER_RUNNING}.
  */
 public class DownTimeGauge implements Gauge<Long> {
 
 	public static final String METRIC_NAME = "downtime";
 
-	private static final long NOT_YET_RUNNING = 0L;
+	private static final long EXPIRED_FAILING = 0L;
 
 	private static final long NO_LONGER_RUNNING = -1L;
 
@@ -55,25 +55,19 @@ public class DownTimeGauge implements Gauge<Long> {
 	public Long getValue() {
 		final JobStatus status = eg.getState();
 
-		if (status == JobStatus.RUNNING) {
-			// running right now - no downtime
-			return 0L;
-		}
-		else if (status.isTerminalState()) {
-			// not running any more -> finished or not on leader
+		// not running any more -> finished or not on leader
+		if (status.isTerminalState()) {
 			return NO_LONGER_RUNNING;
 		}
-		else {
-			final long runningTimestamp = eg.getStatusTimestamp(JobStatus.RUNNING);
-			if (runningTimestamp > 0) {
-				// job was running at some point and is not running now
-				// we use 'Math.max' here to avoid negative timestamps when clocks change
-				return Math.max(System.currentTimeMillis() - runningTimestamp, 0);
-			}
-			else {
-				// job was never scheduled so far
-				return NOT_YET_RUNNING;
-			}
+
+		final long runningTimestamp = eg.getStatusTimestamp(JobStatus.RUNNING);
+		final long failingTimestamp = eg.getStatusTimestamp(JobStatus.FAILING);
+
+		if (failingTimestamp <= runningTimestamp) {
+			return EXPIRED_FAILING;
+		} else {
+			// we use 'Math.max' here to avoid negative timestamps when clocks change
+			return Math.max(System.currentTimeMillis() - failingTimestamp, 0);
 		}
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently the way to calculate the Flink system metric "downtime"  is not consistent with the description in the doc, now the downtime is actually the current timestamp minus the time timestamp when the job started. This pull request fixed this bug so that the DownTimeGauge meet the document description.

## Brief change log

Calculate the downtime metric by using the current system timestamp to minus the latest failing time of the ExecutionGraph except for the following situations:
1. The start time of 'RUNNING' is greater than or equal to the latest 'FAILING' time. That means 'RUNNING' is a later status or the job has never run, and therefore downtime should be 0.
2. Jobs are terminated, so downtime is -1.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
