### PR TITLE
[FLINK-18801][docs][python] Add a "10 minutes to Table API" document under the "Python API" -> "User Guide" -> "Table API" section.

### DIFF
--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
@@ -82,8 +82,8 @@ table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").get_job_client(
 
 {% top %}
 
-Create a TableEnvironment
--------------------------
+Creating a TableEnvironment
+---------------------------
 
 The `TableEnvironment` is a central concept of the Table API and SQL integration. The following code example shows how to create a TableEnvironment:
 
@@ -113,10 +113,10 @@ The `TableEnvironment` is responsible for:
 
 * Creating `Table`s
 * Registering `Table`s as a temporary view
-* Executing SQL queries
-* Registering user-defined (scalar, table, or aggregation) functions, see [General User-defined Functions]({% link dev/python/user-guide/table/udfs/python_udfs.md %}) and [Vectorized User-defined Functions]({% link dev/python/user-guide/table/udfs/vectorized_python_udfs.md %})
-* Configuring the job
-* Managing Python dependencies, see [Dependency Management]({% link dev/python/user-guide/table/dependency_management.md %})
+* Executing SQL queries, see [SQL]({% link dev/table/sql/index.md %}) for more details
+* Registering user-defined (scalar, table, or aggregation) functions, see [General User-defined Functions]({% link dev/python/user-guide/table/udfs/python_udfs.md %}) and [Vectorized User-defined Functions]({% link dev/python/user-guide/table/udfs/vectorized_python_udfs.md %}) for more details
+* Configuring the job, see [Python Configuration]({% link dev/python/user-guide/table/python_config.md %}) for more details
+* Managing Python dependencies, see [Dependency Management]({% link dev/python/user-guide/table/dependency_management.md %}) for more details
 * Submitting the jobs for execution
 
 Currently there are 2 planners available: flink planner and blink planner.
@@ -127,7 +127,7 @@ We recommend using the blink planner as much as possible.
 {% top %}
 
 Creating Tables
--------------
+---------------
 
 `Table` is a core component of the Python Table API. A `Table` is a logical representation of the intermediate result of a Table API Job.
 
@@ -141,6 +141,7 @@ You can create a Table from a list object:
 
 # create a blink batch TableEnvironment
 from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
 table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
@@ -157,7 +158,7 @@ The result is:
 1   2  Hello
 {% endhighlight %}
 
-You can also create the Table with column names:
+You can also create the Table with specified column names:
 
 {% highlight python %}
 
@@ -207,6 +208,11 @@ Now the type of the "id" column is int8.
 You can create a Table using connector DDL:
 
 {% highlight python %}
+# create a blink stream TableEnvironment
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 table_env.execute_sql("""
     CREATE TABLE random_source (
@@ -238,7 +244,7 @@ The result is:
 
 ### Create using a Catalog
 
-A TableEnvironment maintains a map of catalogs of tables which are created with an identifier.
+A `TableEnvironment` maintains a map of catalogs of tables which are created with an identifier.
 
 The tables in a catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
 
@@ -271,8 +277,8 @@ The result is:
 
 {% top %}
 
-Write Queries
--------------
+Writing Queries
+---------------
 
 ### Writing Table API Queries
 
@@ -280,7 +286,7 @@ The `Table` object offers many methods for applying relational operations.
 These methods return new `Table` objects representing the result of applying the relational operations on the input `Table`. 
 These relational operations may be composed of multiple method calls, such as `table.group_by(...).select(...)`.
 
-The [Table API]({{ site.baseurl }}/dev/table/tableApi.html?code_tab=python) documentation describes all Table API operations that are supported on streaming and batch tables.
+The [Table API]({% link dev/table/tableApi.md %}?code_tab=python) documentation describes all Table API operations that are supported on streaming and batch tables.
 
 The following example shows a simple Table API aggregation query:
 
@@ -288,6 +294,7 @@ The following example shows a simple Table API aggregation query:
 
 # using batch table environment to execute the queries
 from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
 table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
@@ -311,11 +318,11 @@ The result is:
 0  Jack       30
 {% endhighlight %}
 
-### Write SQL Queries
+### Writing SQL Queries
 
 Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as Strings.
 
-The [SQL]({{ site.baseurl }}/dev/table/sql/index.html) documentation describes Flink's SQL support for streaming and batch tables.
+The [SQL]({% link dev/table/sql/index.md %}) documentation describes Flink's SQL support for streaming and batch tables.
 
 The following example shows a simple SQL aggregation query:
 
@@ -323,6 +330,7 @@ The following example shows a simple SQL aggregation query:
 
 # use a StreamTableEnvironment to execute the queries
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
@@ -456,14 +464,24 @@ table.to_pandas()
 
 {% endhighlight %}
 
+The result is:
+
+{% highlight text %}
+   id  data
+0   2     5
+1   1     4
+2   4     7
+3   3     6
+{% endhighlight %}
+
 {% top %}
 
-Emit Results
-------------
+Emitting Results
+----------------
 
-### Capturing Data in a Variable
+### Collecting Results to Client
 
-You can call the "to_pandas" method to emit the data from a `Table` object to a pandas DataFrame:
+You can call the "to_pandas" method to [convert a `Table` object to a pandas DataFrame]({% link dev/python/user-guide/table/conversion_of_pandas.md %}#convert-pyflink-table-to-pandas-dataframe):
 
 {% highlight python %}
 
@@ -480,7 +498,7 @@ The result is:
 1   2  Hello
 {% endhighlight %}
 
-Note that "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
+<span class="label label-info">Note</span> "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
 ### Emitting Results to One Sink Table
 
@@ -568,17 +586,17 @@ The result is:
 7> +I(2,Hello)
 {% endhighlight %}
 
-Explain Tables
---------------
+Explaining Tables
+-----------------
 
 The Table API provides a mechanism to explain the logical and optimized query plans used to compute a `Table`. 
-This is done through the `Table.explain()` and `StatementSet.explain()` methods. `Table.explain()`returns the plan for a `Table`. `StatementSet.explain()` returns the plan for multiple sinks. These methods return a String describing three things:
+This is done through the `Table.explain()` or `StatementSet.explain()` methods. `Table.explain()`returns the plan of a `Table`. `StatementSet.explain()` returns the plan for multiple sinks. These methods return a string describing three things:
 
 1. the Abstract Syntax Tree of the relational query, i.e., the unoptimized logical query plan,
 2. the optimized logical query plan, and
 3. the physical execution plan.
 
-`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support executing an `EXPLAIN` statement to get the plans. Please refer to the [EXPLAIN]({{ site.baseurl }}/dev/table/sql/explain.html) page for more details.
+`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support executing an `EXPLAIN` statement to get the plans. Please refer to the [EXPLAIN]({% link dev/table/sql/explain.md %}) page for more details.
 
 The following code shows how to use the `Table.explain()` method:
 
@@ -586,6 +604,7 @@ The following code shows how to use the `Table.explain()` method:
 
 # using a StreamTableEnvironment
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
@@ -640,6 +659,7 @@ The following code shows how to use the `StatementSet.explain()` method:
 
 # using a StreamTableEnvironment
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
@@ -82,7 +82,7 @@ table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").get_job_client(
 
 {% top %}
 
-Creating a TableEnvironment
+Create a TableEnvironment
 ---------------------------
 
 The `TableEnvironment` is a central concept of the Table API and SQL integration. The following code example shows how to create a TableEnvironment:
@@ -126,7 +126,7 @@ We recommend using the blink planner as much as possible.
 
 {% top %}
 
-Creating Tables
+Create Tables
 ---------------
 
 `Table` is a core component of the Python Table API. A `Table` is a logical representation of the intermediate result of a Table API Job.
@@ -277,10 +277,10 @@ The result is:
 
 {% top %}
 
-Writing Queries
+Write Queries
 ---------------
 
-### Writing Table API Queries
+### Write Table API Queries
 
 The `Table` object offers many methods for applying relational operations. 
 These methods return new `Table` objects representing the result of applying the relational operations on the input `Table`. 
@@ -318,7 +318,7 @@ The result is:
 0  Jack       30
 {% endhighlight %}
 
-### Writing SQL Queries
+### Write SQL Queries
 
 Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as Strings.
 
@@ -398,7 +398,7 @@ So, we get this result from the change logs above:
 (3, 19)
 {% endhighlight %}
 
-### Mixing the Table API and SQL
+### Mix the Table API and SQL
 
 The `Table` objects used in Table API and the tables used in SQL can be freely converted to each other.
 
@@ -476,10 +476,10 @@ The result is:
 
 {% top %}
 
-Emitting Results
+Emit Results
 ----------------
 
-### Collecting Results to Client
+### Collect Results to Client
 
 You can call the "to_pandas" method to [convert a `Table` object to a pandas DataFrame]({% link dev/python/user-guide/table/conversion_of_pandas.md %}#convert-pyflink-table-to-pandas-dataframe):
 
@@ -500,7 +500,7 @@ The result is:
 
 <span class="label label-info">Note</span> "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
-### Emitting Results to One Sink Table
+### Emit Results to One Sink Table
 
 You can call the "execute_insert" method to emit the data in a `Table` object to a sink table:
 
@@ -537,7 +537,7 @@ table_env.execute_sql("INSERT INTO sink_table SELECT * FROM table_source") \
 
 {% endhighlight %}
 
-### Emitting Results to Multiple Sink Tables
+### Emit Results to Multiple Sink Tables
 
 You can use a `StatementSet` to emit the `Table`s to multiple sink tables in one job:
 
@@ -586,7 +586,7 @@ The result is:
 7> +I(2,Hello)
 {% endhighlight %}
 
-Explaining Tables
+Explain Tables
 -----------------
 
 The Table API provides a mechanism to explain the logical and optimized query plans used to compute a `Table`. 

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
@@ -1,5 +1,5 @@
 ---
-title: "10 Minutes to Table API"
+title: "10 Minutes to Python Table API"
 nav-parent_id: python_tableapi
 nav-pos: 25
 ---
@@ -246,7 +246,7 @@ The result is:
 
 A `TableEnvironment` maintains a map of catalogs of tables which are created with an identifier.
 
-The tables in a catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
+The tables in a catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions.
 
 The tables and views created via SQL DDL, e.g. "create table ..." and "create view ..." are also stored in a catalog.
 

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
@@ -1,0 +1,712 @@
+---
+title: "10 Minutes to Table API"
+nav-parent_id: python_tableapi
+nav-pos: 25
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document is a short introduction to PyFlink Table API, which is used to help novice users quickly understand the basic usage of PyFlink Table API.
+For advanced usage, please refer to other documents in this User Guide.
+
+* This will be replaced by the TOC
+{:toc}
+
+Common Structure of Python Table API Program 
+--------------------------------------------
+
+All Table API and SQL programs for batch and streaming follow the same pattern. The following code example shows the common structure of Table API and SQL programs.
+
+{% highlight python %}
+
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
+# 1. create a TableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()) 
+
+# 2. create source Table
+table_env.execute_sql("""
+CREATE TABLE datagen (
+ id INT,
+ data STRING
+) WITH (
+ 'connector' = 'datagen',
+ 'fields.id.kind' = 'sequence',
+ 'fields.id.start' = '1',
+ 'fields.id.end' = '10'
+)
+""")
+
+# 3. create sink Table
+table_env.execute_sql("""
+CREATE TABLE print (
+ id INT,
+ data STRING
+) WITH (
+ 'connector' = 'print'
+)
+""")
+
+# 4. query from source table and caculate
+# create a Table from a Table API query:
+tapi_result = table_env.from_path("datagen").select("id + 1, data")
+# or create a Table from a SQL query:
+sql_result = table_env.sql_query("SELECT * FROM datagen").select("id + 1, data")
+
+# 5. emit query result to sink table
+# emit a Table API result Table to a sink table:
+tapi_result.execute_insert("print").get_job_client().get_job_execution_result().result()
+sql_result.execute_insert("print").get_job_client().get_job_execution_result().result()
+# or emit results via SQL query:
+table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+{% top %}
+
+Create a TableEnvironment
+-------------------------
+
+The `TableEnvironment` is a central concept of the Table API and SQL integration. The following code example shows how to create a TableEnvironment:
+
+{% highlight python %}
+
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment, BatchTableEnvironment
+
+# create a blink streaming TableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+# create a blink batch TableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+
+# create a flink streaming TableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_old_planner().build())
+
+# create a flink batch TableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_old_planner().build())
+
+{% endhighlight %}
+
+The `TableEnvironment` is responsible for:
+
+* Creating `Table`s
+* Registering `Table`s to the catalog
+* Executing SQL queries
+* Registering user-defined (scalar, table, or aggregation) functions
+* Offering further configuration options.
+* Add Python dependencies to support running Python UDF on remote cluster
+* Executing jobs.
+
+Currently there are 2 planners available: flink planner and blink planner.
+
+You should explicitly set which planner to use in the current program.
+We recommend using the blink planner as much as possible. 
+The blink planner is more powerful in functionality and performance, and the flink planner is reserved for compatibility.
+
+{% top %}
+
+Create Tables
+-------------
+
+`Table` is the core component of the Table API. A `Table` represents a intermediate result set during a Table API Job.
+
+A `Table` is always bound to a specific `TableEnvironment`. It is not possible to combine tables of different TableEnvironments in same query, e.g., to join or union them.
+
+### Create From A List Object
+
+You can create a Table from a list object:
+
+{% highlight python %}
+
+# create a blink batch TableEnvironment
+from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   _1     _2
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+You can also create the Table with column names:
+
+{% highlight python %}
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id   data
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+By default the table schema is extracted from the data automatically. 
+
+If the table schema is not as your wish, you can specify it manually:
+
+{% highlight python %}
+
+table_without_schema = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+# by default the type of the "id" column is 64 bit int
+default_type = table_without_schema.to_pandas()["id"].dtype
+print('By default the type of the "id" column is %s.' % default_type)
+
+from pyflink.table import DataTypes
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
+                                DataTypes.ROW([DataTypes.FIELD("id", DataTypes.TINYINT()),
+                                               DataTypes.FIELD("data", DataTypes.STRING())]))
+# now the type of the "id" column is 8 bit int
+type = table.to_pandas()["id"].dtype
+print('Now the type of the "id" column is %s.' % type)
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+By default the type of the "id" column is int64.
+Now the type of the "id" column is int8.
+{% endhighlight %}
+
+### Create From Connectors
+
+You can create a Table from connector DDL:
+
+{% highlight python %}
+
+table_env.execute_sql("""
+    CREATE TABLE random_source (
+        id BIGINT, 
+        data TINYINT) 
+    WITH (
+        'connector' = 'datagen',
+        'fields.id.kind'='sequence',
+        'fields.id.start'='1',
+        'fields.id.end'='3',
+        'fields.data.kind'='sequence',
+        'fields.data.start'='4',
+        'fields.data.end'='6'
+    )
+""")
+table = table_env.from_path("random_source")
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id  data
+0   2     5
+1   1     4
+2   3     6
+{% endhighlight %}
+
+### Create From Catalog
+
+A TableEnvironment maintains a map of catalogs of tables which are created with an identifier.
+
+The tables in catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
+
+The tables and views created via SQL DDL, e.g. "create table ..." and "create view ..." is also stored in catalog.
+
+You can also access the tables in catalog via SQL directly.
+
+If you want to use the catalog tables in Table API, you can use the "from_path" method to create the Table API objects from catalog:
+
+{% highlight python %}
+
+# prepare the catalog
+# register Table API tables to catalog
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.create_temporary_view('source_table', table)
+
+# create Table API table from catalog
+new_table = table_env.from_path('source_table')
+new_table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id   data
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+{% top %}
+
+Write Queries
+-------------
+
+### Write Table API Queries
+
+The `Table` object offers many methods to apply relational operations. 
+These methods return a new `Table` object, which represents the result of applying the relational operation on the input `Table`. 
+i.e. you can make a method chaining when using Table API.
+Some relational operations are composed of multiple method calls such as table.groupBy(...).select(), where groupBy(...) specifies a grouping of table, and select(...) the projection on the grouping of table.
+
+The [Table API]({{ site.baseurl }}/dev/table/tableApi.html) document describes all Table API operations that are supported on streaming and batch tables.
+
+The following example shows a simple Table API aggregation query:
+
+{% highlight python %}
+
+# using batch table environment to execute the queries
+from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+
+orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
+                                 ['name', 'country', 'revenue'])
+# compute revenue for all customers from France
+revenue = orders \
+    .select("name, country, revenue") \
+    .where("country === 'FRANCE'") \
+    .group_by("name") \
+    .select("name, revenue.sum AS rev_sum")
+    
+revenue.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   name  rev_sum
+0  Jack       30
+{% endhighlight %}
+
+### Write SQL Queries
+
+Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as regular Strings.
+
+The [SQL]({{ site.baseurl }}/dev/table/sql/index.html) document describes Flink's SQL support for streaming and batch tables.
+
+The following example shows a simple SQL aggregation query:
+
+{% highlight python %}
+
+# using stream table environment to execute the queries
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+
+table_env.execute_sql("""
+    CREATE TABLE random_source (
+        id BIGINT, 
+        data TINYINT) 
+    WITH (
+        'connector' = 'datagen',
+        'fields.id.kind'='sequence',
+        'fields.id.start'='1',
+        'fields.id.end'='8',
+        'fields.data.kind'='sequence',
+        'fields.data.start'='4',
+        'fields.data.end'='11'
+    )
+""")
+
+table_env.execute_sql("""
+    CREATE TABLE print_sink (
+        id BIGINT, 
+        data_sum TINYINT) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+table_env.execute_sql("""
+    INSERT INTO print_sink
+        SELECT id, sum(data) as data_sum FROM 
+            (SELECT id / 2 as id, data FROM random_source)
+        WHERE id > 1
+        GROUP BY id
+""").get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+2> +I(4,11)
+6> +I(2,8)
+8> +I(3,10)
+6> -U(2,8)
+8> -U(3,10)
+6> +U(2,15)
+8> +U(3,19)
+{% endhighlight %}
+
+This output may be difficult to understand. 
+In fact, this is the change logs received by the print sink.
+The output format of the change log is:
+{% highlight python %}
+{subtask id}> {message type}{string format of the value}
+{% endhighlight %}
+For example, "2> +I(4,11)" means this message comes from the 2nd subtask, and "+I" means it is a insert message. "(4, 11)" is the content of the message.
+In addition, "-U" means a retract record (i.e. update-before), which means this message should be deleted or retracted from sink. 
+"+U" means this is an update record (i.e. update-after), which means this message should be updated or inserted to sink.
+
+So we can get such a result set from the change logs above:
+
+{% highlight text %}
+(4, 11)
+(2, 15) 
+(3, 19)
+{% endhighlight %}
+
+### Mix Table API and SQL
+
+The `Table` objects used in Table API and the tables used in SQL can be freely converted to each other.
+
+The following example shows how to use the `Table` object in SQL:
+
+{% highlight python %}
+
+# create a sink table to emit results
+table_env.execute_sql("""
+    CREATE TABLE table_sink (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+# convert the Table API table to SQL view
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.create_temporary_view('table_api_table', table)
+
+# emit the Table API table
+table_env.execute_sql("INSERT INTO table_sink SELECT * FROM table_api_table") \
+    .get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+6> +I(1,Hi)
+6> +I(2,Hello)
+{% endhighlight %}
+
+And the following example shows how to use the SQL tables in Table API:
+
+{% highlight python %}
+
+# create a sql source table
+table_env.execute_sql("""
+    CREATE TABLE sql_source (
+        id BIGINT, 
+        data TINYINT) 
+    WITH (
+        'connector' = 'datagen',
+        'fields.id.kind'='sequence',
+        'fields.id.start'='1',
+        'fields.id.end'='4',
+        'fields.data.kind'='sequence',
+        'fields.data.start'='4',
+        'fields.data.end'='7'
+    )
+""")
+
+# convert the sql table to Table API table
+table = table_env.from_path("sql_source")
+
+# or create the table from a sql query
+table = table_env.sql_query("SELECT * FROM sql_source")
+
+# emit the table
+table.to_pandas()
+
+{% endhighlight %}
+
+{% top %}
+
+Emit Results
+------------
+
+### Emit to Variable
+
+You can call "to_pandas" method to emit the data in a `Table` object to a pandas DataFrame:
+
+{% highlight python %}
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id   data
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+Note that "to_pandas" is not supported on flink planner, and not all data types can be emitted to pandas DataFrame.
+If the `TableEnvironment` is in streaming mode, calling "to_pandas" on the tables which contain retract messages (i.e. update-before) is also not supported.
+
+### Emit to Single Sink Table
+
+You can call "execute_insert" method to emit the data in a `Table` object to a sink table:
+
+{% highlight python %}
+
+table_env.execute_sql("""
+    CREATE TABLE sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table.execute_insert("sink_table").get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+6> +I(1,Hi)
+6> +I(2,Hello)
+{% endhighlight %}
+
+The equivalent SQL way is:
+
+{% highlight python %}
+
+table_env.create_temporary_view("table_source", table)
+table_env.execute_sql("INSERT INTO sink_table SELECT * FROM table_source") \
+    .get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+### Emit to Multiple Sink Tables
+
+You can use the `StatementSet` to emit the `Table`s to multiple sink tables in one job:
+
+{% highlight python %}
+
+# prepare source tables and sink tables
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.create_temporary_view("simple_source", table)
+table_env.execute_sql("""
+    CREATE TABLE first_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+table_env.execute_sql("""
+    CREATE TABLE second_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+# create a statement set
+statement_set = table_env.create_statement_set()
+
+# accept a Table API table
+statement_set.add_insert("first_sink_table", table)
+
+# accept a insert sql query
+statement_set.add_insert_sql("INSERT INTO second_sink_table SELECT * FROM simple_source")
+
+# execute the statement set
+statement_set.execute().get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+7> +I(1,Hi)
+7> +I(1,Hi)
+7> +I(2,Hello)
+7> +I(2,Hello)
+{% endhighlight %}
+
+Explain Tables
+--------------
+
+The Table API provides a mechanism to explain the logical and optimized query plans to compute a `Table`. 
+This is done through the `Table.explain()` method or `StatementSet.explain()` method. `Table.explain()`returns the plan of a `Table`. `StatementSet.explain()` returns the plan of multiple sinks. It returns a String describing three plans:
+
+1. the Abstract Syntax Tree of the relational query, i.e., the unoptimized logical query plan,
+2. the optimized logical query plan, and
+3. the physical execution plan.
+
+`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support execute a `EXPLAIN` statement to get the plans, Please refer to [EXPLAIN]({{ site.baseurl }}/dev/table/sql/explain.html) page.
+
+The following code shows how to use the `Table.explain()` method:
+
+{% highlight python %}
+
+# using stream table environment
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table2 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table = table1 \
+    .where("LIKE(data, 'H%')") \
+    .union_all(table2)
+print(table.explain())
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+== Abstract Syntax Tree ==
+LogicalUnion(all=[true])
+:- LogicalFilter(condition=[LIKE($1, _UTF-16LE'H%')])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_201907291, source: [PythonInputFormatTableSource(id, data)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_1709623525, source: [PythonInputFormatTableSource(id, data)]]])
+
+== Optimized Logical Plan ==
+Union(all=[true], union=[id, data])
+:- Calc(select=[id, data], where=[LIKE(data, _UTF-16LE'H%')])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_201907291, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_1709623525, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
+
+== Physical Execution Plan ==
+Stage 133 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 134 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_201907291, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+                Stage 135 : Operator
+                        content : Calc(select=[id, data], where=[(data LIKE _UTF-16LE'H%')])
+                        ship_strategy : FORWARD
+
+Stage 136 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 137 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_1709623525, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+{% endhighlight %}
+
+The following code shows how to use the `StatementSet.explain()` method:
+
+{% highlight python %}
+
+# using stream table environment
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table2 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.execute_sql("""
+    CREATE TABLE print_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+table_env.execute_sql("""
+    CREATE TABLE black_hole_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'blackhole'
+    )
+""")
+
+statement_set = table_env.create_statement_set()
+
+statement_set.add_insert("print_sink_table", table1.where("LIKE(data, 'H%')"))
+statement_set.add_insert("black_hole_sink_table", table2)
+
+print(statement_set.explain())
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.print_sink_table], fields=[id, data])
++- LogicalFilter(condition=[LIKE($1, _UTF-16LE'H%')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_541737614, source: [PythonInputFormatTableSource(id, data)]]])
+
+LogicalSink(table=[default_catalog.default_database.black_hole_sink_table], fields=[id, data])
++- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_1437429083, source: [PythonInputFormatTableSource(id, data)]]])
+
+== Optimized Logical Plan ==
+Sink(table=[default_catalog.default_database.print_sink_table], fields=[id, data])
++- Calc(select=[id, data], where=[LIKE(data, _UTF-16LE'H%')])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_541737614, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
+
+Sink(table=[default_catalog.default_database.black_hole_sink_table], fields=[id, data])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_1437429083, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
+
+== Physical Execution Plan ==
+Stage 139 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 140 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_541737614, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+                Stage 141 : Operator
+                        content : Calc(select=[id, data], where=[(data LIKE _UTF-16LE'H%')])
+                        ship_strategy : FORWARD
+
+Stage 143 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 144 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_1437429083, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+                Stage 142 : Data Sink
+                        content : Sink: Sink(table=[default_catalog.default_database.print_sink_table], fields=[id, data])
+                        ship_strategy : FORWARD
+
+                        Stage 145 : Data Sink
+                                content : Sink: Sink(table=[default_catalog.default_database.black_hole_sink_table], fields=[id, data])
+                                ship_strategy : FORWARD
+{% endhighlight %}

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
@@ -1,5 +1,5 @@
 ---
-title: "10 Minutes to Python Table API"
+title: "Intro to the Python Table API"
 nav-parent_id: python_tableapi
 nav-pos: 25
 ---
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This document is a short introduction to PyFlink Table API, which is used to help novice users quickly understand the basic usage of PyFlink Table API.
+This document is a short introduction to the PyFlink Table API, which is used to help novice users quickly understand the basic usage of PyFlink Table API.
 For advanced usage, please refer to other documents in this User Guide.
 
 * This will be replaced by the TOC
@@ -177,7 +177,7 @@ The result is:
 
 By default the table schema is extracted from the data automatically. 
 
-If the table schema is not as your wish, you can specify it manually:
+If the automatically generated table schema isn't satisfactory, you can specify it manually:
 
 {% highlight python %}
 
@@ -300,6 +300,7 @@ table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
                                  ['name', 'country', 'revenue'])
+
 # compute revenue for all customers from France
 revenue = orders \
     .select("name, country, revenue") \
@@ -383,7 +384,7 @@ The result is:
 
 In fact, this shows the change logs received by the print sink.
 The output format of a change log is:
-{% highlight python %}
+{% highlight text %}
 {subtask id}> {message type}{string format of the value}
 {% endhighlight %}
 For example, "2> +I(4,11)" means this message comes from the 2nd subtask, and "+I" means it is an insert message. "(4, 11)" is the content of the message.

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.md
@@ -31,48 +31,50 @@ For advanced usage, please refer to other documents in this User Guide.
 Common Structure of Python Table API Program 
 --------------------------------------------
 
-All Table API and SQL programs for batch and streaming follow the same pattern. The following code example shows the common structure of Table API and SQL programs.
+All Table API and SQL programs, both batch and streaming, follow the same pattern. The following code example shows the common structure of Table API and SQL programs.
 
 {% highlight python %}
 
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
 
 # 1. create a TableEnvironment
-table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()) 
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 # 2. create source Table
 table_env.execute_sql("""
-CREATE TABLE datagen (
- id INT,
- data STRING
-) WITH (
- 'connector' = 'datagen',
- 'fields.id.kind' = 'sequence',
- 'fields.id.start' = '1',
- 'fields.id.end' = '10'
-)
+    CREATE TABLE datagen (
+        id INT,
+        data STRING
+    ) WITH (
+        'connector' = 'datagen',
+        'fields.id.kind' = 'sequence',
+        'fields.id.start' = '1',
+        'fields.id.end' = '10'
+    )
 """)
 
 # 3. create sink Table
 table_env.execute_sql("""
-CREATE TABLE print (
- id INT,
- data STRING
-) WITH (
- 'connector' = 'print'
-)
+    CREATE TABLE print (
+        id INT,
+        data STRING
+    ) WITH (
+        'connector' = 'print'
+    )
 """)
 
-# 4. query from source table and caculate
+# 4. query from source table and perform caculations
 # create a Table from a Table API query:
-tapi_result = table_env.from_path("datagen").select("id + 1, data")
+source_table = table_env.from_path("datagen")
 # or create a Table from a SQL query:
-sql_result = table_env.sql_query("SELECT * FROM datagen").select("id + 1, data")
+source_table = table_env.sql_query("SELECT * FROM datagen")
+
+result_table = source_table.select("id + 1, data")
 
 # 5. emit query result to sink table
 # emit a Table API result Table to a sink table:
-tapi_result.execute_insert("print").get_job_client().get_job_execution_result().result()
-sql_result.execute_insert("print").get_job_client().get_job_execution_result().result()
+result_table.execute_insert("print").get_job_client().get_job_execution_result().result()
 # or emit results via SQL query:
 table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").get_job_client().get_job_execution_result().result()
 
@@ -90,45 +92,48 @@ The `TableEnvironment` is a central concept of the Table API and SQL integration
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment, BatchTableEnvironment
 
 # create a blink streaming TableEnvironment
-table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 # create a blink batch TableEnvironment
-table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
 # create a flink streaming TableEnvironment
-table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_old_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_old_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 # create a flink batch TableEnvironment
-table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_old_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_old_planner().build()
+table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
 {% endhighlight %}
 
 The `TableEnvironment` is responsible for:
 
 * Creating `Table`s
-* Registering `Table`s to the catalog
+* Registering `Table`s as a temporary view
 * Executing SQL queries
-* Registering user-defined (scalar, table, or aggregation) functions
-* Offering further configuration options.
-* Add Python dependencies to support running Python UDF on remote cluster
-* Executing jobs.
+* Registering user-defined (scalar, table, or aggregation) functions, see [General User-defined Functions]({% link dev/python/user-guide/table/udfs/python_udfs.md %}) and [Vectorized User-defined Functions]({% link dev/python/user-guide/table/udfs/vectorized_python_udfs.md %})
+* Configuring the job
+* Managing Python dependencies, see [Dependency Management]({% link dev/python/user-guide/table/dependency_management.md %})
+* Submitting the jobs for execution
 
 Currently there are 2 planners available: flink planner and blink planner.
 
 You should explicitly set which planner to use in the current program.
 We recommend using the blink planner as much as possible. 
-The blink planner is more powerful in functionality and performance, and the flink planner is reserved for compatibility.
 
 {% top %}
 
-Create Tables
+Creating Tables
 -------------
 
-`Table` is the core component of the Table API. A `Table` represents a intermediate result set during a Table API Job.
+`Table` is a core component of the Python Table API. A `Table` is a logical representation of the intermediate result of a Table API Job.
 
-A `Table` is always bound to a specific `TableEnvironment`. It is not possible to combine tables of different TableEnvironments in same query, e.g., to join or union them.
+A `Table` is always bound to a specific `TableEnvironment`. It is not possible to combine tables from different TableEnvironments in same query, e.g., to join or union them.
 
-### Create From A List Object
+### Create using a List Object
 
 You can create a Table from a list object:
 
@@ -136,7 +141,8 @@ You can create a Table from a list object:
 
 # create a blink batch TableEnvironment
 from pyflink.table import EnvironmentSettings, BatchTableEnvironment
-table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
 table.to_pandas()
@@ -196,17 +202,17 @@ By default the type of the "id" column is int64.
 Now the type of the "id" column is int8.
 {% endhighlight %}
 
-### Create From Connectors
+### Create using a Connector
 
-You can create a Table from connector DDL:
+You can create a Table using connector DDL:
 
 {% highlight python %}
 
 table_env.execute_sql("""
     CREATE TABLE random_source (
         id BIGINT, 
-        data TINYINT) 
-    WITH (
+        data TINYINT 
+    ) WITH (
         'connector' = 'datagen',
         'fields.id.kind'='sequence',
         'fields.id.start'='1',
@@ -230,22 +236,22 @@ The result is:
 2   3     6
 {% endhighlight %}
 
-### Create From Catalog
+### Create using a Catalog
 
 A TableEnvironment maintains a map of catalogs of tables which are created with an identifier.
 
-The tables in catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
+The tables in a catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
 
-The tables and views created via SQL DDL, e.g. "create table ..." and "create view ..." is also stored in catalog.
+The tables and views created via SQL DDL, e.g. "create table ..." and "create view ..." are also stored in a catalog.
 
-You can also access the tables in catalog via SQL directly.
+You can directly access the tables in a catalog via SQL.
 
-If you want to use the catalog tables in Table API, you can use the "from_path" method to create the Table API objects from catalog:
+If you want to use tables from a catalog with the Table API, you can use the "from_path" method to create the Table API objects:
 
 {% highlight python %}
 
 # prepare the catalog
-# register Table API tables to catalog
+# register Table API tables in the catalog
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
 table_env.create_temporary_view('source_table', table)
 
@@ -268,14 +274,13 @@ The result is:
 Write Queries
 -------------
 
-### Write Table API Queries
+### Writing Table API Queries
 
-The `Table` object offers many methods to apply relational operations. 
-These methods return a new `Table` object, which represents the result of applying the relational operation on the input `Table`. 
-i.e. you can make a method chaining when using Table API.
-Some relational operations are composed of multiple method calls such as table.groupBy(...).select(), where groupBy(...) specifies a grouping of table, and select(...) the projection on the grouping of table.
+The `Table` object offers many methods for applying relational operations. 
+These methods return new `Table` objects representing the result of applying the relational operations on the input `Table`. 
+These relational operations may be composed of multiple method calls, such as `table.group_by(...).select(...)`.
 
-The [Table API]({{ site.baseurl }}/dev/table/tableApi.html) document describes all Table API operations that are supported on streaming and batch tables.
+The [Table API]({{ site.baseurl }}/dev/table/tableApi.html?code_tab=python) documentation describes all Table API operations that are supported on streaming and batch tables.
 
 The following example shows a simple Table API aggregation query:
 
@@ -283,7 +288,8 @@ The following example shows a simple Table API aggregation query:
 
 # using batch table environment to execute the queries
 from pyflink.table import EnvironmentSettings, BatchTableEnvironment
-table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
                                  ['name', 'country', 'revenue'])
@@ -307,24 +313,25 @@ The result is:
 
 ### Write SQL Queries
 
-Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as regular Strings.
+Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as Strings.
 
-The [SQL]({{ site.baseurl }}/dev/table/sql/index.html) document describes Flink's SQL support for streaming and batch tables.
+The [SQL]({{ site.baseurl }}/dev/table/sql/index.html) documentation describes Flink's SQL support for streaming and batch tables.
 
 The following example shows a simple SQL aggregation query:
 
 {% highlight python %}
 
-# using stream table environment to execute the queries
+# use a StreamTableEnvironment to execute the queries
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
-table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 
 table_env.execute_sql("""
     CREATE TABLE random_source (
         id BIGINT, 
-        data TINYINT) 
-    WITH (
+        data TINYINT
+    ) WITH (
         'connector' = 'datagen',
         'fields.id.kind'='sequence',
         'fields.id.start'='1',
@@ -338,8 +345,8 @@ table_env.execute_sql("""
 table_env.execute_sql("""
     CREATE TABLE print_sink (
         id BIGINT, 
-        data_sum TINYINT) 
-    WITH (
+        data_sum TINYINT 
+    ) WITH (
         'connector' = 'print'
     )
 """)
@@ -366,17 +373,16 @@ The result is:
 8> +U(3,19)
 {% endhighlight %}
 
-This output may be difficult to understand. 
-In fact, this is the change logs received by the print sink.
-The output format of the change log is:
+In fact, this shows the change logs received by the print sink.
+The output format of a change log is:
 {% highlight python %}
 {subtask id}> {message type}{string format of the value}
 {% endhighlight %}
-For example, "2> +I(4,11)" means this message comes from the 2nd subtask, and "+I" means it is a insert message. "(4, 11)" is the content of the message.
-In addition, "-U" means a retract record (i.e. update-before), which means this message should be deleted or retracted from sink. 
-"+U" means this is an update record (i.e. update-after), which means this message should be updated or inserted to sink.
+For example, "2> +I(4,11)" means this message comes from the 2nd subtask, and "+I" means it is an insert message. "(4, 11)" is the content of the message.
+In addition, "-U" means a retract record (i.e. update-before), which means this message should be deleted or retracted from the sink. 
+"+U" means this is an update record (i.e. update-after), which means this message should be updated or inserted by the sink.
 
-So we can get such a result set from the change logs above:
+So, we get this result from the change logs above:
 
 {% highlight text %}
 (4, 11)
@@ -384,11 +390,11 @@ So we can get such a result set from the change logs above:
 (3, 19)
 {% endhighlight %}
 
-### Mix Table API and SQL
+### Mixing the Table API and SQL
 
 The `Table` objects used in Table API and the tables used in SQL can be freely converted to each other.
 
-The following example shows how to use the `Table` object in SQL:
+The following example shows how to use a `Table` object in SQL:
 
 {% highlight python %}
 
@@ -396,13 +402,13 @@ The following example shows how to use the `Table` object in SQL:
 table_env.execute_sql("""
     CREATE TABLE table_sink (
         id BIGINT, 
-        data VARCHAR) 
-    WITH (
+        data VARCHAR 
+    ) WITH (
         'connector' = 'print'
     )
 """)
 
-# convert the Table API table to SQL view
+# convert the Table API table to a SQL view
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
 table_env.create_temporary_view('table_api_table', table)
 
@@ -419,7 +425,7 @@ The result is:
 6> +I(2,Hello)
 {% endhighlight %}
 
-And the following example shows how to use the SQL tables in Table API:
+And the following example shows how to use SQL tables in the Table API:
 
 {% highlight python %}
 
@@ -427,8 +433,8 @@ And the following example shows how to use the SQL tables in Table API:
 table_env.execute_sql("""
     CREATE TABLE sql_source (
         id BIGINT, 
-        data TINYINT) 
-    WITH (
+        data TINYINT 
+    ) WITH (
         'connector' = 'datagen',
         'fields.id.kind'='sequence',
         'fields.id.start'='1',
@@ -455,9 +461,9 @@ table.to_pandas()
 Emit Results
 ------------
 
-### Emit to Variable
+### Capturing Data in a Variable
 
-You can call "to_pandas" method to emit the data in a `Table` object to a pandas DataFrame:
+You can call the "to_pandas" method to emit the data from a `Table` object to a pandas DataFrame:
 
 {% highlight python %}
 
@@ -474,20 +480,19 @@ The result is:
 1   2  Hello
 {% endhighlight %}
 
-Note that "to_pandas" is not supported on flink planner, and not all data types can be emitted to pandas DataFrame.
-If the `TableEnvironment` is in streaming mode, calling "to_pandas" on the tables which contain retract messages (i.e. update-before) is also not supported.
+Note that "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
-### Emit to Single Sink Table
+### Emitting Results to One Sink Table
 
-You can call "execute_insert" method to emit the data in a `Table` object to a sink table:
+You can call the "execute_insert" method to emit the data in a `Table` object to a sink table:
 
 {% highlight python %}
 
 table_env.execute_sql("""
     CREATE TABLE sink_table (
         id BIGINT, 
-        data VARCHAR) 
-    WITH (
+        data VARCHAR 
+    ) WITH (
         'connector' = 'print'
     )
 """)
@@ -504,7 +509,7 @@ The result is:
 6> +I(2,Hello)
 {% endhighlight %}
 
-The equivalent SQL way is:
+This could also be done using SQL:
 
 {% highlight python %}
 
@@ -514,9 +519,9 @@ table_env.execute_sql("INSERT INTO sink_table SELECT * FROM table_source") \
 
 {% endhighlight %}
 
-### Emit to Multiple Sink Tables
+### Emitting Results to Multiple Sink Tables
 
-You can use the `StatementSet` to emit the `Table`s to multiple sink tables in one job:
+You can use a `StatementSet` to emit the `Table`s to multiple sink tables in one job:
 
 {% highlight python %}
 
@@ -526,16 +531,16 @@ table_env.create_temporary_view("simple_source", table)
 table_env.execute_sql("""
     CREATE TABLE first_sink_table (
         id BIGINT, 
-        data VARCHAR) 
-    WITH (
+        data VARCHAR 
+    ) WITH (
         'connector' = 'print'
     )
 """)
 table_env.execute_sql("""
     CREATE TABLE second_sink_table (
         id BIGINT, 
-        data VARCHAR) 
-    WITH (
+        data VARCHAR
+    ) WITH (
         'connector' = 'print'
     )
 """)
@@ -543,10 +548,10 @@ table_env.execute_sql("""
 # create a statement set
 statement_set = table_env.create_statement_set()
 
-# accept a Table API table
+# emit the "table" object to the "first_sink_table"
 statement_set.add_insert("first_sink_table", table)
 
-# accept a insert sql query
+# emit the "simple_source" to the "second_sink_table" via a insert sql query
 statement_set.add_insert_sql("INSERT INTO second_sink_table SELECT * FROM simple_source")
 
 # execute the statement set
@@ -566,22 +571,23 @@ The result is:
 Explain Tables
 --------------
 
-The Table API provides a mechanism to explain the logical and optimized query plans to compute a `Table`. 
-This is done through the `Table.explain()` method or `StatementSet.explain()` method. `Table.explain()`returns the plan of a `Table`. `StatementSet.explain()` returns the plan of multiple sinks. It returns a String describing three plans:
+The Table API provides a mechanism to explain the logical and optimized query plans used to compute a `Table`. 
+This is done through the `Table.explain()` and `StatementSet.explain()` methods. `Table.explain()`returns the plan for a `Table`. `StatementSet.explain()` returns the plan for multiple sinks. These methods return a String describing three things:
 
 1. the Abstract Syntax Tree of the relational query, i.e., the unoptimized logical query plan,
 2. the optimized logical query plan, and
 3. the physical execution plan.
 
-`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support execute a `EXPLAIN` statement to get the plans, Please refer to [EXPLAIN]({{ site.baseurl }}/dev/table/sql/explain.html) page.
+`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support executing an `EXPLAIN` statement to get the plans. Please refer to the [EXPLAIN]({{ site.baseurl }}/dev/table/sql/explain.html) page for more details.
 
 The following code shows how to use the `Table.explain()` method:
 
 {% highlight python %}
 
-# using stream table environment
+# using a StreamTableEnvironment
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
-table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
 table2 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
@@ -632,25 +638,26 @@ The following code shows how to use the `StatementSet.explain()` method:
 
 {% highlight python %}
 
-# using stream table environment
+# using a StreamTableEnvironment
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
-table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
 table2 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
 table_env.execute_sql("""
     CREATE TABLE print_sink_table (
         id BIGINT, 
-        data VARCHAR) 
-    WITH (
+        data VARCHAR 
+    ) WITH (
         'connector' = 'print'
     )
 """)
 table_env.execute_sql("""
     CREATE TABLE black_hole_sink_table (
         id BIGINT, 
-        data VARCHAR) 
-    WITH (
+        data VARCHAR 
+    ) WITH (
         'connector' = 'blackhole'
     )
 """)

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "10分钟入门Python Table API"
+title: "Python Table API简介"
 nav-parent_id: python_tableapi
 nav-pos: 25
 ---
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This document is a short introduction to PyFlink Table API, which is used to help novice users quickly understand the basic usage of PyFlink Table API.
+This document is a short introduction to the PyFlink Table API, which is used to help novice users quickly understand the basic usage of PyFlink Table API.
 For advanced usage, please refer to other documents in this User Guide.
 
 * This will be replaced by the TOC
@@ -177,7 +177,7 @@ The result is:
 
 By default the table schema is extracted from the data automatically. 
 
-If the table schema is not as your wish, you can specify it manually:
+If the automatically generated table schema isn't satisfactory, you can specify it manually:
 
 {% highlight python %}
 
@@ -300,6 +300,7 @@ table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
                                  ['name', 'country', 'revenue'])
+
 # compute revenue for all customers from France
 revenue = orders \
     .select("name, country, revenue") \
@@ -383,7 +384,7 @@ The result is:
 
 In fact, this shows the change logs received by the print sink.
 The output format of a change log is:
-{% highlight python %}
+{% highlight text %}
 {subtask id}> {message type}{string format of the value}
 {% endhighlight %}
 For example, "2> +I(4,11)" means this message comes from the 2nd subtask, and "+I" means it is an insert message. "(4, 11)" is the content of the message.

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
@@ -1,0 +1,712 @@
+---
+title: "10分钟入门Table API"
+nav-parent_id: python_tableapi
+nav-pos: 25
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document is a short introduction to PyFlink Table API, which is used to help novice users quickly understand the basic usage of PyFlink Table API.
+For advanced usage, please refer to other documents in this User Guide.
+
+* This will be replaced by the TOC
+{:toc}
+
+Common Structure of Python Table API Program 
+--------------------------------------------
+
+All Table API and SQL programs for batch and streaming follow the same pattern. The following code example shows the common structure of Table API and SQL programs.
+
+{% highlight python %}
+
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
+# 1. create a TableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()) 
+
+# 2. create source Table
+table_env.execute_sql("""
+CREATE TABLE datagen (
+ id INT,
+ data STRING
+) WITH (
+ 'connector' = 'datagen',
+ 'fields.id.kind' = 'sequence',
+ 'fields.id.start' = '1',
+ 'fields.id.end' = '10'
+)
+""")
+
+# 3. create sink Table
+table_env.execute_sql("""
+CREATE TABLE print (
+ id INT,
+ data STRING
+) WITH (
+ 'connector' = 'print'
+)
+""")
+
+# 4. query from source table and caculate
+# create a Table from a Table API query:
+tapi_result = table_env.from_path("datagen").select("id + 1, data")
+# or create a Table from a SQL query:
+sql_result = table_env.sql_query("SELECT * FROM datagen").select("id + 1, data")
+
+# 5. emit query result to sink table
+# emit a Table API result Table to a sink table:
+tapi_result.execute_insert("print").get_job_client().get_job_execution_result().result()
+sql_result.execute_insert("print").get_job_client().get_job_execution_result().result()
+# or emit results via SQL query:
+table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+{% top %}
+
+Create a TableEnvironment
+-------------------------
+
+The `TableEnvironment` is a central concept of the Table API and SQL integration. The following code example shows how to create a TableEnvironment:
+
+{% highlight python %}
+
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment, BatchTableEnvironment
+
+# create a blink streaming TableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+# create a blink batch TableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+
+# create a flink streaming TableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_old_planner().build())
+
+# create a flink batch TableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_old_planner().build())
+
+{% endhighlight %}
+
+The `TableEnvironment` is responsible for:
+
+* Creating `Table`s
+* Registering `Table`s to the catalog
+* Executing SQL queries
+* Registering user-defined (scalar, table, or aggregation) functions
+* Offering further configuration options.
+* Add Python dependencies to support running Python UDF on remote cluster
+* Executing jobs.
+
+Currently there are 2 planners available: flink planner and blink planner.
+
+You should explicitly set which planner to use in the current program.
+We recommend using the blink planner as much as possible. 
+The blink planner is more powerful in functionality and performance, and the flink planner is reserved for compatibility.
+
+{% top %}
+
+Create Tables
+-------------
+
+`Table` is the core component of the Table API. A `Table` represents a intermediate result set during a Table API Job.
+
+A `Table` is always bound to a specific `TableEnvironment`. It is not possible to combine tables of different TableEnvironments in same query, e.g., to join or union them.
+
+### Create From A List Object
+
+You can create a Table from a list object:
+
+{% highlight python %}
+
+# create a blink batch TableEnvironment
+from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   _1     _2
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+You can also create the Table with column names:
+
+{% highlight python %}
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id   data
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+By default the table schema is extracted from the data automatically. 
+
+If the table schema is not as your wish, you can specify it manually:
+
+{% highlight python %}
+
+table_without_schema = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+# by default the type of the "id" column is 64 bit int
+default_type = table_without_schema.to_pandas()["id"].dtype
+print('By default the type of the "id" column is %s.' % default_type)
+
+from pyflink.table import DataTypes
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
+                                DataTypes.ROW([DataTypes.FIELD("id", DataTypes.TINYINT()),
+                                               DataTypes.FIELD("data", DataTypes.STRING())]))
+# now the type of the "id" column is 8 bit int
+type = table.to_pandas()["id"].dtype
+print('Now the type of the "id" column is %s.' % type)
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+By default the type of the "id" column is int64.
+Now the type of the "id" column is int8.
+{% endhighlight %}
+
+### Create From Connectors
+
+You can create a Table from connector DDL:
+
+{% highlight python %}
+
+table_env.execute_sql("""
+    CREATE TABLE random_source (
+        id BIGINT, 
+        data TINYINT) 
+    WITH (
+        'connector' = 'datagen',
+        'fields.id.kind'='sequence',
+        'fields.id.start'='1',
+        'fields.id.end'='3',
+        'fields.data.kind'='sequence',
+        'fields.data.start'='4',
+        'fields.data.end'='6'
+    )
+""")
+table = table_env.from_path("random_source")
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id  data
+0   2     5
+1   1     4
+2   3     6
+{% endhighlight %}
+
+### Create From Catalog
+
+A TableEnvironment maintains a map of catalogs of tables which are created with an identifier.
+
+The tables in catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
+
+The tables and views created via SQL DDL, e.g. "create table ..." and "create view ..." is also stored in catalog.
+
+You can also access the tables in catalog via SQL directly.
+
+If you want to use the catalog tables in Table API, you can use the "from_path" method to create the Table API objects from catalog:
+
+{% highlight python %}
+
+# prepare the catalog
+# register Table API tables to catalog
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.create_temporary_view('source_table', table)
+
+# create Table API table from catalog
+new_table = table_env.from_path('source_table')
+new_table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id   data
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+{% top %}
+
+Write Queries
+-------------
+
+### Write Table API Queries
+
+The `Table` object offers many methods to apply relational operations. 
+These methods return a new `Table` object, which represents the result of applying the relational operation on the input `Table`. 
+i.e. you can make a method chaining when using Table API.
+Some relational operations are composed of multiple method calls such as table.groupBy(...).select(), where groupBy(...) specifies a grouping of table, and select(...) the projection on the grouping of table.
+
+The [Table API]({{ site.baseurl }}/dev/table/tableApi.html) document describes all Table API operations that are supported on streaming and batch tables.
+
+The following example shows a simple Table API aggregation query:
+
+{% highlight python %}
+
+# using batch table environment to execute the queries
+from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+table_env = BatchTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+
+orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
+                                 ['name', 'country', 'revenue'])
+# compute revenue for all customers from France
+revenue = orders \
+    .select("name, country, revenue") \
+    .where("country === 'FRANCE'") \
+    .group_by("name") \
+    .select("name, revenue.sum AS rev_sum")
+    
+revenue.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   name  rev_sum
+0  Jack       30
+{% endhighlight %}
+
+### Write SQL Queries
+
+Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as regular Strings.
+
+The [SQL]({{ site.baseurl }}/dev/table/sql/index.html) document describes Flink's SQL support for streaming and batch tables.
+
+The following example shows a simple SQL aggregation query:
+
+{% highlight python %}
+
+# using stream table environment to execute the queries
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+
+table_env.execute_sql("""
+    CREATE TABLE random_source (
+        id BIGINT, 
+        data TINYINT) 
+    WITH (
+        'connector' = 'datagen',
+        'fields.id.kind'='sequence',
+        'fields.id.start'='1',
+        'fields.id.end'='8',
+        'fields.data.kind'='sequence',
+        'fields.data.start'='4',
+        'fields.data.end'='11'
+    )
+""")
+
+table_env.execute_sql("""
+    CREATE TABLE print_sink (
+        id BIGINT, 
+        data_sum TINYINT) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+table_env.execute_sql("""
+    INSERT INTO print_sink
+        SELECT id, sum(data) as data_sum FROM 
+            (SELECT id / 2 as id, data FROM random_source)
+        WHERE id > 1
+        GROUP BY id
+""").get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+2> +I(4,11)
+6> +I(2,8)
+8> +I(3,10)
+6> -U(2,8)
+8> -U(3,10)
+6> +U(2,15)
+8> +U(3,19)
+{% endhighlight %}
+
+This output may be difficult to understand. 
+In fact, this is the change logs received by the print sink.
+The output format of the change log is:
+{% highlight python %}
+{subtask id}> {message type}{string format of the value}
+{% endhighlight %}
+For example, "2> +I(4,11)" means this message comes from the 2nd subtask, and "+I" means it is a insert message. "(4, 11)" is the content of the message.
+In addition, "-U" means a retract record (i.e. update-before), which means this message should be deleted or retracted from sink. 
+"+U" means this is an update record (i.e. update-after), which means this message should be updated or inserted to sink.
+
+So we can get such a result set from the change logs above:
+
+{% highlight text %}
+(4, 11)
+(2, 15) 
+(3, 19)
+{% endhighlight %}
+
+### Mix Table API and SQL
+
+The `Table` objects used in Table API and the tables used in SQL can be freely converted to each other.
+
+The following example shows how to use the `Table` object in SQL:
+
+{% highlight python %}
+
+# create a sink table to emit results
+table_env.execute_sql("""
+    CREATE TABLE table_sink (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+# convert the Table API table to SQL view
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.create_temporary_view('table_api_table', table)
+
+# emit the Table API table
+table_env.execute_sql("INSERT INTO table_sink SELECT * FROM table_api_table") \
+    .get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+6> +I(1,Hi)
+6> +I(2,Hello)
+{% endhighlight %}
+
+And the following example shows how to use the SQL tables in Table API:
+
+{% highlight python %}
+
+# create a sql source table
+table_env.execute_sql("""
+    CREATE TABLE sql_source (
+        id BIGINT, 
+        data TINYINT) 
+    WITH (
+        'connector' = 'datagen',
+        'fields.id.kind'='sequence',
+        'fields.id.start'='1',
+        'fields.id.end'='4',
+        'fields.data.kind'='sequence',
+        'fields.data.start'='4',
+        'fields.data.end'='7'
+    )
+""")
+
+# convert the sql table to Table API table
+table = table_env.from_path("sql_source")
+
+# or create the table from a sql query
+table = table_env.sql_query("SELECT * FROM sql_source")
+
+# emit the table
+table.to_pandas()
+
+{% endhighlight %}
+
+{% top %}
+
+Emit Results
+------------
+
+### Emit to Variable
+
+You can call "to_pandas" method to emit the data in a `Table` object to a pandas DataFrame:
+
+{% highlight python %}
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table.to_pandas()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+   id   data
+0   1     Hi
+1   2  Hello
+{% endhighlight %}
+
+Note that "to_pandas" is not supported on flink planner, and not all data types can be emitted to pandas DataFrame.
+If the `TableEnvironment` is in streaming mode, calling "to_pandas" on the tables which contain retract messages (i.e. update-before) is also not supported.
+
+### Emit to Single Sink Table
+
+You can call "execute_insert" method to emit the data in a `Table` object to a sink table:
+
+{% highlight python %}
+
+table_env.execute_sql("""
+    CREATE TABLE sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table.execute_insert("sink_table").get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+6> +I(1,Hi)
+6> +I(2,Hello)
+{% endhighlight %}
+
+The equivalent SQL way is:
+
+{% highlight python %}
+
+table_env.create_temporary_view("table_source", table)
+table_env.execute_sql("INSERT INTO sink_table SELECT * FROM table_source") \
+    .get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+### Emit to Multiple Sink Tables
+
+You can use the `StatementSet` to emit the `Table`s to multiple sink tables in one job:
+
+{% highlight python %}
+
+# prepare source tables and sink tables
+table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.create_temporary_view("simple_source", table)
+table_env.execute_sql("""
+    CREATE TABLE first_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+table_env.execute_sql("""
+    CREATE TABLE second_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+
+# create a statement set
+statement_set = table_env.create_statement_set()
+
+# accept a Table API table
+statement_set.add_insert("first_sink_table", table)
+
+# accept a insert sql query
+statement_set.add_insert_sql("INSERT INTO second_sink_table SELECT * FROM simple_source")
+
+# execute the statement set
+statement_set.execute().get_job_client().get_job_execution_result().result()
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+7> +I(1,Hi)
+7> +I(1,Hi)
+7> +I(2,Hello)
+7> +I(2,Hello)
+{% endhighlight %}
+
+Explain Tables
+--------------
+
+The Table API provides a mechanism to explain the logical and optimized query plans to compute a `Table`. 
+This is done through the `Table.explain()` method or `StatementSet.explain()` method. `Table.explain()`returns the plan of a `Table`. `StatementSet.explain()` returns the plan of multiple sinks. It returns a String describing three plans:
+
+1. the Abstract Syntax Tree of the relational query, i.e., the unoptimized logical query plan,
+2. the optimized logical query plan, and
+3. the physical execution plan.
+
+`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support execute a `EXPLAIN` statement to get the plans, Please refer to [EXPLAIN]({{ site.baseurl }}/dev/table/sql/explain.html) page.
+
+The following code shows how to use the `Table.explain()` method:
+
+{% highlight python %}
+
+# using stream table environment
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table2 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table = table1 \
+    .where("LIKE(data, 'H%')") \
+    .union_all(table2)
+print(table.explain())
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+== Abstract Syntax Tree ==
+LogicalUnion(all=[true])
+:- LogicalFilter(condition=[LIKE($1, _UTF-16LE'H%')])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_201907291, source: [PythonInputFormatTableSource(id, data)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_1709623525, source: [PythonInputFormatTableSource(id, data)]]])
+
+== Optimized Logical Plan ==
+Union(all=[true], union=[id, data])
+:- Calc(select=[id, data], where=[LIKE(data, _UTF-16LE'H%')])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_201907291, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_1709623525, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
+
+== Physical Execution Plan ==
+Stage 133 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 134 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_201907291, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+                Stage 135 : Operator
+                        content : Calc(select=[id, data], where=[(data LIKE _UTF-16LE'H%')])
+                        ship_strategy : FORWARD
+
+Stage 136 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 137 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_1709623525, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+{% endhighlight %}
+
+The following code shows how to use the `StatementSet.explain()` method:
+
+{% highlight python %}
+
+# using stream table environment
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+table_env = StreamTableEnvironment.create(environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+
+table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table2 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
+table_env.execute_sql("""
+    CREATE TABLE print_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'print'
+    )
+""")
+table_env.execute_sql("""
+    CREATE TABLE black_hole_sink_table (
+        id BIGINT, 
+        data VARCHAR) 
+    WITH (
+        'connector' = 'blackhole'
+    )
+""")
+
+statement_set = table_env.create_statement_set()
+
+statement_set.add_insert("print_sink_table", table1.where("LIKE(data, 'H%')"))
+statement_set.add_insert("black_hole_sink_table", table2)
+
+print(statement_set.explain())
+
+{% endhighlight %}
+
+The result is:
+
+{% highlight text %}
+== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.print_sink_table], fields=[id, data])
++- LogicalFilter(condition=[LIKE($1, _UTF-16LE'H%')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_541737614, source: [PythonInputFormatTableSource(id, data)]]])
+
+LogicalSink(table=[default_catalog.default_database.black_hole_sink_table], fields=[id, data])
++- LogicalTableScan(table=[[default_catalog, default_database, Unregistered_TableSource_1437429083, source: [PythonInputFormatTableSource(id, data)]]])
+
+== Optimized Logical Plan ==
+Sink(table=[default_catalog.default_database.print_sink_table], fields=[id, data])
++- Calc(select=[id, data], where=[LIKE(data, _UTF-16LE'H%')])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_541737614, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
+
+Sink(table=[default_catalog.default_database.black_hole_sink_table], fields=[id, data])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, Unregistered_TableSource_1437429083, source: [PythonInputFormatTableSource(id, data)]]], fields=[id, data])
+
+== Physical Execution Plan ==
+Stage 139 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 140 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_541737614, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+                Stage 141 : Operator
+                        content : Calc(select=[id, data], where=[(data LIKE _UTF-16LE'H%')])
+                        ship_strategy : FORWARD
+
+Stage 143 : Data Source
+        content : Source: PythonInputFormatTableSource(id, data)
+
+        Stage 144 : Operator
+                content : SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_1437429083, source: [PythonInputFormatTableSource(id, data)]], fields=[id, data])
+                ship_strategy : FORWARD
+
+                Stage 142 : Data Sink
+                        content : Sink: Sink(table=[default_catalog.default_database.print_sink_table], fields=[id, data])
+                        ship_strategy : FORWARD
+
+                        Stage 145 : Data Sink
+                                content : Sink: Sink(table=[default_catalog.default_database.black_hole_sink_table], fields=[id, data])
+                                ship_strategy : FORWARD
+{% endhighlight %}

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
@@ -82,8 +82,8 @@ table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").get_job_client(
 
 {% top %}
 
