### PR TITLE
[FLINK-19061][hive] HiveCatalog fails to get partition column stats i…

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -78,6 +78,7 @@ import org.apache.flink.util.StringUtils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -1305,7 +1306,7 @@ public class HiveCatalog extends AbstractCatalog {
 		try {
 			Partition hivePartition = getHivePartition(tablePath, partitionSpec);
 			Table hiveTable = getHiveTable(tablePath);
-			String partName = getPartitionName(tablePath, partitionSpec, hiveTable);
+			String partName = getEscapedPartitionName(tablePath, partitionSpec, hiveTable);
 			client.updatePartitionColumnStatistics(HiveStatsUtil.createPartitionColumnStats(
 					hivePartition, partName, columnStatistics.getColumnStatisticsData(), hiveVersion));
 		} catch (TableNotExistException | PartitionSpecInvalidException e) {
@@ -1318,14 +1319,12 @@ public class HiveCatalog extends AbstractCatalog {
 		}
 	}
 
-	private String getPartitionName(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, Table hiveTable) throws PartitionSpecInvalidException {
+	// make a valid partition name that escapes special characters
+	private String getEscapedPartitionName(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, Table hiveTable) throws PartitionSpecInvalidException {
 		List<String> partitionCols = getFieldNames(hiveTable.getPartitionKeys());
 		List<String> partitionVals = getOrderedFullPartitionValues(partitionSpec, partitionCols, tablePath);
-		List<String> partKVs = new ArrayList<>();
-		for (int i = 0; i < partitionCols.size(); i++) {
-			partKVs.add(partitionCols.get(i) + "=" + partitionVals.get(i));
-		}
-		return String.join("/", partKVs);
+		String defaultPartName = getHiveConf().getVar(HiveConf.ConfVars.DEFAULTPARTITIONNAME);
+		return FileUtils.makePartName(partitionCols, partitionVals, defaultPartName);
 	}
 
 	@Override
@@ -1375,7 +1374,7 @@ public class HiveCatalog extends AbstractCatalog {
 		try {
 			Partition partition = getHivePartition(tablePath, partitionSpec);
 			Table hiveTable = getHiveTable(tablePath);
-			String partName = getPartitionName(tablePath, partitionSpec, hiveTable);
+			String partName = getEscapedPartitionName(tablePath, partitionSpec, hiveTable);
 			List<String> partNames = new ArrayList<>();
 			partNames.add(partName);
 			Map<String, List<ColumnStatisticsObj>> partitionColumnStatistics =

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -156,7 +156,10 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 		catalog.createDatabase(db1, createDb(), false);
 		CatalogTable catalogTable = createPartitionedTable();
 		catalog.createTable(path1, catalogTable, false);
-		CatalogPartitionSpec partitionSpec = createPartitionSpec();
+		CatalogPartitionSpec partitionSpec = new CatalogPartitionSpec(new HashMap<String, String>() {{
+			put("second", "2010-04-21 09:45:00");
+			put("third", "2000");
+		}});
 		catalog.createPartition(path1, partitionSpec, createPartition(), true);
 		Map<String, CatalogColumnStatisticsDataBase> columnStatisticsDataBaseMap = new HashMap<>();
 		columnStatisticsDataBaseMap.put("first", new CatalogColumnStatisticsDataString(10L, 5.2, 3L, 100L));


### PR DESCRIPTION
…f partition value contains special characters

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the issue that HiveCatalog fails to get partition column stats if partition value contains special characters


## Brief change log

  - Escape partition name when get/alter partition column stats
  - Update test to cover the use case


## Verifying this change

Updated test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
