### PR TITLE
[FLINK-19221][filesystems] Introduce the LocatedFileStatus to save block location RPC requests.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/LocatedFileStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LocatedFileStatus.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * A {@code LocatedFileStatus} is a {@link FileStatus} that contains additionally the location information
+ * of the file directly. The information is accessible through the {@link #getBlockLocations()} ()} method.
+ *
+ * <p>This class eagerly communicates the block information (including locations) when that information
+ * is readily (or cheaply) available. That way users can avoid an additional call to
+ * {@link FileSystem#getFileBlockLocations(FileStatus, long, long)}, which is an additional RPC call for
+ * each file.
+ */
+@Public
+public interface LocatedFileStatus extends FileStatus {
+
+	/**
+	 * Gets the location information for the file. The location is per block, because each block may
+	 * live potentially at a different location.
+	 *
+	 * <p>Files without location information typically expose one block with no host information
+	 * for that block.
+	 */
+	BlockLocation[] getBlockLocations();
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalBlockLocation.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalBlockLocation.java
@@ -20,27 +20,27 @@ package org.apache.flink.core.fs.local;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.BlockLocation;
-
-import java.io.IOException;
+import org.apache.flink.util.StringUtils;
 
 /**
  * Implementation of the {@link BlockLocation} interface for a local file system.
+ *
+ * <p>Local files have only one block that represents the entire file.
+ * The block has no location information, because it is not accessible where the files (or their block)
+ * actually reside, especially in cases where the files are on a mounted file system.
  */
 @Internal
 public class LocalBlockLocation implements BlockLocation {
 
 	private final long length;
 
-	private final String[] hosts;
-
-	public LocalBlockLocation(final String host, final long length) {
-		this.hosts = new String[] { host };
+	public LocalBlockLocation(final long length) {
 		this.length = length;
 	}
 
 	@Override
-	public String[] getHosts() throws IOException {
-		return this.hosts;
+	public String[] getHosts() {
+		return StringUtils.EMPTY_STRING_ARRAY;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -35,15 +35,10 @@ import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.OperatingSystem;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
@@ -61,8 +56,6 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public class LocalFileSystem extends FileSystem {
 
-	private static final Logger LOG = LoggerFactory.getLogger(LocalFileSystem.class);
-
 	/** The URI representing the local file system. */
 	private static final URI LOCAL_URI = OperatingSystem.isWindows() ? URI.create("file:/") : URI.create("file:///");
 
@@ -77,23 +70,12 @@ public class LocalFileSystem extends FileSystem {
 	 * Because Paths are not immutable, we cannot cache the proper path here. */
 	private final URI homeDir;
 
-	/** The host name of this machine. */
-	private final String hostName;
-
 	/**
 	 * Constructs a new <code>LocalFileSystem</code> object.
 	 */
 	public LocalFileSystem() {
 		this.workingDir = new File(System.getProperty("user.dir")).toURI();
 		this.homeDir = new File(System.getProperty("user.home")).toURI();
-
-		String tmp = "unknownHost";
-		try {
-			tmp = InetAddress.getLocalHost().getHostName();
-		} catch (UnknownHostException e) {
-			LOG.error("Could not resolve local host", e);
-		}
-		this.hostName = tmp;
 	}
 
 	// ------------------------------------------------------------------------
@@ -101,7 +83,7 @@ public class LocalFileSystem extends FileSystem {
 	@Override
 	public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len) throws IOException {
 		return new BlockLocation[] {
-				new LocalBlockLocation(hostName, file.getLen())
+				new LocalBlockLocation(file.getLen())
 		};
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -82,9 +82,10 @@ public class LocalFileSystem extends FileSystem {
 
 	@Override
 	public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len) throws IOException {
-		return new BlockLocation[] {
-				new LocalBlockLocation(file.getLen())
-		};
+		if (file instanceof LocalFileStatus) {
+			return ((LocalFileStatus) file).getBlockLocations();
+		}
+		throw new IOException("File status does not belong to the LocalFileSystem: " + file);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -41,6 +41,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @PublicEvolving
 public final class StringUtils {
 
+	/**
+	 * An empty string array. There are just too many places where one needs an empty string array
+	 * and wants to save some object allocation.
+	 */
+	public static final String[] EMPTY_STRING_ARRAY = new String[0];
+
 	private static final char[] HEX_CHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
 	/**

--- a/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/src/main/java/org/apache/flink/fs/anotherdummy/AnotherDummyFSFileSystem.java
+++ b/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/src/main/java/org/apache/flink/fs/anotherdummy/AnotherDummyFSFileSystem.java
@@ -45,8 +45,6 @@ class AnotherDummyFSFileSystem extends FileSystem {
 
 	static final URI FS_URI = URI.create("anotherDummy:///");
 
-	private static final String HOSTNAME = "localhost";
-
 	private final URI workingDir;
 
 	private final URI homeDir;
@@ -93,7 +91,7 @@ class AnotherDummyFSFileSystem extends FileSystem {
 	@Override
 	public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len) throws IOException {
 		return new BlockLocation[] {
-			new LocalBlockLocation(HOSTNAME, file.getLen())
+			new LocalBlockLocation(file.getLen())
 		};
 	}
 

--- a/flink-end-to-end-tests/flink-plugins-test/dummy-fs/src/main/java/org/apache/flink/fs/dummy/DummyFSFileSystem.java
+++ b/flink-end-to-end-tests/flink-plugins-test/dummy-fs/src/main/java/org/apache/flink/fs/dummy/DummyFSFileSystem.java
@@ -45,8 +45,6 @@ class DummyFSFileSystem extends FileSystem {
 
 	static final URI FS_URI = URI.create("dummy:///");
 
-	private static final String HOSTNAME = "localhost";
-
 	private final URI workingDir;
 
 	private final URI homeDir;
@@ -93,7 +91,7 @@ class DummyFSFileSystem extends FileSystem {
 	@Override
 	public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len) throws IOException {
 		return new BlockLocation[] {
-			new LocalBlockLocation(HOSTNAME, file.getLen())
+			new LocalBlockLocation(file.getLen())
 		};
 	}
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileStatus.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileStatus.java
@@ -27,7 +27,7 @@ import org.apache.flink.core.fs.Path;
  */
 public final class HadoopFileStatus implements FileStatus {
 
-	private org.apache.hadoop.fs.FileStatus fileStatus;
+	private final org.apache.hadoop.fs.FileStatus fileStatus;
 
 	/**
 	 * Creates a new file status from an HDFS file status.
@@ -46,12 +46,7 @@ public final class HadoopFileStatus implements FileStatus {
 
 	@Override
 	public long getBlockSize() {
-		long blocksize = fileStatus.getBlockSize();
-		if (blocksize > fileStatus.getLen()) {
-			return fileStatus.getLen();
-		}
-
-		return blocksize;
+		return Math.min(fileStatus.getBlockSize(), fileStatus.getLen());
 	}
 
 	@Override
@@ -69,18 +64,17 @@ public final class HadoopFileStatus implements FileStatus {
 		return fileStatus.getReplication();
 	}
 
-	public org.apache.hadoop.fs.FileStatus getInternalFileStatus() {
-		return this.fileStatus;
-	}
-
 	@Override
 	public Path getPath() {
 		return new Path(fileStatus.getPath().toUri());
 	}
 
-	@SuppressWarnings("deprecation")
 	@Override
 	public boolean isDir() {
-		return fileStatus.isDir();
+		return fileStatus.isDirectory();
+	}
+
+	public org.apache.hadoop.fs.FileStatus getInternalFileStatus() {
+		return this.fileStatus;
 	}
 }

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileStatus.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileStatus.java
@@ -25,7 +25,7 @@ import org.apache.flink.core.fs.Path;
  * Concrete implementation of the {@link FileStatus} interface for the
  * Hadoop Distribution File System.
  */
-public final class HadoopFileStatus implements FileStatus {
+public class HadoopFileStatus implements FileStatus {
 
 	private final org.apache.hadoop.fs.FileStatus fileStatus;
 
@@ -76,5 +76,18 @@ public final class HadoopFileStatus implements FileStatus {
 
 	public org.apache.hadoop.fs.FileStatus getInternalFileStatus() {
 		return this.fileStatus;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new {@code HadoopFileStatus} from Hadoop's {@link org.apache.hadoop.fs.FileStatus}.
+	 * If Hadoop's file status is <i>located</i>, i.e., it contains block information, then this method
+	 * returns an implementation of Flink's {@link org.apache.flink.core.fs.LocatedFileStatus}.
+	 */
+	public static HadoopFileStatus fromHadoopStatus(final org.apache.hadoop.fs.FileStatus fileStatus) {
+		return fileStatus instanceof org.apache.hadoop.fs.LocatedFileStatus
+				? new LocatedHadoopFileStatus((org.apache.hadoop.fs.LocatedFileStatus) fileStatus)
+				: new HadoopFileStatus(fileStatus);
 	}
 }

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/LocatedHadoopFileStatus.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/LocatedHadoopFileStatus.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs;
+
+import org.apache.flink.core.fs.BlockLocation;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.LocatedFileStatus;
+
+/**
+ * Concrete implementation of the {@link FileStatus} interface for the
+ * Hadoop Distribution File System.
+ */
+public final class LocatedHadoopFileStatus extends HadoopFileStatus implements LocatedFileStatus {
+
+	/**
+	 * Creates a new located file status from an HDFS file status.
+	 */
+	public LocatedHadoopFileStatus(org.apache.hadoop.fs.LocatedFileStatus fileStatus) {
+		super(fileStatus);
+	}
+
+	@Override
+	public BlockLocation[] getBlockLocations() {
+		final org.apache.hadoop.fs.BlockLocation[] hadoopLocations =
+				((org.apache.hadoop.fs.LocatedFileStatus) getInternalFileStatus()).getBlockLocations();
+
+		final HadoopBlockLocation[] locations = new HadoopBlockLocation[hadoopLocations.length];
+		for (int i = 0; i < locations.length; i++) {
+			locations[i] = new HadoopBlockLocation(hadoopLocations[i]);
+		}
+		return locations;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR helps to drastically reduce the number of RPC requests made to the file system master (for example the HDFS Name Node) when enumerating the splits in file sources. Previously, we enumerated first all files, and then made a separate RPC call to the name node to get the block locations for each file.

Hadoop has introduced an optimization here that this PR exploits. When the HDFS Client returns a `FileStatus` (description of a file) it frequently returns a `LocatedFileStatus` which already contains all the `BlockLocation` information.

In this PR, we mirror that mechanism in the Flink FileSystem APIs: 
When the `FileStatus` obtained from Hadoop file systems during listing the directory (or getting details for a file) already has the block locations, we use that directly and expose in a Flink `LocatedFileStatus`. That saves the extra RPC call per file to obtain that block location information.


## Brief change log

 - 04e493f0c0d3ba80a2507c4550633a62af45a2e3 : [FLINK-19218] Remove inconsistent/misleading locality information from Local File Splits.
    This is a general cleanup/improvement and makes the implementation of the main change easier.

  - cdc711101c86a58196f0978272a315d03b87e303 : [FLINK-19221] Main change as described above.


## Verifying this change

This change makes a "best effort" attempt and, on purpose, does not add hard tests to enforce this behavior. That is because certain file system implementations or setups may not eagerly expose the location information and we don't want to break compatibility working with them.

The best way to verify this is running a file-heavy batch job against HDFS with this change and observing the reduced number or Name Node RPC requests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** *(a new class, no breaking changes)*
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
