### PR TITLE
[FLINK-19109][task] Ignore isLoopRunning in MailboxExecutor.isIdle

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
@@ -57,8 +57,7 @@ public final class MailboxExecutorImpl implements MailboxExecutor {
 	}
 
 	public boolean isIdle() {
-		return !mailboxProcessor.isMailboxLoopRunning() ||
-			(mailboxProcessor.isDefaultActionUnavailable() && !mailbox.hasMail() && mailbox.getState().isAcceptingMails());
+		return mailboxProcessor.isDefaultActionUnavailable() && !mailbox.hasMail() && mailbox.getState().isAcceptingMails();
 	}
 
 	@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.api;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
+import org.apache.flink.streaming.api.windowing.time.Time;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.UUID;
+
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that watermarks are emitted while file is being read, particularly the last split.
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/FLINK-19109">FLINK-19109</a>
+ */
+public class FileReadingWatermarkITCase {
+	private static final String NUM_WATERMARKS_ACC_NAME = "numWatermarks";
+	private static final int FILE_SIZE_LINES = 100_000;
+	private static final int WATERMARK_INTERVAL_MILLIS = 10;
+	private static final int MIN_EXPECTED_WATERMARKS = 5;
+
+	@Test
+	public void testWatermarkEmissionWithChaining() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(WATERMARK_INTERVAL_MILLIS);
+
+		checkState(env.isChainingEnabled());
+
+		env
+			.readTextFile(getSourceFile().getAbsolutePath())
+			.assignTimestampsAndWatermarks(getExtractorAssigner())
+			.addSink(getWatermarkCounter());
+
+		JobExecutionResult result = env.execute();
+
+		int actual = result.getAccumulatorResult(NUM_WATERMARKS_ACC_NAME);
+
+		assertTrue("too few watermarks emitted: " + actual, actual >= MIN_EXPECTED_WATERMARKS);
+	}
+
+	private File getSourceFile() throws IOException {
+		File file = File.createTempFile(UUID.randomUUID().toString(), null);
+		try (PrintWriter printWriter = new PrintWriter(file)) {
+			for (int i = 0; i < FILE_SIZE_LINES; i++) {
+				printWriter.println(i);
+			}
+		}
+		file.deleteOnExit();
+		return file;
+	}
+
+	private static BoundedOutOfOrdernessTimestampExtractor<String> getExtractorAssigner() {
+		return new BoundedOutOfOrdernessTimestampExtractor<String>(Time.hours(1)) {
+			private final long started = System.currentTimeMillis();
+
+			@Override
+			public long extractTimestamp(String line) {
+				return started + Long.parseLong(line);
+			}
+		};
+	}
+
+	private static SinkFunction<String> getWatermarkCounter() {
+		return new RichSinkFunction<String>() {
+			private final IntCounter numWatermarks = new IntCounter();
+			private long lastWatermark = -1;
+
+			@Override
+			public void open(Configuration parameters) throws Exception {
+				super.open(parameters);
+				getRuntimeContext().addAccumulator(NUM_WATERMARKS_ACC_NAME, numWatermarks);
+			}
+
+			@Override
+			public void close() throws Exception {
+				super.close();
+			}
+
+			@Override
+			public void invoke(String value, SinkFunction.Context context) {
+				if (context.currentWatermark() != lastWatermark) {
+					lastWatermark = context.currentWatermark();
+					numWatermarks.add(1);
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, MailboxExecutor.isIdle checks whether the mailbox loop is running or not.
If not, ContinuousFileReaderOperator continues file processing loop without going through the mailbox.

However, the mailbox can still contain (and receive new) mails (e.g. from timers) that should be processed.
In particular, this check currently prevents periodic watermarks from being emitted.

This PR simply removes this check.

## Verifying this change

- Added FileReadingWatermarkITCase
- Existing tests cover the rest of ContinuousFileReaderOperator (e.g. ContinuousFileProcessingTest)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
