### PR TITLE
[FLINK-17779][Connectors/ORC]Orc file format support filter push down

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
@@ -29,17 +29,28 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.orc.vector.RowDataVectorizer;
 import org.apache.flink.orc.writer.OrcBulkWriterFactory;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.factories.FileSystemFormatFactory;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.utils.PartitionPathUtils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.orc.TypeDescription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -56,6 +67,8 @@ import static org.apache.flink.table.filesystem.RowPartitionComputer.restorePart
  * Orc {@link FileSystemFormatFactory} for file system.
  */
 public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OrcFileSystemFormatFactory.class);
 
 	public static final String IDENTIFIER = "orc";
 
@@ -83,14 +96,227 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 		return orcProperties;
 	}
 
+	private boolean isUnaryValid(CallExpression callExpression) {
+		return callExpression.getChildren().size() == 1 && callExpression.getChildren().get(0) instanceof FieldReferenceExpression;
+	}
+
+	private boolean isBinaryValid(CallExpression callExpression) {
+		return callExpression.getChildren().size() == 2 && ((callExpression.getChildren().get(0) instanceof FieldReferenceExpression && callExpression.getChildren().get(1) instanceof ValueLiteralExpression) ||
+				(callExpression.getChildren().get(0) instanceof ValueLiteralExpression && callExpression.getChildren().get(1) instanceof FieldReferenceExpression));
+	}
+
+	private OrcSplitReader.Predicate toOrcPredicate(Expression expression) {
+		if (expression instanceof CallExpression) {
+			CallExpression callExp = (CallExpression) expression;
+			FunctionDefinition funcDef = callExp.getFunctionDefinition();
+
+			if (funcDef == BuiltInFunctionDefinitions.IS_NULL || funcDef == BuiltInFunctionDefinitions.IS_NOT_NULL || funcDef == BuiltInFunctionDefinitions.NOT) {
+				if (!isUnaryValid(callExp)) {
+					// not a valid predicate
+					LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", callExp);
+					return null;
+				}
+
+				PredicateLeaf.Type colType = toOrcType(((FieldReferenceExpression) callExp.getChildren().get(0)).getOutputDataType());
+				if (colType == null) {
+					// unsupported type
+					LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", callExp);
+					return null;
+				}
+
+				String colName = getColumnName(callExp);
+
+				if (funcDef == BuiltInFunctionDefinitions.IS_NULL) {
+					return new OrcSplitReader.IsNull(colName, colType);
+				} else if (funcDef == BuiltInFunctionDefinitions.IS_NOT_NULL) {
+					return new OrcSplitReader.Not(
+							new OrcSplitReader.IsNull(colName, colType));
+				} else {
+					OrcSplitReader.Predicate c = toOrcPredicate(callExp.getChildren().get(0));
+					if (c == null) {
+						return null;
+					} else {
+						return new OrcSplitReader.Not(c);
+					}
+				}
+			} else if (funcDef == BuiltInFunctionDefinitions.OR) {
+				if (callExp.getChildren().size() < 2) {
+					return null;
+				}
+				Expression left = callExp.getChildren().get(0);
+				Expression right = callExp.getChildren().get(1);
+
+				OrcSplitReader.Predicate c1 = toOrcPredicate(left);
+				OrcSplitReader.Predicate c2 = toOrcPredicate(right);
+				if (c1 == null || c2 == null) {
+					return null;
+				} else {
+					return new OrcSplitReader.Or(c1, c2);
+				}
+			} else {
+				if (!isBinaryValid(callExp)) {
+					// not a valid predicate
+					LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", callExp);
+					return null;
+				}
+
+				PredicateLeaf.Type litType = getLiteralType(callExp);
+				if (litType == null) {
+					// unsupported literal type
+					LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", expression);
+					return null;
+				}
+
+				boolean literalOnRight = literalOnRight(callExp);
+				String colName = getColumnName(callExp);
+
+				// fetch literal and ensure it is serializable
+				Object literalObj = getLiteral(callExp).get();
+				Serializable literal;
+				// validate that literal is serializable
+				if (literalObj instanceof Serializable) {
+					literal = (Serializable) literalObj;
+				} else {
+					LOG.warn("Encountered a non-serializable literal of type {}. " +
+									"Cannot push predicate [{}] into OrcFileSystemFormatFactory. " +
+									"This is a bug and should be reported.",
+							literalObj.getClass().getCanonicalName(), expression);
+					return null;
+				}
+
+				if (funcDef == BuiltInFunctionDefinitions.EQUALS) {
+					return new OrcSplitReader.Equals(colName, litType, literal);
+				} else if (funcDef == BuiltInFunctionDefinitions.NOT_EQUALS) {
+					return new OrcSplitReader.Not(
+							new OrcSplitReader.Equals(colName, litType, literal));
+				} else if (funcDef == BuiltInFunctionDefinitions.GREATER_THAN) {
+					if (literalOnRight) {
+						return new OrcSplitReader.Not(
+								new OrcSplitReader.LessThanEquals(colName, litType, literal));
+					} else {
+						return new OrcSplitReader.LessThan(colName, litType, literal);
+					}
+				} else if (funcDef == BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL) {
+					if (literalOnRight) {
+						return new OrcSplitReader.Not(
+								new OrcSplitReader.LessThan(colName, litType, literal));
+					} else {
+						return new OrcSplitReader.LessThanEquals(colName, litType, literal);
+					}
+				} else if (funcDef == BuiltInFunctionDefinitions.LESS_THAN) {
+					if (literalOnRight) {
+						return new OrcSplitReader.LessThan(colName, litType, literal);
+					} else {
+						return new OrcSplitReader.Not(
+								new OrcSplitReader.LessThanEquals(colName, litType, literal));
+					}
+				} else if (funcDef == BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL) {
+					if (literalOnRight) {
+						return new OrcSplitReader.LessThanEquals(colName, litType, literal);
+					} else {
+						return new OrcSplitReader.Not(
+								new OrcSplitReader.LessThan(colName, litType, literal));
+					}
+				} else {
+					// unsupported predicate
+					LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", expression);
+					return null;
+				}
+			}
+		} else {
+			// unsupported predicate
+			LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", expression);
+			return null;
+		}
+	}
+
+	private String getColumnName(CallExpression comp) {
+		if (literalOnRight(comp)) {
+			return ((FieldReferenceExpression) comp.getChildren().get(0)).getName();
+		} else {
+			return ((FieldReferenceExpression) comp.getChildren().get(1)).getName();
+		}
+	}
+
+	private boolean literalOnRight(CallExpression comp) {
+		if (comp.getChildren().size() == 1 && comp.getChildren().get(0) instanceof FieldReferenceExpression) {
+			return true;
+		} else if (comp.getChildren().get(0) instanceof ValueLiteralExpression
+				&& comp.getChildren().get(1) instanceof FieldReferenceExpression) {
+			return false;
+		} else if (comp.getChildren().get(0) instanceof FieldReferenceExpression
+				&& comp.getChildren().get(1) instanceof ValueLiteralExpression) {
+			return true;
+		} else {
+			throw new RuntimeException("Invalid binary comparison.");
+		}
+	}
+
+	private PredicateLeaf.Type getLiteralType(CallExpression comp) {
+		if (literalOnRight(comp)) {
+			return toOrcType(((ValueLiteralExpression) comp.getChildren().get(1)).getOutputDataType());
+		} else {
+			return toOrcType(((ValueLiteralExpression) comp.getChildren().get(0)).getOutputDataType());
+		}
+	}
+
+	private Optional<?> getLiteral(CallExpression comp) {
+		if (literalOnRight(comp)) {
+			ValueLiteralExpression valueLiteralExpression = (ValueLiteralExpression) comp.getChildren().get(1);
+			return valueLiteralExpression.getValueAs(valueLiteralExpression.getOutputDataType().getConversionClass());
+		} else {
+			ValueLiteralExpression valueLiteralExpression = (ValueLiteralExpression) comp.getChildren().get(0);
+			return valueLiteralExpression.getValueAs(valueLiteralExpression.getOutputDataType().getConversionClass());
+		}
+	}
+
+	private static PredicateLeaf.Type toOrcType(DataType type) {
+		LogicalTypeRoot ltype = type.getLogicalType().getTypeRoot();
+
+		if (ltype == LogicalTypeRoot.TINYINT ||
+				ltype == LogicalTypeRoot.SMALLINT ||
+				ltype == LogicalTypeRoot.INTEGER ||
+				ltype == LogicalTypeRoot.BIGINT) {
+			return PredicateLeaf.Type.LONG;
+		} else if (ltype == LogicalTypeRoot.FLOAT ||
+				ltype == LogicalTypeRoot.DOUBLE) {
+			return PredicateLeaf.Type.FLOAT;
+		} else if (ltype == LogicalTypeRoot.BOOLEAN) {
+			return PredicateLeaf.Type.BOOLEAN;
+		} else if (ltype == LogicalTypeRoot.VARCHAR) {
+			return PredicateLeaf.Type.STRING;
+		} else if (ltype == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE ||
+				ltype == LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE ||
+				ltype == LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE) {
+			return PredicateLeaf.Type.TIMESTAMP;
+		} else if (ltype == LogicalTypeRoot.DATE) {
+			return PredicateLeaf.Type.DATE;
+		} else if (ltype == LogicalTypeRoot.BINARY) {
+			return PredicateLeaf.Type.DECIMAL;
+		} else {
+			// unsupported type
+			return null;
+		}
+	}
+
 	@Override
 	public InputFormat<RowData, ?> createReader(ReaderContext context) {
+		ArrayList<OrcSplitReader.Predicate> orcPredicates = new ArrayList<>();
+
+		for (Expression pred : context.getPushedDownFilters()) {
+			OrcSplitReader.Predicate orcPred = toOrcPredicate(pred);
+			if (orcPred != null) {
+				orcPredicates.add(orcPred);
+			}
+		}
+
 		return new OrcRowDataInputFormat(
 				context.getPaths(),
 				context.getSchema().getFieldNames(),
 				context.getSchema().getFieldDataTypes(),
 				context.getProjectFields(),
 				context.getDefaultPartName(),
+				orcPredicates,
 				context.getPushedDownLimit(),
 				getOrcProperties(context.getFormatOptions()));
 	}
