### PR TITLE
[FLINK-19053][hotfix][doc] Fix Flink Kafka Connector Dependency Error 

### DIFF
--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -52,7 +52,7 @@ For details on Kafka compatibility, please refer to the official [Kafka document
 {% highlight xml %}
 <dependency>
 	<groupId>org.apache.flink</groupId>
-	<artifactId>flink-connector-kafka-011{{ site.scala_version_suffix }}</artifactId>
+	<artifactId>flink-connector-kafka-0.11{{ site.scala_version_suffix }}</artifactId>
 	<version>{{ site.version }}</version>
 </dependency>
 {% endhighlight %}
@@ -61,7 +61,7 @@ For details on Kafka compatibility, please refer to the official [Kafka document
 {% highlight xml %}
 <dependency>
 	<groupId>org.apache.flink</groupId>
-	<artifactId>flink-connector-kafka-010{{ site.scala_version_suffix }}</artifactId>
+	<artifactId>flink-connector-kafka-0.10{{ site.scala_version_suffix }}</artifactId>
 	<version>{{ site.version }}</version>
 </dependency>
 {% endhighlight %}


### PR DESCRIPTION
## What is the purpose of the change
Fix Flink Kafka Connector Dependency Error in Doc

## Brief change log
example：flink-connector-kafka-011{{ site.scala_version_suffix }} change to flink-connector-kafka-0.11{{ site.scala_version_suffix }}


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
