### PR TITLE
[FLINK-19224][state-processor-api] Support reading window operator state

### DIFF
--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -431,7 +431,7 @@ clicks
 </div>
 </div>
 
-This state can be read using the below code.
+This state can be read using the code below.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -466,7 +466,7 @@ ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
 ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend());
 
 savepoint
-    .window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
+    .window(TumblingEventTimeWindows.of(Time.minutes(1)))
     .aggregate("click-window", new ClickCounter(), new ClickReader(), Types.String, Types.INT, Types.INT)
     .print();
 
@@ -502,13 +502,15 @@ val batchEnv = ExecutionEnvironment.getExecutionEnvironment()
 val savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend())
 
 savepoint
-    .window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
+    .window(TumblingEventTimeWindows.of(Time.minutes(1)))
     .aggregate("click-window", new ClickCounter(), new ClickReader(), Types.String, Types.INT, Types.INT)
     .print()
 
 {% endhighlight %}
 </div>
 </div>
+
+{% panel **Note:** Reading state written by a Trigger is not currently supported. %}
 
 ## Writing New Savepoints
 

--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -345,6 +345,44 @@ Along with reading registered state values, each key has access to a `Context` w
 
 {% panel **Note:** When using a `KeyedStateReaderFunction`, all state descriptors must be registered eagerly inside of open. Any attempt to call a `RuntimeContext#get*State` will result in a `RuntimeException`. %}
 
+### Window State
+
+The state processor api supports reading state from a [window operator]({{ site.baseurl }}/dev/stream/operators/windows.html).
+This includes both time based windows along with other types, pre-aggregation, non-aggregated, and windows with evictors.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+
+ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend());
+
+int count = savepoint
+    // The timeWindow method supports reading from any type of time based window, including but not limited to
+    // Tumbling, Sliding, and Session windows for both event time and processing time.
+    .timeWindow()
+    .reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+    .count();
+
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+
+val batchEnv = ExecutionEnvironment.getExecutionEnvironment()
+val savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend())
+
+val count = savepoint
+    // The timeWindow method supports reading from any type of time based window, including but not limited to
+    // Tumbling, Sliding, and Session windows for both event time and processing time.
+    .timeWindow()
+    .reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+    .count();
+
+{% endhighlight %}
+</div>
+</div>
+
 ## Writing New Savepoints
 
 `Savepoint`'s may also be written, which allows such use cases as bootstrapping state based on historical data.

--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -348,36 +348,163 @@ Along with reading registered state values, each key has access to a `Context` w
 ### Window State
 
 The state processor api supports reading state from a [window operator]({{ site.baseurl }}/dev/stream/operators/windows.html).
-This includes both time based windows along with other types, pre-aggregation, non-aggregated, and windows with evictors.
+When reading a window state, users specify the operator id, window assigner, and aggregation type.
+
+Additionally, a `WindowReaderFunction` can be specified to enrich each read with additional information similiar to 
+a `WindowFunction` or `ProcessWindowFunction`.
+
+Suppose a DataStream application that counts the number of clicks per user per minute.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
-ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend());
+class Click {
+    public String userId;
 
-int count = savepoint
-    // The timeWindow method supports reading from any type of time based window, including but not limited to
-    // Tumbling, Sliding, and Session windows for both event time and processing time.
-    .timeWindow()
-    .reduce(uid, new ReduceSum(), Types.INT, Types.INT)
-    .count();
+    public LocalDateTime time;    
+}
+
+class ClickCounter implements AggregateFunction<Click, Integer, Integer> {
+
+	@Override
+	public Integer createAccumulator() {
+		return 0;
+	}
+
+	@Override
+	public Integer add(Click value, Integer accumulator) {
+		return 1 + accumulator;
+	}
+
+	@Override
+	public Integer getResult(Integer accumulator) {
+		return accumulator;
+	}
+
+	@Override
+	public Integer merge(Integer a, Integer b) {
+		return a + b;
+	}
+}
+
+DataStream<Click> clicks = . . . 
+
+clicks
+    .keyBy(click -> click.userId)
+    .window(TumblingEventTimeWindows.of(Time.minutes(1)))
+    .aggregate(new ClickCounter())
+    .uid("click-window")
+    .addSink(new Sink());
 
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
+import java.lang.{Integer => JInteger}
+
+case class Click(userId: String, time: LocalDateTime)
+
+class ClickCounter extends AggregateFunction[Click, JInteger, JInteger] {
+
+	
+	override def createAccumulator(): JInteger = 0
+
+    override def add(value: Click, accumulator: JInteger): JInteger = 1 + accumulator
+    
+    override def getResult(accumulator: JInteger): JInteger = accumulator
+
+    override def merge(a: JInteger, b: JInteger): JInteger = a + b
+}
+
+DataStream[Click] clicks = . . . 
+
+clicks
+    .keyBy(click => click.userId)
+    .window(TumblingEventTimeWindows.of(Time.minutes(1)))
+    .aggregate(new ClickCounter())
+    .uid("click-window")
+    .addSink(new Sink())
+
+{% endhighlight %}
+</div>
+</div>
+
+This state can be read using the below code.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+
+class ClickState {
+    
+    public String userId;
+
+    public int count;
+
+    public TimeWindow window;
+
+    public Set<Long> triggerTimers;
+}
+
+class ClickReader extends WindowReaderFunction<Integer, ClickState, String, TimeWindow> { 
+
+	@Override
+	public void readWindow(String key, Context<TimeWindow> context, Iterable<Integer> elements, Collector<ClickState> out) {
+		ClickState state = new ClickState();
+		state.userId = key;
+		state.count = elements.iterator().next();
+		state.window = context.window();
+		state.triggerTimers = context.registeredEventTimeTimers();
+		
+		out.collect(state);
+	}
+}
+
+ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend());
+
+savepoint
+    .window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
+    .aggregate("click-window", new ClickCounter(), new ClickReader(), Types.String, Types.INT, Types.INT)
+    .print();
+
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+
+import java.lang.{Integer => JInteger, Long => JLong}
+import java.util.{Set => JSet}
+
+case class ClickState(userId: String, count: JInteger, window: TimeWindow, triggerTimers: JSet[JLong])
+
+class ClickReader extends WindowReaderFunction[JInteger, ClickState, String, TimeWindow] { 
+
+	override def readWindow(
+	    key: String,
+	    context: Context[TimeWindow],
+	    elements: Iterable[JInteger],
+	    out: Collector[ClickState]): Unit = {
+		 
+		state = ClickState(
+		    userId = key,
+		    count = elements.iterator().next(),
+		    window = context.window()k
+		    triggerTimers = context.registeredEventTimeTimers())
+		    
+		out.collect(state)
+	}
+}
+
 val batchEnv = ExecutionEnvironment.getExecutionEnvironment()
 val savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend())
 
