### PR TITLE
[FLINK-18622][python] Add limit method in the Python Table API

### DIFF
--- a/docs/dev/python/table-api-users-guide/conversion_of_pandas.md
+++ b/docs/dev/python/table-api-users-guide/conversion_of_pandas.md
@@ -65,6 +65,7 @@ table and serialize them into multiple Arrow batches of Arrow columnar format at
 is determined by the config option [python.fn-execution.arrow.batch.size]({% link dev/python/table-api-users-guide/python_config.md %}#python-fn-execution-arrow-batch-size).
 The serialized data will then be converted to Pandas DataFrame. It will collect the content of the table to
 the client side and so please make sure that the content of the table could fit in memory before calling this method.
+You can limit the number of rows collected to client side via <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.Table.limit">Table.limit</a>
 
 The following example shows how to convert a PyFlink Table to a Pandas DataFrame:
 
@@ -77,5 +78,5 @@ pdf = pd.DataFrame(np.random.rand(1000, 2))
 table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
 
 # Convert the PyFlink Table to a Pandas DataFrame
-pdf = table.to_pandas()
+pdf = table.limit(100).to_pandas()
 {% endhighlight %}

--- a/docs/dev/python/table-api-users-guide/conversion_of_pandas.zh.md
+++ b/docs/dev/python/table-api-users-guide/conversion_of_pandas.zh.md
@@ -62,6 +62,7 @@ table = t_env.from_pandas(pdf,
 在客户端将其序列化为Arrow列存格式，最大Arrow批处理大小
 由配置选项[python.fn-execution.arrow.batch.size]({% link dev/python/table-api-users-guide/python_config.zh.md %}#python-fn-execution-arrow-batch-size) 确定。
 序列化后的数据将被转换为Pandas DataFrame。这意味着需要把表的内容收集到客户端，因此在调用此函数之前，请确保表的内容可以容纳在内存中。
+可以通过<a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.Table.limit">Table.limit</a>，设置收集到客户端的数据的条数。
 
 以下示例显示了如何将PyFlink表转换为Pandas DataFrame：
 
@@ -74,5 +75,5 @@ pdf = pd.DataFrame(np.random.rand(1000, 2))
 table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
 
 # 转换PyFlink Table为Pandas DataFrame
-pdf = table.to_pandas()
+pdf = table.limit(100).to_pandas()
 {% endhighlight %}

--- a/docs/dev/python/table-api-users-guide/intro_to_table_api.md
+++ b/docs/dev/python/table-api-users-guide/intro_to_table_api.md
@@ -501,6 +501,7 @@ The result is:
 1   2  Hello
 {% endhighlight %}
 
+<span class="label label-info">Note</span> "to_pandas" will trigger the materialization of the table and collect table content to the memory of the client, it's good practice to limit the number of rows collected via <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.Table.limit">Table.limit</a>.
 <span class="label label-info">Note</span> "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
 ### Emit Results to One Sink Table

--- a/docs/dev/python/table-api-users-guide/intro_to_table_api.zh.md
+++ b/docs/dev/python/table-api-users-guide/intro_to_table_api.zh.md
@@ -501,6 +501,7 @@ The result is:
 1   2  Hello
 {% endhighlight %}
 
+<span class="label label-info">Note</span> "to_pandas" will trigger the materialization of the table and collect table content to the memory of the client, it's good practice to limit the number of rows collected via <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.Table.limit">Table.limit</a>.
 <span class="label label-info">Note</span> "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
 ### Emit Results to One Sink Table

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -585,6 +585,31 @@ class Table(object):
         """
         return Table(self._j_table.fetch(fetch), self._t_env)
 
+    def limit(self, fetch: int, offset: int = 0):
+        """
+        Limits a (possibly sorted) result to the first n rows.
+
+        This method is a synonym for :func:`~pyflink.table.Table.offset` followed by
+        :func:`~pyflink.table.Table.fetch`.
+
+        Example:
+
+        Returns the first 3 records.
+        ::
+
+            >>> tab.limit(3)
+
+        Skips the first 10 rows and returns the next 5 rows.
+        ::
+
+            >>> tab.limit(5, 10)
+
+        :param fetch: the first number of rows to fetch.
+        :param offset: the number of records to skip, default 0.
+        :return: The result table.
+        """
+        return self.offset(offset).fetch(fetch)
+
     def window(self, window: GroupWindow):
         """
         Defines group window on the records of a table.

--- a/flink-python/pyflink/table/tests/test_sort.py
+++ b/flink-python/pyflink/table/tests/test_sort.py
@@ -31,6 +31,22 @@ class BatchTableSortTests(PyFlinkBatchTableTestCase):
         self.assertEqual('[desc(a)]',
                          query_operation.getOrder().toString())
 
+    def test_limit(self):
+        t = self.t_env.from_elements([(1, "Hello")], ["a", "b"])
+        result = t.limit(1)
+
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual(0, query_operation.getOffset())
+        self.assertEqual(1, query_operation.getFetch())
+
+    def test_limit_with_offset(self):
+        t = self.t_env.from_elements([(1, "Hello")], ["a", "b"])
+        result = t.limit(1, 2)
+
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual(2, query_operation.getOffset())
+        self.assertEqual(1, query_operation.getFetch())
+
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add Table.limit method in the Python Table API to align with the Java Table API*

## Brief change log

  - *Add Table.limit*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_limit and test_limit_with_offset in BatchTableSortTests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
