### PR TITLE
[FLINK-18971] Support to mount kerberos conf as ConfigMap and Keytab …

### DIFF
--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -15,6 +15,12 @@
             <td>List of factories that should be used to instantiate a security context. If multiple are configured, Flink will use the first compatible factory. You should have a NoOpSecurityContextFactory in this list as a fallback.</td>
         </tr>
         <tr>
+            <td><h5>security.kerberos.krb5-conf.path</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the local location of the krb5.conf file. If defined, this conf would be mounted on the JobManager and TaskManager pods for Kubernetes. Note: The KDC defined needs to be visible from inside the containers.</td>
+        </tr>
+        <tr>
             <td><h5>security.kerberos.login.contexts</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -81,6 +81,13 @@ public class SecurityOptions {
 			.withDeprecatedKeys("security.keytab")
 			.withDescription("Absolute path to a Kerberos keytab file that contains the user credentials.");
 
+	public static final ConfigOption<String> KERBEROS_KRB5_PATH =
+		key("security.kerberos.krb5-conf.path")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Specify the local location of the krb5.conf file. If defined, this conf would be mounted on the JobManager and " +
+				"TaskManager pods for Kubernetes. Note: The KDC defined needs to be visible from inside the containers.");
+
 	@Documentation.Section(Documentation.Sections.SECURITY_AUTH_KERBEROS)
 	public static final ConfigOption<Boolean> KERBEROS_LOGIN_USETICKETCACHE =
 		key("security.kerberos.login.use-ticket-cache")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecorator.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.util.StringUtils;
