### PR TITLE
[FLINK-19186][python] Add Python building blocks to make sure the basic functionality of Pandas Batch Group Aggregation could work

### DIFF
--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
@@ -28,7 +28,7 @@ The performance of vectorized Python user-defined functions are usually much hig
 overhead and invocation overhead are much reduced. Besides, users could leverage the popular Python libraries such as Pandas, Numpy, etc for the vectorized Python user-defined functions implementation.
 These Python libraries are highly optimized and provide high-performance data structures and functions. It shares the similar way as the
 [non-vectorized user-defined functions]({% link dev/python/table-api-users-guide/udfs/python_udfs.md %}) on how to define vectorized user-defined functions.
-Users only need to add an extra parameter `function_type="pandas"` in the decorator `udf` to mark it as a vectorized user-defined function.
+Users only need to add an extra parameter `func_type="pandas"` in the decorator `udf` to mark it as a vectorized user-defined function.
 
 **NOTE:** Python UDF execution requires Python version (3.5, 3.6, 3.7 or 3.8) with PyFlink installed. It's required on both the client side and the cluster side. 
 
@@ -49,7 +49,7 @@ The following example shows how to define your own vectorized Python scalar func
 and use it in a query:
 
 {% highlight python %}
-@udf(result_type=DataTypes.BIGINT(), function_type="pandas")
+@udf(result_type=DataTypes.BIGINT(), func_type="pandas")
 def add(i, j):
   return i + j
 

--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
@@ -28,7 +28,7 @@ The performance of vectorized Python user-defined functions are usually much hig
 overhead and invocation overhead are much reduced. Besides, users could leverage the popular Python libraries such as Pandas, Numpy, etc for the vectorized Python user-defined functions implementation.
 These Python libraries are highly optimized and provide high-performance data structures and functions. It shares the similar way as the
 [non-vectorized user-defined functions]({% link dev/python/table-api-users-guide/udfs/python_udfs.md %}) on how to define vectorized user-defined functions.
-Users only need to add an extra parameter `udf_type="pandas"` in the decorator `udf` to mark it as a vectorized user-defined function.
+Users only need to add an extra parameter `function_type="pandas"` in the decorator `udf` to mark it as a vectorized user-defined function.
 
 **NOTE:** Python UDF execution requires Python version (3.5, 3.6, 3.7 or 3.8) with PyFlink installed. It's required on both the client side and the cluster side. 
 
@@ -49,7 +49,7 @@ The following example shows how to define your own vectorized Python scalar func
 and use it in a query:
 
 {% highlight python %}
-@udf(result_type=DataTypes.BIGINT(), udf_type="pandas")
+@udf(result_type=DataTypes.BIGINT(), function_type="pandas")
 def add(i, j):
   return i + j
 

--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
@@ -27,7 +27,7 @@ under the License.
 向量化Python用户自定义函数的性能通常比非向量化Python用户自定义函数要高得多，因为向量化Python用户自定义函数可以大大减少序列化/反序列化的开销和调用开销。
 此外，用户可以利用流行的Python库（例如Pandas，Numpy等）来实现向量化Python用户自定义函数的逻辑。这些Python库通常经过高度优化，并提供了高性能的数据结构和功能。
 向量化用户自定义函数的定义，与[非向量化用户自定义函数]({% link dev/python/table-api-users-guide/udfs/python_udfs.zh.md %})具有相似的方式，
-用户只需要在调用`udf`装饰器时添加一个额外的参数`function_type="pandas"`，将其标记为一个向量化用户自定义函数即可。
+用户只需要在调用`udf`装饰器时添加一个额外的参数`func_type="pandas"`，将其标记为一个向量化用户自定义函数即可。
 
 **注意：**要执行Python UDF，需要安装PyFlink的Python版本（3.5、3.6、3.7 或 3.8）。客户端和群集端都需要安装它。
 
@@ -47,7 +47,7 @@ under the License.
 以下示例显示了如何定义自己的向量化Python标量函数，该函数计算两列的总和，并在查询中使用它：
 
 {% highlight python %}
-@udf(result_type=DataTypes.BIGINT(), function_type="pandas")
+@udf(result_type=DataTypes.BIGINT(), func_type="pandas")
 def add(i, j):
   return i + j
 

--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
@@ -27,7 +27,7 @@ under the License.
 向量化Python用户自定义函数的性能通常比非向量化Python用户自定义函数要高得多，因为向量化Python用户自定义函数可以大大减少序列化/反序列化的开销和调用开销。
 此外，用户可以利用流行的Python库（例如Pandas，Numpy等）来实现向量化Python用户自定义函数的逻辑。这些Python库通常经过高度优化，并提供了高性能的数据结构和功能。
 向量化用户自定义函数的定义，与[非向量化用户自定义函数]({% link dev/python/table-api-users-guide/udfs/python_udfs.zh.md %})具有相似的方式，
-用户只需要在调用`udf`装饰器时添加一个额外的参数`udf_type="pandas"`，将其标记为一个向量化用户自定义函数即可。
+用户只需要在调用`udf`装饰器时添加一个额外的参数`function_type="pandas"`，将其标记为一个向量化用户自定义函数即可。
 
 **注意：**要执行Python UDF，需要安装PyFlink的Python版本（3.5、3.6、3.7 或 3.8）。客户端和群集端都需要安装它。
 
@@ -47,7 +47,7 @@ under the License.
 以下示例显示了如何定义自己的向量化Python标量函数，该函数计算两列的总和，并在查询中使用它：
 
 {% highlight python %}
-@udf(result_type=DataTypes.BIGINT(), udf_type="pandas")
+@udf(result_type=DataTypes.BIGINT(), function_type="pandas")
 def add(i, j):
   return i + j
 

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -42,3 +42,6 @@ cdef class BeamTableFunctionOperation(BeamStatelessFunctionOperation):
 
 cdef class DataStreamStatelessFunctionOperation(BeamStatelessFunctionOperation):
     pass
+
+cdef class PandasAggregateFunctionOperation(BeamStatelessFunctionOperation):
+    pass

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -185,13 +185,10 @@ cdef class PandasAggregateFunctionOperation(BeamStatelessFunctionOperation):
                 ','.join([x[0], y[0]]),
                 dict(chain(x[1].items(), y[1].items())),
                 x[2] + y[2]),
-            [operation_utils.extract_user_defined_function(udf) for udf in udfs])
+            [operation_utils.extract_user_defined_function(udf, True) for udf in udfs])
         variable_dict['wrap_pandas_result'] = operation_utils.wrap_pandas_result
         mapper = eval('lambda value: wrap_pandas_result([%s])' % pandas_functions, variable_dict)
-        if self._is_python_coder:
-            generate_func = lambda it: map(mapper, it)
-        else:
-            generate_func = mapper
+        generate_func = lambda it: map(mapper, it)
         return generate_func, user_defined_funcs
 
 

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -173,6 +173,28 @@ cdef class DataStreamStatelessFunctionOperation(BeamStatelessFunctionOperation):
         func = operation_utils.extract_data_stream_stateless_funcs(udfs)
         return func, []
 
+
+cdef class PandasAggregateFunctionOperation(BeamStatelessFunctionOperation):
+    def __init__(self, name, spec, counter_factory, sampler, consumers):
+        super(PandasAggregateFunctionOperation, self).__init__(name, spec, counter_factory,
+                                                                   sampler, consumers)
+
+    def generate_func(self, udfs):
+        pandas_functions, variable_dict, user_defined_funcs = reduce(
+            lambda x, y: (
+                ','.join([x[0], y[0]]),
+                dict(chain(x[1].items(), y[1].items())),
+                x[2] + y[2]),
+            [operation_utils.extract_user_defined_function(udf) for udf in udfs])
+        variable_dict['wrap_pandas_result'] = operation_utils.wrap_pandas_result
+        mapper = eval('lambda value: wrap_pandas_result([%s])' % pandas_functions, variable_dict)
+        if self._is_python_coder:
+            generate_func = lambda it: map(mapper, it)
+        else:
+            generate_func = mapper
+        return generate_func, user_defined_funcs
+
+
 @bundle_processor.BeamTransformFactory.register_urn(
     operation_utils.SCALAR_FUNCTION_URN, flink_fn_execution_pb2.UserDefinedFunctions)
 def create_scalar_function(factory, transform_id, transform_proto, parameter, consumers):
