### PR TITLE
[FLINK-14870] Remove nullable assumption of task slot sharing group

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -512,16 +512,10 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		final SlotSharingGroup sharingGroup = vertex.getJobVertex().getSlotSharingGroup();
 		final CoLocationConstraint locationConstraint = vertex.getLocationConstraint();
 
-		// sanity check
-		if (locationConstraint != null && sharingGroup == null) {
-			throw new IllegalStateException(
-					"Trying to schedule with co-location constraint but without slot sharing allowed.");
-		}
-
 		// this method only works if the execution is in the state 'CREATED'
 		if (transitionState(CREATED, SCHEDULED)) {
 
-			final SlotSharingGroupId slotSharingGroupId = sharingGroup != null ? sharingGroup.getSlotSharingGroupId() : null;
+			final SlotSharingGroupId slotSharingGroupId = sharingGroup.getSlotSharingGroupId();
 
 			ScheduledUnit toSchedule = locationConstraint == null ?
 					new ScheduledUnit(this, slotSharingGroupId) :

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -72,6 +72,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * An {@code ExecutionJobVertex} is part of the {@link ExecutionGraph}, and the peer
  * to the {@link JobVertex}.
@@ -188,13 +190,8 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		this.inputs = new ArrayList<>(jobVertex.getInputs().size());
 
 		// take the sharing group
-		this.slotSharingGroup = jobVertex.getSlotSharingGroup();
+		this.slotSharingGroup = checkNotNull(jobVertex.getSlotSharingGroup());
 		this.coLocationGroup = jobVertex.getCoLocationGroup();
-
-		// setup the coLocation group
-		if (coLocationGroup != null && slotSharingGroup == null) {
-			throw new JobException("Vertex uses a co-location constraint without using slot sharing");
-		}
 
 		// create the intermediate results
 		this.producedDataSets = new IntermediateResult[jobVertex.getNumberOfProducedIntermediateDataSets()];
@@ -359,7 +356,6 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		return splitAssigner;
 	}
 
-	@Nullable
 	public SlotSharingGroup getSlotSharingGroup() {
 		return slotSharingGroup;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -102,6 +102,7 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 
 	private final SlotSharingGroup slotSharingGroup;
 
+	@Nullable
 	private final CoLocationGroup coLocationGroup;
 
 	private final InputSplit[] inputSplits;
@@ -363,6 +364,7 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		return slotSharingGroup;
 	}
 
