### PR TITLE
[FLINK-19148][docs] Fix crashed table in Flink Table API & SQL docs

### DIFF
--- a/docs/dev/table/types.md
+++ b/docs/dev/table/types.md
@@ -282,6 +282,7 @@ The following data types are supported:
 | `ROW` | |
 | `RAW` | |
 | structured types | Only exposed in user-defined functions yet. |
+
 </div>
 <div data-lang="Python" markdown="1">
 N/A

--- a/docs/dev/table/types.zh.md
+++ b/docs/dev/table/types.zh.md
@@ -255,6 +255,7 @@ N/A
 | `ROW` | |
 | `RAW` | |
 | structured types | 暂只能在用户自定义函数里使用。 |
+
 </div>
 <div data-lang="Python" markdown="1">
 N/A


### PR DESCRIPTION

## What is the purpose of the change

Table crashed in Flink Table API & SQL Docs

[1] https://ci.apache.org/projects/flink/flink-docs-master/dev/table/types.html#new-blink-planner


## Brief change log

Add a blank line to make the markdown table be parsed normally.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
