### PR TITLE
[Hotfix][typos]Modify debug log to print the compiling code

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
@@ -119,7 +119,7 @@ object OperatorCodeGenerator extends Logging {
       }
     """.stripMargin
 
-    LOG.debug(s"Compiling OneInputStreamOperator Code:\n$name")
+    LOG.debug(s"Compiling OneInputStreamOperator Code:\n$operatorCode")
     new GeneratedOperator(operatorName, operatorCode, ctx.references.toArray)
   }
 
@@ -246,7 +246,7 @@ object OperatorCodeGenerator extends Logging {
       }
     """.stripMargin
 
-    LOG.debug(s"Compiling TwoInputStreamOperator Code:\n$name")
+    LOG.debug(s"Compiling TwoInputStreamOperator Code:\n$operatorCode")
     new GeneratedOperator(operatorName, operatorCode, ctx.references.toArray)
   }
 


### PR DESCRIPTION

## What is the purpose of the change

Modify debug log to print the compiling code.

## Brief change log

Modify function name to compiling code in OperatorCodeGenerator#generateOneInputStreamOperator and OperatorCodeGenerator#generateTwoInputStreamOperator

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
