### PR TITLE
[FLINK-19037] Forward ioExecutor from ClusterEntrypoint to Dispatcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -88,6 +88,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -128,6 +129,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
 	private final HistoryServerArchivist historyServerArchivist;
 
+	private final Executor ioExecutor;
+
 	@Nullable
 	private final String metricServiceQueryAddress;
 
@@ -159,6 +162,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 		this.jobGraphWriter = dispatcherServices.getJobGraphWriter();
 		this.jobManagerMetricGroup = dispatcherServices.getJobManagerMetricGroup();
 		this.metricServiceQueryAddress = dispatcherServices.getMetricQueryServiceAddress();
+		this.ioExecutor = dispatcherServices.getIoExecutor();
 
 		this.jobManagerSharedServices = JobManagerSharedServices.fromConfiguration(
 			configuration,
@@ -345,7 +349,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 			} else {
 				return acknowledge;
 			}
-		}, getRpcService().getExecutor());
+		}, ioExecutor);
 	}
 
 	private void persistAndRunJob(JobGraph jobGraph) throws Exception {
@@ -415,7 +419,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 					throw new CompletionException(new JobInitializationException(jobGraph.getJobID(), "Could not instantiate JobManager.", e));
 				}
 			},
-			rpcService.getExecutor()); // do not use main thread executor. Otherwise, Dispatcher is blocked on JobManager creation
+			ioExecutor); // do not use main thread executor. Otherwise, Dispatcher is blocked on JobManager creation
 	}
 
 	@Override
@@ -648,7 +652,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 		}
 		return dispatcherJobTerminationFuture.thenRunAsync(
 			() -> cleanUpJobData(jobId, cleanupHA),
-			getRpcService().getExecutor());
+			ioExecutor);
 	}
 
 	private void cleanUpJobData(JobID jobId, boolean cleanupHA) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
@@ -31,6 +31,8 @@ import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.concurrent.Executor;
+
 /**
  * {@link Dispatcher} services container.
  */
@@ -72,6 +74,9 @@ public class DispatcherServices {
 	@Nonnull
 	private final JobManagerRunnerFactory jobManagerRunnerFactory;
 
+	@Nonnull
+	private final Executor ioExecutor;
+
 	public DispatcherServices(
 			@Nonnull Configuration configuration,
 			@Nonnull HighAvailabilityServices highAvailabilityServices,
@@ -84,7 +89,8 @@ public class DispatcherServices {
 			@Nullable String metricQueryServiceAddress,
 			@Nonnull JobManagerMetricGroup jobManagerMetricGroup,
 			@Nonnull JobGraphWriter jobGraphWriter,
-			@Nonnull JobManagerRunnerFactory jobManagerRunnerFactory) {
+			@Nonnull JobManagerRunnerFactory jobManagerRunnerFactory,
+			@Nonnull Executor ioExecutor) {
 		this.configuration = configuration;
 		this.highAvailabilityServices = highAvailabilityServices;
 		this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
@@ -97,6 +103,7 @@ public class DispatcherServices {
 		this.jobManagerMetricGroup = jobManagerMetricGroup;
 		this.jobGraphWriter = jobGraphWriter;
 		this.jobManagerRunnerFactory = jobManagerRunnerFactory;
+		this.ioExecutor = ioExecutor;
 	}
 
 	@Nonnull
@@ -159,6 +166,11 @@ public class DispatcherServices {
 		return jobManagerRunnerFactory;
 	}
 
+	@Nonnull
+	public Executor getIoExecutor() {
+		return ioExecutor;
+	}
+
 	public static DispatcherServices from(
 			@Nonnull PartialDispatcherServicesWithJobGraphStore partialDispatcherServicesWithJobGraphStore,
 			@Nonnull JobManagerRunnerFactory jobManagerRunnerFactory) {
@@ -174,6 +186,7 @@ public class DispatcherServices {
 			partialDispatcherServicesWithJobGraphStore.getMetricQueryServiceAddress(),
 			partialDispatcherServicesWithJobGraphStore.getJobManagerMetricGroupFactory().create(),
 			partialDispatcherServicesWithJobGraphStore.getJobGraphWriter(),
-			jobManagerRunnerFactory);
+			jobManagerRunnerFactory,
+			partialDispatcherServicesWithJobGraphStore.getIoExecutor());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServices.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.concurrent.Executor;
+
 /**
  * Partial {@link DispatcherServices} services container which needs to
  * be completed before being given to the {@link Dispatcher}.
@@ -65,6 +67,9 @@ public class PartialDispatcherServices {
 	@Nullable
 	private final String metricQueryServiceAddress;
 
+	@Nonnull
+	private final Executor ioExecutor;
+
 	public PartialDispatcherServices(
 			@Nonnull Configuration configuration,
 			@Nonnull HighAvailabilityServices highAvailabilityServices,
@@ -75,7 +80,8 @@ public class PartialDispatcherServices {
 			@Nonnull ArchivedExecutionGraphStore archivedExecutionGraphStore,
 			@Nonnull FatalErrorHandler fatalErrorHandler,
 			@Nonnull HistoryServerArchivist historyServerArchivist,
-			@Nullable String metricQueryServiceAddress) {
+			@Nullable String metricQueryServiceAddress,
+			@Nonnull Executor ioExecutor) {
 		this.configuration = configuration;
 		this.highAvailabilityServices = highAvailabilityServices;
 		this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
@@ -86,6 +92,7 @@ public class PartialDispatcherServices {
 		this.fatalErrorHandler = fatalErrorHandler;
 		this.historyServerArchivist = historyServerArchivist;
 		this.metricQueryServiceAddress = metricQueryServiceAddress;
+		this.ioExecutor = ioExecutor;
 	}
 
 	@Nonnull
@@ -136,5 +143,10 @@ public class PartialDispatcherServices {
 	@Nullable
 	public String getMetricQueryServiceAddress() {
 		return metricQueryServiceAddress;
+	}
+
+	@Nonnull
+	public Executor getIoExecutor() {
+		return ioExecutor;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/PartialDispatcherServicesWithJobGraphStore.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.concurrent.Executor;
+
 /**
  * {@link DispatcherFactory} services container.
  */
@@ -49,6 +51,7 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
 			@Nonnull FatalErrorHandler fatalErrorHandler,
 			@Nonnull HistoryServerArchivist historyServerArchivist,
 			@Nullable String metricQueryServiceAddress,
+			@Nonnull Executor ioExecutor,
 			@Nonnull JobGraphWriter jobGraphWriter) {
 		super(
 			configuration,
@@ -60,7 +63,8 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
 			archivedExecutionGraphStore,
 			fatalErrorHandler,
 			historyServerArchivist,
-			metricQueryServiceAddress);
+			metricQueryServiceAddress,
+			ioExecutor);
 		this.jobGraphWriter = jobGraphWriter;
 	}
 
@@ -81,6 +85,8 @@ public class PartialDispatcherServicesWithJobGraphStore extends PartialDispatche
 			partialDispatcherServices.getFatalErrorHandler(),
 			partialDispatcherServices.getHistoryServerArchivist(),
 			partialDispatcherServices.getMetricQueryServiceAddress(),
+			partialDispatcherServices.getIoExecutor(),
 			jobGraphWriter);
 	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -188,7 +188,8 @@ public class DefaultDispatcherResourceManagerComponentFactory implements Dispatc
 				archivedExecutionGraphStore,
 				fatalErrorHandler,
 				historyServerArchivist,
