### PR TITLE
[FLINK-19228][filesystem] Avoid accessing FileSystem in client for file system connector

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -144,7 +144,7 @@ public class FileSystemTableSink implements
 			builder.setFileSystemFactory(fsFactory);
 			builder.setOverwrite(overwrite);
 			builder.setStaticPartitions(staticPartitions);
-			builder.setTempPath(toStagingPath());
+			builder.setTempPath(new Path(path, ".staging_" + System.currentTimeMillis()));
 			builder.setOutputFileConfig(outputFileConfig);
 			return dataStream.writeUsingOutputFormat(builder.build())
 					.setParallelism(dataStream.getParallelism());
@@ -224,19 +224,6 @@ public class FileSystemTableSink implements
 		}
 		//noinspection unchecked
 		return returnStream.addSink(new DiscardingSink()).setParallelism(1);
-	}
-
-	private Path toStagingPath() {
-		Path stagingDir = new Path(path, ".staging_" + System.currentTimeMillis());
-		try {
-			FileSystem fs = stagingDir.getFileSystem();
-			Preconditions.checkState(
-					fs.exists(stagingDir) || fs.mkdirs(stagingDir),
-					"Failed to create staging dir " + stagingDir);
-			return stagingDir;
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
## What is the purpose of the change

*No corresponding file system plugin exists on the client so that client couldn't access the specific file system. Accessing the file system couldn't be on the client, but could put the work on the job manager or task manager. Method `toStagingPath` doesn't need to check the state of staging directory, directly use `new Path(path, ".staging_" + System.currentTimeMillis())` to set the temporary path.*

## Brief change log

  - *Remove the method `toStagingPath` and directly use `new Path(path, ".staging_" + System.currentTimeMillis())`.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
