### PR TITLE
[FLINK-11779] CLI ignores -m parameter if high-availability is ZOOKEEPER

### DIFF
--- a/docs/_includes/generated/common_host_port_section.html
+++ b/docs/_includes/generated/common_host_port_section.html
@@ -30,7 +30,7 @@
             <td><h5>rest.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The address that should be used by clients to connect to the server.</td>
+            <td>The address that should be used by clients to connect to the server. Attention: This option is respected only if the high-availability configuration is NONE.</td>
         </tr>
         <tr>
             <td><h5>rest.bind-address</h5></td>
@@ -48,7 +48,7 @@
             <td><h5>rest.port</h5></td>
             <td style="word-wrap: break-word;">8081</td>
             <td>Integer</td>
-            <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port.</td>
+            <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port. Attention: This option is respected only if the high-availability configuration is NONE.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.port</h5></td>

--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>rest.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The address that should be used by clients to connect to the server.</td>
+            <td>The address that should be used by clients to connect to the server. Attention: This option is respected only if the high-availability configuration is NONE.</td>
         </tr>
         <tr>
             <td><h5>rest.await-leader-timeout</h5></td>
@@ -54,7 +54,7 @@
             <td><h5>rest.port</h5></td>
             <td style="word-wrap: break-word;">8081</td>
             <td>Integer</td>
-            <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port.</td>
+            <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port. Attention: This option is respected only if the high-availability configuration is NONE.</td>
         </tr>
         <tr>
             <td><h5>rest.retry.delay</h5></td>

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -413,14 +413,31 @@ Action "run" compiles and runs a program.
                                           shutdown when the CLI is terminated
                                           abruptly, e.g., in response to a user
                                           interrupt, such as typing Ctrl + C.
+  Options for Generic CLI mode:
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
+     -e,--executor <arg>   DEPRECATED: Please use the -t option instead which is
+                           also available with the "Application Mode".
+                           The name of the executor to be used for executing the
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: "remote", "local",
+                           "kubernetes-session", "yarn-per-job", "yarn-session".
+     -t,--target <arg>     The deployment target for the given application,
+                           which is equivalent to the "execution.target" config
+                           option. The currently available targets are:
+                           "remote", "local", "kubernetes-session",
+                           "yarn-per-job", "yarn-session", "yarn-application"
+                           and "kubernetes-application".
+
   Options for yarn-cluster mode:
      -d,--detached                        If present, runs the job in detached
                                           mode
-     -m,--jobmanager <arg>                Address of the JobManager to
-                                          which to connect. Use this flag to
-                                          connect to a different JobManager than
-                                          the one specified in the
-                                          configuration.
+     -m,--jobmanager <arg>                Set to yarn-cluster to use YARN
+                                          execution mode.
      -yat,--yarnapplicationType <arg>     Set a custom application type for the
                                           application on YARN
      -yD <property=value>                 use value for given property
@@ -449,23 +466,13 @@ Action "run" compiles and runs a program.
      -z,--zookeeperNamespace <arg>        Namespace to create the Zookeeper
                                           sub-paths for high availability mode
 
-  Options for Generic CLI mode:
-       -D <property=value>   Generic configuration options for
-                             execution/deployment and for the configured executor.
-                             The available options can be found at
-                             https://ci.apache.org/projects/flink/flink-docs-stabl
-                             e/ops/config.html
-       -t,--target <arg>     The deployment target for the given application,
-                             which is equivalent to the "execution.target" config
-                             option. The currently available targets are:
-                             "remote", "local", "kubernetes-session", "yarn-per-job",
-                             "yarn-session", "yarn-application" and "kubernetes-application".
-
   Options for default mode:
-     -m,--jobmanager <arg>           Address of the JobManager to which
-                                     to connect. Use this flag to connect to a
+     -m,--jobmanager <arg>           Address of the JobManager to which to
+                                     connect. Use this flag to connect to a
                                      different JobManager than the one specified
-                                     in the configuration.
+                                     in the configuration. Attention: This
+                                     option is respected only if the
+                                     high-availability configuration is NONE.
      -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths
                                      for high availability mode
 
@@ -492,32 +499,40 @@ Action "list" lists running and scheduled programs.
      -a,--all         Show all programs and their JobIDs
      -r,--running     Show only running programs and their JobIDs
      -s,--scheduled   Show only scheduled programs and their JobIDs
+  Options for Generic CLI mode:
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
+     -e,--executor <arg>   DEPRECATED: Please use the -t option instead which is
+                           also available with the "Application Mode".
+                           The name of the executor to be used for executing the
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: "remote", "local",
+                           "kubernetes-session", "yarn-per-job", "yarn-session".
+     -t,--target <arg>     The deployment target for the given application,
+                           which is equivalent to the "execution.target" config
+                           option. The currently available targets are:
+                           "remote", "local", "kubernetes-session",
+                           "yarn-per-job", "yarn-session", "yarn-application"
+                           and "kubernetes-application".
+
   Options for yarn-cluster mode:
-     -m,--jobmanager <arg>            Address of the JobManager to
-                                      which to connect. Use this flag to connect
-                                      to a different JobManager than the one
-                                      specified in the configuration.
+     -m,--jobmanager <arg>            Set to yarn-cluster to use YARN execution
+                                      mode.
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
 
-  Options for Generic CLI mode:
-         -D <property=value>   Generic configuration options for
-                               execution/deployment and for the configured executor.
-                               The available options can be found at
-                               https://ci.apache.org/projects/flink/flink-docs-stabl
-                               e/ops/config.html
-         -t,--target <arg>     The deployment target for the given application,
-                               which is equivalent to the "execution.target" config
-                               option. The currently available targets are:
-                               "remote", "local", "kubernetes-session", "yarn-per-job",
-                               "yarn-session", "yarn-application" and "kubernetes-application".
-
   Options for default mode:
-     -m,--jobmanager <arg>           Address of the JobManager to which
-                                     to connect. Use this flag to connect to a
+     -m,--jobmanager <arg>           Address of the JobManager to which to
+                                     connect. Use this flag to connect to a
                                      different JobManager than the one specified
-                                     in the configuration.
+                                     in the configuration. Attention: This
+                                     option is respected only if the
+                                     high-availability configuration is NONE.
      -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths
                                      for high availability mode
 
@@ -534,32 +549,40 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
                                           directory is specified, the configured
                                           default will be used
                                           ("state.savepoints.dir").
+  Options for Generic CLI mode:
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
+     -e,--executor <arg>   DEPRECATED: Please use the -t option instead which is
+                           also available with the "Application Mode".
+                           The name of the executor to be used for executing the
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: "remote", "local",
+                           "kubernetes-session", "yarn-per-job", "yarn-session".
+     -t,--target <arg>     The deployment target for the given application,
+                           which is equivalent to the "execution.target" config
+                           option. The currently available targets are:
+                           "remote", "local", "kubernetes-session",
+                           "yarn-per-job", "yarn-session", "yarn-application"
+                           and "kubernetes-application".
+
   Options for yarn-cluster mode:
-     -m,--jobmanager <arg>            Address of the JobManager to
-                                      which to connect. Use this flag to connect
-                                      to a different JobManager than the one
-                                      specified in the configuration.
+     -m,--jobmanager <arg>            Set to yarn-cluster to use YARN execution
+                                      mode.
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
 
-  Options for Generic CLI mode:
-         -D <property=value>   Generic configuration options for
-                               execution/deployment and for the configured executor.
-                               The available options can be found at
-                               https://ci.apache.org/projects/flink/flink-docs-stabl
-                               e/ops/config.html
-         -t,--target <arg>     The deployment target for the given application,
-                               which is equivalent to the "execution.target" config
-                               option. The currently available targets are:
-                               "remote", "local", "kubernetes-session", "yarn-per-job",
-                               "yarn-session", "yarn-application" and "kubernetes-application".
-
   Options for default mode:
-     -m,--jobmanager <arg>           Address of the JobManager to which
-                                     to connect. Use this flag to connect to a
+     -m,--jobmanager <arg>           Address of the JobManager to which to
+                                     connect. Use this flag to connect to a
                                      different JobManager than the one specified
-                                     in the configuration.
+                                     in the configuration. Attention: This
+                                     option is respected only if the
+                                     high-availability configuration is NONE.
      -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths
                                      for high availability mode
 
@@ -577,32 +600,40 @@ Action "cancel" cancels a running program.
                                             no directory is specified, the
                                             configured default directory
                                             (state.savepoints.dir) is used.
+  Options for Generic CLI mode:
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
+     -e,--executor <arg>   DEPRECATED: Please use the -t option instead which is
+                           also available with the "Application Mode".
+                           The name of the executor to be used for executing the
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: "remote", "local",
+                           "kubernetes-session", "yarn-per-job", "yarn-session".
+     -t,--target <arg>     The deployment target for the given application,
+                           which is equivalent to the "execution.target" config
+                           option. The currently available targets are:
+                           "remote", "local", "kubernetes-session",
+                           "yarn-per-job", "yarn-session", "yarn-application"
+                           and "kubernetes-application".
+
   Options for yarn-cluster mode:
-     -m,--jobmanager <arg>            Address of the JobManager to
-                                      which to connect. Use this flag to connect
-                                      to a different JobManager than the one
-                                      specified in the configuration.
+     -m,--jobmanager <arg>            Set to yarn-cluster to use YARN execution
+                                      mode.
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
 
-  Options for Generic CLI mode:
-         -D <property=value>   Generic configuration options for
-                               execution/deployment and for the configured executor.
-                               The available options can be found at
-                               https://ci.apache.org/projects/flink/flink-docs-stabl
-                               e/ops/config.html
-         -t,--target <arg>     The deployment target for the given application,
-                               which is equivalent to the "execution.target" config
-                               option. The currently available targets are:
-                               "remote", "local", "kubernetes-session", "yarn-per-job",
-                               "yarn-session", "yarn-application" and "kubernetes-application".
-
   Options for default mode:
-     -m,--jobmanager <arg>           Address of the JobManager to which
-                                     to connect. Use this flag to connect to a
+     -m,--jobmanager <arg>           Address of the JobManager to which to
+                                     connect. Use this flag to connect to a
                                      different JobManager than the one specified
-                                     in the configuration.
+                                     in the configuration. Attention: This
+                                     option is respected only if the
+                                     high-availability configuration is NONE.
      -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths
                                      for high availability mode
 
@@ -614,32 +645,40 @@ Action "savepoint" triggers savepoints for a running job or disposes existing on
   "savepoint" action options:
      -d,--dispose <arg>       Path of savepoint to dispose.
      -j,--jarfile <jarfile>   Flink program JAR file.
+  Options for Generic CLI mode:
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
+     -e,--executor <arg>   DEPRECATED: Please use the -t option instead which is
+                           also available with the "Application Mode".
+                           The name of the executor to be used for executing the
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: "remote", "local",
+                           "kubernetes-session", "yarn-per-job", "yarn-session".
+     -t,--target <arg>     The deployment target for the given application,
+                           which is equivalent to the "execution.target" config
+                           option. The currently available targets are:
+                           "remote", "local", "kubernetes-session",
+                           "yarn-per-job", "yarn-session", "yarn-application"
+                           and "kubernetes-application".
+
   Options for yarn-cluster mode:
-     -m,--jobmanager <arg>            Address of the JobManager to
-                                      which to connect. Use this flag to connect
-                                      to a different JobManager than the one
-                                      specified in the configuration.
+     -m,--jobmanager <arg>            Set to yarn-cluster to use YARN execution
+                                      mode.
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
 
-  Options for Generic CLI mode:
-         -D <property=value>   Generic configuration options for
-                               execution/deployment and for the configured executor.
-                               The available options can be found at
-                               https://ci.apache.org/projects/flink/flink-docs-stabl
-                               e/ops/config.html
-         -t,--target <arg>     The deployment target for the given application,
-                               which is equivalent to the "execution.target" config
-                               option. The currently available targets are:
-                               "remote", "local", "kubernetes-session", "yarn-per-job",
-                               "yarn-session", "yarn-application" and "kubernetes-application".
-
   Options for default mode:
-     -m,--jobmanager <arg>           Address of the JobManager to which
-                                     to connect. Use this flag to connect to a
+     -m,--jobmanager <arg>           Address of the JobManager to which to
+                                     connect. Use this flag to connect to a
                                      different JobManager than the one specified
-                                     in the configuration.
+                                     in the configuration. Attention: This
+                                     option is respected only if the
+                                     high-availability configuration is NONE.
      -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths
                                      for high availability mode
 {% endhighlight %}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
@@ -32,10 +31,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.slf4j.Logger;
-
-import java.net.InetSocketAddress;
-
-import static org.apache.flink.client.cli.CliFrontend.setJobManagerAddressInConfig;
 
 /**
  * Base class for {@link CustomCommandLine} implementations which specify a JobManager address and
@@ -46,11 +41,6 @@ public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 
 	protected final Option zookeeperNamespaceOption = new Option("z", "zookeeperNamespace", true,
 		"Namespace to create the Zookeeper sub-paths for high availability mode");
-
-
-	protected final Option addressOption = new Option("m", "jobmanager", true,
-		"Address of the JobManager to which to connect. " +
-			"Use this flag to connect to a different JobManager than the one specified in the configuration.");
 
 	protected final Configuration configuration;
 
@@ -69,7 +59,6 @@ public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 
 	@Override
 	public void addGeneralOptions(Options baseOptions) {
-		baseOptions.addOption(addressOption);
 		baseOptions.addOption(zookeeperNamespaceOption);
 	}
 
@@ -77,12 +66,6 @@ public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		final Configuration resultingConfiguration = new Configuration(configuration);
 		resultingConfiguration.setString(DeploymentOptions.TARGET, RemoteExecutor.NAME);
-
-		if (commandLine.hasOption(addressOption.getOpt())) {
-			String addressWithPort = commandLine.getOptionValue(addressOption.getOpt());
-			InetSocketAddress jobManagerAddress = NetUtils.parseHostPortAddress(addressWithPort);
-			setJobManagerAddressInConfig(resultingConfiguration, jobManagerAddress);
-		}
 
 		if (commandLine.hasOption(zookeeperNamespaceOption.getOpt())) {
 			String zkNamespace = commandLine.getOptionValue(zookeeperNamespaceOption.getOpt());

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -66,7 +66,7 @@ public class RestOptions {
 		key("rest.address")
 			.noDefaultValue()
 			.withFallbackKeys(JobManagerOptions.ADDRESS.key())
-			.withDescription("The address that should be used by clients to connect to the server.");
+			.withDescription("The address that should be used by clients to connect to the server. Attention: This option is respected only if the high-availability configuration is NONE.");
 
 	/**
 	 * The port that the REST client connects to and the REST server binds to if {@link #BIND_PORT}
@@ -79,7 +79,7 @@ public class RestOptions {
 			.withDeprecatedKeys(WebOptions.PORT.key())
 			.withDescription(
 				Description.builder()
-					.text("The port that the client connects to. If %s has not been specified, then the REST server will bind to this port.", text(BIND_PORT.key()))
+					.text("The port that the client connects to. If %s has not been specified, then the REST server will bind to this port. Attention: This option is respected only if the high-availability configuration is NONE.", text(BIND_PORT.key()))
 					.build());
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/AbstractYarnCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/AbstractYarnCli.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.cli;
+
+import org.apache.flink.client.cli.AbstractCustomCommandLine;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+import org.apache.flink.yarn.executors.YarnJobClusterExecutor;
+import org.apache.flink.yarn.executors.YarnSessionClusterExecutor;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+abstract class AbstractYarnCli extends AbstractCustomCommandLine {
+
+	public static final String ID = "yarn-cluster";
+
+	protected Option applicationId =
+		new Option("yid", "yarnapplicationId", true, "Attach to running YARN session");
+
+	protected Option addressOption =
+		new Option("m", "jobmanager", true, "Set to " + ID + " to use YARN execution mode.");
+
+	protected AbstractYarnCli(Configuration configuration) {
+		super(configuration);
+	}
+
+	@Override
+	public boolean isActive(CommandLine commandLine) {
+		final String jobManagerOption = commandLine.getOptionValue(addressOption.getOpt(), null);
+		final boolean yarnJobManager = ID.equals(jobManagerOption);
+		final boolean hasYarnAppId = commandLine.hasOption(applicationId.getOpt())
+			|| configuration.getOptional(YarnConfigOptions.APPLICATION_ID).isPresent();
+		final boolean hasYarnExecutor = YarnSessionClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET))
+			|| YarnJobClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
+		return hasYarnExecutor || yarnJobManager || hasYarnAppId;
+	}
+
+	@Override
+	public void addGeneralOptions(Options baseOptions) {
+		super.addGeneralOptions(baseOptions);
+		baseOptions.addOption(applicationId);
+		baseOptions.addOption(addressOption);
+	}
+
+	@Override
+	public String getId() {
+		return ID;
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FallbackYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FallbackYarnSessionCli.java
@@ -19,60 +19,27 @@
 package org.apache.flink.yarn.cli;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.cli.AbstractCustomCommandLine;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.DeploymentOptions;
-import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.configuration.YarnDeploymentTarget;
-import org.apache.flink.yarn.executors.YarnJobClusterExecutor;
-import org.apache.flink.yarn.executors.YarnSessionClusterExecutor;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
 
 /**
  * A stub Yarn Command Line to throw an exception with the correct
  * message when the {@code HADOOP_CLASSPATH} is not set.
  */
 @Internal