-				metricRegistry.getMetricQueryServiceGatewayRpcAddress());
+				metricRegistry.getMetricQueryServiceGatewayRpcAddress(),
+				ioExecutor);
 
 			log.debug("Starting Dispatcher.");
 			dispatcherRunner = dispatcherRunnerFactory.createDispatcherRunner(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -79,6 +79,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -208,7 +209,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 				null,
 				UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
 				jobGraphWriter,
-				jobManagerRunnerFactory));
+				jobManagerRunnerFactory,
+				ForkJoinPool.commonPool()));
 
 		dispatcher.start();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -108,6 +108,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -272,7 +273,8 @@ public class DispatcherTest extends TestLogger {
 					null,
 					UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
 					jobGraphWriter,
-					jobManagerRunnerFactory));
+					jobManagerRunnerFactory,
+					ForkJoinPool.commonPool()));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.is;
@@ -250,7 +251,8 @@ public class MiniDispatcherTest extends TestLogger {
 				null,
 				UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
 				highAvailabilityServices.getJobGraphStore(),
-				testingJobManagerRunnerFactory),
+				testingJobManagerRunnerFactory,
+				ForkJoinPool.commonPool()),
 			new DefaultDispatcherBootstrap(Collections.singletonList(jobGraph)),
 			executionMode);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.contains;
@@ -118,7 +119,8 @@ public class DefaultDispatcherRunnerITCase extends TestLogger {
 			new MemoryArchivedExecutionGraphStore(),
 			fatalErrorHandler,
 			VoidHistoryServerArchivist.INSTANCE,
-			null);
+			null,
+			ForkJoinPool.commonPool());
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -71,6 +71,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
 
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
@@ -152,7 +153,8 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
 				new MemoryArchivedExecutionGraphStore(),
 				fatalErrorHandler,
 				VoidHistoryServerArchivist.INSTANCE,
-				null);
+				null,
+				ForkJoinPool.commonPool());
 
 			final JobGraph jobGraph = createJobGraphWithBlobs();
 


### PR DESCRIPTION
## What is the purpose of the change

Before this change, the dispatcher was using the executor of the RPC service for executing IO or heavy tasks.
Now, we forward the ioExecutor of the ClusterEntrypoint to the Dispatcher.


