### PR TITLE
[FLINK-17273][runtime] ActiveResourceManager closes task manager connection on worker terminated.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -266,7 +266,7 @@ public class KubernetesResourceManagerDriver extends AbstractResourceManagerDriv
 
 					getResourceEventHandler().onWorkerTerminated(
 							new ResourceID(podName),
-							new Exception(pod.getTerminatedDiagnostics()));
+							pod.getTerminatedDiagnostics());
 					stopPod(podName);
 				}
 			}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -264,7 +264,9 @@ public class KubernetesResourceManagerDriver extends AbstractResourceManagerDriv
 						requestResourceFuture.completeExceptionally(new FlinkException("Pod is terminated."));
 					}
 
-					getResourceEventHandler().onWorkerTerminated(new ResourceID(podName));
+					getResourceEventHandler().onWorkerTerminated(
+							new ResourceID(podName),
+							new Exception(pod.getTerminatedDiagnostics()));
 					stopPod(podName);
 				}
 			}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPod.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPod.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.Pod;
+
+import java.util.stream.Collectors;
 
 /**
  * Represent KubernetesPod resource in kubernetes.
@@ -42,5 +45,27 @@ public class KubernetesPod extends KubernetesResource<Pod> {
 				.anyMatch(e -> e.getState() != null && e.getState().getTerminated() != null);
 		}
 		return false;
+	}
+
+	public String getTerminatedDiagnostics() {
+		final StringBuilder sb = new StringBuilder();
+		sb.append("Pod terminated, container termination statuses: [");
+		if (getInternalResource().getStatus() != null) {
+			sb.append(
+				getInternalResource().getStatus().getContainerStatuses()
+					.stream()
+					.filter(containerStatus -> containerStatus.getState() != null && containerStatus.getState().getTerminated() != null)
+					.map((containerStatus) -> {
+						final ContainerStateTerminated containerStateTerminated = containerStatus.getState().getTerminated();
+						return String.format("%s(exitCode=%d, reason=%s, message=%s)",
+							containerStatus.getName(),
+							containerStateTerminated.getExitCode(),
+							containerStateTerminated.getReason(),
+							containerStateTerminated.getMessage());
+					})
+					.collect(Collectors.joining(",")));
+		}
+		sb.append("]");
+		return sb.toString();
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -275,7 +275,7 @@ public class KubernetesResourceManagerDriverTest extends ResourceManagerDriverTe
 			final CompletableFuture<KubernetesWorkerNode> requestResourceFuture = new CompletableFuture<>();
 			final CompletableFuture<ResourceID> onWorkerTerminatedConsumer = new CompletableFuture<>();
 
-			resourceEventHandlerBuilder.setOnWorkerTerminatedConsumer(onWorkerTerminatedConsumer::complete);
+			resourceEventHandlerBuilder.setOnWorkerTerminatedConsumer((resourceId, ignore) -> onWorkerTerminatedConsumer.complete(resourceId));
 
 			runTest(() -> {
 				// request new pod and send onAdded event

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
@@ -44,4 +44,9 @@ public class TestingKubernetesPod extends KubernetesPod {
 	public boolean isTerminated() {
 		return isTerminated;
 	}
+
+	@Override
+	public String getTerminatedDiagnostics() {
+		return "testing-diagnostics";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -197,11 +197,12 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
 	}
 
 	@Override
-	public void onWorkerTerminated(ResourceID resourceId) {
-		log.info("Worker {} is terminated.", resourceId.getStringWithMetadata());
+	public void onWorkerTerminated(ResourceID resourceId, Exception cause) {
+		log.info("Worker {} is terminated. Diagnostics: {}", resourceId.getStringWithMetadata(), cause.getMessage());
 		if (clearStateForWorker(resourceId)) {
 			requestWorkerIfRequired();
 		}
+		closeTaskManagerConnection(resourceId, cause);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -197,12 +197,12 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
 	}
 
 	@Override
-	public void onWorkerTerminated(ResourceID resourceId, Exception cause) {
-		log.info("Worker {} is terminated. Diagnostics: {}", resourceId.getStringWithMetadata(), cause.getMessage());
+	public void onWorkerTerminated(ResourceID resourceId, String diagnostics) {
+		log.info("Worker {} is terminated. Diagnostics: {}", resourceId.getStringWithMetadata(), diagnostics);
 		if (clearStateForWorker(resourceId)) {
 			requestWorkerIfRequired();
 		}
-		closeTaskManagerConnection(resourceId, cause);
+		closeTaskManagerConnection(resourceId, new Exception(diagnostics));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceEventHandler.java
@@ -41,9 +41,9 @@ public interface ResourceEventHandler<WorkerType extends ResourceIDRetrievable> 
 	 * <p>See also {@link ResourceManagerDriver#requestResource}.
 	 *
 	 * @param resourceId Identifier of the terminated worker.
-	 * @param cause The exception which cause the worker terminated.
+	 * @param diagnostics Diagnostic message about the worker termination.
 	 */
