### PR TITLE
[FLINK-18988][table] Continuous query with LATERAL and LIMIT produces…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
@@ -165,6 +165,10 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
       val input = snapshot.getInput.accept(this)
       snapshot.copy(snapshot.getTraitSet, input, snapshot.getPeriod)
 
+    case rank: LogicalRank =>
+      val input = rank.getInput.accept(this)
+      rank.copy(rank.getTraitSet, JCollections.singletonList(input))
+
     case sink: LogicalSink =>
       val newInput = convertSinkInput(sink.getInput)
       new LogicalSink(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -32,6 +32,7 @@ object FlinkStreamProgram {
 
   val SUBQUERY_REWRITE = "subquery_rewrite"
   val TEMPORAL_JOIN_REWRITE = "temporal_join_rewrite"
+  val PRE_DECORRELATE_REWRITE = "pre_decorrelate_rewrite"
   val DECORRELATE = "decorrelate"
   val TIME_INDICATOR = "time_indicator"
   val DEFAULT_REWRITE = "default_rewrite"
@@ -89,6 +90,15 @@ object FlinkStreamProgram {
             .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
             .add(FlinkStreamRuleSets.POST_EXPAND_CLEAN_UP_RULES)
             .build(), "convert enumerable table scan")
+        .build())
+
+    // rewrite before decorrelation
+    chainedProgram.addLast(
+      PRE_DECORRELATE_REWRITE,
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkStreamRuleSets.PRE_DECORRELATION_RULES)
         .build())
 
     // query decorrelation

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -71,6 +71,13 @@ object FlinkStreamRuleSets {
   )
 
   /**
+   * Solid transformations before actual decorrelation.
+   */
+  val PRE_DECORRELATION_RULES: RuleSet = RuleSets.ofList(
+    CorrelateSortToRankRule.INSTANCE
+  )
+
+  /**
     * RuleSet to reduce expressions
     */
   private val REDUCE_EXPRESSION_RULES: RuleSet = RuleSets.ofList(
@@ -317,6 +324,7 @@ object FlinkStreamRuleSets {
     FlinkLogicalDataStreamTableScan.CONVERTER,
     FlinkLogicalIntermediateTableScan.CONVERTER,
     FlinkLogicalExpand.CONVERTER,
+    FlinkLogicalRank.CONVERTER,
     FlinkLogicalWatermarkAssigner.CONVERTER,
     FlinkLogicalWindowAggregate.CONVERTER,
     FlinkLogicalWindowTableAggregate.CONVERTER,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder
+import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelCollations
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Aggregate, Correlate, Filter, JoinRelType, Project, Sort}
+import org.apache.calcite.rex.{RexCall, RexCorrelVariable, RexFieldAccess, RexInputRef, RexLiteral, RexNode}
+import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.util.ImmutableBitSet
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+ * Planner rule that rewrites sort correlation to a Rank.
+ * Typically, the following plan
+ *
+ * {{{
+ *   LogicalProject(state=[$0], name=[$1])
+ *   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+ *      :- LogicalAggregate(group=[{0}])
+ *      :  +- LogicalProject(state=[$1])
+ *      :     +- LogicalTableScan(table=[[default_catalog, default_database, cities]])
+ *      +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+ *         +- LogicalProject(name=[$0], pop=[$2])
+ *            +- LogicalFilter(condition=[=($1, $cor0.state)])
+ *               +- LogicalTableScan(table=[[default_catalog, default_database, cities]])
+ * }}}
+ *
+ * <p>would be transformed to
+ *
+ * {{{
+ *   LogicalProject(state=[$0], name=[$1])
+ *    +- LogicalProject(state=[$1], name=[$0], pop=[$2])
+ *       +- LogicalRank(rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3],
+ *            partitionBy=[$1], orderBy=[$2 DESC], select=[name=$0, state=$1, pop=$2])
+ *          +- LogicalTableScan(table=[[default_catalog, default_database, cities]])
+ * }}}
+ *
+ * <p>To match the Correlate, the LHS needs to be a global Aggregate on a scan, the RHS should
+ * be a Sort with an equal Filter predicate whose keys are same with the LHS grouping keys.
+ *
+ * <p>This rule can only be used in HepPlanner.
+ */
+class CorrelateSortToRankRule extends RelOptRule(
+  operand(classOf[Correlate],
+    operand(classOf[Aggregate],
+      operand(classOf[Project], any())),
+    operand(classOf[Sort],
+      operand(classOf[Project],
+        operand(classOf[Filter], any())))),
+  "CorrelateSortToRankRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val correlate: Correlate = call.rel(0)
+    if (correlate.getJoinType != JoinRelType.INNER) {
+      return false
+    }
+    val agg: Aggregate = call.rel(1)
+    if (agg.getAggCallList.size() > 0
+      || agg.getGroupSets.size() > 1
+      || agg.getGroupSet.cardinality() != 1) {
+      // only one group field is supported now
+      return false
+    }
+    val aggInput: Project = call.rel(2)
+    if (!aggInput.isMapping) {
+      return false
+    }
+    val sort: Sort = call.rel(3)
+    if (sort.offset != null || sort.fetch == null) {
+      // 1. we can not describe the offset using rank
+      // 2. there is no need to transform to rank if no fetch limit
+      return false
+    }
+    val sortInput: Project = call.rel(4)
+    if (!sortInput.isMapping) {
+      return false
+    }
+    val filter: Filter = call.rel(5)
+    val condition = filter.getCondition
+    if (condition.getKind != SqlKind.EQUALS) {
+      return false
+    }
+    // only support one partition key
+    val (inputRef, fieldAccess) = resolveFilterCondition(condition)
+    if (inputRef == null) {
+      return false
+    }
+    val variable = fieldAccess.getReferenceExpr.asInstanceOf[RexCorrelVariable]
+    if (!variable.id.equals(correlate.getCorrelationId)) {
+      return false
+    }
+    aggInput.getInput.getDigest.equals(filter.getInput.getDigest)
+  }
+
+  /**
+   * Resolves the filter condition with specific pattern: input ref and field access.
+   *
+   * @param condition The join condition
+   * @return tuple of operands (RexInputRef, RexFieldAccess),
+   *         or null if the pattern does not match
+   */
+  def resolveFilterCondition(condition: RexNode): (RexInputRef, RexFieldAccess) = {
+    val condCall = condition.asInstanceOf[RexCall]
+    val operand0 = condCall.getOperands.get(0)
+    val operand1 = condCall.getOperands.get(1)
+    if (operand0.isA(SqlKind.INPUT_REF) && operand1.isA(SqlKind.FIELD_ACCESS)) {
+      (operand0.asInstanceOf[RexInputRef], operand1.asInstanceOf[RexFieldAccess])
+    } else if (operand0.isA(SqlKind.FIELD_ACCESS) && operand1.isA(SqlKind.INPUT_REF)) {
+      (operand1.asInstanceOf[RexInputRef], operand0.asInstanceOf[RexFieldAccess])
+    } else {
+      (null, null)
+    }
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val oriBuilder = call.builder()
+    val builder = FlinkRelBuilder.of(oriBuilder.getCluster, oriBuilder.getRelOptSchema)
+
+    val sort: Sort = call.rel(3)
+    val sortInput: Project = call.rel(4)
+    val filter: Filter = call.rel(5)
+
+    val partitionKey: ImmutableBitSet =
+      ImmutableBitSet.of(resolveFilterCondition(filter.getCondition)._1.getIndex)
+
+    val baseType: RelDataType = sortInput.getInput().getRowType
+    val projects = new util.ArrayList[RexNode]()
+    partitionKey.asList().foreach(k => projects.add(RexInputRef.of(k, baseType)))
+    projects.addAll(sortInput.getProjects)
+
+    val oriCollation = sort.getCollation
+    val newFieldCollations = oriCollation.getFieldCollations.map { fc =>
+      val newFieldIdx = sortInput.getProjects.get(fc.getFieldIndex)
+        .asInstanceOf[RexInputRef].getIndex
+      fc.withFieldIndex(newFieldIdx)
+    }
+    val newCollation = RelCollations.of(newFieldCollations)
+
+    val newRel = builder
+      .push(filter.getInput()).asInstanceOf[FlinkRelBuilder]
+      .rank(
+        partitionKey,
+        newCollation,
+        RankType.ROW_NUMBER,
+        new ConstantRankRange(
+          1,
+          sort.fetch.asInstanceOf[RexLiteral].getValueAs(classOf[java.lang.Long])),
+        null,
+        outputRankNumber = false)
+      .project(projects)
+      .build()
+
+    call.transformTo(newRel)
+  }
+}
+
+object CorrelateSortToRankRule {
+  val INSTANCE = new CorrelateSortToRankRule
+}
+
+

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.planner.calcite.FlinkRelBuilder
+import org.apache.flink.table.planner.calcite.{FlinkRelBuilder, FlinkRelFactories}
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -72,6 +72,7 @@ class CorrelateSortToRankRule extends RelOptRule(
     operand(classOf[Sort],
       operand(classOf[Project],
         operand(classOf[Filter], any())))),