@@ -190,6 +212,12 @@ def create_table_function(factory, transform_id, transform_proto, parameter, con
 def create_data_stream_function(factory, transform_id, transform_proto, parameter, consumers):
     return _create_user_defined_function_operation(
         factory, transform_proto, consumers, parameter, DataStreamStatelessFunctionOperation)
+
+@bundle_processor.BeamTransformFactory.register_urn(
+    operation_utils.PANDAS_AGGREGATE_FUNCTION_URN, flink_fn_execution_pb2.UserDefinedFunctions)
+def create_pandas_aggregate_function(factory, transform_id, transform_proto, parameter, consumers):
+    return _create_user_defined_function_operation(
+        factory, transform_proto, consumers, parameter, PandasAggregateFunctionOperation)
 
 def _create_user_defined_function_operation(factory, transform_proto, consumers, udfs_proto,
                                             operation_cls):

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -166,7 +166,7 @@ class PandasAggregateFunctionOperation(StatelessFunctionOperation):
                 ','.join([x[0], y[0]]),
                 dict(chain(x[1].items(), y[1].items())),
                 x[2] + y[2]),
-            [operation_utils.extract_user_defined_function(udf) for udf in udfs])
+            [operation_utils.extract_user_defined_function(udf, True) for udf in udfs])
         variable_dict['wrap_pandas_result'] = operation_utils.wrap_pandas_result
         mapper = eval('lambda value: wrap_pandas_result([%s])' % pandas_functions, variable_dict)
         return lambda it: map(mapper, it), user_defined_funcs

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -155,6 +155,23 @@ class DataStreamStatelessFunctionOperation(StatelessFunctionOperation):
         return lambda it: map(func, it), []
 
 
+class PandasAggregateFunctionOperation(StatelessFunctionOperation):
+    def __init__(self, name, spec, counter_factory, sampler, consumers):
+        super(PandasAggregateFunctionOperation, self).__init__(
+            name, spec, counter_factory, sampler, consumers)
+
+    def generate_func(self, udfs):
+        pandas_functions, variable_dict, user_defined_funcs = reduce(
+            lambda x, y: (
+                ','.join([x[0], y[0]]),
+                dict(chain(x[1].items(), y[1].items())),
+                x[2] + y[2]),
+            [operation_utils.extract_user_defined_function(udf) for udf in udfs])
+        variable_dict['wrap_pandas_result'] = operation_utils.wrap_pandas_result
+        mapper = eval('lambda value: wrap_pandas_result([%s])' % pandas_functions, variable_dict)
+        return lambda it: map(mapper, it), user_defined_funcs
+
+
 @bundle_processor.BeamTransformFactory.register_urn(
     operation_utils.SCALAR_FUNCTION_URN, flink_fn_execution_pb2.UserDefinedFunctions)
 def create_scalar_function(factory, transform_id, transform_proto, parameter, consumers):
