### PR TITLE
[hotfix] [docs] remove inexistent memory unit reference from javadoc

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -349,7 +349,7 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 	 * <p>To make larger values more compact, the common size suffixes are supported:
 	 *
 	 * <ul>
-	 *     <li>q or 1b or 1bytes (bytes)
+	 *     <li>1b or 1bytes (bytes)
 	 *     <li>1k or 1kb or 1kibibytes (interpreted as kibibytes = 1024 bytes)
 	 *     <li>1m or 1mb or 1mebibytes (interpreted as mebibytes = 1024 kibibytes)
 	 *     <li>1g or 1gb or 1gibibytes (interpreted as gibibytes = 1024 mebibytes)


### PR DESCRIPTION
There is no "q" unit/suffix on [`MemoryUnit`](https://github.com/apache/flink/blob/cac40c6b2c4aa2b397b6df562aa23bd1f18dd3b0/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java#L362) enum as described in javadocs