@@ -128,6 +354,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 		private final DataType[] fullFieldTypes;
 		private final int[] selectedFields;
 		private final String partDefaultName;
+		private List<OrcSplitReader.Predicate> pushedDownFilters;
 		private final Properties properties;
 		private final long limit;
 
@@ -140,11 +367,13 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 				DataType[] fullFieldTypes,
 				int[] selectedFields,
 				String partDefaultName,
+				List<OrcSplitReader.Predicate> pushedDownFilters,
 				long limit,
 				Properties properties) {
 			super.setFilePaths(paths);
 			this.limit = limit;
 			this.partDefaultName = partDefaultName;
+			this.pushedDownFilters = pushedDownFilters;
 			this.fullFieldNames = fullFieldNames;
 			this.fullFieldTypes = fullFieldTypes;
 			this.selectedFields = selectedFields;
@@ -172,7 +401,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 					fullFieldTypes,
 					partObjects,
 					selectedFields,
-					new ArrayList<>(),
+					pushedDownFilters,
 					DEFAULT_SIZE,
 					new Path(fileSplit.getPath().toString()),
 					fileSplit.getStart(),

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
@@ -105,7 +105,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 				(callExpression.getChildren().get(0) instanceof ValueLiteralExpression && callExpression.getChildren().get(1) instanceof FieldReferenceExpression));
 	}
 
