### PR TITLE
[FLINK-17818][flink-java] Fixed the CSV Reader API: CSV Reader was not parsing data when no field names are passed as an argument. Added a check to see if it is not empty.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -315,7 +315,7 @@ public class CsvReader {
 	 */
 	public <T> DataSource<T> pojoType(Class<T> pojoType, String... pojoFields) {
 		Preconditions.checkNotNull(pojoType, "The POJO type class must not be null.");
-		Preconditions.checkNotNull(pojoFields, "POJO fields must be specified (not null) if output type is a POJO.");
+		Preconditions.checkArgument(pojoFields != null && pojoFields.length > 0, "POJO fields must be specified (not null) if output type is a POJO.");
 
 		final TypeInformation<T> ti = TypeExtractor.createTypeInfo(pojoType);
 		if (!(ti instanceof PojoTypeInfo)) {

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
@@ -89,8 +89,17 @@ public class CsvReaderITCase extends MultipleProgramsTestBase {
 		compareResultAsText(result, expected);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testPOJOTypeWithoutFieldsOrder() throws Exception {
+		final String inputData = "";
+		final String dataPath = createInputData(inputData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.readCsvFile(dataPath).pojoType(POJOItem.class);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testPOJOTypeWitNullFieldsOrder() throws Exception {
 		final String inputData = "";
 		final String dataPath = createInputData(inputData);
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();


### PR DESCRIPTION
## What is the purpose of the change
CSV Reader was not parsing data when no field names are passed as an argument with a POJO type.

## Brief change log
* Added a check to see if the field names are specified when reading from a CSV file with a POJO.

## Verifying this change
This change added tests and can be verified as follows:
  - Added a test to check if the field names are not specified then throw _IllegalArgumentException_.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
