### PR TITLE
[FLINK-17393][connector/common] Wakeup the SplitFetchers more elegantly.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -40,7 +40,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -61,7 +60,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 	private final FutureNotifier futureNotifier;
 
 	/** A queue to buffer the elements fetched by the fetcher thread. */
-	private final BlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
+	private final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
 
 	/** The state of the splits. */
 	private final Map<String, SplitContext<T, SplitStateT>> splitStates;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
@@ -21,9 +21,9 @@ package org.apache.flink.connector.base.source.reader.fetcher;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
 import java.util.Collection;
-import java.util.concurrent.BlockingQueue;
 import java.util.function.Consumer;
 
 /**
@@ -31,22 +31,22 @@ import java.util.function.Consumer;
  */
 class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 	private final SplitReader<E, SplitT> splitReader;
-	private final BlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
+	private final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
 	private final Consumer<Collection<String>> splitFinishedCallback;
-	private final Thread runningThread;
+	private final int fetcherIndex;
 	private volatile RecordsWithSplitIds<E> lastRecords;
 	private volatile boolean wakeup;
 
 	FetchTask(
 			SplitReader<E, SplitT> splitReader,
-			BlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+			FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
 			Consumer<Collection<String>> splitFinishedCallback,
-			Thread runningThread) {
+			int fetcherIndex) {
 		this.splitReader = splitReader;
 		this.elementsQueue = elementsQueue;
 		this.splitFinishedCallback = splitFinishedCallback;
 		this.lastRecords = null;
-		this.runningThread = runningThread;
+		this.fetcherIndex = fetcherIndex;
 		this.wakeup = false;
 	}
 
@@ -60,10 +60,11 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 			if (!isWakenUp()) {
 				// The order matters here. We must first put the last records into the queue.
 				// This ensures the handling of the fetched records is atomic to wakeup.
-				elementsQueue.put(lastRecords);
-				// The callback does not throw InterruptedException.
-				splitFinishedCallback.accept(lastRecords.finishedSplits());
-				lastRecords = null;
+				if (elementsQueue.put(fetcherIndex, lastRecords)) {
+					// The callback does not throw InterruptedException.
+					splitFinishedCallback.accept(lastRecords.finishedSplits());
+					lastRecords = null;
+				}
 			}
 		} finally {
 			// clean up the potential wakeup effect. It is possible that the fetcher is waken up
@@ -71,7 +72,6 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 			// running thread will be interrupted. The next invocation of run() will see that and
 			// just skip.
 			if (isWakenUp()) {
-				Thread.interrupted();
 				wakeup = false;
 			}
 		}
