### PR TITLE
[FLINK-18842][e2e] Added 10min timeout to building the container.

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -820,7 +820,7 @@ internal_run_with_timeout() {
 
   (
       command_pid=$BASHPID
-      (sleep "${timeout_in_seconds}" # set a timeout for this test
+      (sleep "${timeout_in_seconds}" # set a timeout for this command
       echo "${command_label:-"The command '${command}'"} (pid: $command_pid) did not finish after $timeout_in_seconds seconds."
       eval "${on_failure}"
       kill "$command_pid") & watchdog_pid=$!

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -801,32 +801,44 @@ function extract_job_id_from_job_submission_return() {
     echo "$JOB_ID"
 }
 
-
 #
 # NOTE: This function requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
 #
 kill_test_watchdog() {
-    local watchdog_pid=`cat $TEST_DATA_DIR/job_watchdog.pid`
+    local watchdog_pid=$(cat $TEST_DATA_DIR/job_watchdog.pid)
     echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
     kill $watchdog_pid
 }
 
-run_test_with_timeout() {
-  local TEST_TIMEOUT_SECONDS=$1
-  shift
-  local TEST_COMMAND=$@
+internal_run_with_timeout() {
+  local timeout_in_seconds="$1"
+  local on_failure="$2"
+  local command_label="$3"
+  local command="${@:4}"
 
   on_exit kill_test_watchdog
 
   (
-      cmdpid=$BASHPID
-      (sleep $TEST_TIMEOUT_SECONDS # set a timeout for this test
-      echo "Test (pid: $cmdpid) did not finish after $TEST_TIMEOUT_SECONDS seconds."
-      echo "Printing Flink logs and killing it:"
-      cat ${FLINK_DIR}/log/*
-      kill "$cmdpid") & watchdog_pid=$!
+      command_pid=$BASHPID
+      (sleep "${timeout_in_seconds}" # set a timeout for this test
+      echo "${command_label:-"The command '${command}'"} (pid: $command_pid) did not finish after $timeout_in_seconds seconds."
+      eval "${on_failure}"
+      kill "$command_pid") & watchdog_pid=$!
       echo $watchdog_pid > $TEST_DATA_DIR/job_watchdog.pid
       # invoke
-      $TEST_COMMAND
+      $command
   )
+}
+
+run_on_test_failure() {
+  echo "Printing Flink logs and killing it:"
+  cat ${FLINK_DIR}/log/*
+}
+
+run_test_with_timeout() {
+  internal_run_with_timeout $1 run_on_test_failure "Test" ${@:2}
+}
+
+run_with_timeout() {
+  internal_run_with_timeout $1 "" "" ${@:2}
 }

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -801,15 +801,15 @@ function extract_job_id_from_job_submission_return() {
     echo "$JOB_ID"
 }
 
-#
-# NOTE: This function requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
-#
 kill_test_watchdog() {
     local watchdog_pid=$(cat $TEST_DATA_DIR/job_watchdog.pid)
     echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
     kill $watchdog_pid
 }
 
+#
+# NOTE: This function requires at least Bash version >= 4 due to the usage of $BASHPID. Mac OS in 2020 still ships 3.x
+#
 internal_run_with_timeout() {
   local timeout_in_seconds="$1"
   local on_failure="$2"

--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -50,7 +50,7 @@ function build_image() {
     ./add-custom.sh -u localhost:9999/flink.tgz -n ${image_name}
 
     echo "Building images"
-    docker build --no-cache --network="host" -t ${image_name} dev/${image_name}-debian
+    run_with_timeout 600 docker build --no-cache --network="host" -t ${image_name} dev/${image_name}-debian
     popd
 }
 


### PR DESCRIPTION

## What is the purpose of the change

The docker build of `test_docker_embedded_job.sh` is failing once in a while. We haven't come up with a reason for it, yet. We also struggled to reproduce it. The discussion is happening in FLINK-18842.

## Brief change log

For now, I added a timeout to the docker build to enable the retry that is already in place.

## Verifying this change

This change is already covered by existing tests, such as `test_docker_embedded_job.sh`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable