### PR TITLE
[WIP] single task failure recovery --network stack break from serializer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
@@ -35,6 +35,8 @@ public final class FailoverStrategyFactoryLoader {
 	/** Config name for the {@link RestartPipelinedRegionFailoverStrategy}. */
 	public static final String PIPELINED_REGION_RESTART_STRATEGY_NAME = "region";
 
+	public static final String RESTART_INDIVIDUAL_STRATEGY_NAME = "individual";
+
 	private FailoverStrategyFactoryLoader() {
 	}
 
@@ -55,6 +57,9 @@ public final class FailoverStrategyFactoryLoader {
 
 			case PIPELINED_REGION_RESTART_STRATEGY_NAME:
 				return new RestartPipelinedRegionFailoverStrategy.Factory();
+
+			case RESTART_INDIVIDUAL_STRATEGY_NAME:
+				return new RestartIndividualFailoverStrategy.Factory();
 
 			default:
 				throw new IllegalConfigurationException("Unknown failover strategy: " + strategyParam);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartIndividualFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartIndividualFailoverStrategy.java
@@ -1,0 +1,41 @@
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+public class RestartIndividualFailoverStrategy implements FailoverStrategy {
+
+	/** The log object used for debugging. */
+	private static final Logger LOG = LoggerFactory.getLogger(RestartIndividualFailoverStrategy.class);
+
+	RestartIndividualFailoverStrategy(
+			SchedulingTopology topology,
+			ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+	}
+
+	@Override
+	public Set<ExecutionVertexID> getTasksNeedingRestart(ExecutionVertexID executionVertexId, Throwable cause) {
+		return ImmutableSet.of(executionVertexId);
+	}
+
+	/**
+	 * The factory to instantiate {@link RestartIndividualFailoverStrategy}.
+	 */
+	public static class Factory implements FailoverStrategy.Factory {
+
+		@Override
+		public FailoverStrategy create(
+			final SchedulingTopology topology,
+			final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+			return new RestartIndividualFailoverStrategy(topology, resultPartitionAvailabilityChecker);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
@@ -87,6 +87,8 @@ public interface RecordSerializer<T extends IOReadableWritable> {
 	 */
 	void reset();
 
+	void clear();
+
 	/**
 	 * @return <tt>true</tt> if has some serialized data pending copying to the result {@link BufferBuilder}.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -108,6 +108,13 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	}
 
 	@Override
+	public void clear() {
+		dataBuffer.rewind();
+		dataBuffer.flip();
+		serializationBuffer.clear();
+	}
+
+	@Override
 	public boolean hasSerializedData() {
 		return dataBuffer.hasRemaining();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -91,6 +91,8 @@ public interface ResultPartitionWriter extends AutoCloseable, AvailabilityProvid
 		return addBufferConsumer(bufferConsumer, subpartitionIndex, false);
 	}
 
+	default void cleanBuffers(int subpartitionIndex) {}
+
 	/**
 	 * Returns a reader for the subpartition with the given index.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -154,6 +154,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 			return;
 		}
 
+		LOG.debug("addCreditOrResumeConsumption: " + receiverId);
 		NetworkSequenceViewReader reader = allReaders.get(receiverId);
 		if (reader != null) {
 			operation.accept(reader);
@@ -169,6 +170,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		// The user event triggered event loop callback is used for thread-safe
 		// hand over of reader queues and cancelled producers.
 
+		LOG.debug("userEventTriggered: " + msg.toString());
 		if (msg instanceof NetworkSequenceViewReader) {
 			enqueueAvailableReader((NetworkSequenceViewReader) msg);
 		} else if (msg.getClass() == InputChannelID.class) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -63,7 +63,7 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
 		if (isReleased.compareAndSet(false, true)) {
 			// The view doesn't hold any resources and the parent cannot be restarted. Therefore,
 			// it's OK to notify about consumption as well.
-			parent.onConsumedSubpartition();
+			parent.releaseView();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -202,6 +202,8 @@ public abstract class ResultPartition implements ResultPartitionWriter, BufferPo
 	@Override
 	public BufferBuilder tryGetBufferBuilder(int targetChannel) throws IOException {
 		BufferBuilder bufferBuilder = bufferPool.requestBufferBuilder(targetChannel);
+		LOG.debug("try to get a new buffer builder:" + bufferPool.toString());
+		LOG.debug("buffer consumer Queue size: " + subpartitions[targetChannel].getBufferSize());
 		return bufferBuilder;
 	}
 
@@ -223,6 +225,18 @@ public abstract class ResultPartition implements ResultPartitionWriter, BufferPo
 		}
 
 		return subpartition.add(bufferConsumer, isPriorityEvent);
+	}
+
+	public void cleanBuffers(int subpartitionIndex) {
+		ResultSubpartition subpartition;
+		try {
+			checkInProduceState();
+			subpartition = subpartitions[subpartitionIndex];
+		} catch (Exception ex) {
+			throw ex;
+		}
+
+		subpartition.cleanPartialBufferFromWriter();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -93,6 +93,13 @@ public abstract class ResultSubpartition {
 	 */
 	public abstract boolean add(BufferConsumer bufferConsumer, boolean isPriorityEvent) throws IOException;
 
+	public void cleanPartialBufferFromWriter() {}
+
+	// used for debug only
+	public int getBufferSize() {
+		return -1;
+	}
+
 	/**
 	 * Adds the given buffer.
 	 *

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
@@ -1,0 +1,245 @@
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.test.util.TestUtils.tryExecute;
+
+/** Use RemoteInputChannel. Only for Upstream Reconnection. **/
+
+/**
+ * 1. data size : 83
+ * 2. memory buffer size: 4096
+ * 3. full buffer: 49 record 4067 => 50 record 4150
+ */
+public class ApproximateLocalRecoveryUpstreamDiffTMITCase {
+	private static MiniClusterWithClientResource cluster;
+
+	@Before
+	public void setup() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "individual");
+		config.setString(HighAvailabilityOptions.HA_MODE, RegionFailoverITCase.TestingHAFactory.class.getName());
+
+		config.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4096"));
+		config.setLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 1000000L);
+		config.setString(AkkaOptions.ASK_TIMEOUT, "1 h");
+		//configuration.setString("heartbeat.timeout", "1000000");
+
+		cluster = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+				.setConfiguration(config)
+				.setNumberTaskManagers(2)
+				.setNumberSlotsPerTaskManager(1).build());
+		cluster.before();
+	}
+
+	@AfterClass
+	public static void shutDownExistingCluster() {
+		if (cluster != null) {
+			cluster.after();
+			cluster = null;
+		}
+	}
+
+	@Test
+	public void localTaskFailureRecovery() throws Exception {
+		int numElementsPerTask = 1000000;
+		int producerParallelism = 1;
+		int failAfterElements = 20;
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+		env.setBufferTimeout(0);
+		env.disableOperatorChaining();
+		// env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
+
+		DataStream<Tuple4<Integer, Long, Integer, String>> source =
+			env.addSource(new AppSourceFunction(numElementsPerTask))
+				.setParallelism(producerParallelism)
+				.slotSharingGroup("source");
+
+		source.map(new FailingMapper<>(failAfterElements))
+			.setParallelism(1)
+			.slotSharingGroup("map");
+
+		FailingMapper.failedBefore = false;
+		tryExecute(env, "test");
+	}
+
+	// Schema: (key, timestamp, source instance Id).
+	static class AppSourceFunction extends RichParallelSourceFunction<Tuple4<Integer, Long, Integer, String>>
+		implements ListCheckpointed<Integer> {
+		private static final Logger LOG = LoggerFactory.getLogger(AppSourceFunction.class);
+		private volatile boolean running = true;
+		private final int numElementsPerProducer;
+
+		private int index = 0;
+
+		AppSourceFunction(int numElementsPerProducer) {
+			this.numElementsPerProducer = numElementsPerProducer;
+		}
+
+		@Override
+		public void run(SourceContext<Tuple4<Integer, Long, Integer, String>> ctx) throws Exception{
+			long timestamp = 1593575900000L;
+			int sourceInstanceId = getRuntimeContext().getIndexOfThisSubtask();
+			for (; index < numElementsPerProducer && running; index++) {
+				synchronized (ctx.getCheckpointLock()) {
+					if (index % 100 == 0) {
+						Thread.sleep(500);
+					}
+					System.out.println("Source : [" + index + "," + timestamp + "," + sourceInstanceId + "]");
+					ctx.collect(new Tuple4<>(index, timestamp++, sourceInstanceId, "I am a very long string to test partial records hohoho hahaha"));
+				}
+			}
+			while (running) {
+				Thread.sleep(100);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			LOG.info("Snapshot of Source index " + index + " at checkpoint " + checkpointId);
+			return Collections.singletonList(index);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+
+			index = state.get(0);
+			LOG.info("restore Source index to " + index);
+		}
+	}
+
+	private static class FailingMapper<T> extends RichMapFunction<T, T> implements
+		ListCheckpointed<Integer>, CheckpointListener, Runnable {
+
+		private static final Logger LOG = LoggerFactory.getLogger(FailingMapper.class);
+
+		private static final long serialVersionUID = 6334389850158707313L;
+
+		public static volatile boolean failedBefore;
+
+		private final int failCount;
+		private int numElementsTotal;
+		private int numElementsThisTime;
+
+		private boolean failer;
+		private boolean hasBeenCheckpointed;
+
+		private Thread printer;
+		private volatile boolean printerRunning = true;
+
+		public FailingMapper(int failCount) {
+			this.failCount = failCount;
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			failer = getRuntimeContext().getIndexOfThisSubtask() == 0;
+			printer = new Thread(this, "FailingIdentityMapper Status Printer");
+			printer.start();
+		}
+
+		@Override
+		public T map(T value) throws Exception {
+			// System.out.println("Failing mapper: numElementsThisTime=" + numElementsThisTime + " totalCount=" + numElementsTotal);
+			System.out.println("Failing mapper: " + value.toString());
+			numElementsTotal++;
+			numElementsThisTime++;
+
+			if (!failedBefore) {
+				Thread.sleep(10);
+
+				if (failer && numElementsTotal >= failCount) {
+					failedBefore = true;
+					throw new Exception("Artificial Test Failure");
+				}
+			}
+			return value;
+		}
+
+		@Override
+		public void close() throws Exception {
+			printerRunning = false;
+			if (printer != null) {
+				printer.interrupt();
+				printer = null;
+			}
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			this.hasBeenCheckpointed = true;
+		}
+
+		@Override
+		public void notifyCheckpointAborted(long checkpointId) {
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			LOG.info("Snapshot of FailingMapper numElementsTotal " + numElementsTotal + " at checkpoint " + checkpointId);
+			return Collections.singletonList(numElementsTotal);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+
+			this.numElementsTotal = state.get(0);
+			LOG.info("restore FailingMapper numElementsTotal to " + numElementsTotal);
+		}
+
+		@Override
+		public void run() {
+			while (printerRunning) {
+				try {
+					Thread.sleep(5000);
+				} catch (InterruptedException e) {
+					// ignore
+				}
+				LOG.info("============================> Failing mapper  {}: count={}, totalCount={}",
+					getRuntimeContext().getIndexOfThisSubtask(),
+					numElementsThisTime, numElementsTotal);
+			}
+		}
+	}
+
+}

--- a/flink-tests/src/test/resources/log4j2-test.properties
+++ b/flink-tests/src/test/resources/log4j2-test.properties
@@ -18,7 +18,8 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+#rootLogger.level = INFO
+rootLogger.level = DEBUG
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger


### PR DESCRIPTION
Reference Purpose, WIP.
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

a prototype of single task failure recovery --network stack break from the serializer (`copyFromSerializerToTargetChannel`)


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
