### PR TITLE
[FLINK-19226][Kinesis] Updated FullJitterBackoff defaults for describeStream and describeStreamConsumer

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -232,9 +232,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
-	public static final int DEFAULT_STREAM_DESCRIBE_RETRIES = 10;
+	public static final int DEFAULT_STREAM_DESCRIBE_RETRIES = 50;
 
-	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE = 1000L;
+	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE = 2000L;
 
 	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX = 5000L;
 
@@ -248,11 +248,11 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final int DEFAULT_LIST_SHARDS_RETRIES = 10;
 
-	public static final int DEFAULT_DESCRIBE_STREAM_CONSUMER_RETRIES = 10;
+	public static final int DEFAULT_DESCRIBE_STREAM_CONSUMER_RETRIES = 50;
 
-	public static final long DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE = 200L;
+	public static final long DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE = 2000L;
 
-	public static final long DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX = 1000L;
+	public static final long DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX = 5000L;
 
 	public static final double DEFAULT_DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 


### PR DESCRIPTION
## What is the purpose of the change
Allow FlinkKinesisConsumer to use EFO record publisher with higher parallelism using the default config values.

## Brief change log

- `ConsumerConfigConstants`
  - _Changed default FullJitterBackoff configuration for describeStream and describeStreamConsumer_


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
