### PR TITLE
[FLINK-16905][python] TableEnvironment.from_elements support Expression

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1359,9 +1359,11 @@ class TableEnvironment(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
+        if "__len__" not in dir(elements):
+            elements = list(elements)
 
         # in case all the elements are expressions
-        if all(isinstance(elem, Expression) for elem in elements):
+        if len(elements) > 0 and all(isinstance(elem, Expression) for elem in elements):
             if schema is None:
                 return Table(self._j_tenv.fromValues(to_expression_jarray(elements)), self)
             else:
@@ -1389,9 +1391,6 @@ class TableEnvironment(object):
         else:
             def verify_obj(obj):
                 return obj
-
-        if "__len__" not in dir(elements):
-            elements = list(elements)
 
         # infers the schema if not specified
         if schema is None or isinstance(schema, (list, tuple)):

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -31,7 +31,7 @@ from pyflink.common import JobExecutionResult
 from pyflink.dataset import ExecutionEnvironment
 from pyflink.java_gateway import get_gateway
 from pyflink.serializers import BatchedSerializer, PickleSerializer
-from pyflink.table import Table, EnvironmentSettings, Module
+from pyflink.table import Table, EnvironmentSettings, Module, Expression
 from pyflink.table.catalog import Catalog
 from pyflink.table.descriptors import StreamTableDescriptor, BatchTableDescriptor
 from pyflink.table.serializers import ArrowSerializer
@@ -39,8 +39,10 @@ from pyflink.table.statement_set import StatementSet
 from pyflink.table.table_config import TableConfig
 from pyflink.table.table_result import TableResult
 from pyflink.table.types import _to_java_type, _create_type_verifier, RowType, DataType, \
-    _infer_schema_from_data, _create_converter, from_arrow_type, RowField, create_arrow_schema
+    _infer_schema_from_data, _create_converter, from_arrow_type, RowField, create_arrow_schema, \
+    _to_java_data_type
 from pyflink.table.udf import UserDefinedFunctionWrapper
+from pyflink.table.utils import to_expression_jarray
 from pyflink.util import utils
 from pyflink.util.utils import get_j_env_configuration, is_local_deployment, load_java_class, \
     to_j_explain_detail_arr
@@ -1342,6 +1344,11 @@ class TableEnvironment(object):
             ...                         DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
             ...                                        DataTypes.FIELD("b", DataTypes.STRING())]),
             ...                         False)
+            # create Table from expressions
+            >>> table_env.from_elements([row(1, 'abc', 2.0), row(2, 'def', 3.0)],
+            ...                         DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
+            ...                                        DataTypes.FIELD("b", DataTypes.STRING()),
+            ...                                        DataTypes.FIELD("c", DataTypes.FLOAT())]))
 
         :param elements: The elements to create a table from.
         :type elements: list
@@ -1352,6 +1359,15 @@ class TableEnvironment(object):
         :return: The result table.
         :rtype: pyflink.table.Table
         """
+
+        # in case all the elements are expressions
+        if all(isinstance(elem, Expression) for elem in elements):
+            if schema is None:
+                return Table(self._j_tenv.fromValues(to_expression_jarray(elements)), self)
+            else:
+                return Table(self._j_tenv.fromValues(_to_java_data_type(schema),
+                                                     to_expression_jarray(elements)),
+                             self)
 
         # verifies the elements against the specified schema
         if isinstance(schema, RowType):

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -21,6 +21,7 @@ import datetime
 from decimal import Decimal
 
 from pyflink.table import DataTypes, Row, BatchTableEnvironment, EnvironmentSettings
+from pyflink.table.expressions import row
 from pyflink.table.tests.test_types import ExamplePoint, PythonOnlyPoint, ExamplePointUDT, \
     PythonOnlyUDT
 from pyflink.testing import source_sink_utils
@@ -102,6 +103,25 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,'
                     '86400000,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],'
                     '1,1,2.0,{key=1.0},[65, 66, 67, 68],[1.0, 2.0],[3.0, 4.0]']
+        self.assert_equals(actual, expected)
+
+    def test_from_element_expression(self):
+        t_env = self.t_env
+
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.FLOAT()]
+
+        schema = DataTypes.ROW(
+            list(map(lambda field_name, field_type: DataTypes.FIELD(field_name, field_type),
+                     field_names,
+                     field_types)))
+        table_sink = source_sink_utils.TestAppendSink(field_names, field_types)
+        t_env.register_table_sink("Results", table_sink)
+        t = t_env.from_elements([row(1, 'abc', 2.0), row(2, 'def', 3.0)], schema)
+        t.execute_insert("Results").wait()
+        actual = source_sink_utils.results()
+
+        expected = ['1,abc,2.0', '2,def,3.0']
         self.assert_equals(actual, expected)
 
     def test_blink_from_element(self):


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add support of Expression in TableEnvironment.from_elements*

## Brief change log

  - *Improve TableEnvironment.from_elements to support expression*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_from_element_expression*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (pythonDocs)