@@ -175,6 +192,13 @@ def create_table_function(factory, transform_id, transform_proto, parameter, con
 def create_data_stream_function(factory, transform_id, transform_proto, parameter, consumers):
     return _create_user_defined_function_operation(
         factory, transform_proto, consumers, parameter, DataStreamStatelessFunctionOperation)
+
+
+@bundle_processor.BeamTransformFactory.register_urn(
+    operation_utils.PANDAS_AGGREGATE_FUNCTION_URN, flink_fn_execution_pb2.UserDefinedFunctions)
+def create_pandas_aggregate_function(factory, transform_id, transform_proto, parameter, consumers):
+    return _create_user_defined_function_operation(
+        factory, transform_proto, consumers, parameter, PandasAggregateFunctionOperation)
 
 
 def _create_user_defined_function_operation(factory, transform_proto, consumers, udfs_proto,

--- a/flink-python/pyflink/fn_execution/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/operation_utils.py
@@ -27,9 +27,15 @@ from pyflink.table.udf import DelegationTableFunction, DelegatingScalarFunction
 SCALAR_FUNCTION_URN = "flink:transform:scalar_function:v1"
 TABLE_FUNCTION_URN = "flink:transform:table_function:v1"
 DATA_STREAM_STATELESS_FUNCTION_URN = "flink:transform:datastream_stateless_function:v1"
+PANDAS_AGGREGATE_FUNCTION_URN = "flink:transform:aggregate_function:arrow:v1"
 
 _func_num = 0
 _constant_num = 0
+
+
+def wrap_pandas_result(it):
+    import pandas as pd
+    return [pd.Series([result]) for result in it]
 
 
 def extract_user_defined_function(user_defined_function_proto) -> Tuple[str, Dict, List]:

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -162,7 +162,7 @@ class PythonFunctionFactory(object):
 
     def getPythonFunction(self, moduleName, objectName):
         udf_wrapper = getattr(importlib.import_module(moduleName), objectName)
-        return udf_wrapper._create_judf()
+        return udf_wrapper.java_user_defined_function()
 
     class Java:
         implements = ["org.apache.flink.client.python.PythonFunctionFactory"]

--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -57,6 +57,10 @@ Important classes of Flink Table API:
       user-defined function is executed, such as the metric group, and global job parameters, etc.
     - :class:`pyflink.table.ScalarFunction`
       Base interface for user-defined scalar function.
+    - :class:`pyflink.table.TableFunction`
+      Base interface for user-defined table function.
+    - :class:`pyflink.table.AggregateFunction`
+      Base interface for user-defined aggregate function.
     - :class:`pyflink.table.StatementSet`
       Base interface accepts DML statements or Tables.
 """
@@ -79,9 +83,10 @@ from pyflink.table.table_environment import (TableEnvironment, StreamTableEnviro
 from pyflink.table.table_result import TableResult
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import DataTypes, UserDefinedType, Row, RowKind
-from pyflink.table.udf import FunctionContext, ScalarFunction
+from pyflink.table.udf import FunctionContext, ScalarFunction, TableFunction, AggregateFunction
 
 __all__ = [
+    'AggregateFunction',
     'BatchTableEnvironment',
     'CsvTableSink',
     'CsvTableSource',
@@ -104,6 +109,7 @@ __all__ = [
     'Table',
     'TableConfig',
     'TableEnvironment',
+    'TableFunction',
     'TableResult',
     'TableSchema',
     'TableSink',

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1116,9 +1116,13 @@ class TableEnvironment(object):
         java_function = function.java_user_defined_function()
         # this is a temporary solution and will be unified later when we use the new type
         # system(DataType) to replace the old type system(TypeInformation).
-        if self._is_blink_planner and isinstance(self, BatchTableEnvironment) and \
-                self._is_table_function(java_function):
-            self._register_table_function(name, java_function)
+        if self._is_blink_planner and isinstance(self, BatchTableEnvironment):
+            if self._is_table_function(java_function):
+                self._register_table_function(name, java_function)
+            elif self._is_aggregate_function(java_function):
+                self._register_aggregate_function(name, java_function)
+            else:
+                self._j_tenv.registerFunction(name, java_function)
         else:
             self._j_tenv.registerFunction(name, java_function)
 

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -39,7 +39,7 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
         # general udf
         add = udf(lambda a: a + 1, result_type=DataTypes.INT())
         # pandas udf
-        substract = udf(lambda a: a - 1, result_type=DataTypes.INT(), function_type="pandas")
+        substract = udf(lambda a: a - 1, result_type=DataTypes.INT(), udf_type="pandas")
         max_udaf = udaf(lambda a: a.max(), result_type=DataTypes.INT())
         t.group_by("a") \
             .select(t.a, mean_udaf(add(t.b)), max_udaf(substract(t.c))) \
@@ -92,7 +92,7 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
         self.assert_equals(actual, ["1,2,2.0,6", "2,3,3.0,8", "3,4,4.0,10"])
 
 
-@udaf(result_type=DataTypes.FLOAT(), function_type="pandas")
+@udaf(result_type=DataTypes.FLOAT(), func_type="pandas")
 def mean_udaf(v):
     return v.mean()
 

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -15,9 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from pyflink.table.types import DataTypes
+import unittest
 
-from pyflink.table.udf import udaf
+from pyflink.table.types import DataTypes
+from pyflink.table.udf import udaf, udf, AggregateFunction
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase
 
@@ -32,17 +33,101 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
                  DataTypes.FIELD("c", DataTypes.INT())]))
 
         table_sink = source_sink_utils.TestAppendSink(
-            ['a', 'b'],
-            [DataTypes.TINYINT(), DataTypes.FLOAT()])
+            ['a', 'b', 'c'],
+            [DataTypes.TINYINT(), DataTypes.FLOAT(), DataTypes.INT()])
         self.t_env.register_table_sink("Results", table_sink)
+        # general udf
+        add = udf(lambda a: a + 1, result_type=DataTypes.INT())
+        # pandas udf
+        substract = udf(lambda a: a - 1, result_type=DataTypes.INT(), function_type="pandas")
+        max_udaf = udaf(lambda a: a.max(), result_type=DataTypes.INT())
         t.group_by("a") \
-            .select(t.a, mean_udaf(t.b)) \
+            .select(t.a, mean_udaf(add(t.b)), max_udaf(substract(t.c))) \
             .execute_insert("Results") \
             .wait()
         actual = source_sink_utils.results()
-        self.assert_equals(actual, ["1,5.0", "2,2.0", "3,2.0"])
+        self.assert_equals(actual, ["1,6.0,5", "2,3.0,3", "3,3.0,2"])
+
+    def test_group_aggregate_without_keys(self):
+        t = self.t_env.from_elements(
+            [(1, 2, 3), (3, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT())]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a'],
+            [DataTypes.INT()])
+        min_add = udaf(lambda a, b, c: a.min() + b.min() + c.min(), result_type=DataTypes.INT())
+        self.t_env.register_table_sink("Results", table_sink)
+        t.select(min_add(t.a, t.b, t.c)) \
+            .execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["5"])
+
+    def test_group_aggregate_with_aux_group(self):
+        t = self.t_env.from_elements(
+            [(1, 2, 3), (3, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT())]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c', 'd'],
+            [DataTypes.TINYINT(), DataTypes.INT(), DataTypes.FLOAT(), DataTypes.INT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        self.t_env.get_config().get_configuration().set_string('python.metric.enabled', 'true')
+        self.t_env.register_function("max_add", udaf(MaxAdd(), result_type=DataTypes.INT()))
+        self.t_env.create_temporary_system_function("mean_udaf", mean_udaf)
+        t.group_by("a") \
+            .select("a, a + 1 as b, a + 2 as c") \
+            .group_by("a, b") \
+            .select("a, b, mean_udaf(b), max_add(b, c, 1)") \
+            .execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,2,2.0,6", "2,3,3.0,8", "3,4,4.0,10"])
 
 
-@udaf(result_type=DataTypes.FLOAT(), udaf_type="pandas")
+@udaf(result_type=DataTypes.FLOAT(), function_type="pandas")
 def mean_udaf(v):
     return v.mean()
+
+
+class MaxAdd(AggregateFunction, unittest.TestCase):
+
+    def open(self, function_context):
+        mg = function_context.get_metric_group()
+        self.counter = mg.add_group("key", "value").counter("my_counter")
+        self.counter_sum = 0
+
+    def get_value(self, accumulator):
+        # counter
+        self.counter.inc(10)
+        self.counter_sum += 10
+        self.assertEqual(self.counter_sum, self.counter.get_count())
+        return accumulator[0]
+
+    def create_accumulator(self):
+        return []
+
+    def accumulate(self, accumulator, *args):
+        result = 0
+        for arg in args:
+            result += arg.max()
+        accumulator.append(result)
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -1,0 +1,48 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.table.types import DataTypes
+
+from pyflink.table.udf import udaf
+from pyflink.testing import source_sink_utils
+from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase
+
+
+class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
+    def test_group_aggregate_function(self):
+        t = self.t_env.from_elements(
+            [(1, 2, 3), (3, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT())]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'],
+            [DataTypes.TINYINT(), DataTypes.FLOAT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t.group_by("a") \
+            .select(t.a, mean_udaf(t.b)) \
+            .execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,5.0", "2,2.0", "3,2.0"])
+
+
+@udaf(result_type=DataTypes.FLOAT(), udaf_type="pandas")
+def mean_udaf(v):
+    return v.mean()

--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -32,17 +32,17 @@ from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
 
 class PandasUDFTests(PyFlinkTestCase):
 
-    def test_non_exist_function_type(self):
+    def test_non_exist_func_type(self):
         with self.assertRaisesRegex(ValueError,
-                                    'The function_type must be one of \'general, pandas\''):
-            udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), function_type="non-exist")
+                                    'The func_type must be one of \'general, pandas\''):
+            udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), func_type="non-exist")
 
 
 class PandasUDFITTests(object):
 
     def test_basic_functionality(self):
         # pandas UDF
-        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), function_type="pandas")
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), func_type="pandas")
 
         # general Python UDF
         subtract_one = udf(SubtractOne(), DataTypes.BIGINT(), DataTypes.BIGINT())
@@ -64,14 +64,14 @@ class PandasUDFITTests(object):
         import pandas as pd
         import numpy as np
 
-        @udf(result_type=DataTypes.TINYINT(), function_type="pandas")
+        @udf(result_type=DataTypes.TINYINT(), func_type="pandas")
         def tinyint_func(tinyint_param):
             assert isinstance(tinyint_param, pd.Series)
             assert isinstance(tinyint_param[0], np.int8), \
                 'tinyint_param of wrong type %s !' % type(tinyint_param[0])
             return tinyint_param
 
-        @udf(result_type=DataTypes.SMALLINT(), function_type="pandas")
+        @udf(result_type=DataTypes.SMALLINT(), func_type="pandas")
         def smallint_func(smallint_param):
             assert isinstance(smallint_param, pd.Series)
             assert isinstance(smallint_param[0], np.int16), \
@@ -79,7 +79,7 @@ class PandasUDFITTests(object):
             assert smallint_param[0] == 32767, 'smallint_param of wrong value %s' % smallint_param
             return smallint_param
 
-        @udf(result_type=DataTypes.INT(), function_type="pandas")
+        @udf(result_type=DataTypes.INT(), func_type="pandas")
         def int_func(int_param):
             assert isinstance(int_param, pd.Series)
             assert isinstance(int_param[0], np.int32), \
@@ -87,63 +87,63 @@ class PandasUDFITTests(object):
             assert int_param[0] == -2147483648, 'int_param of wrong value %s' % int_param
             return int_param
 
-        @udf(result_type=DataTypes.BIGINT(), function_type="pandas")
+        @udf(result_type=DataTypes.BIGINT(), func_type="pandas")
         def bigint_func(bigint_param):
             assert isinstance(bigint_param, pd.Series)
             assert isinstance(bigint_param[0], np.int64), \
                 'bigint_param of wrong type %s !' % type(bigint_param[0])
             return bigint_param
 
-        @udf(result_type=DataTypes.BOOLEAN(), function_type="pandas")
+        @udf(result_type=DataTypes.BOOLEAN(), func_type="pandas")
         def boolean_func(boolean_param):
             assert isinstance(boolean_param, pd.Series)
             assert isinstance(boolean_param[0], np.bool_), \
                 'boolean_param of wrong type %s !' % type(boolean_param[0])
             return boolean_param
 
-        @udf(result_type=DataTypes.FLOAT(), function_type="pandas")
+        @udf(result_type=DataTypes.FLOAT(), func_type="pandas")
         def float_func(float_param):
             assert isinstance(float_param, pd.Series)
             assert isinstance(float_param[0], np.float32), \
                 'float_param of wrong type %s !' % type(float_param[0])
             return float_param
 
-        @udf(result_type=DataTypes.DOUBLE(), function_type="pandas")
+        @udf(result_type=DataTypes.DOUBLE(), func_type="pandas")
         def double_func(double_param):
             assert isinstance(double_param, pd.Series)
             assert isinstance(double_param[0], np.float64), \
                 'double_param of wrong type %s !' % type(double_param[0])
             return double_param
 
-        @udf(result_type=DataTypes.STRING(), function_type="pandas")
+        @udf(result_type=DataTypes.STRING(), func_type="pandas")
         def varchar_func(varchar_param):
             assert isinstance(varchar_param, pd.Series)
             assert isinstance(varchar_param[0], str), \
                 'varchar_param of wrong type %s !' % type(varchar_param[0])
             return varchar_param
 
-        @udf(result_type=DataTypes.BYTES(), function_type="pandas")
+        @udf(result_type=DataTypes.BYTES(), func_type="pandas")
         def varbinary_func(varbinary_param):
             assert isinstance(varbinary_param, pd.Series)
             assert isinstance(varbinary_param[0], bytes), \
                 'varbinary_param of wrong type %s !' % type(varbinary_param[0])
             return varbinary_param
 
-        @udf(result_type=DataTypes.DECIMAL(38, 18), function_type="pandas")
+        @udf(result_type=DataTypes.DECIMAL(38, 18), func_type="pandas")
         def decimal_func(decimal_param):
             assert isinstance(decimal_param, pd.Series)
             assert isinstance(decimal_param[0], decimal.Decimal), \
                 'decimal_param of wrong type %s !' % type(decimal_param[0])
             return decimal_param
 
-        @udf(result_type=DataTypes.DATE(), function_type="pandas")
+        @udf(result_type=DataTypes.DATE(), func_type="pandas")
         def date_func(date_param):
             assert isinstance(date_param, pd.Series)
             assert isinstance(date_param[0], datetime.date), \
                 'date_param of wrong type %s !' % type(date_param[0])
             return date_param
 
-        @udf(result_type=DataTypes.TIME(), function_type="pandas")
+        @udf(result_type=DataTypes.TIME(), func_type="pandas")
         def time_func(time_param):
             assert isinstance(time_param, pd.Series)
             assert isinstance(time_param[0], datetime.time), \
@@ -152,7 +152,7 @@ class PandasUDFITTests(object):
 
         timestamp_value = datetime.datetime(1970, 1, 2, 0, 0, 0, 123000)
 
-        @udf(result_type=DataTypes.TIMESTAMP(3), function_type="pandas")
+        @udf(result_type=DataTypes.TIMESTAMP(3), func_type="pandas")
         def timestamp_func(timestamp_param):
             assert isinstance(timestamp_param, pd.Series)
             assert isinstance(timestamp_param[0], datetime.datetime), \
@@ -170,17 +170,17 @@ class PandasUDFITTests(object):
 
         array_str_func = udf(array_func,
                              result_type=DataTypes.ARRAY(DataTypes.STRING()),
-                             function_type="pandas")
+                             func_type="pandas")
 
         array_timestamp_func = udf(array_func,
                                    result_type=DataTypes.ARRAY(DataTypes.TIMESTAMP(3)),
-                                   function_type="pandas")
+                                   func_type="pandas")
 
         array_int_func = udf(array_func,
                              result_type=DataTypes.ARRAY(DataTypes.INT()),
-                             function_type="pandas")
+                             func_type="pandas")
 
-        @udf(result_type=DataTypes.ARRAY(DataTypes.STRING()), function_type="pandas")
+        @udf(result_type=DataTypes.ARRAY(DataTypes.STRING()), func_type="pandas")
         def nested_array_func(nested_array_param):
             assert isinstance(nested_array_param, pd.Series)
             assert isinstance(nested_array_param[0], np.ndarray), \
@@ -193,7 +193,7 @@ class PandasUDFITTests(object):
              DataTypes.FIELD("f3", DataTypes.TIMESTAMP(3)),
              DataTypes.FIELD("f4", DataTypes.ARRAY(DataTypes.INT()))])
 
-        @udf(result_type=row_type, function_type="pandas")
+        @udf(result_type=row_type, func_type="pandas")
         def row_func(row_param):
             assert isinstance(row_param, pd.Series)
             assert isinstance(row_param[0], dict), \
@@ -283,7 +283,7 @@ class BlinkPandasUDFITTests(object):
         local_datetime = pytz.timezone(timezone).localize(
             datetime.datetime(1970, 1, 2, 0, 0, 0, 123000))
 
-        @udf(result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3), function_type="pandas")
+        @udf(result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3), func_type="pandas")
         def local_zoned_timestamp_func(local_zoned_timestamp_param):
             assert isinstance(local_zoned_timestamp_param, pd.Series)
             assert isinstance(local_zoned_timestamp_param[0], datetime.datetime), \
@@ -316,7 +316,7 @@ class StreamPandasUDFITTests(PandasUDFITTests,
 class BatchPandasUDFITTests(PyFlinkBatchTableTestCase):
 
     def test_basic_functionality(self):
-        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), function_type="pandas")
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), func_type="pandas")
 
         # general Python UDF
         subtract_one = udf(SubtractOne(), result_type=DataTypes.BIGINT())
@@ -340,7 +340,7 @@ class BlinkStreamPandasUDFITTests(PandasUDFITTests,
     pass
 
 
-@udf(result_type=DataTypes.BIGINT(), function_type='pandas')
+@udf(result_type=DataTypes.BIGINT(), func_type='pandas')
 def add(i, j):
     return i + j
 

--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -32,17 +32,17 @@ from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
 
 class PandasUDFTests(PyFlinkTestCase):
 
-    def test_non_exist_udf_type(self):
+    def test_non_exist_function_type(self):
         with self.assertRaisesRegex(ValueError,
-                                    'The udf_type must be one of \'general, pandas\''):
-            udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), udf_type="non-exist")
+                                    'The function_type must be one of \'general, pandas\''):
+            udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), function_type="non-exist")
 
 
 class PandasUDFITTests(object):
 
     def test_basic_functionality(self):
         # pandas UDF
-        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), udf_type="pandas")
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), function_type="pandas")
 
         # general Python UDF
         subtract_one = udf(SubtractOne(), DataTypes.BIGINT(), DataTypes.BIGINT())
@@ -64,14 +64,14 @@ class PandasUDFITTests(object):
         import pandas as pd
         import numpy as np
 
-        @udf(result_type=DataTypes.TINYINT(), udf_type="pandas")
+        @udf(result_type=DataTypes.TINYINT(), function_type="pandas")
         def tinyint_func(tinyint_param):
             assert isinstance(tinyint_param, pd.Series)
             assert isinstance(tinyint_param[0], np.int8), \
                 'tinyint_param of wrong type %s !' % type(tinyint_param[0])
             return tinyint_param
 
-        @udf(result_type=DataTypes.SMALLINT(), udf_type="pandas")
+        @udf(result_type=DataTypes.SMALLINT(), function_type="pandas")
         def smallint_func(smallint_param):
             assert isinstance(smallint_param, pd.Series)
             assert isinstance(smallint_param[0], np.int16), \
@@ -79,7 +79,7 @@ class PandasUDFITTests(object):
             assert smallint_param[0] == 32767, 'smallint_param of wrong value %s' % smallint_param
             return smallint_param
 
-        @udf(result_type=DataTypes.INT(), udf_type="pandas")
+        @udf(result_type=DataTypes.INT(), function_type="pandas")
         def int_func(int_param):
             assert isinstance(int_param, pd.Series)
             assert isinstance(int_param[0], np.int32), \
@@ -87,63 +87,63 @@ class PandasUDFITTests(object):
             assert int_param[0] == -2147483648, 'int_param of wrong value %s' % int_param
             return int_param
 
-        @udf(result_type=DataTypes.BIGINT(), udf_type="pandas")
+        @udf(result_type=DataTypes.BIGINT(), function_type="pandas")
         def bigint_func(bigint_param):
             assert isinstance(bigint_param, pd.Series)
             assert isinstance(bigint_param[0], np.int64), \
                 'bigint_param of wrong type %s !' % type(bigint_param[0])
             return bigint_param
 
-        @udf(result_type=DataTypes.BOOLEAN(), udf_type="pandas")
+        @udf(result_type=DataTypes.BOOLEAN(), function_type="pandas")
         def boolean_func(boolean_param):
             assert isinstance(boolean_param, pd.Series)
             assert isinstance(boolean_param[0], np.bool_), \
                 'boolean_param of wrong type %s !' % type(boolean_param[0])
             return boolean_param
 
-        @udf(result_type=DataTypes.FLOAT(), udf_type="pandas")
+        @udf(result_type=DataTypes.FLOAT(), function_type="pandas")
         def float_func(float_param):
             assert isinstance(float_param, pd.Series)
             assert isinstance(float_param[0], np.float32), \
                 'float_param of wrong type %s !' % type(float_param[0])
             return float_param
 
-        @udf(result_type=DataTypes.DOUBLE(), udf_type="pandas")
+        @udf(result_type=DataTypes.DOUBLE(), function_type="pandas")
         def double_func(double_param):
             assert isinstance(double_param, pd.Series)
             assert isinstance(double_param[0], np.float64), \
                 'double_param of wrong type %s !' % type(double_param[0])
             return double_param
 
-        @udf(result_type=DataTypes.STRING(), udf_type="pandas")
+        @udf(result_type=DataTypes.STRING(), function_type="pandas")
         def varchar_func(varchar_param):
             assert isinstance(varchar_param, pd.Series)
             assert isinstance(varchar_param[0], str), \
                 'varchar_param of wrong type %s !' % type(varchar_param[0])
             return varchar_param
 
-        @udf(result_type=DataTypes.BYTES(), udf_type="pandas")
+        @udf(result_type=DataTypes.BYTES(), function_type="pandas")
         def varbinary_func(varbinary_param):
             assert isinstance(varbinary_param, pd.Series)
             assert isinstance(varbinary_param[0], bytes), \
                 'varbinary_param of wrong type %s !' % type(varbinary_param[0])
             return varbinary_param
 
-        @udf(result_type=DataTypes.DECIMAL(38, 18), udf_type="pandas")
+        @udf(result_type=DataTypes.DECIMAL(38, 18), function_type="pandas")
         def decimal_func(decimal_param):
             assert isinstance(decimal_param, pd.Series)
             assert isinstance(decimal_param[0], decimal.Decimal), \
                 'decimal_param of wrong type %s !' % type(decimal_param[0])
             return decimal_param
 
-        @udf(result_type=DataTypes.DATE(), udf_type="pandas")
+        @udf(result_type=DataTypes.DATE(), function_type="pandas")
         def date_func(date_param):
             assert isinstance(date_param, pd.Series)
             assert isinstance(date_param[0], datetime.date), \
                 'date_param of wrong type %s !' % type(date_param[0])
             return date_param
 
-        @udf(result_type=DataTypes.TIME(), udf_type="pandas")
+        @udf(result_type=DataTypes.TIME(), function_type="pandas")
         def time_func(time_param):
             assert isinstance(time_param, pd.Series)
             assert isinstance(time_param[0], datetime.time), \
@@ -152,7 +152,7 @@ class PandasUDFITTests(object):
 
         timestamp_value = datetime.datetime(1970, 1, 2, 0, 0, 0, 123000)
 
-        @udf(result_type=DataTypes.TIMESTAMP(3), udf_type="pandas")
+        @udf(result_type=DataTypes.TIMESTAMP(3), function_type="pandas")
         def timestamp_func(timestamp_param):
             assert isinstance(timestamp_param, pd.Series)
             assert isinstance(timestamp_param[0], datetime.datetime), \
@@ -170,17 +170,17 @@ class PandasUDFITTests(object):
 
         array_str_func = udf(array_func,
                              result_type=DataTypes.ARRAY(DataTypes.STRING()),
-                             udf_type="pandas")
+                             function_type="pandas")
 
         array_timestamp_func = udf(array_func,
                                    result_type=DataTypes.ARRAY(DataTypes.TIMESTAMP(3)),
-                                   udf_type="pandas")
+                                   function_type="pandas")
 
         array_int_func = udf(array_func,
                              result_type=DataTypes.ARRAY(DataTypes.INT()),
-                             udf_type="pandas")
+                             function_type="pandas")
 
-        @udf(result_type=DataTypes.ARRAY(DataTypes.STRING()), udf_type="pandas")
+        @udf(result_type=DataTypes.ARRAY(DataTypes.STRING()), function_type="pandas")
         def nested_array_func(nested_array_param):
             assert isinstance(nested_array_param, pd.Series)
             assert isinstance(nested_array_param[0], np.ndarray), \
@@ -193,7 +193,7 @@ class PandasUDFITTests(object):
              DataTypes.FIELD("f3", DataTypes.TIMESTAMP(3)),
              DataTypes.FIELD("f4", DataTypes.ARRAY(DataTypes.INT()))])
 
-        @udf(result_type=row_type, udf_type="pandas")
+        @udf(result_type=row_type, function_type="pandas")
         def row_func(row_param):
             assert isinstance(row_param, pd.Series)
             assert isinstance(row_param[0], dict), \
@@ -283,7 +283,7 @@ class BlinkPandasUDFITTests(object):
         local_datetime = pytz.timezone(timezone).localize(
             datetime.datetime(1970, 1, 2, 0, 0, 0, 123000))
 
-        @udf(result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3), udf_type="pandas")
+        @udf(result_type=DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3), function_type="pandas")
         def local_zoned_timestamp_func(local_zoned_timestamp_param):
             assert isinstance(local_zoned_timestamp_param, pd.Series)
             assert isinstance(local_zoned_timestamp_param[0], datetime.datetime), \
@@ -316,7 +316,7 @@ class StreamPandasUDFITTests(PandasUDFITTests,
 class BatchPandasUDFITTests(PyFlinkBatchTableTestCase):
 
     def test_basic_functionality(self):
-        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), udf_type="pandas")
+        add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT(), function_type="pandas")
 
         # general Python UDF
         subtract_one = udf(SubtractOne(), result_type=DataTypes.BIGINT())
@@ -340,7 +340,7 @@ class BlinkStreamPandasUDFITTests(PandasUDFITTests,
     pass
 
 
-@udf(result_type=DataTypes.BIGINT(), udf_type='pandas')
+@udf(result_type=DataTypes.BIGINT(), function_type='pandas')
 def add(i, j):
     return i + j
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -124,12 +124,10 @@ class TableFunction(UserDefinedFunction):
 
 class AggregateFunction(UserDefinedFunction):
     """
-
     Base interface for user-defined aggregate function. A user-defined aggregate function maps
     scalar values of multiple rows to a new scalar value.
 
     .. versionadded:: 1.12.0
-
     """
 
     @abc.abstractmethod
@@ -253,7 +251,10 @@ class DelegatingPandasAggregateFunction(AggregateFunction):
         accumulator.append(self.func(*args))
 
 
-class WrapperPandasAggregateFunction(object):
+class PandasAggregateFunctionWrapper(object):
+    """
+    Wrapper for Pandas Aggregate function.
+    """
     def __init__(self, func: AggregateFunction):
         self.func = func
 
@@ -276,7 +277,7 @@ class UserDefinedFunctionWrapper(object):
     etc. It's for internal use only.
     """
 
-    def __init__(self, func, input_types, deterministic=None, name=None):
+    def __init__(self, func, input_types, function_type, deterministic=None, name=None):
         if inspect.isclass(func) or (
                 not isinstance(func, UserDefinedFunction) and not callable(func)):
             raise TypeError(
@@ -306,12 +307,47 @@ class UserDefinedFunctionWrapper(object):
         # default deterministic is True
         self._deterministic = deterministic if deterministic is not None else (
             func.is_deterministic() if isinstance(func, UserDefinedFunction) else True)
+        self._function_type = function_type
+        self._judf_placeholder = None
 
     def __call__(self, *args) -> Expression:
         from pyflink.table import expressions as expr
         return expr.call(self, *args)
 
     def java_user_defined_function(self):
+        if self._judf_placeholder is None:
+            gateway = get_gateway()
+
+            def get_python_function_kind():
+                JPythonFunctionKind = gateway.jvm.org.apache.flink.table.functions.python. \
+                    PythonFunctionKind
+                if self._function_type == "general":
+                    return JPythonFunctionKind.GENERAL
+                elif self._function_type == "pandas":
+                    return JPythonFunctionKind.PANDAS
+                else:
+                    raise TypeError("Unsupported function_type: %s." % self._function_type)
+
+            if self._input_types is not None:
+                j_input_types = utils.to_jarray(
+                    gateway.jvm.TypeInformation, [_to_java_type(i) for i in self._input_types])
+            else:
+                j_input_types = None
+            j_function_kind = get_python_function_kind()
+            func = self._func
+            if not isinstance(self._func, UserDefinedFunction):
+                func = self._create_delegate_function()
+
+            import cloudpickle
+            serialized_func = cloudpickle.dumps(func)
+            self._judf_placeholder = \
+                self._create_judf(serialized_func, j_input_types, j_function_kind)
+        return self._judf_placeholder
+
+    def _create_delegate_function(self) -> UserDefinedFunction:
+        pass
+
+    def _create_judf(self, serialized_func, j_input_types, j_function_kind):
         pass
 
 
@@ -320,49 +356,19 @@ class UserDefinedScalarFunctionWrapper(UserDefinedFunctionWrapper):
     Wrapper for Python user-defined scalar function.
     """
 
-    def __init__(self, func, input_types, result_type, udf_type, deterministic, name):
+    def __init__(self, func, input_types, result_type, function_type, deterministic, name):
         super(UserDefinedScalarFunctionWrapper, self).__init__(
-            func, input_types, deterministic, name)
+            func, input_types, function_type, deterministic, name)
 
         if not isinstance(result_type, DataType):
             raise TypeError(
                 "Invalid returnType: returnType should be DataType but is {}".format(result_type))
         self._result_type = result_type
-        self._udf_type = udf_type
         self._judf_placeholder = None
 
-    def java_user_defined_function(self):
-        if self._judf_placeholder is None:
-            self._judf_placeholder = self._create_judf()
-        return self._judf_placeholder
-
-    def _create_judf(self):
+    def _create_judf(self, serialized_func, j_input_types, j_function_kind):
         gateway = get_gateway()
-
-        def get_python_function_kind(udf_type):
-            JPythonFunctionKind = gateway.jvm.org.apache.flink.table.functions.python.\
-                PythonFunctionKind
-            if udf_type == "general":
-                return JPythonFunctionKind.GENERAL
-            elif udf_type == "pandas":
-                return JPythonFunctionKind.PANDAS
-            else:
-                raise TypeError("Unsupported udf_type: %s." % udf_type)
-
-        func = self._func
-        if not isinstance(self._func, UserDefinedFunction):
-            func = DelegatingScalarFunction(self._func)
-
-        import cloudpickle
-        serialized_func = cloudpickle.dumps(func)
-
-        if self._input_types is not None:
-            j_input_types = utils.to_jarray(
-                gateway.jvm.TypeInformation, [_to_java_type(i) for i in self._input_types])
-        else:
-            j_input_types = None
         j_result_type = _to_java_type(self._result_type)
-        j_function_kind = get_python_function_kind(self._udf_type)
         PythonScalarFunction = gateway.jvm \
             .org.apache.flink.table.functions.python.PythonScalarFunction
         j_scalar_function = PythonScalarFunction(
@@ -375,6 +381,9 @@ class UserDefinedScalarFunctionWrapper(UserDefinedFunctionWrapper):
             _get_python_env())
         return j_scalar_function
 
+    def _create_delegate_function(self) -> UserDefinedFunction:
+        return DelegatingScalarFunction(self._func)
+
 
 class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
     """
@@ -383,7 +392,7 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
 
     def __init__(self, func, input_types, result_types, deterministic=None, name=None):
         super(UserDefinedTableFunctionWrapper, self).__init__(
-            func, input_types, deterministic, name)
+            func, input_types, "general", deterministic, name)
 
         if not isinstance(result_types, collections.Iterable):
             result_types = [result_types]
@@ -395,33 +404,12 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
                         result_type))
 
         self._result_types = result_types
-        self._judtf_placeholder = None
 
-    def java_user_defined_function(self):
-        if self._judtf_placeholder is None:
-            self._judtf_placeholder = self._create_judtf()
-        return self._judtf_placeholder
-
-    def _create_judtf(self):
-        func = self._func
-        if not isinstance(self._func, UserDefinedFunction):
-            func = DelegationTableFunction(self._func)
-
-        import cloudpickle
-        serialized_func = cloudpickle.dumps(func)
-
+    def _create_judf(self, serialized_func, j_input_types, j_function_kind):
         gateway = get_gateway()
-        if self._input_types is not None:
-            j_input_types = utils.to_jarray(
-                gateway.jvm.TypeInformation, [_to_java_type(i) for i in self._input_types])
-        else:
-            j_input_types = None
-
         j_result_types = utils.to_jarray(gateway.jvm.TypeInformation,
                                          [_to_java_type(i) for i in self._result_types])
         j_result_type = gateway.jvm.org.apache.flink.api.java.typeutils.RowTypeInfo(j_result_types)
-        j_function_kind = gateway.jvm.org.apache.flink.table.functions.python. \
-            PythonFunctionKind.GENERAL
         PythonTableFunction = gateway.jvm \
             .org.apache.flink.table.functions.python.PythonTableFunction
         j_table_function = PythonTableFunction(
@@ -434,58 +422,38 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
             _get_python_env())
         return j_table_function
 