-val count = savepoint
-    // The timeWindow method supports reading from any type of time based window, including but not limited to
-    // Tumbling, Sliding, and Session windows for both event time and processing time.
-    .timeWindow()
-    .reduce(uid, new ReduceSum(), Types.INT, Types.INT)
-    .count();
+savepoint
+    .window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
+    .aggregate("click-window", new ClickCounter(), new ClickReader(), Types.String, Types.INT, Types.INT)
+    .print()
 
 {% endhighlight %}
 </div>

--- a/docs/dev/libs/state_processor_api.zh.md
+++ b/docs/dev/libs/state_processor_api.zh.md
@@ -359,6 +359,44 @@ Along with reading registered state values, each key has access to a `Context` w
 
 {% panel **Note:** When using a `KeyedStateReaderFunction`, all state descriptors must be registered eagerly inside of open. Any attempt to call a `RuntimeContext#get*State` will result in a `RuntimeException`. %}
 
+### Window State
+
+The state processor api supports reading state from a [window operator]({{ site.baseurl }}/dev/stream/operators/windows.html).
+This includes both time based windows along with other types, pre-aggregation, non-aggregated, and windows with evictors.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+
+ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend());
+
+int count = savepoint
+    // The timeWindow method supports reading from any type of time based window, including but not limited to
+    // Tumbling, Sliding, and Session windows for both event time and processing time.
+    .timeWindow()
+    .reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+    .count();
+
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+
+val batchEnv = ExecutionEnvironment.getExecutionEnvironment()
+val savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend())
+
+val count = savepoint
+    // The timeWindow method supports reading from any type of time based window, including but not limited to
+    // Tumbling, Sliding, and Session windows for both event time and processing time.
+    .timeWindow()
+    .reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+    .count();
+
+{% endhighlight %}
+</div>
+</div>
+
 ## Writing New Savepoints
 
 `Savepoint`'s may also be written, which allows such use cases as bootstrapping state based on historical data.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
@@ -127,8 +127,7 @@ public class EvictingWindowReader<W extends Window> {
 			keyType,
 			windowSerializer,
 			reduceType,
-			env.getConfig()
-		);
+			env.getConfig());
 
 		return readWindowOperator(uid, outputType, operator);
 	}
@@ -188,8 +187,7 @@ public class EvictingWindowReader<W extends Window> {
 			keyType,
 			windowSerializer,
 			inputType,
-			env.getConfig()
-		);
+			env.getConfig());
 
 		return readWindowOperator(uid, outputType, operator);
 	}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.KeyedStateInputFormat;
+import org.apache.flink.state.api.input.operator.WindowReaderOperator;
+import org.apache.flink.state.api.input.operator.window.AggregateEvictingWindowReaderFunction;
+import org.apache.flink.state.api.input.operator.window.PassThroughReader;
+import org.apache.flink.state.api.input.operator.window.ProcessEvictingWindowReader;
+import org.apache.flink.state.api.input.operator.window.ReduceEvictingWindowReaderFunction;
+import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * This class provides entry points for reading keyed state
+ * written out using the {@code WindowOperator}.
+ *
+ * @param <W> The type of {@code Window}.
+ */
+@PublicEvolving
+public class EvictingWindowReader<W extends Window> {
+
+	/** The batch execution environment. Used for creating inputs for reading state. */
+	private final ExecutionEnvironment env;
+
+	/** The savepoint metadata, which maintains the current set of existing / newly added operator states. */
+	private final SavepointMetadata metadata;
+
+	/**
+	 * The state backend that was previously used to write existing operator states in this savepoint.
+	 * This is also the state backend that will be used when writing again this existing savepoint.
+	 */
+	private final StateBackend stateBackend;
+
+	/**
+	 * The window serializer used to write the window operator.
+	 */
+	private final TypeSerializer<W> windowSerializer;
+
+	EvictingWindowReader(ExecutionEnvironment env, SavepointMetadata metadata, StateBackend stateBackend, TypeSerializer<W> windowSerializer) {
+		Preconditions.checkNotNull(env, "The execution environment must not be null");
+		Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
+		Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
+		Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
+
+		this.env = env;
+		this.metadata = metadata;
+		this.stateBackend = stateBackend;
+		this.windowSerializer = windowSerializer;
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param <T> The type of the reduce function.
+	 * @param <K> The key type of the operator.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <T, K> DataSet<T> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType) throws IOException {
+
+		return reduce(uid, function, new PassThroughReader<>(), keyType, reduceType, reduceType);
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the reduce function.
+	 * @param <OUT> The output type of the reduce function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, StreamRecord<T>, W, OUT> operator = WindowReaderOperator.evictingWindow(
+			new ReduceEvictingWindowReaderFunction<>(readerFunction, function),
+			keyType,
+			windowSerializer,
+			reduceType,
+			env.getConfig()
+		);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param inputType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R> DataSet<R> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> inputType,
+		TypeInformation<R> outputType) throws IOException {
+
+		return aggregate(uid, aggregateFunction, new PassThroughReader<>(), keyType, inputType, outputType);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param inputType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R, OUT> DataSet<OUT> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		WindowReaderFunction<R, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> inputType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, StreamRecord<T>, W, OUT> operator = WindowReaderOperator.evictingWindow(
+			new AggregateEvictingWindowReaderFunction<>(readerFunction, aggregateFunction),
+			keyType,
+			windowSerializer,
+			inputType,
+			env.getConfig()
+		);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated without any preaggregation such as {@code WindowedStream#apply}
+	 * and {@code WindowedStream#process}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param stateType The type of records stored in state.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the records stored in state.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If the savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> process(
+		String uid,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> stateType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, StreamRecord<T>, W, OUT> operator = WindowReaderOperator.evictingWindow(
+			new ProcessEvictingWindowReader<>(readerFunction),
+			keyType,
+			windowSerializer,
+			stateType,
+			env.getConfig());
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	private <K, T, OUT> DataSet<OUT> readWindowOperator(
+		String uid,
+		TypeInformation<OUT> outputType,
+		WindowReaderOperator<?, K, T, W, OUT> operator) throws IOException {
+		KeyedStateInputFormat<K, W, OUT> format = new KeyedStateInputFormat<>(
+			metadata.getOperatorState(uid),
+			stateBackend,
+			env.getConfiguration(),
+			operator);
+
+		return env.createInput(format, outputType);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
@@ -40,6 +40,9 @@ import org.apache.flink.state.api.input.ListStateInputFormat;
 import org.apache.flink.state.api.input.UnionStateInputFormat;
 import org.apache.flink.state.api.input.operator.KeyedStateReaderOperator;
 import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
@@ -284,5 +287,28 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
 			new KeyedStateReaderOperator<>(function, keyTypeInfo));
 
 		return env.createInput(inputFormat, outTypeInfo);
+	}
+
+	/**
+	 * Read window state from an operator in a {@code Savepoint}.
+	 * This method supports reading from any type of time based window, including but not limited to
+	 * Tumbling, Sliding, and Session windows for both event time and processing time.
+	 *
+	 * @return A {@link WindowReader}.
+	 */
+	public WindowReader<TimeWindow> timeWindow() {
+		return new WindowReader<>(env, metadata, stateBackend, new TimeWindow.Serializer());
+	}
+
+	/**
+	 * Read window state from an operator in a {@code Savepoint}.
+	 * This method supports reading from any type of window.
+	 *
+	 * @param assigner The {@link WindowAssigner} used to write out the operator.
+	 * @return A {@link WindowReader}.
+	 */
+	public <W extends Window> WindowReader<W> window(WindowAssigner<?, W> assigner) {
+		TypeSerializer<W> windowSerializer = assigner.getWindowSerializer(env.getConfig());
+		return new WindowReader<>(env, metadata, stateBackend, windowSerializer);
 	}
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
@@ -291,24 +291,26 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
 
 	/**
 	 * Read window state from an operator in a {@code Savepoint}.
-	 * This method supports reading from any type of time based window, including but not limited to
-	 * Tumbling, Sliding, and Session windows for both event time and processing time.
-	 *
-	 * @return A {@link WindowReader}.
-	 */
-	public WindowReader<TimeWindow> timeWindow() {
-		return new WindowReader<>(env, metadata, stateBackend, new TimeWindow.Serializer());
-	}
-
-	/**
-	 * Read window state from an operator in a {@code Savepoint}.
 	 * This method supports reading from any type of window.
 	 *
 	 * @param assigner The {@link WindowAssigner} used to write out the operator.
 	 * @return A {@link WindowReader}.
 	 */
 	public <W extends Window> WindowReader<W> window(WindowAssigner<?, W> assigner) {
+		Preconditions.checkNotNull(assigner, "The window assigner must not be null");
 		TypeSerializer<W> windowSerializer = assigner.getWindowSerializer(env.getConfig());
+		return window(windowSerializer);
+	}
+
+	/**
+	 * Read window state from an operator in a {@code Savepoint}.
+	 * This method supports reading from any type of window.
+	 *
+	 * @param windowSerializer The serializer used for the window type.
+	 * @return A {@link WindowReader}.
+	 */
+	public <W extends Window> WindowReader<W> window(TypeSerializer<W> windowSerializer) {
+		Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
 		return new WindowReader<>(env, metadata, stateBackend, windowSerializer);
 	}
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
@@ -41,7 +41,6 @@ import org.apache.flink.state.api.input.UnionStateInputFormat;
 import org.apache.flink.state.api.input.operator.KeyedStateReaderOperator;
 import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
-import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Preconditions;
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.KeyedStateInputFormat;
+import org.apache.flink.state.api.input.operator.WindowReaderOperator;
+import org.apache.flink.state.api.input.operator.window.PassThroughReader;
+import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * This class provides entry points for reading keyed state
+ * written out using the {@code WindowOperator}.
+ *
+ * @param <W> The type of {@code Window}.
+ */
+@PublicEvolving
+public class WindowReader<W extends Window> {
+
+	/** The batch execution environment. Used for creating inputs for reading state. */
+	private final ExecutionEnvironment env;
+
+	/** The savepoint metadata, which maintains the current set of existing / newly added operator states. */
+	private final SavepointMetadata metadata;
+
+	/**
+	 * The state backend that was previously used to write existing operator states in this savepoint.
+	 * This is also the state backend that will be used when writing again this existing savepoint.
+	 */
+	private final StateBackend stateBackend;
+
+	/**
+	 * The window serializer used to write the window operator.
+	 */
+	private final TypeSerializer<W> windowSerializer;
+
+	WindowReader(ExecutionEnvironment env, SavepointMetadata metadata, StateBackend stateBackend, TypeSerializer<W> windowSerializer) {
+		Preconditions.checkNotNull(env, "The execution environment must not be null");
+		Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
+		Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
+		Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
+
+		this.env = env;
+		this.metadata = metadata;
+		this.stateBackend = stateBackend;
+		this.windowSerializer = windowSerializer;
+	}
+
+	/**
+	 * Reads from a window that uses an evictor.
+	 */
+	public EvictingWindowReader<W> evictor() {
+		return new EvictingWindowReader<>(env, metadata, stateBackend, windowSerializer);
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param <T> The type of the reduce function.
+	 * @param <K> The key type of the operator.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <T, K> DataSet<T> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType) throws IOException {
+
+		return reduce(uid, function, new PassThroughReader<>(), keyType, reduceType, reduceType);
+	}
+
+	/**
+	 * Reads window state generated using a {@link ReduceFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param function The reduce function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param reduceType The type information of the reduce function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the reduce function.
+	 * @param <OUT> The output type of the reduce function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> reduce(
+		String uid,
+		ReduceFunction<T> function,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> reduceType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, T, W, OUT> operator = WindowReaderOperator.reduce(
+			function,
+			readerFunction,
+			keyType,
+			windowSerializer,
+			reduceType);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param keyType The key type of the window.
+	 * @param accType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R> DataSet<R> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<ACC> accType,
+		TypeInformation<R> outputType) throws IOException {
+
+		return aggregate(uid, aggregateFunction, new PassThroughReader<>(), keyType, accType, outputType);
+	}
+
+	/**
+	 * Reads window state generated using an {@link AggregateFunction}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param aggregateFunction The aggregate function used to create the window.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param accType The type information of the accumulator function.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the values that are aggregated.
+	 * @param <ACC> The type of the accumulator (intermediate aggregate state).
+	 * @param <R> The type of the aggregated result.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If savepoint does not contain the specified uid.
+	 */
+	public <K, T, ACC, R, OUT> DataSet<OUT> aggregate(
+		String uid,
+		AggregateFunction<T, ACC, R> aggregateFunction,
+		WindowReaderFunction<R, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<ACC> accType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, R, W, OUT> operator = WindowReaderOperator.aggregate(
+			aggregateFunction,
+			readerFunction,
+			keyType,
+			windowSerializer,
+			accType);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	/**
+	 * Reads window state generated without any preaggregation such as {@code WindowedStream#apply}
+	 * and {@code WindowedStream#process}.
+	 *
+	 * @param uid The uid of the operator.
+	 * @param readerFunction The window reader function.
+	 * @param keyType The key type of the window.
+	 * @param stateType The type of records stored in state.
+	 * @param outputType The output type of the reader function.
+	 * @param <K> The type of the key.
+	 * @param <T> The type of the records stored in state.
+	 * @param <OUT> The output type of the reader function.
+	 * @return A {@code DataSet} of objects read from keyed state.
+	 * @throws IOException If the savepoint does not contain the specified uid.
+	 */
+	public <K, T, OUT> DataSet<OUT> process(
+		String uid,
+		WindowReaderFunction<T, OUT, K, W> readerFunction,
+		TypeInformation<K> keyType,
+		TypeInformation<T> stateType,
+		TypeInformation<OUT> outputType) throws IOException {
+
+		WindowReaderOperator<?, K, T, W, OUT> operator = WindowReaderOperator.process(
+			readerFunction,
+			keyType,
+			windowSerializer,
+			stateType);
+
+		return readWindowOperator(uid, outputType, operator);
+	}
+
+	private <K, T, OUT> DataSet<OUT> readWindowOperator(
+		String uid,
+		TypeInformation<OUT> outputType,
+		WindowReaderOperator<?, K, T, W, OUT> operator) throws IOException {
+		KeyedStateInputFormat<K, W, OUT> format = new KeyedStateInputFormat<>(
+			metadata.getOperatorState(uid),
+			stateBackend,
+			env.getConfiguration(),
+			operator);
+
+		return env.createInput(format, outputType);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.util.Collector;
+
+import java.util.Set;
+
+/**
+ * Base abstract class for functions that are evaluated over keyed (grouped) windows using a context
+ * for retrieving extra information.
+ *
+ * @param <IN> The type of the input value.
+ * @param <OUT> The type of the output value.
+ * @param <KEY> The type of the key.
+ * @param <W> The type of {@code Window} that this window function can be applied on.
+ */
+@PublicEvolving
+public abstract class WindowReaderFunction<IN, OUT, KEY, W extends Window> extends AbstractRichFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Evaluates the window and outputs none or several elements.
+	 *
+	 * @param key The key for which this window is evaluated.
+	 * @param context The context in which the window is being evaluated.
+	 * @param elements The elements in the window being evaluated.
+	 * @param out A collector for emitting elements.
+	 *
+	 * @throws Exception The function may throw exceptions to fail the program and trigger recovery.
+	 */
+	public abstract void readWindow(KEY key, Context<W> context, Iterable<IN> elements, Collector<OUT> out) throws Exception;
+
+	/**
+	 * The context holding window metadata.
+	 */
+	public interface Context<W extends Window> extends java.io.Serializable {
+		/**
+		 * Returns the window that is being evaluated.
+		 */
+		W window();
+
+		/**
+		 * State accessor for per-key and per-window state.
+		 */
+		KeyedStateStore windowState();
+
+		/**
+		 * State accessor for per-key global state.
+		 */
+		KeyedStateStore globalState();
+
+		/**
+		 * @return All registered event time timers for the current window.
+		 */
+		Set<Long> registeredEventTimeTimers() throws Exception;
+
+		/**
+		 * @return All registered processing time timers for the current window.
+		 */
+		Set<Long> registeredProcessingTimeTimers() throws Exception;
+
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
@@ -72,12 +72,12 @@ public abstract class WindowReaderFunction<IN, OUT, KEY, W extends Window> exten
 		KeyedStateStore globalState();
 
 		/**
-		 * @return All registered event time timers for the current window.
+		 * @return All event time timers registered by a trigger for the current window.
 		 */
 		Set<Long> registeredEventTimeTimers() throws Exception;
 
 		/**
-		 * @return All registered processing time timers for the current window.
+		 * @return All processing time timers registered by a trigger for the current window.
 		 */
 		Set<Long> registeredProcessingTimeTimers() throws Exception;
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/WindowReaderOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/WindowReaderOperator.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.DefaultKeyedStateStore;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.operator.window.WindowContents;
+import org.apache.flink.state.api.runtime.SavepointRuntimeContext;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * A {@link StateReaderOperator} for reading {@code WindowOperator} state.
+ *
+ * @param <S> The state type.
+ * @param <KEY> The key type.
+ * @param <IN> The type read from state.
+ * @param <W> The window type.
+ * @param <OUT> The output type of the reader.
+ */
+@Internal
+public class WindowReaderOperator<S extends State, KEY, IN, W extends Window, OUT>
+	extends StateReaderOperator<WindowReaderFunction<IN, OUT, KEY, W>, KEY, W, OUT> {
+
+	private static final String WINDOW_STATE_NAME = "window-contents";
+
+	private static final String WINDOW_TIMER_NAME = "window-timers";
+
+	private final WindowContents<S, IN> contents;
+
+	private final StateDescriptor<S, ?> descriptor;
+
+	private transient Context ctx;
+
+	public static <KEY, T, W extends Window, OUT> WindowReaderOperator<?, KEY, T, W, OUT> reduce(
+		ReduceFunction<T> function,
+		WindowReaderFunction<T, OUT, KEY, W> reader,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<T> inputType) {
+
+		StateDescriptor<ReducingState<T>, T> descriptor = new ReducingStateDescriptor<>(WINDOW_STATE_NAME, function, inputType);
+		return new WindowReaderOperator<>(reader, keyType, windowSerializer, WindowContents.reducingState(), descriptor);
+	}
+
+	public static <KEY, T, ACC, R, OUT, W extends Window> WindowReaderOperator<?, KEY, R, W, OUT> aggregate(
+		AggregateFunction<T, ACC, R> function,
+		WindowReaderFunction<R, OUT, KEY, W> readerFunction,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<ACC> accumulatorType) {
+
+		StateDescriptor<AggregatingState<T, R>, ACC> descriptor = new AggregatingStateDescriptor<>(WINDOW_STATE_NAME, function, accumulatorType);
+		return new WindowReaderOperator<>(readerFunction, keyType, windowSerializer, WindowContents.aggregatingState(), descriptor);
+	}
+
+	public static <KEY, T, W extends Window, OUT> WindowReaderOperator<?, KEY, T, W, OUT> process(
+		WindowReaderFunction<T, OUT, KEY, W> readerFunction,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<T> stateType) {
+
+		StateDescriptor<ListState<T>, List<T>> descriptor = new ListStateDescriptor<>(WINDOW_STATE_NAME, stateType);
+		return new WindowReaderOperator<>(readerFunction, keyType, windowSerializer, WindowContents.listState(), descriptor);
+	}
+
+	public static <KEY, T, W extends Window, OUT> WindowReaderOperator<?, KEY, StreamRecord<T>, W, OUT> evictingWindow(
+		WindowReaderFunction<StreamRecord<T>, OUT, KEY, W> readerFunction,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> windowSerializer,
+		TypeInformation<T> stateType,
+		ExecutionConfig config) {
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<T>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<T>>) new StreamElementSerializer(stateType.createSerializer(config));
+
+		StateDescriptor<ListState<StreamRecord<T>>, List<StreamRecord<T>>> descriptor =
+			new ListStateDescriptor<>(WINDOW_STATE_NAME, streamRecordSerializer);
+
+		return new WindowReaderOperator<>(readerFunction, keyType, windowSerializer, WindowContents.listState(), descriptor);
+	}
+
+	private WindowReaderOperator(
+		WindowReaderFunction<IN, OUT, KEY, W> function,
+		TypeInformation<KEY> keyType,
+		TypeSerializer<W> namespaceSerializer,
+		WindowContents<S, IN> contents,
+		StateDescriptor<S, ?> descriptor) {
+		super(function, keyType, namespaceSerializer);
+
+		Preconditions.checkNotNull(contents, "WindowContents must not be null");
+		Preconditions.checkNotNull(descriptor, "The state descriptor must not be null");
+
+		this.contents = contents;
+		this.descriptor = descriptor;
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		ctx = new Context(getKeyedStateBackend(), getInternalTimerService(WINDOW_TIMER_NAME));
+	}
+
+	@Override
+	public void processElement(KEY key, W namespace, Collector<OUT> out) throws Exception {
+		ctx.window = namespace;
+		S state = getKeyedStateBackend().getPartitionedState(namespace, namespaceSerializer, descriptor);
+		function.readWindow(key, ctx, contents.contents(state), out);
+	}
+
+	@Override
+	public Iterator<Tuple2<KEY, W>> getKeysAndNamespaces(SavepointRuntimeContext ctx) throws Exception {
+		Iterator<Tuple2<KEY, W>> keysAndWindows = getKeyedStateBackend()
+			.<W>getKeysAndNamespaces(descriptor.getName()).iterator();
+
+		return new IteratorWithRemove<>(keysAndWindows);
+	}
+
+	private class Context implements WindowReaderFunction.Context<W> {
+
+		private static final String EVENT_TIMER_STATE = "event-time-timers";
+
+		private static final String PROC_TIMER_STATE = "proc-time-timers";
+
+		W window;
+
+		final PerWindowKeyedStateStore perWindowKeyedStateStore;
+
+		final DefaultKeyedStateStore keyedStateStore;
+
+		ListState<Long> eventTimers;
+
+		ListState<Long> procTimers;
+
+		private Context(KeyedStateBackend<KEY> keyedStateBackend, InternalTimerService<W> timerService) throws Exception {
+			keyedStateStore = new DefaultKeyedStateStore(keyedStateBackend, getExecutionConfig());
+			perWindowKeyedStateStore = new PerWindowKeyedStateStore(keyedStateBackend);
+
+			eventTimers = keyedStateBackend.getPartitionedState(
+				WINDOW_TIMER_NAME,
+				StringSerializer.INSTANCE,
+				new ListStateDescriptor<>(EVENT_TIMER_STATE, Types.LONG));
+
+			timerService.forEachEventTimeTimer((namespace, timer) -> {
+				eventTimers.add(timer);
+			});
+
+			procTimers = keyedStateBackend.getPartitionedState(
+				WINDOW_TIMER_NAME,
+				StringSerializer.INSTANCE,
+				new ListStateDescriptor<>(PROC_TIMER_STATE, Types.LONG));
+
+			timerService.forEachProcessingTimeTimer((namespace, timer) -> {
+				procTimers.add(timer);
+			});
+		}
+
+		@Override
+		public W window() {
+			return window;
+		}
+
+		@Override
+		public KeyedStateStore windowState() {
+			perWindowKeyedStateStore.window = window;
+			return perWindowKeyedStateStore;
+		}
+
+		@Override
+		public KeyedStateStore globalState() {
+			return keyedStateStore;
+		}
+
+		@Override
+		public Set<Long> registeredEventTimeTimers() throws Exception {
+			Iterable<Long> timers = eventTimers.get();
+			if (timers == null) {
+				return Collections.emptySet();
+			}
+
+			return StreamSupport
+				.stream(timers.spliterator(), false)
+				.collect(Collectors.toSet());
+		}
+
+		@Override
+		public Set<Long> registeredProcessingTimeTimers() throws Exception {
+			Iterable<Long> timers = procTimers.get();
+			if (timers == null) {
+				return Collections.emptySet();
+			}
+
+			return StreamSupport
+				.stream(timers.spliterator(), false)
+				.collect(Collectors.toSet());
+		}
+	}
+
+	private class PerWindowKeyedStateStore extends DefaultKeyedStateStore {
+
+		W window;
+
+		PerWindowKeyedStateStore(KeyedStateBackend<?> keyedStateBackend) {
+			super(keyedStateBackend, WindowReaderOperator.this.getExecutionConfig());
+		}
+
+		@Override
+		protected <SS extends State> SS getPartitionedState(StateDescriptor<SS, ?> stateDescriptor) throws Exception {
+			return keyedStateBackend.getPartitionedState(
+				window,
+				namespaceSerializer,
+				stateDescriptor);
+		}
+	}
+
+	private static class IteratorWithRemove<T> implements Iterator<T> {
+
+		private final Iterator<T> iterator;
+
+		private IteratorWithRemove(Iterator<T> iterator) {
+			this.iterator = iterator;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return iterator.hasNext();
+		}
+
+		@Override
+		public T next() {
+			return iterator.next();
+		}
+
+		@Override
+		public void remove() { }
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/AggregateEvictingWindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/AggregateEvictingWindowReaderFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Collections;
+
+/**
+ * A wrapper for reading an evicting window operator with an aggregate function.
+ */
+@Internal
+public class AggregateEvictingWindowReaderFunction<IN, ACC, R, OUT, KEY, W extends Window> extends EvictingWindowReaderFunction<IN, R, OUT, KEY, W> {
+
+	private final AggregateFunction<IN, ACC, R> aggFunction;
+
+	public AggregateEvictingWindowReaderFunction(WindowReaderFunction<R, OUT, KEY, W> wrappedFunction, AggregateFunction<IN, ACC, R> aggFunction) {
+		super(wrappedFunction);
+		this.aggFunction = aggFunction;
+	}
+
+	@Override
+	public Iterable<R> transform(Iterable<StreamRecord<IN>> elements) throws Exception {
+		ACC acc = aggFunction.createAccumulator();
+
+		for (StreamRecord<IN> element : elements) {
+			acc = aggFunction.add(element.getValue(), acc);
+		}
+
+		R result = aggFunction.getResult(acc);
+		return Collections.singletonList(result);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/EvictingWindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/EvictingWindowReaderFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Wrapper for reading state from an evicting window operator.
+ * @param <IN> The input type stored in state.
+ * @param <R> The aggregated type.
+ * @param <OUT> The output type of the reader function.
+ * @param <KEY> The key type.
+ * @param <W> The window type.
+ */
+@Internal
+public abstract class EvictingWindowReaderFunction<IN, R, OUT, KEY, W extends Window> extends WindowReaderFunction<StreamRecord<IN>, OUT, KEY, W> {
+
+	private final WindowReaderFunction<R, OUT, KEY, W> wrappedFunction;
+
+	protected EvictingWindowReaderFunction(WindowReaderFunction<R, OUT, KEY, W> wrappedFunction) {
+		this.wrappedFunction = Preconditions.checkNotNull(wrappedFunction, "Inner reader function cannot be null");
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		FunctionUtils.openFunction(wrappedFunction, parameters);
+	}
+
+	@Override
+	public void close() throws Exception {
+		FunctionUtils.closeFunction(wrappedFunction);
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		FunctionUtils.setFunctionRuntimeContext(wrappedFunction, t);
+	}
+
+	@Override
+	public void readWindow(KEY key, Context<W> context, Iterable<StreamRecord<IN>> elements, Collector<OUT> out) throws Exception {
+		Iterable<R> result = transform(elements);
+		wrappedFunction.readWindow(key, context, result, out);
+	}
+
+	public abstract Iterable<R> transform(Iterable<StreamRecord<IN>> elements) throws Exception;
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/PassThroughReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/PassThroughReader.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.util.Collector;
+
+/**
+ * A {@link WindowReaderFunction} that just emits each input element.
+ *
+ * @param <KEY> The key type.
+ * @param <W> The window type.
+ * @param <IN> The type stored in state.
+ */
+public class PassThroughReader<KEY, W extends Window, IN> extends WindowReaderFunction<IN, IN, KEY, W> {
+
+	@Override
+	public void readWindow(KEY key, Context<W> context, Iterable<IN> elements, Collector<IN> out) {
+		for (IN element : elements) {
+			out.collect(element);
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ProcessEvictingWindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ProcessEvictingWindowReader.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.stream.StreamSupport;
+
+/**
+ * A wrapper function for reading an evicting window with no pre-aggregation.
+ */
+@Internal
+public class ProcessEvictingWindowReader<IN, OUT, KEY, W extends Window> extends EvictingWindowReaderFunction<IN, IN, OUT, KEY, W> {
+
+	public ProcessEvictingWindowReader(WindowReaderFunction<IN, OUT, KEY, W> wrappedFunction) {
+		super(wrappedFunction);
+	}
+
+	@Override
+	public Iterable<IN> transform(Iterable<StreamRecord<IN>> elements) throws Exception {
+		return () -> StreamSupport
+			.stream(elements.spliterator(), false)
+			.map(StreamRecord::getValue)
+			.iterator();
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ReduceEvictingWindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/ReduceEvictingWindowReaderFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Collections;
+
+/**
+ * A wrapper function for reading state from an evicting window operator with a reduce function.
+ */
+@Internal
+public class ReduceEvictingWindowReaderFunction<IN, OUT, KEY, W extends Window> extends EvictingWindowReaderFunction<IN, IN, OUT, KEY, W> {
+
+	private final ReduceFunction<IN> reduceFunction;
+
+	public ReduceEvictingWindowReaderFunction(WindowReaderFunction<IN, OUT, KEY, W> wrappedFunction, ReduceFunction<IN> reduceFunction) {
+		super(wrappedFunction);
+		this.reduceFunction = reduceFunction;
+	}
+
+	@Override
+	public Iterable<IN> transform(Iterable<StreamRecord<IN>> elements) throws Exception {
+		IN curr = null;
+
+		for (StreamRecord<IN> element : elements) {
+			if (curr == null) {
+				curr = element.getValue();
+			} else {
+				curr = reduceFunction.reduce(curr, element.getValue());
+			}
+		}
+
+		return Collections.singletonList(curr);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/WindowContents.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/window/WindowContents.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.operator.window;
+
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.State;
+
+import java.io.Serializable;
+import java.util.Collections;
+
+/**
+ * An abstraction for transforming any {@link State} type into an iterable over its contents.
+ *
+ * @param <S> The initial state type.
+ * @param <IN> The data in state.
+ */
+@FunctionalInterface
+public interface WindowContents<S extends State, IN> extends Serializable {
+
+	static <T> WindowContents<ReducingState<T>, T> reducingState() {
+		return (state) -> Collections.singletonList(state.get());
+	}
+
+	static <IN, OUT> WindowContents<AggregatingState<IN, OUT>, OUT> aggregatingState() {
+		return (state) -> Collections.singletonList(state.get());
+	}
+
+	static <T> WindowContents<ListState<T>, T> listState() {
+		return AppendingState::get;
+	}
+
+	Iterable<IN> contents(S state) throws Exception;
+}
+

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/MemoryStateBackendWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/MemoryStateBackendWindowITCase.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+
+/**
+ * IT Case for reading window state with the memory state backend.
+ */
+public class MemoryStateBackendWindowITCase extends SavepointWindowReaderITCase<MemoryStateBackend> {
+
+	@Override
+	protected MemoryStateBackend getStateBackend() {
+		return new MemoryStateBackend();
+	}
+}
+
+

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/RocksDBStateBackendWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/RocksDBStateBackendWindowITCase.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+
+/**
+ * IT Case for reading window state with the memory state backend.
+ */
+public class RocksDBStateBackendWindowITCase extends SavepointWindowReaderITCase<RocksDBStateBackend> {
+
+	@Override
+	protected RocksDBStateBackend getStateBackend() {
+		return new RocksDBStateBackend((StateBackend) new MemoryStateBackend());
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.evictors.Evictor;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -69,7 +70,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.reduce(new ReduceSum())
 				.uid(uid)
 				.addSink(new DiscardingSink<>());
@@ -81,7 +82,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.reduce(uid, new ReduceSum(), Types.INT, Types.INT)
 			.collect();
 
@@ -103,7 +104,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.evictor(new NoOpEvictor<>())
 				.reduce(new ReduceSum())
 				.uid(uid)
@@ -116,7 +117,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.evictor()
 			.reduce(uid, new ReduceSum(), Types.INT, Types.INT)
 			.collect();
@@ -139,7 +140,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.aggregate(new AggregateSum())
 				.uid(uid)
 				.addSink(new DiscardingSink<>());
@@ -151,7 +152,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.aggregate(uid, new AggregateSum(), Types.INT, Types.INT, Types.INT)
 			.collect();
 
@@ -173,7 +174,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.evictor(new NoOpEvictor<>())
 				.aggregate(new AggregateSum())
 				.uid(uid)
@@ -186,7 +187,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.evictor()
 			.aggregate(uid, new AggregateSum(), Types.INT, Types.INT, Types.INT)
 			.collect();
@@ -209,7 +210,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.process(new NoOpProcessWindowFunction())
 				.uid(uid)
 				.addSink(new DiscardingSink<>());
@@ -221,7 +222,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
 			.collect();
 
@@ -243,7 +244,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.evictor(new NoOpEvictor<>())
 				.process(new NoOpProcessWindowFunction())
 				.uid(uid)
@@ -256,7 +257,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.evictor()
 			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
 			.collect();
@@ -279,7 +280,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.apply(new NoOpWindowFunction())
 				.uid(uid)
 				.addSink(new DiscardingSink<>());
@@ -291,7 +292,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
 			.collect();
 
@@ -313,7 +314,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 					.<Integer>noWatermarks()
 					.withTimestampAssigner((event, timestamp) -> 0))
 				.keyBy(id -> id)
-				.timeWindow(Time.milliseconds(10))
+				.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 				.evictor(new NoOpEvictor<>())
 				.apply(new NoOpWindowFunction())
 				.uid(uid)
@@ -326,7 +327,7 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
 
 		List<Integer> results = savepoint
-			.timeWindow()
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(10)))
 			.evictor()
 			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
 			.collect();

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.utils.AggregateSum;
+import org.apache.flink.state.api.utils.ReduceSum;
+import org.apache.flink.state.api.utils.SavepointTestBase;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
+import org.apache.flink.util.Collector;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * IT Case for reading window operator state.
+ */
+public abstract class SavepointWindowReaderITCase<B extends StateBackend> extends SavepointTestBase {
+	private static final String uid = "stateful-operator";
+
+	private static final Integer[] numbers = { 1, 2, 3 };
+
+	protected abstract B getStateBackend();
+
+	@Test
+	public void testReduceWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.reduce(new ReduceSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testReduceEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.reduce(new ReduceSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.reduce(uid, new ReduceSum(), Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testAggregateWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.aggregate(new AggregateSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.aggregate(uid, new AggregateSum(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testAggregateEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.aggregate(new AggregateSum())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.aggregate(uid, new AggregateSum(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testProcessWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.process(new NoOpProcessWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testProcessEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.process(new NoOpProcessWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testApplyWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.apply(new NoOpWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	@Test
+	public void testApplyEvictorWindowStateReader() throws Exception {
+		String savepointPath = takeSavepoint(numbers, source -> {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.setStateBackend(getStateBackend());
+			env.setParallelism(4);
+
+			env
+				.addSource(source)
+				.rebalance()
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+					.<Integer>noWatermarks()
+					.withTimestampAssigner((event, timestamp) -> 0))
+				.keyBy(id -> id)
+				.timeWindow(Time.milliseconds(10))
+				.evictor(new NoOpEvictor<>())
+				.apply(new NoOpWindowFunction())
+				.uid(uid)
+				.addSink(new DiscardingSink<>());
+
+			return env;
+		});
+
+		ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
+		ExistingSavepoint savepoint = Savepoint.load(batchEnv, savepointPath, getStateBackend());
+
+		List<Integer> results = savepoint
+			.timeWindow()
+			.evictor()
+			.process(uid, new BasicReaderFunction(), Types.INT, Types.INT, Types.INT)
+			.collect();
+
+		Assert.assertThat("Unexpected results from keyed state", results, Matchers.containsInAnyOrder(numbers));
+	}
+
+	private static class NoOpProcessWindowFunction extends ProcessWindowFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void process(Integer integer, Context context, Iterable<Integer> elements, Collector<Integer> out) { }
+	}
+
+	private static class NoOpWindowFunction implements WindowFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void apply(Integer integer, TimeWindow window, Iterable<Integer> input, Collector<Integer> out) { }
+	}
+
+	private static class BasicReaderFunction extends WindowReaderFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void readWindow(Integer key, Context<TimeWindow> context, Iterable<Integer> elements, Collector<Integer> out) throws Exception {
+			Assert.assertEquals("Unexpected window", new TimeWindow(0, 10), context.window());
+			Assert.assertThat("Unexpected registered timers", context.registeredEventTimeTimers(), Matchers.contains(9L));
+
+			out.collect(elements.iterator().next());
+		}
+	}
+
+	private static class NoOpEvictor<W extends Window> implements Evictor<Integer, W> {
+
+		@Override
+		public void evictBefore(Iterable<TimestampedValue<Integer>> elements, int size, W window, EvictorContext evictorContext) {
+		}
+
+		@Override
+		public void evictAfter(Iterable<TimestampedValue<Integer>> elements, int size, W window, EvictorContext evictorContext) {
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/WindowReaderTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/WindowReaderTest.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input;
+
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.state.api.functions.WindowReaderFunction;
+import org.apache.flink.state.api.input.operator.WindowReaderOperator;
+import org.apache.flink.state.api.input.operator.window.PassThroughReader;
+import org.apache.flink.state.api.input.splits.KeyGroupRangeInputSplit;
+import org.apache.flink.state.api.runtime.OperatorIDGenerator;
+import org.apache.flink.state.api.utils.AggregateSum;
+import org.apache.flink.state.api.utils.ReduceSum;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.triggers.TriggerResult;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.util.Collector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests reading window state.
+ */
+@SuppressWarnings("unchecked")
+public class WindowReaderTest {
+
+	private static final int MAX_PARALLELISM = 128;
+
+	private static final String UID = "uid";
+
+	@Test
+	public void testReducingWindow() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.reduce(new ReduceSum()));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			new Configuration(),
+			WindowReaderOperator.reduce(
+				new ReduceSum(),
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Arrays.asList(1, 1), list);
+	}
+
+	@Test
+	public void testSessionWindow() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.window(EventTimeSessionWindows.withGap(Time.milliseconds(3)))
+			.reduce(new ReduceSum()));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			new Configuration(),
+			WindowReaderOperator.reduce(
+				new ReduceSum(),
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Collections.singletonList(2), list);
+	}
+
+	@Test
+	public void testAggregateWindow() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.aggregate(new AggregateSum()));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			new Configuration(),
+			WindowReaderOperator.aggregate(
+				new AggregateSum(),
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Arrays.asList(1, 1), list);
+	}
+
+	@Test
+	public void testProcessReader() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.process(mockProcessWindowFunction(), Types.INT));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Integer> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			new Configuration(),
+			WindowReaderOperator.process(
+				new PassThroughReader<>(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Integer> list = readState(format);
+		Assert.assertEquals(Arrays.asList(1, 1), list);
+	}
+
+	@Test
+	public void testPerPaneAndPerKeyState() throws Exception {
+		WindowOperator<Integer, Integer, ?, Void, ?> operator = getWindowOperator(stream -> stream
+			.timeWindow(Time.milliseconds(1))
+			.trigger(new AlwaysFireTrigger<>())
+			.process(new MultiFireWindow(), Types.INT));
+
+		OperatorState operatorState = getOperatorState(operator);
+
+		KeyedStateInputFormat<Integer, TimeWindow, Tuple2<Integer, Integer>> format = new KeyedStateInputFormat<>(
+			operatorState,
+			new MemoryStateBackend(),
+			new Configuration(),
+			WindowReaderOperator.process(
+				new MultiFireReaderFunction(),
+				Types.INT,
+				new TimeWindow.Serializer(),
+				Types.INT));
+
+		List<Tuple2<Integer, Integer>> list = readState(format);
+		Assert.assertEquals(Arrays.asList(Tuple2.of(2, 1), Tuple2.of(2, 1)), list);
+	}
+
+	private static WindowOperator<Integer, Integer, ?, Void, ?> getWindowOperator(
+		Function<KeyedStream<Integer, Integer>, SingleOutputStreamOperator<Integer>> window) {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		KeyedStream<Integer, Integer> keyedStream = env
+			.addSource(mockSourceFunction())
+			.returns(Integer.class)
+			.keyBy(new IdentityKeySelector<>());
+
+		DataStream<Integer> stream = window
+			.apply(keyedStream)
+			.uid(UID);
+
+		return getLastOperator(stream);
+	}
+
+	private static SourceFunction<Integer> mockSourceFunction() {
+		return (SourceFunction<Integer>) mock(SourceFunction.class);
+	}
+
+	private static <W extends Window> ProcessWindowFunction<Integer, Integer, Integer, W> mockProcessWindowFunction() {
+		return mock(ProcessWindowFunction.class);
+	}
+
+	private static OperatorState getOperatorState(WindowOperator<Integer, Integer, ?, Void, ?> operator) throws Exception {
+		KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Void> harness = new KeyedOneInputStreamOperatorTestHarness<>(
+			operator,
+			new IdentityKeySelector<>(),
+			Types.INT,
+			MAX_PARALLELISM, 1, 0);
+
+		harness.open();
+		harness.processElement(1, 0);
+		harness.processElement(1, 1);
+		OperatorSubtaskState state = harness.snapshot(0, 0L);
+		harness.close();
+
+		OperatorID operatorID = OperatorIDGenerator.fromUid(UID);
+		OperatorState operatorState = new OperatorState(operatorID, 1, MAX_PARALLELISM);
+		operatorState.putState(0, state);
+		return operatorState;
+	}
+
+	private static <T> WindowOperator<Integer, Integer, ?, Void, ?> getLastOperator(DataStream<T> dataStream) {
+		Transformation<T> transformation = dataStream.getTransformation();
+		if (!(transformation instanceof OneInputTransformation)) {
+			Assert.fail("This test only supports window operators");
+		}
+
+		OneInputTransformation<?, ?> oneInput = (OneInputTransformation<?, ?>) transformation;
+		StreamOperator<?> operator = oneInput.getOperator();
+
+		if (!(operator instanceof WindowOperator)) {
+			Assert.fail("This test only supports window operators");
+		}
+
+		return (WindowOperator<Integer, Integer, ?, Void, ?>) operator;
+	}
+
+	@Nonnull
+	private <OUT> List<OUT> readState(KeyedStateInputFormat<Integer, TimeWindow, OUT> format) throws IOException {
+		KeyGroupRangeInputSplit split = format.createInputSplits(1)[0];
+		List<OUT> data = new ArrayList<>();
+
+		format.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
+
+		format.openInputFormat();
+		format.open(split);
+
+		while (!format.reachedEnd()) {
+			data.add(format.nextRecord(null));
+		}
+
+		format.close();
+		format.closeInputFormat();
+
+		return data;
+	}
+
+	private static class IdentityKeySelector<T> implements KeySelector<T, T> {
+
+		@Override
+		public T getKey(T value) {
+			return value;
+		}
+	}
+
+	private static class MultiFireWindow extends ProcessWindowFunction<Integer, Integer, Integer, TimeWindow> {
+
+		@Override
+		public void process(Integer integer, Context context, Iterable<Integer> elements, Collector<Integer> out) throws Exception {
+			Integer element = elements.iterator().next();
+			context.globalState()
+				.getReducingState(new ReducingStateDescriptor<>("per-key", new ReduceSum(), Types.INT))
+				.add(element);
+
+			context.windowState()
+				.getReducingState(new ReducingStateDescriptor<>("per-pane", new ReduceSum(), Types.INT))
+				.add(element);
+		}
+	}
+
+	private static class MultiFireReaderFunction extends WindowReaderFunction<Integer, Tuple2<Integer, Integer>, Integer, TimeWindow> {
+
+		@Override
+		public void readWindow(Integer integer, Context<TimeWindow> context, Iterable<Integer> elements, Collector<Tuple2<Integer, Integer>> out) throws Exception {
+			Integer perKey = context.globalState()
+				.getReducingState(new ReducingStateDescriptor<>("per-key", new ReduceSum(), Types.INT))
+				.get();
+
+			Integer perPane = context.windowState()
+				.getReducingState(new ReducingStateDescriptor<>("per-pane", new ReduceSum(), Types.INT))
+				.get();
+
+			out.collect(Tuple2.of(perKey, perPane));
+		}
+	}
+
+	private static class AlwaysFireTrigger<W extends Window> extends Trigger<Object, W> {
+
+		@Override
+		public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws Exception {
+			return TriggerResult.FIRE;
+		}
+
+		@Override
+		public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) throws Exception {
+			return TriggerResult.FIRE;
+		}
+
+		@Override
+		public TriggerResult onEventTime(long time, W window, TriggerContext ctx) throws Exception {
+			return TriggerResult.FIRE;
+		}
+
+		@Override
+		public void clear(W window, TriggerContext ctx) throws Exception {
+
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/AggregateSum.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/AggregateSum.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.utils;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+
+/**
+ * A simple sum aggregator.
+ */
+public class AggregateSum implements AggregateFunction<Integer, Integer, Integer> {
+
+	@Override
+	public Integer createAccumulator() {
+		return 0;
+	}
+
+	@Override
+	public Integer add(Integer value, Integer accumulator) {
+		return value + accumulator;
+	}
+
+	@Override
+	public Integer getResult(Integer accumulator) {
+		return accumulator;
+	}
+
+	@Override
+	public Integer merge(Integer a, Integer b) {
+		return a + b;
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/ReduceSum.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/ReduceSum.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.utils;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+
+/**
+ * A simple sum reducer.
+ */
+public class ReduceSum implements ReduceFunction<Integer> {
+
+	@Override
+	public Integer reduce(Integer value1, Integer value2) {
+		return value1 + value2;
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/SavepointTestBase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/SavepointTestBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.AbstractID;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +41,10 @@ import java.util.function.Function;
  * A test base that includes utilities for taking a savepoint.
  */
 public abstract class SavepointTestBase extends AbstractTestBase {
+
+	public <T> String takeSavepoint(T[] data, Function<SourceFunction<T>, StreamExecutionEnvironment> jobGraphFactory) throws Exception {
+		return takeSavepoint(Arrays.asList(data), jobGraphFactory);
+	}
 
 	public <T> String takeSavepoint(Collection<T> data, Function<SourceFunction<T>, StreamExecutionEnvironment> jobGraphFactory) throws Exception {
 


### PR DESCRIPTION
## What is the purpose of the change

Add support for reading window operator state with the state processor api. 
This includes:
- TimeWindows and other arbitrary window types
- Pre-aggregated types
- Unaggregated types
- Evictor window state. 



## Verifying this change

UT and IT cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
