### PR TITLE
[FLINK-17826][jdbc] Add missing custom query support on new jdbc connector

### DIFF
--- a/docs/dev/table/connectors/jdbc.md
+++ b/docs/dev/table/connectors/jdbc.md
@@ -154,7 +154,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>The custom query used when scan the database table.</td>
+      <td>The custom query used when scan the database table, if the <code>'scan.query'</code> option is present then the <code>'table-name'</code> option is ignored when the jdbc table is used as source table.</td>
     </tr>     
     <tr>
       <td><h5>scan.partition.column</h5></td>

--- a/docs/dev/table/connectors/jdbc.md
+++ b/docs/dev/table/connectors/jdbc.md
@@ -148,7 +148,14 @@ Connector Options
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>The JDBC password.</td>
-    </tr> 
+    </tr>
+    <tr>
+      <td><h5>scan.query</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>The custom query used when scan the database table.</td>
+    </tr>     
     <tr>
       <td><h5>scan.partition.column</h5></td>
       <td>optional</td>

--- a/docs/dev/table/connectors/jdbc.zh.md
+++ b/docs/dev/table/connectors/jdbc.zh.md
@@ -154,7 +154,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>The custom query used when scan the database table.</td>
+      <td>The custom query used when scan the database table, if the <code>'scan.query'</code> option is present then the <code>'table-name'</code> option is ignored when the jdbc table is used as source table.</td>
     </tr>
     <tr>
       <td><h5>scan.partition.column</h5></td>

--- a/docs/dev/table/connectors/jdbc.zh.md
+++ b/docs/dev/table/connectors/jdbc.zh.md
@@ -150,6 +150,13 @@ Connector Options
       <td>The JDBC password.</td>
     </tr>
     <tr>
+      <td><h5>scan.query</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>The custom query used when scan the database table.</td>
+    </tr>
+    <tr>
       <td><h5>scan.partition.column</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
@@ -86,7 +86,8 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 		.key("scan.query")
 		.stringType()
 		.noDefaultValue()
-		.withDescription("the custom query used when scan the database table.");
+		.withDescription("the custom query used when scan the database table, if the scan.query option is present" +
+			" then the table-name option is ignored when the jdbc table is used as source table.");
 	private static final ConfigOption<String> SCAN_PARTITION_COLUMN = ConfigOptions
 		.key("scan.partition.column")
 		.stringType()

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
@@ -82,6 +82,11 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 			"If not set, it will automatically be derived from the URL.");
 
 	// read config options
+	private static final ConfigOption<String> SCAN_QUERY = ConfigOptions
+		.key("scan.query")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("the custom query used when scan the database table.");
 	private static final ConfigOption<String> SCAN_PARTITION_COLUMN = ConfigOptions
 		.key("scan.partition.column")
 		.stringType()
@@ -184,9 +189,9 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 		final String url = readableConfig.get(URL);
 		final JdbcOptions.Builder builder = JdbcOptions.builder()
 			.setDBUrl(url)
-			.setTableName(readableConfig.get(TABLE_NAME))
 			.setDialect(JdbcDialects.get(url).get());
 
+		readableConfig.getOptional(TABLE_NAME).ifPresent(builder::setTableName);
 		readableConfig.getOptional(DRIVER).ifPresent(builder::setDriverName);
 		readableConfig.getOptional(USERNAME).ifPresent(builder::setUsername);
 		readableConfig.getOptional(PASSWORD).ifPresent(builder::setPassword);
@@ -203,6 +208,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 			builder.setNumPartitions(readableConfig.get(SCAN_PARTITION_NUM));
 		}
 		readableConfig.getOptional(SCAN_FETCH_SIZE).ifPresent(builder::setFetchSize);
+		readableConfig.getOptional(SCAN_QUERY).ifPresent(builder::setQuery);
 		return builder.build();
 	}
 
@@ -253,6 +259,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 		optionalOptions.add(DRIVER);
 		optionalOptions.add(USERNAME);
 		optionalOptions.add(PASSWORD);
+		optionalOptions.add(SCAN_QUERY);
 		optionalOptions.add(SCAN_PARTITION_COLUMN);
 		optionalOptions.add(SCAN_PARTITION_LOWER_BOUND);
 		optionalOptions.add(SCAN_PARTITION_UPPER_BOUND);

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
@@ -98,8 +98,9 @@ public class JdbcDynamicTableSource implements ScanTableSource, LookupTableSourc
 			builder.setFetchSize(readOptions.getFetchSize());
 		}
 		final JdbcDialect dialect = options.getDialect();