+    def _create_delegate_function(self) -> UserDefinedFunction:
+        return DelegationTableFunction(self._func)
+
 
 class UserDefinedAggregateFunctionWrapper(UserDefinedFunctionWrapper):
     """
     Wrapper for Python user-defined aggregate function.
     """
-    def __init__(self, func, input_types, result_type, udaf_type, deterministic, name):
+    def __init__(self, func, input_types, result_type, accumulator_type, function_type,
+                 deterministic, name):
         super(UserDefinedAggregateFunctionWrapper, self).__init__(
-            func, input_types, deterministic, name)
+            func, input_types, function_type, deterministic, name)
 
         if not isinstance(result_type, DataType):
             raise TypeError(
                 "Invalid returnType: returnType should be DataType but is {}".format(result_type))
+        if accumulator_type is not None and not isinstance(accumulator_type, DataType):
+            raise TypeError(
+                "Invalid accumulator_type: accumulator_type should be DataType but is {}".format(
+                    accumulator_type))
         self._result_type = result_type
-        self._udaf_type = udaf_type
-        self._judaf_placeholder = None
+        self._accumulator_type = accumulator_type
 
-    def java_user_defined_function(self):
-        if self._judaf_placeholder is None:
-            self._judaf_placeholder = self._create_judaf()
-        return self._judaf_placeholder
-
-    def _create_judaf(self):
-        gateway = get_gateway()
-
-        def get_python_function_kind(udf_type):
-            JPythonFunctionKind = gateway.jvm.org.apache.flink.table.functions.python. \
-                PythonFunctionKind
-            if udf_type == "general":
-                return JPythonFunctionKind.GENERAL
-            elif udf_type == "pandas":
-                return JPythonFunctionKind.PANDAS
-            else:
-                raise TypeError("Unsupported udf_type: %s." % udf_type)
-
-        func = self._func
-        if not isinstance(self._func, UserDefinedFunction):
-            func = DelegatingPandasAggregateFunction(self._func)
-
-        if self._udaf_type == "pandas":
-            func = WrapperPandasAggregateFunction(func)
-
-        if self._input_types is not None:
-            j_input_types = utils.to_jarray(
-                gateway.jvm.TypeInformation, [_to_java_type(i) for i in self._input_types])
-        else:
-            j_input_types = None
-
-        import cloudpickle
-        serialized_func = cloudpickle.dumps(func)
+    def _create_judf(self, serialized_func, j_input_types, j_function_kind):
+        if self._function_type == "pandas" and not self._accumulator_type:
+            from pyflink.table.types import DataTypes
+            self._accumulator_type = DataTypes.ARRAY(self._result_type)
 
         j_result_type = _to_java_type(self._result_type)
-        j_function_kind = get_python_function_kind(self._udaf_type)
+        j_accumulator_type = _to_java_type(self._accumulator_type)
+
+        gateway = get_gateway()
         PythonAggregateFunction = gateway.jvm \
             .org.apache.flink.table.functions.python.PythonAggregateFunction
         j_aggregate_function = PythonAggregateFunction(
@@ -493,10 +461,14 @@ class UserDefinedAggregateFunctionWrapper(UserDefinedFunctionWrapper):
             bytearray(serialized_func),
             j_input_types,
             j_result_type,
+            j_accumulator_type,
             j_function_kind,
             self._deterministic,
             _get_python_env())
         return j_aggregate_function
+
+    def _create_delegate_function(self) -> UserDefinedFunction:
+        return DelegatingPandasAggregateFunction(self._func)
 
 
 # TODO: support to configure the python execution environment
@@ -506,22 +478,22 @@ def _get_python_env():
     return gateway.jvm.org.apache.flink.table.functions.python.PythonEnv(exec_type)
 
 
-def _create_udf(f, input_types, result_type, udf_type, deterministic, name):
+def _create_udf(f, input_types, result_type, function_type, deterministic, name):
     return UserDefinedScalarFunctionWrapper(
-        f, input_types, result_type, udf_type, deterministic, name)
+        f, input_types, result_type, function_type, deterministic, name)
 
 
 def _create_udtf(f, input_types, result_types, deterministic, name):
     return UserDefinedTableFunctionWrapper(f, input_types, result_types, deterministic, name)
 
 
