### PR TITLE
[FLINK-19248] add missing lastJobExecutionResult assignment after job finished in ContexEnvironment

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -76,6 +76,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 			final JobExecutionResult  jobExecutionResult = getJobExecutionResult(jobClient);
 			jobListeners.forEach(jobListener ->
 					jobListener.onJobExecuted(jobExecutionResult, null));
+			this.lastJobExecutionResult = jobExecutionResult;
 			return jobExecutionResult;
 		} catch (Throwable t) {
 			jobListeners.forEach(jobListener ->


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes  [issue FLINK-19248](https://issues.apache.org/jira/browse/FLINK-19248) opened by myself.

## Brief change log

- assign the jobExecutionResult to lastJobExecutionResult after job finished in ContextEnvironment

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. I add only one line of code in ContextEnvironment to fix the issue, it can be verified as [issue FLINK-19248](https://issues.apache.org/jira/browse/FLINK-19248) says.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