+  FlinkRelFactories.FLINK_REL_BUILDER,
   "CorrelateSortToRankRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
@@ -138,8 +139,7 @@ class CorrelateSortToRankRule extends RelOptRule(
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val oriBuilder = call.builder()
-    val builder = FlinkRelBuilder.of(oriBuilder.getCluster, oriBuilder.getRelOptSchema)
+    val builder = call.builder().asInstanceOf[FlinkRelBuilder]
 
     val sort: Sort = call.rel(3)
     val sortInput: Project = call.rel(4)
@@ -182,5 +182,3 @@ class CorrelateSortToRankRule extends RelOptRule(
 object CorrelateSortToRankRule {
   val INSTANCE = new CorrelateSortToRankRule
 }
-
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.flink.table.planner.calcite.{FlinkRelBuilder, FlinkRelFactories}
+import org.apache.flink.table.planner.plan.utils.SortUtil
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -139,7 +140,7 @@ class CorrelateSortToRankRule extends RelOptRule(
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val builder = call.builder().asInstanceOf[FlinkRelBuilder]
+    val builder = call.builder()
 
     val sort: Sort = call.rel(3)
     val sortInput: Project = call.rel(4)

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.xml
@@ -1,0 +1,351 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAggCallNotSupported">
+    <Resource name="sql">
+      <![CDATA[
+SELECT mf0, f1
+FROM
+  (SELECT max(f0) as mf0 FROM t1) t2,
+  LATERAL (
+    SELECT f1, f2
+    FROM t1
+    WHERE f0 = t2.mf0
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(mf0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{}], mf0=[MAX($0)])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.mf0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(mf0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{}], mf0=[MAX($0)])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.mf0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggInputNonMappingNotSupported">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f0, f1
+FROM
+  (SELECT DISTINCT f0 FROM (SELECT f0 + f1 as f0 from t1)) t2,
+  LATERAL (
+    SELECT f1, f2
+    FROM t1
+    WHERE f0 = t2.f0
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[+($0, $1)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=(CAST($0):BIGINT, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[+($0, $1)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=(CAST($0):BIGINT, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCorrelateSortToRank">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f0, f1
+FROM
+  (SELECT DISTINCT f0 FROM t1) t2,
+  LATERAL (
+    SELECT f1, f2
+    FROM t1
+    WHERE f0 = t2.f0
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalRank(rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[$0], orderBy=[$2 DESC], select=[f0=$0, f1=$1, f2=$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonInnerJoinNotSupported">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f0, f1
+FROM
+  (SELECT DISTINCT f0 FROM t1) t2
+  NATURAL LEFT JOIN
+  LATERAL (
+    SELECT f1, f2
+    FROM t1
+    WHERE f0 = t2.f0
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFilterConditionNotCorrelationID">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f0, f1
+FROM
+  (SELECT DISTINCT f0 FROM t1) t2,
+  LATERAL (
+    SELECT f1, f2
+    FROM t1
+    WHERE t2.f0 = f0 + 1
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($cor0.f0, +($0, 1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($cor0.f0, +($0, 1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultipleGroupingsNotSupported">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f0, f2
+FROM
+  (SELECT DISTINCT f0, f1 FROM t1) t2,
+  LATERAL (
+    SELECT f2
+    FROM t1
+    WHERE f0 = t2.f0 AND f1 = t2.f1
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$0], f2=[$2])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+   :- LogicalAggregate(group=[{0, 1}])
+   :  +- LogicalProject(f0=[$0], f1=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f2=[$2])
+         +- LogicalFilter(condition=[AND(=($0, $cor0.f0), =($1, $cor0.f1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(f0=[$0], f2=[$2])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+   :- LogicalAggregate(group=[{0, 1}])
+   :  +- LogicalProject(f0=[$0], f1=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f2=[$2])
+         +- LogicalFilter(condition=[AND(=($0, $cor0.f0), =($1, $cor0.f1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortWithOffsetNotSupported">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f0, f1
+FROM
+  (SELECT DISTINCT f0 FROM t1) t2,
+  LATERAL (
+    SELECT f1, f2
+    FROM t1
+    WHERE f0 = t2.f0
+    ORDER BY f2 DESC
+    OFFSET 2 ROWS
+    FETCH NEXT 3 ROWS ONLY
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], offset=[2], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], offset=[2], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonEqualConditionNotSupported">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f0, f1
+FROM
+  (SELECT DISTINCT f0 FROM t1) t2,
+  LATERAL (
+    SELECT f1, f2
+    FROM t1
+    WHERE f0 > t2.f0
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[>($0, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(f0=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f1=[$1], f2=[$2])
+         +- LogicalFilter(condition=[>($0, $cor0.f0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -42,6 +42,44 @@ Sink(table=[default_catalog.default_database.sink], fields=[name, eat, cnt])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelateSortToRank">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b
+FROM
+  (SELECT DISTINCT a FROM MyTable) T1,
+  LATERAL (
+    SELECT b, c
+    FROM MyTable
+    WHERE a = T1.a
+    ORDER BY c
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(a=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(b=[$1], c=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.a)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[a], orderBy=[c DESC], select=[a, b, c])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNestedTopN">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.scala
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.flink.table.planner.plan.optimize.program.{FlinkChainedProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE, StreamOptimizeContext}
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.tools.RuleSets
+import org.junit.{Before, Test}
+
+/**
+  * Test for [[CalcRankTransposeRule]].
+  */
+class CorrelateSortToRankRuleTest extends TableTestBase {
+  private val util = streamTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    val programs = new FlinkChainedProgram[StreamOptimizeContext]()
+    programs.addLast(
+      "rules",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+          .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+          .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+          .add(RuleSets.ofList(CorrelateSortToRankRule.INSTANCE))
+          .build())
+    util.replaceStreamProgram(programs)
+
+    val createTable =
+      s"""
+         |create table t1(
+         |  f0 int,
+         |  f1 bigint,
+         |  f2 varchar(20)
+         |) with (
+         |  'connector' = 'values',
+         |  'bounded' = 'false'
+         |)
+         |""".stripMargin
+    util.tableEnv.executeSql(createTable)
+  }
+
+  @Test
+  def testCorrelateSortToRank(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f1
+         |FROM
+         |  (SELECT DISTINCT f0 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f1, f2
+         |    FROM t1
+         |    WHERE f0 = t2.f0
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testNonInnerJoinNotSupported(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f1
+         |FROM
+         |  (SELECT DISTINCT f0 FROM t1) t2
+         |  NATURAL LEFT JOIN
+         |  LATERAL (
+         |    SELECT f1, f2
+         |    FROM t1
+         |    WHERE f0 = t2.f0
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testAggCallNotSupported(): Unit = {
+    val query =
+      s"""
+         |SELECT mf0, f1
+         |FROM
+         |  (SELECT max(f0) as mf0 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f1, f2
+         |    FROM t1
+         |    WHERE f0 = t2.mf0
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test // TODO: this is a valid case to support
+  def testMultipleGroupingsNotSupported(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f2
+         |FROM
+         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f2
+         |    FROM t1
+         |    WHERE f0 = t2.f0 AND f1 = t2.f1
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testAggInputNonMappingNotSupported(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f1
+         |FROM
+         |  (SELECT DISTINCT f0 FROM (SELECT f0 + f1 as f0 from t1)) t2,
+         |  LATERAL (
+         |    SELECT f1, f2
+         |    FROM t1
+         |    WHERE f0 = t2.f0
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testSortWithOffsetNotSupported(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f1
+         |FROM
+         |  (SELECT DISTINCT f0 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f1, f2
+         |    FROM t1
+         |    WHERE f0 = t2.f0
+         |    ORDER BY f2 DESC
+         |    OFFSET 2 ROWS
+         |    FETCH NEXT 3 ROWS ONLY
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testNonEqualConditionNotSupported(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f1
+         |FROM
+         |  (SELECT DISTINCT f0 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f1, f2
+         |    FROM t1
+         |    WHERE f0 > t2.f0
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
+  @Test
+  def testFilterConditionNotCorrelationID(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f1
+         |FROM
+         |  (SELECT DISTINCT f0 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f1, f2
+         |    FROM t1
+         |    WHERE t2.f0 = f0 + 1
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
@@ -670,5 +670,23 @@ class RankTest extends TableTestBase {
       + "from view2 where row_num <= 3")
   }
 
+  @Test
+  def testCorrelateSortToRank(): Unit = {
+    val query =
+      s"""
+         |SELECT a, b
+         |FROM
+         |  (SELECT DISTINCT a FROM MyTable) T1,
+         |  LATERAL (
+         |    SELECT b, c
+         |    FROM MyTable
+         |    WHERE a = T1.a
+         |    ORDER BY c
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
   // TODO add tests about multi-sinks and udf
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -533,6 +533,20 @@ object TestData {
     row(5L, "US Dollar")
   )
 
+  // [city, state, population]
+  val citiesData: Seq[Row] = Seq(
+    row("Los_Angeles", "CA", 3979576),
+    row("Phoenix", "AZ", 1680992),
+    row("Houston", "TX", 2320268),
+    row("San_Diego", "CA", 1423851),
+    row("San_Francisco", "CA", 881549),
+    row("New_York", "NY", 8336817),
+    row("Dallas", "TX", 1343573),
+    row("San_Antonio", "TX", 1547253),
+    row("San_Jose", "CA", 1021795),
+    row("Chicago", "IL", 2695598),
+    row("Austin", "TX", 978908))
+
   // kind[currency, rate]
   val ratesHistoryData: Seq[Row] = Seq(
     changelogRow("+I", "US Dollar", JLong.valueOf(102L)),


### PR DESCRIPTION
… wrong result

The batch mode rank only supports RANK function, so we only rewrite the
stream mode query.

## What is the purpose of the change

Fix the query of pattern:
```sql
SELECT state, name
FROM
  (SELECT DISTINCT state FROM cities) states,
  LATERAL (
    SELECT name, pop
    FROM cities
    WHERE state = states.state
    ORDER BY pop
    DESC LIMIT 3
  )
```
Before the patch, the query generates a wrong plan then wrong results.

## Brief change log

  - Add a new rule `CorrelateSortToRankRule` for the rewrite
  - Add plan test and IT test

## Verifying this change

Added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
