### PR TITLE
[FLINK-19277][python] Introduce BatchArrowPythonGroupWindowAggregateFunctionOperator

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperator.java
@@ -104,7 +104,8 @@ abstract class AbstractBatchArrowPythonAggregateFunctionOperator
 	protected abstract void invokeCurrentBatch() throws Exception;
 
 	boolean isNewKey(BinaryRowData currentKey) {
-		return lastGroupKey.getSizeInBytes() != currentKey.getSizeInBytes() ||
+		return lastGroupKey == null ||
+			(lastGroupKey.getSizeInBytes() != currentKey.getSizeInBytes()) ||
 			!(BinaryRowDataUtil.byteArrayEquals(
 				currentKey.getSegments()[0].getHeapMemory(),
 				lastGroupKey.getSegments()[0].getHeapMemory(),

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
@@ -69,12 +69,10 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
 	@Override
 	public void bufferInput(RowData input) throws Exception {
 		BinaryRowData currentKey = groupKeyProjection.apply(input).copy();
-		if (lastGroupKey == null) {
-			lastGroupKey = currentKey;
-			lastGroupSet = groupSetProjection.apply(input).copy();
-			forwardedInputQueue.add(lastGroupSet);
-		} else if (isNewKey(currentKey)) {
-			invokeCurrentBatch();
+		if (isNewKey(currentKey)) {
+			if (lastGroupKey != null) {
+				invokeCurrentBatch();
+			}
 			lastGroupKey = currentKey;
 			lastGroupSet = groupSetProjection.apply(input).copy();
 			forwardedInputQueue.add(lastGroupSet);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.JoinedRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+import org.apache.flink.table.runtime.operators.window.grouping.HeapWindowsGrouping;
+import org.apache.flink.table.runtime.operators.window.grouping.WindowsGrouping;
+import org.apache.flink.table.runtime.util.RowIterator;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.LinkedList;
+
+/**
+ * The Batch Arrow Python {@link AggregateFunction} Operator for Group Window Aggregation.
+ */
+@Internal
+public class BatchArrowPythonGroupWindowAggregateFunctionOperator
+	extends AbstractBatchArrowPythonAggregateFunctionOperator {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The Infos of the Window.
+	 * 0 -> start of the Window.
+	 * 1 -> end of the Window.
+	 * 2 -> row time of the Window.
+	 */
+	private final int[] namedProperties;
+
+	/**
+	 * The row time index of the input data.
+	 */
+	private final int inputTimeFieldIndex;
+
+	/**
+	 * The window elements buffer size limit used in group window agg operator.
+	 */
+	private final int maxLimitSize;
+
+	/**
+	 * The window size of the window.
+	 */
+	private final long windowSize;
+
+	/**
+	 * The sliding size of the sliding window.
+	 */
+	private final long slideSize;
+
+	private transient WindowsGrouping windowsGrouping;
+
+	/**
+	 * The GenericRowData reused holding the property of the window, such as window start, window
+	 * end and window time.
+	 */
+	private transient GenericRowData windowProperty;
+
+	/**
+	 * The JoinedRowData reused holding the window agg execution result.
+	 */
+	private transient JoinedRowData windowAggResult;
+
+	/**
+	 * The queue holding the input groupSet with the TimeWindow for which the execution results
+	 * have not been received.
+	 */
+	private transient LinkedList<Tuple2<RowData, TimeWindow>> inputKeyAndWindow;
+
+	public BatchArrowPythonGroupWindowAggregateFunctionOperator(
+		Configuration config,
+		PythonFunctionInfo[] pandasAggFunctions,
+		RowType inputType,
+		RowType outputType,
+		int inputTimeFieldIndex,
+		int maxLimitSize,
+		long windowSize,
+		long slideSize,
+		int[] namedProperties,
+		int[] groupKey,
+		int[] groupingSet,
+		int[] udafInputOffsets) {
+		super(config, pandasAggFunctions, inputType, outputType, groupKey, groupingSet, udafInputOffsets);
+		this.namedProperties = namedProperties;
+		this.inputTimeFieldIndex = inputTimeFieldIndex;
+		this.maxLimitSize = maxLimitSize;
+		this.windowSize = windowSize;
+		this.slideSize = slideSize;
+	}
+
+	@Override
+	public void open() throws Exception {
+		userDefinedFunctionOutputType = new RowType(
+			outputType.getFields().subList(groupingSet.length, outputType.getFieldCount() - namedProperties.length));
+		super.open();
+		inputKeyAndWindow = new LinkedList<>();
+		windowProperty = new GenericRowData(namedProperties.length);
+		windowAggResult = new JoinedRowData();
+		windowsGrouping = new HeapWindowsGrouping(
+			maxLimitSize, windowSize, slideSize, inputTimeFieldIndex, false);
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		windowsGrouping.close();
+	}
+
+	@Override
+	public void bufferInput(RowData input) throws Exception {
+		// always copy the projection result as the generated Projection reuses the projection result
+		BinaryRowData currentKey = groupKeyProjection.apply(input).copy();
+		currentKey.setRowKind(input.getRowKind());
+		if (lastGroupKey == null) {
+			lastGroupKey = currentKey;
+			lastGroupSet = groupSetProjection.apply(input).copy();
+		} else if (isNewKey(currentKey)) {
+			invokeCurrentBatch();
+			lastGroupKey = currentKey;
+			lastGroupSet = groupSetProjection.apply(input).copy();
+		}
+	}
+
+	@Override
+	protected void invokeCurrentBatch() throws Exception {
+		windowsGrouping.advanceWatermarkToTriggerAllWindows();
+		triggerWindowProcess();
+		windowsGrouping.reset();
+	}
+
+	@Override
+	public void processElementInternal(RowData value) throws Exception {
+		windowsGrouping.addInputToBuffer((BinaryRowData) value);
+		triggerWindowProcess();
+	}
+
+	@Override
+	@SuppressWarnings("ConstantConditions")
+	public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
+		byte[] udafResult = resultTuple.f0;
+		int length = resultTuple.f1;
+		bais.setBuffer(udafResult, 0, length);
+		int rowCount = arrowSerializer.load();
+		for (int i = 0; i < rowCount; i++) {
+			Tuple2<RowData, TimeWindow> input = inputKeyAndWindow.poll();
+			RowData key = input.f0;
+			TimeWindow window = input.f1;
+			setWindowProperty(window);
+			windowAggResult.replace(key, arrowSerializer.read(i));
+			rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
+		}
+	}
+
+	private void triggerWindowProcess() throws Exception {
+		while (windowsGrouping.hasTriggerWindow()) {
+			RowIterator<BinaryRowData> elementIterator =
+				windowsGrouping.buildTriggerWindowElementsIterator();
+			TimeWindow currentWindow = windowsGrouping.getTriggerWindow();
+			while (elementIterator.advanceNext()) {
+				BinaryRowData winElement = elementIterator.getRow();
+				arrowSerializer.write(getFunctionInput(winElement));
+				currentBatchCount++;
+			}
+			if (currentBatchCount > 0) {
+				inputKeyAndWindow.add(Tuple2.of(lastGroupSet, currentWindow));
+				arrowSerializer.finishCurrentBatch();
+				pythonFunctionRunner.process(baos.toByteArray());
+				elementCount += currentBatchCount;
+				checkInvokeFinishBundleByCount();
+				currentBatchCount = 0;
+				baos.reset();
+			}
+		}
+	}
+
+	private void setWindowProperty(TimeWindow currentWindow) {
+		for (int i = 0; i < namedProperties.length; i++) {
+			switch (namedProperties[i]) {
+				case 0:
+					windowProperty.setField(i, TimestampData.fromEpochMillis(currentWindow.getStart()));
+					break;
+				case 1:
+					windowProperty.setField(i, TimestampData.fromEpochMillis(currentWindow.getEnd()));
+					break;
+				case 2:
+					windowProperty.setField(i, TimestampData.fromEpochMillis(currentWindow.maxTimestamp()));
+					break;
+			}
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/ArrowPythonAggregateFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/ArrowPythonAggregateFunctionOperatorTestBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.types.RowKind;
 
 import java.util.Collection;
 
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.binaryrow;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
 
 /**
@@ -67,6 +68,16 @@ public abstract class ArrowPythonAggregateFunctionOperatorTestBase {
 			return row(fields);
 		} else {
 			RowData row = row(fields);
+			row.setRowKind(RowKind.DELETE);
+			return row;
+		}
+	}
+
+	protected RowData newBinaryRow(boolean accumulateMsg, Object... fields) {
+		if (accumulateMsg) {
+			return binaryrow(fields);
+		} else {
+			RowData row = binaryrow(fields);
 			row.setRowKind(RowKind.DELETE);
 			return row;
 		}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.api.DataTypes;
@@ -46,8 +45,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * Test for {@link BatchArrowPythonGroupAggregateFunctionOperator}. These test that:
  *
  * <ul>
- * <li>FinishBundle is called when checkpoint is encountered</li>
- * <li>Watermarks are buffered and only sent to downstream when finishedBundle is triggered</li>
+ * 		<li>FinishBundle is called when bundled element count reach to max bundle size</li>
+ * 		<li>FinishBundle is called when bundled time reach to max bundle time</li>
  * </ul>
  */
 public class BatchArrowPythonGroupAggregateFunctionOperatorTest
@@ -68,34 +67,6 @@ public class BatchArrowPythonGroupAggregateFunctionOperatorTest
 		testHarness.close();
 
 		expectedOutput.add(new StreamRecord<>(newRow(true, "c1", 0L)));
-		expectedOutput.add(new StreamRecord<>(newRow(true, "c2", 2L)));
-
-		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
-	}
-
-	@Test
-	public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
-		Configuration conf = new Configuration();
-		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
-
-		long initialTime = 0L;
-		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
-
-		testHarness.open();
-
-		testHarness.processElement(new StreamRecord<>(newRow(true, "c1", "c2", 0L), initialTime + 1));
-		testHarness.processElement(new StreamRecord<>(newRow(true, "c1", "c4", 1L), initialTime + 2));
-		testHarness.processElement(new StreamRecord<>(newRow(true, "c2", "c6", 2L), initialTime + 3));
-		// checkpoint trigger finishBundle
-		testHarness.prepareSnapshotPreBarrier(0L);
-
-		expectedOutput.add(new StreamRecord<>(newRow(true, "c1", 0L)));
-
-		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
-
-		testHarness.close();
-
 		expectedOutput.add(new StreamRecord<>(newRow(true, "c2", 2L)));
 
 		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
@@ -154,32 +125,6 @@ public class BatchArrowPythonGroupAggregateFunctionOperatorTest
 		expectedOutput.add(new StreamRecord<>(newRow(true, "c2", 2L)));
 
 		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
-	}
-
-	@Test
-	public void testWatermarkProcessedOnFinishBundle() throws Exception {
-		Configuration conf = new Configuration();
-		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
-		long initialTime = 0L;
-		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
-
-		testHarness.open();
-
-		testHarness.processElement(new StreamRecord<>(newRow(true, "c1", "c2", 0L), initialTime + 1));
-		testHarness.processElement(new StreamRecord<>(newRow(true, "c2", "c6", 2L), initialTime + 2));
-		testHarness.processWatermark(initialTime + 2);
-		assertOutputEquals("Watermark has been processed", expectedOutput, testHarness.getOutput());
-
-		// checkpoint trigger finishBundle
-		testHarness.prepareSnapshotPreBarrier(0L);
-
-		expectedOutput.add(new StreamRecord<>(newRow(true, "c1", 0L)));
-		expectedOutput.add(new Watermark(initialTime + 2));
-
-		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
-
-		testHarness.close();
 	}
 
 	@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperatorTest.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.PythonOptions;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.operators.python.aggregate.arrow.AbstractArrowPythonAggregateFunctionOperator;
+import org.apache.flink.table.runtime.operators.python.aggregate.arrow.ArrowPythonAggregateFunctionOperatorTestBase;
+import org.apache.flink.table.runtime.utils.PassThroughPythonAggregateFunctionRunner;
+import org.apache.flink.table.runtime.utils.PythonTestUtils;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Test for {@link BatchArrowPythonGroupWindowAggregateFunctionOperatorTest}. These test that:
+ *
+ * <ul>
+ * <li>FinishBundle is called when checkpoint is encountered</li>
+ * <li>Watermarks are buffered and only sent to downstream when finishedBundle is triggered</li>
+ * </ul>
+ */
+public class BatchArrowPythonGroupWindowAggregateFunctionOperatorTest extends ArrowPythonAggregateFunctionOperatorTestBase {
+	@Test
+	public void testGroupAggregateFunction() throws Exception {
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(
+			new Configuration());
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c2", 0L, 0L), initialTime + 1));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c4", 1L, 6000L), initialTime + 2));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c6", 2L, 10000L), initialTime + 3));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 0L), initialTime + 3));
+
+		testHarness.close();
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 1L, TimestampData.fromEpochMillis(5000L), TimestampData.fromEpochMillis(15000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 2L, TimestampData.fromEpochMillis(10000L), TimestampData.fromEpochMillis(20000L))));
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
+		Configuration conf = new Configuration();
+		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c2", 0L, 0L), initialTime + 1));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c4", 1L, 6000L), initialTime + 2));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c6", 2L, 10000L), initialTime + 3));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 0L), initialTime + 3));
+		// checkpoint trigger finishBundle
+		testHarness.prepareSnapshotPreBarrier(0L);
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 1L, TimestampData.fromEpochMillis(5000L), TimestampData.fromEpochMillis(15000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 2L, TimestampData.fromEpochMillis(10000L), TimestampData.fromEpochMillis(20000L))));
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testFinishBundleTriggeredByCount() throws Exception {
+		Configuration conf = new Configuration();
+		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 6);
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c2", 0L, 0L), initialTime + 1));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c4", 1L, 6000L), initialTime + 2));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c6", 2L, 10000L), initialTime + 3));
+
+		assertOutputEquals("FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 0L), initialTime + 3));
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 1L, TimestampData.fromEpochMillis(5000L), TimestampData.fromEpochMillis(15000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 2L, TimestampData.fromEpochMillis(10000L), TimestampData.fromEpochMillis(20000L))));
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testFinishBundleTriggeredByTime() throws Exception {
+		Configuration conf = new Configuration();
+		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+		conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c2", 0L, 0L), initialTime + 1));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c4", 1L, 6000L), initialTime + 2));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c6", 2L, 10000L), initialTime + 3));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 0L), initialTime + 3));
+		assertOutputEquals("FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(1000L);
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 1L, TimestampData.fromEpochMillis(5000L), TimestampData.fromEpochMillis(15000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 2L, TimestampData.fromEpochMillis(10000L), TimestampData.fromEpochMillis(20000L))));
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c2", 3L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testWatermarkProcessedOnFinishBundle() throws Exception {
+		Configuration conf = new Configuration();
+		conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c2", 0L, 0L), initialTime + 1));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c4", 1L, 6000L), initialTime + 2));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c1", "c6", 2L, 10000L), initialTime + 3));
+		testHarness.processElement(new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 0L), initialTime + 3));
+		testHarness.processWatermark(initialTime + 2);
+		assertOutputEquals("Watermark has been processed", expectedOutput, testHarness.getOutput());
+
+		// checkpoint trigger finishBundle
+		testHarness.prepareSnapshotPreBarrier(0L);
+
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(-5000L), TimestampData.fromEpochMillis(5000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 0L, TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(10000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 1L, TimestampData.fromEpochMillis(5000L), TimestampData.fromEpochMillis(15000L))));
+		expectedOutput.add(new StreamRecord<>(
+			newRow(true, "c1", 2L, TimestampData.fromEpochMillis(10000L), TimestampData.fromEpochMillis(20000L))));
+		expectedOutput.add(new Watermark(initialTime + 2));
+
+		assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Override
+	public LogicalType[] getOutputLogicalType() {
+		return new LogicalType[]{
+			DataTypes.STRING().getLogicalType(),
+			DataTypes.BIGINT().getLogicalType()
+		};
+	}
+
+	@Override
+	public RowType getInputType() {
+		return new RowType(Arrays.asList(
+			new RowType.RowField("f1", new VarCharType()),
+			new RowType.RowField("f2", new VarCharType()),
+			new RowType.RowField("f3", new BigIntType()),
+			new RowType.RowField("rowTime", new BigIntType())));
+	}
+
+	@Override
+	public RowType getOutputType() {
+		return new RowType(Arrays.asList(
+			new RowType.RowField("f1", new VarCharType()),
+			new RowType.RowField("f2", new BigIntType()),
+			new RowType.RowField("windowStart", new TimestampType(3)),
+			new RowType.RowField("windowEnd", new TimestampType(3))));
+	}
+
+	@Override
+	public AbstractArrowPythonAggregateFunctionOperator getTestOperator(
+		Configuration config,
+		PythonFunctionInfo[] pandasAggregateFunctions,
+		RowType inputType,
+		RowType outputType,
+		int[] groupingSet,
+		int[] udafInputOffsets) {
+		// SlidingWindow(10000L, 5000L)
+		return new PassThroughBatchArrowPythonGroupWindowAggregateFunctionOperator(
+			config,
+			pandasAggregateFunctions,
+			inputType,
+			outputType,
+			3,
+			100000,
+			10000L,
+			5000L,
+			new int[]{0, 1},
+			groupingSet,
+			groupingSet,
+			udafInputOffsets
+		);
+	}
+
+	private static class PassThroughBatchArrowPythonGroupWindowAggregateFunctionOperator
+		extends BatchArrowPythonGroupWindowAggregateFunctionOperator {
+		PassThroughBatchArrowPythonGroupWindowAggregateFunctionOperator(
+			Configuration config,
+			PythonFunctionInfo[] pandasAggFunctions,
+			RowType inputType,
+			RowType outputType,
+			int inputTimeFieldIndex,
+			int maxLimitSize,
+			long windowSize,
+			long slideSize,
+			int[] namedProperties,
+			int[] groupKey,
+			int[] groupingSet,
+			int[] udafInputOffsets) {
+			super(config, pandasAggFunctions, inputType, outputType, inputTimeFieldIndex,
+				maxLimitSize, windowSize, slideSize, namedProperties, groupKey, groupingSet, udafInputOffsets);
+		}
+
+		@Override
+		public PythonFunctionRunner createPythonFunctionRunner() {
+			return new PassThroughPythonAggregateFunctionRunner(
+				getRuntimeContext().getTaskName(),
+				PythonTestUtils.createTestEnvironmentManager(),
+				userDefinedFunctionInputType,
+				userDefinedFunctionOutputType,
+				getFunctionUrn(),
+				getUserDefinedFunctionsProto(),
+				getInputOutputCoderUrn(),
+				new HashMap<>(),
+				PythonTestUtils.createMockFlinkMetricContainer()
+			);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will introduce BatchArrowPythonGroupWindowAggregateFunctionOperator for supporting Pandas Batch Group Window Aggregation*


## Brief change log

  - *add BatchArrowPythonGroupWindowAggregateFunctionOperator*

## Verifying this change

This change added tests and can be verified as follows:

  - *BatchArrowPythonGroupWindowAggregateFunctionOperatorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
