### PR TITLE
[FLINK-19187][examples-table] Add a new basic Table API example

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -57,16 +57,24 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- Flink core -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -99,6 +99,28 @@ under the License.
 				<executions>
 
 					<execution>
+						<id>GettingStartedExample</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+
+						<configuration>
+							<classifier>GettingStartedExample</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.table.examples.java.basics.GettingStartedExample</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>org/apache/flink/table/examples/java/basics/GettingStartedExample*</include>
+							</includes>
+						</configuration>
+					</execution>
+
+					<execution>
 						<id>StreamSQLExample</id>
 						<phase>package</phase>
 						<goals>
@@ -264,6 +286,7 @@ under the License.
 						<id>rename</id>
 						<configuration>
 							<target>
+								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-GettingStartedExample.jar" tofile="${project.basedir}/target/GettingStartedExample.jar"/>
 								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-StreamSQLExample.jar" tofile="${project.basedir}/target/StreamSQLExample.jar"/>
 								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-StreamWindowSQLExample.jar" tofile="${project.basedir}/target/StreamWindowSQLExample.jar"/>
 								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-WordCountSQL.jar" tofile="${project.basedir}/target/WordCountSQL.jar"/>

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/GettingStartedExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/GettingStartedExample.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.java.basics;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.range;
+import static org.apache.flink.table.api.Expressions.withColumns;
+
+/**
+ * Example for getting started with the Table & SQL API.
+ *
+ * <p>The example shows how to create, transform, and query a table. It should give a first impression
+ * about the look-and-feel of the API without going too much into details. See the other examples for
+ * using connectors or more complex operations.
+ *
+ * <p>In particular, the example shows how to
+ * <ul>
+ *     <li>setup a {@link TableEnvironment},
+ *     <li>use the environment for creating example tables, registering views, and executing SQL queries,
+ *     <li>transform tables with filters and projections,
+ *     <li>declare user-defined functions,
+ *     <li>and print/collect results locally.
+ * </ul>
+ *
+ * <p>The example executes two Flink jobs. The results are written to stdout.
+ */
+public final class GettingStartedExample {
+
+	public static void main(String[] args) throws Exception {
+
+		// setup the unified API
+		// in this case: declare that the table programs should be executed in batch mode
+		final EnvironmentSettings settings = EnvironmentSettings.newInstance()
+			.inBatchMode()
+			.build();
+		final TableEnvironment env = TableEnvironment.create(settings);
+
+		// create a table with example data without a connector required
+		final Table rawCustomers = env.fromValues(
+			Row.of("Guillermo Smith", LocalDate.parse("1992-12-12"), "4081 Valley Road", "08540", "New Jersey", "m", true, 0, 78, 3),
+			Row.of("Valeria Mendoza", LocalDate.parse("1970-03-28"), "1239  Rainbow Road", "90017", "Los Angeles", "f", true, 9, 39, 0),
+			Row.of("Leann Holloway", LocalDate.parse("1989-05-21"), "2359 New Street", "97401", "Eugene", null, true, null, null, null),
+			Row.of("Brandy Sanders", LocalDate.parse("1956-05-26"), "4891 Walkers-Ridge-Way", "73119", "Oklahoma City", "m", false, 9, 39, 0),
+			Row.of("John Turner", LocalDate.parse("1982-10-02"), "2359 New Street", "60605", "Chicago", "m", true, 12, 39, 0),
+			Row.of("Ellen Ortega", LocalDate.parse("1985-06-18"), "2448 Rodney STreet", "85023", "Phoenix", "f", true, 0, 78, 3)
+		);
+
+		// handle ranges of columns easily
+		final Table truncatedCustomers = rawCustomers.select(withColumns(range(1, 7)));
+
+		// name columns
+		final Table namedCustomers = truncatedCustomers
+			.as("name", "date_of_birth", "street", "zip_code", "city", "gender", "has_newsletter");
+
+		// register a view temporarily
+		env.createTemporaryView("customers", namedCustomers);
+
+		// use SQL whenever you like
+		// call execute() and print() to get insights
+		env
+			.sqlQuery(
+				"SELECT " +
+				"  COUNT(*) AS `number of customers`, " +
+				"  AVG(YEAR(date_of_birth)) AS `average birth year` " +
+				"FROM `customers`"
+			)
+			.execute()
+			.print();
+
+		// or further transform the data using the fluent Table API
+		// e.g. filter, project fields, or call a user-defined function
+		final Table youngCustomers = env
+			.from("customers")
+			.filter($("gender").isNotNull())
+			.filter($("has_newsletter").isEqual(true))
+			.filter($("date_of_birth").isGreaterOrEqual(LocalDate.parse("1980-01-01")))
+			.select(
+				$("name").upperCase(),
+				$("date_of_birth"),
+				call(AddressNormalizer.class, $("street"), $("zip_code"), $("city")).as("address")
+			);
+
+		// use execute() and collect() to retrieve your results from the cluster
+		// this can be useful for testing before storing it in an external system
+		try (CloseableIterator<Row> iterator = youngCustomers.execute().collect()) {
+			final Set<Row> expectedOutput = new HashSet<>();
+			expectedOutput.add(Row.of("GUILLERMO SMITH", LocalDate.parse("1992-12-12"), "4081 VALLEY ROAD, 08540, NEW JERSEY"));
+			expectedOutput.add(Row.of("JOHN TURNER", LocalDate.parse("1982-10-02"), "2359 NEW STREET, 60605, CHICAGO"));
+			expectedOutput.add(Row.of("ELLEN ORTEGA", LocalDate.parse("1985-06-18"), "2448 RODNEY STREET, 85023, PHOENIX"));
+
+			final Set<Row> actualOutput = new HashSet<>();
+			iterator.forEachRemaining(actualOutput::add);
+
+			if (actualOutput.equals(expectedOutput)) {
+				System.out.println("SUCCESS!");
+			} else {
+				System.out.println("FAILURE!");
+			}
+		}
+	}
+
+	/**
+	 * We can put frequently used procedures in user-defined functions.
+	 *
+	 * <p>It is possible to call third-party libraries here as well.
+	 */
+	public static class AddressNormalizer extends ScalarFunction {
+
+		// the 'eval()' method defines input and output types (reflectively extracted)
+		// and contains the runtime logic
+		public String eval(String street, String zipCode, String city) {
+			return normalize(street) + ", " + normalize(zipCode) + ", " + normalize(city);
+		}
+
+		private String normalize(String s) {
+			return s.toUpperCase().replaceAll("\\W", " ").replaceAll("\\s+", " ").trim();
+		}
+	}
+}

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/GettingStartedExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/GettingStartedExample.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.scala.basics
+
+import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment, _}
+import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.types.Row
+import org.apache.flink.util.CloseableIterator
+
+import java.time.LocalDate
+
+import scala.collection.JavaConverters._
+
+/**
+ * Example for getting started with the Table & SQL API in Scala.
+ *
+ * The example shows how to create, transform, and query a table. It should give a first impression
+ * about the look-and-feel of the API without going too much into details. See the other examples for
+ * using connectors or more complex operations.
+ *
+ * In particular, the example shows how to
+ *   - setup a [[TableEnvironment]],
+ *   - use the environment for creating example tables, registering views, and executing SQL queries,
+ *   - transform tables with filters and projections,
+ *   - declare user-defined functions,
+ *   - and print/collect results locally.
+ *
+ * The example executes two Flink jobs. The results are written to stdout.
+ */
+object GettingStartedExample {
+
+  def main(args: Array[String]): Unit = {
+
+    // setup the unified API
+    // in this case: declare that the table programs should be executed in batch mode
+    val settings = EnvironmentSettings.newInstance()
+      .inBatchMode()
+      .build()
+    val env = TableEnvironment.create(settings)
+
+    // create a table with example data without a connector required
+    val rawCustomers = env.fromValues(
+      row("Guillermo Smith", LocalDate.parse("1992-12-12"), "4081 Valley Road", "08540", "New Jersey", "m", true, 0, 78, 3),
+      row("Valeria Mendoza", LocalDate.parse("1970-03-28"), "1239  Rainbow Road", "90017", "Los Angeles", "f", true, 9, 39, 0),
+      row("Leann Holloway", LocalDate.parse("1989-05-21"), "2359 New Street", "97401", "Eugene", null, true, null, null, null),
+      row("Brandy Sanders", LocalDate.parse("1956-05-26"), "4891 Walkers-Ridge-Way", "73119", "Oklahoma City", "m", false, 9, 39, 0),
+      row("John Turner", LocalDate.parse("1982-10-02"), "2359 New Street", "60605", "Chicago", "m", true, 12, 39, 0),
+      row("Ellen Ortega", LocalDate.parse("1985-06-18"), "2448 Rodney STreet", "85023", "Phoenix", "f", true, 0, 78, 3)
+    )
+
+    // handle ranges of columns easily
+    val truncatedCustomers = rawCustomers.select(withColumns(1 to 7))
+
+    // name columns
+    val namedCustomers = truncatedCustomers
+      .as("name", "date_of_birth", "street", "zip_code", "city", "gender", "has_newsletter")
+
+    // register a view temporarily
+    env.createTemporaryView("customers", namedCustomers)
+
+    // use SQL whenever you like
+    // call execute() and print() to get insights
+    env
+      .sqlQuery("""
+        |SELECT
+        |  COUNT(*) AS `number of customers`,
+        |  AVG(YEAR(date_of_birth)) AS `average birth year`
+        |FROM `customers`
+        |""".stripMargin
+      )
+      .execute()
+      .print()
+
+    // or further transform the data using the fluent Table API
+    // e.g. filter, project fields, or call a user-defined function
+    val youngCustomers = env
+      .from("customers")
+      .filter($"gender".isNotNull)
+      .filter($"has_newsletter" === true)
+      .filter($"date_of_birth" >= LocalDate.parse("1980-01-01"))
+      .select(
+        $"name".upperCase(),
+        $"date_of_birth",
+        call(classOf[AddressNormalizer], $"street", $"zip_code", $"city").as("address")
+      )
+
+    // use execute() and collect() to retrieve your results from the cluster
+    // this can be useful for testing before storing it in an external system
+    var iterator: CloseableIterator[Row] = null
+    try {
+      iterator = youngCustomers.execute().collect()
+      val actualOutput = iterator.asScala.toSet
+
+      val expectedOutput = Set(
+        Row.of("GUILLERMO SMITH", LocalDate.parse("1992-12-12"), "4081 VALLEY ROAD, 08540, NEW JERSEY"),
+        Row.of("JOHN TURNER", LocalDate.parse("1982-10-02"), "2359 NEW STREET, 60605, CHICAGO"),
+        Row.of("ELLEN ORTEGA", LocalDate.parse("1985-06-18"), "2448 RODNEY STREET, 85023, PHOENIX")
+      )
+
+      if (actualOutput == expectedOutput) {
+        println("SUCCESS!")
+      } else {
+        println("FAILURE!")
+      }
+    } finally {
+      if (iterator != null) {
+        iterator.close()
+      }
+    }
+  }
+
+  /**
+   * We can put frequently used procedures in user-defined functions.
+   *
+   * It is possible to call third-party libraries here as well.
+   */
+  class AddressNormalizer extends ScalarFunction {
+
+    // the 'eval()' method defines input and output types (reflectively extracted)
+    // and contains the runtime logic
+    def eval(street: String, zipCode: String, city: String): String = {
+      normalize(street) + ", " + normalize(zipCode) + ", " + normalize(city)
+    }
+
+    private def normalize(s: String) = {
+      s.toUpperCase.replaceAll("\\W", " ").replaceAll("\\s+", " ").trim
+    }
+  }
+}

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/StreamSQLExample.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.examples.scala
+package org.apache.flink.table.examples.scala.basics
 
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.scala._

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/TPCHQuery3Table.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/TPCHQuery3Table.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.examples.scala
+package org.apache.flink.table.examples.scala.basics
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/WordCountSQL.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/WordCountSQL.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.examples.scala
+package org.apache.flink.table.examples.scala.basics
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/WordCountTable.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/basics/WordCountTable.scala
@@ -15,21 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.examples.scala
+
+package org.apache.flink.table.examples.scala.basics
 
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 
 /**
-  * Simple example for demonstrating the use of Table API on a Stream Table.
+  * Simple example for demonstrating the use of the Table API for a Word Count in Scala.
   *
   * This example shows how to:
-  *  - Convert DataStreams to Tables
-  *  - Apply union, select, and filter operations
+  *  - Convert DataSets to Tables
+  *  - Apply group, aggregate, select, and filter operations
+  *
   */
