### PR TITLE
[FLINK-19133] Open custom partitioners in KafkaSerializationSchemaWrapper

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaSerializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaSerializationSchemaWrapper.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka.internals;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.streaming.connectors.kafka.KafkaContextAware;
 import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema;
@@ -32,6 +33,7 @@ import javax.annotation.Nullable;
  * {@link org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner} to the
  * {@link KafkaSerializationSchema}.
  */
+@Internal
 public class KafkaSerializationSchemaWrapper<T> implements KafkaSerializationSchema<T>, KafkaContextAware<T> {
 
 	private final FlinkKafkaPartitioner<T> partitioner;
@@ -40,6 +42,8 @@ public class KafkaSerializationSchemaWrapper<T> implements KafkaSerializationSch
 	private boolean writeTimestamp;
 
 	private int[] partitions;
+	private int parallelInstanceId;
+	private int numParallelInstances;
 
 	public KafkaSerializationSchemaWrapper(
 			String topic,
@@ -55,6 +59,9 @@ public class KafkaSerializationSchemaWrapper<T> implements KafkaSerializationSch
 	@Override
 	public void open(SerializationSchema.InitializationContext context) throws Exception {
 		serializationSchema.open(context);
+		if (partitioner != null) {
+			partitioner.open(parallelInstanceId, numParallelInstances);
+		}
 	}
 
 	@Override
@@ -87,6 +94,16 @@ public class KafkaSerializationSchemaWrapper<T> implements KafkaSerializationSch
 	@Override
 	public void setPartitions(int[] partitions) {
 		this.partitions = partitions;
+	}
+
+	@Override
+	public void setParallelInstanceId(int parallelInstanceId) {
+		this.parallelInstanceId = parallelInstanceId;
+	}
+
+	@Override
+	public void setNumParallelInstances(int numParallelInstances) {
+		this.numParallelInstances = numParallelInstances;
 	}
 
 	public void setWriteTimestamp(boolean writeTimestamp) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -792,8 +792,20 @@ public class FlinkKafkaProducer<IN>
 			};
 		}
 
+		RuntimeContext ctx = getRuntimeContext();
+
+		if (flinkKafkaPartitioner != null) {
+			flinkKafkaPartitioner.open(ctx.getIndexOfThisSubtask(), ctx.getNumberOfParallelSubtasks());
+		}
+
+		if (kafkaSchema instanceof KafkaContextAware) {
+			KafkaContextAware<IN> contextAwareSchema = (KafkaContextAware<IN>) kafkaSchema;
+			contextAwareSchema.setParallelInstanceId(ctx.getIndexOfThisSubtask());
+			contextAwareSchema.setNumParallelInstances(ctx.getNumberOfParallelSubtasks());
+		}
+
 		if (kafkaSchema != null) {
-			kafkaSchema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+			kafkaSchema.open(() -> ctx.getMetricGroup().addGroup("user"));
 		}
 
 		super.open(configuration);
@@ -1229,22 +1241,8 @@ public class FlinkKafkaProducer<IN>
 	private FlinkKafkaInternalProducer<byte[], byte[]> initProducer(boolean registerMetrics) {
 		FlinkKafkaInternalProducer<byte[], byte[]> producer = createProducer();
 
-		RuntimeContext ctx = getRuntimeContext();
-
-		if (flinkKafkaPartitioner != null) {
-			flinkKafkaPartitioner.open(ctx.getIndexOfThisSubtask(), ctx.getNumberOfParallelSubtasks());
-		}
-
-		if (kafkaSchema instanceof KafkaContextAware) {
-			KafkaContextAware<IN> contextAwareSchema =
-					(KafkaContextAware<IN>) kafkaSchema;
-
-			contextAwareSchema.setParallelInstanceId(ctx.getIndexOfThisSubtask());
-			contextAwareSchema.setNumParallelInstances(ctx.getNumberOfParallelSubtasks());
-		}
-
 		LOG.info("Starting FlinkKafkaInternalProducer ({}/{}) to produce into default topic {}",
-			ctx.getIndexOfThisSubtask() + 1, ctx.getNumberOfParallelSubtasks(), defaultTopicId);
+			getRuntimeContext().getIndexOfThisSubtask() + 1, getRuntimeContext().getNumberOfParallelSubtasks(), defaultTopicId);
 
 		// register Kafka metrics to Flink accumulators
 		if (registerMetrics && !Boolean.parseBoolean(producerConfig.getProperty(KEY_DISABLE_METRICS, "false"))) {


### PR DESCRIPTION
## What is the purpose of the change

Fix the issue that custom partitioners were not opened.

## Brief change log

  - Moved openning of the partitioner from initProducer to open
  - Call Partitioner#open in KafkaSerializationSchemaWrapper#open


## Verifying this change

Added test FlinkKafkaProducerTest#testOpenKafkaCustomPartitioner

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