-	private OrcSplitReader.Predicate toOrcPredicate(Expression expression) {
+	public OrcSplitReader.Predicate toOrcPredicate(Expression expression) {
 		if (expression instanceof CallExpression) {
 			CallExpression callExp = (CallExpression) expression;
 			FunctionDefinition funcDef = callExp.getFunctionDefinition();
@@ -270,7 +270,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 		}
 	}
 
-	private static PredicateLeaf.Type toOrcType(DataType type) {
+	public PredicateLeaf.Type toOrcType(DataType type) {
 		LogicalTypeRoot ltype = type.getLogicalType().getTypeRoot();
 
 		if (ltype == LogicalTypeRoot.TINYINT ||

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
@@ -86,7 +86,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 
 	@Override
 	public InputFormat<RowData, ?> createReader(ReaderContext context) {
-		ArrayList<OrcSplitReader.Predicate> orcPredicates = new ArrayList<>();
+		List<OrcSplitReader.Predicate> orcPredicates = new ArrayList<>();
 
 		for (Expression pred : context.getPushedDownFilters()) {
 			OrcSplitReader.Predicate orcPred = OrcFilters.toOrcPredicate(pred);

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.orc;
 
-import org.apache.flink.table.expressions.*;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.DataType;
@@ -36,7 +39,6 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -239,14 +241,18 @@ public class OrcFilters {
 	private static Object toOrcObject(PredicateLeaf.Type litType, Object literalObj){
 		switch (litType){
 			case DATE:
-				if(literalObj instanceof LocalDate){
+				if (literalObj instanceof LocalDate){
 					LocalDate localDate = (LocalDate) literalObj;
 					return Date.valueOf(localDate);
+				} else {
+					return literalObj;
 				}
 			case TIMESTAMP:
-				if(literalObj instanceof LocalDateTime){
+				if (literalObj instanceof LocalDateTime){
 					LocalDateTime localDateTime = (LocalDateTime) literalObj;
 					return Timestamp.valueOf(localDateTime);
+				} else {
+					return literalObj;
 				}
 			default:
 				return literalObj;

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import org.apache.flink.shaded.curator4.com.google.common.collect.ImmutableMap;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Utility class that provides helper methods to work with Orc Filter PushDown.
+ */
+public class OrcFilters {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OrcFileSystemFormatFactory.class);
+
+	private static final ImmutableMap<FunctionDefinition, Function<CallExpression, OrcSplitReader.Predicate>> FILTERS =
+			new ImmutableMap.Builder<FunctionDefinition, Function<CallExpression, OrcSplitReader.Predicate>>()
+					.put(BuiltInFunctionDefinitions.IS_NULL, createIsNullPredicateConverter())
+					.put(BuiltInFunctionDefinitions.IS_NOT_NULL, createIsNotNullPredicateConverter())
+					.put(BuiltInFunctionDefinitions.NOT, createNotPredicateConverter())
+					.put(BuiltInFunctionDefinitions.OR, createOrPredicateConverter())
+					.put(BuiltInFunctionDefinitions.EQUALS, createEqualsPredicateConverter())
+					.put(BuiltInFunctionDefinitions.NOT_EQUALS, createNotEqualsPredicateConverter())
+					.put(BuiltInFunctionDefinitions.GREATER_THAN, createGreaterThanPredicateConverter())
+					.put(BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL, createGreaterThanEqualsPredicateConverter())
+					.put(BuiltInFunctionDefinitions.LESS_THAN, createLessThanPredicateConverter())
+					.put(BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL, createLessThanEqualsPredicateConverter())
+					.build();
+
+	private static boolean isUnaryValid(CallExpression callExpression) {
+		return callExpression.getChildren().size() == 1 && callExpression.getChildren().get(0) instanceof FieldReferenceExpression;
+	}
+
+	private static boolean isBinaryValid(CallExpression callExpression) {
+		return callExpression.getChildren().size() == 2 && ((callExpression.getChildren().get(0) instanceof FieldReferenceExpression && callExpression.getChildren().get(1) instanceof ValueLiteralExpression) ||
+				(callExpression.getChildren().get(0) instanceof ValueLiteralExpression && callExpression.getChildren().get(1) instanceof FieldReferenceExpression));
+	}
+
+	private static Tuple2<String, PredicateLeaf.Type> getTuple2Args(CallExpression callExp){
+		if (!isUnaryValid(callExp)) {
+			// not a valid predicate
+			LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", callExp);
+			return null;
+		}
+
+		PredicateLeaf.Type colType = toOrcType(((FieldReferenceExpression) callExp.getChildren().get(0)).getOutputDataType());
+		if (colType == null) {
+			// unsupported type
+			LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", callExp);
+			return null;
+		}
+
+		String colName = getColumnName(callExp);
+
+		return Tuple2.of(colName, colType);
+	}
+
+	private static Tuple3<String, PredicateLeaf.Type, Serializable> getTuple3Args(CallExpression callExp){
+		if (!isBinaryValid(callExp)) {
+			// not a valid predicate
+			LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", callExp);
+			return null;
+		}
+
+		PredicateLeaf.Type litType = getLiteralType(callExp);
+		if (litType == null) {
+			// unsupported literal type
+			LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", callExp);
+			return null;
+		}
+
+		String colName = getColumnName(callExp);
+
+		// fetch literal and ensure it is serializable
+		Object literalObj = getLiteral(callExp).get();
+		Serializable literal;
+		// validate that literal is serializable
+		if (literalObj instanceof Serializable) {
+			literal = (Serializable) literalObj;
+		} else {
+			LOG.warn("Encountered a non-serializable literal of type {}. " +
+							"Cannot push predicate [{}] into OrcFileSystemFormatFactory. " +
+							"This is a bug and should be reported.",
+					literalObj.getClass().getCanonicalName(), callExp);
+			return null;
+		}
+
+		return Tuple3.of(colName, litType, literal);
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createIsNullPredicateConverter(){
+		return callExp -> {
+				Tuple2<String, PredicateLeaf.Type> tuple2 = getTuple2Args(callExp);
+
+				if (tuple2 == null){
+					return null;
+				}
+
+				return new OrcSplitReader.IsNull(tuple2.f0, tuple2.f1);
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createIsNotNullPredicateConverter(){
+		return callExp -> {
+
+			Tuple2<String, PredicateLeaf.Type> tuple2 = getTuple2Args(callExp);
+
+			if (tuple2 == null){
+				return null;
+			}
+
+			return new OrcSplitReader.Not(
+					new OrcSplitReader.IsNull(tuple2.f0, tuple2.f1));
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createNotPredicateConverter(){
+		return callExp -> {
+			if (callExp.getChildren().size() != 1) {
+				// not a valid predicate
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", callExp);
+				return null;
+			}
+
+			OrcSplitReader.Predicate c = toOrcPredicate(callExp.getChildren().get(0));
+			if (c == null) {
+				return null;
+			} else {
+				return new OrcSplitReader.Not(c);
+			}
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createOrPredicateConverter(){
+		return callExp -> {
+			if (callExp.getChildren().size() < 2) {
+				return null;
+			}
+			Expression left = callExp.getChildren().get(0);
+			Expression right = callExp.getChildren().get(1);
+
+			OrcSplitReader.Predicate c1 = toOrcPredicate(left);
+			OrcSplitReader.Predicate c2 = toOrcPredicate(right);
+			if (c1 == null || c2 == null) {
+				return null;
+			} else {
+				return new OrcSplitReader.Or(c1, c2);
+			}
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createEqualsPredicateConverter(){
+		return callExp -> {
+			Tuple3<String, PredicateLeaf.Type, Serializable> tuple3 = getTuple3Args(callExp);
+
+			if (tuple3 == null){
+				return null;
+			}
+			return new OrcSplitReader.Equals(tuple3.f0, tuple3.f1, tuple3.f2);
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createNotEqualsPredicateConverter(){
+		return callExp -> {
+			Tuple3<String, PredicateLeaf.Type, Serializable> tuple3 = getTuple3Args(callExp);
+
+			if (tuple3 == null){
+				return null;
+			}
+
+			return new OrcSplitReader.Not(
+					new OrcSplitReader.Equals(tuple3.f0, tuple3.f1, tuple3.f2));
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createGreaterThanPredicateConverter(){
+		return callExp -> {
+
+			Tuple3<String, PredicateLeaf.Type, Serializable> tuple3 = getTuple3Args(callExp);
+
+			if (tuple3 == null){
+				return null;
+			}
+
+			boolean literalOnRight = literalOnRight(callExp);
+
+			if (literalOnRight) {
+				return new OrcSplitReader.Not(
+						new OrcSplitReader.LessThanEquals(tuple3.f0, tuple3.f1, tuple3.f2));
+			} else {
+				return new OrcSplitReader.LessThan(tuple3.f0, tuple3.f1, tuple3.f2);
+			}
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createGreaterThanEqualsPredicateConverter(){
+		return callExp -> {
+
+			Tuple3<String, PredicateLeaf.Type, Serializable> tuple3 = getTuple3Args(callExp);
+
+			if (tuple3 == null){
+				return null;
+			}
+
+			boolean literalOnRight = literalOnRight(callExp);
+
+			if (literalOnRight) {
+				return new OrcSplitReader.Not(
+						new OrcSplitReader.LessThan(tuple3.f0, tuple3.f1, tuple3.f2));
+			} else {
+				return new OrcSplitReader.LessThanEquals(tuple3.f0, tuple3.f1, tuple3.f2);
+			}
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createLessThanPredicateConverter(){
+		return callExp -> {
+
+			Tuple3<String, PredicateLeaf.Type, Serializable> tuple3 = getTuple3Args(callExp);
+
+			if (tuple3 == null){
+				return null;
+			}
+
+			boolean literalOnRight = literalOnRight(callExp);
+
+			if (literalOnRight) {
+				return new OrcSplitReader.LessThan(tuple3.f0, tuple3.f1, tuple3.f2);
+			} else {
+				return new OrcSplitReader.Not(
+						new OrcSplitReader.LessThanEquals(tuple3.f0, tuple3.f1, tuple3.f2));
+			}
+		};
+	}
+
+	private static Function<CallExpression, OrcSplitReader.Predicate> createLessThanEqualsPredicateConverter(){
+		return callExp -> {
+
+			Tuple3<String, PredicateLeaf.Type, Serializable> tuple3 = getTuple3Args(callExp);
+
+			if (tuple3 == null){
+				return null;
+			}
+
+			boolean literalOnRight = literalOnRight(callExp);
+
+			if (literalOnRight) {
+				return new OrcSplitReader.LessThanEquals(tuple3.f0, tuple3.f1, tuple3.f2);
+			} else {
+				return new OrcSplitReader.Not(
+						new OrcSplitReader.LessThan(tuple3.f0, tuple3.f1, tuple3.f2));
+			}
+		};
+	}
+
+	public static OrcSplitReader.Predicate toOrcPredicate(Expression expression) {
+		if (expression instanceof CallExpression) {
+			CallExpression callExp = (CallExpression) expression;
+			if (FILTERS.get(callExp.getFunctionDefinition()) == null) {
+				// unsupported predicate
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", expression);
+				return null;
+			}
+			return FILTERS.get(callExp.getFunctionDefinition()).apply(callExp);
+		} else {
+			// unsupported predicate
+			LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcFileSystemFormatFactory.", expression);
+			return null;
+		}
+	}
+
+	private static String getColumnName(CallExpression comp) {
+		if (literalOnRight(comp)) {
+			return ((FieldReferenceExpression) comp.getChildren().get(0)).getName();
+		} else {
+			return ((FieldReferenceExpression) comp.getChildren().get(1)).getName();
+		}
+	}
+
+	private static boolean literalOnRight(CallExpression comp) {
+		if (comp.getChildren().size() == 1 && comp.getChildren().get(0) instanceof FieldReferenceExpression) {
+			return true;
+		} else if (comp.getChildren().get(0) instanceof ValueLiteralExpression
+				&& comp.getChildren().get(1) instanceof FieldReferenceExpression) {
+			return false;
+		} else if (comp.getChildren().get(0) instanceof FieldReferenceExpression
+				&& comp.getChildren().get(1) instanceof ValueLiteralExpression) {
+			return true;
+		} else {
+			throw new RuntimeException("Invalid binary comparison.");
+		}
+	}
+
+	private static PredicateLeaf.Type getLiteralType(CallExpression comp) {
+		if (literalOnRight(comp)) {
+			return toOrcType(((ValueLiteralExpression) comp.getChildren().get(1)).getOutputDataType());
+		} else {
+			return toOrcType(((ValueLiteralExpression) comp.getChildren().get(0)).getOutputDataType());
+		}
+	}
+
+	private static Optional<?> getLiteral(CallExpression comp) {
+		if (literalOnRight(comp)) {
+			ValueLiteralExpression valueLiteralExpression = (ValueLiteralExpression) comp.getChildren().get(1);
+			return valueLiteralExpression.getValueAs(valueLiteralExpression.getOutputDataType().getConversionClass());
+		} else {
+			ValueLiteralExpression valueLiteralExpression = (ValueLiteralExpression) comp.getChildren().get(0);
+			return valueLiteralExpression.getValueAs(valueLiteralExpression.getOutputDataType().getConversionClass());
+		}
+	}
+
+	private static PredicateLeaf.Type toOrcType(DataType type) {
+		LogicalTypeRoot ltype = type.getLogicalType().getTypeRoot();
+		switch (ltype){
+			case TINYINT:
+			case SMALLINT:
+			case INTEGER:
+			case BIGINT:
+				return PredicateLeaf.Type.LONG;
+			case FLOAT:
+			case DOUBLE:
+				return PredicateLeaf.Type.FLOAT;
+			case BOOLEAN:
+				return PredicateLeaf.Type.BOOLEAN;
+			case VARCHAR:
+				return PredicateLeaf.Type.STRING;
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+			case TIMESTAMP_WITH_TIME_ZONE:
+				return PredicateLeaf.Type.TIMESTAMP;
+			case DATE:
+				return PredicateLeaf.Type.DATE;
+			case BINARY:
+				return PredicateLeaf.Type.DECIMAL;
+			default:
+				return null;
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit Tests for {@link OrcFileSystemFormatFactory}.
  */
-public class OrcFileSystemFormatFactoryTest {
+public class OrcFileSystemFilterTest {
 
 	@Test
 	@SuppressWarnings("unchecked")

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFormatFactoryTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFormatFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit Tests for {@link OrcFileSystemFormatFactoryTest}.
+ */
+public class OrcFileSystemFormatFactoryTest {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testApplyPredicate(){
+
+		OrcFileSystemFormatFactory orcFileSystemFormatFactory = new OrcFileSystemFormatFactory();
+		List<ResolvedExpression> args = new ArrayList<>();
+
+		// equal
+		FieldReferenceExpression fieldReferenceExpression = new FieldReferenceExpression("long1", DataTypes.BIGINT(), 0, 0);
+		ValueLiteralExpression valueLiteralExpression = new ValueLiteralExpression(10);
+		args.add(fieldReferenceExpression);
+		args.add(valueLiteralExpression);
+
+		CallExpression equalExpression = new CallExpression(BuiltInFunctionDefinitions.EQUALS, args, DataTypes.BOOLEAN());
+		OrcSplitReader.Predicate predicate1 = orcFileSystemFormatFactory.toOrcPredicate(equalExpression);
+		OrcSplitReader.Predicate predicate2 = new OrcSplitReader.Equals("long1", PredicateLeaf.Type.LONG, 10);
+		assertTrue(predicate1.toString().equals(predicate2.toString()));
+
+		// greater than
+		CallExpression greaterExpression = new CallExpression(BuiltInFunctionDefinitions.GREATER_THAN, args, DataTypes.BOOLEAN());
+		OrcSplitReader.Predicate predicate3 = orcFileSystemFormatFactory.toOrcPredicate(greaterExpression);
+		OrcSplitReader.Predicate predicate4 = new OrcSplitReader.Not(new OrcSplitReader.LessThanEquals("long1", PredicateLeaf.Type.LONG, 10));
+		assertTrue(predicate3.toString().equals(predicate4.toString()));
+
+		// less than
+		CallExpression lessExpression = new CallExpression(BuiltInFunctionDefinitions.LESS_THAN, args, DataTypes.BOOLEAN());
+		OrcSplitReader.Predicate predicate5 = orcFileSystemFormatFactory.toOrcPredicate(lessExpression);
+		OrcSplitReader.Predicate predicate6 = new OrcSplitReader.LessThan("long1", PredicateLeaf.Type.LONG, 10);
+		assertTrue(predicate5.toString().equals(predicate6.toString()));
+	}
+}

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFormatFactoryTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFormatFactoryTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 
 /**
- * Unit Tests for {@link OrcFileSystemFormatFactoryTest}.
+ * Unit Tests for {@link OrcFileSystemFormatFactory}.
  */
 public class OrcFileSystemFormatFactoryTest {
 

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFormatFactoryTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFormatFactoryTest.java
@@ -42,8 +42,6 @@ public class OrcFileSystemFormatFactoryTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testApplyPredicate(){
-
-		OrcFileSystemFormatFactory orcFileSystemFormatFactory = new OrcFileSystemFormatFactory();
 		List<ResolvedExpression> args = new ArrayList<>();
 
 		// equal
@@ -53,19 +51,19 @@ public class OrcFileSystemFormatFactoryTest {
 		args.add(valueLiteralExpression);
 
 		CallExpression equalExpression = new CallExpression(BuiltInFunctionDefinitions.EQUALS, args, DataTypes.BOOLEAN());
-		OrcSplitReader.Predicate predicate1 = orcFileSystemFormatFactory.toOrcPredicate(equalExpression);
+		OrcSplitReader.Predicate predicate1 = OrcFilters.toOrcPredicate(equalExpression);
 		OrcSplitReader.Predicate predicate2 = new OrcSplitReader.Equals("long1", PredicateLeaf.Type.LONG, 10);
 		assertTrue(predicate1.toString().equals(predicate2.toString()));
 
 		// greater than
 		CallExpression greaterExpression = new CallExpression(BuiltInFunctionDefinitions.GREATER_THAN, args, DataTypes.BOOLEAN());
-		OrcSplitReader.Predicate predicate3 = orcFileSystemFormatFactory.toOrcPredicate(greaterExpression);
+		OrcSplitReader.Predicate predicate3 = OrcFilters.toOrcPredicate(greaterExpression);
 		OrcSplitReader.Predicate predicate4 = new OrcSplitReader.Not(new OrcSplitReader.LessThanEquals("long1", PredicateLeaf.Type.LONG, 10));
 		assertTrue(predicate3.toString().equals(predicate4.toString()));
 
 		// less than
 		CallExpression lessExpression = new CallExpression(BuiltInFunctionDefinitions.LESS_THAN, args, DataTypes.BOOLEAN());
-		OrcSplitReader.Predicate predicate5 = orcFileSystemFormatFactory.toOrcPredicate(lessExpression);
+		OrcSplitReader.Predicate predicate5 = OrcFilters.toOrcPredicate(lessExpression);
 		OrcSplitReader.Predicate predicate6 = new OrcSplitReader.LessThan("long1", PredicateLeaf.Type.LONG, 10);
 		assertTrue(predicate5.toString().equals(predicate6.toString()));
 	}

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
@@ -19,12 +19,14 @@
 package org.apache.flink.orc;
 
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
+import org.apache.flink.types.Row;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -34,6 +36,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -84,5 +87,60 @@ public class OrcFileSystemITCase extends BatchFileSystemITCaseBase {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@Override
+	public void before() {
+		super.before();
+		super.tableEnv().executeSql(String.format(
+				"create table orcFilterTable (" +
+						"x string," +
+						"y int," +
+						"a int," +
+						"b bigint," +
+						"c boolean," +
+						"d string" +
+						") with (" +
+						"'connector' = 'filesystem'," +
+						"'path' = '%s'," +
+						"%s)", super.resultPath(), String.join(",\n", formatProperties())));
+	}
+
+	@Test
+	public void testOrcFilterPushDown(){
+		super.tableEnv().executeSql(
+				"insert into orcFilterTable select x, y, a, b, case when y >= 10 then false else true end as c, case when a = 1 then null else x end as d from originalT");
+
+		check("select x, y from orcFilterTable where x = 'x11' and 11 = y",
+				Collections.singletonList(
+						Row.of("x11", "11")));
+
+		check("select x, y from orcFilterTable where 4 <= y and y < 8 and x <> 'x6'",
+				Arrays.asList(
+						Row.of("x4", "4"),
+						Row.of("x5", "5"),
+						Row.of("x7", "7")));
+
+		check("select x, y from orcFilterTable where x = 'x1' and not y >= 3",
+				Collections.singletonList(
+						Row.of("x1", "1")));
+
+		check("select x, y from orcFilterTable where c and y > 2 and y < 4",
+				Collections.singletonList(
+						Row.of("x3", "3")));
+
+		check("select x, y from orcFilterTable where d is null and x = 'x5'",
+				Collections.singletonList(
+						Row.of("x5", "5")));
+
+		check("select x, y from orcFilterTable where d is not null and y > 25",
+				Arrays.asList(
+						Row.of("x26", "26"),
+						Row.of("x27", "27")));
+
+		check("select x, y from orcFilterTable where (d is not null and y > 26) or (d is null and x = 'x3')",
+				Arrays.asList(
+						Row.of("x3", "3"),
+						Row.of("x27", "27")));
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently OrcFileSystemFormatFactory does not support filter pushdown, this PR implements this feature


## Brief change log

create the conversion between CallExpression and Orc FilterPredicate 

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - The list of expressions that support filter pushdown: 
```
is null 
is not null 
= 
<>
>
>=
<
<=
```
