### PR TITLE
[FLINK-15974][python] Support to use the Python UDF directly in the Python Table API

### DIFF
--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -20,8 +20,8 @@ from typing import Union
 from pyflink import add_version_doc
 from pyflink.java_gateway import get_gateway
 from pyflink.table.expression import Expression, _get_java_expression, TimePointUnit
-from pyflink.table.types import _to_java_data_type, DataType
-from pyflink.table.udf import UserDefinedFunctionWrapper
+from pyflink.table.types import _to_java_data_type, DataType, _to_java_type
+from pyflink.table.udf import UserDefinedFunctionWrapper, UserDefinedTableFunctionWrapper
 from pyflink.util.utils import to_jarray
 
 
@@ -538,9 +538,44 @@ def call(f: Union[str, UserDefinedFunctionWrapper], *args) -> Expression:
     :param args: parameters of the user-defined function.
     """
     gateway = get_gateway()
-    return Expression(gateway.jvm.Expressions.call(
-        f if isinstance(f, str) else f.java_user_defined_function(),
-        to_jarray(gateway.jvm.Object, [_get_java_expression(arg) for arg in args])))
+
+    if isinstance(f, str):
+        return Expression(gateway.jvm.Expressions.call(
+            f, to_jarray(gateway.jvm.Object, [_get_java_expression(arg) for arg in args])))
+
+    def get_function_definition(f):
+        if isinstance(f, UserDefinedTableFunctionWrapper):
+            """
+            TypeInference was not supported for TableFunction in the old planner. Use
+            TableFunctionDefinition to work around this issue.
+            """
+            j_result_types = to_jarray(gateway.jvm.TypeInformation,
+                                       [_to_java_type(i) for i in f._result_types])
+            j_result_type = gateway.jvm.org.apache.flink.api.java.typeutils.RowTypeInfo(
+                j_result_types)
+            return gateway.jvm.org.apache.flink.table.functions.TableFunctionDefinition(
+                'f', f.java_user_defined_function(), j_result_type)
+        else:
+            return f.java_user_defined_function()
+
+    expressions_clz = gateway.jvm.Class \
+        .forName('org.apache.flink.table.api.Expressions', False,
+                 get_gateway().jvm.Thread.currentThread().getContextClassLoader())
+    function_definition_clz = gateway.jvm.Class \
+        .forName('org.apache.flink.table.functions.FunctionDefinition', False,
+                 get_gateway().jvm.Thread.currentThread().getContextClassLoader())
+    j_object_array_type = to_jarray(gateway.jvm.Object, []).getClass()
+
+    api_call_method = expressions_clz.getDeclaredMethod(
+        "apiCall",
+        to_jarray(gateway.jvm.Class, [function_definition_clz, j_object_array_type]))
+    api_call_method.setAccessible(True)
+
+    return Expression(api_call_method.invoke(
+        None,
+        to_jarray(gateway.jvm.Object,
+                  [get_function_definition(f),
+                   to_jarray(gateway.jvm.Object, [_get_java_expression(arg) for arg in args])])))
 
 
 _add_version_doc()

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -22,8 +22,7 @@ from pyflink.java_gateway import get_gateway
 from pyflink.table.expression import Expression, _get_java_expression, TimePointUnit
 from pyflink.table.types import _to_java_data_type, DataType, _to_java_type
 from pyflink.table.udf import UserDefinedFunctionWrapper, UserDefinedTableFunctionWrapper
-from pyflink.util.utils import to_jarray
-
+from pyflink.util.utils import to_jarray, load_java_class
 
 __all__ = ['if_then_else', 'lit', 'col', 'range_', 'and_', 'or_', 'UNBOUNDED_ROW',
            'UNBOUNDED_RANGE', 'CURRENT_ROW', 'CURRENT_RANGE', 'current_date', 'current_time',
@@ -558,12 +557,8 @@ def call(f: Union[str, UserDefinedFunctionWrapper], *args) -> Expression:
         else:
             return f.java_user_defined_function()
 
-    expressions_clz = gateway.jvm.Class \
-        .forName('org.apache.flink.table.api.Expressions', False,
-                 get_gateway().jvm.Thread.currentThread().getContextClassLoader())
-    function_definition_clz = gateway.jvm.Class \
-        .forName('org.apache.flink.table.functions.FunctionDefinition', False,
-                 get_gateway().jvm.Thread.currentThread().getContextClassLoader())
+    expressions_clz = load_java_class("org.apache.flink.table.api.Expressions")
+    function_definition_clz = load_java_class('org.apache.flink.table.functions.FunctionDefinition')
     j_object_array_type = to_jarray(gateway.jvm.Object, []).getClass()
 
     api_call_method = expressions_clz.getDeclaredMethod(

--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -21,7 +21,6 @@ import decimal
 import pytz
 
 from pyflink.table import DataTypes, Row
-from pyflink.table import expressions as E
 from pyflink.table.tests.test_udf import SubtractOne
 from pyflink.table.udf import udf
 from pyflink.testing import source_sink_utils
@@ -42,15 +41,10 @@ class PandasUDFITTests(object):
 
     def test_basic_functionality(self):
         # pandas UDF
-        self.t_env.create_temporary_system_function(
-            "add_one",
-            udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function("add", add)
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), udf_type="pandas")
 
         # general Python UDF
-        self.t_env.create_temporary_system_function(
-            "subtract_one", udf(SubtractOne(), DataTypes.BIGINT(), DataTypes.BIGINT()))
+        subtract_one = udf(SubtractOne(), DataTypes.BIGINT(), DataTypes.BIGINT())
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b', 'c', 'd'],
@@ -59,8 +53,8 @@ class PandasUDFITTests(object):
 
         t = self.t_env.from_elements([(1, 2, 3), (2, 5, 6), (3, 1, 9)], ['a', 'b', 'c'])
         exec_insert_table(
-            t.where(E.call('add_one', t.b) <= 3)
-             .select("a, b + 1, add(a + 1, subtract_one(c)) + 2, add(add_one(a), 1L)"),
+            t.where(add_one(t.b) <= 3)
+             .select(t.a, t.b + 1, add(t.a + 1, subtract_one(t.c)) + 2, add(add_one(t.a), 1)),
             "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1,3,6,3", "3,2,14,5"])
@@ -69,12 +63,14 @@ class PandasUDFITTests(object):
         import pandas as pd
         import numpy as np
 
+        @udf(result_type=DataTypes.TINYINT(), udf_type="pandas")
         def tinyint_func(tinyint_param):
             assert isinstance(tinyint_param, pd.Series)
             assert isinstance(tinyint_param[0], np.int8), \
                 'tinyint_param of wrong type %s !' % type(tinyint_param[0])
             return tinyint_param
 
+        @udf(result_type=DataTypes.SMALLINT(), udf_type="pandas")
         def smallint_func(smallint_param):
             assert isinstance(smallint_param, pd.Series)
             assert isinstance(smallint_param[0], np.int16), \
@@ -82,6 +78,7 @@ class PandasUDFITTests(object):
             assert smallint_param[0] == 32767, 'smallint_param of wrong value %s' % smallint_param
             return smallint_param
 
+        @udf(result_type=DataTypes.INT(), udf_type="pandas")
         def int_func(int_param):
             assert isinstance(int_param, pd.Series)
             assert isinstance(int_param[0], np.int32), \
@@ -89,54 +86,63 @@ class PandasUDFITTests(object):
             assert int_param[0] == -2147483648, 'int_param of wrong value %s' % int_param
             return int_param
 
+        @udf(result_type=DataTypes.BIGINT(), udf_type="pandas")
         def bigint_func(bigint_param):
             assert isinstance(bigint_param, pd.Series)
             assert isinstance(bigint_param[0], np.int64), \
                 'bigint_param of wrong type %s !' % type(bigint_param[0])
             return bigint_param
 
+        @udf(result_type=DataTypes.BOOLEAN(), udf_type="pandas")
         def boolean_func(boolean_param):
             assert isinstance(boolean_param, pd.Series)
             assert isinstance(boolean_param[0], np.bool_), \
                 'boolean_param of wrong type %s !' % type(boolean_param[0])
             return boolean_param
 
+        @udf(result_type=DataTypes.FLOAT(), udf_type="pandas")
         def float_func(float_param):
             assert isinstance(float_param, pd.Series)
             assert isinstance(float_param[0], np.float32), \
                 'float_param of wrong type %s !' % type(float_param[0])
             return float_param
 
+        @udf(result_type=DataTypes.DOUBLE(), udf_type="pandas")
         def double_func(double_param):
             assert isinstance(double_param, pd.Series)
             assert isinstance(double_param[0], np.float64), \
                 'double_param of wrong type %s !' % type(double_param[0])
             return double_param
 
+        @udf(result_type=DataTypes.STRING(), udf_type="pandas")
         def varchar_func(varchar_param):
             assert isinstance(varchar_param, pd.Series)
             assert isinstance(varchar_param[0], str), \
                 'varchar_param of wrong type %s !' % type(varchar_param[0])
             return varchar_param
 
+        @udf(result_type=DataTypes.BYTES(), udf_type="pandas")
         def varbinary_func(varbinary_param):
             assert isinstance(varbinary_param, pd.Series)
             assert isinstance(varbinary_param[0], bytes), \
                 'varbinary_param of wrong type %s !' % type(varbinary_param[0])
             return varbinary_param
 
+        @udf(result_type=DataTypes.DECIMAL(38, 18), udf_type="pandas")
         def decimal_func(decimal_param):
             assert isinstance(decimal_param, pd.Series)
             assert isinstance(decimal_param[0], decimal.Decimal), \
                 'decimal_param of wrong type %s !' % type(decimal_param[0])
             return decimal_param
 
+        @udf(result_type=DataTypes.DATE(), udf_type="pandas")
         def date_func(date_param):
             assert isinstance(date_param, pd.Series)
             assert isinstance(date_param[0], datetime.date), \
                 'date_param of wrong type %s !' % type(date_param[0])
             return date_param
 
+        @udf(result_type=DataTypes.TIME(), udf_type="pandas")
         def time_func(time_param):
             assert isinstance(time_param, pd.Series)
             assert isinstance(time_param[0], datetime.time), \
@@ -145,6 +151,7 @@ class PandasUDFITTests(object):
 
         timestamp_value = datetime.datetime(1970, 1, 2, 0, 0, 0, 123000)
 
+        @udf(result_type=DataTypes.TIMESTAMP(3), udf_type="pandas")
         def timestamp_func(timestamp_param):
             assert isinstance(timestamp_param, pd.Series)
             assert isinstance(timestamp_param[0], datetime.datetime), \
@@ -160,95 +167,37 @@ class PandasUDFITTests(object):
                 'array_param of wrong type %s !' % type(array_param[0])
             return array_param
 
+        array_str_func = udf(array_func,
+                             result_type=DataTypes.ARRAY(DataTypes.STRING()),
+                             udf_type="pandas")
+
+        array_timestamp_func = udf(array_func,
+                                   result_type=DataTypes.ARRAY(DataTypes.TIMESTAMP(3)),
+                                   udf_type="pandas")
+
+        array_int_func = udf(array_func,
+                             result_type=DataTypes.ARRAY(DataTypes.INT()),
+                             udf_type="pandas")
+
+        @udf(result_type=DataTypes.ARRAY(DataTypes.STRING()), udf_type="pandas")
         def nested_array_func(nested_array_param):
             assert isinstance(nested_array_param, pd.Series)
             assert isinstance(nested_array_param[0], np.ndarray), \
                 'nested_array_param of wrong type %s !' % type(nested_array_param[0])
             return pd.Series(nested_array_param[0])
 
-        def row_func(row_param):
-            assert isinstance(row_param, pd.Series)
-            assert isinstance(row_param[0], dict), \
-                'row_param of wrong type %s !' % type(row_param[0])
-            return row_param
-
-        self.t_env.create_temporary_system_function(
-            "tinyint_func",
-            udf(tinyint_func, result_type=DataTypes.TINYINT(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "smallint_func",
-            udf(smallint_func, result_type=DataTypes.SMALLINT(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "int_func",
-            udf(int_func, result_type=DataTypes.INT(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "bigint_func",
-            udf(bigint_func, result_type=DataTypes.BIGINT(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "boolean_func",
-            udf(boolean_func, result_type=DataTypes.BOOLEAN(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "float_func",
-            udf(float_func, result_type=DataTypes.FLOAT(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "double_func",
-            udf(double_func, result_type=DataTypes.DOUBLE(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "varchar_func",
-            udf(varchar_func, result_type=DataTypes.STRING(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "varbinary_func",
-            udf(varbinary_func, result_type=DataTypes.BYTES(), udf_type="pandas"))
-
-        self.t_env.register_function(
-            "decimal_func",
-            udf(decimal_func, result_type=DataTypes.DECIMAL(38, 18), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "date_func",
-            udf(date_func, result_type=DataTypes.DATE(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "time_func",
-            udf(time_func, result_type=DataTypes.TIME(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "timestamp_func",
-            udf(timestamp_func, result_type=DataTypes.TIMESTAMP(3), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "array_str_func",
-            udf(array_func, result_type=DataTypes.ARRAY(DataTypes.STRING()), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "array_timestamp_func",
-            udf(array_func, result_type=DataTypes.ARRAY(DataTypes.TIMESTAMP(3)), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "array_int_func",
-            udf(array_func, result_type=DataTypes.ARRAY(DataTypes.INT()), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function(
-            "nested_array_func",
-            udf(nested_array_func,
-                result_type=DataTypes.ARRAY(DataTypes.STRING()), udf_type="pandas"))
-
         row_type = DataTypes.ROW(
             [DataTypes.FIELD("f1", DataTypes.INT()),
              DataTypes.FIELD("f2", DataTypes.STRING()),
              DataTypes.FIELD("f3", DataTypes.TIMESTAMP(3)),
              DataTypes.FIELD("f4", DataTypes.ARRAY(DataTypes.INT()))])
-        self.t_env.create_temporary_system_function(
-            "row_func",
-            udf(row_func, result_type=row_type, udf_type="pandas"))
+
+        @udf(result_type=row_type, udf_type="pandas")
+        def row_func(row_param):
+            assert isinstance(row_param, pd.Series)
+            assert isinstance(row_param[0], dict), \
+                'row_param of wrong type %s !' % type(row_param[0])
+            return row_param
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
@@ -292,27 +241,27 @@ class PandasUDFITTests(object):
                  DataTypes.FIELD("t", DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING()))),
                  DataTypes.FIELD("u", row_type)]))
 
-        exec_insert_table(t.select("tinyint_func(a),"
-                                   "smallint_func(b),"
-                                   "int_func(c),"
-                                   "bigint_func(d),"
-                                   "boolean_func(e),"
-                                   "boolean_func(f),"
-                                   "float_func(g),"
-                                   "double_func(h),"
-                                   "varchar_func(i),"
-                                   "varchar_func(j),"
-                                   "varbinary_func(k),"
-                                   "decimal_func(l),"
-                                   "decimal_func(m),"
-                                   "date_func(n),"
-                                   "time_func(o),"
-                                   "timestamp_func(p),"
-                                   "array_str_func(q),"
-                                   "array_timestamp_func(r),"
-                                   "array_int_func(s),"
-                                   "nested_array_func(t),"
-                                   "row_func(u)"), "Results")
+        exec_insert_table(t.select(tinyint_func(t.a),
+                                   smallint_func(t.b),
+                                   int_func(t.c),
+                                   bigint_func(t.d),
+                                   boolean_func(t.e),
+                                   boolean_func(t.f),
+                                   float_func(t.g),
+                                   double_func(t.h),
+                                   varchar_func(t.i),
+                                   varchar_func(t.j),
+                                   varbinary_func(t.k),
+                                   decimal_func(t.l),
+                                   decimal_func(t.m),
+                                   date_func(t.n),
+                                   time_func(t.o),
+                                   timestamp_func(t.p),
+                                   array_str_func(t.q),
+                                   array_timestamp_func(t.r),
+                                   array_int_func(t.s),
+                                   nested_array_func(t.t),
+                                   row_func(t.u)), "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual,
                            ["1,32767,-2147483648,1,true,false,1.0,1.0,hello,中文,"
@@ -331,6 +280,7 @@ class BlinkPandasUDFITTests(object):
         local_datetime = pytz.timezone(timezone).localize(
             datetime.datetime(1970, 1, 2, 0, 0, 0, 123000))
 
+        @udf(result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3), udf_type="pandas")
         def local_zoned_timestamp_func(local_zoned_timestamp_param):
             assert isinstance(local_zoned_timestamp_param, pd.Series)
             assert isinstance(local_zoned_timestamp_param[0], datetime.datetime), \
@@ -341,12 +291,6 @@ class BlinkPandasUDFITTests(object):
                 (local_zoned_timestamp_param[0], local_datetime)
             return local_zoned_timestamp_param
 
-        self.t_env.create_temporary_system_function(
-            "local_zoned_timestamp_func",
-            udf(local_zoned_timestamp_func,
-                result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3),
-                udf_type="pandas"))
-
         table_sink = source_sink_utils.TestAppendSink(
             ['a'], [DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)])
         self.t_env.register_table_sink("Results", table_sink)
@@ -355,7 +299,7 @@ class BlinkPandasUDFITTests(object):
             [(local_datetime,)],
             DataTypes.ROW([DataTypes.FIELD("a", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))]))
 
-        exec_insert_table(t.select("local_zoned_timestamp_func(local_zoned_timestamp_func(a))"),
+        exec_insert_table(t.select(local_zoned_timestamp_func(local_zoned_timestamp_func(t.a))),
                           "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1970-01-02T00:00:00.123Z"])
@@ -369,19 +313,14 @@ class StreamPandasUDFITTests(PandasUDFITTests,
 class BatchPandasUDFITTests(PyFlinkBatchTableTestCase):
 
     def test_basic_functionality(self):
-        self.t_env.create_temporary_system_function(
-            "add_one",
-            udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), udf_type="pandas"))
-
-        self.t_env.create_temporary_system_function("add", add)
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), udf_type="pandas")
 
         # general Python UDF
-        self.t_env.create_temporary_system_function(
-            "subtract_one", udf(SubtractOne(), result_type=DataTypes.BIGINT()))
+        subtract_one = udf(SubtractOne(), result_type=DataTypes.BIGINT())
 
         t = self.t_env.from_elements([(1, 2, 3), (2, 5, 6), (3, 1, 9)], ['a', 'b', 'c'])
-        t = t.where("add_one(b) <= 3") \
-            .select("a, b + 1, add(a + 1, subtract_one(c)) + 2, add(add_one(a), 1L)")
+        t = t.where(add_one(t.b) <= 3) \
+            .select(t.a, t.b + 1, add(t.a + 1, subtract_one(t.c)) + 2, add(add_one(t.a), 1))
         result = self.collect(t)
         self.assert_equals(result, ["1,3,6,3", "3,2,14,5"])
 

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -20,7 +20,7 @@ import unittest
 
 import pytz
 
-from pyflink.table import DataTypes
+from pyflink.table import DataTypes, expressions as expr
 from pyflink.table.udf import ScalarFunction, udf
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
@@ -34,28 +34,21 @@ class UserDefinedFunctionTests(object):
         # test metric disabled.
         self.t_env.get_config().get_configuration().set_string('python.metric.enabled', 'false')
         # test lambda function
-        self.t_env.create_temporary_system_function(
-            "add_one", udf(lambda i: i + 1, result_type=DataTypes.BIGINT()))
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT())
 
         # test Python ScalarFunction
-        self.t_env.create_temporary_system_function(
-            "subtract_one", udf(SubtractOne(), result_type=DataTypes.BIGINT()))
-
-        # test Python function
-        self.t_env.create_temporary_system_function("add", add)
+        subtract_one = udf(SubtractOne(), result_type=DataTypes.BIGINT())
 
         # test callable function
-        self.t_env.create_temporary_system_function(
-            "add_one_callable", udf(CallablePlus(), result_type=DataTypes.BIGINT()))
+        add_one_callable = udf(CallablePlus(), result_type=DataTypes.BIGINT())
 
         def partial_func(col, param):
             return col + param
 
         # test partial function
         import functools
-        self.t_env.create_temporary_system_function(
-            "add_one_partial",
-            udf(functools.partial(partial_func, param=1), result_type=DataTypes.BIGINT()))
+        add_one_partial = udf(functools.partial(partial_func, param=1),
+                              result_type=DataTypes.BIGINT())
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b', 'c', 'd', 'e', 'f'],
@@ -65,19 +58,16 @@ class UserDefinedFunctionTests(object):
 
         t = self.t_env.from_elements([(1, 2, 3), (2, 5, 6), (3, 1, 9)], ['a', 'b', 'c'])
         exec_insert_table(
-            t.where("add_one(b) <= 3").select(
-                "add_one(a), subtract_one(b), add(a, c), add_one_callable(a), "
-                "add_one_partial(a), a"),
+            t.where(add_one(t.b) <= 3).select(
+                add_one(t.a), subtract_one(t.b), add(t.a, t.c), add_one_callable(t.a),
+                add_one_partial(t.a), t.a),
             "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["2,1,4,2,2,1", "4,0,12,4,4,3"])
 
     def test_chaining_scalar_function(self):
-        self.t_env.create_temporary_system_function(
-            "add_one", udf(lambda i: i + 1, result_type=DataTypes.BIGINT()))
-        self.t_env.create_temporary_system_function(
-            "subtract_one", udf(SubtractOne(), result_type=DataTypes.BIGINT()))
-        self.t_env.create_temporary_system_function("add", add)
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT())
+        subtract_one = udf(SubtractOne(), result_type=DataTypes.BIGINT())
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b', 'c'],
@@ -85,7 +75,8 @@ class UserDefinedFunctionTests(object):
         self.t_env.register_table_sink("Results", table_sink)
 
         t = self.t_env.from_elements([(1, 2, 1), (2, 5, 2), (3, 1, 3)], ['a', 'b', 'c'])
-        exec_insert_table(t.select("add(add_one(a), subtract_one(b)), c, 1"), "Results")
+        exec_insert_table(t.select(add(add_one(t.a), subtract_one(t.b)), t.c, expr.lit(1)),
+                          "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["3,1,1", "7,2,1", "4,3,1"])
 
@@ -93,15 +84,14 @@ class UserDefinedFunctionTests(object):
         t1 = self.t_env.from_elements([(2, "Hi")], ['a', 'b'])
         t2 = self.t_env.from_elements([(2, "Flink")], ['c', 'd'])
 
-        self.t_env.create_temporary_system_function("f", udf(lambda i: i,
-                                                             result_type=DataTypes.BIGINT()))
+        f = udf(lambda i: i, result_type=DataTypes.BIGINT())
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b', 'c', 'd'],
             [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.BIGINT(), DataTypes.STRING()])
         self.t_env.register_table_sink("Results", table_sink)
 
-        exec_insert_table(t1.join(t2).where("f(a) = c"), "Results")
+        exec_insert_table(t1.join(t2).where(f(t1.a) == t2.c), "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["2,Hi,2,Flink"])
 
@@ -109,15 +99,14 @@ class UserDefinedFunctionTests(object):
         t1 = self.t_env.from_elements([(1, "Hi"), (2, "Hi")], ['a', 'b'])
         t2 = self.t_env.from_elements([(2, "Flink")], ['c', 'd'])
 
-        self.t_env.create_temporary_system_function("f", udf(lambda i: i,
-                                                             result_type=DataTypes.BIGINT()))
+        f = udf(lambda i: i, result_type=DataTypes.BIGINT())
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b', 'c', 'd'],
             [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.BIGINT(), DataTypes.STRING()])
         self.t_env.register_table_sink("Results", table_sink)
 
-        exec_insert_table(t1.join(t2).where("f(a) = f(c)"), "Results")
+        exec_insert_table(t1.join(t2).where(f(t1.a) == f(t2.c)), "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["2,Hi,2,Flink"])
 
@@ -224,33 +213,207 @@ class UserDefinedFunctionTests(object):
 
     def test_open(self):
         self.t_env.get_config().get_configuration().set_string('python.metric.enabled', 'true')
-        self.t_env.create_temporary_system_function(
-            "subtract", udf(Subtract(), result_type=DataTypes.BIGINT()))
+        subtract = udf(Subtract(), result_type=DataTypes.BIGINT())
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b'], [DataTypes.BIGINT(), DataTypes.BIGINT()])
         self.t_env.register_table_sink("Results", table_sink)
 
         t = self.t_env.from_elements([(1, 2), (2, 5), (3, 4)], ['a', 'b'])
-        exec_insert_table(t.select("a, subtract(b)"), "Results")
+        exec_insert_table(t.select(t.a, subtract(t.b)), "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1,1", "2,4", "3,3"])
 
     def test_udf_without_arguments(self):
-        self.t_env.create_temporary_system_function("one", udf(
-            lambda: 1, result_type=DataTypes.BIGINT(), deterministic=True))
-        self.t_env.create_temporary_system_function("two", udf(
-            lambda: 2, result_type=DataTypes.BIGINT(), deterministic=False))
+        one = udf(lambda: 1, result_type=DataTypes.BIGINT(), deterministic=True)
+        two = udf(lambda: 2, result_type=DataTypes.BIGINT(), deterministic=False)
 
         table_sink = source_sink_utils.TestAppendSink(['a', 'b'],
                                                       [DataTypes.BIGINT(), DataTypes.BIGINT()])
         self.t_env.register_table_sink("Results", table_sink)
 
         t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
-        exec_insert_table(t.select("one(), two()"), "Results")
+        exec_insert_table(t.select(one(), two()), "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1,2", "1,2", "1,2"])
 
+    def test_all_data_types_expression(self):
+
+        @udf(result_type=DataTypes.BOOLEAN())
+        def boolean_func(bool_param):
+            assert isinstance(bool_param, bool), 'bool_param of wrong type %s !' \
+                                                 % type(bool_param)
+            return bool_param
+
+        @udf(result_type=DataTypes.TINYINT())
+        def tinyint_func(tinyint_param):
+            assert isinstance(tinyint_param, int), 'tinyint_param of wrong type %s !' \
+                                                   % type(tinyint_param)
+            return tinyint_param
+
+        @udf(result_type=DataTypes.SMALLINT())
+        def smallint_func(smallint_param):
+            assert isinstance(smallint_param, int), 'smallint_param of wrong type %s !' \
+                                                    % type(smallint_param)
+            assert smallint_param == 32767, 'smallint_param of wrong value %s' % smallint_param
+            return smallint_param
+
+        @udf(result_type=DataTypes.INT())
+        def int_func(int_param):
+            assert isinstance(int_param, int), 'int_param of wrong type %s !' \
+                                               % type(int_param)
+            assert int_param == -2147483648, 'int_param of wrong value %s' % int_param
+            return int_param
+
+        @udf(result_type=DataTypes.BIGINT())
+        def bigint_func(bigint_param):
+            assert isinstance(bigint_param, int), 'bigint_param of wrong type %s !' \
+                                                  % type(bigint_param)
+            return bigint_param
+
+        @udf(result_type=DataTypes.BIGINT())
+        def bigint_func_none(bigint_param):
+            assert bigint_param is None, 'bigint_param %s should be None!' % bigint_param
+            return bigint_param
+
+        @udf(result_type=DataTypes.FLOAT())
+        def float_func(float_param):
+            assert isinstance(float_param, float) and float_equal(float_param, 1.23, 1e-6), \
+                'float_param is wrong value %s !' % float_param
+            return float_param
+
+        @udf(result_type=DataTypes.DOUBLE())
+        def double_func(double_param):
+            assert isinstance(double_param, float) and float_equal(double_param, 1.98932, 1e-7), \
+                'double_param is wrong value %s !' % double_param
+            return double_param
+
+        @udf(result_type=DataTypes.BYTES())
+        def bytes_func(bytes_param):
+            assert bytes_param == b'flink', \
+                'bytes_param is wrong value %s !' % bytes_param
+            return bytes_param
+
+        @udf(result_type=DataTypes.STRING())
+        def str_func(str_param):
+            assert str_param == 'pyflink', \
+                'str_param is wrong value %s !' % str_param
+            return str_param
+
+        @udf(result_type=DataTypes.DATE())
+        def date_func(date_param):
+            from datetime import date
+            assert date_param == date(year=2014, month=9, day=13), \
+                'date_param is wrong value %s !' % date_param
+            return date_param
+
+        @udf(result_type=DataTypes.TIME())
+        def time_func(time_param):
+            from datetime import time
+            assert time_param == time(hour=12, minute=0, second=0, microsecond=123000), \
+                'time_param is wrong value %s !' % time_param
+            return time_param
+
+        @udf(result_type=DataTypes.TIMESTAMP(3))
+        def timestamp_func(timestamp_param):
+            from datetime import datetime
+            assert timestamp_param == datetime(2018, 3, 11, 3, 0, 0, 123000), \
+                'timestamp_param is wrong value %s !' % timestamp_param
+            return timestamp_param
+
+        @udf(result_type=DataTypes.ARRAY(DataTypes.BIGINT()))
+        def array_func(array_param):
+            assert array_param == [[1, 2, 3]], \
+                'array_param is wrong value %s !' % array_param
+            return array_param[0]
+
+        @udf(result_type=DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING()))
+        def map_func(map_param):
+            assert map_param == {1: 'flink', 2: 'pyflink'}, \
+                'map_param is wrong value %s !' % map_param
+            return map_param
+
+        @udf(result_type=DataTypes.DECIMAL(38, 18))
+        def decimal_func(decimal_param):
+            from decimal import Decimal
+            assert decimal_param == Decimal('1000000000000000000.050000000000000000'), \
+                'decimal_param is wrong value %s !' % decimal_param
+            return decimal_param
+
+        @udf(result_type=DataTypes.DECIMAL(38, 18))
+        def decimal_cut_func(decimal_param):
+            from decimal import Decimal
+            assert decimal_param == Decimal('1000000000000000000.059999999999999999'), \
+                'decimal_param is wrong value %s !' % decimal_param
+            return decimal_param
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q'],
+            [DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.TINYINT(),
+             DataTypes.BOOLEAN(), DataTypes.SMALLINT(), DataTypes.INT(),
+             DataTypes.FLOAT(), DataTypes.DOUBLE(), DataTypes.BYTES(),
+             DataTypes.STRING(), DataTypes.DATE(), DataTypes.TIME(),
+             DataTypes.TIMESTAMP(3), DataTypes.ARRAY(DataTypes.BIGINT()),
+             DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING()),
+             DataTypes.DECIMAL(38, 18), DataTypes.DECIMAL(38, 18)])
+        self.t_env.register_table_sink("Results", table_sink)
+
+        import datetime
+        import decimal
+        t = self.t_env.from_elements(
+            [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
+              bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
+              datetime.time(hour=12, minute=0, second=0, microsecond=123000),
+              datetime.datetime(2018, 3, 11, 3, 0, 0, 123000), [[1, 2, 3]],
+              {1: 'flink', 2: 'pyflink'}, decimal.Decimal('1000000000000000000.05'),
+              decimal.Decimal('1000000000000000000.05999999999999999899999999999'))],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.BIGINT()),
+                 DataTypes.FIELD("b", DataTypes.BIGINT()),
+                 DataTypes.FIELD("c", DataTypes.TINYINT()),
+                 DataTypes.FIELD("d", DataTypes.BOOLEAN()),
+                 DataTypes.FIELD("e", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("f", DataTypes.INT()),
+                 DataTypes.FIELD("g", DataTypes.FLOAT()),
+                 DataTypes.FIELD("h", DataTypes.DOUBLE()),
+                 DataTypes.FIELD("i", DataTypes.BYTES()),
+                 DataTypes.FIELD("j", DataTypes.STRING()),
+                 DataTypes.FIELD("k", DataTypes.DATE()),
+                 DataTypes.FIELD("l", DataTypes.TIME()),
+                 DataTypes.FIELD("m", DataTypes.TIMESTAMP(3)),
+                 DataTypes.FIELD("n", DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT()))),
+                 DataTypes.FIELD("o", DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING())),
+                 DataTypes.FIELD("p", DataTypes.DECIMAL(38, 18)),
+                 DataTypes.FIELD("q", DataTypes.DECIMAL(38, 18))]))
+
+        exec_insert_table(t.select(bigint_func(t.a),
+                                   bigint_func_none(t.b),
+                                   tinyint_func(t.c),
+                                   boolean_func(t.d),
+                                   smallint_func(t.e),
+                                   int_func(t.f),
+                                   float_func(t.g),
+                                   double_func(t.h),
+                                   bytes_func(t.i),
+                                   str_func(t.j),
+                                   date_func(t.k),
+                                   time_func(t.l),
+                                   timestamp_func(t.m),
+                                   array_func(t.n),
+                                   map_func(t.o),
+                                   decimal_func(t.p),
+                                   decimal_cut_func(t.q)),
+                          "Results")
+        actual = source_sink_utils.results()
+        # Currently the sink result precision of DataTypes.TIME(precision) only supports 0.
+        self.assert_equals(actual,
+                           ["1,null,1,true,32767,-2147483648,1.23,1.98932,"
+                            "[102, 108, 105, 110, 107],pyflink,2014-09-13,"
+                            "12:00:00,2018-03-11 03:00:00.123,[1, 2, 3],"
+                            "{1=flink, 2=pyflink},1000000000000000000.050000000000000000,"
+                            "1000000000000000000.059999999999999999"])
+
     def test_all_data_types(self):
+
         def boolean_func(bool_param):
             assert isinstance(bool_param, bool), 'bool_param of wrong type %s !' \
                                                  % type(bool_param)
@@ -479,14 +642,11 @@ class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
 class PyFlinkBatchUserDefinedFunctionTests(PyFlinkBatchTableTestCase):
 
     def test_chaining_scalar_function(self):
-        self.t_env.create_temporary_system_function(
-            "add_one", udf(lambda i: i + 1, result_type=DataTypes.BIGINT()))
-        self.t_env.create_temporary_system_function(
-            "subtract_one", udf(SubtractOne(), result_type=DataTypes.BIGINT()))
-        self.t_env.create_temporary_system_function("add", add)
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT())
+        subtract_one = udf(SubtractOne(), result_type=DataTypes.BIGINT())
 
-        t = self.t_env.from_elements([(1, 2, 1), (2, 5, 2), (3, 1, 3)], ['a', 'b', 'c'])\
-            .select("add(add_one(a), subtract_one(b)), c, 1")
+        t = self.t_env.from_elements([(1, 2, 1), (2, 5, 2), (3, 1, 3)], ['a', 'b', 'c'])
+        t = t.select(add(add_one(t.a), subtract_one(t.b)), t.c, expr.lit(1))
 
         result = self.collect(t)
         self.assertEqual(result, ["3,1,1", "7,2,1", "4,3,1"])
@@ -563,15 +723,11 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
         local_datetime = pytz.timezone(timezone).localize(
             datetime.datetime(1970, 1, 1, 0, 0, 0, 123000))
 
+        @udf(result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))
         def local_zoned_timestamp_func(local_zoned_timestamp_param):
             assert local_zoned_timestamp_param == local_datetime, \
                 'local_zoned_timestamp_param is wrong value %s !' % local_zoned_timestamp_param
             return local_zoned_timestamp_param
-
-        self.t_env.create_temporary_system_function(
-            "local_zoned_timestamp_func",
-            udf(local_zoned_timestamp_func,
-                result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)))
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a'], [DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)])
@@ -581,7 +737,7 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
             [(local_datetime,)],
             DataTypes.ROW([DataTypes.FIELD("a", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))]))
 
-        exec_insert_table(t.select("local_zoned_timestamp_func(local_zoned_timestamp_func(a))"),
+        exec_insert_table(t.select(local_zoned_timestamp_func(local_zoned_timestamp_func(t.a))),
                           "Results")
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1970-01-01T00:00:00.123Z"])

--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -31,17 +31,12 @@ class UserDefinedTableFunctionTests(object):
             ['a', 'b', 'c'],
             [DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.BIGINT()])
 
-        self.t_env.register_function(
-            "multi_emit", udtf(MultiEmit(), result_types=[DataTypes.BIGINT(), DataTypes.BIGINT()]))
-
-        self.t_env.register_function("condition_multi_emit", condition_multi_emit)
-
-        self.t_env.register_function(
-            "multi_num", udf(MultiNum(), result_type=DataTypes.BIGINT()))
+        multi_emit = udtf(MultiEmit(), result_types=[DataTypes.BIGINT(), DataTypes.BIGINT()])
+        multi_num = udf(MultiNum(), result_type=DataTypes.BIGINT())
 
         t = self.t_env.from_elements([(1, 1, 3), (2, 1, 6), (3, 2, 9)], ['a', 'b', 'c'])
-        t = t.join_lateral("multi_emit(a, multi_num(b)) as (x, y)") \
-            .left_outer_join_lateral("condition_multi_emit(x, y) as m") \
+        t = t.join_lateral(multi_emit(t.a, multi_num(t.b)).alias('x', 'y'))
+        t = t.left_outer_join_lateral(condition_multi_emit(t.x, t.y).alias('m')) \
             .select("x, y, m")
         actual = self._get_output(t)
         self.assert_equals(actual,

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -22,6 +22,7 @@ import inspect
 
 from pyflink.java_gateway import get_gateway
 from pyflink.metrics import MetricGroup
+from pyflink.table import Expression
 from pyflink.table.types import DataType, _to_java_type
 from pyflink.util import utils
 
@@ -184,7 +185,7 @@ class UserDefinedFunctionWrapper(object):
         self._deterministic = deterministic if deterministic is not None else (
             func.is_deterministic() if isinstance(func, UserDefinedFunction) else True)
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> Expression:
         from pyflink.table import expressions as expr
         return expr.call(self, *args)
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -184,6 +184,10 @@ class UserDefinedFunctionWrapper(object):
         self._deterministic = deterministic if deterministic is not None else (
             func.is_deterministic() if isinstance(func, UserDefinedFunction) else True)
 
+    def __call__(self, *args):
+        from pyflink.table import expressions as expr
+        return expr.call(self, *args)
+
     def java_user_defined_function(self):
         pass
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add support to use the Python UDF directly in the Python Table API. E.g. for Python UDF inc, users could use it directly in the Python Table API: tab.select(inc(tab.a)).insert_into("sink")*

## Brief change log
  - Add __call__ method in **UserDefinedFunctionWrapper** which will allow to call the user-defined function directly in the Python Table API program
  - Improve expressions.call method to support TableFunction in the old planner.
  - Fix FlinkTypeFactory which doesn't works well with the old Decimal TypeInformation in blink planner.
  - Update the tests in test_udf.py, test_udtf.py, test_pandas_udf.py to use this feature.

## Verifying this change

This change is already covered by the updated existing tests test_udf.py, test_pandas_udf.py, etc.*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will add documentation in a separate PR)
