### PR TITLE
[FLINK-18992][table] Fix Table API renameColumns method annotation error

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1187,8 +1187,8 @@ public interface Table {
 	 * <pre>
 	 * {@code
 	 *   tab.renameColumns(
-	 *      $("a").as($("a1")),
-	 *      $("b").as($("b1"))
+	 *      $("a").as("a1"),
+	 *      $("b").as("b1")
 	 *   );
 	 * }
 	 * </pre>
@@ -1198,8 +1198,8 @@ public interface Table {
 	 * <pre>
 	 * {@code
 	 *   tab.renameColumns(
-	 *      $"a" as $"a1",
-	 *      $"b" as $"b1"
+	 *      $"a" as "a1",
+	 *      $"b" as "b1"
 	 *   )
 	 * }
 	 * </pre>


### PR DESCRIPTION
## What is the purpose of the change
Fix Table API renameColumns method annotation error

## Brief change log
example：table.renameColumns($("a").as($("a1"))  change to table.renameColumns($("a").as("a1")


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
