### PR TITLE
[FLINK-19100] Update the avro format in respect to required dependencies

### DIFF
--- a/docs/dev/table/connectors/formats/avro.md
+++ b/docs/dev/table/connectors/formats/avro.md
@@ -39,7 +39,8 @@ In order to setup the Avro format, the following table provides dependency infor
 <div class="codetabs" markdown="1">
 <div data-lang="SQL Client JAR" markdown="1">
 You can download flink-avro from [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/{{site.version}}/flink-avro-{{site.version}}-sql-jar.jar),
-and requires additional [Hadoop dependency]({% link ops/deployment/hadoop.md %}) for cluster execution.
+which, additionally requires Avro and its transitive dependencies. Different Avro versions require different dependencies, see e.g. the compile dependencies for Avro
+ 1.8.2 [here](https://mvnrepository.com/artifact/org.apache.avro/avro/1.8.2). 
 </div>
 <div data-lang="Maven dependency" markdown="1">
 {% highlight xml %}


### PR DESCRIPTION
## What is the purpose of the change

Correct the required dependencies for avro format. Avro instead of whole hadoop.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