-public class FallbackYarnSessionCli extends AbstractCustomCommandLine {
-
-	public static final String ID = "yarn-cluster";
-
-	private final Option applicationId;
+public class FallbackYarnSessionCli extends AbstractYarnCli {
 
 	public FallbackYarnSessionCli(Configuration configuration) {
 		super(configuration);
-		applicationId = new Option("yid", "yarnapplicationId", true, "Attach to running YARN session");
-	}
-
-	@Override
-	public void addGeneralOptions(Options baseOptions) {
-		super.addGeneralOptions(baseOptions);
-		baseOptions.addOption(applicationId);
 	}
 
 	@Override
 	public boolean isActive(CommandLine commandLine) {
-		if (originalIsActive(commandLine)) {
+		if (super.isActive(commandLine)) {
 			throw new IllegalStateException(YarnDeploymentTarget.ERROR_MESSAGE);
 		}
 		return false;
-	}
-
-	private boolean originalIsActive(CommandLine commandLine) {
-		final String jobManagerOption = commandLine.getOptionValue(addressOption.getOpt(), null);
-		final boolean yarnJobManager = ID.equals(jobManagerOption);
-		final boolean hasYarnAppId = commandLine.hasOption(applicationId.getOpt())
-				|| configuration.getOptional(YarnConfigOptions.APPLICATION_ID).isPresent();
-		final boolean hasYarnExecutor = YarnSessionClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET))
-				|| YarnJobClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
-		return hasYarnExecutor || yarnJobManager || hasYarnAppId;
-	}
-
-	@Override
-	public String getId() {
-		return ID;
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn.cli;
 
-import org.apache.flink.client.cli.AbstractCustomCommandLine;
 import org.apache.flink.client.cli.CliArgsException;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.client.deployment.ClusterClientFactory;
@@ -92,16 +91,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Class handling the command line interface to the YARN session.
  */
-public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
+public class FlinkYarnSessionCli extends AbstractYarnCli {
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkYarnSessionCli.class);
 
 	//------------------------------------ Constants   -------------------------
 
 	private static final long CLIENT_POLLING_INTERVAL_MS = 3000L;
-
-	/** The id for the CommandLine interface. */
-	private static final String ID = "yarn-cluster";
-
 	// YARN-session related constants
 	private static final String YARN_PROPERTIES_FILE = ".yarn-properties-";
 	private static final String YARN_APPLICATION_ID_KEY = "applicationID";
@@ -116,8 +111,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 	//------------------------------------ Command Line argument options -------------------------
 	// the prefix transformation is used by the CliFrontend static constructor.
 	private final Option query;
-	// --- or ---
-	private final Option applicationId;
 	// --- or ---
 	private final Option queue;
 	private final Option shipPath;
@@ -186,7 +179,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		// Create the command line options
 
 		query = new Option(shortPrefix + "q", longPrefix + "query", false, "Display available YARN resources (memory, cores)");
-		applicationId = new Option(shortPrefix + "id", longPrefix + "applicationId", true, "Attach to running YARN session");
 		queue = new Option(shortPrefix + "qu", longPrefix + "queue", true, "Specify YARN queue.");
 		shipPath = new Option(shortPrefix + "t", longPrefix + "ship", true, "Ship files in the specified directory (t for transfer)");
 		flinkJar = new Option(shortPrefix + "j", longPrefix + "jar", true, "Path to Flink jar file");
@@ -297,18 +289,10 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 
 	@Override
 	public boolean isActive(CommandLine commandLine) {
-		final String jobManagerOption = commandLine.getOptionValue(addressOption.getOpt(), null);
-		final boolean yarnJobManager = ID.equals(jobManagerOption);
-		final boolean hasYarnAppId = commandLine.hasOption(applicationId.getOpt())
-				|| configuration.getOptional(YarnConfigOptions.APPLICATION_ID).isPresent();
-		final boolean hasYarnExecutor = YarnSessionClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET))
-				|| YarnJobClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
-		return hasYarnExecutor || yarnJobManager || hasYarnAppId || (isYarnPropertiesFileMode(commandLine) && yarnApplicationIdFromYarnProperties != null);
-	}
-
-	@Override
-	public String getId() {
-		return ID;
+		if (!super.isActive(commandLine)) {
+			return (isYarnPropertiesFileMode(commandLine) && yarnApplicationIdFromYarnProperties != null);
+		}
+		return true;
 	}
 
 	@Override
@@ -318,12 +302,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		for (Object option : allOptions.getOptions()) {
 			baseOptions.addOption((Option) option);
 		}
-	}
-
-	@Override
-	public void addGeneralOptions(Options baseOptions) {
-		super.addGeneralOptions(baseOptions);
-		baseOptions.addOption(applicationId);
 	}
 
 	@Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

1. Change the help messages of -m parameter of `DefaultCLI` and `FlinkYarnSessionCli`.
2. Document that "rest.address" and "rest.address.port" is respected only if the high-availability is NONE.


## Brief change log

  - Remove the "-m" options from the `AbstractCustomCommandLine `
  - Add the "-m" options to `DefaultCLI` and add some description`This option is respected only if the high-availability is NONE.`
  - Add the "-m" options to `FlinkYarnSessionCli` and add some description `Specify the yarn cluster mode if the argument equals yarn-cluster`
  - Document that "rest.address" and "rest.address.port" is respected only if the high-availability is NONE.

## Verifying this change

Verify the help message manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)



