### PR TITLE
[FLINK-18335] [tests] Add more debuging logs for NotifyCheckpointAbortedITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -79,8 +79,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -99,7 +97,6 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(Parameterized.class)
 public class NotifyCheckpointAbortedITCase extends TestLogger {
-	private static final Logger LOG = LoggerFactory.getLogger(NotifyCheckpointAbortedITCase.class);
 
 	private static final long DECLINE_CHECKPOINT_ID = 2L;
 	private static final long TEST_TIMEOUT = 100000;
@@ -180,23 +177,23 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
 		clusterClient.submitJob(jobGraph).get();
 
 		TestingCompletedCheckpointStore.addCheckpointLatch.await();
-		LOG.info("The checkpoint to abort is ready to add to checkpoint store.");
+		log.info("The checkpoint to abort is ready to add to checkpoint store.");
 		TestingCompletedCheckpointStore.abortCheckpointLatch.trigger();
 
-		LOG.info("Verifying whether all operators have been notified of checkpoint-1 aborted.");
+		log.info("Verifying whether all operators have been notified of checkpoint-1 aborted.");
 		verifyAllOperatorsNotifyAborted();
-		LOG.info("Verified that all operators have been notified of checkpoint-1 aborted.");
+		log.info("Verified that all operators have been notified of checkpoint-1 aborted.");
 		resetAllOperatorsNotifyAbortedLatches();
 		verifyAllOperatorsNotifyAbortedTimes(1);
 
 		DeclineSink.waitLatch.trigger();
-		LOG.info("Verifying whether all operators have been notified of checkpoint-2 aborted.");
+		log.info("Verifying whether all operators have been notified of checkpoint-2 aborted.");
 		verifyAllOperatorsNotifyAborted();
-		LOG.info("Verified that all operators have been notified of checkpoint-2 aborted.");
+		log.info("Verified that all operators have been notified of checkpoint-2 aborted.");
 		verifyAllOperatorsNotifyAbortedTimes(2);
 
 		clusterClient.cancel(jobID).get();
-		LOG.info("Test is verified successfully as expected.");
+		log.info("Test is verified successfully as expected.");
 	}
 
 	private void verifyAllOperatorsNotifyAborted() throws InterruptedException {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -79,6 +79,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -97,8 +99,10 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(Parameterized.class)
 public class NotifyCheckpointAbortedITCase extends TestLogger {
+	private static final Logger LOG = LoggerFactory.getLogger(NotifyCheckpointAbortedITCase.class);
+
 	private static final long DECLINE_CHECKPOINT_ID = 2L;
-	private static final long TEST_TIMEOUT = 60000;
+	private static final long TEST_TIMEOUT = 100000;
 	private static final String DECLINE_SINK_NAME = "DeclineSink";
 	private static MiniClusterWithClientResource cluster;
 
@@ -176,17 +180,23 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
 		clusterClient.submitJob(jobGraph).get();
 
 		TestingCompletedCheckpointStore.addCheckpointLatch.await();
+		LOG.info("The checkpoint to abort is ready to add to checkpoint store.");
 		TestingCompletedCheckpointStore.abortCheckpointLatch.trigger();
 
+		LOG.info("Verifying whether all operators have been notified of checkpoint-1 aborted.");
 		verifyAllOperatorsNotifyAborted();
+		LOG.info("Verified that all operators have been notified of checkpoint-1 aborted.");
 		resetAllOperatorsNotifyAbortedLatches();
 		verifyAllOperatorsNotifyAbortedTimes(1);
 
 		DeclineSink.waitLatch.trigger();
+		LOG.info("Verifying whether all operators have been notified of checkpoint-2 aborted.");
 		verifyAllOperatorsNotifyAborted();
+		LOG.info("Verified that all operators have been notified of checkpoint-2 aborted.");
 		verifyAllOperatorsNotifyAbortedTimes(2);
 
 		clusterClient.cancel(jobID).get();
+		LOG.info("Test is verified successfully as expected.");
 	}
 
 	private void verifyAllOperatorsNotifyAborted() throws InterruptedException {


### PR DESCRIPTION
## What is the purpose of the change

Someone reported that NotifyCheckpointAbortedITCase is not stable in FLINK-18335. However, I cannot reproduce this problem locally and on my private CI.
Thus, as discussed in the ticket, we plan to increase the timeout and add more debuging logs.


## Brief change log

  - Add more debuging logs for `NotifyCheckpointAbortedITCase`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
