### PR TITLE
[FLINK-19227][Table SQL / API] The catalog is still created after opening failed in catalog registering

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -223,6 +223,9 @@ public class HiveCatalog extends AbstractCatalog {
 	public void open() throws CatalogException {
 		if (client == null) {
 			client = HiveMetastoreClientFactory.create(hiveConf, hiveVersion);
+			if (client == null) {
+				throw new CatalogException("Can not open hive catalog because create hive metastore client failed.");
+			}
 			LOG.info("Connected to Hive metastore");
 		}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -223,9 +223,6 @@ public class HiveCatalog extends AbstractCatalog {
 	public void open() throws CatalogException {
 		if (client == null) {
 			client = HiveMetastoreClientFactory.create(hiveConf, hiveVersion);
-			if (client == null) {
-				throw new CatalogException("Can not open hive catalog because create hive metastore client failed.");
-			}
 			LOG.info("Connected to Hive metastore");
 		}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -187,8 +187,8 @@ public final class CatalogManager {
 			throw new CatalogException(format("Catalog %s already exists.", catalogName));
 		}
 
-		catalogs.put(catalogName, catalog);
 		catalog.open();
+		catalogs.put(catalogName, catalog);
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -182,7 +182,6 @@ public final class CatalogManager {
 	public void registerCatalog(String catalogName, Catalog catalog) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "Catalog name cannot be null or empty.");
 		checkNotNull(catalog, "Catalog cannot be null");
-
 		if (catalogs.containsKey(catalogName)) {
 			throw new CatalogException(format("Catalog %s already exists.", catalogName));
 		}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -182,6 +182,7 @@ public final class CatalogManager {
 	public void registerCatalog(String catalogName, Catalog catalog) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(catalogName), "Catalog name cannot be null or empty.");
 		checkNotNull(catalog, "Catalog cannot be null");
+
 		if (catalogs.containsKey(catalogName)) {
 			throw new CatalogException(format("Catalog %s already exists.", catalogName));
 		}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.catalog;
 
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
@@ -33,8 +31,8 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.catalog.stats.Date;
 import org.apache.flink.table.functions.TestGenericUDF;
 import org.apache.flink.table.functions.TestSimpleUDF;
-
 import org.apache.flink.table.utils.TableEnvironmentMock;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -42,7 +40,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 /**
  * Test for GenericInMemoryCatalog.

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -41,8 +41,8 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for GenericInMemoryCatalog.


### PR DESCRIPTION
## What is the purpose of the change

When I create the HiveCatalog and Flink is not able to connect to the HiveMetastore, the statement can not be executed, but the catalog is still created. Subsequent attempts to query the tables result in a NPE.

In CatalogManager.registerCatalog.
Consider open is a relatively easy operation to fail, we should put catalog into catalog manager after its open.


## Brief change log

- have a double check about hive metastore client is whether created successfully and fail fast if not.
- put catalog into catalog manager when the catalog is opened successfully.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not documented)