### PR TITLE
[FLINK-14435] Added memory configuration to TaskManagers REST endpoint

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -4119,16 +4119,16 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
               "frameworkOffHeap" : {
                 "type" : "integer"
               },
-              "managedTotal" : {
+              "jvmMetaspace" : {
                 "type" : "integer"
               },
-              "metaspaceMax" : {
+              "jvmOverhead" : {
                 "type" : "integer"
               },
-              "networkMax" : {
+              "managedMemory" : {
                 "type" : "integer"
               },
-              "overheadMax" : {
+              "networkMemory" : {
                 "type" : "integer"
               },
               "taskHeap" : {
@@ -4326,16 +4326,16 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "frameworkOffHeap" : {
           "type" : "integer"
         },
-        "managedTotal" : {
+        "jvmMetaspace" : {
           "type" : "integer"
         },
-        "metaspaceMax" : {
+        "jvmOverhead" : {
           "type" : "integer"
         },
-        "networkMax" : {
+        "managedMemory" : {
           "type" : "integer"
         },
-        "overheadMax" : {
+        "networkMemory" : {
           "type" : "integer"
         },
         "taskHeap" : {

--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -4109,6 +4109,42 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "id" : {
             "type" : "any"
           },
+          "memoryConfiguration" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:taskexecutor:TaskExecutorMemoryConfiguration",
+            "properties" : {
+              "frameworkHeap" : {
+                "type" : "integer"
+              },
+              "frameworkOffHeap" : {
+                "type" : "integer"
+              },
+              "managedTotal" : {
+                "type" : "integer"
+              },
+              "metaspaceMax" : {
+                "type" : "integer"
+              },
+              "networkMax" : {
+                "type" : "integer"
+              },
+              "overheadMax" : {
+                "type" : "integer"
+              },
+              "taskHeap" : {
+                "type" : "integer"
+              },
+              "taskOffHeap" : {
+                "type" : "integer"
+              },
+              "totalFlinkMemory" : {
+                "type" : "integer"
+              },
+              "totalProcessMemory" : {
+                "type" : "integer"
+              }
+            }
+          },
           "path" : {
             "type" : "string"
           },
@@ -4279,6 +4315,42 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "id" : {
       "type" : "any"
+    },
+    "memoryConfiguration" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:taskexecutor:TaskExecutorMemoryConfiguration",
+      "properties" : {
+        "frameworkHeap" : {
+          "type" : "integer"
+        },
+        "frameworkOffHeap" : {
+          "type" : "integer"
+        },
+        "managedTotal" : {
+          "type" : "integer"
+        },
+        "metaspaceMax" : {
+          "type" : "integer"
+        },
+        "networkMax" : {
+          "type" : "integer"
+        },
+        "overheadMax" : {
+          "type" : "integer"
+        },
+        "taskHeap" : {
+          "type" : "integer"
+        },
+        "taskOffHeap" : {
+          "type" : "integer"
+        },
+        "totalFlinkMemory" : {
+          "type" : "integer"
+        },
+        "totalProcessMemory" : {
+          "type" : "integer"
+        }
+      }
     },
     "metrics" : {
       "type" : "object",

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -63,6 +63,7 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
@@ -637,6 +638,7 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 				resourceID,
 				1234,
 				new HardwareDescription(1, 2L, 3L, 4L),
+				new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
 				registerSlotProfile,
 				registerSlotProfile);
 			CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -72,6 +72,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
@@ -669,6 +670,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				task1Executor.resourceID,
 				dataPort,
 				hardwareDescription,
+				new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
 				ResourceProfile.ZERO,
 				ResourceProfile.ZERO);
 			CompletableFuture<RegistrationResponse> successfulFuture =

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2740,34 +2740,22 @@
                   "taskOffHeap" : {
                     "type" : "integer"
                   },
-                  "networkMin" : {
+                  "networkMemory" : {
                     "type" : "integer"
                   },
-                  "networkMax" : {
+                  "managedMemory" : {
                     "type" : "integer"
                   },
-                  "networkFraction" : {
-                    "type" : "number"
-                  },
-                  "managedTotal" : {
+                  "jvmMetaspace" : {
                     "type" : "integer"
                   },
-                  "managedFraction" : {
-                    "type" : "number"
-                  },
-                  "metaspaceMax" : {
+                  "jvmOverhead" : {
                     "type" : "integer"
                   },
-                  "overheadMin" : {
+                  "totalFlinkMemory" : {
                     "type" : "integer"
                   },
-                  "overheadMax" : {
-                    "type" : "integer"
-                  },
-                  "overheadFraction" : {
-                    "type" : "number"
-                  },
-                  "memoryTotal" : {
+                  "totalProcessMemory" : {
                     "type" : "integer"
                   }
                 }
@@ -2906,34 +2894,22 @@
             "taskOffHeap" : {
               "type" : "integer"
             },
-            "networkMin" : {
+            "networkMemory" : {
               "type" : "integer"
             },
-            "networkMax" : {
+            "managedMemory" : {
               "type" : "integer"
             },
-            "networkFraction" : {
-              "type" : "number"
-            },
-            "managedTotal" : {
+            "jvmMetaspace" : {
               "type" : "integer"
             },
-            "managedFraction" : {
-              "type" : "number"
-            },
-            "metaspaceMax" : {
+            "jvmOverhead" : {
               "type" : "integer"
             },
-            "overheadMin" : {
+            "totalFlinkMemory" : {
               "type" : "integer"
             },
-            "overheadMax" : {
-              "type" : "integer"
-            },
-            "overheadFraction" : {
-              "type" : "number"
-            },
-            "memoryTotal" : {
+            "totalProcessMemory" : {
               "type" : "integer"
             }
           }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2723,6 +2723,54 @@
                     "type" : "integer"
                   }
                 }
+              },
+              "memoryConfiguration" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:taskexecutor:TaskExecutorMemoryConfiguration",
+                "properties" : {
+                  "frameworkHeap" : {
+                    "type" : "integer"
+                  },
+                  "taskHeap" : {
+                    "type" : "integer"
+                  },
+                  "frameworkOffHeap" : {
+                    "type" : "integer"
+                  },
+                  "taskOffHeap" : {
+                    "type" : "integer"
+                  },
+                  "networkMin" : {
+                    "type" : "integer"
+                  },
+                  "networkMax" : {
+                    "type" : "integer"
+                  },
+                  "networkFraction" : {
+                    "type" : "number"
+                  },
+                  "managedTotal" : {
+                    "type" : "integer"
+                  },
+                  "managedFraction" : {
+                    "type" : "number"
+                  },
+                  "metaspaceMax" : {
+                    "type" : "integer"
+                  },
+                  "overheadMin" : {
+                    "type" : "integer"
+                  },
+                  "overheadMax" : {
+                    "type" : "integer"
+                  },
+                  "overheadFraction" : {
+                    "type" : "number"
+                  },
+                  "memoryTotal" : {
+                    "type" : "integer"
+                  }
+                }
               }
             }
           }
@@ -2838,6 +2886,54 @@
               "type" : "integer"
             },
             "managedMemory" : {
+              "type" : "integer"
+            }
+          }
+        },
+        "memoryConfiguration" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:taskexecutor:TaskExecutorMemoryConfiguration",
+          "properties" : {
+            "frameworkHeap" : {
+              "type" : "integer"
+            },
+            "taskHeap" : {
+              "type" : "integer"
+            },
+            "frameworkOffHeap" : {
+              "type" : "integer"
+            },
+            "taskOffHeap" : {
+              "type" : "integer"
+            },
+            "networkMin" : {
+              "type" : "integer"
+            },
+            "networkMax" : {
+              "type" : "integer"
+            },
+            "networkFraction" : {
+              "type" : "number"
+            },
+            "managedTotal" : {
+              "type" : "integer"
+            },
+            "managedFraction" : {
+              "type" : "number"
+            },
+            "metaspaceMax" : {
+              "type" : "integer"
+            },
+            "overheadMin" : {
+              "type" : "integer"
+            },
+            "overheadMax" : {
+              "type" : "integer"
+            },
+            "overheadFraction" : {
+              "type" : "number"
+            },
+            "memoryTotal" : {
               "type" : "integer"
             }
           }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -551,7 +551,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 					slotManager.getNumberFreeSlotsOf(taskExecutor.getInstanceID()),
 					slotManager.getRegisteredResourceOf(taskExecutor.getInstanceID()),
 					slotManager.getFreeResourceOf(taskExecutor.getInstanceID()),
-					taskExecutor.getHardwareDescription()));
+					taskExecutor.getHardwareDescription(),
+					taskExecutor.getMemoryConfiguration()));
 		}
 
 		return CompletableFuture.completedFuture(taskManagerInfos);
@@ -575,7 +576,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				slotManager.getNumberFreeSlotsOf(instanceId),
 				slotManager.getRegisteredResourceOf(instanceId),
 				slotManager.getFreeResourceOf(instanceId),
-				taskExecutor.getHardwareDescription());
+				taskExecutor.getHardwareDescription(),
+				taskExecutor.getMemoryConfiguration());
 
 			return CompletableFuture.completedFuture(taskManagerInfo);
 		}
