### PR TITLE
[FLINK-18695][network] Netty fakes heap buffer allocationn with direct buffers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
@@ -225,31 +225,31 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 	}
 
 	// ------------------------------------------------------------------------
-	// Prohibit heap buffer allocations
+	// Fakes heap buffer allocations with direct buffers currently.
 	// ------------------------------------------------------------------------
 
 	@Override
 	public ByteBuf heapBuffer() {
-		throw new UnsupportedOperationException("Heap buffer");
+		return directBuffer();
 	}
 
 	@Override
 	public ByteBuf heapBuffer(int initialCapacity) {
-		throw new UnsupportedOperationException("Heap buffer");
+		return directBuffer(initialCapacity);
 	}
 
 	@Override
 	public ByteBuf heapBuffer(int initialCapacity, int maxCapacity) {
-		throw new UnsupportedOperationException("Heap buffer");
+		return directBuffer(initialCapacity, maxCapacity);
 	}
 
 	@Override
 	public CompositeByteBuf compositeHeapBuffer() {
-		throw new UnsupportedOperationException("Heap buffer");
+		return compositeDirectBuffer();
 	}
 
 	@Override
 	public CompositeByteBuf compositeHeapBuffer(int maxNumComponents) {
-		throw new UnsupportedOperationException("Heap buffer");
+		return compositeDirectBuffer(maxNumComponents);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyBufferPoolTest.java
@@ -43,37 +43,14 @@ public class NettyBufferPoolTest {
 		assertTrue(nettyBufferPool.ioBuffer(128).isDirect());
 		assertTrue(nettyBufferPool.ioBuffer(128, 256).isDirect());
 
-		// Disallow heap buffers
-		try {
-			nettyBufferPool.heapBuffer();
-			fail("Unexpected heap buffer operation");
-		} catch (UnsupportedOperationException ignored) {
-		}
+		// Currently we fakes the heap buffer allocation with direct buffers
+		assertTrue(nettyBufferPool.heapBuffer().isDirect());
+		assertTrue(nettyBufferPool.heapBuffer(128).isDirect());
+		assertTrue(nettyBufferPool.heapBuffer(128, 256).isDirect());
 
-		try {
-			nettyBufferPool.heapBuffer(128);
-			fail("Unexpected heap buffer operation");
-		} catch (UnsupportedOperationException ignored) {
-		}
-
-		try {
-			nettyBufferPool.heapBuffer(128, 256);
-			fail("Unexpected heap buffer operation");
-		} catch (UnsupportedOperationException ignored) {
-		}
-
-		// Disallow composite heap buffers
-		try {
-			nettyBufferPool.compositeHeapBuffer();
-			fail("Unexpected heap buffer operation");
-		} catch (UnsupportedOperationException ignored) {
-		}
-
-		try {
-			nettyBufferPool.compositeHeapBuffer(2);
-			fail("Unexpected heap buffer operation");
-		} catch (UnsupportedOperationException ignored) {
-		}
+		// Composite buffers allocates the corresponding type of buffers when extending its capacity
+		assertTrue(nettyBufferPool.compositeHeapBuffer().capacity(1024).isDirect());
+		assertTrue(nettyBufferPool.compositeHeapBuffer(10).capacity(1024).isDirect());
 
 		// Is direct buffer pooled!
 		assertTrue(nettyBufferPool.isDirectBufferPooled());


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the `NettyBufferPool` to also allocate direct buffers for the heap buffer request. This enables us not to change the memory footprint when upgrade Netty to 4.1.50-FINAL. In the future we could further decide how to adjust the Netty memory management. 

## Brief change log

- 3ef9f728f6a8005a7f91846bf32df96ee718c626 returns direct buffers for all the heap buffer allocation methods.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
