### PR TITLE
[FLINK-19038][table] It doesn't support to call Table.limit() continuously

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/SortOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/SortOperationFactory.java
@@ -77,14 +77,10 @@ final class SortOperationFactory {
 			int offset,
 			QueryOperation child,
 			PostResolverFactory postResolverFactory) {
-		SortQueryOperation previousSort = validateAndGetChildSort(child, postResolverFactory);
+		SortQueryOperation previousSort = getChildSort(child, postResolverFactory);
 
 		if (offset < 0) {
 			throw new ValidationException("Offset should be greater or equal 0");
-		}
-
-		if (previousSort.getOffset() != -1) {
-			throw new ValidationException("OFFSET already defined");
 		}
 
 		return new SortQueryOperation(previousSort.getOrder(), previousSort.getChild(), offset, -1);
@@ -102,7 +98,7 @@ final class SortOperationFactory {
 			int fetch,
 			QueryOperation child,
 			PostResolverFactory postResolverFactory) {
-		SortQueryOperation previousSort = validateAndGetChildSort(child, postResolverFactory);
+		SortQueryOperation previousSort = getChildSort(child, postResolverFactory);
 
 		if (fetch < 0) {
 			throw new ValidationException("Fetch should be greater or equal 0");
@@ -113,16 +109,12 @@ final class SortOperationFactory {
 		return new SortQueryOperation(previousSort.getOrder(), previousSort.getChild(), offset, fetch);
 	}
 
-	private SortQueryOperation validateAndGetChildSort(QueryOperation child, PostResolverFactory postResolverFactory) {
+	private SortQueryOperation getChildSort(QueryOperation child, PostResolverFactory postResolverFactory) {
 		final SortQueryOperation previousSort;
 		if (child instanceof SortQueryOperation) {
 			previousSort = (SortQueryOperation) child;
 		} else {
 			previousSort = (SortQueryOperation) createSort(Collections.emptyList(), child, postResolverFactory);
-		}
-
-		if ((previousSort).getFetch() != -1) {
-			throw new ValidationException("FETCH is already defined.");
 		}
 
 		return previousSort;

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/SortValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/SortValidationTest.scala
@@ -27,22 +27,6 @@ import org.junit._
 class SortValidationTest extends TableTestBase {
 
   @Test(expected = classOf[ValidationException])
-  def testFetchBeforeOffset(): Unit = {
-    val util = batchTestUtil()
-    val ds = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
-
-    ds.orderBy('a.asc).fetch(5).offset(10)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testOffsetBeforeOffset(): Unit = {
-    val util = batchTestUtil()
-    val ds = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
-
-    ds.orderBy('a.asc).offset(10).offset(5)
-  }
-
-  @Test(expected = classOf[ValidationException])
   def testNegativeFetch(): Unit = {
     val util = batchTestUtil()
     val ds = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/LegacyLimitITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/LegacyLimitITCase.scala
@@ -40,6 +40,9 @@ class LegacyLimitITCase extends BatchTestBase {
     assertEquals(
       executeQuery(tEnv.from("LimitTable").fetch(5)).size,
       5)
+    assertEquals(
+      executeQuery(tEnv.from("LimitTable").fetch(5).fetch(3)).size,
+      3)
   }
 
   @Test
@@ -54,5 +57,8 @@ class LegacyLimitITCase extends BatchTestBase {
     assertEquals(
       executeQuery(tEnv.from("LimitTable").limit(5, 5)).size,
       5)
+    assertEquals(
+      executeQuery(tEnv.from("LimitTable").limit(5, 5).limit(3, 3)).size,
+      3)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SortITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SortITCase.scala
@@ -82,9 +82,12 @@ class SortITCase extends BatchTestBase {
   @Test
   def testOrderByFetch(): Unit = {
     val ds = CollectionBatchExecTable.get3TupleDataSet(tEnv)
-    val t = ds.orderBy('_1.asc).offset(0).fetch(5)
+    var t = ds.orderBy('_1.asc).offset(0).fetch(5)
     implicit def tupleOrdering[T <: Product] = Ordering.by((x : T) =>
       x.productElement(0).asInstanceOf[Int] )
     compare(t, sortExpectedly(tupleDataSetStrings, 0, 5))
+
+    t = ds.orderBy('_1.asc).offset(0).fetch(5).fetch(3)
+    compare(t, sortExpectedly(tupleDataSetStrings, 0, 3))
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/SortValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/SortValidationTest.scala
@@ -27,22 +27,6 @@ import org.junit._
 class SortValidationTest extends TableTestBase {
 
   @Test(expected = classOf[ValidationException])
-  def testFetchBeforeOffset(): Unit = {
-    val util = batchTestUtil()
-    val ds = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
-
-    ds.orderBy('a.asc).fetch(5).offset(10)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testOffsetBeforeOffset(): Unit = {
-    val util = batchTestUtil()
-    val ds = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
-
-    ds.orderBy('a.asc).offset(10).offset(5)
-  }
-
-  @Test(expected = classOf[ValidationException])
   def testNegativeFetch(): Unit = {
     val util = batchTestUtil()
     val ds = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)


### PR DESCRIPTION
## What is the purpose of the change

*Method `validateAndGetChildSort` of `SortOperationFactory` checks the fetch of `previousSort`, which doesn't support continuously fetch or limit. Indeed in SQL perspective, Flink SQL supports continuously fetch or limit, therefore the `fetch` and `limit` Table API also needs to support this case. `validateAndGetChildSort` should remove the check of `previousSort` fetch.*

## Brief change log

  - *Method `validateAndGetChildSort` and `createLimitWithOffset` remove the check of `previousSort` fetch.*

## Verifying this change

  - *Method `testFetch` and `testOffsetAndFetch` of `LegacyLimitITCase` add test cases for continuously fetch or limit.*
  - *Method `testOrderByFetch` of `SortITCase ` add test cases for continuously fetch.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)