-		String query = dialect.getSelectFromStatement(
-			options.getTableName(), physicalSchema.getFieldNames(), new String[0]);
+		String query = readOptions.getQuery().orElseGet(
+			() -> dialect.getSelectFromStatement(
+				options.getTableName(), physicalSchema.getFieldNames(), new String[0]));
 		if (readOptions.getPartitionColumnName().isPresent()) {
 			long lowerBound = readOptions.getPartitionLowerBound().get();
 			long upperBound = readOptions.getPartitionUpperBound().get();

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
@@ -43,8 +43,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test for {@link JdbcTableSource} and {@link JdbcUpsertTableSink} created
- * by {@link JdbcTableSourceSinkFactory}.
+ * Test for {@link JdbcDynamicTableSource} and {@link JdbcDynamicTableSink} created
+ * by {@link JdbcDynamicTableFactory}.
  */
 public class JdbcDynamicTableFactoryTest {
 
@@ -63,6 +63,7 @@ public class JdbcDynamicTableFactoryTest {
 		properties.put("driver", "org.apache.derby.jdbc.EmbeddedDriver");
 		properties.put("username", "user");
 		properties.put("password", "pass");
+		properties.put("scan.query", "select * from mytable");
 
 		// validation for source
 		DynamicTableSource actualSource = createTableSource(properties);
@@ -78,9 +79,13 @@ public class JdbcDynamicTableFactoryTest {
 			.setCacheExpireMs(10_000)
 			.setMaxRetryTimes(3)
 			.build();
+		JdbcReadOptions jdbcReadOptions = JdbcReadOptions.builder()
+			.setQuery("select * from mytable")
+			.build();
+
 		JdbcDynamicTableSource expectedSource = new JdbcDynamicTableSource(
 			options,
-			JdbcReadOptions.builder().build(),
+			jdbcReadOptions,
 			lookupOptions,
 			schema);
 		assertEquals(expectedSource, actualSource);
@@ -110,6 +115,7 @@ public class JdbcDynamicTableFactoryTest {
 	@Test
 	public void testJdbcReadProperties() {
 		Map<String, String> properties = getAllOptions();
+		properties.put("scan.query", "select * from mytable");
 		properties.put("scan.partition.column", "aaa");
 		properties.put("scan.partition.lower-bound", "-10");
 		properties.put("scan.partition.upper-bound", "100");
@@ -128,6 +134,7 @@ public class JdbcDynamicTableFactoryTest {
 			.setPartitionUpperBound(100)
 			.setNumPartitions(10)
 			.setFetchSize(20)
+			.setQuery("select * from mytable")
 			.build();
 		JdbcLookupOptions lookupOptions = JdbcLookupOptions.builder()
 			.setCacheMaxSize(-1)

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSourceITCase.java
@@ -36,6 +36,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -91,10 +92,7 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
 	@Test
 	public void testJdbcSource() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		EnvironmentSettings envSettings = EnvironmentSettings.newInstance()
-			.useBlinkPlanner()
-			.inStreamingMode()
-			.build();
+		EnvironmentSettings envSettings = EnvironmentSettings.newInstance().build();
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
 
 		tEnv.executeSql(
@@ -110,8 +108,7 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
 				"  'connector'='jdbc'," +
 				"  'url'='" + DB_URL + "'," +
 				"  'table-name'='" + INPUT_TABLE + "'" +
-				")"
-		);
+				")");
 
 		Iterator<Row> collected = tEnv.executeSql("SELECT * FROM " + INPUT_TABLE).collect();
 		List<String> result = Lists.newArrayList(collected).stream()
@@ -123,6 +120,34 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
 				"1,2020-01-01T15:35:00.123456,2020-01-01T15:35:00.123456789,15:35,1.175E-37,1.79769E308,100.1234",
 				"2,2020-01-01T15:36:01.123456,2020-01-01T15:36:01.123456789,15:36:01,-1.175E-37,-1.79769E308,101.1234")
 			.sorted().collect(Collectors.toList());
+		assertEquals(expected, result);
+	}
+
+	@Test
+	public void testJdbcSourceWithCustomQuery() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		EnvironmentSettings envSettings = EnvironmentSettings.newInstance().build();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+
+		tEnv.executeSql(
+			"CREATE TABLE " + INPUT_TABLE + "(" +
+				"id BIGINT," +
+				"timestamp6_col TIMESTAMP(6)," +
+				"timestamp9_col TIMESTAMP(9)" +
+				") WITH (" +
+				"  'connector'='jdbc'," +
+				"  'url'='" + DB_URL + "'," +
+				"  'table-name'='" + INPUT_TABLE + "'," +
+				"  'scan.query'='select id, timestamp6_col, timestamp9_col from " + INPUT_TABLE + " where id > 1 '" +
+				")");
+
+		Iterator<Row> collected = tEnv.executeSql("SELECT * FROM " + INPUT_TABLE).collect();
+		List<String> result = Lists.newArrayList(collected).stream()
+			.map(Row::toString)
+			.sorted()
+			.collect(Collectors.toList());
+		List<String> expected = new ArrayList<>();
+		expected.add("2,2020-01-01T15:36:01.123456,2020-01-01T15:36:01.123456789");
 		assertEquals(expected, result);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request add `scan.query` option for dynamic JDBC connector.


## Brief change log

  - introduce option `scan.query`
  - use custom query first when scan a JDBC table

## Verifying this change

- Add unit test in `JdbcDynamicTableFactoryTest` and ITCase in `JdbcDynamicTableSourceITCase`. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs )
