### PR TITLE
[FLINK-19251][connectors] Avoid confusing queue handling in "SplitReader.handleSplitsChanges()"

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/AddSplitsTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/AddSplitsTask.java
@@ -21,43 +21,35 @@ package org.apache.flink.connector.base.source.reader.fetcher;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 /**
  * The task to add splits.
  */
 class AddSplitsTask<SplitT extends SourceSplit> implements SplitFetcherTask {
+
 	private final SplitReader<?, SplitT> splitReader;
 	private final List<SplitT> splitsToAdd;
-	private final Queue<SplitsChange<SplitT>> splitsChanges;
 	private final Map<String, SplitT> assignedSplits;
-	private boolean splitsChangesAdded;
 
 	AddSplitsTask(
 			SplitReader<?, SplitT> splitReader,
 			List<SplitT> splitsToAdd,
-			Queue<SplitsChange<SplitT>> splitsChanges,
 			Map<String, SplitT> assignedSplits) {
 		this.splitReader = splitReader;
 		this.splitsToAdd = splitsToAdd;
-		this.splitsChanges = splitsChanges;
 		this.assignedSplits = assignedSplits;
-		this.splitsChangesAdded = false;
 	}
 
 	@Override
 	public boolean run() {
-		if (!splitsChangesAdded) {
-			splitsChanges.add(new SplitsAddition<>(splitsToAdd));
-			splitsToAdd.forEach(s -> assignedSplits.put(s.splitId(), s));
-			splitsChangesAdded = true;
+		for (SplitT s : splitsToAdd) {
+			assignedSplits.put(s.splitId(), s);
 		}
-		splitReader.handleSplitsChanges(splitsChanges);
-		return splitsChanges.isEmpty();
+		splitReader.handleSplitsChanges(new SplitsAddition<>(splitsToAdd));
+		return true;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 
 import java.io.IOException;
-import java.util.Queue;
 
 /**
  * An interface used to read from splits. The implementation could either read from a single split or from
@@ -49,9 +48,9 @@ public interface SplitReader<E, SplitT extends SourceSplit> {
 	/**
 	 * Handle the split changes. This call should be non-blocking.
 	 *
-	 * @param splitsChanges a queue with split changes that has not been handled by this SplitReader.
+	 * @param splitsChanges the split changes that the SplitReader needs to handle.
 	 */
-	void handleSplitsChanges(Queue<SplitsChange<SplitT>> splitsChanges);
+	void handleSplitsChanges(SplitsChange<SplitT> splitsChanges);
 
 	/**
 	 * Wake up the split reader in case the fetcher thread is blocking in

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Queue;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -73,10 +72,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 				}
 
 				@Override
-				public void handleSplitsChanges(Queue<SplitsChange<MockSourceSplit>> splitsChanges) {
-					// We have to handle split changes first, otherwise fetch will not be called.
-					splitsChanges.clear();
-				}
+				public void handleSplitsChanges(SplitsChange<MockSourceSplit> splitsChanges) {}
 
 				@Override
 				public void wakeUp() {
@@ -127,7 +123,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 		FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
 			new FutureCompletingBlockingQueue<>();
 		MockSplitReader mockSplitReader =
-			new MockSplitReader(2, true, true);
+			new MockSplitReader(2, true);
 		return new MockSourceReader(
 			elementsQueue,
 			() -> mockSplitReader,

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
@@ -141,9 +141,7 @@ public class SplitFetcherManagerTest {
 		}
 
 		@Override
-		public void handleSplitsChanges(Queue<SplitsChange<SplitT>> splitsChanges) {
-			splitsChanges.clear();
-		}
+		public void handleSplitsChanges(SplitsChange<SplitT> splitsChanges) {}
 
 		@Override
 		public void wakeUp() {}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -166,7 +166,7 @@ public class SplitFetcherTest {
 				new SplitFetcher<>(
 						0,
 						elementQueue,
-						new MockSplitReader(2, true, true),
+						new MockSplitReader(2, true),
 						() -> {});
 
 		// Prepare the splits.

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
@@ -75,7 +75,7 @@ public class MockBaseSource implements Source<Integer, MockSourceSplit, List<Moc
 		config.setLong(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
 		return new MockSourceReader(
 				elementsQueue,
-				() -> new MockSplitReader(2, true, true),
+				() -> new MockSplitReader(2, true),
 				config,
 				readerContext);
 	}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/TestingSplitReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/TestingSplitReader.java
@@ -26,7 +26,6 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Queue;
 
 /**
  * A {@code SplitReader} that returns a pre-defined set of records (by split).
@@ -59,9 +58,7 @@ public class TestingSplitReader<E, SplitT extends SourceSplit> implements SplitR
 	}
 
 	@Override
-	public void handleSplitsChanges(Queue<SplitsChange<SplitT>> splitsChanges) {
-		splitsChanges.clear();
-	}
+	public void handleSplitsChanges(SplitsChange<SplitT> splitsChanges) {}
 
 	@Override
 	public void wakeUp() {


### PR DESCRIPTION
## What is the purpose of the change

Currently, the method `SplitReader.handleSplitsChanges()` gets passed a queue of split changes to handle. The method may decide to handle all of them, or only a subset of them. It it handles a subset of them, the method is later invoked with the remaining changes.

In practice, this ends up being confusing and problematic:

  - It is important to remove the elements from the queue. If you just iterate over the splits, or the splits will get handles multiple time.
  - If the queue is not left empty, the task to handle the changes is immediately re-enqueued and the method immediately re-invoked. No other operation can happen before all split changes from the queue are handled. That means you have to handle all splits immediately, just spread it out over multiple method invocations.

A simpler contract would be to simply pass a the split changes (list of splits) directly only once.
The fetcher would pick those changes up and can internally stash them if it wants to process them later.
For all source implementations we did so far, this was sufficient and easier.

## Brief change log

  - Change signature of `void handleSplitsChanges(Queue<SplitsChange<SplitT>> splitsChanges)`
    to `void handleSplitsChanges(SplitsChange<SplitT> splitsChanges);`
  - Adjust invoking and testing code

## Verifying this change

This change is a simple rework already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
