### PR TITLE
[FLINK-15467][task] Wait for sourceTaskThread to finish before exiting from StreamTask.invoke [1.10]

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -464,6 +464,24 @@ public class SourceStreamTaskTest {
 		testHarness.waitForTaskCompletion();
 	}
 
+	@Test
+	public void testWaitsForSourceThreadOnCancel() throws Exception {
+		StreamTaskTestHarness<String> harness = new StreamTaskTestHarness<>(SourceStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO);
+
+		harness.setupOutputForSingletonOperatorChain();
+		harness.getStreamConfig().setStreamOperator(new StreamSource<>(new NonStoppingSource()));
+
+		harness.invoke();
+		NonStoppingSource.waitForStart();
+
+		harness.getTask().cancel();
+		harness.waitForTaskCompletion(500, true); // allow task to exit prematurely
+		assertTrue(harness.taskThread.isAlive());
+
+		NonStoppingSource.forceCancel();
+		harness.waitForTaskCompletion(Long.MAX_VALUE, true);
+	}
+
 	private static class MockSource implements SourceFunction<Tuple2<Long, Integer>>, ListCheckpointed<Serializable> {
 		private static final long serialVersionUID = 1;
 
@@ -567,6 +585,37 @@ public class SourceStreamTaskTest {
 				Thread.sleep(checkpointInterval);
 			}
 			return true;
+		}
+	}
+
+	private static class NonStoppingSource implements SourceFunction<String> {
+		private static final long serialVersionUID = 1L;
+		private static boolean running = true;
+		private static CompletableFuture<Void> startFuture = new CompletableFuture<>();
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			startFuture.complete(null);
+			while (running) {
+				try {
+					Thread.sleep(500);
+				} catch (InterruptedException e) {
+					// ignore
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			// do nothing - ignore usual cancellation
+		}
+
+		static void forceCancel() {
+			running = false;
+		}
+
+		static void waitForStart() {
+			startFuture.join();
 		}
 	}
 


### PR DESCRIPTION
(Unchanged backport of https://github.com/apache/flink/pull/13000)

## What is the purpose of the change

Wait for the LegacySourceFunctionThread to finish when cancelling the task.
This prevents premature freeing of resources, particularly LibraryCache (see [FLINK-15467](https://issues.apache.org/jira/browse/FLINK-15467) discussion).

Implemented by waiting in `SourceStreamTask.invoke()` for the `sourceThread` to complete.

There were several existing tests failures (listed below) which were fixed by completing the future if thread isn't alive; or by returning a completed future if a task is failing.
## Verifying this change

* Added unit test: `SourceStreamTaskTest.testWaitsForSourceThreadOnCancel`

* Tested manually on a local cluster

* Existing tests covering different scenarios of task exit and cancellation: `InterruptSensitiveRestoreTest`, `StreamTaskTest.testEarlyCanceling`, `FastFailuresITCase`


## Does this pull request potentially affect one of the following parts:

* Dependencies (does it add or upgrade a dependency): no

* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

* The serializers: no

* The runtime per-record code paths (performance sensitive): no

* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no

* The S3 file system connector: no


## Documentation

* Does this pull request introduce a new feature? no

* If yes, how is the feature documented? no