-def _create_udaf(f, input_types, result_type, udaf_type, deterministic, name):
+def _create_udaf(f, input_types, result_type, accumulator_type, function_type, deterministic, name):
     return UserDefinedAggregateFunctionWrapper(
-        f, input_types, result_type, udaf_type, deterministic, name)
+        f, input_types, result_type, accumulator_type, function_type, deterministic, name)
 
 
 def udf(f=None, input_types=None, result_type=None, deterministic=None, name=None,
-        udf_type="general"):
+        function_type="general"):
     """
     Helper method for creating a user-defined function.
 
@@ -552,23 +524,25 @@ def udf(f=None, input_types=None, result_type=None, deterministic=None, name=Non
     :type deterministic: bool
     :param name: the function name.
     :type name: str
-    :param udf_type: the type of the python function, available value: general, pandas,
+    :param function_type: the type of the python function, available value: general, pandas,
                      (default: general)
-    :type udf_type: str
+    :type function_type: str
     :return: UserDefinedScalarFunctionWrapper or function.
     :rtype: UserDefinedScalarFunctionWrapper or function
 
     .. versionadded:: 1.10.0
     """
-    if udf_type not in ('general', 'pandas'):
-        raise ValueError("The udf_type must be one of 'general, pandas', got %s." % udf_type)
+    if function_type not in ('general', 'pandas'):
+        raise ValueError("The function_type must be one of 'general, pandas', got %s."
+                         % function_type)
 
     # decorator
     if f is None:
         return functools.partial(_create_udf, input_types=input_types, result_type=result_type,
-                                 udf_type=udf_type, deterministic=deterministic, name=name)
+                                 function_type=function_type, deterministic=deterministic,
+                                 name=name)
     else:
-        return _create_udf(f, input_types, result_type, udf_type, deterministic, name)
+        return _create_udf(f, input_types, result_type, function_type, deterministic, name)
 
 
 def udtf(f=None, input_types=None, result_types=None, deterministic=None, name=None):
@@ -614,8 +588,8 @@ def udtf(f=None, input_types=None, result_types=None, deterministic=None, name=N
         return _create_udtf(f, input_types, result_types, deterministic, name)
 
 
-def udaf(f=None, input_types=None, result_type=None, deterministic=None, name=None,
-         udaf_type="pandas"):
+def udaf(f=None, input_types=None, result_type=None, accumulator_type=None, deterministic=None,
+         name=None, function_type="pandas"):
     """
     Helper method for creating a user-defined aggregate function.
 
@@ -623,7 +597,7 @@ def udaf(f=None, input_types=None, result_type=None, deterministic=None, name=No
         ::
 
             >>> # The input_types is optional.
-            >>> @udaf(result_type=DataTypes.FLOAT(), udaf_type="pandas")
+            >>> @udaf(result_type=DataTypes.FLOAT(), function_type="pandas")
             ... def mean_udaf(v):
             ...     return v.mean()
 
@@ -633,24 +607,30 @@ def udaf(f=None, input_types=None, result_type=None, deterministic=None, name=No
     :type input_types: list[DataType] or DataType
     :param result_type: the result data type.
     :type result_type: DataType
+    :param accumulator_type: the accumulator data type.
+    :type accumulator_type: DataType
     :param deterministic: the determinism of the function's results. True if and only if a call to
                           this function is guaranteed to always return the same result given the
                           same parameters. (default True)
     :type deterministic: bool
     :param name: the function name.
     :type name: str
-    :param udaf_type: the type of the python function, available value: general, pandas,
+    :param function_type: the type of the python function, available value: general, pandas,
                      (default: pandas)
-    :type udaf_type: str
+    :type function_type: str
     :return: UserDefinedAggregateFunctionWrapper or function.
     :rtype: UserDefinedAggregateFunctionWrapper or function
 
-
     .. versionadded:: 1.12.0
     """
+    if function_type not in ('general', 'pandas'):
+        raise ValueError("The function_type must be one of 'general, pandas', got %s."
+                         % function_type)
     # decorator
     if f is None:
         return functools.partial(_create_udaf, input_types=input_types, result_type=result_type,
-                                 udaf_type=udaf_type, deterministic=deterministic, name=name)
+                                 accumulator_type=accumulator_type, function_type=function_type,
+                                 deterministic=deterministic, name=name)
     else:
-        return _create_udaf(f, input_types, result_type, udaf_type, deterministic, name)
+        return _create_udaf(f, input_types, result_type, accumulator_type, function_type,
+                            deterministic, name)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
@@ -43,6 +43,7 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
 	private final byte[] serializedAggregateFunction;
 	private final TypeInformation[] inputTypes;
 	private final TypeInformation resultType;
+	private final TypeInformation accumulatorType;
 	private final PythonFunctionKind pythonFunctionKind;
 	private final boolean deterministic;
 	private final PythonEnv pythonEnv;
@@ -52,6 +53,7 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
 		byte[] serializedAggregateFunction,
 		TypeInformation[] inputTypes,
 		TypeInformation resultType,
+		TypeInformation accumulatorType,
 		PythonFunctionKind pythonFunctionKind,
 		boolean deterministic,
 		PythonEnv pythonEnv) {
@@ -59,6 +61,7 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
 		this.serializedAggregateFunction = serializedAggregateFunction;
 		this.inputTypes = inputTypes;
 		this.resultType = resultType;
+		this.accumulatorType = accumulatorType;
 		this.pythonFunctionKind = pythonFunctionKind;
 		this.deterministic = deterministic;
 		this.pythonEnv = pythonEnv;
@@ -106,7 +109,7 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
 
 	@Override
 	public TypeInformation getAccumulatorType() {
-		return resultType;
+		return accumulatorType;
 	}
 
 	@Override
@@ -120,6 +123,7 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
 		}
 		return builder
 			.outputTypeStrategy(TypeStrategies.explicit(TypeConversions.fromLegacyInfoToDataType(resultType)))
