### PR TITLE
[FLINK-14422][runtime] Expose network memory usage to TaskManagerDetailsHandler's endpoint

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -4255,7 +4255,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">Returns details for a task manager.</td>
+      <td colspan="2">Returns details for a task manager. "metrics.memorySegmentsAvailable" and "metrics.memorySegmentsTotal" are deprecated. Please use "metrics.nettyShuffleMemorySegmentsAvailable" and "metrics.nettyShuffleMemorySegmentsTotal" instead.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -4408,6 +4408,24 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "type" : "integer"
         },
         "memorySegmentsTotal" : {
+          "type" : "integer"
+        },
+        "nettyShuffleMemoryAvailable" : {
+          "type" : "integer"
+        },
+        "nettyShuffleMemorySegmentsAvailable" : {
+          "type" : "integer"
+        },
+        "nettyShuffleMemorySegmentsTotal" : {
+          "type" : "integer"
+        },
+        "nettyShuffleMemorySegmentsUsed" : {
+          "type" : "integer"
+        },
+        "nettyShuffleMemoryTotal" : {
+          "type" : "integer"
+        },
+        "nettyShuffleMemoryUsed" : {
           "type" : "integer"
         },
         "nonHeapCommitted" : {

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1097,15 +1097,35 @@ Metrics related to data exchange between task executors using netty network comm
   </thead>
   <tbody>
     <tr>
-      <th rowspan="2"><strong>TaskManager</strong></th>
-      <td rowspan="2">Status.Shuffle.Netty</td>
+      <th rowspan="6"><strong>TaskManager</strong></th>
+      <td rowspan="6">Status.Shuffle.Netty</td>
       <td>AvailableMemorySegments</td>
       <td>The number of unused memory segments.</td>
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>UsedMemorySegments</td>
+      <td>The number of used memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>TotalMemorySegments</td>
       <td>The number of allocated memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>AvailableMemory</td>
+      <td>The amount of unused memory in bytes.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>UsedMemory</td>
+      <td>The amount of used memory in bytes.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>TotalMemory</td>
+      <td>The amount of allocated memory in bytes.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1096,15 +1096,35 @@ Metrics related to data exchange between task executors using netty network comm
   </thead>
   <tbody>
     <tr>
-      <th rowspan="2"><strong>TaskManager</strong></th>
-      <td rowspan="2">Status.Shuffle.Netty</td>
+      <th rowspan="6"><strong>TaskManager</strong></th>
+      <td rowspan="6">Status.Shuffle.Netty</td>
       <td>AvailableMemorySegments</td>
       <td>The number of unused memory segments.</td>
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>UsedMemorySegments</td>
+      <td>The number of used memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>TotalMemorySegments</td>
       <td>The number of allocated memory segments.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>AvailableMemory</td>
+      <td>The amount of unused memory in bytes.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>UsedMemory</td>
+      <td>The amount of used memory in bytes.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>TotalMemory</td>
+      <td>The amount of totally allocated memory in bytes.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2963,6 +2963,24 @@
             "memorySegmentsTotal" : {
               "type" : "integer"
             },
+            "nettyShuffleMemorySegmentsAvailable" : {
+              "type" : "integer"
+            },
+            "nettyShuffleMemorySegmentsUsed" : {
+              "type" : "integer"
+            },
+            "nettyShuffleMemorySegmentsTotal" : {
+              "type" : "integer"
+            },
+            "nettyShuffleMemoryAvailable" : {
+              "type" : "integer"
+            },
+            "nettyShuffleMemoryUsed" : {
+              "type" : "integer"
+            },
+            "nettyShuffleMemoryTotal" : {
+              "type" : "integer"
+            },
             "garbageCollectors" : {
               "type" : "array",
               "items" : {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -268,13 +268,29 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 	}
 
 	public int getTotalNumberOfMemorySegments() {
-		return totalNumberOfMemorySegments;
+		return isDestroyed() ? 0 : totalNumberOfMemorySegments;
+	}
+
+	public long getTotalMemory() {
+		return getTotalNumberOfMemorySegments() * memorySegmentSize;
 	}
 
 	public int getNumberOfAvailableMemorySegments() {
 		synchronized (availableMemorySegments) {
 			return availableMemorySegments.size();
 		}
+	}
+
+	public long getAvailableMemory() {
+		return getNumberOfAvailableMemorySegments() * memorySegmentSize;
+	}
+
+	public int getNumberOfUsedMemorySegments() {
+		return getTotalNumberOfMemorySegments() - getNumberOfAvailableMemorySegments();
+	}
+
+	public long getUsedMemory() {
+		return getNumberOfUsedMemorySegments() * memorySegmentSize;
 	}
 
 	public int getNumberOfRegisteredBufferPools() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
@@ -137,13 +137,13 @@ public class TaskManagerDetailsHandler extends AbstractResourceManagerHandler<Re
 		long mappedUsed = Long.valueOf(tmMetrics.getMetric("Status.JVM.Memory.Mapped.MemoryUsed", "0"));
 		long mappedMax = Long.valueOf(tmMetrics.getMetric("Status.JVM.Memory.Mapped.TotalCapacity", "0"));
 
-		long networkMemorySegmentsAvailable = Long.valueOf(tmMetrics.getMetric("Status.Network.AvailableMemorySegments", "0"));
-		long networkMemorySegmentsUsed = Long.valueOf(tmMetrics.getMetric("Status.Network.UsedMemorySegments", "0"));
-		long networkMemorySegmentsTotal = Long.valueOf(tmMetrics.getMetric("Status.Network.TotalMemorySegments", "0"));
+		long networkMemorySegmentsAvailable = Long.valueOf(tmMetrics.getMetric("Status.Shuffle.Netty.AvailableMemorySegments", "0"));
+		long networkMemorySegmentsUsed = Long.valueOf(tmMetrics.getMetric("Status.Shuffle.Netty.UsedMemorySegments", "0"));
+		long networkMemorySegmentsTotal = Long.valueOf(tmMetrics.getMetric("Status.Shuffle.Netty.TotalMemorySegments", "0"));
 
-		long networkMemoryAvailable = Long.valueOf(tmMetrics.getMetric("Status.Network.AvailableMemory", "0"));
-		long networkMemoryUsed = Long.valueOf(tmMetrics.getMetric("Status.Network.UsedMemory", "0"));
-		long networkMemoryTotal = Long.valueOf(tmMetrics.getMetric("Status.Network.TotalMemory", "0"));
+		long networkMemoryAvailable = Long.valueOf(tmMetrics.getMetric("Status.Shuffle.Netty.AvailableMemory", "0"));
+		long networkMemoryUsed = Long.valueOf(tmMetrics.getMetric("Status.Shuffle.Netty.UsedMemory", "0"));
+		long networkMemoryTotal = Long.valueOf(tmMetrics.getMetric("Status.Shuffle.Netty.TotalMemory", "0"));
 
 		final List<TaskManagerMetricsInfo.GarbageCollectorInfo> garbageCollectorInfo = createGarbageCollectorInfo(tmMetrics);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
@@ -137,8 +137,13 @@ public class TaskManagerDetailsHandler extends AbstractResourceManagerHandler<Re
 		long mappedUsed = Long.valueOf(tmMetrics.getMetric("Status.JVM.Memory.Mapped.MemoryUsed", "0"));
 		long mappedMax = Long.valueOf(tmMetrics.getMetric("Status.JVM.Memory.Mapped.TotalCapacity", "0"));
 
-		long memorySegmentsAvailable = Long.valueOf(tmMetrics.getMetric("Status.Network.AvailableMemorySegments", "0"));
-		long memorySegmentsTotal = Long.valueOf(tmMetrics.getMetric("Status.Network.TotalMemorySegments", "0"));
+		long networkMemorySegmentsAvailable = Long.valueOf(tmMetrics.getMetric("Status.Network.AvailableMemorySegments", "0"));
+		long networkMemorySegmentsUsed = Long.valueOf(tmMetrics.getMetric("Status.Network.UsedMemorySegments", "0"));
+		long networkMemorySegmentsTotal = Long.valueOf(tmMetrics.getMetric("Status.Network.TotalMemorySegments", "0"));
+
+		long networkMemoryAvailable = Long.valueOf(tmMetrics.getMetric("Status.Network.AvailableMemory", "0"));
+		long networkMemoryUsed = Long.valueOf(tmMetrics.getMetric("Status.Network.UsedMemory", "0"));
+		long networkMemoryTotal = Long.valueOf(tmMetrics.getMetric("Status.Network.TotalMemory", "0"));
 
 		final List<TaskManagerMetricsInfo.GarbageCollectorInfo> garbageCollectorInfo = createGarbageCollectorInfo(tmMetrics);
 
@@ -155,8 +160,12 @@ public class TaskManagerDetailsHandler extends AbstractResourceManagerHandler<Re
 			mappedCount,
 			mappedUsed,
 			mappedMax,
-			memorySegmentsAvailable,
-			memorySegmentsTotal,
+			networkMemorySegmentsAvailable,
+			networkMemorySegmentsUsed,
+			networkMemorySegmentsTotal,
+			networkMemoryAvailable,
+			networkMemoryUsed,
+			networkMemoryTotal,
 			garbageCollectorInfo);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsHeaders.java
@@ -72,6 +72,6 @@ public class TaskManagerDetailsHeaders implements MessageHeaders<EmptyRequestBod
 
 	@Override
 	public String getDescription() {
-		return "Returns details for a task manager.";
+		return "Returns details for a task manager. \"metrics.memorySegmentsAvailable\" and \"metrics.memorySegmentsTotal\" are deprecated. Please use \"metrics.nettyShuffleMemorySegmentsAvailable\" and \"metrics.nettyShuffleMemorySegmentsTotal\" instead.";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.messages.taskmanager;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.rest.messages.ResourceProfileInfo;
@@ -40,7 +41,6 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 
 	public static final String FIELD_NAME_METRICS = "metrics";
 
-	@JsonProperty(FIELD_NAME_METRICS)
 	private final TaskManagerMetricsInfo taskManagerMetrics;
 
 	@JsonCreator
@@ -84,6 +84,12 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 			taskManagerInfo.getHardwareDescription(),
 			taskManagerInfo.getMemoryConfiguration(),
 			taskManagerMetrics);
+	}
+
+	@JsonProperty(FIELD_NAME_METRICS)
+	@VisibleForTesting
+	public final TaskManagerMetricsInfo getTaskManagerMetricsInfo() {
+		return this.taskManagerMetrics;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerMetricsInfo.java
@@ -56,9 +56,23 @@ public class TaskManagerMetricsInfo {
 
 	public static final String FIELD_NAME_MAPPED_MAX = "mappedMax";
 
+	@Deprecated
 	public static final String FIELD_NAME_NETWORK_MEMORY_SEGMENTS_AVAILABLE = "memorySegmentsAvailable";
 
-	public static final String FIELD_NAME_NETWORK_MEMROY_SEGMENTS_TOTAL = "memorySegmentsTotal";
+	@Deprecated
+	public static final String FIELD_NAME_NETWORK_MEMORY_SEGMENTS_TOTAL = "memorySegmentsTotal";
+
+	public static final String FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_AVAILABLE = "nettyShuffleMemorySegmentsAvailable";
+
+	public static final String FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_USED = "nettyShuffleMemorySegmentsUsed";
+
+	public static final String FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_TOTAL = "nettyShuffleMemorySegmentsTotal";
+
+	public static final String FIELD_NAME_SHUFFLE_MEMORY_AVAILABLE = "nettyShuffleMemoryAvailable";
+
+	public static final String FIELD_NAME_SHUFFLE_MEMORY_USED = "nettyShuffleMemoryUsed";
+
+	public static final String FIELD_NAME_SHUFFLE_MEMORY_TOTAL = "nettyShuffleMemoryTotal";
 
 	public static final String FIELD_NAME_GARBAGE_COLLECTORS = "garbageCollectors";
 
@@ -106,18 +120,73 @@ public class TaskManagerMetricsInfo {
 	@JsonProperty(FIELD_NAME_MAPPED_MAX)
 	private final long mappedMax;
 
-	// --------- Network buffer pool -------------
+	// --------- Shuffle Netty buffer pool -------------
 
-	@JsonProperty(FIELD_NAME_NETWORK_MEMORY_SEGMENTS_AVAILABLE)
-	private final long memorySegmentsAvailable;
+	@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_AVAILABLE)
+	private final long shuffleMemorySegmentsAvailable;
 
-	@JsonProperty(FIELD_NAME_NETWORK_MEMROY_SEGMENTS_TOTAL)
-	private final long memorySegmentsTotal;
+	@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_USED)
+	private final long shuffleMemorySegmentsUsed;
+
+	@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_TOTAL)
+	private final long shuffleMemorySegmentsTotal;
+
+	@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_AVAILABLE)
+	private final long shuffleMemoryAvailable;
+
+	@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_USED)
+	private final long shuffleMemoryUsed;
+
+	@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_TOTAL)
+	private final long shuffleMemoryTotal;
 
 	// --------- Garbage collectors -------------
 
 	@JsonProperty(FIELD_NAME_GARBAGE_COLLECTORS)
 	private final List<GarbageCollectorInfo> garbageCollectorsInfo;