-	void onWorkerTerminated(ResourceID resourceId, Exception cause);
+	void onWorkerTerminated(ResourceID resourceId, String diagnostics);
 
 	/**
 	 * Notifies that an error has occurred that the process cannot proceed.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceEventHandler.java
@@ -41,8 +41,9 @@ public interface ResourceEventHandler<WorkerType extends ResourceIDRetrievable> 
 	 * <p>See also {@link ResourceManagerDriver#requestResource}.
 	 *
 	 * @param resourceId Identifier of the terminated worker.
+	 * @param cause The exception which cause the worker terminated.
 	 */
-	void onWorkerTerminated(ResourceID resourceId);
+	void onWorkerTerminated(ResourceID resourceId, Exception cause);
 
 	/**
 	 * Notifies that an error has occurred that the process cannot proceed.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -194,7 +194,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 						is(TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(flinkConfig, WORKER_RESOURCE_SPEC)));
 
 				// first worker failed before register, verify requesting another worker from driver
-				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0), new Exception()));
+				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0), "terminate for testing"));
 				TaskExecutorProcessSpec taskExecutorProcessSpec2 =
 						requestWorkerFromDriverFutures.get(1).get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
@@ -248,7 +248,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 				assertThat(registerTaskExecutorFuture1.get(TIMEOUT_SEC, TimeUnit.SECONDS), instanceOf(RegistrationResponse.Success.class));
 
 				// first worker terminated, verify requesting another worker from driver
-				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0), new Exception()));
+				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0), "terminate for testing"));
 				TaskExecutorProcessSpec taskExecutorProcessSpec2 =
 						requestWorkerFromDriverFutures.get(1).get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
@@ -298,7 +298,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 
 				// worker terminated, verify not requesting new worker
 				runInMainThread(() -> {
-					getResourceManager().onWorkerTerminated(tmResourceId, new Exception());
+					getResourceManager().onWorkerTerminated(tmResourceId, "terminate for testing");
 					// needs to return something, so that we can use `get()` to make sure the main thread processing
 					// finishes before the assertions
 					return null;
@@ -327,8 +327,8 @@ public class ActiveResourceManagerTest extends TestLogger {
 			runTest(() -> {
 				// request a new worker, terminate it after registered
 				runInMainThread(() -> getResourceManager().startNewWorker(WORKER_RESOURCE_SPEC))
-					.thenCompose((ignrore) -> registerTaskExecutor(tmResourceId, taskExecutorGateway))
-					.thenRun(() -> runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceId, new Exception())));
+					.thenCompose((ignore) -> registerTaskExecutor(tmResourceId, taskExecutorGateway))
+					.thenRun(() -> runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceId, "terminate for testing")));
 				// verify task manager connection is closed
 				disconnectResourceManagerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
 			});

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntime
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
@@ -193,7 +194,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 						is(TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(flinkConfig, WORKER_RESOURCE_SPEC)));
 
 				// first worker failed before register, verify requesting another worker from driver
-				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0)));
+				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0), new Exception()));
 				TaskExecutorProcessSpec taskExecutorProcessSpec2 =
 						requestWorkerFromDriverFutures.get(1).get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
@@ -247,7 +248,7 @@ public class ActiveResourceManagerTest extends TestLogger {
 				assertThat(registerTaskExecutorFuture1.get(TIMEOUT_SEC, TimeUnit.SECONDS), instanceOf(RegistrationResponse.Success.class));
 
 				// first worker terminated, verify requesting another worker from driver
-				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0)));
+				runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceIds.get(0), new Exception()));
 				TaskExecutorProcessSpec taskExecutorProcessSpec2 =
 						requestWorkerFromDriverFutures.get(1).get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
@@ -297,12 +298,39 @@ public class ActiveResourceManagerTest extends TestLogger {
 
 				// worker terminated, verify not requesting new worker
 				runInMainThread(() -> {
-					getResourceManager().onWorkerTerminated(tmResourceId);
+					getResourceManager().onWorkerTerminated(tmResourceId, new Exception());
 					// needs to return something, so that we can use `get()` to make sure the main thread processing
 					// finishes before the assertions
 					return null;
 				}).get(TIMEOUT_SEC, TimeUnit.SECONDS);
 				assertFalse(requestWorkerFromDriverFutures.get(1).isDone());
+			});
+		}};
+	}
+
+	@Test
+	public void testCloseTaskManagerConnectionOnWorkerTerminated() throws Exception {
+		new Context() {{
+			final ResourceID tmResourceId = ResourceID.generate();
+			final CompletableFuture<TaskExecutorProcessSpec> requestWorkerFromDriverFuture = new CompletableFuture<>();
+			final CompletableFuture<Void> disconnectResourceManagerFuture = new CompletableFuture<>();
+
+			final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+				.setDisconnectResourceManagerConsumer((ignore) -> disconnectResourceManagerFuture.complete(null))
+				.createTestingTaskExecutorGateway();
+
+			driverBuilder.setRequestResourceFunction(taskExecutorProcessSpec -> {
+				requestWorkerFromDriverFuture.complete(taskExecutorProcessSpec);
+				return CompletableFuture.completedFuture(tmResourceId);
+			});
+
+			runTest(() -> {
+				// request a new worker, terminate it after registered
+				runInMainThread(() -> getResourceManager().startNewWorker(WORKER_RESOURCE_SPEC))
+					.thenCompose((ignrore) -> registerTaskExecutor(tmResourceId, taskExecutorGateway))
+					.thenRun(() -> runInMainThread(() -> getResourceManager().onWorkerTerminated(tmResourceId, new Exception())));
+				// verify task manager connection is closed
+				disconnectResourceManagerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
 			});
 		}};
 	}
@@ -419,7 +447,12 @@ public class ActiveResourceManagerTest extends TestLogger {
 
 		CompletableFuture<RegistrationResponse> registerTaskExecutor(ResourceID resourceID) {
 			final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-					.createTestingTaskExecutorGateway();
+				.createTestingTaskExecutorGateway();
+			return registerTaskExecutor(resourceID, taskExecutorGateway);
+		}
+
+		CompletableFuture<RegistrationResponse> registerTaskExecutor(
+				ResourceID resourceID, TaskExecutorGateway taskExecutorGateway) {
 			RPC_SERVICE_RESOURCE.getTestingRpcService().registerGateway(resourceID.toString(), taskExecutorGateway);
 
 			final TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceEventHandler.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -31,12 +32,12 @@ import java.util.function.Consumer;
 public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievable> implements ResourceEventHandler<WorkerType> {
 
 	private final Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer;
-	private final Consumer<ResourceID> onWorkerTerminatedConsumer;
+	private final BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer;
 	private final Consumer<Throwable> onErrorConsumer;
 
 	private TestingResourceEventHandler(
 			Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer,
-			Consumer<ResourceID> onWorkerTerminatedConsumer,
+			BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer,
 			Consumer<Throwable> onErrorConsumer) {
 		this.onPreviousAttemptWorkersRecoveredConsumer = onPreviousAttemptWorkersRecoveredConsumer;
 		this.onWorkerTerminatedConsumer = onWorkerTerminatedConsumer;
@@ -49,8 +50,8 @@ public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievabl
 	}
 
 	@Override
-	public void onWorkerTerminated(ResourceID resourceId) {
-		onWorkerTerminatedConsumer.accept(resourceId);
+	public void onWorkerTerminated(ResourceID resourceId, Exception cause) {
+		onWorkerTerminatedConsumer.accept(resourceId, cause);
 	}
 
 	@Override
@@ -67,7 +68,7 @@ public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievabl
 	 */
 	public static class Builder<WorkerType extends ResourceIDRetrievable> {
 		private Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer = (ignore) -> {};
-		private Consumer<ResourceID> onWorkerTerminatedConsumer = (ignore) -> {};
+		private BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer = (ignore1, ignore2) -> {};
 		private Consumer<Throwable> onErrorConsumer = (ignore) -> {};
 
 		private Builder() {}
@@ -78,7 +79,7 @@ public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievabl
 			return this;
 		}
 