@@ -782,7 +784,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				taskExecutorGateway,
 				newWorker,
 				taskExecutorRegistration.getDataPort(),
-				taskExecutorRegistration.getHardwareDescription());
+				taskExecutorRegistration.getHardwareDescription(),
+				taskExecutorRegistration.getMemoryConfiguration());
 
 			log.info("Registering TaskManager with ResourceID {} ({}) at ResourceManager", taskExecutorResourceId.getStringWithMetadata(), taskExecutorAddress);
 			taskExecutors.put(taskExecutorResourceId, registration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskExecutorRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskExecutorRegistration.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 
 import java.io.Serializable;
 
@@ -53,6 +54,11 @@ public class TaskExecutorRegistration implements Serializable {
 	private final HardwareDescription hardwareDescription;
 
 	/**
+	 * Memory configuration of the registering TaskExecutor.
+	 */
+	private final TaskExecutorMemoryConfiguration memoryConfiguration;
+
+	/**
 	 * The default resource profile for slots requested with unknown resource requirements.
 	 */
 	private final ResourceProfile defaultSlotResourceProfile;
@@ -67,12 +73,14 @@ public class TaskExecutorRegistration implements Serializable {
 			final ResourceID resourceId,
 			final int dataPort,
 			final HardwareDescription hardwareDescription,
+			final TaskExecutorMemoryConfiguration memoryConfiguration,
 			final ResourceProfile defaultSlotResourceProfile,
 			final ResourceProfile totalResourceProfile) {
 		this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
 		this.resourceId = checkNotNull(resourceId);
 		this.dataPort = dataPort;
 		this.hardwareDescription = checkNotNull(hardwareDescription);
+		this.memoryConfiguration = checkNotNull(memoryConfiguration);
 		this.defaultSlotResourceProfile = checkNotNull(defaultSlotResourceProfile);
 		this.totalResourceProfile = checkNotNull(totalResourceProfile);
 	}
@@ -91,6 +99,10 @@ public class TaskExecutorRegistration implements Serializable {
 
 	public HardwareDescription getHardwareDescription() {
 		return hardwareDescription;
+	}
+
+	public TaskExecutorMemoryConfiguration getMemoryConfiguration() {
+		return memoryConfiguration;
 	}
 
 	public ResourceProfile getDefaultSlotResourceProfile() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager.registration;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -34,17 +35,21 @@ public class WorkerRegistration<WorkerType extends ResourceIDRetrievable> extend
 
 	private final HardwareDescription hardwareDescription;
 
+	private final TaskExecutorMemoryConfiguration memoryConfiguration;
+
 	public WorkerRegistration(
 			TaskExecutorGateway taskExecutorGateway,
 			WorkerType worker,
 			int dataPort,
-			HardwareDescription hardwareDescription) {
+			HardwareDescription hardwareDescription,
+			TaskExecutorMemoryConfiguration memoryConfiguration) {
 
 		super(worker.getResourceID(), taskExecutorGateway);
 
 		this.worker = Preconditions.checkNotNull(worker);
 		this.dataPort = dataPort;
 		this.hardwareDescription = Preconditions.checkNotNull(hardwareDescription);
+		this.memoryConfiguration = Preconditions.checkNotNull(memoryConfiguration);
 	}
 
 	public WorkerType getWorker() {
@@ -57,5 +62,9 @@ public class WorkerRegistration<WorkerType extends ResourceIDRetrievable> extend
 
 	public HardwareDescription getHardwareDescription() {
 		return hardwareDescription;
+	}
+
+	public TaskExecutorMemoryConfiguration getMemoryConfiguration() {
+		return memoryConfiguration;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.rest.messages.ResourceProfileInfo;
 import org.apache.flink.runtime.rest.messages.json.ResourceIDDeserializer;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -53,6 +54,7 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 			@JsonProperty(FIELD_NAME_TOTAL_RESOURCE) ResourceProfileInfo totalResource,
 			@JsonProperty(FIELD_NAME_AVAILABLE_RESOURCE) ResourceProfileInfo freeResource,
 			@JsonProperty(FIELD_NAME_HARDWARE) HardwareDescription hardwareDescription,
+			@JsonProperty(FIELD_NAME_MEMORY) TaskExecutorMemoryConfiguration memoryConfiguration,
 			@JsonProperty(FIELD_NAME_METRICS) TaskManagerMetricsInfo taskManagerMetrics) {
 		super(
 			resourceId,
@@ -63,7 +65,8 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 			numberAvailableSlots,
 			totalResource,
 			freeResource,
-			hardwareDescription);
+			hardwareDescription,
+			memoryConfiguration);
 
 		this.taskManagerMetrics = Preconditions.checkNotNull(taskManagerMetrics);
 	}
@@ -79,6 +82,7 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 			taskManagerInfo.getTotalResource(),
 			taskManagerInfo.getFreeResource(),
 			taskManagerInfo.getHardwareDescription(),
+			taskManagerInfo.getMemoryConfiguration(),
 			taskManagerMetrics);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.json.ResourceIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.ResourceIDSerializer;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -59,6 +60,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 
 	public static final String FIELD_NAME_HARDWARE = "hardware";
 
+	public static final String FIELD_NAME_MEMORY = "memoryConfiguration";
+
 	private static final long serialVersionUID = 1L;
 
 	@JsonProperty(FIELD_NAME_RESOURCE_ID)
@@ -89,6 +92,9 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 	@JsonProperty(FIELD_NAME_HARDWARE)
 	private final HardwareDescription hardwareDescription;
 
+	@JsonProperty(FIELD_NAME_MEMORY)
+	private final TaskExecutorMemoryConfiguration memoryConfiguration;
+
 	@JsonCreator
 	public TaskManagerInfo(
 			@JsonDeserialize(using = ResourceIDDeserializer.class) @JsonProperty(FIELD_NAME_RESOURCE_ID) ResourceID resourceId,
@@ -99,7 +105,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			@JsonProperty(FIELD_NAME_NUMBER_AVAILABLE_SLOTS) int numberAvailableSlots,
 			@JsonProperty(FIELD_NAME_TOTAL_RESOURCE) ResourceProfileInfo totalResource,
 			@JsonProperty(FIELD_NAME_AVAILABLE_RESOURCE) ResourceProfileInfo freeResource,
-			@JsonProperty(FIELD_NAME_HARDWARE) HardwareDescription hardwareDescription) {
+			@JsonProperty(FIELD_NAME_HARDWARE) HardwareDescription hardwareDescription,
+			@JsonProperty(FIELD_NAME_MEMORY) TaskExecutorMemoryConfiguration memoryConfiguration) {
 		this.resourceId = Preconditions.checkNotNull(resourceId);
 		this.address = Preconditions.checkNotNull(address);
 		this.dataPort = dataPort;
@@ -109,6 +116,7 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 		this.totalResource = totalResource;
 		this.freeResource = freeResource;
 		this.hardwareDescription = Preconditions.checkNotNull(hardwareDescription);
+		this.memoryConfiguration = Preconditions.checkNotNull(memoryConfiguration);
 	}
 
 	public TaskManagerInfo(
@@ -120,7 +128,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			int numberAvailableSlots,
 			ResourceProfile totalResource,
 			ResourceProfile freeResource,
-			HardwareDescription hardwareDescription) {
+			HardwareDescription hardwareDescription,
+			TaskExecutorMemoryConfiguration memoryConfiguration) {
 		this(resourceId,
 			address,
 			dataPort,
@@ -129,7 +138,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			numberAvailableSlots,
 			ResourceProfileInfo.fromResrouceProfile(totalResource),
 			ResourceProfileInfo.fromResrouceProfile(freeResource),
-			hardwareDescription);
+			hardwareDescription,
+			memoryConfiguration);
 	}
 
 	public ResourceID getResourceId() {
@@ -168,6 +178,10 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 		return hardwareDescription;
 	}
 
+	public TaskExecutorMemoryConfiguration getMemoryConfiguration() {
+		return memoryConfiguration;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -185,7 +199,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			Objects.equals(freeResource, that.freeResource) &&
 			Objects.equals(resourceId, that.resourceId) &&
 			Objects.equals(address, that.address) &&
-			Objects.equals(hardwareDescription, that.hardwareDescription);
+			Objects.equals(hardwareDescription, that.hardwareDescription) &&
+			Objects.equals(memoryConfiguration, that.memoryConfiguration);
 	}
 
 	@Override
@@ -199,6 +214,7 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			numberAvailableSlots,
 			totalResource,
 			freeResource,
-			hardwareDescription);
+			hardwareDescription,
+			memoryConfiguration);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -228,6 +228,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	private final HardwareDescription hardwareDescription;
 
