### PR TITLE
[FLINK-19112][table] Improve usability during constant expression reduction

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ConstantFunctionContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ConstantFunctionContext.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.externalresource.ExternalResourceInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.table.api.TableException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@link FunctionContext} for constant expression reduction. It is used when a function is called
+ * with constant expressions or constant expressions can be derived from the given statement.
+ *
+ * <p>Since constant expression reduction happens during planning, methods that reference Flink's runtime
+ * context are not available.
+ *
+ * @see FunctionDefinition#isDeterministic()
+ */
+@Internal
+public final class ConstantFunctionContext extends FunctionContext {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ConstantFunctionContext.class);
+
+	private static UnregisteredMetricsGroup metricsGroup = new UnregisteredMetricsGroup();
+
+	private final Map<String, String> jobParameters;
+
+	public ConstantFunctionContext(Configuration configuration) {
+		super(null);
+		this.jobParameters = configuration.getOptional(PipelineOptions.GLOBAL_JOB_PARAMETERS)
+			.map(HashMap::new)
+			.orElseGet(HashMap::new);
+	}
+
+	@Override
+	public MetricGroup getMetricGroup() {
+		LOG.warn(
+			"Calls to FunctionContext.getMetricGroup will have no effect during constant expression reduction.");
+		return metricsGroup;
+	}
+
+	@Override
+	public File getCachedFile(String name) {
+		throw new TableException(
+			"Calls to FunctionContext.getCachedFile are not available during constant expression reduction.");
+	}
+
+	@Override
+	public String getJobParameter(String key, String defaultValue) {
+		return jobParameters.getOrDefault(key, defaultValue);
+	}
+
+	@Override
+	public Set<ExternalResourceInfo> getExternalResourceInfos(String resourceName) {
+		throw new TableException(
+			"Calls to FunctionContext.getExternalResourceInfos are not available during constant expression reduction.");
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ConstantFunctionContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ConstantFunctionContext.java
@@ -48,7 +48,7 @@ public final class ConstantFunctionContext extends FunctionContext {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ConstantFunctionContext.class);
 
-	private static UnregisteredMetricsGroup metricsGroup = new UnregisteredMetricsGroup();
+	private static final UnregisteredMetricsGroup metricsGroup = new UnregisteredMetricsGroup();
 
 	private final Map<String, String> jobParameters;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionContext.java
@@ -78,10 +78,7 @@ public class FunctionContext {
 	public String getJobParameter(String key, String defaultValue) {
 		final GlobalJobParameters conf = context.getExecutionConfig().getGlobalJobParameters();
 		if (conf != null) {
-			final String value = conf.toMap().get(key);
-			if (value != null) {
-				return value;
-			}
+			return conf.toMap().getOrDefault(key, defaultValue);
 		}
 		return defaultValue;
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionContext.java
@@ -77,11 +77,13 @@ public class FunctionContext {
 	 */
 	public String getJobParameter(String key, String defaultValue) {
 		final GlobalJobParameters conf = context.getExecutionConfig().getGlobalJobParameters();
-		if (conf != null && conf.toMap().containsKey(key)) {
-			return conf.toMap().get(key);
-		} else {
-			return defaultValue;
+		if (conf != null) {
+			final String value = conf.toMap().get(key);
+			if (value != null) {
+				return value;
+			}
 		}
+		return defaultValue;
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionDefinition.java
@@ -68,8 +68,12 @@ public interface FunctionDefinition {
 	 *
 	 * <p>It returns <code>true</code> if and only if a call to this function is guaranteed to
 	 * always return the same result given the same parameters. <code>true</code> is
-	 * assumed by default. If the function is not pure functional like <code>random(), date(), now(), ...</code>
+	 * assumed by default. If the function is not purely functional like <code>random(), date(), now(), ...</code>
 	 * this method must return <code>false</code>.
+	 *
+	 * <p>Furthermore, return <code>false</code> if the planner should always execute this function
+	 * on the cluster side. In other words: the planner should not perform constant expression reduction
+	 * during planning for constant calls to this function.
 	 */
 	default boolean isDeterministic() {
 		return true;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunction.java
@@ -32,7 +32,19 @@ import java.io.Serializable;
  * Base class for all user-defined functions.
  *
  * <p>User-defined functions combine the logical definition of a function for validation and planning
- * and contain a corresponding runtime implementation.
+ * (see {@link FunctionDefinition}) and contain a corresponding runtime implementation.
+ *
+ * <p>A runtime implementation might be called at two different stages:
+ * <ul>
+ *     <li>During planning (i.e. pre-flight phase): If a function is called with constant expressions
+ *     or constant expressions can be derived from the given statement, a function is pre-evaluated
+ *     for constant expression reduction and might not be executed on the cluster anymore. Use
+ *     {@link #isDeterministic()} to disable constant expression reduction in this case. For example,
+ *     the following calls to {@code ABS} are executed during planning:
+ *     {@code SELECT ABS(-1) FROM t} and {@code SELECT ABS(field) FROM t WHERE field = -1}.
+ *     <li>During runtime (i.e. cluster execution): If a function is called with non-constant expressions
+ *     or {@link #isDeterministic()} returns false.
+ * </ul>
  *
  * @see ScalarFunction
  * @see TableFunction

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -19,12 +19,10 @@
 package org.apache.flink.table.planner.codegen
 
 import org.apache.flink.api.common.functions.{MapFunction, RichMapFunction}
-import org.apache.flink.configuration.Configuration
-import org.apache.flink.metrics.MetricGroup
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.data.binary.{BinaryStringData, BinaryStringDataUtil}
 import org.apache.flink.table.data.{DecimalData, GenericRowData, TimestampData}
-import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
+import org.apache.flink.table.functions.{ConstantFunctionContext, FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
@@ -35,8 +33,6 @@ import org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
-
-import java.io.File
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -235,35 +231,6 @@ class ExpressionReducer(
       valueArg,
       targetType,
       true)
-  }
-}
-
-/**
-  * A [[ConstantFunctionContext]] allows to obtain user-defined configuration information set
-  * in [[TableConfig]].
-  *
-  * @param parameters User-defined configuration set in [[TableConfig]].
-  */
-class ConstantFunctionContext(parameters: Configuration) extends FunctionContext(null) {
-
-  override def getMetricGroup: MetricGroup = {
-    throw new UnsupportedOperationException("getMetricGroup is not supported when optimizing")
-  }
-
-  override def getCachedFile(name: String): File = {
-    throw new UnsupportedOperationException("getCachedFile is not supported when optimizing")
-  }
-
-  /**
-    * Gets the user-defined configuration value associated with the given key as a string.
-    *
-    * @param key          key pointing to the associated value
-    * @param defaultValue default value which is returned in case user-defined configuration
-    *                     value is null or there is no value associated with the given key
-    * @return (default) value associated with the given key
-    */
-  override def getJobParameter(key: String, defaultValue: String): String = {
-    parameters.getString(key, defaultValue)
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.xml
@@ -16,6 +16,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testExpressionReductionWithPythonUDF">
+    <Resource name="sql">
+      <![CDATA[SELECT PyUdf(), MyUdf(1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[PyUdf()], EXPR$1=[MyUdf(1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[f0 AS EXPR$0, CAST(2) AS EXPR$1])
++- PythonCalc(select=[PyUdf() AS f0])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testExpressionReductionWithUDF">
     <Resource name="sql">
       <![CDATA[SELECT MyUdf(1) FROM MyTable]]>
@@ -50,21 +68,20 @@ Calc(select=[11 AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testExpressionReductionWithPythonUDF">
+  <TestCase name="testExpressionReductionWithRichUDFAndInvalidOpen">
     <Resource name="sql">
-      <![CDATA[SELECT PyUdf(), MyUdf(1) FROM MyTable]]>
+      <![CDATA[SELECT myUdf(1 + 1) FROM MyTable]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(EXPR$0=[PyUdf()], EXPR$1=[MyUdf(1)])
+LogicalProject(EXPR$0=[myUdf(+(1, 1))])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[f0 AS EXPR$0, CAST(2) AS EXPR$1])
-+- PythonCalc(select=[PyUdf() AS f0])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+Calc(select=[myUdf(+(1, 1)) AS EXPR$0])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -211,6 +211,9 @@ class RichFunc1 extends ScalarFunction {
 
   override def open(context: FunctionContext): Unit = {
     added = context.getJobParameter("int.value", "0").toInt
+    if (context.getJobParameter("fail-for-cached-file", "false").toBoolean) {
+      context.getCachedFile("FAIL")
+    }
   }
 
   def eval(index: Int): Int = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
@@ -44,7 +44,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
   @Test
   def testExpressionReductionWithRichUDF(): Unit = {
     util.addFunction("MyUdf", new RichFunc1)
-    util.getTableEnv.getConfig.getConfiguration.setString("int.value", "10")
+    util.getTableEnv.getConfig.addJobParameter("int.value", "10")
     util.verifyPlan("SELECT myUdf(1) FROM MyTable")
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
@@ -49,6 +49,15 @@ class ExpressionReductionRulesTest extends TableTestBase {
   }
 
   @Test
+  def testExpressionReductionWithRichUDFAndInvalidOpen(): Unit = {
+    util.addFunction("MyUdf", new RichFunc1)
+    // FunctionContext.getCachedFile will fail during expression reduction
+    // it will be executed during runtime though
+    util.getTableEnv.getConfig.addJobParameter("fail-for-cached-file", "true")
+    util.verifyPlan("SELECT myUdf(1 + 1) FROM MyTable")
+  }
+
+  @Test
   def testExpressionReductionWithPythonUDF(): Unit = {
     util.addFunction("PyUdf", DeterministicPythonFunc)
     util.addFunction("MyUdf", Func1)


### PR DESCRIPTION
## What is the purpose of the change

Improves the usability of functions during constant expression reduction.

## Brief change log

- Throw more meaningful exceptions.
- Make metrics a no-op instead of throwing an exception.
- Use job parameters instead of entire configuration.
- Give meaningful exception for `getExternalResourceInfos` instead of NPE
- Add more documentation at various locations

## Verifying this change

This change is already covered by existing tests, such as `ExpressionReductionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
