### PR TITLE
[FLINK-19188][examples-table] Add a new streaming SQL example

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -57,6 +57,13 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- Table connectors and formats -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-csv</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- Flink core -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -124,6 +131,28 @@ under the License.
 
 							<includes>
 								<include>org/apache/flink/table/examples/java/basics/GettingStartedExample*</include>
+							</includes>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>UpdatingTopCityExample</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+
+						<configuration>
+							<classifier>UpdatingTopCityExample</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.table.examples.java.basics.UpdatingTopCityExample</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>org/apache/flink/table/examples/java/basics/UpdatingTopCityExample*</include>
 							</includes>
 						</configuration>
 					</execution>

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/UpdatingTopCityExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/UpdatingTopCityExample.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.java.basics;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Example for aggregating and ranking data using Flink SQL on updating (but bounded) streams.
+ *
+ * <p>The example shows how to declare a table using SQL DDL for reading insert-only data and handling
+ * updating data. It should give a first impression about Flink SQL as a changelog processor. The example
+ * uses some streaming operations that produce a stream of updates. See the other examples for pure CDC
+ * processing and more complex operations.
+ *
+ * <p>In particular, the example shows how to
+ * <ul>
+ *     <li>setup a {@link TableEnvironment},
+ *     <li>use the environment for creating a CSV file with example data,
+ *     <li>aggregate the incoming INSERT changes,
+ *     <li>compute a top-N result,
+ *     <li>collect and materialize the updating stream locally.
+ * </ul>
+ *
+ * <p>The example executes two Flink jobs. The results are written to stdout.
+ *
+ * <p>Note: Make sure to include the SQL CSV format when submitting this example to Flink (e.g. via
+ * command line). This step is not necessary when executing the example in an IDE.
+ */
+public final class UpdatingTopCityExample {
+
+	public static void main(String[] args) throws Exception {
+		// prepare the session
+		final EnvironmentSettings settings = EnvironmentSettings.newInstance()
+			.inStreamingMode()
+			.build();
+		final TableEnvironment env = TableEnvironment.create(settings);
+
+		// create an empty temporary CSV directory for this example
+		final String populationDirPath = createTemporaryDirectory();
+
+		// register a table in the catalog that points to the CSV file
+		env.executeSql(
+			"CREATE TABLE PopulationUpdates (" +
+			"  city STRING," +
+			"  state STRING," +
+			"  update_year INT," +
+			"  population_diff INT" +
+			") WITH (" +
+			"  'connector' = 'filesystem'," +
+			"  'path' = '" + populationDirPath + "'," +
+			"  'format' = 'csv'" +
+			")"
+		);
+
+		// insert some example data into the table
+		final TableResult insertionResult = env.executeSql(
+			"INSERT INTO PopulationUpdates VALUES" +
+			"  ('Los Angeles', 'CA', 2013, 13106100), " +
+			"  ('Los Angeles', 'CA', 2014, 72600), " +
+			"  ('Los Angeles', 'CA', 2015, 72300), " +
+			"  ('Chicago', 'IL', 2013, 9553270), " +
+			"  ('Chicago', 'IL', 2014, 11340), " +
+			"  ('Chicago', 'IL', 2015, -6730), " +
+			"  ('Houston', 'TX', 2013, 6330660), " +
+			"  ('Houston', 'TX', 2014, 172960), " +
+			"  ('Houston', 'TX', 2015, 172940), " +
+			"  ('Phoenix', 'AZ', 2013, 4404680), " +
+			"  ('Phoenix', 'AZ', 2014, 86740), " +
+			"  ('Phoenix', 'AZ', 2015, 89700), " +
+			"  ('San Antonio', 'TX', 2013, 2280580), " +
+			"  ('San Antonio', 'TX', 2014, 49180), " +
+			"  ('San Antonio', 'TX', 2015, 50870), " +
+			"  ('San Francisco', 'CA', 2013, 4521310), " +
+			"  ('San Francisco', 'CA', 2014, 65940), " +
+			"  ('San Francisco', 'CA', 2015, 62290), " +
+			"  ('Dallas', 'TX', 2013, 6817520), " +
+			"  ('Dallas', 'TX', 2014, 137740), " +
+			"  ('Dallas', 'TX', 2015, 154020)"
+		);
+
+		// since all cluster operations of the Table API are executed asynchronously,
+		// we need wait until the insertion has been completed,
+		// an exception is thrown in case of an error
+		insertionResult.await();
+
+		// read from table and aggregate the total population per city
+		final Table currentPopulation = env.sqlQuery(
+			"SELECT city, state, MAX(update_year) AS latest_year, SUM(population_diff) AS population " +
+			"FROM PopulationUpdates " +
+			"GROUP BY city, state"
+		);
+
+		// either define a nested SQL statement with sub-queries
+		// or divide the problem into sub-views which will be optimized
+		// as a whole during planning
+		env.createTemporaryView("CurrentPopulation", currentPopulation);
+
+		// find the top 2 cities with the highest population per state,
+		// we use a sub-query that is correlated with every unique state,
+		// for every state we rank by population and return the top 2 cities
+		final Table topCitiesPerState = env.sqlQuery(
+			"SELECT state, city, latest_year, population " +
+			"FROM " +
+			"  (SELECT DISTINCT state FROM CurrentPopulation) States," +
+			"  LATERAL (" +
+			"    SELECT city, latest_year, population" +
+			"    FROM CurrentPopulation" +
+			"    WHERE state = States.state" +
+			"    ORDER BY population DESC, latest_year DESC" +
+			"    LIMIT 2" +
+			"  )"
+		);
+
+		// uncomment the following line to get insights into the continuously evaluated query,
+		// execute this pipeline by using the local client as an implicit sink
+		// topCitiesPerState.execute().print();
+
+		// because we execute the pipeline in streaming mode, the output shows how the result evolves
+		// and is updated over time when new information for a city is ingested:
+		// +----+-------+-------------+-------------+-------------+
+		// | op | state |        city | latest_year |  population |
+		// +----+-------+-------------+-------------+-------------+
+		// | +I |    CA | Los Angeles |        2013 |    13106100 |
+		// | -D |    CA | Los Angeles |        2013 |    13106100 |
+		// | +I |    CA | Los Angeles |        2014 |    13178700 |
+		// | -D |    CA | Los Angeles |        2014 |    13178700 |
+		// | +I |    CA | Los Angeles |        2015 |    13251000 |
+		// ...
+
+		// the changelog can be applied (i.e. materialized) in an external system,
+		// usually a key-value store can be used as a table sink,
+		// but to show the underlying changelog capabilities we simply use
+		// execute().collect() and a List where we maintain updates
+		try (CloseableIterator<Row> iterator = topCitiesPerState.execute().collect()) {
+			final List<Row> materializedUpdates = new ArrayList<>();
+			iterator.forEachRemaining(row -> {
+				final RowKind kind = row.getKind();
+				switch (kind) {
+					case INSERT:
+					case UPDATE_BEFORE:
+						row.setKind(RowKind.INSERT); // for equality
+						materializedUpdates.add(row);
+						break;
+					case UPDATE_AFTER:
+					case DELETE:
+						row.setKind(RowKind.INSERT); // for equality
+						materializedUpdates.remove(row);
+						break;
+				}
+			});
+			// show the final output table if the result is a bounded stream,
+			// the output should exclude San Antonio because it has a smaller population than
+			// Houston or Dallas in Texas (TX)
+			materializedUpdates.forEach(System.out::println);
+		}
+	}
+
+	/**
+	 * Creates an empty temporary directory for CSV files and returns the absolute path.
+	 */
+	private static String createTemporaryDirectory() throws IOException {
+		final Path tempDirectory = Files.createTempDirectory("population");
+		return tempDirectory.toString();
+	}
+}

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/UpdatingTopCityExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/UpdatingTopCityExampleITCase.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.java.basics;
+
+import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for {@link UpdatingTopCityExample}.
+ */
+public class UpdatingTopCityExampleITCase extends ExampleOutputTestBase {
+
+	@Test
+	public void testExample() throws Exception {
+		UpdatingTopCityExample.main(new String[0]);
+		final String consoleOutput = getOutputString();
+		assertThat(consoleOutput, containsString("AZ,Phoenix,2015,4581120"));
+		assertThat(consoleOutput, containsString("IL,Chicago,2015,9557880"));
+		assertThat(consoleOutput, containsString("CA,San Francisco,2015,4649540"));
+		assertThat(consoleOutput, containsString("CA,Los Angeles,2015,13251000"));
+		assertThat(consoleOutput, containsString("TX,Dallas,2015,7109280"));
+		assertThat(consoleOutput, containsString("TX,Houston,2015,6676560"));
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
@@ -163,6 +163,10 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
       val input = snapshot.getInput.accept(this)
       snapshot.copy(snapshot.getTraitSet, input, snapshot.getPeriod)
 
+    case rank: LogicalRank =>
+      val input = rank.getInput.accept(this)
+      rank.copy(rank.getTraitSet, JCollections.singletonList(input))
+
     case sink: LogicalSink =>
       val newInput = convertSinkInput(sink.getInput)
       new LogicalSink(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -32,6 +32,7 @@ object FlinkStreamProgram {
 
   val SUBQUERY_REWRITE = "subquery_rewrite"
   val TEMPORAL_JOIN_REWRITE = "temporal_join_rewrite"
+  val PRE_DECORRELATE_REWRITE = "pre_decorrelate_rewrite"
   val DECORRELATE = "decorrelate"
   val TIME_INDICATOR = "time_indicator"
   val DEFAULT_REWRITE = "default_rewrite"
@@ -89,6 +90,15 @@ object FlinkStreamProgram {
             .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
             .add(FlinkStreamRuleSets.POST_EXPAND_CLEAN_UP_RULES)
             .build(), "convert enumerable table scan")
+        .build())
+
+    // rewrite before decorrelation
+    chainedProgram.addLast(
+      PRE_DECORRELATE_REWRITE,
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkStreamRuleSets.PRE_DECORRELATION_RULES)
         .build())
 
     // query decorrelation

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -69,6 +69,13 @@ object FlinkStreamRuleSets {
   )
 
   /**
+   * Solid transformations before actual decorrelation.
+   */
+  val PRE_DECORRELATION_RULES: RuleSet = RuleSets.ofList(
+    CorrelateSortToRankRule.INSTANCE
+  )
+
+  /**
     * RuleSet to reduce expressions
     */
   private val REDUCE_EXPRESSION_RULES: RuleSet = RuleSets.ofList(
@@ -314,6 +321,7 @@ object FlinkStreamRuleSets {
     FlinkLogicalDataStreamTableScan.CONVERTER,
     FlinkLogicalIntermediateTableScan.CONVERTER,
     FlinkLogicalExpand.CONVERTER,
+    FlinkLogicalRank.CONVERTER,
     FlinkLogicalWatermarkAssigner.CONVERTER,
     FlinkLogicalWindowAggregate.CONVERTER,
     FlinkLogicalWindowTableAggregate.CONVERTER,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder
+import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelCollations
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Aggregate, Correlate, Filter, JoinRelType, Project, Sort}
+import org.apache.calcite.rex.{RexCall, RexCorrelVariable, RexFieldAccess, RexInputRef, RexLiteral, RexNode}
+import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.util.ImmutableBitSet
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+ * Planner rule that rewrites sort correlation to a Rank.
+ * Typically, the following plan
+ *
+ * {{{
+ *   LogicalProject(state=[$0], name=[$1])
+ *   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+ *      :- LogicalAggregate(group=[{0}])
+ *      :  +- LogicalProject(state=[$1])
+ *      :     +- LogicalTableScan(table=[[default_catalog, default_database, cities]])
+ *      +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+ *         +- LogicalProject(name=[$0], pop=[$2])
+ *            +- LogicalFilter(condition=[=($1, $cor0.state)])
+ *               +- LogicalTableScan(table=[[default_catalog, default_database, cities]])
+ * }}}
+ *
+ * <p>would be transformed to
+ *
+ * {{{
+ *   LogicalProject(state=[$0], name=[$1])
+ *    +- LogicalProject(state=[$1], name=[$0], pop=[$2])
+ *       +- LogicalRank(rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3],
+ *            partitionBy=[$1], orderBy=[$2 DESC], select=[name=$0, state=$1, pop=$2])
+ *          +- LogicalTableScan(table=[[default_catalog, default_database, cities]])
+ * }}}
+ *
+ * <p>To match the Correlate, the LHS needs to be a global Aggregate on a scan, the RHS should
+ * be a Sort with an equal Filter predicate whose keys are same with the LHS grouping keys.
+ *
+ * <p>This rule can only be used in HepPlanner.
+ */
+class CorrelateSortToRankRule extends RelOptRule(
+  operand(classOf[Correlate],
+    operand(classOf[Aggregate],
+      operand(classOf[Project], any())),
+    operand(classOf[Sort],
+      operand(classOf[Project],
+        operand(classOf[Filter], any())))),
+  "CorrelateSortToRankRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val correlate: Correlate = call.rel(0)
+    if (correlate.getJoinType != JoinRelType.INNER) {
+      return false
+    }
+    val agg: Aggregate = call.rel(1)
+    if (agg.getAggCallList.size() > 0
+      || agg.getGroupSets.size() > 1
+      || agg.getGroupSet.cardinality() != 1) {
+      // only one group field is supported now
+      return false
+    }
+    val aggInput: Project = call.rel(2)
+    if (!aggInput.isMapping) {
+      return false
+    }
+    val sort: Sort = call.rel(3)
+    if (sort.offset != null || sort.fetch == null) {
+      // 1. we can not describe the offset using rank
+      // 2. there is no need to transform to rank if no fetch limit
+      return false
+    }
+    val sortInput: Project = call.rel(4)
+    if (!sortInput.isMapping) {
+      return false
+    }
+    val filter: Filter = call.rel(5)
+    val condition = filter.getCondition
+    if (condition.getKind != SqlKind.EQUALS) {
+      return false
+    }
+    // only support one partition key
+    val (inputRef, fieldAccess) = resolveFilterCondition(condition)
+    if (inputRef == null) {
+      return false
+    }
+    val variable = fieldAccess.getReferenceExpr.asInstanceOf[RexCorrelVariable]
+    if (!variable.id.equals(correlate.getCorrelationId)) {
+      return false
+    }
+    aggInput.getInput.getDigest.equals(filter.getInput.getDigest)
+  }
+
+  /**
+   * Resolves the filter condition with specific pattern: input ref and field access.
+   *
+   * @param condition The join condition
+   * @return tuple of operands (RexInputRef, RexFieldAccess),
+   *         or null if the pattern does not match
+   */
+  def resolveFilterCondition(condition: RexNode): (RexInputRef, RexFieldAccess) = {
+    val condCall = condition.asInstanceOf[RexCall]
+    val operand0 = condCall.getOperands.get(0)
+    val operand1 = condCall.getOperands.get(1)
+    if (operand0.isA(SqlKind.INPUT_REF) && operand1.isA(SqlKind.FIELD_ACCESS)) {
+      (operand0.asInstanceOf[RexInputRef], operand1.asInstanceOf[RexFieldAccess])
+    } else if (operand0.isA(SqlKind.FIELD_ACCESS) && operand1.isA(SqlKind.INPUT_REF)) {
+      (operand1.asInstanceOf[RexInputRef], operand0.asInstanceOf[RexFieldAccess])
+    } else {
+      (null, null)
+    }
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val oriBuilder = call.builder()
+    val builder = FlinkRelBuilder.of(oriBuilder.getCluster, oriBuilder.getRelOptSchema)
+
+    val sort: Sort = call.rel(3)
+    val sortInput: Project = call.rel(4)
+    val filter: Filter = call.rel(5)
+
+    val partitionKey: ImmutableBitSet =
+      ImmutableBitSet.of(resolveFilterCondition(filter.getCondition)._1.getIndex)
+
+    val baseType: RelDataType = sortInput.getInput().getRowType
+    val projects = new util.ArrayList[RexNode]()
+    partitionKey.asList().foreach(k => projects.add(RexInputRef.of(k, baseType)))
+    projects.addAll(sortInput.getProjects)
+
+    val oriCollation = sort.getCollation
+    val newFieldCollations = oriCollation.getFieldCollations.map { fc =>
+      val newFieldIdx = sortInput.getProjects.get(fc.getFieldIndex)
+        .asInstanceOf[RexInputRef].getIndex
+      fc.withFieldIndex(newFieldIdx)
+    }
+    val newCollation = RelCollations.of(newFieldCollations)
+
+    val newRel = builder
+      .push(filter.getInput()).asInstanceOf[FlinkRelBuilder]
+      .rank(
+        partitionKey,
+        newCollation,
+        RankType.ROW_NUMBER,
+        new ConstantRankRange(
+          1,
+          sort.fetch.asInstanceOf[RexLiteral].getValueAs(classOf[java.lang.Long])),
+        null,
+        outputRankNumber = false)
+      .project(projects)
+      .build()
+
+    call.transformTo(newRel)
+  }
+}
+
+object CorrelateSortToRankRule {
+  val INSTANCE = new CorrelateSortToRankRule
+}
+
+

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -843,4 +843,42 @@ Sink(table=[default_catalog.default_database.sink], fields=[name, eat, cnt])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelateSortToRank">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b
+FROM
+  (SELECT DISTINCT a FROM MyTable) T1,
+  LATERAL (
+    SELECT b, c
+    FROM MyTable
+    WHERE a = T1.a
+    ORDER BY c
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+   :- LogicalAggregate(group=[{0}])
+   :  +- LogicalProject(a=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(b=[$1], c=[$2])
+         +- LogicalFilter(condition=[=($0, $cor0.a)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[a], orderBy=[c DESC], select=[a, b, c])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
@@ -672,5 +672,23 @@ class RankTest extends TableTestBase {
       + "from view2 where row_num <= 3")
   }
 
+  @Test
+  def testCorrelateSortToRank(): Unit = {
+    val query =
+      s"""
+         |SELECT a, b
+         |FROM
+         |  (SELECT DISTINCT a FROM MyTable) T1,
+         |  LATERAL (
+         |    SELECT b, c
+         |    FROM MyTable
+         |    WHERE a = T1.a
+         |    ORDER BY c
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyPlan(query)
+  }
+
   // TODO add tests about multi-sinks and udf
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -499,6 +499,20 @@ object TestData {
     row(5L, "US Dollar")
   )
 
+  // [city, state, population]
+  val citiesData: Seq[Row] = Seq(
+    row("Los_Angeles", "CA", 3979576),
+    row("Phoenix", "AZ", 1680992),
+    row("Houston", "TX", 2320268),
+    row("San_Diego", "CA", 1423851),
+    row("San_Francisco", "CA", 881549),
+    row("New_York", "NY", 8336817),
+    row("Dallas", "TX", 1343573),
+    row("San_Antonio", "TX", 1547253),
+    row("San_Jose", "CA", 1021795),
+    row("Chicago", "IL", 2695598),
+    row("Austin", "TX", 978908))
+
   // kind[currency, rate]
   val ratesHistoryData: Seq[Row] = Seq(
     changelogRow("+I", "US Dollar", JLong.valueOf(102L)),


### PR DESCRIPTION
## What is the purpose of the change

Example for aggregating and ranking data using Flink SQL on updating (but bounded) streams.

This PR depends on #13291.

## Brief change log

The example shows how to declare a table using SQL DDL for reading insert-only data and handling
 updating data. It should give a first impression about Flink SQL as a changelog processor. The example
 uses some streaming operations that produce a stream of updates. See the other examples for pure CDC
 processing and more complex operations.

## Verifying this change

This change added tests and can be verified as follows: `UpdatingTopCityExample`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