-Create a TableEnvironment
--------------------------
+Creating a TableEnvironment
+---------------------------
 
 The `TableEnvironment` is a central concept of the Table API and SQL integration. The following code example shows how to create a TableEnvironment:
 
@@ -113,10 +113,10 @@ The `TableEnvironment` is responsible for:
 
 * Creating `Table`s
 * Registering `Table`s as a temporary view
-* Executing SQL queries
-* Registering user-defined (scalar, table, or aggregation) functions, see [General User-defined Functions]({% link dev/python/user-guide/table/udfs/python_udfs.zh.md %}) and [Vectorized User-defined Functions]({% link dev/python/user-guide/table/udfs/vectorized_python_udfs.zh.md %})
-* Configuring the job
-* Managing Python dependencies, see [Dependency Management]({% link dev/python/user-guide/table/dependency_management.zh.md %})
+* Executing SQL queries, see [SQL]({% link dev/table/sql/index.zh.md %}) for more details
+* Registering user-defined (scalar, table, or aggregation) functions, see [General User-defined Functions]({% link dev/python/user-guide/table/udfs/python_udfs.zh.md %}) and [Vectorized User-defined Functions]({% link dev/python/user-guide/table/udfs/vectorized_python_udfs.zh.md %}) for more details
+* Configuring the job, see [Python Configuration]({% link dev/python/user-guide/table/python_config.zh.md %}) for more details
+* Managing Python dependencies, see [Dependency Management]({% link dev/python/user-guide/table/dependency_management.zh.md %}) for more details
 * Submitting the jobs for execution
 
 Currently there are 2 planners available: flink planner and blink planner.
