### PR TITLE
[FLINK-16768][tests] Let the watchdog also monitor mvn logs

### DIFF
--- a/tools/ci/test_controller.sh
+++ b/tools/ci/test_controller.sh
@@ -30,7 +30,7 @@ fi
 source "${HERE}/stage.sh"
 source "${HERE}/maven-utils.sh"
 source "${HERE}/controller_utils.sh"
-source "${HERE}/watchdog.sh"
+
 STAGE=$1
 
 # =============================================================================
@@ -68,6 +68,10 @@ export JAVA_TOOL_OPTIONS="-XX:+HeapDumpOnOutOfMemoryError"
 
 # some tests provide additional logs if they find this variable
 export IS_CI=true
+
+export WATCHDOG_ADDITIONAL_MONITORING_FILES="$DEBUG_FILES_OUTPUT_DIR/mvn-*.log"
+
+source "${HERE}/watchdog.sh"
 
 # =============================================================================
 # Step 1: Rebuild jars and install Flink to local maven repository

--- a/tools/ci/watchdog.sh
+++ b/tools/ci/watchdog.sh
@@ -38,8 +38,26 @@ CMD_EXIT="/tmp/watchdog.exit"
 # Utility functions
 # ============================================= 
 
+max_of() {
+  local max number
+
+  max="$1"
+
+  for number in "${@:2}"; do
+    if ((number > max)); then
+      max="$number"
+    fi
+  done
+
+  printf '%d\n' "$max"
+}
+
+# Returns the highest modification time out of $CMD_OUT (which is the command output file)
+# and any file(s) named "mvn-*.log" (which are logging files created by Flink's tests)
 mod_time () {
-	echo `stat -c "%Y" $CMD_OUT`
+	CMD_OUT_MOD_TIME=`stat -c "%Y" $CMD_OUT`
+	ADDITIONAL_FILES_MOD_TIMES=`stat -c "%Y" $WATCHDOG_ADDITIONAL_MONITORING_FILES 2> /dev/null`
+	echo `max_of $CMD_OUT_MOD_TIME $ADDITIONAL_FILES_MOD_TIMES`
 }
 
 the_time() {


### PR DESCRIPTION
This experimental change aims to make the watchdog more accurate by extending the monitoring from the output to log files produced by the tests.
In particular the S3 tests seem to produce no output while they are producing output to the log files.

The risk of this change is that a hanging test is still producing log output (e.g. the test is stuck in a retry-loop).