+			.accumulatorTypeStrategy(TypeStrategies.explicit(TypeConversions.fromLegacyInfoToDataType(accumulatorType)))
 			.build();
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * The wrapper of user defined python aggregate function.
+ */
+@Internal
+public class PythonAggregateFunction extends AggregateFunction implements PythonFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String name;
+	private final byte[] serializedAggregateFunction;
+	private final TypeInformation[] inputTypes;
+	private final TypeInformation resultType;
+	private final PythonFunctionKind pythonFunctionKind;
+	private final boolean deterministic;
+	private final PythonEnv pythonEnv;
+
+	public PythonAggregateFunction(
+		String name,
+		byte[] serializedAggregateFunction,
+		TypeInformation[] inputTypes,
+		TypeInformation resultType,
+		PythonFunctionKind pythonFunctionKind,
+		boolean deterministic,
+		PythonEnv pythonEnv) {
+		this.name = name;
+		this.serializedAggregateFunction = serializedAggregateFunction;
+		this.inputTypes = inputTypes;
+		this.resultType = resultType;
+		this.pythonFunctionKind = pythonFunctionKind;
+		this.deterministic = deterministic;
+		this.pythonEnv = pythonEnv;
+	}
+
+	public void accumulate(Object accumulator, Object... args) {
+		throw new UnsupportedOperationException(
+			"This method is a placeholder and should not be called.");
+	}
+
+	@Override
+	public Object getValue(Object accumulator) {
+		return null;
+	}
+
+	@Override
+	public Object createAccumulator() {
+		return null;
+	}
+
+	@Override
+	public byte[] getSerializedPythonFunction() {
+		return serializedAggregateFunction;
+	}
+
+	@Override
+	public PythonEnv getPythonEnv() {
+		return pythonEnv;
+	}
+
+	@Override
+	public PythonFunctionKind getPythonFunctionKind() {
+		return pythonFunctionKind;
+	}
+
+	@Override
+	public boolean isDeterministic() {
+		return deterministic;
+	}
+
+	@Override
+	public TypeInformation getResultType() {
+		return resultType;
+	}
+
+	@Override
+	public TypeInformation getAccumulatorType() {
+		return resultType;
+	}
+
+	@Override
+	public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+		TypeInference.Builder builder = TypeInference.newBuilder();
+		if (inputTypes != null) {
+			final List<DataType> argumentDataTypes = Stream.of(inputTypes)
+				.map(TypeConversions::fromLegacyInfoToDataType)
+				.collect(Collectors.toList());
+			builder.typedArguments(argumentDataTypes);
+		}
+		return builder
+			.outputTypeStrategy(TypeStrategies.explicit(TypeConversions.fromLegacyInfoToDataType(resultType)))
+			.build();
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.common
+
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo}
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction
+import org.apache.flink.table.planner.functions.utils.AggSqlFunction
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+trait CommonPythonAggregate extends CommonPythonBase {
+
+  protected def extractPythonAggregateFunctionInfos(
+      aggCalls: Seq[AggregateCall]): (Array[Int], Array[PythonFunctionInfo]) = {
+    val inputNodes = new mutable.LinkedHashMap[Integer, Integer]()
+    val pythonFunctionInfos: Seq[PythonFunctionInfo] = aggCalls.map {
+      aggregateCall: AggregateCall =>
+        val inputs = new mutable.ArrayBuffer[AnyRef]()
+        val argList = aggregateCall.getArgList
+        for (arg <- argList) {
+          inputNodes.get(arg) match {
+            case Some(existing) => inputs.append(existing)
+            case None => val inputOffset = Integer.valueOf(inputNodes.size)
+              inputs.append(inputOffset)
+              inputNodes.put(arg, inputOffset)
+          }
+        }
+        val pythonFunction = aggregateCall.getAggregation match {
+          case function: AggSqlFunction =>
+            function.aggregateFunction.asInstanceOf[PythonFunction]
+          case function: BridgingSqlAggFunction =>
+            function.getDefinition.asInstanceOf[PythonFunction]
+        }
+        new PythonFunctionInfo(pythonFunction, inputs.toArray)
+    }
+    val udafInputOffsets = inputNodes.toArray.map(_._1.toInt)
+    (udafInputOffsets, pythonFunctionInfos.toArray)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
@@ -19,15 +19,23 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.operators.DamBehavior
-import org.apache.flink.table.api.TableException
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.functions.python.PythonFunctionInfo
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
+import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
 import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecPythonGroupAggregate.ARROW_PYTHON_AGGREGATE_FUNCTION_OPERATOR_NAME
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.flink.table.types.logical.RowType
 
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelTraitSet}
 import org.apache.calcite.rel.RelDistribution.Type.{HASH_DISTRIBUTED, SINGLETON}
@@ -66,7 +74,8 @@ class BatchExecPythonGroupAggregate(
     aggCalls.zip(aggFunctions),
     isMerge = false,
     isFinal = true)
-  with BatchExecNode[RowData] {
+  with BatchExecNode[RowData]
+  with CommonPythonAggregate {
 
   override def getDamBehavior: DamBehavior = DamBehavior.FULL_DAM
 
@@ -168,6 +177,78 @@ class BatchExecPythonGroupAggregate(
 
   override protected def translateToPlanInternal(
       planner: BatchPlanner): Transformation[RowData] = {
-    throw new TableException("The implementation will be in FLINK-19186.")
+    val input = getInputNodes.get(0).translateToPlan(planner)
+      .asInstanceOf[Transformation[RowData]]
+    val outputType = FlinkTypeFactory.toLogicalRowType(getRowType)
+    val inputType = FlinkTypeFactory.toLogicalRowType(inputRowType)
+
+    val ret = createPythonOneInputTransformation(
+      input,
+      inputType,
+      outputType,
+      grouping,
+      getConfig(planner.getExecEnv, planner.getTableConfig))
+    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+      ExecNode.setManagedMemoryWeight(
+        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+    }
+    ret
   }
+
+  private[this] def createPythonOneInputTransformation(
+      inputTransform: Transformation[RowData],
+      inputRowType: RowType,
+      outputRowType: RowType,
+      groupingSet: Array[Int],
+      config: Configuration): OneInputTransformation[RowData, RowData] = {
+
+    val (pythonUdafInputOffsets, pythonFunctionInfos) =
+      extractPythonAggregateFunctionInfos(aggCalls)
+
+    val pythonOperator = getPythonAggregateFunctionOperator(
+      config,
+      inputRowType,
+      outputRowType,
+      pythonUdafInputOffsets,
+      pythonFunctionInfos)
+
+    new OneInputTransformation(
+      inputTransform,
+      "BatchExecPythonGroupAggregate",
+      pythonOperator,
+      InternalTypeInfo.of(outputRowType),
+      inputTransform.getParallelism)
+  }
+
+  private[this] def getPythonAggregateFunctionOperator(
+      config: Configuration,
+      inputRowType: RowType,
+      outputRowType: RowType,
+      udafInputOffsets: Array[Int],
+      pythonFunctionInfos: Array[PythonFunctionInfo]): OneInputStreamOperator[RowData, RowData] = {
+    val clazz = loadClass(ARROW_PYTHON_AGGREGATE_FUNCTION_OPERATOR_NAME)
+
+    val ctor = clazz.getConstructor(
+      classOf[Configuration],
+      classOf[Array[PythonFunctionInfo]],
+      classOf[RowType],
+      classOf[RowType],
+      classOf[Array[Int]],
+      classOf[Array[Int]],
+      classOf[Array[Int]])
+    ctor.newInstance(
+      config,
+      pythonFunctionInfos,
+      inputRowType,
+      outputRowType,
+      grouping,
+      grouping ++ auxGrouping,
+      udafInputOffsets).asInstanceOf[OneInputStreamOperator[RowData, RowData]]
+  }
+}
+
+object BatchExecPythonGroupAggregate {
+  val ARROW_PYTHON_AGGREGATE_FUNCTION_OPERATOR_NAME: String =
+    "org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch." +
+      "BatchArrowPythonGroupAggregateFunctionOperator"
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
@@ -186,7 +186,6 @@ class BatchExecPythonGroupAggregate(
       input,
       inputType,
       outputType,
-      grouping,
       getConfig(planner.getExecEnv, planner.getTableConfig))
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
       ExecNode.setManagedMemoryWeight(
@@ -199,7 +198,6 @@ class BatchExecPythonGroupAggregate(
       inputTransform: Transformation[RowData],
       inputRowType: RowType,
       outputRowType: RowType,
-      groupingSet: Array[Int],
       config: Configuration): OneInputTransformation[RowData, RowData] = {
 
     val (pythonUdafInputOffsets, pythonFunctionInfos) =


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add Python building blocks to make sure the basic functionality of Pandas Batch Group Aggregation could work*


## Brief change log

  - *Add Aggregation interface*
  - *Add udaf decorator*
  - *Add PandasAggregateFunctionOperation*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add IT test test_group_aggregate_function in test_pandas_udaf.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
