### PR TITLE
[FLINK-19147] Support CliClient AutoClose interface

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -127,16 +127,15 @@ public class SqlClient {
 	 * @param executor executor
 	 */
 	private void openCli(String sessionId, Executor executor) {
-		CliClient cli = null;
-		try {
-			Path historyFilePath;
-			if (options.getHistoryFilePath() != null) {
-				historyFilePath = Paths.get(options.getHistoryFilePath());
-			} else {
-				historyFilePath = Paths.get(System.getProperty("user.home"),
-						SystemUtils.IS_OS_WINDOWS ? "flink-sql-history" : ".flink-sql-history");
-			}
-			cli = new CliClient(sessionId, executor, historyFilePath);
+		Path historyFilePath;
+		if (options.getHistoryFilePath() != null) {
+			historyFilePath = Paths.get(options.getHistoryFilePath());
+		} else {
+			historyFilePath = Paths.get(System.getProperty("user.home"),
+				SystemUtils.IS_OS_WINDOWS ? "flink-sql-history" : ".flink-sql-history");
+		}
+
+		try (CliClient cli = new CliClient(sessionId, executor, historyFilePath)) {
 			// interactive CLI mode
 			if (options.getUpdateStatement() == null) {
 				cli.open();
@@ -147,10 +146,6 @@ public class SqlClient {
 				if (!success) {
 					throw new SqlClientException("Could not submit given SQL update statement to cluster.");
 				}
-			}
-		} finally {
-			if (cli != null) {
-				cli.close();
 			}
 		}
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -60,7 +60,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * SQL CLI client.
  */
-public class CliClient {
+public class CliClient implements AutoCloseable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(CliClient.class);
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -122,16 +122,10 @@ public class CliClientTest extends TestLogger {
 		SessionContext session = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(session);
 
-		CliClient cliClient = null;
-		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream())) {
-			cliClient = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath());
-
-			cliClient.open();
+		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream());
+			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			client.open();
 			assertThat(executor.getNumExecuteSqlCalls(), is(1));
-		} finally {
-			if (cliClient != null) {
-				cliClient.close();
-			}
 		}
 	}
 
@@ -144,18 +138,13 @@ public class CliClientTest extends TestLogger {
 			.build();
 
 		InputStream inputStream = new ByteArrayInputStream("use catalog cat;\n".getBytes());
-		CliClient cliClient = null;
 		SessionContext sessionContext = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(sessionContext);
 
-		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream())) {
-			cliClient = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath());
-			cliClient.open();
+		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream());
+			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			client.open();
 			assertThat(executor.getNumExecuteSqlCalls(), is(1));
-		} finally {
-			if (cliClient != null) {
-				cliClient.close();
-			}
 		}
 	}
 
@@ -166,19 +155,14 @@ public class CliClientTest extends TestLogger {
 		// proctimee() is invalid
 		InputStream inputStream = new ByteArrayInputStream("create table tbl(a int, b as proctimee());\n".getBytes());
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream(256);
-		CliClient cliClient = null;
 		SessionContext sessionContext = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(sessionContext);
 
-		try (Terminal terminal = new DumbTerminal(inputStream, outputStream)) {
-			cliClient = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath());
-			cliClient.open();
+		try (Terminal terminal = new DumbTerminal(inputStream, outputStream);
+			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			client.open();
 			String output = new String(outputStream.toByteArray());
 			assertTrue(output.contains("No match found for function signature proctimee()"));
-		} finally {
-			if (cliClient != null) {
-				cliClient.close();
-			}
 		}
 	}
 
@@ -239,19 +223,14 @@ public class CliClientTest extends TestLogger {
 		String sessionId = mockExecutor.openSession(context);
 
 		InputStream inputStream = new ByteArrayInputStream("help;\nuse catalog cat;\n".getBytes());
-		CliClient cliClient = null;
-		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream())) {
-			Path historyFilePath = File.createTempFile("history", "tmp").toPath();
-			cliClient = new CliClient(terminal, sessionId, mockExecutor, historyFilePath);
-			cliClient.open();
+		Path historyFilePath = File.createTempFile("history", "tmp").toPath();
+		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream());
+			 CliClient client = new CliClient(terminal, sessionId, mockExecutor, historyFilePath)) {
+			client.open();
 			List<String> content = Files.readAllLines(historyFilePath);
 			assertEquals(2, content.size());
 			assertTrue(content.get(0).contains("help"));
 			assertTrue(content.get(1).contains("use catalog cat"));
-		} finally {
-			if (cliClient != null) {
-				cliClient.close();
-			}
 		}
 	}
 