-		public Builder<WorkerType> setOnWorkerTerminatedConsumer(Consumer<ResourceID> onWorkerTerminatedConsumer) {
+		public Builder<WorkerType> setOnWorkerTerminatedConsumer(BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer) {
 			this.onWorkerTerminatedConsumer = Preconditions.checkNotNull(onWorkerTerminatedConsumer);
 			return this;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceEventHandler.java
@@ -32,12 +32,12 @@ import java.util.function.Consumer;
 public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievable> implements ResourceEventHandler<WorkerType> {
 
 	private final Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer;
-	private final BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer;
+	private final BiConsumer<ResourceID, String> onWorkerTerminatedConsumer;
 	private final Consumer<Throwable> onErrorConsumer;
 
 	private TestingResourceEventHandler(
 			Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer,
-			BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer,
+			BiConsumer<ResourceID, String> onWorkerTerminatedConsumer,
 			Consumer<Throwable> onErrorConsumer) {
 		this.onPreviousAttemptWorkersRecoveredConsumer = onPreviousAttemptWorkersRecoveredConsumer;
 		this.onWorkerTerminatedConsumer = onWorkerTerminatedConsumer;
@@ -50,8 +50,8 @@ public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievabl
 	}
 
 	@Override
-	public void onWorkerTerminated(ResourceID resourceId, Exception cause) {
-		onWorkerTerminatedConsumer.accept(resourceId, cause);
+	public void onWorkerTerminated(ResourceID resourceId, String diagnostics) {
+		onWorkerTerminatedConsumer.accept(resourceId, diagnostics);
 	}
 
 	@Override
@@ -68,7 +68,7 @@ public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievabl
 	 */
 	public static class Builder<WorkerType extends ResourceIDRetrievable> {
 		private Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer = (ignore) -> {};
-		private BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer = (ignore1, ignore2) -> {};
+		private BiConsumer<ResourceID, String> onWorkerTerminatedConsumer = (ignore1, ignore2) -> {};
 		private Consumer<Throwable> onErrorConsumer = (ignore) -> {};
 
 		private Builder() {}
@@ -79,7 +79,7 @@ public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievabl
 			return this;
 		}
 
-		public Builder<WorkerType> setOnWorkerTerminatedConsumer(BiConsumer<ResourceID, Exception> onWorkerTerminatedConsumer) {
+		public Builder<WorkerType> setOnWorkerTerminatedConsumer(BiConsumer<ResourceID, String> onWorkerTerminatedConsumer) {
 			this.onWorkerTerminatedConsumer = Preconditions.checkNotNull(onWorkerTerminatedConsumer);
 			return this;
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the problem that active RMs does not close the task manager connection on worker terminated. Without this fix, RM has to wait for heartbeat timeout to find out that TM has terminated.

## Verifying this change

* Add `ActiveResourceManagerTest#testCloseTaskManagerConnectionOnWorkerTerminated`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
