### PR TITLE
[FLINK-19178][runtime] Extend managed memory weight/fraction interfaces for various use cases.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.common.operators.util;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.ResourceSpec;
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -72,20 +71,5 @@ public class OperatorValidationUtils {
 		Preconditions.checkArgument(minResources.lessThanOrEqual(preferredResources),
 			"The resources must be either both UNKNOWN or both not UNKNOWN. If not UNKNOWN,"
 				+ " the preferred resources must be greater than or equal to the min resources.");
-	}
-
-	public static void validateResourceRequirements(
-			final ResourceSpec minResources,
-			final ResourceSpec preferredResources,
-			final int managedMemoryWeight) {
-
-		validateMinAndPreferredResources(minResources, preferredResources);
-		Preconditions.checkArgument(
-			managedMemoryWeight >= 0,
-			"managed memory weight must be no less than zero, was: " + managedMemoryWeight);
-		Preconditions.checkArgument(
-			minResources.equals(ResourceSpec.UNKNOWN) || managedMemoryWeight == Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT,
-			"The resources and managed memory weight should not be specified at the same time. " +
-				"resources: " + minResources + ", managed memory weight: " + managedMemoryWeight);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -242,7 +242,7 @@ public abstract class Transformation<T> {
 	 * @param preferredResources The preferred resource of this transformation.
 	 */
 	public void setResources(ResourceSpec minResources, ResourceSpec preferredResources) {
-		OperatorValidationUtils.validateResourceRequirements(minResources, preferredResources, managedMemoryWeight);
+		OperatorValidationUtils.validateMinAndPreferredResources(minResources, preferredResources);
 		this.minResources = checkNotNull(minResources);
 		this.preferredResources = checkNotNull(preferredResources);
 	}
@@ -277,7 +277,6 @@ public abstract class Transformation<T> {
 	 * @throws IllegalArgumentException Thrown, if non-UNKNOWN resources are already set to this transformation
 	 */
 	public void setManagedMemoryWeight(int managedMemoryWeight) {
-		OperatorValidationUtils.validateResourceRequirements(minResources, preferredResources, managedMemoryWeight);
 		this.managedMemoryWeight = managedMemoryWeight;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -145,7 +145,7 @@ public abstract class Transformation<T> {
 	 * Each entry in this map represents a use case that this transformation needs managed memory for. The key of the
 	 * entry indicates the use case, while the value is the use-case-specific weight for this transformation. Managed
 	 * memory reserved for an OPERATOR scope use case will be shared by all the declaring transformations within a slot
-	 * according to this weight. For SLOT scope use cases, the weights are ignored.
+	 * according to this weight. For SLOT scope use cases, only the keys matter and the values (weights) are ignored.
 	 */
 	private final Map<ManagedMemoryUseCase, Integer> managedMemoryUseCaseWeights = new HashMap<>();
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -412,13 +412,14 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.managed.consumer-weights")
 			.mapType()
 			.defaultValue(new HashMap<String, String>() {{
-				put("DATAPROC", "70");
-				put("PYTHON", "30");
+				put(ManagedMemoryConsumerNames.DATAPROC, "70");
+				put(ManagedMemoryConsumerNames.PYTHON, "30");
 			}})
 			.withDescription("Managed memory weights for different kinds of consumers. A slot’s managed memory is"
 				+ " shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless"
-				+ " of the number of consumers from each kind. Currently supported kinds of consumers are DATAPROC (for"
-				+ " RocksDB state backend in streaming and built-in algorithms in batch) and PYTHON (for python processes).");
+				+ " of the number of consumers from each kind. Currently supported kinds of consumers are "
+				+ ManagedMemoryConsumerNames.DATAPROC + " (for RocksDB state backend in streaming and built-in"
+				+ " algorithms in batch) and " + ManagedMemoryConsumerNames.PYTHON + " (for python processes).");
 	/**
 	 * Min Network Memory size for TaskExecutors.
 	 */
@@ -566,4 +567,9 @@ public class TaskManagerOptions {
 
 	/** Not intended to be instantiated. */
 	private TaskManagerOptions() {}
+
+	private static class ManagedMemoryConsumerNames {
+		private static final String DATAPROC = "DATAPROC";
+		private static final String PYTHON = "PYTHON";
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -26,6 +26,8 @@ import org.apache.flink.configuration.description.Description;
 import org.apache.flink.util.TimeUtils;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
@@ -401,6 +403,22 @@ public class TaskManagerOptions {
 			.withDescription("Fraction of Total Flink Memory to be used as Managed Memory, if Managed Memory size is not"
 				+ " explicitly specified.");
 
+	/**
+	 * Weights of managed memory consumers.
+	 */
+	// Do not advertise this option until the feature is completed.
+	@Documentation.ExcludeFromDocumentation
+	public static final ConfigOption<Map<String, String>> MANAGED_MEMORY_CONSUMER_WEIGHTS =
+		key("taskmanager.memory.managed.consumer-weights")
+			.mapType()
+			.defaultValue(new HashMap<String, String>() {{
+				put("DATAPROC", "70");
+				put("PYTHON", "30");
+			}})
+			.withDescription("Managed memory weights for different kinds of consumers. A slot’s managed memory is"
+				+ " shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless"
+				+ " of the number of consumers from each kind. Currently supported kinds of consumers are DATAPROC (for"
+				+ " RocksDB state backend in streaming and built-in algorithms in batch) and PYTHON (for python processes).");
 	/**
 	 * Min Network Memory size for TaskExecutors.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Use cases of managed memory.
+ */
+public enum ManagedMemoryUseCase {
+	BATCH_OP(Scope.OPERATOR),
+	ROCKSDB(Scope.SLOT),
+	PYTHON(Scope.SLOT);
+
+	public final Scope scope;
+
+	ManagedMemoryUseCase(Scope scope) {
+		this.scope = Preconditions.checkNotNull(scope);
+	}
+
+	/**
+	 * Scope at which memory is managed for a use case.
+	 */
+	public enum Scope {
+		SLOT,
+		OPERATOR
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.dag;
 
-import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.TestLogger;
 
@@ -46,22 +45,6 @@ public class TransformationTest extends TestLogger {
 	public void testSetManagedMemoryWeight() {
 		transformation.setManagedMemoryWeight(123);
 		assertEquals(123, transformation.getManagedMemoryWeight());
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testSetManagedMemoryWeightFailIfResourcesIsSpecified() {
-		final ResourceSpec resources = ResourceSpec.newBuilder(1.0, 100).build();
-		transformation.setResources(resources, resources);
-
-		transformation.setManagedMemoryWeight(123);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testSetResourcesFailIfManagedMemoryWeightIsSpecified() {
-		transformation.setManagedMemoryWeight(123);
-
-		final ResourceSpec resources = ResourceSpec.newBuilder(1.0, 100).build();
-		transformation.setResources(resources, resources);
 	}
 
 	/**

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperatorBase.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperatorBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonConfig;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
@@ -271,8 +272,9 @@ public abstract class AbstractPythonFunctionOperatorBase<OUT>
 			.add(MemorySize.parse(config.getPythonDataBufferMemorySize()))
 			.getBytes();
 		MemoryManager memoryManager = getContainingTask().getEnvironment().getMemoryManager();
+		// TODO python operators should declare and use fraction of the PYTHON use case
 		long availableManagedMemory = memoryManager.computeMemorySize(
-			getOperatorConfig().getManagedMemoryFraction());
+			getOperatorConfig().getManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP));
 		if (requiredPythonWorkerMemory <= availableManagedMemory) {
 			memoryManager.reserveMemory(this, requiredPythonWorkerMemory);
 			LOG.info("Reserved memory {} for Python worker.", requiredPythonWorkerMemory);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -236,7 +237,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
 
 		OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.5);
+		testHarness.getStreamConfig().setManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP, 0.5);
 		testHarness.setup(getOutputTypeSerializer(dataType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.python.table;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -195,7 +196,7 @@ public abstract class PythonTableFunctionOperatorTestBase<IN, OUT, UDTFIN> {
 
 		OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.5);
+		testHarness.getStreamConfig().setManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP, 0.5);
 		return testHarness;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
@@ -607,9 +608,9 @@ public class StreamGraph implements Pipeline {
 		}
 	}
 
-	public void setManagedMemoryWeight(int vertexID, int managedMemoryWeight) {
+	public void addManagedMemoryUseCaseWeights(int vertexID, Map<ManagedMemoryUseCase, Integer> managedMemoryUseCaseWeights) {
 		if (getStreamNode(vertexID) != null) {
-			getStreamNode(vertexID).setManagedMemoryWeight(managedMemoryWeight);
+			getStreamNode(vertexID).addManagedMemoryUseCaseWeights(managedMemoryUseCaseWeights);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -308,7 +309,7 @@ public class StreamGraphGenerator {
 			streamGraph.setResources(transform.getId(), transform.getMinResources(), transform.getPreferredResources());
 		}
 
-		streamGraph.setManagedMemoryWeight(transform.getId(), transform.getManagedMemoryWeight());
+		streamGraph.setManagedMemoryWeight(transform.getId(), transform.getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP));
 
 		return transformedIds;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -309,7 +308,7 @@ public class StreamGraphGenerator {
 			streamGraph.setResources(transform.getId(), transform.getMinResources(), transform.getPreferredResources());
 		}
 
-		streamGraph.setManagedMemoryWeight(transform.getId(), transform.getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP));
+		streamGraph.addManagedMemoryUseCaseWeights(transform.getId(), transform.getManagedMemoryUseCaseWeights());
 
 		return transformedIds;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
@@ -37,7 +38,10 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -47,8 +51,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 @Internal
 public class StreamNode implements Serializable {
-
-	public static final int DEFAULT_MANAGED_MEMORY_WEIGHT = 1;
 
 	private static final long serialVersionUID = 1L;
 
@@ -61,7 +63,7 @@ public class StreamNode implements Serializable {
 	private int maxParallelism;
 	private ResourceSpec minResources = ResourceSpec.DEFAULT;
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
-	private int managedMemoryWeight = DEFAULT_MANAGED_MEMORY_WEIGHT;
+	private final Map<ManagedMemoryUseCase, Integer> managedMemoryUseCaseWeights = new HashMap<>();
 	private long bufferTimeout;
 	private final String operatorName;
 	private @Nullable String slotSharingGroup;
@@ -202,12 +204,12 @@ public class StreamNode implements Serializable {
 		this.preferredResources = preferredResources;
 	}
 
-	public void setManagedMemoryWeight(int managedMemoryWeight) {
-		this.managedMemoryWeight = managedMemoryWeight;
+	public void addManagedMemoryUseCaseWeights(Map<ManagedMemoryUseCase, Integer> managedMemoryUseCase) {
+		managedMemoryUseCaseWeights.putAll(managedMemoryUseCase);
 	}
 
-	public int getManagedMemoryWeight() {
-		return managedMemoryWeight;
+	public Map<ManagedMemoryUseCase, Integer> getManagedMemoryUseCaseWeights() {
+		return Collections.unmodifiableMap(managedMemoryUseCaseWeights);
 	}
 
 	public long getBufferTimeout() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -49,6 +48,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 @Internal
 public class StreamNode implements Serializable {
 
+	public static final int DEFAULT_MANAGED_MEMORY_WEIGHT = 1;
+
 	private static final long serialVersionUID = 1L;
 
 	private final int id;
@@ -60,7 +61,7 @@ public class StreamNode implements Serializable {
 	private int maxParallelism;
 	private ResourceSpec minResources = ResourceSpec.DEFAULT;
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
-	private int managedMemoryWeight = Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT;
+	private int managedMemoryWeight = DEFAULT_MANAGED_MEMORY_WEIGHT;
 	private long bufferTimeout;
 	private final String operatorName;
 	private @Nullable String slotSharingGroup;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -184,7 +184,7 @@ public class StreamingJobGraphGenerator {
 			Collections.unmodifiableMap(jobVertices),
 			Collections.unmodifiableMap(vertexConfigs),
 			Collections.unmodifiableMap(chainedConfigs),
-			id -> streamGraph.getStreamNode(id).getManagedMemoryUseCaseWeights().getOrDefault(ManagedMemoryUseCase.BATCH_OP, 0));
+			id -> streamGraph.getStreamNode(id).getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP));
 
 		configureCheckpointing();
 
@@ -824,7 +824,7 @@ public class StreamingJobGraphGenerator {
 
 		final int groupManagedMemoryWeight = slotSharingGroup.getJobVertexIds().stream()
 			.flatMap(vid -> vertexOperators.get(vid).stream())
-			.mapToInt(operatorManagedMemoryWeightRetriever::apply)
+			.mapToInt((id) -> id == null ? 0 : operatorManagedMemoryWeightRetriever.apply(id))
 			.sum();
 
 		for (JobVertexID jobVertexID : slotSharingGroup.getJobVertexIds()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -852,7 +852,10 @@ public class StreamingJobGraphGenerator {
 			final StreamConfig operatorConfig) {
 
 		if (groupResourceSpec.equals(ResourceSpec.UNKNOWN)) {
-			operatorConfig.setManagedMemoryFraction(
+			// For now, only consider managed memory for batch algorithms.
+			// TODO: extend managed memory fraction calculations w.r.t. various managed memory use cases.
+			operatorConfig.setManagedMemoryUseCaseFraction(
+					ManagedMemoryUseCase.BATCH_OP,
 					groupManagedMemoryWeight > 0 ?
 							getFractionRoundedDown(operatorManagedMemoryWeight, groupManagedMemoryWeight) :
 							0.0);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -862,6 +862,7 @@ public class StreamingJobGraphGenerator {
 		} else {
 			// Supporting for fine grained resource specs is still under developing.
 			// This branch should not be executed in production. Not throwing exception for testing purpose.
+			// TODO: support calculating managed memory fractions for fine grained resource specs
 			LOG.error("Failed setting managed memory fractions. " +
 					" Operators may not be able to use managed memory properly." +
 					" Calculating managed memory fractions with fine grained resource spec is currently not supported.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
@@ -177,11 +178,13 @@ public class StreamingJobGraphGenerator {
 
 		setSlotSharingAndCoLocation();
 
+		// For now, only consider managed memory for batch algorithms.
+		// TODO: extend managed memory fraction calculations w.r.t. various managed memory use cases.
 		setManagedMemoryFraction(
 			Collections.unmodifiableMap(jobVertices),
 			Collections.unmodifiableMap(vertexConfigs),
 			Collections.unmodifiableMap(chainedConfigs),
-			id -> streamGraph.getStreamNode(id).getManagedMemoryWeight());
+			id -> streamGraph.getStreamNode(id).getManagedMemoryUseCaseWeights().getOrDefault(ManagedMemoryUseCase.BATCH_OP, 0));
 
 		configureCheckpointing();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -84,6 +84,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME;
@@ -184,7 +185,7 @@ public class StreamingJobGraphGenerator {
 			Collections.unmodifiableMap(jobVertices),
 			Collections.unmodifiableMap(vertexConfigs),
 			Collections.unmodifiableMap(chainedConfigs),
-			id -> streamGraph.getStreamNode(id).getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP));
+			id -> Optional.ofNullable(streamGraph.getStreamNode(id).getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP)));
 
 		configureCheckpointing();
 
@@ -775,7 +776,7 @@ public class StreamingJobGraphGenerator {
 			final Map<Integer, JobVertex> jobVertices,
 			final Map<Integer, StreamConfig> operatorConfigs,
 			final Map<Integer, Map<Integer, StreamConfig>> vertexChainedConfigs,
-			final java.util.function.Function<Integer, Integer> operatorManagedMemoryWeightRetriever) {
+			final java.util.function.Function<Integer, Optional<Integer>> operatorManagedMemoryWeightRetriever) {
 
 		// all slot sharing groups in this job
 		final Set<SlotSharingGroup> slotSharingGroups = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -820,17 +821,17 @@ public class StreamingJobGraphGenerator {
 			final Map<JobVertexID, Set<Integer>> vertexOperators,
 			final Map<Integer, StreamConfig> operatorConfigs,
 			final Map<Integer, Map<Integer, StreamConfig>> vertexChainedConfigs,
-			final java.util.function.Function<Integer, Integer> operatorManagedMemoryWeightRetriever) {
+			final java.util.function.Function<Integer, Optional<Integer>> operatorManagedMemoryWeightRetriever) {
 
 		final int groupManagedMemoryWeight = slotSharingGroup.getJobVertexIds().stream()
 			.flatMap(vid -> vertexOperators.get(vid).stream())
-			.mapToInt((id) -> id == null ? 0 : operatorManagedMemoryWeightRetriever.apply(id))
+			.mapToInt(id -> operatorManagedMemoryWeightRetriever.apply(id).orElse(0))
 			.sum();
 
 		for (JobVertexID jobVertexID : slotSharingGroup.getJobVertexIds()) {
 			for (int operatorNodeId : vertexOperators.get(jobVertexID)) {
 				final StreamConfig operatorConfig = operatorConfigs.get(operatorNodeId);
-				final int operatorManagedMemoryWeight = operatorManagedMemoryWeightRetriever.apply(operatorNodeId);
+				final int operatorManagedMemoryWeight = operatorManagedMemoryWeightRetriever.apply(operatorNodeId).orElse(0);
 				setManagedMemoryFractionForOperator(
 					slotSharingGroup.getResourceSpec(),
 					operatorManagedMemoryWeight,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -181,7 +181,6 @@ public class StreamingJobGraphGenerator {
 			Collections.unmodifiableMap(jobVertices),
 			Collections.unmodifiableMap(vertexConfigs),
 			Collections.unmodifiableMap(chainedConfigs),
-			id -> streamGraph.getStreamNode(id).getMinResources(),
 			id -> streamGraph.getStreamNode(id).getManagedMemoryWeight());
 
 		configureCheckpointing();
@@ -773,7 +772,6 @@ public class StreamingJobGraphGenerator {
 			final Map<Integer, JobVertex> jobVertices,
 			final Map<Integer, StreamConfig> operatorConfigs,
 			final Map<Integer, Map<Integer, StreamConfig>> vertexChainedConfigs,
-			final java.util.function.Function<Integer, ResourceSpec> operatorResourceRetriever,
 			final java.util.function.Function<Integer, Integer> operatorManagedMemoryWeightRetriever) {
 
 		// all slot sharing groups in this job
@@ -809,7 +807,6 @@ public class StreamingJobGraphGenerator {
 				vertexOperators,
 				operatorConfigs,
 				vertexChainedConfigs,
-				operatorResourceRetriever,
 				operatorManagedMemoryWeightRetriever);
 		}
 	}
@@ -820,7 +817,6 @@ public class StreamingJobGraphGenerator {
 			final Map<JobVertexID, Set<Integer>> vertexOperators,
 			final Map<Integer, StreamConfig> operatorConfigs,
 			final Map<Integer, Map<Integer, StreamConfig>> vertexChainedConfigs,
-			final java.util.function.Function<Integer, ResourceSpec> operatorResourceRetriever,
 			final java.util.function.Function<Integer, Integer> operatorManagedMemoryWeightRetriever) {
 
 		final int groupManagedMemoryWeight = slotSharingGroup.getJobVertexIds().stream()
@@ -831,10 +827,8 @@ public class StreamingJobGraphGenerator {
 		for (JobVertexID jobVertexID : slotSharingGroup.getJobVertexIds()) {
 			for (int operatorNodeId : vertexOperators.get(jobVertexID)) {
 				final StreamConfig operatorConfig = operatorConfigs.get(operatorNodeId);
-				final ResourceSpec operatorResourceSpec = operatorResourceRetriever.apply(operatorNodeId);
 				final int operatorManagedMemoryWeight = operatorManagedMemoryWeightRetriever.apply(operatorNodeId);
 				setManagedMemoryFractionForOperator(
-					operatorResourceSpec,
 					slotSharingGroup.getResourceSpec(),
 					operatorManagedMemoryWeight,
 					groupManagedMemoryWeight,
@@ -849,26 +843,23 @@ public class StreamingJobGraphGenerator {
 	}
 
 	private static void setManagedMemoryFractionForOperator(
-			final ResourceSpec operatorResourceSpec,
 			final ResourceSpec groupResourceSpec,
 			final int operatorManagedMemoryWeight,
 			final int groupManagedMemoryWeight,
 			final StreamConfig operatorConfig) {
 
-		final double managedMemoryFraction;
-
 		if (groupResourceSpec.equals(ResourceSpec.UNKNOWN)) {
-			managedMemoryFraction = groupManagedMemoryWeight > 0
-				? getFractionRoundedDown(operatorManagedMemoryWeight, groupManagedMemoryWeight)
-				: 0.0;
+			operatorConfig.setManagedMemoryFraction(
+					groupManagedMemoryWeight > 0 ?
+							getFractionRoundedDown(operatorManagedMemoryWeight, groupManagedMemoryWeight) :
+							0.0);
 		} else {
-			final long groupManagedMemoryBytes = groupResourceSpec.getManagedMemory().getBytes();
-			managedMemoryFraction = groupManagedMemoryBytes > 0
-				? getFractionRoundedDown(operatorResourceSpec.getManagedMemory().getBytes(), groupManagedMemoryBytes)
-				: 0.0;
+			// Supporting for fine grained resource specs is still under developing.
+			// This branch should not be executed in production. Not throwing exception for testing purpose.
+			LOG.error("Failed setting managed memory fractions. " +
+					" Operators may not be able to use managed memory properly." +
+					" Calculating managed memory fractions with fine grained resource spec is currently not supported.");
 		}
-
-		operatorConfig.setManagedMemoryFraction(managedMemoryFraction);
 	}
 
 	private static double getFractionRoundedDown(final long dividend, final long divisor) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -557,10 +557,11 @@ public class StreamGraphGeneratorTest extends TestLogger {
 
 		final StreamGraph streamGraph = env.getStreamGraph();
 		for (StreamNode streamNode : streamGraph.getStreamNodes()) {
-			final int expectedWeight = streamNode.getOperatorName().contains("source")
-				? 123
-				: StreamNode.DEFAULT_MANAGED_MEMORY_WEIGHT;
-			assertEquals(expectedWeight, streamNode.getManagedMemoryWeight());
+			if (streamNode.getOperatorName().contains("source")) {
+				assertThat(streamNode.getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP), is(123));
+			} else {
+				assertThat(streamNode.getManagedMemoryUseCaseWeights().size(), is(0));
+			}
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.streaming.api.datastream.ConnectedStreams;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -551,14 +552,14 @@ public class StreamGraphGeneratorTest extends TestLogger {
 	public void testSetManagedMemoryWeight() {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		final DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
-		source.getTransformation().setManagedMemoryWeight(123);
+		source.getTransformation().declareManagedMemoryUseCase(ManagedMemoryUseCase.BATCH_OP, 123);
 		source.print().name("sink");
 
 		final StreamGraph streamGraph = env.getStreamGraph();
 		for (StreamNode streamNode : streamGraph.getStreamNodes()) {
 			final int expectedWeight = streamNode.getOperatorName().contains("source")
 				? 123
-				: Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT;
+				: StreamNode.DEFAULT_MANAGED_MEMORY_WEIGHT;
 			assertEquals(expectedWeight, streamNode.getManagedMemoryWeight());
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -550,15 +550,16 @@ public class StreamGraphGeneratorTest extends TestLogger {
 
 	@Test
 	public void testSetManagedMemoryWeight() {
+		final int weight = 123;
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		final DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
-		source.getTransformation().declareManagedMemoryUseCase(ManagedMemoryUseCase.BATCH_OP, 123);
+		source.getTransformation().declareManagedMemoryUseCase(ManagedMemoryUseCase.BATCH_OP, weight);
 		source.print().name("sink");
 
 		final StreamGraph streamGraph = env.getStreamGraph();
 		for (StreamNode streamNode : streamGraph.getStreamNodes()) {
 			if (streamNode.getOperatorName().contains("source")) {
-				assertThat(streamNode.getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP), is(123));
+				assertThat(streamNode.getManagedMemoryUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP), is(weight));
 			} else {
 				assertThat(streamNode.getManagedMemoryUseCaseWeights().size(), is(0));
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -796,17 +796,17 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final JobVertex vertex3 = jobGraph.getVerticesSortedTopologicallyFromSources().get(2);
 
 		final StreamConfig sourceConfig = new StreamConfig(vertex1.getConfiguration());
-		assertEquals(1.0 / 6, sourceConfig.getManagedMemoryFraction(), 0.000001);
+		assertEquals(1.0 / 6, sourceConfig.getManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP), 0.000001);
 
 		final StreamConfig map1Config = Iterables.getOnlyElement(
 			sourceConfig.getTransitiveChainedTaskConfigs(StreamingJobGraphGeneratorTest.class.getClassLoader()).values());
-		assertEquals(2.0 / 6, map1Config.getManagedMemoryFraction(), 0.000001);
+		assertEquals(2.0 / 6, map1Config.getManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP), 0.000001);
 
 		final StreamConfig map2Config = new StreamConfig(vertex2.getConfiguration());
-		assertEquals(3.0 / 6, map2Config.getManagedMemoryFraction(), 0.000001);
+		assertEquals(3.0 / 6, map2Config.getManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP), 0.000001);
 
 		final StreamConfig map3Config = new StreamConfig(vertex3.getConfiguration());
-		assertEquals(1.0, map3Config.getManagedMemoryFraction(), 0.000001);
+		assertEquals(1.0, map3Config.getManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP), 0.000001);
 
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.io.TypeSerializerInputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.InputOutputFormatContainer;
 import org.apache.flink.runtime.jobgraph.InputOutputFormatVertex;
@@ -841,10 +842,10 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		opMethod.invoke(map3, resourceSpecs.get(3));
 
 		if (managedMemoryWeights != null) {
-			source.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(0));
-			map1.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(1));
-			map2.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(2));
-			map3.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(3));
+			source.getTransformation().declareManagedMemoryUseCase(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(0));
+			map1.getTransformation().declareManagedMemoryUseCase(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(1));
+			map2.getTransformation().declareManagedMemoryUseCase(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(2));
+			map3.getTransformation().declareManagedMemoryUseCase(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(3));
 		}
 
 		return StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory
 import org.apache.flink.streaming.api.transformations.{OneInputTransformation, TwoInputTransformation}
 import org.apache.flink.table.api.TableException
@@ -112,15 +113,18 @@ object ExecNode {
   def setManagedMemoryWeight[T](
       transformation: Transformation[T],
       memoryBytes: Long = 0): Transformation[T] = {
-    if (transformation.getManagedMemoryWeight != Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT) {
-      throw new TableException("Managed memory weight has been set, this should not happen.")
-    }
 
     // Using Bytes can easily overflow
     // Using KibiBytes to cast to int
     // Careful about zero
-    val memoryKibiBytes = if (memoryBytes == 0) 0 else Math.max(1, (memoryBytes >> 10).toInt)
-    transformation.setManagedMemoryWeight(memoryKibiBytes)
+    if (memoryBytes != 0) {
+      val memoryKibiBytes = if (memoryBytes == 0) 0 else Math.max(1, (memoryBytes >> 10).toInt)
+      val previousWeight = transformation.declareManagedMemoryUseCase(
+        ManagedMemoryUseCase.BATCH_OP, memoryKibiBytes)
+      if (previousWeight.isPresent) {
+        throw new TableException("Managed memory weight has been set, this should not happen.")
+      }
+    }
     transformation
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
@@ -30,8 +30,9 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical._
 import org.apache.flink.util.function.FunctionWithException
 import org.junit.Assert
-
 import java.util
+
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 
 import scala.collection.JavaConverters._
 
@@ -74,7 +75,7 @@ abstract class BatchAggTestBase extends AggTestBase(isBatchMode = true) {
     val streamConfig = testHarness.getStreamConfig
     streamConfig.setStreamOperatorFactory(args._1)
     streamConfig.setOperatorID(new OperatorID)
-    streamConfig.setManagedMemoryFraction(0.99)
+    streamConfig.setManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP, .99)
 
     testHarness.invoke()
     testHarness.waitForTaskRunning()

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators;
 
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
@@ -51,6 +52,6 @@ public class TableStreamOperator<OUT> extends AbstractStreamOperator<OUT> {
 	 */
 	public long computeMemorySize() {
 		return getContainingTask().getEnvironment().getMemoryManager().computeMemorySize(
-				getOperatorConfig().getManagedMemoryFraction());
+				getOperatorConfig().getManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP));
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.join;
 
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -266,7 +267,7 @@ public class Int2HashJoinOperatorTest implements Serializable {
 			testHarness.getStreamConfig().setStreamOperatorFactory((StreamOperatorFactory<?>) operator);
 		}
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.base.IntComparator;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.runtime.TupleComparator;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.sort.MergeIterator;
 import org.apache.flink.runtime.operators.testutils.Match;
@@ -254,7 +255,7 @@ public class RandomSortMergeInnerJoinTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.join;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
@@ -84,7 +85,7 @@ public class String2HashJoinOperatorTest implements Serializable {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.join;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -148,7 +149,7 @@ public class String2SortMergeJoinOperatorTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryUseCaseFraction(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -59,6 +60,7 @@ import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowO
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.function;
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.inputSer;
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.inputType;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -206,7 +208,7 @@ public class BufferDataOverWindowOperatorTest {
 				StreamConfig conf = mock(StreamConfig.class);
 				when(conf.<RowData>getTypeSerializerIn1(getUserCodeClassloader()))
 						.thenReturn(inputSer);
-				when(conf.getManagedMemoryFraction())
+				when(conf.getManagedMemoryUseCaseFraction(eq(ManagedMemoryUseCase.BATCH_OP)))
 						.thenReturn(0.99);
 				return conf;
 			}


### PR DESCRIPTION
## What is the purpose of the change

This PR extends interfaces for getting/setting managed memory weights/fractions with respect to various use cases. It also introduces a configuration option setting use case weights.

This PR does not touch the fraction calculations (which is changed in a separate following PR), thus should not change any behaviors in production.

## Brief change log

- 6a178ff1a861550d36984fae1fdd4c39f1ed992e: Disable fraction calculation for fine grained resource specs, because the original calculation does not work with various use cases.
- b1a0d26eda1107f5475834c414f218afc8fbdc1f: Introduce `ManagedMemoryUseCase`
- 2f4011193d0020d461de81049499387c3bea0db6..96d78c11c6e6aaf408504d45d70a7e69283f016c: Extend managed memory weight/fraction interfaces in `Transformation`, `StreamNode`, `StreamConfig` to support various use cases.
- 1e0209f0df58ecdc3460d426262fc89d035b83f6: Introduce configuration option for setting use case weights