@@ -303,18 +282,13 @@ public class CliClientTest extends TestLogger {
 	private String testExecuteSql(TestingExecutor executor, String sql) throws IOException {
 		InputStream inputStream = new ByteArrayInputStream((sql + "\n").getBytes());
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream(256);
-		CliClient cliClient = null;
 		SessionContext sessionContext = new SessionContext("test-session", new Environment());
 		String sessionId = executor.openSession(sessionContext);
 
-		try (Terminal terminal = new DumbTerminal(inputStream, outputStream)) {
-			cliClient = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath());
-			cliClient.open();
+		try (Terminal terminal = new DumbTerminal(inputStream, outputStream);
+			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			client.open();
 			return new String(outputStream.toByteArray());
-		} finally {
-			if (cliClient != null) {
-				cliClient.close();
-			}
 		}
 	}
 
@@ -325,23 +299,17 @@ public class CliClientTest extends TestLogger {
 		String sessionId = mockExecutor.openSession(context);
 		mockExecutor.failExecution = failExecution;
 
-		CliClient cli = null;
-		try {
-			cli = new CliClient(
-					TerminalUtils.createDummyTerminal(),
-					sessionId,
-					mockExecutor,
-					File.createTempFile("history", "tmp").toPath());
+		try (CliClient cli = new CliClient(
+			TerminalUtils.createDummyTerminal(),
+			sessionId,
+			mockExecutor,
+			File.createTempFile("history", "tmp").toPath())) {
 			if (testFailure) {
 				assertFalse(cli.submitUpdate(statement));
 			} else {
 				assertTrue(cli.submitUpdate(statement));
 				assertEquals(statement, mockExecutor.receivedStatement);
 				assertEquals(context, mockExecutor.receivedContext);
-			}
-		} finally {
-			if (cli != null) {
-				cli.close();
 			}
 		}
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -123,7 +123,7 @@ public class CliClientTest extends TestLogger {
 		String sessionId = executor.openSession(session);
 
 		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream());
-			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			CliClient client = new CliClient(terminal, sessionId, executor, historyTempFile())) {
 			client.open();
 			assertThat(executor.getNumExecuteSqlCalls(), is(1));
 		}
@@ -142,7 +142,7 @@ public class CliClientTest extends TestLogger {
 		String sessionId = executor.openSession(sessionContext);
 
 		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream());
-			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			CliClient client = new CliClient(terminal, sessionId, executor, historyTempFile())) {
 			client.open();
 			assertThat(executor.getNumExecuteSqlCalls(), is(1));
 		}
@@ -159,7 +159,7 @@ public class CliClientTest extends TestLogger {
 		String sessionId = executor.openSession(sessionContext);
 
 		try (Terminal terminal = new DumbTerminal(inputStream, outputStream);
-			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			CliClient client = new CliClient(terminal, sessionId, executor, historyTempFile())) {
 			client.open();
 			String output = new String(outputStream.toByteArray());
 			assertTrue(output.contains("No match found for function signature proctimee()"));
@@ -223,9 +223,10 @@ public class CliClientTest extends TestLogger {
 		String sessionId = mockExecutor.openSession(context);
 
 		InputStream inputStream = new ByteArrayInputStream("help;\nuse catalog cat;\n".getBytes());
-		Path historyFilePath = File.createTempFile("history", "tmp").toPath();
+		Path historyFilePath = historyTempFile();
 		try (Terminal terminal = new DumbTerminal(inputStream, new MockOutputStream());
-			 CliClient client = new CliClient(terminal, sessionId, mockExecutor, historyFilePath)) {
+			CliClient client = new CliClient(terminal, sessionId,
+				mockExecutor, historyFilePath)) {
 			client.open();
 			List<String> content = Files.readAllLines(historyFilePath);
 			assertEquals(2, content.size());
@@ -286,7 +287,7 @@ public class CliClientTest extends TestLogger {
 		String sessionId = executor.openSession(sessionContext);
 
 		try (Terminal terminal = new DumbTerminal(inputStream, outputStream);
-			 CliClient client = new CliClient(terminal, sessionId, executor, File.createTempFile("history", "tmp").toPath())) {
+			CliClient client = new CliClient(terminal, sessionId, executor, historyTempFile())) {
 			client.open();
 			return new String(outputStream.toByteArray());
 		}
@@ -303,7 +304,7 @@ public class CliClientTest extends TestLogger {
 			TerminalUtils.createDummyTerminal(),
 			sessionId,
 			mockExecutor,
-			File.createTempFile("history", "tmp").toPath())) {
+			historyTempFile())) {
 			if (testFailure) {
 				assertFalse(cli.submitUpdate(statement));
 			} else {
@@ -342,6 +343,10 @@ public class CliClientTest extends TestLogger {
 			results.retainAll(notExpectedHints);
 			assertEquals(0, results.size());
 		}
+	}
+
+	private Path historyTempFile() throws IOException {
+		return File.createTempFile("history", "tmp").toPath();
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Since JDK7, using `try-with-resources` to process exceptions. When the resource implement `AutoClose` interface it could release automatic. 

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
