### PR TITLE
[FLINK-19108][table] Stop expanding the identifiers with scope aliase…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/Expander.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/Expander.java
@@ -94,7 +94,12 @@ public class Expander {
 			}
 
 			@Override public Void visit(SqlIdentifier identifier) {
-				identifiers.putIfAbsent(identifier.getParserPosition(), identifier);
+				// See SqlUtil#deriveAliasFromOrdinal, there is no good solution
+				// to distinguish between system alias (EXPR${number}) and user defines,
+				// and we stop expanding all of them.
+				if (!identifier.names.get(0).startsWith("EXPR$")) {
+					identifiers.putIfAbsent(identifier.getParserPosition(), identifier);
+				}
 				return null;
 			}
 		});


### PR DESCRIPTION
…d by the system with 'EXPR$' prefix

## What is the purpose of the change

For query

```sql
create view tmp_view as
select * from (
  select f0,
  row_number() over (partition by f0 order by f0 desc) as rowNum
  from source) -- the query would be aliased as "EXPR$1"
  where rowNum = 1
```
When validation, the inner query would have alias assigned by the system with prefix "EXPR$1", when in the `Expander`, we replace the id in the inner query all with this prefix which is wrong because we do not add the alias to the inner query anymore.

To solve the problem, skip the expanding of id with "EXPR$" just like how SqlUtil#deriveAliasFromOrdinal added it.

This was introduced by FLINK-18750.

## Brief change log

- Add fix in `Expander` and add tests


## Verifying this change

Added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
