### PR TITLE
[FLINK-18604][connectors/HBase] HBase ConnectorDescriptor can not work in Table API

### DIFF
--- a/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
+++ b/flink-connectors/flink-connector-hbase/src/main/java/org/apache/flink/table/descriptors/HBase.java
@@ -41,7 +41,7 @@ public class HBase extends ConnectorDescriptor {
 	private DescriptorProperties properties = new DescriptorProperties();
 
 	public HBase() {
-		super(CONNECTOR_TYPE_VALUE_HBASE, 1, true);
+		super(CONNECTOR_TYPE_VALUE_HBASE, 1, false);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
@@ -242,6 +242,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 		tEnv.connect(new HBase()
+			.version("1.4.3")
 			.tableName(TEST_TABLE_1)
 			.zookeeperQuorum(getZookeeperQuorum()))
 			.withSchema(new Schema()

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
@@ -31,12 +31,15 @@ import org.apache.flink.connector.hbase.util.HBaseTestBase;
 import org.apache.flink.connector.hbase.util.PlannerType;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.BatchTableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
+import org.apache.flink.table.descriptors.HBase;
+import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
@@ -235,7 +238,34 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 	}
 
 	@Test
-	public void testTableSourceReadAsByteArray() {
+	public void testTableSourceWithTableAPI() throws Exception {
+		StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
+		tEnv.connect(new HBase()
+			.tableName(TEST_TABLE_1)
+			.zookeeperQuorum(getZookeeperQuorum()))
+			.withSchema(new Schema()
+				.field("rowkey", DataTypes.INT())
+				.field("family2", DataTypes.ROW(DataTypes.FIELD("col1", DataTypes.STRING()), DataTypes.FIELD("col2", DataTypes.BIGINT())))
+				.field("family3", DataTypes.ROW(DataTypes.FIELD("col1", DataTypes.DOUBLE()), DataTypes.FIELD("col2", DataTypes.BOOLEAN()), DataTypes.FIELD("col3", DataTypes.STRING())))
+				.field("family1", DataTypes.ROW(DataTypes.FIELD("col1", DataTypes.INT()))));
+		Table table = tEnv.sqlQuery("SELECT * FROM hTable AS h");
+		List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+		String expected =
+			"1,Hello-1,100,1.01,false,Welt-1,10\n" +
+				"2,Hello-2,200,2.02,true,Welt-2,20\n" +
+				"3,Hello-3,300,3.03,false,Welt-3,30\n" +
+				"4,null,400,4.04,true,Welt-4,40\n" +
+				"5,Hello-5,500,5.05,false,Welt-5,50\n" +
+				"6,Hello-6,600,6.06,true,Welt-6,60\n" +
+				"7,Hello-7,700,7.07,false,Welt-7,70\n" +
+				"8,null,800,8.08,true,Welt-8,80\n";
+
+		TestBaseUtils.compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testTableSourceReadAsByteArray() throws Exception {
 		TableEnvironment tEnv = createBatchTableEnv();
 
 		if (isLegacyConnector) {

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseConnectorITCase.java
@@ -248,7 +248,8 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 				.field("rowkey", DataTypes.INT())
 				.field("family2", DataTypes.ROW(DataTypes.FIELD("col1", DataTypes.STRING()), DataTypes.FIELD("col2", DataTypes.BIGINT())))
 				.field("family3", DataTypes.ROW(DataTypes.FIELD("col1", DataTypes.DOUBLE()), DataTypes.FIELD("col2", DataTypes.BOOLEAN()), DataTypes.FIELD("col3", DataTypes.STRING())))
-				.field("family1", DataTypes.ROW(DataTypes.FIELD("col1", DataTypes.INT()))));
+				.field("family1", DataTypes.ROW(DataTypes.FIELD("col1", DataTypes.INT()))))
+			.createTemporaryTable("hTable");
 		Table table = tEnv.sqlQuery("SELECT * FROM hTable AS h");
 		List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
 		String expected =

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDescriptorTest.java
@@ -22,7 +22,17 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.Registration;
 import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.descriptors.*;
+import org.apache.flink.table.descriptors.ConnectTableDescriptor;
+import org.apache.flink.table.descriptors.Descriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.DescriptorTestBase;
+import org.apache.flink.table.descriptors.DescriptorValidator;
+import org.apache.flink.table.descriptors.FormatDescriptor;
+import org.apache.flink.table.descriptors.HBase;
+import org.apache.flink.table.descriptors.HBaseValidator;
+import org.apache.flink.table.descriptors.Rowtime;
+import org.apache.flink.table.descriptors.Schema;
+import org.apache.flink.table.descriptors.StreamTableDescriptor;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -119,7 +129,7 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 
 	@Test
 	public void testFormatNeed(){
-		String expected="The connector org.apache.flink.table.descriptors.HBase does not require a format description but org.apache.flink.connector.hbase.HBaseDescriptorTest$1 found.";
+		String expected = "The connector org.apache.flink.table.descriptors.HBase does not require a format description but org.apache.flink.connector.hbase.HBaseDescriptorTest$1 found.";
 		AtomicReference<CatalogTableImpl> reference = new AtomicReference<>();
 		HBase hBase = new HBase();
 		Registration registration = (path, table) -> reference.set((CatalogTableImpl) table);
@@ -134,12 +144,12 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 			.withSchema(new Schema()
 				.field("f0", DataTypes.INT())
 				.rowtime(new Rowtime().timestampsFromField("f0")));
-		String actual=null;
+		String actual = null;
 		try {
 			descriptor.toProperties();
 		} catch (Exception e) {
 			actual = e.getMessage();
 		}
-		Assert.assertEquals(expected,actual);
+		Assert.assertEquals(expected, actual);
 	}
 }

--- a/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-connector-hbase/src/test/java/org/apache/flink/connector/hbase/HBaseDescriptorTest.java
@@ -18,13 +18,11 @@
 
 package org.apache.flink.connector.hbase;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.descriptors.Descriptor;
-import org.apache.flink.table.descriptors.DescriptorProperties;
-import org.apache.flink.table.descriptors.DescriptorTestBase;
-import org.apache.flink.table.descriptors.DescriptorValidator;
-import org.apache.flink.table.descriptors.HBase;
-import org.apache.flink.table.descriptors.HBaseValidator;
+import org.apache.flink.table.api.internal.Registration;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.descriptors.*;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Test case for {@link HBase} descriptor.
@@ -116,5 +115,31 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 			}
 			Assert.assertTrue("The case#" + i + " didn't get the expected error", caughtExpectedException);
 		}
+	}
+
+	@Test
+	public void testFormatNeed(){
+		String expected="The connector org.apache.flink.table.descriptors.HBase does not require a format description but org.apache.flink.connector.hbase.HBaseDescriptorTest$1 found.";
+		AtomicReference<CatalogTableImpl> reference = new AtomicReference<>();
+		HBase hBase = new HBase();
+		Registration registration = (path, table) -> reference.set((CatalogTableImpl) table);
+		ConnectTableDescriptor descriptor = new StreamTableDescriptor(
+			registration, hBase)
+			.withFormat(new FormatDescriptor("myFormat", 1) {
+				@Override
+				protected Map<String, String> toFormatProperties() {
+					return new HashMap<>();
+				}
+			})
+			.withSchema(new Schema()
+				.field("f0", DataTypes.INT())
+				.rowtime(new Rowtime().timestampsFromField("f0")));
+		String actual=null;
+		try {
+			descriptor.toProperties();
+		} catch (Exception e) {
+			actual = e.getMessage();
+		}
+		Assert.assertEquals(expected,actual);
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
HBase ConnectorDescriptor can not work in Table API

## Brief change log
HBase ConnectorDescriptor can not work in Table API

## Verifying this change

This change is already covered by following tests:
testFormatNeed()
testTableSourceWithTableAPI()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