+	private final TaskExecutorMemoryConfiguration memoryConfiguration;
+
 	private FileCache fileCache;
 
 	/** The heartbeat manager for job manager in the task manager. */
@@ -297,6 +299,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.resourceManagerLeaderRetriever = haServices.getResourceManagerLeaderRetriever();
 
 		this.hardwareDescription = HardwareDescription.extractFromSystem(taskExecutorServices.getManagedMemorySize());
+		this.memoryConfiguration = TaskExecutorMemoryConfiguration.create(taskManagerConfiguration.getConfiguration());
 
 		this.resourceManagerAddress = null;
 		this.resourceManagerConnection = null;
@@ -1128,6 +1131,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			getResourceID(),
 			unresolvedTaskManagerLocation.getDataPort(),
 			hardwareDescription,
+			memoryConfiguration,
 			taskManagerConfiguration.getDefaultSlotResourceProfile(),
 			taskManagerConfiguration.getTotalResourceProfile()
 		);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.MoreObjects;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.configuration.TaskManagerOptions.FRAMEWORK_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.JVM_METASPACE;
+import static org.apache.flink.configuration.TaskManagerOptions.JVM_OVERHEAD_MAX;
+import static org.apache.flink.configuration.TaskManagerOptions.MANAGED_MEMORY_SIZE;
+import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_MAX;
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_OFF_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_FLINK_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_PROCESS_MEMORY;
+
+/**
+ * TaskExecutorConfiguration collects the configuration of a TaskExecutor instance.
+ */
+public class TaskExecutorMemoryConfiguration implements Serializable {
+
+	public static final String FIELD_NAME_FRAMEWORK_HEAP = "frameworkHeap";
+	public static final String FIELD_NAME_TASK_HEAP = "taskHeap";
+
+	public static final String FIELD_NAME_FRAMEWORK_OFFHEAP = "frameworkOffHeap";
+	public static final String FIELD_NAME_TASK_OFFHEAP = "taskOffHeap";
+
+	public static final String FIELD_NAME_NETWORK = "networkMax";
+
+	public static final String FIELD_NAME_MANAGED_TOTAL = "managedTotal";
+
+	public static final String FIELD_NAME_METASPACE_MAX = "metaspaceMax";
+
+	public static final String FIELD_NAME_OVERHEAD = "overheadMax";
+
+	public static final String FIELD_NAME_TOTAL_FLINK_MEMORY = "totalFlinkMemory";
+
+	public static final String FIELD_NAME_TOTAL_PROCESS_MEMORY = "totalProcessMemory";
+
+	@JsonProperty(FIELD_NAME_FRAMEWORK_HEAP)
+	@JsonInclude
+	private final Long frameworkHeap;
+
+	@JsonProperty(FIELD_NAME_TASK_HEAP)
+	private final Long taskHeap;
+
+	@JsonProperty(FIELD_NAME_FRAMEWORK_OFFHEAP)
+	private final Long frameworkOffHeap;
+
+	@JsonProperty(FIELD_NAME_TASK_OFFHEAP)
+	private final Long taskOffHeap;
+
+	@JsonProperty(FIELD_NAME_NETWORK)
+	private final Long networkMemory;
+
+	@JsonProperty(FIELD_NAME_MANAGED_TOTAL)
+	private final Long managedMemoryTotal;
+
+	@JsonProperty(FIELD_NAME_METASPACE_MAX)
+	private final Long jvmMetaspaceMax;
+
+	@JsonProperty(FIELD_NAME_OVERHEAD)
+	private final Long jvmOverhead;
+
+	@JsonProperty(FIELD_NAME_TOTAL_FLINK_MEMORY)
+	private final Long totalFlinkMemory;
+
+	@JsonProperty(FIELD_NAME_TOTAL_PROCESS_MEMORY)
+	private final Long totalProcessMemory;
+
+	private static Long getConfigurationValue(Configuration config, ConfigOption<? extends MemorySize> option) {
+		MemorySize memorySize = config.get(option);
+		return memorySize != null ? memorySize.getBytes() : null;
+	}
+
+	/**
+	 * Factory method for initializing a TaskExecutorMemoryConfiguration based on the passed Configuration.
+	 * @param config The Configuration used for initializing the TaskExecutorMemoryConfiguration.
+	 * @return The newly instantiated TaskExecutorMemoryConfiguration.
+	 */
+	public static TaskExecutorMemoryConfiguration create(Configuration config) {
+		return new TaskExecutorMemoryConfiguration(
+				getConfigurationValue(config, FRAMEWORK_HEAP_MEMORY),
+				getConfigurationValue(config, TASK_HEAP_MEMORY),
+				getConfigurationValue(config, FRAMEWORK_OFF_HEAP_MEMORY),
+				getConfigurationValue(config, TASK_OFF_HEAP_MEMORY),
+				getConfigurationValue(config, NETWORK_MEMORY_MAX),
+				getConfigurationValue(config, MANAGED_MEMORY_SIZE),
+				getConfigurationValue(config, JVM_METASPACE),
+			getConfigurationValue(config, JVM_OVERHEAD_MAX),
+				getConfigurationValue(config, TOTAL_FLINK_MEMORY),
+				getConfigurationValue(config, TOTAL_PROCESS_MEMORY)
+		);
+	}
+
+	@JsonCreator
+	public TaskExecutorMemoryConfiguration(
+			@JsonProperty(FIELD_NAME_FRAMEWORK_HEAP) Long frameworkHeap,
+			@JsonProperty(FIELD_NAME_TASK_HEAP) Long taskHeap,
+			@JsonProperty(FIELD_NAME_FRAMEWORK_OFFHEAP) Long frameworkOffHeap,
+			@JsonProperty(FIELD_NAME_TASK_OFFHEAP) Long taskOffHeap,
+			@JsonProperty(FIELD_NAME_NETWORK) Long networkMemory,
+			@JsonProperty(FIELD_NAME_MANAGED_TOTAL) Long managedMemoryTotal,
+			@JsonProperty(FIELD_NAME_METASPACE_MAX) Long jvmMetaspaceMax,
+			@JsonProperty(FIELD_NAME_OVERHEAD) Long jvmOverhead,
+			@JsonProperty(FIELD_NAME_TOTAL_FLINK_MEMORY) Long totalFlinkMemory,
+			@JsonProperty(FIELD_NAME_TOTAL_PROCESS_MEMORY) Long totalProcessMemory) {
+		this.frameworkHeap = frameworkHeap;
+		this.taskHeap = taskHeap;
+		this.frameworkOffHeap = frameworkOffHeap;
+		this.taskOffHeap = taskOffHeap;
+		this.networkMemory = networkMemory;
+		this.managedMemoryTotal = managedMemoryTotal;
+		this.jvmMetaspaceMax = jvmMetaspaceMax;
+		this.jvmOverhead = jvmOverhead;
+		this.totalFlinkMemory = totalFlinkMemory;
+		this.totalProcessMemory = totalProcessMemory;
+	}
+
+	/**
+	 * Returns the configured heap size used by the framework.
+	 */
+	public Long getFrameworkHeap() {
+		return frameworkHeap;
+	}
+
+	/**
+	 * Returns the configured heap size used by the tasks.
+	 */
+	public Long getTaskHeap() {
+		return taskHeap;
+	}
+
+	/**
+	 * Returns the configured off-heap size used by the framework.
+	 */
+	public Long getFrameworkOffHeap() {
+		return frameworkOffHeap;
+	}
+
+	/**
+	 * Returns the configured off-heap size used by the tasks.
+	 */
+	public Long getTaskOffHeap() {
+		return taskOffHeap;
+	}
+
+	/**
+	 * Returns the configured maximum network memory.
+	 */
+	public Long getNetworkMemory() {
+		return networkMemory;
+	}
+
+	/**
+	 * Returns the total amount of memory reserved for by the MemoryManager.
+	 */
+	public Long getManagedMemoryTotal() {
+		return managedMemoryTotal;
+	}
+
+	/**
+	 * Returns the maximum Metaspace size allowed for the task manager.
+	 */
+	public Long getJvmMetaspaceMax() {
+		return jvmMetaspaceMax;
+	}
+
+	/**
+	 * Returns the threshold for defining the maximum amount of memory used for the JVM overhead.
+	 */
+	public Long getJvmOverhead() {
+		return jvmOverhead;
+	}
+
+	/**
+	 * Returns the amount of memory configured to be used by Flink excluding things like JVM Metaspace and other JVM overhead.
+	 */
+	public Long getTotalFlinkMemory() {
+		return totalFlinkMemory;
+	}
+
+	/**
+	 * Returns the total amount of memory configured to be used by the JVM including all the different memory pools.
+	 */
+	public Long getTotalProcessMemory() {
+		return totalProcessMemory;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TaskExecutorMemoryConfiguration that = (TaskExecutorMemoryConfiguration) o;
+		return Objects.equals(frameworkHeap, that.frameworkHeap) &&
+			Objects.equals(taskHeap, that.taskHeap) &&
+			Objects.equals(frameworkOffHeap, that.frameworkOffHeap) &&
+			Objects.equals(taskOffHeap, that.taskOffHeap) &&
+			Objects.equals(networkMemory, that.networkMemory) &&
+			Objects.equals(managedMemoryTotal, that.managedMemoryTotal) &&
+			Objects.equals(jvmMetaspaceMax, that.jvmMetaspaceMax) &&
+			Objects.equals(jvmOverhead, that.jvmOverhead) &&
+			Objects.equals(totalFlinkMemory, that.totalFlinkMemory) &&
+			Objects.equals(totalProcessMemory, that.totalProcessMemory);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+			frameworkHeap,
+			taskHeap, frameworkOffHeap,
+			taskOffHeap,
+			networkMemory,
+			managedMemoryTotal,
+			jvmMetaspaceMax,
+			jvmOverhead,
+			totalFlinkMemory,
+			totalProcessMemory);
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+			.add(FIELD_NAME_FRAMEWORK_HEAP, frameworkHeap)
+			.add(FIELD_NAME_TASK_HEAP, taskHeap)
+			.add(FIELD_NAME_FRAMEWORK_OFFHEAP, frameworkOffHeap)
+			.add(FIELD_NAME_TASK_OFFHEAP, taskOffHeap)
+			.add(FIELD_NAME_NETWORK, networkMemory)
+			.add(FIELD_NAME_MANAGED_TOTAL, managedMemoryTotal)
+			.add(FIELD_NAME_METASPACE_MAX, jvmMetaspaceMax)
+			.add(FIELD_NAME_OVERHEAD, jvmOverhead)
+			.add(FIELD_NAME_TOTAL_FLINK_MEMORY, totalFlinkMemory)
+			.add(FIELD_NAME_TOTAL_PROCESS_MEMORY, totalProcessMemory)
+			.toString();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
@@ -52,13 +52,13 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 	public static final String FIELD_NAME_FRAMEWORK_OFFHEAP = "frameworkOffHeap";
 	public static final String FIELD_NAME_TASK_OFFHEAP = "taskOffHeap";
 
-	public static final String FIELD_NAME_NETWORK = "networkMax";
+	public static final String FIELD_NAME_NETWORK_MEMORY = "networkMemory";
 
-	public static final String FIELD_NAME_MANAGED_TOTAL = "managedTotal";
+	public static final String FIELD_NAME_MANAGED_MEMORY = "managedMemory";
 
-	public static final String FIELD_NAME_METASPACE_MAX = "metaspaceMax";
+	public static final String FIELD_NAME_JVM_METASPACE = "jvmMetaspace";
 
-	public static final String FIELD_NAME_OVERHEAD = "overheadMax";
+	public static final String FIELD_NAME_JVM_OVERHEAD = "jvmOverhead";
 
 	public static final String FIELD_NAME_TOTAL_FLINK_MEMORY = "totalFlinkMemory";
 
@@ -77,16 +77,16 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 	@JsonProperty(FIELD_NAME_TASK_OFFHEAP)
 	private final Long taskOffHeap;
 
-	@JsonProperty(FIELD_NAME_NETWORK)
+	@JsonProperty(FIELD_NAME_NETWORK_MEMORY)
 	private final Long networkMemory;
 
-	@JsonProperty(FIELD_NAME_MANAGED_TOTAL)
+	@JsonProperty(FIELD_NAME_MANAGED_MEMORY)
 	private final Long managedMemoryTotal;
 
-	@JsonProperty(FIELD_NAME_METASPACE_MAX)
-	private final Long jvmMetaspaceMax;
+	@JsonProperty(FIELD_NAME_JVM_METASPACE)
+	private final Long jvmMetaspace;
 
-	@JsonProperty(FIELD_NAME_OVERHEAD)
+	@JsonProperty(FIELD_NAME_JVM_OVERHEAD)
 	private final Long jvmOverhead;
 
 	@JsonProperty(FIELD_NAME_TOTAL_FLINK_MEMORY)
@@ -126,10 +126,10 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 			@JsonProperty(FIELD_NAME_TASK_HEAP) Long taskHeap,
 			@JsonProperty(FIELD_NAME_FRAMEWORK_OFFHEAP) Long frameworkOffHeap,
 			@JsonProperty(FIELD_NAME_TASK_OFFHEAP) Long taskOffHeap,
-			@JsonProperty(FIELD_NAME_NETWORK) Long networkMemory,
-			@JsonProperty(FIELD_NAME_MANAGED_TOTAL) Long managedMemoryTotal,
-			@JsonProperty(FIELD_NAME_METASPACE_MAX) Long jvmMetaspaceMax,
-			@JsonProperty(FIELD_NAME_OVERHEAD) Long jvmOverhead,
+			@JsonProperty(FIELD_NAME_NETWORK_MEMORY) Long networkMemory,
+			@JsonProperty(FIELD_NAME_MANAGED_MEMORY) Long managedMemoryTotal,
+			@JsonProperty(FIELD_NAME_JVM_METASPACE) Long jvmMetaspace,
+			@JsonProperty(FIELD_NAME_JVM_OVERHEAD) Long jvmOverhead,
 			@JsonProperty(FIELD_NAME_TOTAL_FLINK_MEMORY) Long totalFlinkMemory,
 			@JsonProperty(FIELD_NAME_TOTAL_PROCESS_MEMORY) Long totalProcessMemory) {
 		this.frameworkHeap = frameworkHeap;
@@ -138,7 +138,7 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 		this.taskOffHeap = taskOffHeap;
 		this.networkMemory = networkMemory;
 		this.managedMemoryTotal = managedMemoryTotal;
-		this.jvmMetaspaceMax = jvmMetaspaceMax;
+		this.jvmMetaspace = jvmMetaspace;
 		this.jvmOverhead = jvmOverhead;
 		this.totalFlinkMemory = totalFlinkMemory;
 		this.totalProcessMemory = totalProcessMemory;
@@ -189,8 +189,8 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 	/**
 	 * Returns the maximum Metaspace size allowed for the task manager.
 	 */
-	public Long getJvmMetaspaceMax() {
-		return jvmMetaspaceMax;
+	public Long getJvmMetaspace() {
+		return jvmMetaspace;
 	}
 
 	/**
@@ -229,7 +229,7 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 			Objects.equals(taskOffHeap, that.taskOffHeap) &&
 			Objects.equals(networkMemory, that.networkMemory) &&
 			Objects.equals(managedMemoryTotal, that.managedMemoryTotal) &&
-			Objects.equals(jvmMetaspaceMax, that.jvmMetaspaceMax) &&
+			Objects.equals(jvmMetaspace, that.jvmMetaspace) &&
 			Objects.equals(jvmOverhead, that.jvmOverhead) &&
 			Objects.equals(totalFlinkMemory, that.totalFlinkMemory) &&
 			Objects.equals(totalProcessMemory, that.totalProcessMemory);
@@ -243,7 +243,7 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 			taskOffHeap,
 			networkMemory,
 			managedMemoryTotal,
-			jvmMetaspaceMax,
+			jvmMetaspace,
 			jvmOverhead,
 			totalFlinkMemory,
 			totalProcessMemory);
@@ -256,10 +256,10 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
 			.add(FIELD_NAME_TASK_HEAP, taskHeap)
 			.add(FIELD_NAME_FRAMEWORK_OFFHEAP, frameworkOffHeap)
 			.add(FIELD_NAME_TASK_OFFHEAP, taskOffHeap)
-			.add(FIELD_NAME_NETWORK, networkMemory)
-			.add(FIELD_NAME_MANAGED_TOTAL, managedMemoryTotal)
-			.add(FIELD_NAME_METASPACE_MAX, jvmMetaspaceMax)
-			.add(FIELD_NAME_OVERHEAD, jvmOverhead)
+			.add(FIELD_NAME_NETWORK_MEMORY, networkMemory)
+			.add(FIELD_NAME_MANAGED_MEMORY, managedMemoryTotal)
+			.add(FIELD_NAME_JVM_METASPACE, jvmMetaspace)
+			.add(FIELD_NAME_JVM_OVERHEAD, jvmOverhead)
 			.add(FIELD_NAME_TOTAL_FLINK_MEMORY, totalFlinkMemory)
 			.add(FIELD_NAME_TOTAL_PROCESS_MEMORY, totalProcessMemory)
 			.toString();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorHeartbeatPayload;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -187,6 +188,7 @@ public class ResourceManagerPartitionLifecycleTest extends TestLogger {
 			taskExecutorId,
 			1234,
 			new HardwareDescription(42, 1337L, 1337L, 0L),
+			new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
 			ResourceProfile.ZERO,
 			ResourceProfile.ZERO);
 		final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerTaskExecutor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
@@ -243,6 +244,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 				taskExecutorResourceID,
 				dataPort,
 				hardwareDescription,
+				new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
 				ResourceProfile.ZERO,
 				ResourceProfile.ZERO);
 
@@ -353,6 +355,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 				taskExecutorResourceID,
 				dataPort,
 				hardwareDescription,
+				new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
 				ResourceProfile.ZERO,
 				ResourceProfile.ZERO),
 			TIMEOUT);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
@@ -166,6 +167,7 @@ public class ResourceManagerTest extends TestLogger {
 			taskExecutorId,
 			dataPort,
 			hardwareDescription,
+			new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
 			ResourceProfile.ZERO,
 			ResourceProfile.ZERO);
 		final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerTaskExecutor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntime
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
@@ -427,6 +428,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 					resourceID,
 					1234,
 					new HardwareDescription(1, 2L, 3L, 4L),
+					TaskExecutorMemoryConfiguration.create(flinkConfig),
 					ResourceProfile.ZERO,
 					ResourceProfile.ZERO);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfoTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 
 import java.util.Random;
 import java.util.UUID;
@@ -55,6 +56,17 @@ public class TaskManagerInfoTest extends RestResponseMarshallingTestBase<TaskMan
 			ResourceProfile.ZERO,
 			new HardwareDescription(
 				random.nextInt(),
+				random.nextLong(),
+				random.nextLong(),
+				random.nextLong()),
+			new TaskExecutorMemoryConfiguration(
+				random.nextLong(),
+				random.nextLong(),
+				random.nextLong(),
+				random.nextLong(),
+				random.nextLong(),
+				random.nextLong(),
+				random.nextLong(),
 				random.nextLong(),
 				random.nextLong(),
 				random.nextLong()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfigurationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.apache.flink.configuration.TaskManagerOptions.FRAMEWORK_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.JVM_METASPACE;
+import static org.apache.flink.configuration.TaskManagerOptions.JVM_OVERHEAD_FRACTION;
+import static org.apache.flink.configuration.TaskManagerOptions.JVM_OVERHEAD_MAX;
+import static org.apache.flink.configuration.TaskManagerOptions.JVM_OVERHEAD_MIN;
+import static org.apache.flink.configuration.TaskManagerOptions.MANAGED_MEMORY_FRACTION;
+import static org.apache.flink.configuration.TaskManagerOptions.MANAGED_MEMORY_SIZE;
+import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_FRACTION;
+import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_MAX;
+import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_MIN;
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_OFF_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_PROCESS_MEMORY;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests the initialization of TaskExecutorMemoryConfiguration.
+ */
+public class TaskExecutorMemoryConfigurationTest extends TestLogger {
+
+	@Test
+	public void testInitializationWithAllValuesBeingSet() {
+		Configuration config = new Configuration();
+
+		config.set(FRAMEWORK_HEAP_MEMORY, new MemorySize(1));
+		config.set(TASK_HEAP_MEMORY, new MemorySize(2));
+		config.set(FRAMEWORK_OFF_HEAP_MEMORY, new MemorySize(3));
+		config.set(TASK_OFF_HEAP_MEMORY, new MemorySize(4));
+		config.set(NETWORK_MEMORY_MIN, new MemorySize(5));
+		config.set(NETWORK_MEMORY_MAX, new MemorySize(6));
+		config.set(NETWORK_MEMORY_FRACTION, 0.1f);
+		config.set(MANAGED_MEMORY_SIZE, new MemorySize(7));
+		config.set(MANAGED_MEMORY_FRACTION, 0.2f);
+		config.set(JVM_METASPACE, new MemorySize(8));
+		config.set(JVM_OVERHEAD_MIN, new MemorySize(9));
+		config.set(JVM_OVERHEAD_MAX, new MemorySize(10));
+		config.set(JVM_OVERHEAD_FRACTION, 0.3f);
+		config.set(TOTAL_PROCESS_MEMORY, new MemorySize(11));
+
+		TaskExecutorMemoryConfiguration actual = TaskExecutorMemoryConfiguration.create(config);
+		TaskExecutorMemoryConfiguration expected = new TaskExecutorMemoryConfiguration(
+			1L,
+			2L,
+			3L,
+			4L,
+			5L,
+			6L,
+			7L,
+			8L,
+			9L,
+			10L);
+
+		assertThat(actual, is(expected));
+	}
+
+	@Test
+	public void testInitializationWithMissingValues() {
+		Configuration config = new Configuration();
+
+		TaskExecutorMemoryConfiguration actual = TaskExecutorMemoryConfiguration.create(config);
+		TaskExecutorMemoryConfiguration expected = new TaskExecutorMemoryConfiguration(
+			FRAMEWORK_HEAP_MEMORY.defaultValue().getBytes(),
+			null,
+			FRAMEWORK_OFF_HEAP_MEMORY.defaultValue().getBytes(),
+			TASK_OFF_HEAP_MEMORY.defaultValue().getBytes(),
+			NETWORK_MEMORY_MAX.defaultValue().getBytes(),
+			null,
+			JVM_METASPACE.defaultValue().getBytes(),
+			JVM_OVERHEAD_MAX.defaultValue().getBytes(),
+			null,
+			null);
+
+		assertThat(actual, is(expected));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfigurationTest.java
@@ -37,6 +37,7 @@ import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_M
 import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_MIN;
 import static org.apache.flink.configuration.TaskManagerOptions.TASK_HEAP_MEMORY;
 import static org.apache.flink.configuration.TaskManagerOptions.TASK_OFF_HEAP_MEMORY;
+import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_FLINK_MEMORY;
 import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_PROCESS_MEMORY;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -63,7 +64,8 @@ public class TaskExecutorMemoryConfigurationTest extends TestLogger {
 		config.set(JVM_OVERHEAD_MIN, new MemorySize(9));
 		config.set(JVM_OVERHEAD_MAX, new MemorySize(10));
 		config.set(JVM_OVERHEAD_FRACTION, 0.3f);
-		config.set(TOTAL_PROCESS_MEMORY, new MemorySize(11));
+		config.set(TOTAL_FLINK_MEMORY, new MemorySize(11));
+		config.set(TOTAL_PROCESS_MEMORY, new MemorySize(12));
 
 		TaskExecutorMemoryConfiguration actual = TaskExecutorMemoryConfiguration.create(config);
 		TaskExecutorMemoryConfiguration expected = new TaskExecutorMemoryConfiguration(
@@ -71,12 +73,12 @@ public class TaskExecutorMemoryConfigurationTest extends TestLogger {
 			2L,
 			3L,
 			4L,
-			5L,
 			6L,
 			7L,
 			8L,
-			9L,
-			10L);
+			10L,
+			11L,
+			12L);
 
 		assertThat(actual, is(expected));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
@@ -69,6 +69,18 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 
 	private static final HardwareDescription TASK_MANAGER_HARDWARE_DESCRIPTION = HardwareDescription.extractFromSystem(Long.MAX_VALUE);
 
+	private static final TaskExecutorMemoryConfiguration TASK_MANAGER_MEMORY_CONFIGURATION = new TaskExecutorMemoryConfiguration(
+		1L,
+		2L,
+		3L,
+		4L,
+		5L,
+		6L,
+		7L,
+		8L,
+		9L,
+		10L);
+
 	private TestingRpcService rpcService;
 
 	private TestingResourceManagerGateway testingResourceManagerGateway;
@@ -84,11 +96,13 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 			final ResourceID actualResourceId = taskExecutorRegistration.getResourceId();
 			final Integer actualDataPort = taskExecutorRegistration.getDataPort();
 			final HardwareDescription actualHardwareDescription = taskExecutorRegistration.getHardwareDescription();
+			final TaskExecutorMemoryConfiguration actualMemoryConfiguration = taskExecutorRegistration.getMemoryConfiguration();
 
 			assertThat(actualAddress, is(equalTo(TASK_MANAGER_ADDRESS)));
 			assertThat(actualResourceId, is(equalTo(TASK_MANAGER_RESOURCE_ID)));
 			assertThat(actualDataPort, is(equalTo(TASK_MANAGER_DATA_PORT)));
 			assertThat(actualHardwareDescription, is(equalTo(TASK_MANAGER_HARDWARE_DESCRIPTION)));
+			assertThat(actualMemoryConfiguration, is(TASK_MANAGER_MEMORY_CONFIGURATION));
 
 			return CompletableFuture.completedFuture(successfulRegistration());
 		});
@@ -103,6 +117,7 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 			TASK_MANAGER_RESOURCE_ID,
 			TASK_MANAGER_DATA_PORT,
 			TASK_MANAGER_HARDWARE_DESCRIPTION,
+			TASK_MANAGER_MEMORY_CONFIGURATION,
 			ResourceProfile.ZERO,
 			ResourceProfile.ZERO
 		);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
@@ -424,6 +425,7 @@ public class YarnResourceManagerTest extends TestLogger {
 					taskManagerResourceId,
 					dataPort,
 					hardwareDescription,
+					new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
 					ResourceProfile.ZERO,
 					ResourceProfile.ZERO);
 				CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway


### PR DESCRIPTION
## What is the purpose of the change

Added configuration details of each TaskManager to the TaskManager's REST endpoint.

## Brief change log

- The data is extracted from the configuration provided to the TaskExecutor during initialization.
- A new POJO TaskExecutorMemoryConfiguration is added.
- A test for extracting the right information out of the configuration is added.

## Verifying this change

A new test was added covering random values but also default values for each configuration parameter. Additionally, that change was verified manually on a local standalone cluster accessing the REST endpoint for one TaskManager.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
