### PR TITLE
[FLINK-19121][hive] Avoid accessing HDFS frequently in HiveBulkWriterFactory

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -30,8 +30,10 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.HadoopPathBasedBulkFormatBuilder;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
+import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink.BucketsBuilder;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.CheckpointRollingPolicy;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -46,7 +48,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.filesystem.FileSystemOutputFormat;
 import org.apache.flink.table.filesystem.FileSystemTableSink;
 import org.apache.flink.table.filesystem.FileSystemTableSink.TableBucketAssigner;
-import org.apache.flink.table.filesystem.FileSystemTableSink.TableRollingPolicy;
 import org.apache.flink.table.sinks.AppendStreamTableSink;
 import org.apache.flink.table.sinks.OverwritableTableSink;
 import org.apache.flink.table.sinks.PartitionableTableSink;
@@ -74,6 +75,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -185,8 +187,7 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 						tableSchema.getFieldDataTypes(),
 						partitionColumns);
 				TableBucketAssigner assigner = new TableBucketAssigner(partComputer);
-				TableRollingPolicy rollingPolicy = new TableRollingPolicy(
-						true,
+				HiveRollingPolicy rollingPolicy = new HiveRollingPolicy(
 						conf.get(SINK_ROLLING_POLICY_FILE_SIZE).getBytes(),
 						conf.get(SINK_ROLLING_POLICY_ROLLOVER_INTERVAL).toMillis());
 
@@ -236,7 +237,7 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 			HiveWriterFactory recordWriterFactory,
 			StorageDescriptor sd,
 			TableBucketAssigner assigner,
-			TableRollingPolicy rollingPolicy,
+			HiveRollingPolicy rollingPolicy,
 			OutputFileConfig outputFileConfig) {
 		HiveBulkWriterFactory hadoopBulkFactory = new HiveBulkWriterFactory(recordWriterFactory);
 		return new HadoopPathBasedBulkFormatBuilder<>(
@@ -327,5 +328,47 @@ public class HiveTableSink implements AppendStreamTableSink, PartitionableTableS
 	@Override
 	public void setOverwrite(boolean overwrite) {
 		this.overwrite = overwrite;
+	}
+
+	/**
+	 * Getting size of the file is too expensive. See {@link HiveBulkWriterFactory#create}.
+	 * We can't check for every element, which will cause great pressure on DFS.
+	 * Therefore, in this implementation, only check the file size in
+	 * {@link #shouldRollOnProcessingTime}, which can effectively avoid DFS pressure.
+	 */
+	private static class HiveRollingPolicy extends CheckpointRollingPolicy<RowData, String> {
+
+		private final long rollingFileSize;
+		private final long rollingTimeInterval;
+
+		private HiveRollingPolicy(
+				long rollingFileSize,
+				long rollingTimeInterval) {
+			Preconditions.checkArgument(rollingFileSize > 0L);
+			Preconditions.checkArgument(rollingTimeInterval > 0L);
+			this.rollingFileSize = rollingFileSize;
+			this.rollingTimeInterval = rollingTimeInterval;
+		}
+
+		@Override
+		public boolean shouldRollOnCheckpoint(PartFileInfo<String> partFileState) {
+			return true;
+		}
+
+		@Override
+		public boolean shouldRollOnEvent(PartFileInfo<String> partFileState, RowData element) {
+			return false;
+		}
+
+		@Override
+		public boolean shouldRollOnProcessingTime(
+				PartFileInfo<String> partFileState, long currentTime) {
+			try {
+				return currentTime - partFileState.getCreationTime() >= rollingTimeInterval ||
+						partFileState.getSize() > rollingFileSize;
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

In HadoopPathBasedBulkWriter, getSize will invoke `FileSystem.exists` and `FileSystem.getFileStatus`, but it is invoked per record.
There will be lots of visits to HDFS, may make HDFS pressure too high.


## Brief change log

Creating a new `HiveRollingPolicy`:
* Getting size of the file is too expensive. See `HiveBulkWriterFactory#create`. We can't check for every element, which will cause great pressure on DFS. Therefore, in this implementation, only check the file size in `shouldRollOnProcessingTime`, which can effectively avoid DFS pressure.

## Verifying this change

Manually testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no