-object StreamTableExample {
+object WordCountTable {
 
   // *************************************************************************
   //     PROGRAM
@@ -38,34 +39,24 @@ object StreamTableExample {
   def main(args: Array[String]): Unit = {
 
     // set up execution environment
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = StreamTableEnvironment.create(env)
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = BatchTableEnvironment.create(env)
 
-    val orderA = env.fromCollection(Seq(
-      Order(1L, "beer", 3),
-      Order(1L, "diaper", 4),
-      Order(3L, "rubber", 2))).toTable(tEnv)
-
-    val orderB = env.fromCollection(Seq(
-      Order(2L, "pen", 3),
-      Order(2L, "rubber", 3),
-      Order(4L, "beer", 1))).toTable(tEnv)
-
-    // union the two tables
-    val result: DataStream[Order] = orderA.unionAll(orderB)
-      .select('user, 'product, 'amount)
-      .where('amount > 2)
-      .toAppendStream[Order]
+    val input = env.fromElements(WC("hello", 1), WC("hello", 1), WC("ciao", 1))
+    val expr = input.toTable(tEnv)
+    val result = expr
+      .groupBy($"word")
+      .select($"word", $"frequency".sum as "frequency")
+      .filter($"frequency" === 2)
+      .toDataSet[WC]
 
     result.print()
-
-    env.execute()
   }
 
   // *************************************************************************
   //     USER DATA TYPES
   // *************************************************************************
 
-  case class Order(user: Long, product: String, amount: Int)
+  case class WC(word: String, frequency: Long)
 
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/GettingStartedExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/GettingStartedExampleITCase.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.java.basics;
+
+import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for Java {@link GettingStartedExample}.
+ */
+public class GettingStartedExampleITCase extends ExampleOutputTestBase {
+
+	@Test
+	public void testExample() throws Exception {
+		GettingStartedExample.main(new String[0]);
+		final String consoleOutput = getOutputString();
+		assertThat(consoleOutput, containsString("|                    6 |                 1979 |"));
+		assertThat(consoleOutput, containsString("SUCCESS!"));
+	}
+}

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/GettingStartedExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/GettingStartedExampleITCase.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.scala.basics;
+
+import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for Scala {@link GettingStartedExample}.
+ */
+public class GettingStartedExampleITCase extends ExampleOutputTestBase {
+
+	@Test
+	public void testExample() {
+		GettingStartedExample.main(new String[0]);
+		final String consoleOutput = getOutputString();
+		assertThat(consoleOutput, containsString("|                    6 |                 1979 |"));
+		assertThat(consoleOutput, containsString("SUCCESS!"));
+	}
+}

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/utils/ExampleOutputTestBase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/utils/ExampleOutputTestBase.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.utils;
+
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/**
+ * Test base for validating the example output to stdout.
+ */
+public abstract class ExampleOutputTestBase {
+
+	@ClassRule
+	public static MiniClusterWithClientResource miniClusterResource = new MiniClusterWithClientResource(
+		new MiniClusterResourceConfiguration.Builder()
+			.setNumberTaskManagers(1)
+			.setNumberSlotsPerTaskManager(1)
+			.build());
+
+	private PrintStream originalPrintStream;
+
+	private ByteArrayOutputStream testOutputStream;
+
+	@Before
+	public void init() {
+		originalPrintStream = System.out;
+		testOutputStream = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(testOutputStream));
+	}
+
+	protected String getOutputString() {
+		return testOutputStream.toString();
+	}
+
+	@After
+	public void finalize() {
+		System.setOut(originalPrintStream);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Example for getting started with the Table & SQL API in Java & Scala.

## Brief change log

The example shows how to create, transform, and query a table. It should give a first impression
about the look-and-feel of the API without going too much into details. See the other examples for
using connectors or more complex operations.

## Verifying this change

The example uses print and is untested.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
