### PR TITLE
[FLINK-19094][docs] Revise the description of watermark strategy in Flink Table document

### DIFF
--- a/docs/dev/table/connectors/index.md
+++ b/docs/dev/table/connectors/index.md
@@ -228,7 +228,7 @@ The following watermark strategies are supported:
 <div data-lang="DDL" markdown="1">
 {% highlight sql %}
 -- Sets a watermark strategy for strictly ascending rowtime attributes. Emits a watermark of the
--- maximum observed timestamp so far. Rows that have a timestamp smaller to the max timestamp
+-- maximum observed timestamp so far. Rows that have a timestamp bigger to the max timestamp
 -- are not late.
 CREATE TABLE MyTable (
   ts_field TIMESTAMP(3),
@@ -238,7 +238,7 @@ CREATE TABLE MyTable (
 )
 
 -- Sets a watermark strategy for ascending rowtime attributes. Emits a watermark of the maximum
--- observed timestamp so far minus 1. Rows that have a timestamp equal to the max timestamp
+-- observed timestamp so far minus 1. Rows that have a timestamp bigger or equal to the max timestamp
 -- are not late.
 CREATE TABLE MyTable (
   ts_field TIMESTAMP(3),

--- a/docs/dev/table/connectors/index.zh.md
+++ b/docs/dev/table/connectors/index.zh.md
@@ -228,7 +228,7 @@ The following watermark strategies are supported:
 <div data-lang="DDL" markdown="1">
 {% highlight sql %}
 -- Sets a watermark strategy for strictly ascending rowtime attributes. Emits a watermark of the
--- maximum observed timestamp so far. Rows that have a timestamp smaller to the max timestamp
+-- maximum observed timestamp so far. Rows that have a timestamp bigger to the max timestamp
 -- are not late.
 CREATE TABLE MyTable (
   ts_field TIMESTAMP(3),
@@ -238,7 +238,7 @@ CREATE TABLE MyTable (
 )
 
 -- Sets a watermark strategy for ascending rowtime attributes. Emits a watermark of the maximum
--- observed timestamp so far minus 1. Rows that have a timestamp equal to the max timestamp
+-- observed timestamp so far minus 1. Rows that have a timestamp bigger or equal to the max timestamp
 -- are not late.
 CREATE TABLE MyTable (
   ts_field TIMESTAMP(3),

--- a/docs/dev/table/sql/create.md
+++ b/docs/dev/table/sql/create.md
@@ -190,11 +190,11 @@ Flink provides several commonly used watermark strategies.
 
 - Strictly ascending timestamps: `WATERMARK FOR rowtime_column AS rowtime_column`.
 
-  Emits a watermark of the maximum observed timestamp so far. Rows that have a timestamp smaller to the max timestamp are not late.
+  Emits a watermark of the maximum observed timestamp so far. Rows that have a timestamp bigger to the max timestamp are not late.
 
 - Ascending timestamps: `WATERMARK FOR rowtime_column AS rowtime_column - INTERVAL '0.001' SECOND`.
 
-  Emits a watermark of the maximum observed timestamp so far minus 1. Rows that have a timestamp equal and smaller to the max timestamp are not late.
+  Emits a watermark of the maximum observed timestamp so far minus 1. Rows that have a timestamp bigger or equal to the max timestamp are not late.
 
 - Bounded out of orderness timestamps: `WATERMARK FOR rowtime_column AS rowtime_column - INTERVAL 'string' timeUnit`.
 

--- a/docs/dev/table/sql/create.zh.md
+++ b/docs/dev/table/sql/create.zh.md
@@ -190,11 +190,11 @@ Flink 提供了几种常用的 watermark 策略。
 
 - 严格递增时间戳： `WATERMARK FOR rowtime_column AS rowtime_column`。
 
-  发出到目前为止已观察到的最大时间戳的 watermark ，时间戳小于最大时间戳的行被认为没有迟到。
+  发出到目前为止已观察到的最大时间戳的 watermark ，时间戳大于最大时间戳的行被认为没有迟到。
 
 - 递增时间戳： `WATERMARK FOR rowtime_column AS rowtime_column - INTERVAL '0.001' SECOND`。
 
-  发出到目前为止已观察到的最大时间戳减 1 的 watermark ，时间戳等于或小于最大时间戳的行被认为没有迟到。
+  发出到目前为止已观察到的最大时间戳减 1 的 watermark ，时间戳大于或等于最大时间戳的行被认为没有迟到。
 
 - 有界乱序时间戳： `WATERMARK FOR rowtime_column AS rowtime_column - INTERVAL 'string' timeUnit`。
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix the watermark strategy description in Flink Table document. The late event is whose timestamp smaller or equal to current watermark.


## Brief change log

  - Revise the the description in file `index.md`,`index.zh.md`, `create.md`,`create.zh.md`,

## Verifying this change

This change is a trivial doc fix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