@@ -127,7 +127,7 @@ We recommend using the blink planner as much as possible.
 {% top %}
 
 Creating Tables
--------------
+---------------
 
 `Table` is a core component of the Python Table API. A `Table` is a logical representation of the intermediate result of a Table API Job.
 
@@ -141,6 +141,7 @@ You can create a Table from a list object:
 
 # create a blink batch TableEnvironment
 from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
 table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
@@ -157,7 +158,7 @@ The result is:
 1   2  Hello
 {% endhighlight %}
 
-You can also create the Table with column names:
+You can also create the Table with specified column names:
 
 {% highlight python %}
 
@@ -207,6 +208,11 @@ Now the type of the "id" column is int8.
 You can create a Table using connector DDL:
 
 {% highlight python %}
+# create a blink stream TableEnvironment
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
 table_env.execute_sql("""
     CREATE TABLE random_source (
@@ -238,7 +244,7 @@ The result is:
 
 ### Create using a Catalog
 
-A TableEnvironment maintains a map of catalogs of tables which are created with an identifier.
+A `TableEnvironment` maintains a map of catalogs of tables which are created with an identifier.
 
 The tables in a catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
 
@@ -271,8 +277,8 @@ The result is:
 
 {% top %}
 
-Write Queries
--------------
+Writing Queries
+---------------
 
 ### Writing Table API Queries
 
@@ -280,7 +286,7 @@ The `Table` object offers many methods for applying relational operations.
 These methods return new `Table` objects representing the result of applying the relational operations on the input `Table`. 
 These relational operations may be composed of multiple method calls, such as `table.group_by(...).select(...)`.
 
-The [Table API]({{ site.baseurl }}/zh/dev/table/tableApi.html?code_tab=python) documentation describes all Table API operations that are supported on streaming and batch tables.
+The [Table API]({% link dev/table/tableApi.zh.md %}?code_tab=python) documentation describes all Table API operations that are supported on streaming and batch tables.
 
 The following example shows a simple Table API aggregation query:
 
@@ -288,6 +294,7 @@ The following example shows a simple Table API aggregation query:
 
 # using batch table environment to execute the queries
 from pyflink.table import EnvironmentSettings, BatchTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
 table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
@@ -311,11 +318,11 @@ The result is:
 0  Jack       30
 {% endhighlight %}
 
-### Write SQL Queries
+### Writing SQL Queries
 
 Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as Strings.
 
-The [SQL]({{ site.baseurl }}/zh/dev/table/sql/index.html) documentation describes Flink's SQL support for streaming and batch tables.
+The [SQL]({% link dev/table/sql/index.zh.md %}) documentation describes Flink's SQL support for streaming and batch tables.
 
 The following example shows a simple SQL aggregation query:
 
@@ -323,6 +330,7 @@ The following example shows a simple SQL aggregation query:
 
 # use a StreamTableEnvironment to execute the queries
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
@@ -456,14 +464,24 @@ table.to_pandas()
 
 {% endhighlight %}
 
+The result is:
+
+{% highlight text %}
+   id  data
+0   2     5
+1   1     4
+2   4     7
+3   3     6
+{% endhighlight %}
+
 {% top %}
 
-Emit Results
-------------
+Emitting Results
+----------------
 
-### Capturing Data in a Variable
+### Collecting Results to Client
 
-You can call the "to_pandas" method to emit the data from a `Table` object to a pandas DataFrame:
+You can call the "to_pandas" method to [convert a `Table` object to a pandas DataFrame]({% link dev/python/user-guide/table/conversion_of_pandas.zh.md %}#convert-pyflink-table-to-pandas-dataframe):
 
 {% highlight python %}
 
@@ -480,7 +498,7 @@ The result is:
 1   2  Hello
 {% endhighlight %}
 
-Note that "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
+<span class="label label-info">Note</span> "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
 ### Emitting Results to One Sink Table
 
@@ -568,17 +586,17 @@ The result is:
 7> +I(2,Hello)
 {% endhighlight %}
 
-Explain Tables
---------------
+Explaining Tables
+-----------------
 
 The Table API provides a mechanism to explain the logical and optimized query plans used to compute a `Table`. 
-This is done through the `Table.explain()` and `StatementSet.explain()` methods. `Table.explain()`returns the plan for a `Table`. `StatementSet.explain()` returns the plan for multiple sinks. These methods return a String describing three things:
+This is done through the `Table.explain()` or `StatementSet.explain()` methods. `Table.explain()`returns the plan of a `Table`. `StatementSet.explain()` returns the plan for multiple sinks. These methods return a string describing three things:
 
 1. the Abstract Syntax Tree of the relational query, i.e., the unoptimized logical query plan,
 2. the optimized logical query plan, and
 3. the physical execution plan.
 
-`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support executing an `EXPLAIN` statement to get the plans. Please refer to the [EXPLAIN]({{ site.baseurl }}/zh/dev/table/sql/explain.html) page for more details.
+`TableEnvironment.explain_sql()` and `TableEnvironment.execute_sql()` support executing an `EXPLAIN` statement to get the plans. Please refer to the [EXPLAIN]({% link dev/table/sql/explain.zh.md %}) page for more details.
 
 The following code shows how to use the `Table.explain()` method:
 
@@ -586,6 +604,7 @@ The following code shows how to use the `Table.explain()` method:
 
 # using a StreamTableEnvironment
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
@@ -640,6 +659,7 @@ The following code shows how to use the `StatementSet.explain()` method:
 
 # using a StreamTableEnvironment
 from pyflink.table import EnvironmentSettings, StreamTableEnvironment
+
 env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
 table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "10分钟入门Table API"
+title: "10分钟入门Python Table API"
 nav-parent_id: python_tableapi
 nav-pos: 25
 ---
@@ -246,7 +246,7 @@ The result is:
 
 A `TableEnvironment` maintains a map of catalogs of tables which are created with an identifier.
 
-The tables in a catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions and clusters.
+The tables in a catalog may either be temporary, and tied to the lifecycle of a single Flink session, or permanent, and visible across multiple Flink sessions.
 
 The tables and views created via SQL DDL, e.g. "create table ..." and "create view ..." are also stored in a catalog.
 

--- a/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
+++ b/docs/dev/python/user-guide/table/10_minutes_to_table_api.zh.md
@@ -82,7 +82,7 @@ table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").get_job_client(
 
 {% top %}
 
-Creating a TableEnvironment
+Create a TableEnvironment
 ---------------------------
 
 The `TableEnvironment` is a central concept of the Table API and SQL integration. The following code example shows how to create a TableEnvironment:
@@ -126,7 +126,7 @@ We recommend using the blink planner as much as possible.
 
 {% top %}
 
-Creating Tables
+Create Tables
 ---------------
 
 `Table` is a core component of the Python Table API. A `Table` is a logical representation of the intermediate result of a Table API Job.
@@ -277,10 +277,10 @@ The result is:
 
 {% top %}
 
-Writing Queries
+Write Queries
 ---------------
 
-### Writing Table API Queries
+### Write Table API Queries
 
 The `Table` object offers many methods for applying relational operations. 
 These methods return new `Table` objects representing the result of applying the relational operations on the input `Table`. 
@@ -318,7 +318,7 @@ The result is:
 0  Jack       30
 {% endhighlight %}
 
-### Writing SQL Queries
+### Write SQL Queries
 
 Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as Strings.
 
@@ -398,7 +398,7 @@ So, we get this result from the change logs above:
 (3, 19)
 {% endhighlight %}
 
-### Mixing the Table API and SQL
+### Mix the Table API and SQL
 
 The `Table` objects used in Table API and the tables used in SQL can be freely converted to each other.
 
@@ -476,10 +476,10 @@ The result is:
 
 {% top %}
 
-Emitting Results
+Emit Results
 ----------------
 
-### Collecting Results to Client
+### Collect Results to Client
 
 You can call the "to_pandas" method to [convert a `Table` object to a pandas DataFrame]({% link dev/python/user-guide/table/conversion_of_pandas.zh.md %}#convert-pyflink-table-to-pandas-dataframe):
 
@@ -500,7 +500,7 @@ The result is:
 
 <span class="label label-info">Note</span> "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
-### Emitting Results to One Sink Table
+### Emit Results to One Sink Table
 
 You can call the "execute_insert" method to emit the data in a `Table` object to a sink table:
 
@@ -537,7 +537,7 @@ table_env.execute_sql("INSERT INTO sink_table SELECT * FROM table_source") \
 
 {% endhighlight %}
 
-### Emitting Results to Multiple Sink Tables
+### Emit Results to Multiple Sink Tables
 
 You can use a `StatementSet` to emit the `Table`s to multiple sink tables in one job:
 
@@ -586,7 +586,7 @@ The result is:
 7> +I(2,Hello)
 {% endhighlight %}
 
-Explaining Tables
+Explain Tables
 -----------------
 
 The Table API provides a mechanism to explain the logical and optimized query plans used to compute a `Table`. 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds a "10 minutes to Table API" document under the "Python API" -> "User Guide" -> "Table API" section.*


## Brief change log

  - *Add a "10 minutes to Table API" document under the "Python API" -> "User Guide" -> "Table API" section.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