+
+	public TaskManagerMetricsInfo(
+			long heapUsed,
+			long heapCommitted,
+			long heapMax,
+			long nonHeapUsed,
+			long nonHeapCommitted,
+			long nonHeapMax,
+			long directCount,
+			long directUsed,
+			long directMax,
+			long mappedCount,
+			long mappedUsed,
+			long mappedMax,
+			long shuffleMemorySegmentsAvailable,
+			long shuffleMemorySegmentsUsed,
+			long shuffleMemorySegmentsTotal,
+			long shuffleMemoryAvailable,
+			long shuffleMemoryUsed,
+			long shuffleMemoryTotal,
+			List<GarbageCollectorInfo> garbageCollectorsInfo) {
+		this(heapUsed,
+			heapCommitted,
+			heapMax,
+			nonHeapUsed,
+			nonHeapCommitted,
+			nonHeapMax,
+			directCount,
+			directUsed,
+			directMax,
+			mappedCount,
+			mappedUsed,
+			mappedMax,
+			-1,
+			-1,
+			shuffleMemorySegmentsAvailable,
+			shuffleMemorySegmentsUsed,
+			shuffleMemorySegmentsTotal,
+			shuffleMemoryAvailable,
+			shuffleMemoryUsed,
+			shuffleMemoryTotal,
+			garbageCollectorsInfo);
+	}
 
 	@JsonCreator
 	public TaskManagerMetricsInfo(
@@ -133,8 +202,14 @@ public class TaskManagerMetricsInfo {
 			@JsonProperty(FIELD_NAME_MAPPED_COUNT) long mappedCount,
 			@JsonProperty(FIELD_NAME_MAPPED_USED) long mappedUsed,
 			@JsonProperty(FIELD_NAME_MAPPED_MAX) long mappedMax,
-			@JsonProperty(FIELD_NAME_NETWORK_MEMORY_SEGMENTS_AVAILABLE) long memorySegmentsAvailable,
-			@JsonProperty(FIELD_NAME_NETWORK_MEMROY_SEGMENTS_TOTAL) long memorySegmentsTotal,
+			@JsonProperty(FIELD_NAME_NETWORK_MEMORY_SEGMENTS_AVAILABLE) long ignoredNetworkMemorySegmentsAvailable,
+			@JsonProperty(FIELD_NAME_NETWORK_MEMORY_SEGMENTS_TOTAL) long ignoredNetworkMemorySegmentsTotal,
+			@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_AVAILABLE) long shuffleMemorySegmentsAvailable,
+			@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_USED) long shuffleMemorySegmentsUsed,
+			@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_SEGMENTS_TOTAL) long shuffleMemorySegmentsTotal,
+			@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_AVAILABLE) long shuffleMemoryAvailable,
+			@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_USED) long shuffleMemoryUsed,
+			@JsonProperty(FIELD_NAME_SHUFFLE_MEMORY_TOTAL) long shuffleMemoryTotal,
 			@JsonProperty(FIELD_NAME_GARBAGE_COLLECTORS) List<GarbageCollectorInfo> garbageCollectorsInfo) {
 		this.heapUsed = heapUsed;
 		this.heapCommitted = heapCommitted;
@@ -148,9 +223,25 @@ public class TaskManagerMetricsInfo {
 		this.mappedCount = mappedCount;
 		this.mappedUsed = mappedUsed;
 		this.mappedMax = mappedMax;
-		this.memorySegmentsAvailable = memorySegmentsAvailable;
-		this.memorySegmentsTotal = memorySegmentsTotal;
+		this.shuffleMemorySegmentsAvailable = shuffleMemorySegmentsAvailable;
+		this.shuffleMemorySegmentsUsed = shuffleMemorySegmentsUsed;
+		this.shuffleMemorySegmentsTotal = shuffleMemorySegmentsTotal;
+		this.shuffleMemoryAvailable = shuffleMemoryAvailable;
+		this.shuffleMemoryUsed = shuffleMemoryUsed;
+		this.shuffleMemoryTotal = shuffleMemoryTotal;
 		this.garbageCollectorsInfo = Preconditions.checkNotNull(garbageCollectorsInfo);
+	}
+
+	@Deprecated
+	@JsonProperty(FIELD_NAME_NETWORK_MEMORY_SEGMENTS_AVAILABLE)
+	private long getMemorySegmentsAvailable() {
+		return this.shuffleMemorySegmentsAvailable;
+	}
+
+	@Deprecated
+	@JsonProperty(FIELD_NAME_NETWORK_MEMORY_SEGMENTS_TOTAL)
+	private long getMemorySegmentsTotal() {
+		return this.shuffleMemorySegmentsTotal;
 	}
 
 	@Override
@@ -174,14 +265,18 @@ public class TaskManagerMetricsInfo {
 			mappedCount == that.mappedCount &&
 			mappedUsed == that.mappedUsed &&
 			mappedMax == that.mappedMax &&
-			memorySegmentsAvailable == that.memorySegmentsAvailable &&
-			memorySegmentsTotal == that.memorySegmentsTotal &&
+			shuffleMemorySegmentsAvailable == that.shuffleMemorySegmentsAvailable &&
+			shuffleMemorySegmentsUsed == that.shuffleMemorySegmentsUsed &&
+			shuffleMemorySegmentsTotal == that.shuffleMemorySegmentsTotal &&
+			shuffleMemoryAvailable == that.shuffleMemoryAvailable &&
+			shuffleMemoryUsed == that.shuffleMemoryUsed &&
+			shuffleMemoryTotal == that.shuffleMemoryTotal &&
 			Objects.equals(garbageCollectorsInfo, that.garbageCollectorsInfo);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(heapUsed, heapCommitted, heapMax, nonHeapUsed, nonHeapCommitted, nonHeapMax, directCount, directUsed, directMax, mappedCount, mappedUsed, mappedMax, memorySegmentsAvailable, memorySegmentsTotal, garbageCollectorsInfo);
+		return Objects.hash(heapUsed, heapCommitted, heapMax, nonHeapUsed, nonHeapCommitted, nonHeapMax, directCount, directUsed, directMax, mappedCount, mappedUsed, mappedMax, shuffleMemorySegmentsAvailable, shuffleMemorySegmentsUsed, shuffleMemorySegmentsTotal, shuffleMemoryAvailable, shuffleMemoryUsed, shuffleMemoryTotal, garbageCollectorsInfo);
 	}
 
 	/**
@@ -236,6 +331,12 @@ public class TaskManagerMetricsInfo {
 
 	public static TaskManagerMetricsInfo empty() {
 		return new TaskManagerMetricsInfo(
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
 			0L,
 			0L,
 			0L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -102,6 +102,8 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
 	private volatile Function<ResourceID, CompletableFuture<Collection<LogInfo>>> requestTaskManagerLogListFunction;
 
+	private volatile Function<ResourceID, CompletableFuture<TaskManagerInfo>> requestTaskManagerInfoFunction;
+
 	private volatile Function<ResourceID, CompletableFuture<ThreadDumpInfo>> requestThreadDumpFunction;
 
 	public TestingResourceManagerGateway() {
@@ -164,6 +166,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
 	public void setRequestTaskManagerLogListFunction(Function<ResourceID, CompletableFuture<Collection<LogInfo>>> requestTaskManagerLogListFunction) {
 		this.requestTaskManagerLogListFunction = requestTaskManagerLogListFunction;
+	}
+
+	public void setRequestTaskManagerInfoFunction(Function<ResourceID, CompletableFuture<TaskManagerInfo>> requestTaskManagerInfoFunction) {
+		this.requestTaskManagerInfoFunction = requestTaskManagerInfoFunction;
 	}
 
 	public void setDisconnectTaskExecutorConsumer(Consumer<Tuple2<ResourceID, Throwable>> disconnectTaskExecutorConsumer) {
@@ -313,7 +319,13 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
 	@Override
 	public CompletableFuture<TaskManagerInfo> requestTaskManagerInfo(ResourceID resourceId, Time timeout) {
-		return FutureUtils.completedExceptionally(new UnsupportedOperationException("Not yet implemented"));
+		final Function<ResourceID, CompletableFuture<TaskManagerInfo>> function = requestTaskManagerInfoFunction;
+
+		if (function != null) {
+			return function.apply(resourceId);
+		} else {
+			return FutureUtils.completedExceptionally(new IllegalStateException("No requestTaskManagerInfoFunction was set."));
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.taskmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.metrics.dump.MetricDump;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsInfo;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerFileMessageParameters;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMetricsInfo;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests the {@link TaskManagerDetailsHandler} implementation.
+ */
+public class TaskManagerDetailsHandlerTest extends TestLogger {
+
+	private static final ResourceID TASK_MANAGER_ID = ResourceID.generate();
+
+	private TestingResourceManagerGateway resourceManagerGateway;
+	private MetricFetcher metricFetcher;
+
+	private TaskManagerDetailsHandler testInstance;
+
+	@Before
+	public void setup() throws HandlerRequestException {
+		resourceManagerGateway = new TestingResourceManagerGateway();
+		metricFetcher = new TestingMetricFetcher();
+
+		testInstance = new TaskManagerDetailsHandler(
+			() -> CompletableFuture.completedFuture(null),
+			TestingUtils.TIMEOUT(),
+			Collections.emptyMap(),
+			TaskManagerDetailsHeaders.getInstance(),
+			() -> CompletableFuture.completedFuture(resourceManagerGateway),
+			metricFetcher
+		);
+	}
+
+	@Test
+	public void testTaskManagerMetricsInfoExtraction() throws RestHandlerException, ExecutionException, InterruptedException, JsonProcessingException, HandlerRequestException {
+		initializeMetricStore(metricFetcher.getMetricStore());
+		resourceManagerGateway.setRequestTaskManagerInfoFunction(taskManagerId -> CompletableFuture.completedFuture(createEmptyTaskManagerInfo()));
+
+		HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> request = createRequest();
+		TaskManagerDetailsInfo taskManagerDetailsInfo = testInstance.handleRequest(request, resourceManagerGateway).get();
+
+		TaskManagerMetricsInfo actual = taskManagerDetailsInfo.getTaskManagerMetricsInfo();
+		TaskManagerMetricsInfo expected = new TaskManagerMetricsInfo(
+			1L,
+			2L,
+			3L,
+			4L,
+			5L,
+			6L,
+			7L,
+			8L,
+			9L,
+			10L,
+			11L,
+			12L,
+			15L,
+			16L,
+			17L,
+			18L,
+			19L,
+			20L,
+			Collections.emptyList()
+		);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		String actualJson = objectMapper.writeValueAsString(actual);
+		String expectedJson = objectMapper.writeValueAsString(expected);
+
+		assertThat(actualJson, is(expectedJson));
+	}
+
+	private static void initializeMetricStore(MetricStore metricStore) {
+		QueryScopeInfo.TaskManagerQueryScopeInfo tmScope = new QueryScopeInfo.TaskManagerQueryScopeInfo(TASK_MANAGER_ID.toString(), "Status");
+
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Heap.Used", 1));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Heap.Committed", 2));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Heap.Max", 3));
+
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.NonHeap.Used", 4));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.NonHeap.Committed", 5));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.NonHeap.Max", 6));
+
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Direct.Count", 7));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Direct.MemoryUsed", 8));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Direct.TotalCapacity", 9));
+
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Mapped.Count", 10));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Mapped.MemoryUsed", 11));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "JVM.Memory.Mapped.TotalCapacity", 12));
+
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Network.AvailableMemorySegments", 13));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Network.TotalMemorySegments", 14));
+
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Shuffle.Netty.AvailableMemorySegments", 15));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Shuffle.Netty.UsedMemorySegments", 16));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Shuffle.Netty.TotalMemorySegments", 17));
+
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Shuffle.Netty.AvailableMemory", 18));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Shuffle.Netty.UsedMemory", 19));
+		metricStore.add(new MetricDump.CounterDump(tmScope, "Shuffle.Netty.TotalMemory", 20));
+	}
+
+	private static TaskManagerInfo createEmptyTaskManagerInfo() {
+		return new TaskManagerInfo(
+			TASK_MANAGER_ID,
+			UUID.randomUUID().toString(),
+			0,
+			0L,
+			0,
+			0,
+			ResourceProfile.ZERO,
+			ResourceProfile.ZERO,
+			new HardwareDescription(
+				0,
+				0L,
+				0L,
+				0L),
+			new TaskExecutorMemoryConfiguration(
+				0L,
+				0L,
+				0L,
+				0L,
+				0L,
+				0L,
+				0L,
+				0L,
+				0L,
+				0L));
+	}
+
+	private static HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> createRequest() throws HandlerRequestException {
+		Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(TaskManagerIdPathParameter.KEY, TASK_MANAGER_ID.toString());
+
+		return new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new TaskManagerFileMessageParameters(),
+			pathParameters,
+			Collections.emptyMap()
+		);
+	}
+
+	private static class TestingMetricFetcher implements MetricFetcher {
+
+		private final MetricStore metricStore = new MetricStore();
+
+		@Override
+		public MetricStore getMetricStore() {
+			return metricStore;
+		}
+
+		@Override
+		public void update() {
+			// nothing to do
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfoTest.java
@@ -65,6 +65,10 @@ public class TaskManagerDetailsInfoTest extends RestResponseMarshallingTestBase<
 			random.nextLong(),
 			random.nextLong(),
 			random.nextLong(),
+			random.nextLong(),
+			random.nextLong(),
+			random.nextLong(),
+			random.nextLong(),
 			garbageCollectorsInfo);
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

The goal is to expose network memory usage to Flink's web UI.

## Brief change log

* The `NetworkBufferPool` got extended to also expose memory information and the used memory segment count.
  * `NetworkBufferPool::getTotalNumberOfMemorySegments` was adapted to return `0` in case the BufferPool was destroyed.
* The `NettyShuffleMetricFactory` was extended to expose the newly introduced properties.
* The `TaskManagerDetailsHandler` is forwarding the new metrics to the REST API endpoint.

## Verifying this change

This change added tests and can be verified as follows:
* `NetworkBufferPoolTest` was extended

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
