### PR TITLE
[FLINK-19286][runtime] Improve pipelined region scheduling performance

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -27,8 +27,10 @@ import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
 import org.apache.flink.runtime.scheduler.SchedulerOperations;
 import org.apache.flink.util.IterableUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,6 +55,8 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 
 	private final Map<IntermediateResultPartitionID, Set<SchedulingPipelinedRegion>> partitionConsumerRegions = new HashMap<>();
 
+	private final Map<SchedulingPipelinedRegion, List<ExecutionVertexID>> regionVerticesSorted = new IdentityHashMap<>();
+
 	public PipelinedRegionSchedulingStrategy(
 			final SchedulerOperations schedulerOperations,
 			final SchedulingTopology schedulingTopology) {
@@ -71,6 +75,11 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 				partitionConsumerRegions.computeIfAbsent(partition.getId(), pid -> new HashSet<>()).add(region);
 				correlatedResultPartitions.computeIfAbsent(partition.getResultId(), rid -> new HashSet<>()).add(partition);
 			}
+		}
+
+		for (SchedulingExecutionVertex vertex : schedulingTopology.getVertices()) {
+			final SchedulingPipelinedRegion region = schedulingTopology.getPipelinedRegionOfVertex(vertex.getId());
+			regionVerticesSorted.computeIfAbsent(region, r -> new ArrayList<>()).add(vertex.getId());
 		}
 	}
 
@@ -127,13 +136,9 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 
 		checkState(areRegionVerticesAllInCreatedState(region), "BUG: trying to schedule a region which is not in CREATED state");
 
-		final Set<ExecutionVertexID> verticesToSchedule = IterableUtils.toStream(region.getVertices())
-			.map(SchedulingExecutionVertex::getId)
-			.collect(Collectors.toSet());
 		final List<ExecutionVertexDeploymentOption> vertexDeploymentOptions =
-			SchedulingStrategyUtils.createExecutionVertexDeploymentOptionsInTopologicalOrder(
-				schedulingTopology,
-				verticesToSchedule,
+			SchedulingStrategyUtils.createExecutionVertexDeploymentOptions(
+				regionVerticesSorted.get(region),
 				id -> deploymentOption);
 		schedulerOperations.allocateSlotsAndDeploy(vertexDeploymentOptions);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -139,13 +139,21 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 	}
 
 	private boolean areRegionInputsAllConsumable(final SchedulingPipelinedRegion region) {
-		return IterableUtils.toStream(region.getConsumedResults())
-			.allMatch(partition -> partition.getState() == ResultPartitionState.CONSUMABLE);
+		for (SchedulingResultPartition partition : region.getConsumedResults()) {
+			if (partition.getState() != ResultPartitionState.CONSUMABLE) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private boolean areRegionVerticesAllInCreatedState(final SchedulingPipelinedRegion region) {
-		return IterableUtils.toStream(region.getVertices())
-			.allMatch(vertex -> vertex.getState() == ExecutionState.CREATED);
+		for (SchedulingExecutionVertex vertex : region.getVertices()) {
+			if (vertex.getState() != ExecutionState.CREATED) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.IterableUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -80,6 +81,14 @@ class SchedulingStrategyUtils {
 	static List<SchedulingPipelinedRegion> sortPipelinedRegionsInTopologicalOrder(
 			final SchedulingTopology topology,
 			final Set<SchedulingPipelinedRegion> regions) {
+
+		// Avoid the O(V) (V is the number of vertices in the topology) sorting
+		// complexity if the given set of regions is small enough
+		if (regions.size() == 0) {
+			return Collections.emptyList();
+		} else if (regions.size() == 1) {
+			return Collections.singletonList(regions.iterator().next());
+		}
 
 		return IterableUtils.toStream(topology.getVertices())
 			.map(SchedulingExecutionVertex::getId)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.scheduler.DeploymentOption;
 import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
 import org.apache.flink.util.IterableUtils;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -59,6 +61,20 @@ class SchedulingStrategyUtils {
 				executionVertexID,
 				deploymentOptionRetriever.apply(executionVertexID)))
 			.collect(Collectors.toList());
+	}
+
+	static List<ExecutionVertexDeploymentOption> createExecutionVertexDeploymentOptions(
+			final Collection<ExecutionVertexID> verticesToDeploy,
+			final Function<ExecutionVertexID, DeploymentOption> deploymentOptionRetriever) {
+
+		final List<ExecutionVertexDeploymentOption> deploymentOptions = new ArrayList<>(verticesToDeploy.size());
+		for (ExecutionVertexID executionVertexId : verticesToDeploy) {
+			final ExecutionVertexDeploymentOption deploymentOption = new ExecutionVertexDeploymentOption(
+				executionVertexId,
+				deploymentOptionRetriever.apply(executionVertexId));
+			deploymentOptions.add(deploymentOption);
+		}
+		return deploymentOptions;
 	}
 
 	static List<SchedulingPipelinedRegion> sortPipelinedRegionsInTopologicalOrder(


### PR DESCRIPTION
## What is the purpose of the change

This PR is to fix the performance regression of pipelined region scheduling due to the suboptimal implementation of PipelinedRegionSchedulingStrategy, including:
1. topologically sorting of vertices to deploy
2. unnecessary O(V) loop when sorting an empty set of regions

## Verifying this change

This change is already covered by existing tests of pipelined region scheduling

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
