### PR TITLE
[FLINK-19022][runtime]Register the TerminationFuture of ResourceManager and Dispatcher with DispatcherResourceManagerComponent

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -202,8 +202,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 	public void onStart() throws Exception {
 		try {
 			startDispatcherServices();
-		} catch (Exception e) {
-			final DispatcherException exception = new DispatcherException(String.format("Could not start the Dispatcher %s", getAddress()), e);
+		} catch (Throwable t) {
+			final DispatcherException exception = new DispatcherException(String.format("Could not start the Dispatcher %s", getAddress()), t);
 			onFatalError(exception);
 			throw exception;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/AbstractDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/AbstractDispatcherLeaderProcess.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.util.AutoCloseableAsync;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -177,6 +178,16 @@ public abstract class AbstractDispatcherLeaderProcess implements DispatcherLeade
 		dispatcherService = createdDispatcherService;
 		dispatcherGatewayFuture.complete(createdDispatcherService.getGateway());
 		FutureUtils.forward(createdDispatcherService.getShutDownFuture(), shutDownFuture);
+		handleUnexpectedDispatcherServiceTermination(createdDispatcherService);
+	}
+
+	private void handleUnexpectedDispatcherServiceTermination(DispatcherGatewayService createdDispatcherService) {
+		createdDispatcherService.getTerminationFuture().whenComplete(
+				(ignored, throwable) -> {
+					runIfStateIs(State.RUNNING, () -> {
+						handleError(new FlinkException("Unexpected termination of DispatcherService.", throwable));
+					});
+				});
 	}
 
 	final <V> Optional<V> supplyUnsynchronizedIfRunning(Supplier<V> supplier) {
@@ -225,11 +236,15 @@ public abstract class AbstractDispatcherLeaderProcess implements DispatcherLeade
 		}
 
 		if (throwable != null) {
-			closeAsync();
-			fatalErrorHandler.onFatalError(throwable);
+			handleError(throwable);
 		}
 
 		return null;
+	}
+
+	private void handleError(Throwable throwable) {
+		closeAsync();
+		fatalErrorHandler.onFatalError(throwable);
 	}
 
 	/**
@@ -264,5 +279,7 @@ public abstract class AbstractDispatcherLeaderProcess implements DispatcherLeade
 		CompletableFuture<Void> onRemovedJobGraph(JobID jobId);
 
 		CompletableFuture<ApplicationStatus> getShutDownFuture();
+
+		CompletableFuture<Void> getTerminationFuture();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/AbstractDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/AbstractDispatcherLeaderProcess.java
@@ -139,6 +139,8 @@ public abstract class AbstractDispatcherLeaderProcess implements DispatcherLeade
 	private void closeInternal() {
 		log.info("Stopping {}.", getClass().getSimpleName());
 
+		state = State.STOPPED;
+
 		final CompletableFuture<Void> dispatcherServiceTerminationFuture = closeDispatcherService();
 
 		final CompletableFuture<Void> onCloseTerminationFuture = FutureUtils.composeAfterwards(
@@ -148,8 +150,6 @@ public abstract class AbstractDispatcherLeaderProcess implements DispatcherLeade
 		FutureUtils.forward(
 			onCloseTerminationFuture,
 			this.terminationFuture);
-
-		state = State.STOPPED;
 	}
 
 	private CompletableFuture<Void> closeDispatcherService() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherGatewayService.java
@@ -56,6 +56,11 @@ public class DefaultDispatcherGatewayService implements AbstractDispatcherLeader
 	}
 
 	@Override
+	public CompletableFuture<Void> getTerminationFuture() {
+		return dispatcher.getTerminationFuture();
+	}
+
+	@Override
 	public CompletableFuture<Void> closeAsync() {
 		return dispatcher.closeAsync();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -212,7 +212,8 @@ public class DefaultDispatcherResourceManagerComponentFactory implements Dispatc
 				DefaultResourceManagerService.createFor(resourceManager),
 				dispatcherLeaderRetrievalService,
 				resourceManagerRetrievalService,
-				webMonitorEndpoint);
+				webMonitorEndpoint,
+				fatalErrorHandler);
 
 		} catch (Exception exception) {
 			// clean up all started components

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -209,7 +209,7 @@ public class DefaultDispatcherResourceManagerComponentFactory implements Dispatc
 
 			return new DispatcherResourceManagerComponent(
 				dispatcherRunner,
-				resourceManager,
+				DefaultResourceManagerService.createFor(resourceManager),
 				dispatcherLeaderRetrievalService,
 				resourceManagerRetrievalService,
 				webMonitorEndpoint);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultResourceManagerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultResourceManagerService.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Default {@link DispatcherResourceManagerComponent.ResourceManagerService} implementation which
+ * uses a {@link ResourceManager} instance.
+ */
+public class DefaultResourceManagerService implements DispatcherResourceManagerComponent.ResourceManagerService {
+
+	private final ResourceManager<?> resourceManager;
+
+	private DefaultResourceManagerService(ResourceManager<?> resourceManager) {
+		this.resourceManager = resourceManager;
+	}
+
+	@Override
+	public ResourceManagerGateway getGateway() {
+		return resourceManager.getSelfGateway(ResourceManagerGateway.class);
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		return resourceManager.closeAsync();
+	}
+
+	public static DefaultResourceManagerService createFor(ResourceManager<?> resourceManager) {
+		return new DefaultResourceManagerService(resourceManager);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultResourceManagerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultResourceManagerService.java
@@ -41,6 +41,11 @@ public class DefaultResourceManagerService implements DispatcherResourceManagerC
 	}
 
 	@Override
+	public CompletableFuture<Void> getTerminationFuture() {
+		return resourceManager.getTerminationFuture();
+	}
+
+	@Override
 	public CompletableFuture<Void> closeAsync() {
 		return resourceManager.closeAsync();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
@@ -61,7 +61,7 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
 	private final LeaderRetrievalService resourceManagerRetrievalService;
 
 	@Nonnull
-	private final WebMonitorEndpoint<?> webMonitorEndpoint;
+	private final AutoCloseableAsync webMonitorEndpoint;
 
 	private final CompletableFuture<Void> terminationFuture;
 
@@ -74,7 +74,7 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
 			@Nonnull ResourceManager<?> resourceManager,
 			@Nonnull LeaderRetrievalService dispatcherLeaderRetrievalService,
 			@Nonnull LeaderRetrievalService resourceManagerRetrievalService,
-			@Nonnull WebMonitorEndpoint<?> webMonitorEndpoint) {
+			@Nonnull AutoCloseableAsync webMonitorEndpoint) {
 		this.dispatcherRunner = dispatcherRunner;
 		this.resourceManager = resourceManager;
 		this.dispatcherLeaderRetrievalService = dispatcherLeaderRetrievalService;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -216,8 +216,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	public final void onStart() throws Exception {
 		try {
 			startResourceManagerServices();
-		} catch (Exception e) {
-			final ResourceManagerException exception = new ResourceManagerException(String.format("Could not start the ResourceManager %s", getAddress()), e);
+		} catch (Throwable t) {
+			final ResourceManagerException exception = new ResourceManagerException(String.format("Could not start the ResourceManager %s", getAddress()), t);
 			onFatalError(exception);
 			throw exception;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -127,8 +127,10 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
 		super.postStop();
 
 		if (rpcEndpointTerminationResult.isSuccess()) {
+			log.debug("The RpcEndpoint {} terminated successfully.", rpcEndpoint.getEndpointId());
 			terminationFuture.complete(null);
 		} else {
+			log.info("The RpcEndpoint {} failed.", rpcEndpoint.getEndpointId(), rpcEndpointTerminationResult.getFailureCause());
 			terminationFuture.completeExceptionally(rpcEndpointTerminationResult.getFailureCause());
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -360,8 +360,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	public void onStart() throws Exception {
 		try {
 			startTaskExecutorServices();
-		} catch (Exception e) {
-			final TaskManagerException exception = new TaskManagerException(String.format("Could not start the TaskExecutor %s", getAddress()), e);
+		} catch (Throwable t) {
+			final TaskManagerException exception = new TaskManagerException(String.format("Could not start the TaskExecutor %s", getAddress()), t);
 			onFatalError(exception);
 			throw exception;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToServiceAdapter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToServiceAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Simple adapter for {@link TaskExecutor} to adapt to {@link TaskManagerRunner.TaskExecutorService}.
+ */
+public class TaskExecutorToServiceAdapter implements TaskManagerRunner.TaskExecutorService {
+
+	private final TaskExecutor taskExecutor;
+
+	private TaskExecutorToServiceAdapter(TaskExecutor taskExecutor) {
+		this.taskExecutor = taskExecutor;
+	}
+
+	@Override
+	public void start() {
+		taskExecutor.start();
+	}
+
+	@Override
+	public CompletableFuture<Void> getTerminationFuture() {
+		return taskExecutor.getTerminationFuture();
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		return taskExecutor.closeAsync();
+	}
+
+	public static TaskExecutorToServiceAdapter createFor(TaskExecutor taskExecutor) {
+		return new TaskExecutorToServiceAdapter(taskExecutor);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -67,6 +67,7 @@ import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.TaskManagerExceptionUtils;
 
@@ -121,13 +122,16 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 	/** Executor used to run future callbacks. */
 	private final ExecutorService executor;
 
-	private final TaskExecutor taskManager;
+	private final TaskExecutorService taskExecutorService;
 
 	private final CompletableFuture<Void> terminationFuture;
 
 	private boolean shutdown;
 
-	public TaskManagerRunner(Configuration configuration, PluginManager pluginManager) throws Exception {
+	public TaskManagerRunner(
+			Configuration configuration,
+			PluginManager pluginManager,
+			TaskExecutorServiceFactory taskExecutorServiceFactory) throws Exception {
 		this.configuration = checkNotNull(configuration);
 
 		timeout = AkkaUtils.getTimeoutAsTime(configuration);
@@ -165,7 +169,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 				ExternalResourceUtils.getExternalResourceAmountMap(configuration),
 				ExternalResourceUtils.externalResourceDriversFromConfig(configuration, pluginManager));
 
-		taskManager = startTaskManager(
+		taskExecutorService = taskExecutorServiceFactory.createTaskExecutor(
 			this.configuration,
 			this.resourceId,
 			rpcService,
@@ -179,8 +183,19 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		this.terminationFuture = new CompletableFuture<>();
 		this.shutdown = false;
+		handleUnexpectedTaskExecutorServiceTermination();
 
 		MemoryLogger.startIfConfigured(LOG, configuration, terminationFuture);
+	}
+
+	private void handleUnexpectedTaskExecutorServiceTermination() {
+		taskExecutorService.getTerminationFuture().whenComplete((unused, throwable) -> {
+			synchronized (lock) {
+				if (!shutdown) {
+					onFatalError(new FlinkException("Unexpected termination of the TaskExecutor.", throwable));
+				}
+			}
+		});
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -188,7 +203,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 	// --------------------------------------------------------------------------------------------
 
 	public void start() throws Exception {
-		taskManager.start();
+		taskExecutorService.start();
 	}
 
 	@Override
@@ -197,7 +212,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			if (!shutdown) {
 				shutdown = true;
 
-				final CompletableFuture<Void> taskManagerTerminationFuture = taskManager.closeAsync();
+				final CompletableFuture<Void> taskManagerTerminationFuture = taskExecutorService.closeAsync();
 
 				final CompletableFuture<Void> serviceTerminationFuture = FutureUtils.composeAfterwards(
 					taskManagerTerminationFuture,
@@ -317,7 +332,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 	}
 
 	public static void runTaskManager(Configuration configuration, PluginManager pluginManager) throws Exception {
-		final TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, pluginManager);
+		final TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, pluginManager, TaskManagerRunner::createTaskExecutorService);
 
 		taskManagerRunner.start();
 	}
@@ -349,6 +364,33 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 	// --------------------------------------------------------------------------------------------
 	//  Static utilities
 	// --------------------------------------------------------------------------------------------
+
+	public static TaskExecutorService createTaskExecutorService(
+			Configuration configuration,
+			ResourceID resourceID,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			BlobCacheService blobCacheService,
+			boolean localCommunicationOnly,
+			ExternalResourceInfoProvider externalResourceInfoProvider,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+
+		final TaskExecutor taskExecutor = startTaskManager(
+				configuration,
+				resourceID,
+				rpcService,
+				highAvailabilityServices,
+				heartbeatServices,
+				metricRegistry,
+				blobCacheService,
+				localCommunicationOnly,
+				externalResourceInfoProvider,
+				fatalErrorHandler);
+
+		return TaskExecutorToServiceAdapter.createFor(taskExecutor);
+	}
 
 	public static TaskExecutor startTaskManager(
 			Configuration configuration,
@@ -488,5 +530,28 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 					? InetAddress.getLocalHost().getHostName() + "-" + new AbstractID().toString().substring(0, 6)
 					: rpcAddress + ":" + rpcPort + "-" + new AbstractID().toString().substring(0, 6)),
 			config.getString(TaskManagerOptionsInternal.TASK_MANAGER_RESOURCE_ID_METADATA, ""));
+	}
+
+	/**
+	 * Factory for {@link TaskExecutor}.
+	 */
+	public interface TaskExecutorServiceFactory {
+		TaskExecutorService createTaskExecutor(
+				Configuration configuration,
+				ResourceID resourceID,
+				RpcService rpcService,
+				HighAvailabilityServices highAvailabilityServices,
+				HeartbeatServices heartbeatServices,
+				MetricRegistry metricRegistry,
+				BlobCacheService blobCacheService,
+				boolean localCommunicationOnly,
+				ExternalResourceInfoProvider externalResourceInfoProvider,
+				FatalErrorHandler fatalErrorHandler) throws Exception;
+	}
+
+	public interface TaskExecutorService extends AutoCloseableAsync {
+		void start();
+
+		CompletableFuture<Void> getTerminationFuture();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
@@ -51,6 +52,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.core.testutils.FlinkMatchers.willNotComplete;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -171,6 +174,46 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
 			// verify that we completed the dispatcher leader process shut down
 			terminationFuture.get();
 		}
+	}
+
+	@Test
+	public void unexpectedDispatcherServiceTerminationWhileRunning_callsFatalErrorHandler() {
+		final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		dispatcherServiceFactory = TestingDispatcherServiceFactory.newBuilder()
+				.setCreateFunction((ignoredA, ignoredB, ignoredC) -> TestingDispatcherGatewayService.newBuilder()
+						.setTerminationFuture(terminationFuture)
+						.build())
+				.build();
+		final SessionDispatcherLeaderProcess dispatcherLeaderProcess = createDispatcherLeaderProcess();
+		dispatcherLeaderProcess.start();
+
+		final FlinkException expectedFailure = new FlinkException("Expected test failure.");
+		terminationFuture.completeExceptionally(expectedFailure);
+
+		final Throwable error = fatalErrorHandler.getErrorFuture().join();
+		assertThat(error, containsCause(expectedFailure));
+
+		fatalErrorHandler.clearError();
+	}
+
+	@Test
+	public void unexpectedDispatcherServiceTerminationWhileNotRunning_doesNotCallFatalErrorHandler() {
+		final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		dispatcherServiceFactory = TestingDispatcherServiceFactory.newBuilder()
+				.setCreateFunction((ignoredA, ignoredB, ignoredC) -> TestingDispatcherGatewayService.newBuilder()
+						.setTerminationFuture(terminationFuture)
+						.withManualTerminationFutureCompletion()
+						.build())
+				.build();
+		final SessionDispatcherLeaderProcess dispatcherLeaderProcess = createDispatcherLeaderProcess();
+		dispatcherLeaderProcess.start();
+
+		dispatcherLeaderProcess.closeAsync();
+
+		final FlinkException expectedFailure = new FlinkException("Expected test failure.");
+		terminationFuture.completeExceptionally(expectedFailure);
+
+		assertThat(fatalErrorHandler.getErrorFuture(), willNotComplete(Duration.ofMillis(10)));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -147,7 +147,8 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
 		final CompletableFuture<Void> dispatcherServiceTerminationFuture = new CompletableFuture<>();
 		dispatcherServiceFactory = TestingDispatcherServiceFactory.newBuilder()
 			.setCreateFunction((ignoredA, ignoredB, ignoredC) -> TestingDispatcherGatewayService.newBuilder()
-				.setTerminationFutureSupplier(() -> dispatcherServiceTerminationFuture)
+				.setTerminationFuture(dispatcherServiceTerminationFuture)
+				.withManualTerminationFutureCompletion()
 				.build())
 			.build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/TestingDispatcherRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/TestingDispatcherRunner.java
@@ -52,6 +52,9 @@ public class TestingDispatcherRunner implements DispatcherRunner {
 		return new Builder();
 	}
 
+	/**
+	 * Builder for {@link TestingDispatcherRunner}.
+	 */
 	public static final class Builder {
 		private CompletableFuture<ApplicationStatus> shutDownFuture = new CompletableFuture<>();
 		private Supplier<CompletableFuture<Void>> closeAsyncSupplier = FutureUtils::completedVoidFuture;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/TestingDispatcherRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/TestingDispatcherRunner.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.runner;
+
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * Testing implementation of {@link DispatcherRunner}.
+ */
+public class TestingDispatcherRunner implements DispatcherRunner {
+	private final CompletableFuture<ApplicationStatus> shutDownFuture;
+	private final Supplier<CompletableFuture<Void>> closeAsyncSupplier;
+
+	private TestingDispatcherRunner(
+			CompletableFuture<ApplicationStatus> shutDownFuture,
+			Supplier<CompletableFuture<Void>> closeAsyncSupplier) {
+		this.shutDownFuture = shutDownFuture;
+		this.closeAsyncSupplier = closeAsyncSupplier;
+	}
+
+	@Override
+	public CompletableFuture<ApplicationStatus> getShutDownFuture() {
+		return shutDownFuture;
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		return closeAsyncSupplier.get();
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private CompletableFuture<ApplicationStatus> shutDownFuture = new CompletableFuture<>();
+		private Supplier<CompletableFuture<Void>> closeAsyncSupplier = FutureUtils::completedVoidFuture;
+
+		public Builder setCloseAsyncSupplier(Supplier<CompletableFuture<Void>> closeAsyncSupplier) {
+			this.closeAsyncSupplier = closeAsyncSupplier;
+			return this;
+		}
+
+		public Builder setShutDownFuture(CompletableFuture<ApplicationStatus> shutDownFuture) {
+			this.shutDownFuture = shutDownFuture;
+			return this;
+		}
+
+		public TestingDispatcherRunner build() {
+			return new TestingDispatcherRunner(
+					shutDownFuture,
+					closeAsyncSupplier);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentTest.java
@@ -62,10 +62,10 @@ public class DispatcherResourceManagerComponentTest extends TestLogger {
 			TestingFatalErrorHandler fatalErrorHandler,
 			TestingResourceManagerService resourceManagerService) {
 		return new DispatcherResourceManagerComponent(
-			TestingDispatcherRunner.newBuilder().build(),
+				TestingDispatcherRunner.newBuilder().build(),
 				resourceManagerService,
-			new SettableLeaderRetrievalService(),
-			new SettableLeaderRetrievalService(),
+				new SettableLeaderRetrievalService(),
+				new SettableLeaderRetrievalService(),
 				FutureUtils::completedVoidFuture,
 				fatalErrorHandler);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.dispatcher.runner.TestingDispatcherRunner;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.core.testutils.FlinkMatchers.willNotComplete;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link DispatcherResourceManagerComponent}.
+ */
+public class DispatcherResourceManagerComponentTest extends TestLogger {
+
+	@Test
+	public void unexpectedResourceManagerTermination_failsFatally() {
+		final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+		final TestingResourceManagerService resourceManagerService = TestingResourceManagerService
+			.newBuilder()
+			.setTerminationFuture(terminationFuture)
+			.build();
+
+		createDispatcherResourceManagerComponent(fatalErrorHandler, resourceManagerService);
+
+		final FlinkException expectedException = new FlinkException("Expected test exception.");
+
+		terminationFuture.completeExceptionally(expectedException);
+
+		final Throwable error = fatalErrorHandler.getException();
+		assertThat(error, containsCause(expectedException));
+	}
+
+	private DispatcherResourceManagerComponent createDispatcherResourceManagerComponent(
+			TestingFatalErrorHandler fatalErrorHandler,
+			TestingResourceManagerService resourceManagerService) {
+		return new DispatcherResourceManagerComponent(
+			TestingDispatcherRunner.newBuilder().build(),
+				resourceManagerService,
+			new SettableLeaderRetrievalService(),
+			new SettableLeaderRetrievalService(),
+				FutureUtils::completedVoidFuture,
+				fatalErrorHandler);
+	}
+
+	@Test
+	public void unexpectedResourceManagerTermination_ifNotRunning_doesNotFailFatally() {
+		final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+		final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		final TestingResourceManagerService resourceManagerService = TestingResourceManagerService
+				.newBuilder()
+				.setTerminationFuture(terminationFuture)
+				.withManualTerminationFutureCompletion()
+				.build();
+
+		final DispatcherResourceManagerComponent dispatcherResourceManagerComponent = createDispatcherResourceManagerComponent(
+				fatalErrorHandler,
+				resourceManagerService);
+
+		dispatcherResourceManagerComponent.closeAsync();
+
+		final FlinkException expectedException = new FlinkException("Expected test exception.");
+		terminationFuture.completeExceptionally(expectedException);
+
+		final CompletableFuture<Throwable> errorFuture = fatalErrorHandler.getErrorFuture();
+		assertThat(errorFuture, willNotComplete(Duration.ofMillis(10L)));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/TestingResourceManagerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/TestingResourceManagerService.java
@@ -63,6 +63,9 @@ public class TestingResourceManagerService implements DispatcherResourceManagerC
 		return new Builder();
 	}
 
+	/**
+	 * Builder for {@link TestingResourceManagerService}.
+	 */
 	public static final class Builder {
 		private ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 		private CompletableFuture<Void> terminationFuture = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/TestingResourceManagerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/TestingResourceManagerService.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.component;
+
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Testing implementation of {@link DispatcherResourceManagerComponent.ResourceManagerService}.
+ */
+public class TestingResourceManagerService implements DispatcherResourceManagerComponent.ResourceManagerService {
+	private final ResourceManagerGateway resourceManagerGateway;
+
+	private final CompletableFuture<Void> terminationFuture;
+	private final boolean completeTerminationFutureOnClose;
+
+	private TestingResourceManagerService(
+			ResourceManagerGateway resourceManagerGateway,
+			CompletableFuture<Void> terminationFuture,
+			boolean completeTerminationFutureOnClose) {
+		this.resourceManagerGateway = resourceManagerGateway;
+		this.terminationFuture = terminationFuture;
+		this.completeTerminationFutureOnClose = completeTerminationFutureOnClose;
+	}
+
+	@Override
+	public ResourceManagerGateway getGateway() {
+		return resourceManagerGateway;
+	}
+
+	@Override
+	public CompletableFuture<Void> getTerminationFuture() {
+		return terminationFuture;
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		if (completeTerminationFutureOnClose) {
+			terminationFuture.complete(null);
+		}
+		return getTerminationFuture();
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
+		private CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		private boolean completeTerminationFutureOnClose = true;
+
+		public Builder setResourceManagerGateway(ResourceManagerGateway resourceManagerGateway) {
+			this.resourceManagerGateway = resourceManagerGateway;
+			return this;
+		}
+
+		public Builder setTerminationFuture(CompletableFuture<Void> terminationFuture) {
+			this.terminationFuture = terminationFuture;
+			return this;
+		}
+
+		public Builder withManualTerminationFutureCompletion() {
+			completeTerminationFutureOnClose = false;
+			return this;
+		}
+
+		public TestingResourceManagerService build() {
+			return new TestingResourceManagerService(resourceManagerGateway, terminationFuture, completeTerminationFutureOnClose);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TimeUtils;
 
@@ -36,7 +37,10 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.net.InetAddress;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.core.testutils.FlinkMatchers.willNotComplete;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -144,6 +148,58 @@ public class TaskManagerRunnerTest extends TestLogger {
 		assertThat(taskManagerResourceID.getResourceIdString(), containsString(InetAddress.getLocalHost().getHostName()));
 	}
 
+	@Test
+	public void testUnexpectedTaskManagerTerminationFailsRunnerFatally() throws Exception {
+		final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		final TestingTaskExecutorService taskExecutorService = TestingTaskExecutorService.newBuilder()
+				.setTerminationFuture(terminationFuture)
+				.build();
+		final TaskManagerRunner taskManagerRunner = createTaskManagerRunner(
+				createConfiguration(),
+				(configuration,
+				resourceID,
+				rpcService,
+				highAvailabilityServices,
+				heartbeatServices,
+				metricRegistry,
+				blobCacheService,
+				localCommunicationOnly,
+				externalResourceInfoProvider,
+				fatalErrorHandler) -> taskExecutorService);
+
+		terminationFuture.completeExceptionally(new FlinkException("Test exception."));
+
+		Integer statusCode = systemExitTrackingSecurityManager.getSystemExitFuture().get();
+		assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
+	}
+
+	@Test
+	public void testUnexpectedTaskManagerTerminationAfterRunnerCloseWillBeIgnored() throws Exception {
+		final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		final TestingTaskExecutorService taskExecutorService = TestingTaskExecutorService.newBuilder()
+				.setTerminationFuture(terminationFuture)
+				.withManualTerminationFutureCompletion()
+				.build();
+		final TaskManagerRunner taskManagerRunner = createTaskManagerRunner(
+				createConfiguration(),
+				(configuration,
+				resourceID,
+				rpcService,
+				highAvailabilityServices,
+				heartbeatServices,
+				metricRegistry,
+				blobCacheService,
+				localCommunicationOnly,
+				externalResourceInfoProvider,
+				fatalErrorHandler) -> taskExecutorService);
+
+		taskManagerRunner.closeAsync();
+
+		terminationFuture.completeExceptionally(new FlinkException("Test exception."));
+
+		assertThat(systemExitTrackingSecurityManager.getSystemExitFuture(), willNotComplete(Duration.ofMillis(10L)));
+	}
+
 	private static Configuration createConfiguration() {
 		final Configuration configuration = new Configuration();
 		configuration.setString(JobManagerOptions.ADDRESS, "localhost");
@@ -152,8 +208,12 @@ public class TaskManagerRunnerTest extends TestLogger {
 	}
 
 	private static TaskManagerRunner createTaskManagerRunner(final Configuration configuration) throws Exception {
+		return createTaskManagerRunner(configuration, TaskManagerRunner::createTaskExecutorService);
+	}
+
+	private static TaskManagerRunner createTaskManagerRunner(final Configuration configuration, TaskManagerRunner.TaskExecutorServiceFactory taskExecutorServiceFactory) throws Exception {
 		final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
-		TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, pluginManager);
+		TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, pluginManager, taskExecutorServiceFactory);
 		taskManagerRunner.start();
 		return taskManagerRunner;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorService.java
@@ -59,6 +59,9 @@ public class TestingTaskExecutorService implements TaskManagerRunner.TaskExecuto
 		return new Builder();
 	}
 
+	/**
+	 * Builder for {@link TestingTaskExecutorService}.
+	 */
 	public static final class Builder {
 		private Runnable startRunnable = () -> {};
 		private CompletableFuture<Void> terminationFuture = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorService.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Testing implementation of {@link TaskManagerRunner.TaskExecutorService}.
+ */
+public class TestingTaskExecutorService implements TaskManagerRunner.TaskExecutorService {
+	private final Runnable startRunnable;
+	private final CompletableFuture<Void> terminationFuture;
+	private final boolean completeTerminationFutureOnClose;
+
+	private TestingTaskExecutorService(
+			Runnable startRunnable,
+			CompletableFuture<Void> terminationFuture,
+			boolean completeTerminationFutureOnClose) {
+		this.startRunnable = startRunnable;
+		this.terminationFuture = terminationFuture;
+		this.completeTerminationFutureOnClose = completeTerminationFutureOnClose;
+	}
+
+	@Override
+	public void start() {
+		startRunnable.run();
+	}
+
+	@Override
+	public CompletableFuture<Void> getTerminationFuture() {
+		return terminationFuture;
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		if (completeTerminationFutureOnClose) {
+			terminationFuture.complete(null);
+		}
+		return terminationFuture;
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private Runnable startRunnable = () -> {};
+		private CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		private boolean completeTerminationFutureOnClose = true;
+
+		public Builder setStartRunnable(Runnable startRunnable) {
+			this.startRunnable = startRunnable;
+			return this;
+		}
+
+		public Builder setTerminationFuture(CompletableFuture<Void> terminationFuture) {
+			this.terminationFuture = terminationFuture;
+			return this;
+		}
+
+		public Builder withManualTerminationFutureCompletion() {
+			completeTerminationFutureOnClose = false;
+			return this;
+		}
+
+		TestingTaskExecutorService build() {
+			return new TestingTaskExecutorService(
+					startRunnable,
+					terminationFuture,
+					completeTerminationFutureOnClose);
+		}
+	}
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkMatchers.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkMatchers.java
@@ -89,6 +89,13 @@ public class FlinkMatchers {
 		return new ContainsCauseMatcher(failureCause);
 	}
 
+	/**
+	 * Checks that a {@link CompletableFuture} won't complete within the given timeout.
+	 */
+	public static Matcher<CompletableFuture<?>> willNotComplete(Duration timeout) {
+		return new WillNotCompleteMatcher(timeout);
+	}
+
 	// ------------------------------------------------------------------------
 
 	/** This class should not be instantiated. */
@@ -265,6 +272,43 @@ public class FlinkMatchers {
 			}
 
 			return Optional.empty();
+		}
+	}
+
+	private static final class WillNotCompleteMatcher extends TypeSafeDiagnosingMatcher<CompletableFuture<?>> {
+
+		private final Duration timeout;
+
+		private WillNotCompleteMatcher(Duration timeout) {
+			this.timeout = timeout;
+		}
+
+		@Override
+		protected boolean matchesSafely(
+				CompletableFuture<?> item,
+				Description mismatchDescription) {
+
+			try {
+				final Object value = item.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+				mismatchDescription.appendText("The given future completed with ")
+						.appendValue(value);
+			} catch (TimeoutException timeoutException) {
+				return true;
+			} catch (InterruptedException e) {
+				mismatchDescription.appendText("The waiting thread was interrupted.");
+			} catch (ExecutionException e) {
+				mismatchDescription.appendText("The given future was completed exceptionally: ")
+						.appendValue(e);
+			}
+
+			return false;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("The given future should not complete within ")
+					.appendValue(timeout.toMillis())
+					.appendText(" ms.");
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -273,7 +273,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 			final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(config);
 			// Start the task manager process
 			for (int i = 0; i < numberOfTaskManagers; i++) {
-				taskManagerRunners[i] = new TaskManagerRunner(config, pluginManager);
+				taskManagerRunners[i] = new TaskManagerRunner(config, pluginManager, TaskManagerRunner::createTaskExecutorService);
 				taskManagerRunners[i].start();
 			}
 


### PR DESCRIPTION
## What is the purpose of the change

Help analyze the cause of the abnormality and exit the program normally

## Brief change log

1. add log when RpcEndpoint start/stop failed.
2.Register the TerminationFuture of ResourceManager and Dispatcher with DispatcherResourceManagerComponent.

## Verifying this change

no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
