### PR TITLE
[FLINK-19262][API/DataStream] Can not setParallelism for FLIP-27 source

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -78,6 +78,7 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 						new SourceOperatorFactory<>(source, timestampsAndWatermarks),
 						outTypeInfo,
 						environment.getParallelism()));
+		this.isParallel = true;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 public class DataStreamSourceTest {
 
 	/**
-	 * test Constructor for new Sources (FLIP-27).
+	 * Test constructor for new Sources (FLIP-27).
 	 */
 	@Test
 	public void testConstructor(){

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.mocks.MockSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test for {@link DataStreamSource}.
+ */
+public class DataStreamSourceTest {
+
+	/**
+	 * test Constructor for new Sources (FLIP-27).
+	 */
+	@Test
+	public void testConstructor(){
+		Integer expectParallelism = 100;
+		Boolean expectIsParallel = true;
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		MockSource mockSource = new MockSource(Boundedness.BOUNDED, 10);
+		DataStreamSource<Integer> stream = new DataStreamSource<Integer>(
+			env,
+			mockSource,
+			WatermarkStrategy.noWatermarks() ,
+			null,
+			"TestingSource");
+		stream.setParallelism(100);
+
+		assertEquals(expectIsParallel, stream.isParallel);
+
+		Integer actual = Integer.valueOf(stream.getParallelism());
+		assertEquals(expectParallelism, actual);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
@@ -36,21 +36,18 @@ public class DataStreamSourceTest {
 	 */
 	@Test
 	public void testConstructor(){
-		Integer expectParallelism = 100;
-		Boolean expectIsParallel = true;
+		int expectParallelism = 100;
+		boolean expectIsParallel = true;
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		MockSource mockSource = new MockSource(Boundedness.BOUNDED, 10);
-		DataStreamSource<Integer> stream = new DataStreamSource<Integer>(
-			env,
+		DataStreamSource<Integer> stream = env.fromSource(
 			mockSource,
-			WatermarkStrategy.noWatermarks() ,
-			null,
+			WatermarkStrategy.noWatermarks(),
 			"TestingSource");
-		stream.setParallelism(100);
+		stream.setParallelism(expectParallelism);
 
 		assertEquals(expectIsParallel, stream.isParallel);
 
-		Integer actual = Integer.valueOf(stream.getParallelism());
-		assertEquals(expectParallelism, actual);
+		assertEquals(expectParallelism, stream.getParallelism());
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
@@ -35,7 +35,7 @@ public class DataStreamSourceTest {
 	 * Test constructor for new Sources (FLIP-27).
 	 */
 	@Test
-	public void testConstructor(){
+	public void testConstructor() {
 		int expectParallelism = 100;
 		boolean expectIsParallel = true;
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Can not setParallelism for FLIP-27 source

## Brief change log
Can not setParallelism for FLIP-27 source

## Verifying this change
This change added tests and can be verified as follows:
testConstructor() in class `DataStreamSourceTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
