### PR TITLE
[FLINK-13857] Remove deprecated ExecutionConfig#get/setCodeAnalysisMode

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/CodeAnalysisMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/CodeAnalysisMode.java
@@ -19,21 +19,12 @@
 package org.apache.flink.api.common;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
 
 /**
- * Specifies to which extent user-defined functions are analyzed in order
- * to give the Flink optimizer an insight of UDF internals and inform
- * the user about common implementation mistakes.
- *
- * The analyzer gives hints about:
- *  - ForwardedFields semantic properties
- *  - Warnings if static fields are modified by a Function
- *  - Warnings if a FilterFunction modifies its input objects
- *  - Warnings if a Function returns null
- *  - Warnings if a tuple access uses a wrong index
- *  - Information about the number of object creations (for manual optimization)
- *
  * @deprecated The code analysis code has been removed and this enum has no effect.
+ * <b>NOTE</b> It can not be removed from the codebase for now, because it had been serialized as part
+ * of the {@link ExecutionConfig} which in turn had been serialized as part of the {@link PojoSerializer}.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-core/src/main/java/org/apache/flink/api/common/CodeAnalysisMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/CodeAnalysisMode.java
@@ -19,12 +19,16 @@
 package org.apache.flink.api.common;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
 
 /**
  * @deprecated The code analysis code has been removed and this enum has no effect.
  * <b>NOTE</b> It can not be removed from the codebase for now, because it had been serialized as part
  * of the {@link ExecutionConfig} which in turn had been serialized as part of the {@link PojoSerializer}.
+ *
+ * <p>This class can be removed when we drop support for pre 1.8 serializer snapshots that contained java
+ * serialized serializers ({@link TypeSerializerConfigSnapshot}).
  */
 @PublicEvolving
 @Deprecated

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -126,9 +126,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	private boolean autoTypeRegistrationEnabled = true;
 
 	private boolean forceAvro = false;
-
-	private CodeAnalysisMode codeAnalysisMode = CodeAnalysisMode.DISABLE;
-
 	private long autoWatermarkInterval = 0;
 
 	/**
@@ -723,23 +720,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	public boolean isObjectReuseEnabled() {
 		return objectReuse;
 	}
-	
-	/**
-	 * @deprecated The code analysis code has been removed and this method has no effect.
-	 */
-	@PublicEvolving
-	@Deprecated
-	public void setCodeAnalysisMode(CodeAnalysisMode codeAnalysisMode) {
-	}
-	
-	/**
-	 * @deprecated The code analysis code has been removed and this method does not return anything interesting.
-	 */
-	@PublicEvolving
-	@Deprecated
-	public CodeAnalysisMode getCodeAnalysisMode() {
-		return codeAnalysisMode;
-	}
 
 	/**
 	 * @deprecated Ineffective. Will be removed at 2.0.
@@ -994,7 +974,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 				objectReuse == other.objectReuse &&
 				autoTypeRegistrationEnabled == other.autoTypeRegistrationEnabled &&
 				forceAvro == other.forceAvro &&
-				Objects.equals(codeAnalysisMode, other.codeAnalysisMode) &&
 				Objects.equals(globalJobParameters, other.globalJobParameters) &&
 				autoWatermarkInterval == other.autoWatermarkInterval &&
 				registeredTypesWithKryoSerializerClasses.equals(other.registeredTypesWithKryoSerializerClasses) &&
@@ -1022,7 +1001,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 			objectReuse,
 			autoTypeRegistrationEnabled,
 			forceAvro,
-			codeAnalysisMode,
 			globalJobParameters,
 			autoWatermarkInterval,
 			registeredTypesWithKryoSerializerClasses,
@@ -1048,7 +1026,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 			", objectReuse=" + objectReuse +
 			", autoTypeRegistrationEnabled=" + autoTypeRegistrationEnabled +
 			", forceAvro=" + forceAvro +
-			", codeAnalysisMode=" + codeAnalysisMode +
 			", autoWatermarkInterval=" + autoWatermarkInterval +
 			", latencyTrackingInterval=" + latencyTrackingInterval +
 			", isLatencyTrackingConfigured=" + isLatencyTrackingConfigured +

--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/FunctionAnnotation.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/FunctionAnnotation.java
@@ -376,24 +376,6 @@ public class FunctionAnnotation {
 	}
 
 	/**
-	 * The SkipCodeAnalysis annotation declares that a function will not be analyzed by Flink's
-	 * code analysis capabilities independent of the configured {@link org.apache.flink.api.common.CodeAnalysisMode}.
-	 *
-	 * <p>If this annotation is not present the static code analyzer pre-interprets user-defined
-	 * functions in order to get implementation insights for program improvements that can be
-	 * printed to the log as hints, automatically applied, or disabled (see
-	 * {@link org.apache.flink.api.common.ExecutionConfig}).
-	 *
-	 * @deprecated The code analysis code has been removed and this annotation has no effect.
-	 */
-	@Target(ElementType.TYPE)
-	@Retention(RetentionPolicy.RUNTIME)
-	@PublicEvolving
-	@Deprecated
-	public @interface SkipCodeAnalysis {
-	}
-
-	/**
 	 * Private constructor to prevent instantiation. This class is intended only as a container.
 	 */
 	private FunctionAnnotation() {}

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
@@ -184,8 +184,5 @@ public class PlanGenerator {
 		LOG.debug("Registered Kryo default Serializers Classes {}",
 				config.getDefaultKryoSerializerClasses().entrySet().toString());
 		LOG.debug("Registered POJO types: {}", config.getRegisteredPojoTypes().toString());
-
-		// print information about static code analysis
-		LOG.debug("Static code analysis mode: {}", config.getCodeAnalysisMode());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Removed the ExecutionConfig#get/setCodeAnalysisMode and related classes. We must leave the CodeAnalysisMode enum for now as it is required for java serialization of PojoSerializer.


## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
