### PR TITLE
[FLINK-19179] Extend managed memory fraction calculation for various use cases.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/OperatorValidationUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.common.operators.util;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.ResourceSpec;
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -72,20 +71,5 @@ public class OperatorValidationUtils {
 		Preconditions.checkArgument(minResources.lessThanOrEqual(preferredResources),
 			"The resources must be either both UNKNOWN or both not UNKNOWN. If not UNKNOWN,"
 				+ " the preferred resources must be greater than or equal to the min resources.");
-	}
-
-	public static void validateResourceRequirements(
-			final ResourceSpec minResources,
-			final ResourceSpec preferredResources,
-			final int managedMemoryWeight) {
-
-		validateMinAndPreferredResources(minResources, preferredResources);
-		Preconditions.checkArgument(
-			managedMemoryWeight >= 0,
-			"managed memory weight must be no less than zero, was: " + managedMemoryWeight);
-		Preconditions.checkArgument(
-			minResources.equals(ResourceSpec.UNKNOWN) || managedMemoryWeight == Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT,
-			"The resources and managed memory weight should not be specified at the same time. " +
-				"resources: " + minResources + ", managed memory weight: " + managedMemoryWeight);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -24,11 +24,18 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.util.OperatorValidationUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -98,8 +105,6 @@ public abstract class Transformation<T> {
 	// Has to be equal to StreamGraphGenerator.UPPER_BOUND_MAX_PARALLELISM
 	public static final int UPPER_BOUND_MAX_PARALLELISM = 1 << 15;
 
-	public static final int DEFAULT_MANAGED_MEMORY_WEIGHT = 1;
-
 	// This is used to assign a unique ID to every Transformation
 	protected static Integer idCounter = 0;
 
@@ -139,12 +144,17 @@ public abstract class Transformation<T> {
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
 
 	/**
-	 * This weight indicates how much this transformation relies on managed memory, so that
-	 * transformation highly relies on managed memory would be able to acquire more managed
-	 * memory in runtime (linear association). Note that it only works in cases of UNKNOWN
-	 * resources.
+	 * Each entry in this map represents a operator scope use case that this transformation needs managed memory for.
+	 * The keys indicate the use cases, while the values are the use-case-specific weights for this transformation.
+	 * Managed memory reserved for a use case will be shared by all the declaring transformations within a slot
+	 * according to this weight.
 	 */
-	private int managedMemoryWeight = DEFAULT_MANAGED_MEMORY_WEIGHT;
+	private final Map<ManagedMemoryUseCase, Integer> managedMemoryOperatorScopeUseCaseWeights = new HashMap<>();
+
+	/**
+	 * Slot scope use cases that this transformation needs managed memory for.
+	 */
+	private final Set<ManagedMemoryUseCase> managedMemorySlotScopeUseCases = new HashSet<>();
 
 	/**
 	 * User-specified ID for this transformation. This is used to assign the
@@ -266,30 +276,46 @@ public abstract class Transformation<T> {
 	}
 
 	/**
-	 * Set the managed memory weight which indicates how much this transformation relies
-	 * on managed memory, so that a transformation highly relies on managed memory would
-	 * be able to acquire more managed memory in runtime (linear association). The default
-	 * weight value is 1. Note that currently it's only allowed to set the weight in cases
-	 * of UNKNOWN resources.
-	 *
-	 * @param managedMemoryWeight The managed memory weight of this transformation
-	 *
-	 * @throws IllegalArgumentException Thrown, if non-UNKNOWN resources are already set to this transformation
+	 * Declares that this transformation contains certain operator scope managed memory use case.
+	 * @param managedMemoryUseCase The use case that this transformation declares needing managed memory for.
+	 * @param weight Use-case-specific weights for this transformation. Used for sharing managed memory across
+	 *                 transformations for OPERATOR scope use cases.
+	 * @return The previous weight, if exist.
 	 */
-	public void setManagedMemoryWeight(int managedMemoryWeight) {
-		this.managedMemoryWeight = managedMemoryWeight;
+	public Optional<Integer> declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase managedMemoryUseCase, int weight) {
+		Preconditions.checkNotNull(managedMemoryUseCase);
+		Preconditions.checkArgument(managedMemoryUseCase.scope == ManagedMemoryUseCase.Scope.OPERATOR,
+			"Use case is not operator scope.");
+		Preconditions.checkArgument(weight > 0,
+			"Weights for operator scope use cases must be greater than 0.");
+
+		return Optional.ofNullable(managedMemoryOperatorScopeUseCaseWeights.put(managedMemoryUseCase, weight));
 	}
 
 	/**
-	 * Get the managed memory weight which indicates how much this transformation relies
-	 * on managed memory, so that a transformation highly relies on managed memory would
-	 * be able to acquire more managed memory in runtime (linear association). The default
-	 * weight value is 1. Note that it only works in cases of UNKNOWN resources.
-	 *
-	 * @return The managed memory weight of this transformation
+	 * Declares that this transformation contains certain slot scope managed memory use case.
+	 * @param managedMemoryUseCase The use case that this transformation declares needing managed memory for.
 	 */
-	public int getManagedMemoryWeight() {
-		return managedMemoryWeight;
+	public void declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase managedMemoryUseCase) {
+		Preconditions.checkNotNull(managedMemoryUseCase);
+		Preconditions.checkArgument(managedMemoryUseCase.scope == ManagedMemoryUseCase.Scope.SLOT);
+
+		managedMemorySlotScopeUseCases.add(managedMemoryUseCase);
+	}
+
+	/**
+	 * Get operator scope use cases that this transformation needs managed memory for, and the use-case-specific weights
+	 * for this transformation. The weights are used for sharing managed memory across transformations for the use cases.
+	 */
+	public Map<ManagedMemoryUseCase, Integer> getManagedMemoryOperatorScopeUseCaseWeights() {
+		return Collections.unmodifiableMap(managedMemoryOperatorScopeUseCaseWeights);
+	}
+
+	/**
+	 * Get slot scope use cases that this transformation needs managed memory for.
+	 */
+	public Set<ManagedMemoryUseCase> getManagedMemorySlotScopeUseCases() {
+		return Collections.unmodifiableSet(managedMemorySlotScopeUseCases);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -242,7 +242,7 @@ public abstract class Transformation<T> {
 	 * @param preferredResources The preferred resource of this transformation.
 	 */
 	public void setResources(ResourceSpec minResources, ResourceSpec preferredResources) {
-		OperatorValidationUtils.validateResourceRequirements(minResources, preferredResources, managedMemoryWeight);
+		OperatorValidationUtils.validateMinAndPreferredResources(minResources, preferredResources);
 		this.minResources = checkNotNull(minResources);
 		this.preferredResources = checkNotNull(preferredResources);
 	}
@@ -277,7 +277,6 @@ public abstract class Transformation<T> {
 	 * @throws IllegalArgumentException Thrown, if non-UNKNOWN resources are already set to this transformation
 	 */
 	public void setManagedMemoryWeight(int managedMemoryWeight) {
-		OperatorValidationUtils.validateResourceRequirements(minResources, preferredResources, managedMemoryWeight);
 		this.managedMemoryWeight = managedMemoryWeight;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -26,6 +26,8 @@ import org.apache.flink.configuration.description.Description;
 import org.apache.flink.util.TimeUtils;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
@@ -402,6 +404,23 @@ public class TaskManagerOptions {
 				+ " explicitly specified.");
 
 	/**
+	 * Weights of managed memory consumers.
+	 */
+	// Do not advertise this option until the feature is completed.
+	@Documentation.ExcludeFromDocumentation
+	public static final ConfigOption<Map<String, String>> MANAGED_MEMORY_CONSUMER_WEIGHTS =
+		key("taskmanager.memory.managed.consumer-weights")
+			.mapType()
+			.defaultValue(new HashMap<String, String>() {{
+				put(ManagedMemoryConsumerNames.DATAPROC, "70");
+				put(ManagedMemoryConsumerNames.PYTHON, "30");
+			}})
+			.withDescription("Managed memory weights for different kinds of consumers. A slot’s managed memory is"
+				+ " shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless"
+				+ " of the number of consumers from each kind. Currently supported kinds of consumers are "
+				+ ManagedMemoryConsumerNames.DATAPROC + " (for RocksDB state backend in streaming and built-in"
+				+ " algorithms in batch) and " + ManagedMemoryConsumerNames.PYTHON + " (for python processes).");
+	/**
 	 * Min Network Memory size for TaskExecutors.
 	 */
 	@Documentation.Section(Documentation.Sections.COMMON_MEMORY)
@@ -548,4 +567,10 @@ public class TaskManagerOptions {
 
 	/** Not intended to be instantiated. */
 	private TaskManagerOptions() {}
+
+	/** Valid names of managed memory consumers. */
+	public static class ManagedMemoryConsumerNames {
+		public static final String DATAPROC = "DATAPROC";
+		public static final String PYTHON = "PYTHON";
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Use cases of managed memory.
+ */
+public enum ManagedMemoryUseCase {
+	BATCH_OP(Scope.OPERATOR),
+	ROCKSDB(Scope.SLOT),
+	PYTHON(Scope.SLOT);
+
+	public final Scope scope;
+
+	ManagedMemoryUseCase(Scope scope) {
+		this.scope = Preconditions.checkNotNull(scope);
+	}
+
+	/**
+	 * Scope at which memory is managed for a use case.
+	 */
+	public enum Scope {
+		SLOT,
+		OPERATOR
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.dag;
 
-import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.TestLogger;
 
@@ -46,22 +45,6 @@ public class TransformationTest extends TestLogger {
 	public void testSetManagedMemoryWeight() {
 		transformation.setManagedMemoryWeight(123);
 		assertEquals(123, transformation.getManagedMemoryWeight());
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testSetManagedMemoryWeightFailIfResourcesIsSpecified() {
-		final ResourceSpec resources = ResourceSpec.newBuilder(1.0, 100).build();
-		transformation.setResources(resources, resources);
-
-		transformation.setManagedMemoryWeight(123);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testSetResourcesFailIfManagedMemoryWeightIsSpecified() {
-		transformation.setManagedMemoryWeight(123);
-
-		final ResourceSpec resources = ResourceSpec.newBuilder(1.0, 100).build();
-		transformation.setResources(resources, resources);
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.dag;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
@@ -27,7 +28,9 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests for {@link Transformation}.
@@ -42,9 +45,31 @@ public class TransformationTest extends TestLogger {
 	}
 
 	@Test
-	public void testSetManagedMemoryWeight() {
-		transformation.setManagedMemoryWeight(123);
-		assertEquals(123, transformation.getManagedMemoryWeight());
+	public void testDeclareManagedMemoryUseCase() {
+		transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 123);
+		transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.ROCKSDB);
+		assertThat(transformation.getManagedMemoryOperatorScopeUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP), is(123));
+		assertThat(transformation.getManagedMemorySlotScopeUseCases(), contains(ManagedMemoryUseCase.ROCKSDB));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDeclareManagedMemoryOperatorScopeUseCaseFailWrongScope() {
+		transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.PYTHON, 123);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDeclareManagedMemoryOperatorScopeUseCaseFailZeroWeight() {
+		transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 0);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDeclareManagedMemoryOperatorScopeUseCaseFailNegativeWeight() {
+		transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, -1);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDeclareManagedMemorySlotScopeUseCaseFailWrongScope() {
+		transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.BATCH_OP);
 	}
 
 	/**

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonConfig;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
@@ -278,8 +279,11 @@ public abstract class AbstractPythonFunctionOperator<OUT>
 			.add(MemorySize.parse(config.getPythonDataBufferMemorySize()))
 			.getBytes();
 		MemoryManager memoryManager = getContainingTask().getEnvironment().getMemoryManager();
+		// TODO python operators should declare and use fraction of the PYTHON use case
 		long availableManagedMemory = memoryManager.computeMemorySize(
-			getOperatorConfig().getManagedMemoryFraction());
+			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.BATCH_OP,
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
 		if (requiredPythonWorkerMemory <= availableManagedMemory) {
 			memoryManager.reserveMemory(this, requiredPythonWorkerMemory);
 			LOG.info("Reserved memory {} for Python worker.", requiredPythonWorkerMemory);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.python.aggregate;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -341,7 +342,7 @@ public class PythonStreamGroupAggregateOperatorTest {
 				1,
 				1,
 				0);
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
 		testHarness.setup(new RowDataSerializer(outputType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/ArrowPythonAggregateFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/ArrowPythonAggregateFunctionOperatorTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.python.aggregate.arrow;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
@@ -58,7 +59,7 @@ public abstract class ArrowPythonAggregateFunctionOperatorTestBase {
 
 		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
 		testHarness.setup(new RowDataSerializer(outputType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -236,7 +237,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
 
 		OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
 		testHarness.setup(getOutputTypeSerializer(dataType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.python.table;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -195,7 +196,7 @@ public abstract class PythonTableFunctionOperatorTestBase<IN, OUT, UDTFIN> {
 
 		OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
 		return testHarness;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util.config.memory;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utils for configuration and calculations related to managed memory and its various use cases.
+ */
+public enum ManagedMemoryUtils {
+	;
+
+	private static final int MANAGED_MEMORY_FRACTION_SCALE = 16;
+
+	public static double convertToFractionOfSlot(
+			ManagedMemoryUseCase useCase,
+			double fractionOfUseCase,
+			Set<ManagedMemoryUseCase> allUseCases,
+			Configuration config) {
+		final Map<ManagedMemoryUseCase, Integer> allUseCaseWeights = getManagedMemoryUseCaseWeightsFromConfig(config);
+		final int totalWeights = allUseCases.stream()
+			.mapToInt((uc) -> allUseCaseWeights.getOrDefault(uc, 0))
+			.sum();
+		final int useCaseWeight = allUseCaseWeights.getOrDefault(useCase, 0);
+		final double useCaseFractionOfSlot = totalWeights > 0 ?
+			getFractionRoundedDown(useCaseWeight, totalWeights) :
+			0.0;
+
+		return fractionOfUseCase * useCaseFractionOfSlot;
+	}
+
+	@VisibleForTesting
+	static Map<ManagedMemoryUseCase, Integer> getManagedMemoryUseCaseWeightsFromConfig(Configuration config) {
+		return config.get(TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS)
+			.entrySet().stream()
+			.flatMap((entry) -> {
+				final String consumer = entry.getKey();
+				final int weight = Integer.parseInt(entry.getValue());
+				if (weight < 0) {
+					throw new IllegalConfigurationException(String.format(
+						"Managed memory weight should not be negative. Configured weight for %s is %d.", consumer, weight));
+				}
+				switch (consumer) {
+					case TaskManagerOptions.ManagedMemoryConsumerNames.DATAPROC:
+						return Stream.of(
+							Tuple2.of(ManagedMemoryUseCase.BATCH_OP, weight),
+							Tuple2.of(ManagedMemoryUseCase.ROCKSDB, weight));
+					case TaskManagerOptions.ManagedMemoryConsumerNames.PYTHON:
+						return Stream.of(Tuple2.of(ManagedMemoryUseCase.PYTHON, weight));
+					default:
+						throw new IllegalConfigurationException("Unknown managed memory consumer: " + consumer);
+				}
+			})
+			.collect(Collectors.toMap(
+				(tuple2) -> tuple2.f0,
+				(tuple2) -> tuple2.f1));
+	}
+
+	public static double getFractionRoundedDown(final long dividend, final long divisor) {
+		return BigDecimal.valueOf(dividend)
+			.divide(BigDecimal.valueOf(divisor), MANAGED_MEMORY_FRACTION_SCALE, BigDecimal.ROUND_DOWN)
+			.doubleValue();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util.config.memory;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link ManagedMemoryUtils}.
+ */
+public class ManagedMemoryUtilsTest extends TestLogger {
+
+	private static final double DELTA = 0.000001;
+
+	private static final int DATA_PROC_WEIGHT = 111;
+	private static final int PYTHON_WEIGHT = 222;
+
+	private static final UnmodifiableConfiguration CONFIG_WITH_ALL_USE_CASES =
+		new UnmodifiableConfiguration(new Configuration() {{
+			set(
+				TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS,
+				new HashMap<String, String>() {{
+					put(TaskManagerOptions.ManagedMemoryConsumerNames.DATAPROC, String.valueOf(DATA_PROC_WEIGHT));
+					put(TaskManagerOptions.ManagedMemoryConsumerNames.PYTHON, String.valueOf(PYTHON_WEIGHT));
+				}});
+		}});
+
+	@Test
+	public void testGetWeightsFromConfig() {
+		final Map<ManagedMemoryUseCase, Integer> expectedWeights = new HashMap<ManagedMemoryUseCase, Integer>() {{
+			put(ManagedMemoryUseCase.ROCKSDB, DATA_PROC_WEIGHT);
+			put(ManagedMemoryUseCase.BATCH_OP, DATA_PROC_WEIGHT);
+			put(ManagedMemoryUseCase.PYTHON, PYTHON_WEIGHT);
+		}};
+
+		final Map<ManagedMemoryUseCase, Integer> configuredWeights =
+			ManagedMemoryUtils.getManagedMemoryUseCaseWeightsFromConfig(CONFIG_WITH_ALL_USE_CASES);
+
+		assertThat(configuredWeights, is(expectedWeights));
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testGetWeightsFromConfigFailUnknownUseCase() {
+		final Configuration config = new Configuration() {{
+			set(TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS, Collections.singletonMap("UNKNOWN_KEY", "123"));
+		}};
+
+		ManagedMemoryUtils.getManagedMemoryUseCaseWeightsFromConfig(config);
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testGetWeightsFromConfigFailNegativeWeight() {
+		final Configuration config = new Configuration() {{
+			set(TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS,
+				Collections.singletonMap(TaskManagerOptions.ManagedMemoryConsumerNames.DATAPROC, "-123"));
+		}};
+
+		ManagedMemoryUtils.getManagedMemoryUseCaseWeightsFromConfig(config);
+	}
+
+	@Test
+	public void testConvertToFractionOfSlot() {
+		final ManagedMemoryUseCase useCase = ManagedMemoryUseCase.BATCH_OP;
+		final double fractionOfUseCase = 0.3;
+
+		final double fractionOfSlot = ManagedMemoryUtils.convertToFractionOfSlot(
+			useCase,
+			fractionOfUseCase,
+			new HashSet<ManagedMemoryUseCase>() {{
+				add(ManagedMemoryUseCase.BATCH_OP);
+				add(ManagedMemoryUseCase.PYTHON);
+			}},
+			CONFIG_WITH_ALL_USE_CASES);
+
+		assertEquals(fractionOfUseCase / 3, fractionOfSlot, DELTA);
+	}
+
+	@Test
+	public void testConvertToFractionOfSlotWeightNotConfigured() {
+		final ManagedMemoryUseCase useCase = ManagedMemoryUseCase.BATCH_OP;
+		final double fractionOfUseCase = 0.3;
+
+		final Configuration config = new Configuration() {{
+			set(TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS, Collections.emptyMap());
+		}};
+
+		final double fractionOfSlot = ManagedMemoryUtils.convertToFractionOfSlot(
+			useCase,
+			fractionOfUseCase,
+			new HashSet<ManagedMemoryUseCase>() {{
+				add(ManagedMemoryUseCase.BATCH_OP);
+				add(ManagedMemoryUseCase.PYTHON);
+			}},
+			config);
+
+		assertEquals(0.0, fractionOfSlot, DELTA);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -564,7 +564,7 @@ public class StreamGraph implements Pipeline {
 			Set<ManagedMemoryUseCase> slotScopeUseCases) {
 		if (getStreamNode(vertexID) != null) {
 			getStreamNode(vertexID).setManagedMemoryUseCaseWeights(operatorScopeUseCaseWeights, slotScopeUseCases);
-		} 
+		}
 	}
 
 	public void setOneInputStateKey(Integer vertexID, KeySelector<?, ?> keySelector, TypeSerializer<?> keySerializer) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
@@ -557,10 +558,13 @@ public class StreamGraph implements Pipeline {
 		}
 	}
 
-	public void setManagedMemoryWeight(int vertexID, int managedMemoryWeight) {
+	public void setManagedMemoryUseCaseWeights(
+			int vertexID,
+			Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights,
+			Set<ManagedMemoryUseCase> slotScopeUseCases) {
 		if (getStreamNode(vertexID) != null) {
-			getStreamNode(vertexID).setManagedMemoryWeight(managedMemoryWeight);
-		}
+			getStreamNode(vertexID).setManagedMemoryUseCaseWeights(operatorScopeUseCaseWeights, slotScopeUseCases);
+		} 
 	}
 
 	public void setOneInputStateKey(Integer vertexID, KeySelector<?, ?> keySelector, TypeSerializer<?> keySerializer) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -302,7 +303,7 @@ public class StreamGraphGenerator {
 			streamGraph.setResources(transform.getId(), transform.getMinResources(), transform.getPreferredResources());
 		}
 
-		streamGraph.setManagedMemoryWeight(transform.getId(), transform.getManagedMemoryWeight());
+		streamGraph.setManagedMemoryWeight(transform.getId(), transform.getManagedMemoryOperatorScopeUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP));
 
 		return transformedIds;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -303,7 +302,10 @@ public class StreamGraphGenerator {
 			streamGraph.setResources(transform.getId(), transform.getMinResources(), transform.getPreferredResources());
 		}
 
-		streamGraph.setManagedMemoryWeight(transform.getId(), transform.getManagedMemoryOperatorScopeUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP));
+		streamGraph.setManagedMemoryUseCaseWeights(
+			transform.getId(),
+			transform.getManagedMemoryOperatorScopeUseCaseWeights(),
+			transform.getManagedMemorySlotScopeUseCases());
 
 		return transformedIds;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
@@ -36,8 +37,13 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -46,8 +52,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 @Internal
 public class StreamNode implements Serializable {
-
-	public static final int DEFAULT_MANAGED_MEMORY_WEIGHT = 1;
 
 	private static final long serialVersionUID = 1L;
 
@@ -60,7 +64,8 @@ public class StreamNode implements Serializable {
 	private int maxParallelism;
 	private ResourceSpec minResources = ResourceSpec.DEFAULT;
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
-	private int managedMemoryWeight = DEFAULT_MANAGED_MEMORY_WEIGHT;
+	private final Map<ManagedMemoryUseCase, Integer> managedMemoryOperatorScopeUseCaseWeights = new HashMap<>();
+	private final Set<ManagedMemoryUseCase> managedMemorySlotScopeUseCases = new HashSet<>();
 	private long bufferTimeout;
 	private final String operatorName;
 	private @Nullable String slotSharingGroup;
@@ -197,12 +202,18 @@ public class StreamNode implements Serializable {
 		this.preferredResources = preferredResources;
 	}
 
-	public void setManagedMemoryWeight(int managedMemoryWeight) {
-		this.managedMemoryWeight = managedMemoryWeight;
+	public void setManagedMemoryUseCaseWeights(
+			Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights, Set<ManagedMemoryUseCase> slotScopeUseCases) {
+		managedMemoryOperatorScopeUseCaseWeights.putAll(operatorScopeUseCaseWeights);
+		managedMemorySlotScopeUseCases.addAll(slotScopeUseCases);
 	}
 
-	public int getManagedMemoryWeight() {
-		return managedMemoryWeight;
+	public Map<ManagedMemoryUseCase, Integer> getManagedMemoryOperatorScopeUseCaseWeights() {
+		return Collections.unmodifiableMap(managedMemoryOperatorScopeUseCaseWeights);
+	}
+
+	public Set<ManagedMemoryUseCase> getManagedMemorySlotScopeUseCases() {
+		return Collections.unmodifiableSet(managedMemorySlotScopeUseCases);
 	}
 
 	public long getBufferTimeout() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -48,6 +47,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 @Internal
 public class StreamNode implements Serializable {
 
+	public static final int DEFAULT_MANAGED_MEMORY_WEIGHT = 1;
+
 	private static final long serialVersionUID = 1L;
 
 	private final int id;
@@ -59,7 +60,7 @@ public class StreamNode implements Serializable {
 	private int maxParallelism;
 	private ResourceSpec minResources = ResourceSpec.DEFAULT;
 	private ResourceSpec preferredResources = ResourceSpec.DEFAULT;
-	private int managedMemoryWeight = Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT;
+	private int managedMemoryWeight = DEFAULT_MANAGED_MEMORY_WEIGHT;
 	private long bufferTimeout;
 	private final String operatorName;
 	private @Nullable String slotSharingGroup;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.WithMasterCheckpointHook;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
@@ -73,7 +74,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -99,8 +99,6 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class StreamingJobGraphGenerator {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamingJobGraphGenerator.class);
-
-	private static final int MANAGED_MEMORY_FRACTION_SCALE = 16;
 
 	private static final long DEFAULT_NETWORK_BUFFER_TIMEOUT = 100L;
 
@@ -854,7 +852,7 @@ public class StreamingJobGraphGenerator {
 		if (groupResourceSpec.equals(ResourceSpec.UNKNOWN)) {
 			operatorConfig.setManagedMemoryFraction(
 					groupManagedMemoryWeight > 0 ?
-							getFractionRoundedDown(operatorManagedMemoryWeight, groupManagedMemoryWeight) :
+						ManagedMemoryUtils.getFractionRoundedDown(operatorManagedMemoryWeight, groupManagedMemoryWeight) :
 							0.0);
 		} else {
 			// Supporting for fine grained resource specs is still under developing.
@@ -864,12 +862,6 @@ public class StreamingJobGraphGenerator {
 					" Operators may not be able to use managed memory properly." +
 					" Calculating managed memory fractions with fine grained resource spec is currently not supported.");
 		}
-	}
-
-	private static double getFractionRoundedDown(final long dividend, final long divisor) {
-		return BigDecimal.valueOf(dividend)
-			.divide(BigDecimal.valueOf(divisor), MANAGED_MEMORY_FRACTION_SCALE, BigDecimal.ROUND_DOWN)
-			.doubleValue();
 	}
 
 	private void configureCheckpointing() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -850,7 +850,10 @@ public class StreamingJobGraphGenerator {
 			final StreamConfig operatorConfig) {
 
 		if (groupResourceSpec.equals(ResourceSpec.UNKNOWN)) {
-			operatorConfig.setManagedMemoryFraction(
+			// For now, only consider managed memory for batch algorithms.
+			// TODO: extend managed memory fraction calculations w.r.t. various managed memory use cases.
+			operatorConfig.setManagedMemoryFractionOperatorOfUseCase(
+					ManagedMemoryUseCase.BATCH_OP,
 					groupManagedMemoryWeight > 0 ?
 						ManagedMemoryUtils.getFractionRoundedDown(operatorManagedMemoryWeight, groupManagedMemoryWeight) :
 							0.0);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.streaming.api.datastream.ConnectedStreams;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -480,14 +481,14 @@ public class StreamGraphGeneratorTest extends TestLogger {
 	public void testSetManagedMemoryWeight() {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		final DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
-		source.getTransformation().setManagedMemoryWeight(123);
+		source.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 123);
 		source.print().name("sink");
 
 		final StreamGraph streamGraph = env.getStreamGraph();
 		for (StreamNode streamNode : streamGraph.getStreamNodes()) {
 			final int expectedWeight = streamNode.getOperatorName().contains("source")
 				? 123
-				: Transformation.DEFAULT_MANAGED_MEMORY_WEIGHT;
+				: StreamNode.DEFAULT_MANAGED_MEMORY_WEIGHT;
 			assertEquals(expectedWeight, streamNode.getManagedMemoryWeight());
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.io.TypeSerializerInputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.InputOutputFormatContainer;
 import org.apache.flink.runtime.jobgraph.InputOutputFormatVertex;
@@ -841,10 +842,10 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		opMethod.invoke(map3, resourceSpecs.get(3));
 
 		if (managedMemoryWeights != null) {
-			source.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(0));
-			map1.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(1));
-			map2.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(2));
-			map3.getTransformation().setManagedMemoryWeight(managedMemoryWeights.get(3));
+			source.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(0));
+			map1.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(1));
+			map2.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(2));
+			map3.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(3));
 		}
 
 		return StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -817,7 +817,6 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		operatorScopeManagedMemoryUseCaseWeights.add(Collections.singletonMap(ManagedMemoryUseCase.BATCH_OP, 1));
 		slotScopeManagedMemoryUseCases.add(Collections.emptySet());
 
-
 		// slotSharingGroup1 contains batch and python use cases: v1(source[batch]) -> map1[batch, python]), v2(map2[python])
 		// slotSharingGroup2 contains batch use case only: v3(map3[batch])
 		final JobGraph jobGraph = createJobGraphForManagedMemoryFractionTest(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.io.TypeSerializerInputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.InputOutputFormatContainer;
@@ -90,8 +91,6 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -100,6 +99,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator.areOperatorsChainable;
@@ -788,41 +788,80 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 	public void testManagedMemoryFractionForUnknownResourceSpec() throws Exception {
 		final ResourceSpec resource = ResourceSpec.UNKNOWN;
 		final List<ResourceSpec> resourceSpecs = Arrays.asList(resource, resource, resource, resource);
-		final List<Integer> managedMemoryWeights = Arrays.asList(1, 2, 3, 4);
-		final Configuration taskManagerConfig = new Configuration();
 
-		// v1(source -> map1), v2(map2) are in the same slot sharing group, v3(map3) is in a different group
-		final JobGraph jobGraph = createJobGraphForManagedMemoryFractionTest(resourceSpecs, managedMemoryWeights);
+		final Configuration taskManagerConfig = new Configuration() {{
+			set(
+				TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS,
+				new HashMap<String, String>() {{
+					put(TaskManagerOptions.ManagedMemoryConsumerNames.DATAPROC, "6");
+					put(TaskManagerOptions.ManagedMemoryConsumerNames.PYTHON, "4");
+				}});
+		}};
+
+		final List<Map<ManagedMemoryUseCase, Integer>> operatorScopeManagedMemoryUseCaseWeights = new ArrayList<>();
+		final List<Set<ManagedMemoryUseCase>> slotScopeManagedMemoryUseCases = new ArrayList<>();
+
+		// source: batch
+		operatorScopeManagedMemoryUseCaseWeights.add(Collections.singletonMap(ManagedMemoryUseCase.BATCH_OP, 1));
+		slotScopeManagedMemoryUseCases.add(Collections.emptySet());
+
+		// map1: batch, python
+		operatorScopeManagedMemoryUseCaseWeights.add(Collections.singletonMap(ManagedMemoryUseCase.BATCH_OP, 1));
+		slotScopeManagedMemoryUseCases.add(Collections.singleton(ManagedMemoryUseCase.PYTHON));
+
+		// map3: python
+		operatorScopeManagedMemoryUseCaseWeights.add(Collections.emptyMap());
+		slotScopeManagedMemoryUseCases.add(Collections.singleton(ManagedMemoryUseCase.PYTHON));
+
+		// map3: batch
+		operatorScopeManagedMemoryUseCaseWeights.add(Collections.singletonMap(ManagedMemoryUseCase.BATCH_OP, 1));
+		slotScopeManagedMemoryUseCases.add(Collections.emptySet());
+
+
+		// slotSharingGroup1 contains batch and python use cases: v1(source[batch]) -> map1[batch, python]), v2(map2[python])
+		// slotSharingGroup2 contains batch use case only: v3(map3[batch])
+		final JobGraph jobGraph = createJobGraphForManagedMemoryFractionTest(
+			resourceSpecs,
+			operatorScopeManagedMemoryUseCaseWeights,
+			slotScopeManagedMemoryUseCases);
 		final JobVertex vertex1 = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 		final JobVertex vertex2 = jobGraph.getVerticesSortedTopologicallyFromSources().get(1);
 		final JobVertex vertex3 = jobGraph.getVerticesSortedTopologicallyFromSources().get(2);
 
 		final StreamConfig sourceConfig = new StreamConfig(vertex1.getConfiguration());
-		assertEquals(1.0 / 6,
-			sourceConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.BATCH_OP, taskManagerConfig),
-			0.000001);
+		verifyFractions(sourceConfig,
+			0.6 / 2,
+			0.0,
+			0.0,
+			taskManagerConfig);
 
 		final StreamConfig map1Config = Iterables.getOnlyElement(
 			sourceConfig.getTransitiveChainedTaskConfigs(StreamingJobGraphGeneratorTest.class.getClassLoader()).values());
-		assertEquals(2.0 / 6,
-			map1Config.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.BATCH_OP, taskManagerConfig),
-			0.000001);
+		verifyFractions(map1Config,
+			0.6 / 2,
+			0.4,
+			0.0,
+			taskManagerConfig);
 
 		final StreamConfig map2Config = new StreamConfig(vertex2.getConfiguration());
-		assertEquals(3.0 / 6,
-			map2Config.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.BATCH_OP, taskManagerConfig),
-			0.000001);
+		verifyFractions(map2Config,
+			0.0,
+			0.4,
+			0.0,
+			taskManagerConfig);
 
 		final StreamConfig map3Config = new StreamConfig(vertex3.getConfiguration());
-		assertEquals(1.0,
-			map3Config.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.BATCH_OP, taskManagerConfig),
-			0.000001);
-
+		verifyFractions(map3Config,
+			1.0,
+			0.0,
+			0.0,
+			taskManagerConfig);
 	}
 
 	private JobGraph createJobGraphForManagedMemoryFractionTest(
 		final List<ResourceSpec> resourceSpecs,
-		@Nullable final List<Integer> managedMemoryWeights) throws Exception {
+		final List<Map<ManagedMemoryUseCase, Integer>> operatorScopeUseCaseWeights,
+		final List<Set<ManagedMemoryUseCase>> slotScopeUseCases) throws Exception {
 
 		final Method opMethod = getSetResourcesMethodAndSetAccessible(SingleOutputStreamOperator.class);
 
@@ -851,14 +890,45 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final DataStream<Integer> map3 = map2.rebalance().map(value -> value).slotSharingGroup("test");
 		opMethod.invoke(map3, resourceSpecs.get(3));
 
-		if (managedMemoryWeights != null) {
-			source.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(0));
-			map1.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(1));
-			map2.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(2));
-			map3.getTransformation().declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, managedMemoryWeights.get(3));
-		}
+		declareManagedMemoryUseCaseForTranformation(source.getTransformation(), operatorScopeUseCaseWeights.get(0), slotScopeUseCases.get(0));
+		declareManagedMemoryUseCaseForTranformation(map1.getTransformation(), operatorScopeUseCaseWeights.get(1), slotScopeUseCases.get(1));
+		declareManagedMemoryUseCaseForTranformation(map2.getTransformation(), operatorScopeUseCaseWeights.get(2), slotScopeUseCases.get(2));
+		declareManagedMemoryUseCaseForTranformation(map3.getTransformation(), operatorScopeUseCaseWeights.get(3), slotScopeUseCases.get(3));
 
 		return StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+	}
+
+	private void declareManagedMemoryUseCaseForTranformation(
+			Transformation<?> transformation,
+			Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights,
+			Set<ManagedMemoryUseCase> slotScopeUseCases) {
+		for (Map.Entry<ManagedMemoryUseCase, Integer> entry : operatorScopeUseCaseWeights.entrySet()) {
+			transformation.declareManagedMemoryUseCaseAtOperatorScope(entry.getKey(), entry.getValue());
+		}
+		for (ManagedMemoryUseCase useCase : slotScopeUseCases) {
+			transformation.declareManagedMemoryUseCaseAtSlotScope(useCase);
+		}
+	}
+
+	private void verifyFractions(
+			StreamConfig streamConfig,
+			double expectedBatchFrac,
+			double expectedPythonFrac,
+			double expectedRocksdbFrac,
+			Configuration tmConfig) {
+		final double delta = 0.000001;
+		assertEquals(
+			expectedRocksdbFrac,
+			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.ROCKSDB, tmConfig),
+			delta);
+		assertEquals(
+			expectedPythonFrac,
+			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.PYTHON, tmConfig),
+			delta);
+		assertEquals(
+			expectedBatchFrac,
+			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.BATCH_OP, tmConfig),
+			delta);
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.codegen.agg.batch
 
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.runtime.execution.Environment
 import org.apache.flink.runtime.jobgraph.OperatorID
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
@@ -30,7 +31,6 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical._
 import org.apache.flink.util.function.FunctionWithException
 import org.junit.Assert
-
 import java.util
 
 import scala.collection.JavaConverters._
@@ -74,7 +74,7 @@ abstract class BatchAggTestBase extends AggTestBase(isBatchMode = true) {
     val streamConfig = testHarness.getStreamConfig
     streamConfig.setStreamOperatorFactory(args._1)
     streamConfig.setOperatorID(new OperatorID)
-    streamConfig.setManagedMemoryFraction(0.99)
+    streamConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, .99)
 
     testHarness.invoke()
     testHarness.waitForTaskRunning()

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators;
 
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
@@ -51,6 +52,8 @@ public class TableStreamOperator<OUT> extends AbstractStreamOperator<OUT> {
 	 */
 	public long computeMemorySize() {
 		return getContainingTask().getEnvironment().getMemoryManager().computeMemorySize(
-				getOperatorConfig().getManagedMemoryFraction());
+				getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+					ManagedMemoryUseCase.BATCH_OP,
+					getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.join;
 
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -266,7 +267,7 @@ public class Int2HashJoinOperatorTest implements Serializable {
 			testHarness.getStreamConfig().setStreamOperatorFactory((StreamOperatorFactory<?>) operator);
 		}
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.base.IntComparator;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.runtime.TupleComparator;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.sort.MergeIterator;
 import org.apache.flink.runtime.operators.testutils.Match;
@@ -254,7 +255,7 @@ public class RandomSortMergeInnerJoinTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.join;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
@@ -84,7 +85,7 @@ public class String2HashJoinOperatorTest implements Serializable {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.join;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -148,7 +149,7 @@ public class String2SortMergeJoinOperatorTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		testHarness.getStreamConfig().setStreamOperator(operator);
 		testHarness.getStreamConfig().setOperatorID(new OperatorID());
-		testHarness.getStreamConfig().setManagedMemoryFraction(0.99);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
 
 		long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -59,6 +61,8 @@ import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowO
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.function;
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.inputSer;
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.inputType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -206,7 +210,7 @@ public class BufferDataOverWindowOperatorTest {
 				StreamConfig conf = mock(StreamConfig.class);
 				when(conf.<RowData>getTypeSerializerIn1(getUserCodeClassloader()))
 						.thenReturn(inputSer);
-				when(conf.getManagedMemoryFraction())
+				when(conf.getManagedMemoryFractionOperatorUseCaseOfSlot(eq(ManagedMemoryUseCase.BATCH_OP), any(Configuration.class)))
 						.thenReturn(0.99);
 				return conf;
 			}


### PR DESCRIPTION
## What is the purpose of the change

This PR contains changes for both FLINK-19178 & FLINK-19179. Extends the managed memory weight/fraction configurations and settings with respect to multiple use cases.

## Brief change log

- 7e42981c8e71dec5749720e0d32b96dbe66bde52: Disable managed memory fractions for fine grained resource specs. Currently we do not have fine grained resource specs in production, and the original calculation logic for it does not work with multiple use cases. We can enable it with a proper calculation logic later when we need it.
- 3387a0e1f5bc577e90e101fe12482960ea435a7e: Introduce configuration options for managed memory use case weights.
- 22b5a92fd720a91324d91a5a198f906c50b76fc1: Extend `Transformation` interfaces for various managed memory use cases.
- 36c563e1caedf95f53666fda82a03e9030a96c0b: Extend `StreamNode` interfaces for various managed memory use cases.
- 33fb6d84e06f6e04df86c9bc3d1f24b695c206d6: Introduce `ManagedMemoryUtils`.
- 9211bcee3b433bb857c5917a545255bfc8368a26: Extend `StreamConfig` interfaces for various managed memory use cases.
- b1405ce3314c2799cd8172b50b4653389f36eca9: Implement new fraction calculation logics.

## Verifying this change

- Add `ManagedMemoryUtilsTest`
- Update `StreamingJobGraphGeneratorTest`