+
+import org.apache.flink.shaded.guava18.com.google.common.io.Files;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Mount the custom Kerberos Configuration and Credential to the JobManager(s)/TaskManagers.
+ */
+public class KerberosMountDecorator extends AbstractKubernetesStepDecorator {
+	private static final Logger LOG = LoggerFactory.getLogger(KerberosMountDecorator.class);
+
+	private final AbstractKubernetesParameters kubernetesParameters;
+	private final SecurityConfiguration securityConfig;
+
+	public KerberosMountDecorator(AbstractKubernetesParameters kubernetesParameters) {
+		this.kubernetesParameters = checkNotNull(kubernetesParameters);
+		this.securityConfig = new SecurityConfiguration(kubernetesParameters.getFlinkConfiguration());
+	}
+
+	@Override
+	public FlinkPod decorateFlinkPod(FlinkPod flinkPod) {
+		PodBuilder podBuilder = new PodBuilder(flinkPod.getPod());
+		ContainerBuilder containerBuilder = new ContainerBuilder(flinkPod.getMainContainer());
+
+		if (!StringUtils.isNullOrWhitespaceOnly(securityConfig.getKeytab()) && !StringUtils.isNullOrWhitespaceOnly(securityConfig.getPrincipal())) {
+			podBuilder = podBuilder
+				.editOrNewSpec()
+					.addNewVolume()
+						.withName(Constants.KERBEROS_KEYTAB_VOLUME)
+						.withNewSecret()
+							.withSecretName(getKerberosKeytabSecretName(kubernetesParameters.getClusterId()))
+							.endSecret()
+					.endVolume()
+				.endSpec();
+
+			containerBuilder = containerBuilder
+				.addNewVolumeMount()
+					.withName(Constants.KERBEROS_KEYTAB_VOLUME)
+					.withMountPath(Constants.KERBEROS_KEYTAB_MOUNT_POINT)
+				.endVolumeMount();
+		}
+
+		if (!StringUtils.isNullOrWhitespaceOnly(kubernetesParameters.getFlinkConfiguration().get(SecurityOptions.KERBEROS_KRB5_PATH))) {
+			final File krb5Conf = new File(kubernetesParameters.getFlinkConfiguration().get(SecurityOptions.KERBEROS_KRB5_PATH));
+			podBuilder = podBuilder
+				.editOrNewSpec()
+				.addNewVolume()
+					.withName(Constants.KERBEROS_KRB5CONF_VOLUME)
+					.withNewConfigMap()
+						.withName(getKerberosKrb5confConfigMapName(kubernetesParameters.getClusterId()))
+						.withItems(new KeyToPathBuilder()
+							.withKey(krb5Conf.getName())
+							.withPath(krb5Conf.getName())
+							.build())
+					.endConfigMap()
+				.endVolume()
+				.endSpec();
+
+			containerBuilder = containerBuilder
+				.addNewVolumeMount()
+					.withName(Constants.KERBEROS_KRB5CONF_VOLUME)
+					.withMountPath(Constants.KERBEROS_KRB5CONF_MOUNT_DIR + "/krb5.conf")
+					.withSubPath("krb5.conf")
+				.endVolumeMount();
+		}
+
+		return new FlinkPod(podBuilder.build(), containerBuilder.build());
+	}
+
+	@Override
+	public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
+
+		final List<HasMetadata> resources = new ArrayList<>();
+
+		if (!StringUtils.isNullOrWhitespaceOnly(securityConfig.getKeytab()) && !StringUtils.isNullOrWhitespaceOnly(securityConfig.getPrincipal())) {
+			final File keytab = new File(securityConfig.getKeytab());
+			if (!keytab.exists()) {
+				LOG.warn("Could not found the kerberos keytab file in {}.", keytab.getAbsolutePath());
+			} else {
+				resources.add(new SecretBuilder()
+					.withNewMetadata()
+						.withName(getKerberosKeytabSecretName(kubernetesParameters.getClusterId()))
+					.endMetadata()
+					.addToData(keytab.getName(), Base64.getEncoder().encodeToString(Files.toByteArray(keytab)))
+					.build());
+
+				// Set keytab path in the container. One should make sure this decorator is triggered before FlinkConfMountDecorator.
+				kubernetesParameters.getFlinkConfiguration().set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, String.format("%s/%s", Constants.KERBEROS_KEYTAB_MOUNT_POINT, keytab.getName()));
+			}
+		}
+
+		if (!StringUtils.isNullOrWhitespaceOnly(kubernetesParameters.getFlinkConfiguration().get(SecurityOptions.KERBEROS_KRB5_PATH))) {
+			final File krb5Conf = new File(kubernetesParameters.getFlinkConfiguration().get(SecurityOptions.KERBEROS_KRB5_PATH));
+			if (!krb5Conf.exists()) {
+				LOG.warn("Could not found the kerberos config file in {}.", krb5Conf.getAbsolutePath());
+			} else {
+				resources.add(
+					new ConfigMapBuilder()
+						.withNewMetadata()
+							.withName(getKerberosKrb5confConfigMapName(kubernetesParameters.getClusterId()))
+						.endMetadata()
+						.addToData(krb5Conf.getName(), Files.toString(krb5Conf, StandardCharsets.UTF_8))
+						.build());
+			}
+		}
+		return resources;
+	}
+
+	public static String getKerberosKeytabSecretName(String clusterId) {
+		return Constants.KERBEROS_KEYTAB_SECRET_PREFIX + clusterId;
+	}
+
+	public static String getKerberosKrb5confConfigMapName(String clusterID) {
+		return Constants.KERBEROS_KRB5CONF_CONFIG_MAP_PREFIX + clusterID;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorato
 import org.apache.flink.kubernetes.kubeclient.decorators.InitJobManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.JavaCmdJobManagerDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.KerberosMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.MountSecretsDecorator;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
@@ -64,6 +65,7 @@ public class KubernetesJobManagerFactory {
 			new InternalServiceDecorator(kubernetesJobManagerParameters),
 			new ExternalServiceDecorator(kubernetesJobManagerParameters),
 			new HadoopConfMountDecorator(kubernetesJobManagerParameters),
+			new KerberosMountDecorator(kubernetesJobManagerParameters),
 			new FlinkConfMountDecorator(kubernetesJobManagerParameters)};
 
 		for (KubernetesStepDecorator stepDecorator: stepDecorators) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator
 import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.JavaCmdTaskManagerDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.KerberosMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.MountSecretsDecorator;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
@@ -46,6 +47,7 @@ public class KubernetesTaskManagerFactory {
 			new MountSecretsDecorator(kubernetesTaskManagerParameters),
 			new JavaCmdTaskManagerDecorator(kubernetesTaskManagerParameters),
 			new HadoopConfMountDecorator(kubernetesTaskManagerParameters),
+			new KerberosMountDecorator(kubernetesTaskManagerParameters),
 			new FlinkConfMountDecorator(kubernetesTaskManagerParameters)};
 
 		for (KubernetesStepDecorator stepDecorator: stepDecorators) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -39,6 +39,13 @@ public class Constants {
 	public static final String ENV_HADOOP_CONF_DIR = "HADOOP_CONF_DIR";
 	public static final String ENV_HADOOP_HOME = "HADOOP_HOME";
 
+	public static final String KERBEROS_KEYTAB_VOLUME = "kerberos-keytab-volume";
+	public static final String KERBEROS_KEYTAB_SECRET_PREFIX = "kerberos-keytab-";
+	public static final String KERBEROS_KEYTAB_MOUNT_POINT = "/opt/kerberos/kerberos-keytab";
+	public static final String KERBEROS_KRB5CONF_VOLUME = "kerberos-krb5conf-volume";
+	public static final String KERBEROS_KRB5CONF_CONFIG_MAP_PREFIX = "kerberos-krb5conf-";
+	public static final String KERBEROS_KRB5CONF_MOUNT_DIR = "/etc";
+
 	public static final String FLINK_REST_SERVICE_SUFFIX = "-rest";
 
 	public static final String NAME_SEPARATOR = "-";

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
@@ -50,6 +50,8 @@ public class KubernetesTestBase extends TestLogger {
 	protected static final String NAMESPACE = "test";
 	protected static final String CLUSTER_ID = "my-flink-cluster1";
 	protected static final String CONTAINER_IMAGE = "flink-k8s-test:latest";
+	protected static final String KEYTAB_FILE = "keytab";
+	protected static final String KRB5_CONF_FILE = "krb5.conf";
 	protected static final KubernetesConfigOptions.ImagePullPolicy CONTAINER_IMAGE_PULL_POLICY =
 		KubernetesConfigOptions.ImagePullPolicy.IfNotPresent;
 	protected static final int JOB_MANAGER_MEMORY = 768;
@@ -63,6 +65,8 @@ public class KubernetesTestBase extends TestLogger {
 	protected File flinkConfDir;
 
 	protected File hadoopConfDir;
+
+	protected File kerberosDir;
 
 	protected final Configuration flinkConfig = new Configuration();
 
@@ -86,6 +90,7 @@ public class KubernetesTestBase extends TestLogger {
 	public final void setup() throws Exception {
 		flinkConfDir = temporaryFolder.newFolder().getAbsoluteFile();
 		hadoopConfDir = temporaryFolder.newFolder().getAbsoluteFile();
+		kerberosDir = temporaryFolder.newFolder().getAbsoluteFile();
 
 		setupFlinkConfig();
 		writeFlinkConfiguration();
@@ -121,5 +126,10 @@ public class KubernetesTestBase extends TestLogger {
 	protected void generateHadoopConfFileItems() throws IOException {
 		KubernetesTestUtils.createTemporyFile("some data", hadoopConfDir, "core-site.xml");
 		KubernetesTestUtils.createTemporyFile("some data", hadoopConfDir, "hdfs-site.xml");
+	}
+
+	protected void generateKerberosFileItems() throws IOException {
+		KubernetesTestUtils.createTemporyFile("some keytab", kerberosDir, KEYTAB_FILE);
+		KubernetesTestUtils.createTemporyFile("some conf", kerberosDir, KRB5_CONF_FILE);
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
@@ -24,17 +24,13 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.kubernetes.KubernetesTestBase;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Base test class for the JobManager side.
  */
-public class KubernetesJobManagerTestBase extends KubernetesTestBase {
+public class KubernetesJobManagerTestBase extends KubernetesPodTestBase {
 
 	protected static final double JOB_MANAGER_CPU = 2.0;
 	protected static final int JOB_MANAGER_MEMORY = 768;
@@ -44,30 +40,7 @@ public class KubernetesJobManagerTestBase extends KubernetesTestBase {
 	protected static final int RPC_PORT = 7123;
 	protected static final int BLOB_SERVER_PORT = 8346;
 
-	protected final Map<String, String> customizedEnvs = new HashMap<String, String>() {
-		{
-			put("key1", "value1");
-			put("key2", "value2");
-		}
-	};
-
-	protected final Map<String, String> userLabels = new HashMap<String, String>() {
-		{
-			put("label1", "value1");
-			put("label2", "value2");
-		}
-	};
-
-	protected final Map<String, String> nodeSelector = new HashMap<String, String>() {
-		{
-			put("env", "production");
-			put("disk", "ssd");
-		}
-	};
-
 	protected KubernetesJobManagerParameters kubernetesJobManagerParameters;
-
-	protected FlinkPod baseFlinkPod;
 
 	@Override
 	protected void setupFlinkConfig() {
@@ -94,7 +67,5 @@ public class KubernetesJobManagerTestBase extends KubernetesTestBase {
 			.createClusterSpecification();
 
 		this.kubernetesJobManagerParameters = new KubernetesJobManagerParameters(flinkConfig, clusterSpecification);
-
-		this.baseFlinkPod = new FlinkPod.Builder().build();
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesPodTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesPodTestBase.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.kubernetes.KubernetesTestBase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base test class for the Kubernetes Pod.
+ */
+public class KubernetesPodTestBase extends KubernetesTestBase {
+
+	protected final Map<String, String> customizedEnvs = new HashMap<String, String>() {
+		{
+			put("key1", "value1");
+			put("key2", "value2");
+		}
+	};
+
+	protected final Map<String, String> userLabels = new HashMap<String, String>() {
+		{
+			put("label1", "value1");
+			put("label2", "value2");
+		}
+	};
+
+	protected final Map<String, String> nodeSelector = new HashMap<String, String>() {
+		{
+			put("env", "production");
+			put("disk", "ssd");
+		}
+	};
+
+	protected FlinkPod baseFlinkPod = new FlinkPod.Builder().build();
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -21,7 +21,6 @@ package org.apache.flink.kubernetes.kubeclient;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.kubernetes.KubernetesTestBase;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -29,13 +28,10 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.externalresource.ExternalResourceUtils;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Base test class for the TaskManager side.
  */
-public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
+public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
 
 	protected static final int RPC_PORT = 12345;
 
@@ -45,34 +41,11 @@ public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
 	protected static final int TOTAL_PROCESS_MEMORY = 1184;
 	protected static final double TASK_MANAGER_CPU = 2.0;
 
-	protected final Map<String, String> customizedEnvs = new HashMap<String, String>() {
-		{
-			put("key1", "value1");
-			put("key2", "value2");
-		}
-	};
-
-	protected final Map<String, String> userLabels = new HashMap<String, String>() {
-		{
-			put("label1", "value1");
-			put("label2", "value2");
-		}
-	};
-
-	protected final Map<String, String> nodeSelector = new HashMap<String, String>() {
-		{
-			put("env", "production");
-			put("disk", "ssd");
-		}
-	};
-
 	protected TaskExecutorProcessSpec taskExecutorProcessSpec;
 
 	protected ContaineredTaskManagerParameters containeredTaskManagerParameters;
 
 	protected KubernetesTaskManagerParameters kubernetesTaskManagerParameters;
-
-	protected FlinkPod baseFlinkPod = new FlinkPod.Builder().build();
 
 	@Override
 	protected void setupFlinkConfig() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecoratorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.KubernetesPodTestBase;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParametersTest;
+import org.apache.flink.kubernetes.utils.Constants;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * General tests for the {@link KerberosMountDecoratorTest}.
+ */
+public class KerberosMountDecoratorTest extends KubernetesPodTestBase {
+
+	private KerberosMountDecorator kerberosMountDecorator;
+
+	private AbstractKubernetesParametersTest.TestingKubernetesParameters testingKubernetesParameters;
+
+	@Override
+	protected void setupFlinkConfig() {
+		super.setupFlinkConfig();
+
+		flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, kerberosDir.toString() + "/" + KEYTAB_FILE);
+		flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, "test");
+		flinkConfig.set(SecurityOptions.KERBEROS_KRB5_PATH, kerberosDir.toString() + "/" + KRB5_CONF_FILE);
+	}
+
+	@Override
+	protected void onSetup() throws Exception {
+		super.onSetup();
+
+		generateKerberosFileItems();
+
+		this.testingKubernetesParameters = new AbstractKubernetesParametersTest.TestingKubernetesParameters(flinkConfig);
+		this.kerberosMountDecorator = new KerberosMountDecorator(testingKubernetesParameters);
+	}
+
+	@Test
+	public void testWhetherPodOrContainerIsDecorated() {
+		final FlinkPod resultFlinkPod = kerberosMountDecorator.decorateFlinkPod(baseFlinkPod);
+		assertNotEquals(baseFlinkPod.getPod(), resultFlinkPod.getPod());
+		assertNotEquals(baseFlinkPod.getMainContainer(), resultFlinkPod.getMainContainer());
+	}
+
+	@Test
+	public void testConfEditWhenBuildAccompanyingKubernetesResources() throws IOException {
+		kerberosMountDecorator.buildAccompanyingKubernetesResources();
+
+		assertEquals(
+			String.format("%s/%s", Constants.KERBEROS_KEYTAB_MOUNT_POINT, KEYTAB_FILE),
+			this.testingKubernetesParameters.getFlinkConfiguration().get(SecurityOptions.KERBEROS_LOGIN_KEYTAB));
+	}
+
+	@Test
+	public void testDecoratedFlinkContainer() {
+		final Container resultMainContainer = kerberosMountDecorator.decorateFlinkPod(baseFlinkPod).getMainContainer();
+		assertEquals(2, resultMainContainer.getVolumeMounts().size());
+
+		final VolumeMount keytabVolumeMount = resultMainContainer.getVolumeMounts()
+			.stream()
+			.filter(x -> x.getName().equals(Constants.KERBEROS_KEYTAB_VOLUME))
+			.collect(Collectors.toList()).get(0);
+		final VolumeMount krb5ConfVolumeMount = resultMainContainer.getVolumeMounts()
+			.stream()
+			.filter(x -> x.getName().equals(Constants.KERBEROS_KRB5CONF_VOLUME))
+			.collect(Collectors.toList()).get(0);
+		assertNotNull(keytabVolumeMount);
+		assertNotNull(krb5ConfVolumeMount);
+		assertEquals(Constants.KERBEROS_KEYTAB_MOUNT_POINT, keytabVolumeMount.getMountPath());
+		assertEquals(Constants.KERBEROS_KRB5CONF_MOUNT_DIR + "/krb5.conf", krb5ConfVolumeMount.getMountPath());
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.kubeclient.factory;
 
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.kubernetes.KubernetesTestUtils;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
@@ -28,6 +29,7 @@ import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorato
 import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.KerberosMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
@@ -37,12 +39,14 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +79,9 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 
 		flinkConfig.set(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS, ENTRY_POINT_CLASS);
 		flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
+		flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, kerberosDir.toString() + "/" + KEYTAB_FILE);
+		flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, "test");
+		flinkConfig.set(SecurityOptions.KERBEROS_KRB5_PATH, kerberosDir.toString() + "/" + KRB5_CONF_FILE);
 	}
 
 	@Override
@@ -84,12 +91,12 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOGBACK_NAME);
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, CONFIG_FILE_LOG4J_NAME);
 
-		this.kubernetesJobManagerSpecification =
-			KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+		generateKerberosFileItems();
 	}
 
 	@Test
-	public void testDeploymentMetadata() {
+	public void testDeploymentMetadata() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 		final Deployment resultDeployment = this.kubernetesJobManagerSpecification.getDeployment();
 		assertEquals(Constants.APPS_API_VERSION, resultDeployment.getApiVersion());
 		assertEquals(KubernetesUtils.getDeploymentName(CLUSTER_ID), resultDeployment.getMetadata().getName());
@@ -100,7 +107,9 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	}
 
 	@Test
-	public void testDeploymentSpec() {
+	public void testDeploymentSpec() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+
 		final DeploymentSpec resultDeploymentSpec = this.kubernetesJobManagerSpecification.getDeployment().getSpec();
 		assertEquals(1, resultDeploymentSpec.getReplicas().intValue());
 
@@ -115,13 +124,15 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	}
 
 	@Test
-	public void testPodSpec() {
+	public void testPodSpec() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+
 		final PodSpec resultPodSpec =
 			this.kubernetesJobManagerSpecification.getDeployment().getSpec().getTemplate().getSpec();
 
 		assertEquals(1, resultPodSpec.getContainers().size());
 		assertEquals(SERVICE_ACCOUNT_NAME, resultPodSpec.getServiceAccountName());
-		assertEquals(1, resultPodSpec.getVolumes().size());
+		assertEquals(3, resultPodSpec.getVolumes().size());
 
 		final Container resultedMainContainer = resultPodSpec.getContainers().get(0);
 		assertEquals(KubernetesJobManagerParameters.JOB_MANAGER_MAIN_CONTAINER_NAME, resultedMainContainer.getName());
@@ -142,13 +153,15 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 		assertEquals(1, resultedMainContainer.getCommand().size());
 		assertEquals(2, resultedMainContainer.getArgs().size());
 
-		assertEquals(1, resultedMainContainer.getVolumeMounts().size());
+		assertEquals(3, resultedMainContainer.getVolumeMounts().size());
 	}
 
 	@Test
-	public void testAdditionalResourcesSize() {
+	public void testAdditionalResourcesSize() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+
 		final List<HasMetadata> resultAdditionalResources = this.kubernetesJobManagerSpecification.getAccompanyingResources();
-		assertEquals(3, resultAdditionalResources.size());
+		assertEquals(5, resultAdditionalResources.size());
 
 		final List<HasMetadata> resultServices = resultAdditionalResources
 			.stream()
@@ -160,11 +173,19 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 			.stream()
 			.filter(x -> x instanceof ConfigMap)
 			.collect(Collectors.toList());
-		assertEquals(1, resultConfigMaps.size());
+		assertEquals(2, resultConfigMaps.size());
+
+		final List<HasMetadata> resultSecrets = resultAdditionalResources
+			.stream()
+			.filter(x -> x instanceof Secret)
+			.collect(Collectors.toList());
+		assertEquals(1, resultSecrets.size());
 	}
 
 	@Test
-	public void testServices() {
+	public void testServices() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+
 		final List<Service> resultServices = this.kubernetesJobManagerSpecification.getAccompanyingResources()
 			.stream()
 			.filter(x -> x instanceof Service)
@@ -202,7 +223,46 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	}
 
 	@Test
-	public void testFlinkConfConfigMap() {
+	public void testKerberosConfConfigMap() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+
+		final ConfigMap resultConfigMap = (ConfigMap) this.kubernetesJobManagerSpecification.getAccompanyingResources()
+			.stream()
+			.filter(x -> x instanceof ConfigMap &&
+				x.getMetadata().getName().equals(KerberosMountDecorator.getKerberosKrb5confConfigMapName(CLUSTER_ID)))
+			.collect(Collectors.toList())
+			.get(0);
+
+		assertEquals(Constants.API_VERSION, resultConfigMap.getApiVersion());
+
+		assertEquals(KerberosMountDecorator.getKerberosKrb5confConfigMapName(CLUSTER_ID),
+			resultConfigMap.getMetadata().getName());
+
+		final Map<String, String> resultDatas = resultConfigMap.getData();
+		assertEquals(1, resultDatas.size());
+		assertEquals("some conf", resultDatas.get(KRB5_CONF_FILE));
+	}
+
+	@Test
+	public void testKerberosKeytabSecret() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+
+		final Secret resultSecret = (Secret) this.kubernetesJobManagerSpecification.getAccompanyingResources()
+			.stream()
+			.filter(x -> x instanceof Secret &&
+				x.getMetadata().getName().equals(KerberosMountDecorator.getKerberosKeytabSecretName(CLUSTER_ID)))
+			.collect(Collectors.toList())
+			.get(0);
+
+		final Map<String, String> resultDatas = resultSecret.getData();
+		assertEquals(1, resultDatas.size());
+		assertEquals(Base64.getEncoder().encodeToString("some keytab".getBytes()), resultDatas.get(KEYTAB_FILE));
+	}
+
+	@Test
+	public void testFlinkConfConfigMap() throws IOException {
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
+
 		final ConfigMap resultConfigMap = (ConfigMap) this.kubernetesJobManagerSpecification.getAccompanyingResources()
 			.stream()
 			.filter(x -> x instanceof ConfigMap &&

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.kubeclient.factory;
 
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.kubernetes.KubernetesTestUtils;
 import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
@@ -41,6 +42,15 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 	private Pod resultPod;
 
 	@Override
+	protected void setupFlinkConfig() {
+		super.setupFlinkConfig();
+
+		flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, kerberosDir.toString() + "/" + KEYTAB_FILE);
+		flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, "test");
+		flinkConfig.set(SecurityOptions.KERBEROS_KRB5_PATH, kerberosDir.toString() + "/" + KRB5_CONF_FILE);
+	}
+
+	@Override
 	protected void onSetup() throws Exception {
 		super.onSetup();
 
@@ -50,6 +60,8 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 		setHadoopConfDirEnv();
 		generateHadoopConfFileItems();
 
+		generateKerberosFileItems();
+
 		this.resultPod =
 			KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(kubernetesTaskManagerParameters).getInternalResource();
 	}
@@ -58,7 +70,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 	public void testPod() {
 		assertEquals(POD_NAME, this.resultPod.getMetadata().getName());
 		assertEquals(5, this.resultPod.getMetadata().getLabels().size());
-		assertEquals(2, this.resultPod.getSpec().getVolumes().size());
+		assertEquals(4, this.resultPod.getSpec().getVolumes().size());
 	}
 
 	@Test
@@ -81,6 +93,6 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 		assertEquals(1, resultMainContainer.getPorts().size());
 		assertEquals(1, resultMainContainer.getCommand().size());
 		assertEquals(2, resultMainContainer.getArgs().size());
-		assertEquals(2, resultMainContainer.getVolumeMounts().size());
+		assertEquals(4, resultMainContainer.getVolumeMounts().size());
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
@@ -78,7 +78,10 @@ public class AbstractKubernetesParametersTest extends TestLogger {
 		assertThat(testingKubernetesParameters.getConfigDirectory(), is(confDirInPod));
 	}
 
-	private class TestingKubernetesParameters extends AbstractKubernetesParameters {
+	/**
+	 * KubernetesParameters for testing usecase.
+	 */
+	public static class TestingKubernetesParameters extends AbstractKubernetesParameters {
 
 		public TestingKubernetesParameters(Configuration flinkConfig) {
 			super(flinkConfig);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -153,7 +153,7 @@ public class MesosUtils {
 			HadoopConfOverlay.newBuilder().fromEnvironment(configuration).build(),
 			HadoopUserOverlay.newBuilder().fromEnvironment(configuration).build(),
 			KeytabOverlay.newBuilder().fromEnvironment(configuration).build(),
-			Krb5ConfOverlay.newBuilder().fromEnvironment(configuration).build(),
+			Krb5ConfOverlay.newBuilder().fromEnvironmentOrConfiguration(configuration).build(),
 			SSLStoreOverlay.newBuilder().fromEnvironment(configuration).build()
 		);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -407,7 +407,7 @@ public class BootstrapTools {
 		if (flinkConfig.getString(CoreOptions.FLINK_TM_JVM_OPTIONS).length() > 0) {
 			javaOpts += " " + flinkConfig.getString(CoreOptions.FLINK_TM_JVM_OPTIONS);
 		}
-		//applicable only for YarnMiniCluster secure test run
+
 		//krb5.conf file will be available as local resource in JM/TM container
 		if (hasKrb5) {
 			javaOpts += " -Djava.security.krb5.conf=krb5.conf";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlay.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.clusterframework.overlays;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 
@@ -87,10 +88,11 @@ public class Krb5ConfOverlay extends AbstractContainerOverlay {
 		 * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/KerberosReq.html">Java documentation</a>.
 		 * Note that the JRE doesn't support the KRB5_CONFIG environment variable (JDK-7045913).
 		 */
-		public Builder fromEnvironment(Configuration globalConfiguration) {
+		public Builder fromEnvironmentOrConfiguration(Configuration globalConfiguration) {
 
 			// check the system property
-			String krb5Config = System.getProperty(JAVA_SECURITY_KRB5_CONF);
+			String krb5Config = System.getProperty(JAVA_SECURITY_KRB5_CONF) != null ?
+					System.getProperty(JAVA_SECURITY_KRB5_CONF) : globalConfiguration.get(SecurityOptions.KERBEROS_KRB5_PATH);
 			if (krb5Config != null && krb5Config.length() != 0) {
 				krb5ConfPath = new File(krb5Config);
 				if (!krb5ConfPath.exists()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlay.java
@@ -21,10 +21,12 @@ package org.apache.flink.runtime.clusterframework.overlays;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -32,10 +34,10 @@ import java.io.IOException;
 /**
  * Overlays a Kerberos configuration file into a container.
  *
- * The following files are copied to the container:
+ * <p>The following files are copied to the container:
  *  - krb5.conf
  *
- * The following Java system properties are set in the container:
+ * <p>The following Java system properties are set in the container:
  *  - java.security.krb5.conf
  */
 public class Krb5ConfOverlay extends AbstractContainerOverlay {
@@ -57,7 +59,7 @@ public class Krb5ConfOverlay extends AbstractContainerOverlay {
 
 	@Override
 	public void configure(ContainerSpecification container) throws IOException {
-		if(krb5Conf != null) {
+		if (krb5Conf != null) {
 			container.getArtifacts().add(ContainerSpecification.Artifact.newBuilder()
 				.setSource(krb5Conf)
 				.setDest(TARGET_PATH)
@@ -81,7 +83,7 @@ public class Krb5ConfOverlay extends AbstractContainerOverlay {
 		/**
 		 * Configures the overlay using the current environment.
 		 *
-		 * Locates the krb5.conf configuration file as per
+		 * <p>Locates the krb5.conf configuration file as per
 		 * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/KerberosReq.html">Java documentation</a>.
 		 * Note that the JRE doesn't support the KRB5_CONFIG environment variable (JDK-7045913).
 		 */
@@ -89,9 +91,9 @@ public class Krb5ConfOverlay extends AbstractContainerOverlay {
 
 			// check the system property
 			String krb5Config = System.getProperty(JAVA_SECURITY_KRB5_CONF);
-			if(krb5Config != null && krb5Config.length() != 0) {
+			if (krb5Config != null && krb5Config.length() != 0) {
 				krb5ConfPath = new File(krb5Config);
-				if(!krb5ConfPath.exists()) {
+				if (!krb5ConfPath.exists()) {
 					throw new IllegalStateException("java.security.krb5.conf refers to a non-existent file");
 				}
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlayTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.clusterframework.overlays;
 
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -30,6 +31,9 @@ import static org.apache.flink.runtime.clusterframework.overlays.Krb5ConfOverlay
 import static org.apache.flink.runtime.clusterframework.overlays.Krb5ConfOverlay.TARGET_PATH;
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests for {@link Krb5ConfOverlay}.
+ */
 public class Krb5ConfOverlayTest extends ContainerOverlayTestBase {
 
 	@Rule

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/Krb5ConfOverlayTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.clusterframework.overlays;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 
@@ -26,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 
 import static org.apache.flink.runtime.clusterframework.overlays.Krb5ConfOverlay.JAVA_SECURITY_KRB5_CONF;
 import static org.apache.flink.runtime.clusterframework.overlays.Krb5ConfOverlay.TARGET_PATH;
@@ -59,5 +62,23 @@ public class Krb5ConfOverlayTest extends ContainerOverlayTestBase {
 
 		ContainerSpecification containerSpecification = new ContainerSpecification();
 		overlay.configure(containerSpecification);
+	}
+
+	@Test
+	public void testBuildOverlayFromConf() throws IOException {
+		final File krb5conf = tempFolder.newFile();
+		final Configuration configuration = new Configuration();
+		configuration.set(SecurityOptions.KERBEROS_KRB5_PATH, krb5conf.getPath());
+		final Krb5ConfOverlay overlay = Krb5ConfOverlay.newBuilder().fromEnvironmentOrConfiguration(configuration).build();
+		assertEquals(overlay.krb5Conf.getPath(), krb5conf.getPath());
+	}
+
+	@Test
+	public void testBuildOverlayFromEnv() throws IOException {
+		final File krb5conf = tempFolder.newFile();
+		final Configuration configuration = new Configuration();
+		System.setProperty(JAVA_SECURITY_KRB5_CONF, krb5conf.getPath());
+		final Krb5ConfOverlay overlay = Krb5ConfOverlay.newBuilder().fromEnvironmentOrConfiguration(configuration).build();
+		assertEquals(overlay.krb5Conf.getPath(), krb5conf.getPath());
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -402,8 +402,6 @@ public final class Utils {
 
 		//To support Yarn Secure Integration Test Scenario
 		LocalResource yarnConfResource = null;
-		LocalResource krb5ConfResource = null;
-		boolean hasKrb5 = false;
 		if (remoteYarnConfPath != null) {
 			log.info("TM:Adding remoteYarnConfPath {} to the container local resource bucket", remoteYarnConfPath);
 			Path yarnConfPath = new Path(remoteYarnConfPath);
@@ -411,8 +409,11 @@ public final class Utils {
 			yarnConfResource = registerLocalResource(fs, yarnConfPath, LocalResourceType.FILE);
 		}
 
+		// register krb5.conf
+		LocalResource krb5ConfResource = null;
+		boolean hasKrb5 = false;
 		if (remoteKrb5Path != null) {
-			log.info("TM:Adding remoteKrb5Path {} to the container local resource bucket", remoteKrb5Path);
+			log.info("Adding remoteKrb5Path {} to the container local resource bucket", remoteKrb5Path);
 			Path krb5ConfPath = new Path(remoteKrb5Path);
 			FileSystem fs = krb5ConfPath.getFileSystem(yarnConfig);
 			krb5ConfResource = registerLocalResource(fs, krb5ConfPath, LocalResourceType.FILE);


### PR DESCRIPTION
…as Secrete


## What is the purpose of the change

Support to mount kerberos conf as ConfigMap and Keytab as Secrete


## Brief change log

- Add "kubernetes.kerberos.krb5-conf.path" Config option, which specify the local location of the krb5.conf file to be mounted on the JobManager and TaskManager for Kerberos.
- Introduce KerberosMountDecorator


## Verifying this change

This change added tests and can be verified as follows:

- Existing UTs and IT cases.
- KerberosMountDecoratorTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