+	@Nullable
 	public CoLocationGroup getCoLocationGroup() {
 		return coLocationGroup;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -103,6 +103,7 @@ public class JobVertex implements java.io.Serializable {
 	private String name;
 
 	/** Optionally, a sharing group that allows subtasks from different job vertices to run concurrently in one slot. */
+	@Nullable
 	private SlotSharingGroup slotSharingGroup;
 
 	/** The group inside which the vertex subtasks share slots. */
@@ -364,25 +365,29 @@ public class JobVertex implements java.io.Serializable {
 	 * @param grp The slot sharing group to associate the vertex with.
 	 */
 	public void setSlotSharingGroup(SlotSharingGroup grp) {
+		checkNotNull(grp);
+
 		if (this.slotSharingGroup != null) {
 			this.slotSharingGroup.removeVertexFromGroup(this.getID(), this.getMinResources());
 		}
 
+		grp.addVertexToGroup(this.getID(), this.getMinResources());
 		this.slotSharingGroup = grp;
-		if (grp != null) {
-			grp.addVertexToGroup(this.getID(), this.getMinResources());
-		}
 	}
 
 	/**
 	 * Gets the slot sharing group that this vertex is associated with. Different vertices in the same
-	 * slot sharing group can run one subtask each in the same slot. If the vertex is not associated with
-	 * a slot sharing group, this method returns {@code null}.
+	 * slot sharing group can run one subtask each in the same slot.
 	 *
-	 * @return The slot sharing group to associate the vertex with, or {@code null}, if not associated with one.
+	 * @return The slot sharing group to associate the vertex with
 	 */
-	@Nullable
 	public SlotSharingGroup getSlotSharingGroup() {
+		if (slotSharingGroup == null) {
+			// create a new slot sharing group for this vertex if it was in no other slot sharing group.
+			// this should only happen in testing cases at the moment because production code path will
+			// always set a value to it before used
+			setSlotSharingGroup(new SlotSharingGroup());
+		}
 		return slotSharingGroup;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -106,6 +106,7 @@ public class JobVertex implements java.io.Serializable {
 	private SlotSharingGroup slotSharingGroup;
 
 	/** The group inside which the vertex subtasks share slots. */
+	@Nullable
 	private CoLocationGroup coLocationGroup;
 
 	/** Optional, the name of the operator, such as 'Flat Map' or 'Join', to be included in the JSON plan. */
@@ -433,6 +434,7 @@ public class JobVertex implements java.io.Serializable {
 		}
 	}
 
+	@Nullable
 	public CoLocationGroup getCoLocationGroup() {
 		return coLocationGroup;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduledUnit.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduledUnit.java
@@ -34,7 +34,6 @@ public class ScheduledUnit {
 
 	private final ExecutionVertexID executionVertexId;
 
-	@Nullable
 	private final SlotSharingGroupId slotSharingGroupId;
 
 	@Nullable
@@ -46,10 +45,10 @@ public class ScheduledUnit {
 	public ScheduledUnit(Execution task) {
 		this(
 			task,
-			null);
+			new SlotSharingGroupId());
 	}
 
-	public ScheduledUnit(Execution task, @Nullable SlotSharingGroupId slotSharingGroupId) {
+	public ScheduledUnit(Execution task, SlotSharingGroupId slotSharingGroupId) {
 		this(
 			task,
 			slotSharingGroupId,
@@ -58,7 +57,7 @@ public class ScheduledUnit {
 
 	public ScheduledUnit(
 			Execution task,
-			@Nullable SlotSharingGroupId slotSharingGroupId,
+			SlotSharingGroupId slotSharingGroupId,
 			@Nullable CoLocationConstraint coLocationConstraint) {
 		this(
 			Preconditions.checkNotNull(task).getVertex().getID(),
@@ -69,7 +68,7 @@ public class ScheduledUnit {
 	@VisibleForTesting
 	public ScheduledUnit(
 			JobVertexID jobVertexId,
-			@Nullable SlotSharingGroupId slotSharingGroupId,
+			SlotSharingGroupId slotSharingGroupId,
 			@Nullable CoLocationConstraint coLocationConstraint) {
 		this(
 			new ExecutionVertexID(jobVertexId, 0),
@@ -79,7 +78,7 @@ public class ScheduledUnit {
 
 	public ScheduledUnit(
 			ExecutionVertexID executionVertexId,
-			@Nullable SlotSharingGroupId slotSharingGroupId,
+			SlotSharingGroupId slotSharingGroupId,
 			@Nullable CoLocationConstraint coLocationConstraint) {
 
 		this.executionVertexId = Preconditions.checkNotNull(executionVertexId);
@@ -98,7 +97,6 @@ public class ScheduledUnit {
 		return executionVertexId.getSubtaskIndex();
 	}
 
-	@Nullable
 	public SlotSharingGroupId getSlotSharingGroupId() {
 		return slotSharingGroupId;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 /**
@@ -155,9 +154,11 @@ public class SchedulerImpl implements Scheduler {
 			ScheduledUnit scheduledUnit,
 			SlotProfile slotProfile,
 			Time allocationTimeout) {
-		CompletableFuture<LogicalSlot> allocationFuture = scheduledUnit.getSlotSharingGroupId() == null ?
-			allocateSingleSlot(slotRequestId, slotProfile, allocationTimeout) :
-			allocateSharedSlot(slotRequestId, scheduledUnit, slotProfile, allocationTimeout);
+		CompletableFuture<LogicalSlot> allocationFuture = allocateSharedSlot(
+			slotRequestId,
+			scheduledUnit,
+			slotProfile,
+			allocationTimeout);
 
 		allocationFuture.whenComplete((LogicalSlot slot, Throwable failure) -> {
 			if (failure != null) {
@@ -197,34 +198,6 @@ public class SchedulerImpl implements Scheduler {
 
 	//---------------------------
 
-	private CompletableFuture<LogicalSlot> allocateSingleSlot(
-			SlotRequestId slotRequestId,
-			SlotProfile slotProfile,
-			@Nullable Time allocationTimeout) {
-
-		Optional<SlotAndLocality> slotAndLocality = tryAllocateFromAvailable(slotRequestId, slotProfile);
-
-		if (slotAndLocality.isPresent()) {
-			// already successful from available
-			try {
-				return CompletableFuture.completedFuture(
-					completeAllocationByAssigningPayload(slotRequestId, slotAndLocality.get()));
-			} catch (FlinkException e) {
-				return FutureUtils.completedExceptionally(e);
-			}
-		} else {
-			// we allocate by requesting a new slot
-			return requestNewAllocatedSlot(slotRequestId, slotProfile, allocationTimeout)
-				.thenApply((PhysicalSlot allocatedSlot) -> {
-					try {
-						return completeAllocationByAssigningPayload(slotRequestId, new SlotAndLocality(allocatedSlot, Locality.UNKNOWN));
-					} catch (FlinkException e) {
-						throw new CompletionException(e);
-					}
-				});
-		}
-	}
-
 	@Nonnull
 	private CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
 			SlotRequestId slotRequestId,
@@ -234,28 +207,6 @@ public class SchedulerImpl implements Scheduler {
 			return slotPool.requestNewAllocatedBatchSlot(slotRequestId, slotProfile.getPhysicalSlotResourceProfile());
 		} else {
 			return slotPool.requestNewAllocatedSlot(slotRequestId, slotProfile.getPhysicalSlotResourceProfile(), allocationTimeout);
-		}
-	}
-
-	@Nonnull
-	private LogicalSlot completeAllocationByAssigningPayload(
-		@Nonnull SlotRequestId slotRequestId,
-		@Nonnull SlotAndLocality slotAndLocality) throws FlinkException {
-
-		final PhysicalSlot allocatedSlot = slotAndLocality.getSlot();
-
-		try {
-			final SingleLogicalSlot singleTaskSlot = SingleLogicalSlot.allocateFromPhysicalSlot(
-				slotRequestId,
-				allocatedSlot,
-				slotAndLocality.getLocality(),
-				this,
-				true);
-			return singleTaskSlot;
-		} catch (Throwable t) {
-			final FlinkException flinkException = new FlinkException(t);
-			slotPool.releaseSlot(slotRequestId, flinkException);
-			throw flinkException;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -44,7 +44,6 @@ public class ExecutionVertexSchedulingRequirements {
 
 	private final ResourceProfile physicalSlotResourceProfile;
 
-	@Nullable
 	private final SlotSharingGroupId slotSharingGroupId;
 
 	@Nullable
@@ -55,13 +54,13 @@ public class ExecutionVertexSchedulingRequirements {
 			@Nullable AllocationID previousAllocationId,
 			ResourceProfile taskResourceProfile,
 			ResourceProfile physicalSlotResourceProfile,
-			@Nullable SlotSharingGroupId slotSharingGroupId,
+			SlotSharingGroupId slotSharingGroupId,
 			@Nullable CoLocationConstraint coLocationConstraint) {
 		this.executionVertexId = checkNotNull(executionVertexId);
 		this.previousAllocationId = previousAllocationId;
 		this.taskResourceProfile = checkNotNull(taskResourceProfile);
 		this.physicalSlotResourceProfile = checkNotNull(physicalSlotResourceProfile);
-		this.slotSharingGroupId = slotSharingGroupId;
+		this.slotSharingGroupId = checkNotNull(slotSharingGroupId);
 		this.coLocationConstraint = coLocationConstraint;
 	}
 
@@ -82,7 +81,6 @@ public class ExecutionVertexSchedulingRequirements {
 		return physicalSlotResourceProfile;
 	}
 
-	@Nullable
 	public SlotSharingGroupId getSlotSharingGroupId() {
 		return slotSharingGroupId;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirementsMapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirementsMapper.java
@@ -43,7 +43,7 @@ public final class ExecutionVertexSchedulingRequirementsMapper {
 			.withPreviousAllocationId(latestPriorAllocation)
 			.withTaskResourceProfile(executionVertex.getResourceProfile())
 			.withPhysicalSlotResourceProfile(getPhysicalSlotResourceProfile(executionVertex))
-			.withSlotSharingGroupId(slotSharingGroup == null ? null : slotSharingGroup.getSlotSharingGroupId())
+			.withSlotSharingGroupId(slotSharingGroup.getSlotSharingGroupId())
 			.withCoLocationConstraint(executionVertex.getLocationConstraint())
 			.build();
 	}
@@ -58,9 +58,7 @@ public final class ExecutionVertexSchedulingRequirementsMapper {
 	 */
 	public static ResourceProfile getPhysicalSlotResourceProfile(final ExecutionVertex executionVertex) {
 		final SlotSharingGroup slotSharingGroup = executionVertex.getJobVertex().getSlotSharingGroup();
-		return slotSharingGroup == null
-			? executionVertex.getResourceProfile()
-			: ResourceProfile.fromResourceSpec(slotSharingGroup.getResourceSpec(), MemorySize.ZERO);
+		return ResourceProfile.fromResourceSpec(slotSharingGroup.getResourceSpec(), MemorySize.ZERO);
 	}
 
 	private ExecutionVertexSchedulingRequirementsMapper() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -32,8 +32,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -89,8 +89,10 @@ public class VertexSlotSharingTest {
 			SlotSharingGroup group1;
 			SlotSharingGroup group2;
 
-			// verify that v1 tasks have no slot sharing group
-			assertNull(eg.getJobVertex(v1.getID()).getSlotSharingGroup());
+			// verify that v1 tasks are not in the same slot sharing group as v2
+			assertNotEquals(
+				eg.getJobVertex(v1.getID()).getSlotSharingGroup(),
+				eg.getJobVertex(v2.getID()).getSlotSharingGroup());
 
 			// v2 and v3 are shared
 			group1 = eg.getJobVertex(v2.getID()).getSlotSharingGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/DummyScheduledUnit.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/DummyScheduledUnit.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmanager.scheduler;
 
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 /**
@@ -27,7 +28,7 @@ public class DummyScheduledUnit extends ScheduledUnit {
 	public DummyScheduledUnit() {
 		super(
 			new JobVertexID(),
-			null,
+			new SlotSharingGroupId(),
 			null);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.TestingComponentMainThreadExecutor;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
@@ -249,7 +250,7 @@ public class SchedulerIsolatedTasksTest extends SchedulerTestBase {
 
 		testingSlotProvider.allocateSlot(
 			new SlotRequestId(),
-			new ScheduledUnit(new JobVertexID(), null, null),
+			new ScheduledUnit(new JobVertexID(), new SlotSharingGroupId(), null),
 			SlotProfile.priorAllocation(
 				taskResourceProfile,
 				physicalSlotResourceProfile,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -161,7 +161,10 @@ public abstract class SchedulerTestBase extends TestLogger {
 
 		public void releaseTaskManager(ResourceID resourceId) {
 			try {
-				supplyInMainThreadExecutor(() -> slotPool.releaseTaskManager(resourceId, null));
+				supplyInMainThreadExecutor(
+					() -> slotPool.releaseTaskManager(
+						resourceId,
+						new Exception("Releasing TaskManager in SlotPool for tests")));
 			} catch (Exception e) {
 				throw new RuntimeException("Should not have happened.", e);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -302,7 +302,9 @@ public class SlotPoolImplTest extends TestLogger {
 
 			logicalSlot.tryAssignPayload(new DummyPayload(releaseFuture));
 
-			slotPool.releaseTaskManager(taskManagerLocation.getResourceID(), null);
+			slotPool.releaseTaskManager(
+				taskManagerLocation.getResourceID(),
+				new Exception("Releasing TaskManager in SlotPool for tests"));
 
 			releaseFuture.get();
 			assertFalse(logicalSlot.isAlive());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSpreadOutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSlotSpreadOutTest.java
@@ -130,7 +130,7 @@ public class SlotPoolSlotSpreadOutTest extends TestLogger {
 	}
 
 	private ScheduledUnit createSimpleSlotRequest() {
-		return new ScheduledUnit(new JobVertexID(), null, null);
+		return new ScheduledUnit(new JobVertexID(), new SlotSharingGroupId(), null);
 	}
 
 	private CompletableFuture<LogicalSlot> allocateSlot(ScheduledUnit scheduledUnit) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocatorTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocatorTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 import java.util.ArrayList;
@@ -36,8 +37,11 @@ class ExecutionSlotAllocatorTestUtils {
 			new ArrayList<>(executionVertexIds.length);
 
 		for (ExecutionVertexID executionVertexId : executionVertexIds) {
-			schedulingRequirements.add(new ExecutionVertexSchedulingRequirements.Builder()
-					.withExecutionVertexId(executionVertexId).build());
+			schedulingRequirements.add(
+				new ExecutionVertexSchedulingRequirements.Builder()
+					.withExecutionVertexId(executionVertexId)
+					.withSlotSharingGroupId(new SlotSharingGroupId())
+					.build());
 		}
 		return schedulingRequirements;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/OneSlotPerExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/OneSlotPerExecutionSlotAllocatorTest.java
@@ -223,6 +223,7 @@ public class OneSlotPerExecutionSlotAllocatorTest extends TestLogger {
 		final List<ExecutionVertexSchedulingRequirements> schedulingRequirements = Collections.singletonList(
 			new ExecutionVertexSchedulingRequirements.Builder()
 				.withExecutionVertexId(new ExecutionVertexID(new JobVertexID(), 0))
+				.withSlotSharingGroupId(new SlotSharingGroupId())
 				.withCoLocationConstraint(coLocationConstraint)
 				.build()
 		);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingPayload;
@@ -425,6 +426,7 @@ public class SlotSharingExecutionSlotAllocatorTest {
 				.map(id -> new ExecutionVertexSchedulingRequirements
 					.Builder()
 					.withExecutionVertexId(id)
+					.withSlotSharingGroupId(new SlotSharingGroupId())
 					.build())
 				.collect(Collectors.toList());
 			return allocator.allocateSlotsFor(requirements);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -87,6 +87,7 @@ import java.util.Set;
 
 import static org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -696,12 +697,12 @@ public class StreamingJobGraphGenerator {
 			final JobVertex vertex = entry.getValue();
 			final String slotSharingGroupKey = streamGraph.getStreamNode(entry.getKey()).getSlotSharingGroup();
 
+			checkNotNull(slotSharingGroupKey, "StreamNode slot sharing group must not be null");
+
 			final SlotSharingGroup effectiveSlotSharingGroup;
-			if (slotSharingGroupKey == null) {
-				effectiveSlotSharingGroup = null;
-			} else if (slotSharingGroupKey.equals(StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP)) {
+			if (slotSharingGroupKey.equals(StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP)) {
 				// fallback to the region slot sharing group by default
-				effectiveSlotSharingGroup = vertexRegionSlotSharingGroups.get(vertex.getID());
+				effectiveSlotSharingGroup = checkNotNull(vertexRegionSlotSharingGroups.get(vertex.getID()));
 			} else {
 				effectiveSlotSharingGroup = specifiedSlotSharingGroups.computeIfAbsent(
 					slotSharingGroupKey, k -> new SlotSharingGroup());


### PR DESCRIPTION
## What is the purpose of the change

This PR is to remove the nullable assumption of task slot sharing group.
And as a result it also removes the single logical slot allocation code path which is not used anymore.
It can decrease the maintenance burden and the complexity to develop the scheduler, including pipelined
region scheduler and declarative scheduler.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