@@ -92,12 +92,12 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 			splitReader.wakeUp();
 		} else {
 			// The task might be blocking on enqueuing the records, just interrupt.
-			runningThread.interrupt();
+			elementsQueue.wakeUpPuttingThread(fetcherIndex);
 		}
 	}
 
 	private boolean isWakenUp() {
-		return wakeup || runningThread.isInterrupted();
+		return wakeup;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -49,19 +49,18 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 	private final Map<String, SplitT> assignedSplits;
 	/** The current split assignments for this fetcher. */
 	private final Queue<SplitsChange<SplitT>> splitChanges;
-	private final BlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
+	private final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
 	private final SplitReader<E, SplitT> splitReader;
 	private final Runnable shutdownHook;
 	private final AtomicBoolean wakeUp;
 	private final AtomicBoolean closed;
 	private FetchTask<E, SplitT> fetchTask;
-	private volatile Thread runningThread;
 	private volatile SplitFetcherTask runningTask = null;
 	private volatile boolean isIdle;
 
 	SplitFetcher(
 			int id,
-			BlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+			FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
 			SplitReader<E, SplitT> splitReader,
 			Runnable shutdownHook) {
 
@@ -82,14 +81,13 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 		LOG.info("Starting split fetcher {}", id);
 		try {
 			// Remove the split from the assignments if it is already done.
-			runningThread = Thread.currentThread();
 			this.fetchTask = new FetchTask<>(
 					splitReader,
 					elementsQueue,
 					ids -> {
 						ids.forEach(assignedSplits::remove);
 						updateIsIdle();
-					}, runningThread);
+					}, id);
 			while (!closed.get()) {
 				runOnce();
 			}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -66,7 +65,7 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 	private final AtomicReference<Throwable> uncaughtFetcherException;
 
 	/** The element queue that the split fetchers will put elements into. */
-	private final BlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
+	private final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
 
 	/** A map keeping track of all the split fetchers. */
 	protected final Map<Integer, SplitFetcher<E, SplitT>> fetchers;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
@@ -57,7 +57,7 @@ public class FutureCompletingBlockingQueue<T> {
 	/**
 	 * The default capacity for the queue.
 	 */
-	private static final Integer DEFAULT_CAPACITY = 10000;
+	private static final Integer DEFAULT_CAPACITY = 1;
 
 	public FutureCompletingBlockingQueue(FutureNotifier futureNotifier) {
 		this(futureNotifier, DEFAULT_CAPACITY);

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
@@ -18,28 +18,44 @@
 
 package org.apache.flink.connector.base.source.reader.synchronization;
 
-import java.util.Collection;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A BlockingQueue that allows a consuming thread to be notified asynchronously on element
- * availability when the queue is empty.
- *
- * <p>Implementation wise, it is a subclass of {@link LinkedBlockingQueue} that ensures all
- * the methods adding elements into the queue will complete the elements availability future.
- *
- * <p>The overriding methods must first put the elements into the queue then check and complete
- * the future if needed. This is required to ensure the thread waiting for more messages will
- * not lose a notification.
+ * A custom implementation of blocking queue with the following features.
+ * <ul>
+ *     <li>
+ *         It allows a consuming thread to be notified asynchronously on element availability when the
+ *         queue is empty.
+ *     </li>
+ *     <li>
+ *         Allows the putting threads to be gracefully waken up without interruption.
+ *     </li>
+ * </ul>
  *
  * @param <T> the type of the elements in the queue.
  */
-public class FutureCompletingBlockingQueue<T> extends LinkedBlockingQueue<T> {
-
+public class FutureCompletingBlockingQueue<T> {
+	private final int capacity;
 	private final FutureNotifier futureNotifier;
+
+	/** The element queue. */
+	private final Queue<T> queue;
+	/** The lock for synchronization. */
+	private final Lock lock;
+	/** The per-thread conditions that are waiting on putting elements. */
+	private final Queue<Condition> notFull;
+	/** The shared conditions for getting elements. */
+	private final Condition notEmpty;
+	/** The per-thread conditions and wakeUp flags. */
+	private ConditionAndFlag[] putConditionAndFlags;
+
 	/**
-	 * The default capacity for {@link LinkedBlockingQueue}.
+	 * The default capacity for the queue.
 	 */
 	private static final Integer DEFAULT_CAPACITY = 10000;
 
@@ -48,53 +64,211 @@ public class FutureCompletingBlockingQueue<T> extends LinkedBlockingQueue<T> {
 	}
 
 	public FutureCompletingBlockingQueue(FutureNotifier futureNotifier, int capacity) {
-		super(capacity);
+		this.capacity = capacity;
 		this.futureNotifier = futureNotifier;
+		this.queue = new ArrayDeque<>(capacity);
+		this.lock = new ReentrantLock();
+		this.putConditionAndFlags = new ConditionAndFlag[1];
+		this.notFull = new ArrayDeque<>();
+		this.notEmpty = lock.newCondition();
 	}
 
-	@Override
-	public void put(T t) throws InterruptedException {
-		super.put(t);
+	/**
+	 * Put an element into the queue. The thread blocks if the queue is full.
+	 *
+	 * @param threadIndex the index of the thread.
+	 * @param element the element to put.
+	 * @return true if the element has been successfully put into the queue, false otherwise.
+	 * @throws InterruptedException when the thread is interrupted.
+	 */
+	public boolean put(int threadIndex, T element) throws InterruptedException {
+		if (element == null) {
+			throw new NullPointerException();
+		}
+		lock.lockInterruptibly();
+		try {
+			while (queue.size() >= capacity) {
+				if (getAndResetWakeUpFlag(threadIndex)) {
+					return false;
+				}
+				waitOnPut(threadIndex);
+			}
+			enqueue(element);
+			return true;
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Get and remove the first element from the queue. The call blocks if the queue is empty.
+	 *
+	 * @return the first element in the queue.
+	 * @throws InterruptedException when the thread is interrupted.
+	 */
+	public T take() throws InterruptedException{
+		lock.lock();
+		try {
+			while (queue.size() == 0) {
+				notEmpty.await();
+			}
+			return dequeue();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Get and remove the first element from the queue. Null is retuned if the queue is empty.
+	 *
+	 * @return the first element from the queue, or Null if the queue is empty.
+	 */
+	public T poll() {
+		lock.lock();
+		try {
+			if (queue.size() == 0) {
+				return null;
+			}
+			return dequeue();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Get the first element from the queue without removing it.
+	 *
+	 * @return the first element in the queue, or Null if the queue is empty.
+	 */
+	public T peek() {
+		lock.lock();
+		try {
+			return queue.peek();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	public int size() {
+		lock.lock();
+		try {
+			return queue.size();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	public boolean isEmpty() {
+		lock.lock();
+		try {
+			return queue.isEmpty();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	public int remainingCapacity() {
+		lock.lock();
+		try {
+			return capacity - queue.size();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	public void wakeUpPuttingThread(int threadIndex) {
+		lock.lock();
+		try {
+			maybeCreateCondition(threadIndex);
+			ConditionAndFlag caf = putConditionAndFlags[threadIndex];
+			if (caf != null) {
+				caf.setWakeUp(true);
+				caf.condition().signal();
+			}
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	// --------------- private helpers -------------------------
+
+	private void enqueue(T element) {
+		int sizeBefore = queue.size();
+		queue.add(element);
 		futureNotifier.notifyComplete();
-	}
-
-	@Override
-	public boolean offer(T t, long timeout, TimeUnit unit) throws InterruptedException {
-		if (super.offer(t, timeout, unit)) {
-			futureNotifier.notifyComplete();
-			return true;
-		} else {
-			return false;
+		if (sizeBefore == 0) {
+			notEmpty.signal();
+		}
+		if (sizeBefore < capacity - 1 && !notFull.isEmpty()) {
+			signalNextPutter();
 		}
 	}
 
-	@Override
-	public boolean offer(T t) {
-		if (super.offer(t)) {
-			futureNotifier.notifyComplete();
-			return true;
-		} else {
-			return false;
+	private T dequeue() {
+		int sizeBefore = queue.size();
+		T element = queue.poll();
+		if (sizeBefore == capacity && !notFull.isEmpty()) {
+			signalNextPutter();
+		}
+		if (sizeBefore > 1) {
+			notEmpty.signal();
+		}
+		return element;
+	}
+
+	private void waitOnPut(int fetcherIndex) throws InterruptedException {
+		maybeCreateCondition(fetcherIndex);
+		Condition cond = putConditionAndFlags[fetcherIndex].condition();
+		notFull.add(cond);
+		cond.await();
+	}
+
+	private void signalNextPutter() {
+		if (!notFull.isEmpty()) {
+			notFull.poll().signal();
 		}
 	}
 
-	@Override
-	public boolean add(T t) {
-		if (super.add(t)) {
-			futureNotifier.notifyComplete();
-			return true;
-		} else {
-			return false;
+	private void maybeCreateCondition(int threadIndex) {
+		if (putConditionAndFlags.length < threadIndex + 1) {
+			putConditionAndFlags = Arrays.copyOf(putConditionAndFlags, threadIndex + 1);
+		}
+
+		if (putConditionAndFlags[threadIndex] == null) {
+			putConditionAndFlags[threadIndex] = new ConditionAndFlag(lock.newCondition());
 		}
 	}
 
-	@Override
-	public boolean addAll(Collection<? extends T> c) {
-		if (super.addAll(c)) {
-			futureNotifier.notifyComplete();
+	private boolean getAndResetWakeUpFlag(int threadIndex) {
+		maybeCreateCondition(threadIndex);
+		if (putConditionAndFlags[threadIndex].getWakeUp()) {
+			putConditionAndFlags[threadIndex].setWakeUp(false);
 			return true;
-		} else {
-			return false;
+		}
+		return false;
+	}
+
+	// --------------- private per thread state ------------
+
+	private static class ConditionAndFlag {
+		private final Condition cond;
+		private boolean wakeUp;
+
+		private ConditionAndFlag(Condition cond) {
+			this.cond = cond;
+			this.wakeUp = false;
+		}
+
+		private Condition condition() {
+			return cond;
+		}
+
+		private boolean getWakeUp() {
+			return wakeUp;
+		}
+
+		private void setWakeUp(boolean value) {
+			wakeUp = value;
 		}
 	}
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.connector.base.source.reader.fetcher;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureNotifier;
 
 import org.junit.Test;
 
@@ -29,8 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,9 +45,11 @@ public class SplitFetcherTest {
 	private static final int NUM_RECORDS_PER_SPLIT = 10_000;
 	private static final int INTERRUPT_RECORDS_INTERVAL = 10;
 	private static final int NUM_TOTAL_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
+
 	@Test
 	public void testWakeup() throws InterruptedException {
-		BlockingQueue<RecordsWithSplitIds<int[]>> elementQueue = new ArrayBlockingQueue<>(1);
+		FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementQueue =
+			new FutureCompletingBlockingQueue<>(new FutureNotifier(), 1);
 		SplitFetcher<int[], MockSourceSplit> fetcher =
 				new SplitFetcher<>(
 						0,

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.fail;
  * The unit test for {@link FutureCompletingBlockingQueue}.
  */
 public class FutureCompletingBlockingQueueTest {
-	private static final Integer DEFAULT_CAPACITY = 10000;
+	private static final Integer DEFAULT_CAPACITY = 1;
 	private static final Integer SPECIFIED_CAPACITY = 20000;
 
 	@Test

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
@@ -20,16 +20,129 @@ package org.apache.flink.connector.base.source.reader.synchronization;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * The unit test for {@link FutureCompletingBlockingQueue}.
  */
 public class FutureCompletingBlockingQueueTest {
-
-
 	private static final Integer DEFAULT_CAPACITY = 10000;
 	private static final Integer SPECIFIED_CAPACITY = 20000;
+
+	@Test
+	public void testBasics() throws InterruptedException {
+		FutureNotifier futureNotifier = new FutureNotifier();
+		FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>(futureNotifier, 5);
+
+		CompletableFuture<Void> future = futureNotifier.future();
+		assertTrue(queue.isEmpty());
+		assertEquals(0, queue.size());
+
+		queue.put(0, 1234);
+
+		assertTrue(future.isDone());
+		assertEquals(1, queue.size());
+		assertFalse(queue.isEmpty());
+		assertEquals(4, queue.remainingCapacity());
+		assertNotNull(queue.peek());
+		assertEquals(1234, (int) queue.peek());
+		assertEquals(1234, (int) queue.poll());
+
+		assertEquals(0, queue.size());
+		assertTrue(queue.isEmpty());
+		assertEquals(5, queue.remainingCapacity());
+	}
+
+	@Test
+	public void testPoll() throws InterruptedException {
+		FutureNotifier futureNotifier = new FutureNotifier();
+		FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>(futureNotifier);
+		queue.put(0, 1234);
+		Integer value = queue.poll();
+		assertNotNull(value);
+		assertEquals(1234, (int) value);
+	}
+
+	@Test
+	public void testWakeUpPut() throws InterruptedException {
+		FutureNotifier futureNotifier = new FutureNotifier();
+		FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>(futureNotifier, 1);
+
+		CountDownLatch latch = new CountDownLatch(1);
+		new Thread(() -> {
+			try {
+				assertTrue(queue.put(0, 1234));
+				assertFalse(queue.put(0, 1234));
+				latch.countDown();
+			} catch (InterruptedException e) {
+				fail("Interrupted unexpectedly.");
+			}
+		}).start();
+
+		queue.wakeUpPuttingThread(0);
+		latch.await();
+		assertEquals(0, latch.getCount());
+	}
+
+	@Test
+	public void testConcurrency() throws InterruptedException {
+		FutureNotifier futureNotifier = new FutureNotifier();
+		FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>(futureNotifier, 5);
+		final int numValuesPerThread = 10000;
+		final int numPuttingThreads = 5;
+		List<Thread> threads = new ArrayList<>();
+
+		for (int i = 0; i < numPuttingThreads; i++) {
+			final int index = i;
+			Thread t = new Thread(() -> {
+				for (int j = 0; j < numValuesPerThread; j++) {
+					int base = index * numValuesPerThread;
+					try {
+						queue.put(index, base + j);
+					} catch (InterruptedException e) {
+						fail("putting thread interrupted.");
+					}
+				}
+			});
+			t.start();
+			threads.add(t);
+		}
+
+		BitSet bitSet = new BitSet();
+		AtomicInteger count = new AtomicInteger(0);
+		for (int i = 0; i < 5; i++) {
+			Thread t = new Thread(() -> {
+				while (count.get() < numPuttingThreads * numValuesPerThread) {
+					Integer value = queue.poll();
+					if (value == null) {
+						continue;
+					}
+					count.incrementAndGet();
+					if (bitSet.get(value)) {
+						fail("Value " + value + " has been consumed before");
+					}
+					synchronized (bitSet) {
+						bitSet.set(value);
+					}
+				}});
+			t.start();
+			threads.add(t);
+		}
+		for (Thread t : threads) {
+			t.join();
+		}
+	}
 
 	@Test
 	public void testFutureCompletingBlockingQueueConstructor() {


### PR DESCRIPTION
## What is the purpose of the change
Currently the `FetchTask`s can only be waken up via `Thread.interrupt()` when the thread is blocking on putting an element into the `FutureCompletingBlockingQueue`. To ensure the thread is waken up, `FetchTask#wakeUp()` pessimistically interrupts the split fetcher thread. This means that the split fetcher thread might also be interrupted while it is in `SplitReader#fetch()`. This interruption is problematic because the `SplitReader` does not necessarily handle interruptions.

This patch solves the problem by adding some logic to the `FutureCompletingBlockingQueue` so that a thread blocking on putting an element into the queue can be waken up elegantly.

## Brief change log
a1ca80ac6de0f : Add logic to the `FutureCompletingBlockingQueue` to allow a putting thread to be waken up elegantly.
38b675997be8 : Change the default capacity of `FutureCompletingBlockingQueue` to 1.


## Verifying this change

This change added tests:
* org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueueTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (in the worst case yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
