### PR TITLE
[FLINK-19270] Extract an inteface from AbstractKeyedStateBackend

### DIFF
--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
@@ -24,8 +24,8 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -69,7 +69,7 @@ final class StubStateBackend implements StateBackend {
 	}
 
 	@Override
-	public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
+	public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
 		Environment env,
 		JobID jobID,
 		String operatorIdentifier,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,10 +47,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <K> Type of the key by which state is keyed.
  */
 public abstract class AbstractKeyedStateBackend<K> implements
-	KeyedStateBackend<K>,
-	SnapshotStrategy<SnapshotResult<KeyedStateHandle>>,
-	Closeable,
-	CheckpointListener {
+		CheckpointableKeyedStateBackend<K>,
+		CheckpointListener {
 
 	/** The key serializer. */
 	protected final TypeSerializer<K> keySerializer;
@@ -225,6 +222,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	/**
 	 * @see KeyedStateBackend
 	 */
+	@Override
 	public KeyGroupRange getKeyGroupRange() {
 		return keyGroupRange;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointableKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointableKeyedStateBackend.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import java.io.Closeable;
+
+/**
+ * Interface that combines both, the {@link KeyedStateBackend} interface, which encapsulates methods
+ * responsible for keyed state management and the {@link SnapshotStrategy} which tells the system
+ * how to snapshot the underlying state.
+ *
+ * <p><b>NOTE:</b> Implementations of this class can be notified about a checkpoint result it can additionally implement
+ * the {@link CheckpointListener} interface.
+ *
+ * @param <K> The key by which state is keyed.
+ */
+public interface CheckpointableKeyedStateBackend<K> extends
+		KeyedStateBackend<K>,
+		SnapshotStrategy<SnapshotResult<KeyedStateHandle>>,
+		Closeable {
+
+	/**
+	 * Returns the key groups which the state backend is responsible for.
+	 */
+	KeyGroupRange getKeyGroupRange();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -61,7 +61,7 @@ import java.util.Collection;
  * to store checkpoint and recovery metadata and is typically also used by the keyed- and operator state
  * backends to store checkpointed state.
  *
- * <p>The {@link AbstractKeyedStateBackend} and {@link OperatorStateBackend} created by this state
+ * <p>The {@link CheckpointableKeyedStateBackend} and {@link OperatorStateBackend} created by this state
  * backend define how to hold the working state for keys and operators. They also define how to checkpoint
  * that state, frequently using the raw bytes storage (via the {@code CheckpointStreamFactory}).
  * However, it is also possible that for example a keyed state backend simply implements the bridge to
@@ -121,7 +121,7 @@ public interface StateBackend extends java.io.Serializable {
 	//  Structure Backends 
 	// ------------------------------------------------------------------------
 	/**
-	 * Creates a new {@link AbstractKeyedStateBackend} that is responsible for holding <b>keyed state</b>
+	 * Creates a new {@link CheckpointableKeyedStateBackend} that is responsible for holding <b>keyed state</b>
 	 * and checkpointing it.
 	 *
 	 * <p><i>Keyed State</i> is state where each value is bound to a key.
@@ -143,7 +143,7 @@ public interface StateBackend extends java.io.Serializable {
 	 *
 	 * @throws Exception This method may forward all exceptions that occur while instantiating the backend.
 	 */
-	<K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
+	<K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
 		Environment env,
 		JobID jobID,
 		String operatorIdentifier,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/HeapKeyedStateBackendAsyncByDefaultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/HeapKeyedStateBackendAsyncByDefaultTest.java
@@ -35,6 +35,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.Collections;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -68,7 +70,7 @@ public class HeapKeyedStateBackendAsyncByDefaultTest {
 
 	private void validateSupportForAsyncSnapshots(StateBackend backend) throws Exception {
 
-		AbstractKeyedStateBackend<Integer> keyedStateBackend = backend.createKeyedStateBackend(
+		CheckpointableKeyedStateBackend<Integer> keyedStateBackend = backend.createKeyedStateBackend(
 			new DummyEnvironment("Test", 1, 0),
 			new JobID(),
 			"testOperator",
@@ -82,7 +84,8 @@ public class HeapKeyedStateBackendAsyncByDefaultTest {
 			new CloseableRegistry()
 		);
 
-		assertTrue(keyedStateBackend.supportsAsynchronousSnapshots());
+		assertThat(keyedStateBackend, instanceOf(AbstractKeyedStateBackend.class));
+		assertTrue(((AbstractKeyedStateBackend<?>) keyedStateBackend).supportsAsynchronousSnapshots());
 
 		IOUtils.closeQuietly(keyedStateBackend);
 		keyedStateBackend.dispose();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
@@ -26,8 +26,8 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
@@ -58,7 +58,7 @@ public abstract class StateBackendTestContext {
 
 	private MockEnvironment env;
 
-	private AbstractKeyedStateBackend<String> keyedStateBackend;
+	private CheckpointableKeyedStateBackend<String> keyedStateBackend;
 
 	protected StateBackendTestContext(TtlTimeProvider timeProvider) {
 		this.timeProvider = Preconditions.checkNotNull(timeProvider);
@@ -168,7 +168,7 @@ public abstract class StateBackendTestContext {
 	}
 
 	@SuppressWarnings("unchecked")
-	public <B extends AbstractKeyedStateBackend> B getKeyedStateBackend() {
+	public <B extends CheckpointableKeyedStateBackend<String>> B getKeyedStateBackend() {
 		return (B) keyedStateBackend;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -74,19 +74,16 @@ public class InternalTimeServiceManager<K> {
 
 	private final Map<String, InternalTimerServiceImpl<K, ?>> timerServices;
 
-	private final boolean useLegacySynchronousSnapshots;
-
 	InternalTimeServiceManager(
-		KeyGroupRange localKeyGroupRange,
-		KeyContext keyContext,
-		PriorityQueueSetFactory priorityQueueSetFactory,
-		ProcessingTimeService processingTimeService, boolean useLegacySynchronousSnapshots) {
+			KeyGroupRange localKeyGroupRange,
+			KeyContext keyContext,
+			PriorityQueueSetFactory priorityQueueSetFactory,
+			ProcessingTimeService processingTimeService) {
 
 		this.localKeyGroupRange = Preconditions.checkNotNull(localKeyGroupRange);
 		this.priorityQueueSetFactory = Preconditions.checkNotNull(priorityQueueSetFactory);
 		this.keyContext = Preconditions.checkNotNull(keyContext);
 		this.processingTimeService = Preconditions.checkNotNull(processingTimeService);
-		this.useLegacySynchronousSnapshots = useLegacySynchronousSnapshots;
 
 		this.timerServices = new HashMap<>();
 	}
@@ -196,7 +193,6 @@ public class InternalTimeServiceManager<K> {
 	}
 
 	public void snapshotStateForKeyGroup(DataOutputView stream, int keyGroupIdx) throws IOException {
-		Preconditions.checkState(useLegacySynchronousSnapshots);
 		InternalTimerServiceSerializationProxy<K> serializationProxy =
 			new InternalTimerServiceSerializationProxy<>(this, keyGroupIdx);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -192,7 +192,7 @@ public class InternalTimeServiceManager<K> {
 		}
 	}
 
-	public void snapshotStateForKeyGroup(DataOutputView stream, int keyGroupIdx) throws IOException {
+	private void snapshotStateForKeyGroup(DataOutputView stream, int keyGroupIdx) throws IOException {
 		InternalTimerServiceSerializationProxy<K> serializationProxy =
 			new InternalTimerServiceSerializationProxy<>(this, keyGroupIdx);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
@@ -43,7 +43,7 @@ public interface StreamOperatorStateContext {
 	/**
 	 * Returns the keyed state backend for the stream operator. This method returns null for non-keyed operators.
 	 */
-	AbstractKeyedStateBackend<?> keyedStateBackend();
+	CheckpointableKeyedStateBackend<?> keyedStateBackend();
 
 	/**
 	 * Returns the internal timer service manager for the stream operator. This method returns null for non-keyed

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -182,7 +182,7 @@ public class StreamOperatorStateHandler {
 		try {
 			if (timeServiceManager.isPresent()) {
 				checkState(keyedStateBackend != null, "keyedStateBackend should be available with timeServiceManager");
-				timeServiceManager.get().snapshotState(keyedStateBackend, snapshotContext, operatorName);
+				timeServiceManager.get().snapshotState(snapshotContext, operatorName);
 			}
 			streamOperator.snapshotState(snapshotContext);
 
@@ -218,13 +218,13 @@ public class StreamOperatorStateHandler {
 	}
 
 	public void notifyCheckpointComplete(long checkpointId) throws Exception {
-		if (keyedStateBackend != null && keyedStateBackend instanceof CheckpointListener) {
+		if (keyedStateBackend instanceof CheckpointListener) {
 			((CheckpointListener) keyedStateBackend).notifyCheckpointComplete(checkpointId);
 		}
 	}
 
 	public void notifyCheckpointAborted(long checkpointId) throws Exception {
-		if (keyedStateBackend != null && keyedStateBackend instanceof CheckpointListener) {
+		if (keyedStateBackend instanceof CheckpointListener) {
 			((CheckpointListener) keyedStateBackend).notifyCheckpointAborted(checkpointId);
 		}
 	}
@@ -278,7 +278,7 @@ public class StreamOperatorStateHandler {
 		}
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({"unchecked"})
 	public void setCurrentKey(Object key) {
 		if (keyedStateBackend != null) {
 			try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -29,8 +29,9 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultKeyedStateStore;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
@@ -67,7 +68,7 @@ public class StreamOperatorStateHandler {
 
 	/** Backend for keyed state. This might be empty if we're not on a keyed stream. */
 	@Nullable
-	private final AbstractKeyedStateBackend<?> keyedStateBackend;
+	private final CheckpointableKeyedStateBackend<?> keyedStateBackend;
 	private final CloseableRegistry closeableRegistry;
 	@Nullable
 	private final DefaultKeyedStateStore keyedStateStore;
@@ -125,10 +126,10 @@ public class StreamOperatorStateHandler {
 				closer.register(keyedStateBackend);
 			}
 			if (operatorStateBackend != null) {
-				closer.register(() -> operatorStateBackend.dispose());
+				closer.register(operatorStateBackend::dispose);
 			}
 			if (keyedStateBackend != null) {
-				closer.register(() -> keyedStateBackend.dispose());
+				closer.register(keyedStateBackend::dispose);
 			}
 		}
 	}
@@ -217,14 +218,14 @@ public class StreamOperatorStateHandler {
 	}
 
 	public void notifyCheckpointComplete(long checkpointId) throws Exception {
-		if (keyedStateBackend != null) {
-			keyedStateBackend.notifyCheckpointComplete(checkpointId);
+		if (keyedStateBackend != null && keyedStateBackend instanceof CheckpointListener) {
+			((CheckpointListener) keyedStateBackend).notifyCheckpointComplete(checkpointId);
 		}
 	}
 
 	public void notifyCheckpointAborted(long checkpointId) throws Exception {
-		if (keyedStateBackend != null) {
-			keyedStateBackend.notifyCheckpointAborted(checkpointId);
+		if (keyedStateBackend != null && keyedStateBackend instanceof CheckpointListener) {
+			((CheckpointListener) keyedStateBackend).notifyCheckpointAborted(checkpointId);
 		}
 	}
 
@@ -241,7 +242,7 @@ public class StreamOperatorStateHandler {
 			TypeSerializer<N> namespaceSerializer,
 			StateDescriptor<S, T> stateDescriptor) throws Exception {
 
-		if (keyedStateStore != null) {
+		if (keyedStateBackend != null) {
 			return keyedStateBackend.getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
 		}
 		else {
@@ -268,7 +269,7 @@ public class StreamOperatorStateHandler {
 	    state backend, or being set on the state directly.
 	    */
 
-		if (keyedStateStore != null) {
+		if (keyedStateBackend != null) {
 			return keyedStateBackend.getPartitionedState(namespace, namespaceSerializer, stateDescriptor);
 		} else {
 			throw new RuntimeException("Cannot create partitioned state. The keyed state " +
@@ -282,8 +283,8 @@ public class StreamOperatorStateHandler {
 		if (keyedStateBackend != null) {
 			try {
 				// need to work around type restrictions
-				@SuppressWarnings("unchecked,rawtypes")
-				AbstractKeyedStateBackend rawBackend = (AbstractKeyedStateBackend) keyedStateBackend;
+				@SuppressWarnings("rawtypes")
+				CheckpointableKeyedStateBackend rawBackend = keyedStateBackend;
 
 				rawBackend.setCurrentKey(key);
 			} catch (Exception e) {
@@ -292,7 +293,6 @@ public class StreamOperatorStateHandler {
 		}
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	public Object getCurrentKey() {
 		if (keyedStateBackend != null) {
 			return keyedStateBackend.getCurrentKey();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -216,12 +217,15 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		}
 
 		final KeyGroupRange keyGroupRange = keyedStatedBackend.getKeyGroupRange();
+		final boolean requiresSnapshotLegacyTimers = keyedStatedBackend instanceof AbstractKeyedStateBackend &&
+			((AbstractKeyedStateBackend<K>) keyedStatedBackend).requiresLegacySynchronousTimerSnapshots();
 
 		final InternalTimeServiceManager<K> timeServiceManager = new InternalTimeServiceManager<>(
 			keyGroupRange,
 			keyContext,
 			keyedStatedBackend,
-			processingTimeService);
+			processingTimeService,
+			requiresSnapshotLegacyTimers);
 
 		// and then initialize the timer services
 		for (KeyGroupStatePartitionStreamProvider streamProvider : rawKeyedStates) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
@@ -175,7 +175,7 @@ public class StateInitializationContextImplTest {
 
 			@Override
 			protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
-				AbstractKeyedStateBackend<K> keyedStatedBackend,
+				CheckpointableKeyedStateBackend<K> keyedStatedBackend,
 				KeyContext keyContext,
 				ProcessingTimeService processingTimeService,
 				Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -130,7 +131,9 @@ public class StreamOperatorStateHandlerTest {
 			stateHandler.initializeOperatorState(checkpointedStreamOperator);
 
 			assertThat(stateContext.operatorStateBackend().getRegisteredStateNames(), is(not(empty())));
-			assertThat(stateContext.keyedStateBackend().numKeyValueStatesByName(), equalTo(1));
+			assertThat(
+				((AbstractKeyedStateBackend<?>) stateContext.keyedStateBackend()).numKeyValueStatesByName(),
+				equalTo(1));
 
 			try {
 				stateHandler.snapshotState(
@@ -165,7 +168,9 @@ public class StreamOperatorStateHandlerTest {
 
 			assertThat(stateContext.operatorStateBackend().getRegisteredBroadcastStateNames(), is(empty()));
 			assertThat(stateContext.operatorStateBackend().getRegisteredStateNames(), is(empty()));
-			assertThat(stateContext.keyedStateBackend().numKeyValueStatesByName(), is(0));
+			assertThat(
+				((AbstractKeyedStateBackend<?>) stateContext.keyedStateBackend()).numKeyValueStatesByName(),
+				equalTo(0));
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
@@ -103,12 +104,12 @@ public class StreamTaskStateInitializerImplTest {
 			new UnregisteredMetricsGroup());
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
-		AbstractKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
+		CheckpointableKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
 		InternalTimeServiceManager<?> timeServiceManager = stateContext.internalTimerServiceManager();
 		CloseableIterable<KeyGroupStatePartitionStreamProvider> keyedStateInputs = stateContext.rawKeyedStateInputs();
 		CloseableIterable<StatePartitionStreamProvider> operatorStateInputs = stateContext.rawOperatorStateInputs();
 
-		Assert.assertEquals(false, stateContext.isRestored());
+		Assert.assertFalse("Expected the context to NOT be restored", stateContext.isRestored());
 		Assert.assertNotNull(operatorStateBackend);
 		Assert.assertNotNull(keyedStateBackend);
 		Assert.assertNotNull(timeServiceManager);
@@ -214,12 +215,12 @@ public class StreamTaskStateInitializerImplTest {
 			new UnregisteredMetricsGroup());
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
-		AbstractKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
+		CheckpointableKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
 		InternalTimeServiceManager<?> timeServiceManager = stateContext.internalTimerServiceManager();
 		CloseableIterable<KeyGroupStatePartitionStreamProvider> keyedStateInputs = stateContext.rawKeyedStateInputs();
 		CloseableIterable<StatePartitionStreamProvider> operatorStateInputs = stateContext.rawOperatorStateInputs();
 
-		Assert.assertEquals(true, stateContext.isRestored());
+		Assert.assertTrue("Expected the context to be restored", stateContext.isRestored());
 
 		Assert.assertNotNull(operatorStateBackend);
 		Assert.assertNotNull(keyedStateBackend);
@@ -285,7 +286,7 @@ public class StreamTaskStateInitializerImplTest {
 				stateBackend) {
 				@Override
 				protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
-					AbstractKeyedStateBackend<K> keyedStatedBackend,
+					CheckpointableKeyedStateBackend<K> keyedStatedBackend,
 					KeyContext keyContext,
 					ProcessingTimeService processingTimeService,
 					Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DoneFuture;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
@@ -1640,7 +1641,7 @@ public class StreamTaskTest extends TestLogger {
 					}
 
 					@Override
-					public AbstractKeyedStateBackend<?> keyedStateBackend() {
+					public CheckpointableKeyedStateBackend<?> keyedStateBackend() {
 						return controller.keyedStateBackend();
 					}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
@@ -63,6 +63,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -167,10 +168,10 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 				stateBackend = fsstateBackend;
 				break;
 			case ROCKSDB_FULLY_ASYNC:
-				stateBackend = new RocksDBStateBackend(fsstateBackend, false);
+				stateBackend = new RocksDBStateBackend(fsstateBackend, TernaryBoolean.FALSE);
 				break;
 			case ROCKSDB_INCREMENTAL:
-				stateBackend = new RocksDBStateBackend(fsstateBackend, true);
+				stateBackend = new RocksDBStateBackend(fsstateBackend, TernaryBoolean.TRUE);
 				break;
 			default:
 				throw new IllegalStateException(String.format("Do not support statebackend type %s", stateBackendEnum));
@@ -239,10 +240,10 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 				return new StreamTaskStateInitializerImpl(env, stateBackend) {
 					@Override
 					protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
-						AbstractKeyedStateBackend<K> keyedStatedBackend,
+						CheckpointableKeyedStateBackend<K> keyedStatedBackend,
 						KeyContext keyContext,
 						ProcessingTimeService processingTimeService,
-						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) {
 
 						return null;
 					}
@@ -290,7 +291,7 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 			this.verifyRestore = verifyRestore;
 		}
 
-		private boolean verifyRestore;
+		private final boolean verifyRestore;
 		private ValueState<Integer> keyedState;
 		private ListState<Integer> opState;
 


### PR DESCRIPTION

## What is the purpose of the change

This commit extracts a minimal interface from AbstractKeyedStateBackend.
This interface is returned by StateBackend interface, making it easier
to implement custom keyed state backend without pulling in all the logic
of AbstractKeyedStateBackend.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
