### PR TITLE
[FLINK-19093][task] Fix isActive check in AsyncCheckpointRunnable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -366,11 +366,10 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 		synchronized (lock) {
 			if (closed) {
 				LOG.debug("Cannot register Closeable, this subtaskCheckpointCoordinator is already closed. Closing argument.");
-				final boolean running = asyncCheckpointRunnable.isRunning();
 				closeQuietly(asyncCheckpointRunnable);
 				checkState(
-					!running,
-					"SubtaskCheckpointCoordinatorImpl was closed without closing asyncCheckpointRunnable %s",
+					!checkpoints.containsKey(checkpointId),
+					"SubtaskCheckpointCoordinator was closed without releasing asyncCheckpointRunnable for checkpoint %s",
 					checkpointId);
 			} else if (checkpoints.containsKey(checkpointId)) {
 				closeQuietly(asyncCheckpointRunnable);


### PR DESCRIPTION
## What is the purpose of the change

This is a follow up fix for #13267:
On close, `SubtaskCheckpointCoordinator` "collects" runnables to close under the lock,
but it actually closes them outside of the synchronized section.
Therefore, runnable can observe `coordinator.isClosed && runnable.isRunning` state and throws an exception.

This PR replaces `asyncCheckpointRunnable.isRunning()` check with `!checkpoints.containsKey(checkpointId)`.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager no, Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
