### PR TITLE
[FLINK-19058][hotfix][doc] Dataset transformations document page error

### DIFF
--- a/docs/dev/batch/dataset_transformations.md
+++ b/docs/dev/batch/dataset_transformations.md
@@ -1470,7 +1470,7 @@ return (collect), zero, one, or more elements.
 public class PointAssigner
          implements FlatJoinFunction<Tuple2<String, String>, Rating, Tuple2<String, Integer>> {
   @Override
-  public void join(Tuple2<String, String> movie, Rating rating
+  public void join(Tuple2<String, String> movie, Rating rating,
     Collector<Tuple2<String, Integer>> out) {
   if (rating == null ) {
     out.collect(new Tuple2<String, Integer>(movie.f0, -1));

--- a/docs/dev/batch/dataset_transformations.zh.md
+++ b/docs/dev/batch/dataset_transformations.zh.md
@@ -1470,7 +1470,7 @@ return (collect), zero, one, or more elements.
 public class PointAssigner
          implements FlatJoinFunction<Tuple2<String, String>, Rating, Tuple2<String, Integer>> {
   @Override
-  public void join(Tuple2<String, String> movie, Rating rating
+  public void join(Tuple2<String, String> movie, Rating rating,
     Collector<Tuple2<String, Integer>> out) {
   if (rating == null ) {
     out.collect(new Tuple2<String, Integer>(movie.f0, -1));


### PR DESCRIPTION
## What is the purpose of the change
Fix Dataset transformations document page error

## Brief change log
"public void join(Tuple2<String, String> movie, Rating rating
Collector<Tuple2<String, Integer>> out)"
 change to
"public void join(Tuple2<String, String> movie, Rating rating,
Collector<Tuple2<String, Integer>> out)"



## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)