### PR TITLE
[FLINK-18980][e2e] Add timeout to get logs from stalling test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -46,58 +46,62 @@ function test_cleanup {
 
 on_exit test_cleanup
 
-setup_kafka_dist
-setup_confluent_dist
+function schema_registry_test {
+  setup_kafka_dist
+  setup_confluent_dist
 
-retry_times_with_backoff_and_cleanup 3 5 test_setup test_cleanup
+  retry_times_with_backoff_and_cleanup 3 5 test_setup test_cleanup
 
-TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-confluent-schema-registry/target/TestAvroConsumerConfluent.jar
+  TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-confluent-schema-registry/target/TestAvroConsumerConfluent.jar
 
-INPUT_MESSAGE_1='{"name":"Alyssa","favoriteNumber":"250","favoriteColor":"green","eventType":"meeting"}'
-INPUT_MESSAGE_2='{"name":"Charlie","favoriteNumber":"10","favoriteColor":"blue","eventType":"meeting"}'
-INPUT_MESSAGE_3='{"name":"Ben","favoriteNumber":"7","favoriteColor":"red","eventType":"meeting"}'
-USER_SCHEMA='{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string","default":""},{"name":"favoriteNumber","type":"string","default":""},{"name":"favoriteColor","type":"string","default":""},{"name":"eventType","type":{"name":"EventType","type":"enum","symbols":["meeting"]}}]}'
+  INPUT_MESSAGE_1='{"name":"Alyssa","favoriteNumber":"250","favoriteColor":"green","eventType":"meeting"}'
+  INPUT_MESSAGE_2='{"name":"Charlie","favoriteNumber":"10","favoriteColor":"blue","eventType":"meeting"}'
+  INPUT_MESSAGE_3='{"name":"Ben","favoriteNumber":"7","favoriteColor":"red","eventType":"meeting"}'
+  USER_SCHEMA='{"namespace":"example.avro","type":"record","name":"User","fields":[{"name":"name","type":"string","default":""},{"name":"favoriteNumber","type":"string","default":""},{"name":"favoriteColor","type":"string","default":""},{"name":"eventType","type":{"name":"EventType","type":"enum","symbols":["meeting"]}}]}'
 
-curl -X POST \
-  ${SCHEMA_REGISTRY_URL}/subjects/users-value/versions \
-  -H 'cache-control: no-cache' \
-  -H 'content-type: application/vnd.schemaregistry.v1+json' \
-  -d '{"schema": "{\"namespace\": \"example.avro\",\"type\": \"record\",\"name\": \"User\",\"fields\": [{\"name\": \"name\", \"type\": \"string\", \"default\": \"\"},{\"name\": \"favoriteNumber\",  \"type\": \"string\", \"default\": \"\"},{\"name\": \"favoriteColor\", \"type\": \"string\", \"default\": \"\"},{\"name\": \"eventType\",\"type\": {\"name\": \"EventType\",\"type\": \"enum\", \"symbols\": [\"meeting\"] }}]}"}'
+  curl -X POST \
+    ${SCHEMA_REGISTRY_URL}/subjects/users-value/versions \
+    -H 'cache-control: no-cache' \
+    -H 'content-type: application/vnd.schemaregistry.v1+json' \
+    -d '{"schema": "{\"namespace\": \"example.avro\",\"type\": \"record\",\"name\": \"User\",\"fields\": [{\"name\": \"name\", \"type\": \"string\", \"default\": \"\"},{\"name\": \"favoriteNumber\",  \"type\": \"string\", \"default\": \"\"},{\"name\": \"favoriteColor\", \"type\": \"string\", \"default\": \"\"},{\"name\": \"eventType\",\"type\": {\"name\": \"EventType\",\"type\": \"enum\", \"symbols\": [\"meeting\"] }}]}"}'
 
-echo "Sending messages to Kafka topic [test-avro-input] ..."
+  echo "Sending messages to Kafka topic [test-avro-input] ..."
 
-send_messages_to_kafka_avro $INPUT_MESSAGE_1 test-avro-input $USER_SCHEMA
-send_messages_to_kafka_avro $INPUT_MESSAGE_2 test-avro-input $USER_SCHEMA
-send_messages_to_kafka_avro $INPUT_MESSAGE_3 test-avro-input $USER_SCHEMA
+  send_messages_to_kafka_avro $INPUT_MESSAGE_1 test-avro-input $USER_SCHEMA
+  send_messages_to_kafka_avro $INPUT_MESSAGE_2 test-avro-input $USER_SCHEMA
+  send_messages_to_kafka_avro $INPUT_MESSAGE_3 test-avro-input $USER_SCHEMA
 
-start_cluster
+  start_cluster
 
-create_kafka_topic 1 1 test-string-out
-create_kafka_topic 1 1 test-avro-out
+  create_kafka_topic 1 1 test-string-out
+  create_kafka_topic 1 1 test-avro-out
 
-# Read Avro message from [test-avro-input], check the schema and send message to [test-string-ou]
-$FLINK_DIR/bin/flink run -d $TEST_PROGRAM_JAR \
-  --input-topic test-avro-input --output-string-topic test-string-out --output-avro-topic test-avro-out --output-subject test-output-subject \
-  --bootstrap.servers localhost:9092 --group.id myconsumer --auto.offset.reset earliest \
-  --schema-registry-url ${SCHEMA_REGISTRY_URL}
+  # Read Avro message from [test-avro-input], check the schema and send message to [test-string-ou]
+  $FLINK_DIR/bin/flink run -d $TEST_PROGRAM_JAR \
+    --input-topic test-avro-input --output-string-topic test-string-out --output-avro-topic test-avro-out --output-subject test-output-subject \
+    --bootstrap.servers localhost:9092 --group.id myconsumer --auto.offset.reset earliest \
+    --schema-registry-url ${SCHEMA_REGISTRY_URL}
 
-#echo "Reading messages from Kafka topic [test-string-ou] ..."
+  echo "Reading messages from Kafka topic [test-string-out] ..."
 
-KEY_1_STRING_MSGS=$(read_messages_from_kafka 3 test-string-out Alyssa_consumer | grep Alyssa)
-KEY_2_STRING_MSGS=$(read_messages_from_kafka 3 test-string-out Charlie_consumer | grep Charlie)
-KEY_3_STRING_MSGS=$(read_messages_from_kafka 3 test-string-out Ben_consumer | grep Ben)
+  KEY_1_STRING_MSGS=$(read_messages_from_kafka 3 test-string-out Alyssa_consumer | grep Alyssa)
+  KEY_2_STRING_MSGS=$(read_messages_from_kafka 3 test-string-out Charlie_consumer | grep Charlie)
+  KEY_3_STRING_MSGS=$(read_messages_from_kafka 3 test-string-out Ben_consumer | grep Ben)
 
-## Verifying STRING output with actual message
-verify_output $INPUT_MESSAGE_1 "$KEY_1_STRING_MSGS"
-verify_output $INPUT_MESSAGE_2 "$KEY_2_STRING_MSGS"
-verify_output $INPUT_MESSAGE_3 "$KEY_3_STRING_MSGS"
+  ## Verifying STRING output with actual message
+  verify_output $INPUT_MESSAGE_1 "$KEY_1_STRING_MSGS"
+  verify_output $INPUT_MESSAGE_2 "$KEY_2_STRING_MSGS"
+  verify_output $INPUT_MESSAGE_3 "$KEY_3_STRING_MSGS"
 
-KEY_1_AVRO_MSGS=$(read_messages_from_kafka_avro 3 test-avro-out $USER_SCHEMA Alyssa_consumer_1 | grep Alyssa)
-KEY_2_AVRO_MSGS=$(read_messages_from_kafka_avro 3 test-avro-out $USER_SCHEMA Charlie_consumer_1 | grep Charlie)
-KEY_3_AVRO_MSGS=$(read_messages_from_kafka_avro 3 test-avro-out $USER_SCHEMA Ben_consumer_1 | grep Ben)
+  KEY_1_AVRO_MSGS=$(read_messages_from_kafka_avro 3 test-avro-out $USER_SCHEMA Alyssa_consumer_1 | grep Alyssa)
+  KEY_2_AVRO_MSGS=$(read_messages_from_kafka_avro 3 test-avro-out $USER_SCHEMA Charlie_consumer_1 | grep Charlie)
+  KEY_3_AVRO_MSGS=$(read_messages_from_kafka_avro 3 test-avro-out $USER_SCHEMA Ben_consumer_1 | grep Ben)
 
-## Verifying AVRO output with actual message
-verify_output $INPUT_MESSAGE_1 "$KEY_1_AVRO_MSGS"
-verify_output $INPUT_MESSAGE_2 "$KEY_2_AVRO_MSGS"
-verify_output $INPUT_MESSAGE_3 "$KEY_3_AVRO_MSGS"
+  ## Verifying AVRO output with actual message
+  verify_output $INPUT_MESSAGE_1 "$KEY_1_AVRO_MSGS"
+  verify_output $INPUT_MESSAGE_2 "$KEY_2_AVRO_MSGS"
+  verify_output $INPUT_MESSAGE_3 "$KEY_3_AVRO_MSGS"
+}
+
+run_test_with_timeout 900 schema_registry_test
 


### PR DESCRIPTION
The `test_confluent_schema_registry.sh` e2e test has stalled forever in at least one instance. 
From the logs it seems that the test job gets submitted successfully, but then the schema registry is returning a 500 error:
```
2020-08-17T22:10:51.8856950Z [2020-08-17 22:10:49,775] INFO 127.0.0.1 - - [17/Aug/2020:22:10:49 +0000] "POST /subjects/test-output-subject/versions HTTP/1.1" 500 61  524 (io.confluent.rest-utils.requests:77)
``` 
From that point, the test is not making any progress anymore.

With this PR, we are adding a timeout of 15 minutes to the test. If the test is stalling for that long, we'll print the Flink logs.