### PR TITLE
[FLINK-19269] Make the PushingAsyncDataInput.DataOutput aware of endOfInput

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.EndOfInputUtil;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
@@ -71,10 +72,6 @@ public abstract class AbstractInput<IN, OUT> implements Input<IN>, BoundedOneInp
 
 	@Override
 	public void endInput() throws Exception {
-		if (owner instanceof BoundedOneInput && inputId == 1) {
-			((BoundedOneInput) owner).endInput();
-		} else if (owner instanceof BoundedMultiInput) {
-			((BoundedMultiInput) owner).endInput(inputId);
-		}
+		EndOfInputUtil.endInput(owner, inputId);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
@@ -33,7 +33,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * {@link AbstractStreamOperatorV2}.
  */
 @Experimental
-public abstract class AbstractInput<IN, OUT> implements Input<IN> {
+public abstract class AbstractInput<IN, OUT> implements Input<IN>, BoundedOneInput {
 	/**
 	 * {@code KeySelector} for extracting a key from an element being processed. This is used to
 	 * scope keyed state to a key. This is null if the operator is not a keyed operator.
@@ -67,5 +67,14 @@ public abstract class AbstractInput<IN, OUT> implements Input<IN> {
 	@Override
 	public void setKeyContextElement(StreamRecord record) throws Exception {
 		owner.internalSetKeyContextElement(record, stateKeySelector);
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		if (owner instanceof BoundedOneInput && inputId == 1) {
+			((BoundedOneInput) owner).endInput();
+		} else if (owner instanceof BoundedMultiInput) {
+			((BoundedMultiInput) owner).endInput(inputId);
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -60,13 +60,12 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 			final StreamStatusMaintainer streamStatusMaintainer,
 			final OperatorChain<?, ?> operatorChain) throws Exception {
 
-		run(lockingObject, streamStatusMaintainer, output, operatorChain);
+		run(lockingObject, streamStatusMaintainer, output);
 	}
 
 	public void run(final Object lockingObject,
 			final StreamStatusMaintainer streamStatusMaintainer,
-			final Output<StreamRecord<OUT>> collector,
-			final OperatorChain<?, ?> operatorChain) throws Exception {
+			final Output<StreamRecord<OUT>> collector) throws Exception {
 
 		final TimeCharacteristic timeCharacteristic = getOperatorConfig().getTimeCharacteristic();
 
@@ -107,7 +106,11 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 				// in theory, the subclasses of StreamSource may implement the BoundedOneInput interface,
 				// so we still need the following call to end the input
 				synchronized (lockingObject) {
-					operatorChain.endMainOperatorInput(1);
+					if (this instanceof BoundedOneInput) {
+						((BoundedOneInput) this).endInput();
+					} else if (this instanceof BoundedMultiInput) {
+						((BoundedMultiInput) this).endInput(1);
+					}
 				}
 			}
 		} finally {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
@@ -21,6 +21,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 
+import java.io.IOException;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -42,5 +44,10 @@ public abstract class AbstractDataOutput<T> implements EndOfInputAwareDataOutput
 	@Override
 	public void emitStreamStatus(StreamStatus streamStatus) {
 		streamStatusMaintainer.toggleStreamStatus(streamStatus);
+	}
+
+	@Override
+	public void close() throws IOException {
+		// do nothing by default
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractDataOutput.java
@@ -30,7 +30,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The output type
  */
 @Internal
-public abstract class AbstractDataOutput<T> implements PushingAsyncDataInput.DataOutput<T> {
+public abstract class AbstractDataOutput<T> implements EndOfInputAwareDataOutput<T> {
 
 	/** The maintainer toggles the current stream status. */
 	protected final StreamStatusMaintainer streamStatusMaintainer;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputAwareDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputAwareDataOutput.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A {@link PushingAsyncDataInput.DataOutput} interface that will be notified upon receiving end of input.
+ *
+ * @param <T> The type encapsulated with the stream record.
+ */
+@Internal
+public interface EndOfInputAwareDataOutput<T> extends PushingAsyncDataInput.DataOutput<T> {
+	void endOutput() throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputAwareDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputAwareDataOutput.java
@@ -20,12 +20,14 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
 
+import java.io.Closeable;
+
 /**
  * A {@link PushingAsyncDataInput.DataOutput} interface that will be notified upon receiving end of input.
  *
  * @param <T> The type encapsulated with the stream record.
  */
 @Internal
-public interface EndOfInputAwareDataOutput<T> extends PushingAsyncDataInput.DataOutput<T> {
+public interface EndOfInputAwareDataOutput<T> extends PushingAsyncDataInput.DataOutput<T>, Closeable {
 	void endOutput() throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+
+/**
+ * Utils for forwarding the end of input signal to the {@link BoundedOneInput} and {@link BoundedMultiInput}.
+ */
+public final class EndOfInputUtil {
+
+	/**
+	 * Notifies the given input about end of input.
+	 */
+	public static void endInput(Input<?> input) throws Exception {
+		if (input instanceof BoundedOneInput) {
+			((BoundedOneInput) input).endInput();
+		}
+	}
+
+	/**
+	 * Notifies the given operator about end of input.
+	 */
+	public static void endInput(OneInputStreamOperator<?, ?> operator) throws Exception {
+		if (operator instanceof BoundedOneInput) {
+			((BoundedOneInput) operator).endInput();
+		}
+	}
+
+	/**
+	 * Notifies the given operator about end of input of given index.
+	 */
+	public static void endInput(TwoInputStreamOperator<?, ?, ?> operator, int inputIdx) throws Exception {
+		if (operator instanceof BoundedMultiInput) {
+			((BoundedMultiInput) operator).endInput(inputIdx);
+		}
+	}
+
+	/**
+	 * Notifies the given operator about end of input of given index.
+	 */
+	public static void endInput(MultipleInputStreamOperator<?> operator, int inputIdx) throws Exception {
+		if (operator instanceof BoundedOneInput && inputIdx == 1) {
+			((BoundedOneInput) operator).endInput();
+		}
+		if (operator instanceof BoundedMultiInput) {
+			((BoundedMultiInput) operator).endInput(inputIdx);
+		}
+	}
+
+	private EndOfInputUtil() {
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/EndOfInputUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.io;
 
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.Input;
@@ -29,13 +30,12 @@ import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
  * Utils for forwarding the end of input signal to the {@link BoundedOneInput} and {@link BoundedMultiInput}.
  */
 public final class EndOfInputUtil {
-
 	/**
 	 * Notifies the given input about end of input.
 	 */
 	public static void endInput(Input<?> input) throws Exception {
 		if (input instanceof BoundedOneInput) {
-			((BoundedOneInput) input).endInput();
+			endInput((BoundedOneInput) input);
 		}
 	}
 
@@ -44,7 +44,7 @@ public final class EndOfInputUtil {
 	 */
 	public static void endInput(OneInputStreamOperator<?, ?> operator) throws Exception {
 		if (operator instanceof BoundedOneInput) {
-			((BoundedOneInput) operator).endInput();
+			endInput((BoundedOneInput) operator);
 		}
 	}
 
@@ -53,7 +53,7 @@ public final class EndOfInputUtil {
 	 */
 	public static void endInput(TwoInputStreamOperator<?, ?, ?> operator, int inputIdx) throws Exception {
 		if (operator instanceof BoundedMultiInput) {
-			((BoundedMultiInput) operator).endInput(inputIdx);
+			endInput((BoundedMultiInput) operator, inputIdx);
 		}
 	}
 
@@ -61,12 +61,53 @@ public final class EndOfInputUtil {
 	 * Notifies the given operator about end of input of given index.
 	 */
 	public static void endInput(MultipleInputStreamOperator<?> operator, int inputIdx) throws Exception {
-		if (operator instanceof BoundedOneInput && inputIdx == 1) {
-			((BoundedOneInput) operator).endInput();
-		}
 		if (operator instanceof BoundedMultiInput) {
-			((BoundedMultiInput) operator).endInput(inputIdx);
+			endInput((BoundedMultiInput) operator, inputIdx);
 		}
+	}
+
+	/**
+	 * Notifies the given operator about end of input of given index.
+	 */
+	public static void endInput(AbstractStreamOperatorV2<?> operator, int inputIdx) throws Exception {
+		if (operator instanceof BoundedOneInput) {
+			if (inputIdx == 1) {
+				endInput((BoundedOneInput) operator);
+			} else {
+				throw new IllegalStateException(
+					String.format(
+						"Illegal combination of multiple input stream operator and BoundedOneInput for class: %s." +
+							" Multiple input operators can implement only BoundedMultiInput interface.",
+						operator.getClass()
+					));
+			}
+		} else if (operator instanceof BoundedMultiInput) {
+			endInput((BoundedMultiInput) operator, inputIdx);
+		}
+	}
+
+	private static void endInput(BoundedOneInput boundedOneInput) throws Exception {
+		if (boundedOneInput instanceof BoundedMultiInput) {
+			throw new IllegalStateException(
+				String.format(
+					"Illegal combination of one input stream operator and BoundedMultiInput for class: %s." +
+						" Only two/multi input operators can implement BoundedMultiInput interface.",
+					boundedOneInput.getClass()
+				));
+		}
+		boundedOneInput.endInput();
+	}
+
+	private static void endInput(BoundedMultiInput boundedMultiInput, int inputIdx) throws Exception {
+		if (boundedMultiInput instanceof BoundedOneInput) {
+			throw new IllegalStateException(
+				String.format(
+					"Illegal combination of multiple input stream operator and BoundedOneInput for class: %s." +
+						" Multiple input operators can implement only BoundedMultiInput interface.",
+					boundedMultiInput.getClass()
+				));
+		}
+		boundedMultiInput.endInput(inputIdx);
 	}
 
 	private EndOfInputUtil() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
@@ -57,7 +57,5 @@ public interface PushingAsyncDataInput<T> extends AvailabilityProvider {
 		void emitStreamStatus(StreamStatus streamStatus) throws Exception;
 
 		void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception;
-
-		default void endOutput() throws Exception {}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
@@ -57,5 +57,7 @@ public interface PushingAsyncDataInput<T> extends AvailabilityProvider {
 		void emitStreamStatus(StreamStatus streamStatus) throws Exception;
 
 		void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception;
+
+		default void endOutput() throws Exception {}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -260,7 +260,22 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 		}
 
 		public void close() throws IOException {
-			taskInput.close();
+			IOException ex = null;
+			try {
+				taskInput.close();
+			} catch (IOException e) {
+				ex = e;
+			}
+
+			try {
+				dataOutput.close();
+			} catch (IOException e) {
+				ex = ExceptionUtils.firstOrSuppressed(e, ex);
+			}
+
+			if (ex != null) {
+				throw ex;
+			}
 		}
 
 		public CompletableFuture<?> prepareSnapshot(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,21 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 
 	@Override
 	public void close() throws IOException {
-		input.close();
+		IOException ex = null;
+		try {
+			input.close();
+		} catch (IOException e) {
+			ex = e;
+		}
+
+		try {
+			output.close();
+		} catch (IOException e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		if (ex != null) {
+			throw ex;
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
-import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,16 +44,12 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	private final StreamTaskInput<IN> input;
 	private final DataOutput<IN> output;
 
-	private final OperatorChain<?, ?> operatorChain;
-
 	public StreamOneInputProcessor(
 			StreamTaskInput<IN> input,
-			DataOutput<IN> output,
-			OperatorChain<?, ?> operatorChain) {
+			DataOutput<IN> output) {
 
 		this.input = checkNotNull(input);
 		this.output = checkNotNull(output);
-		this.operatorChain = checkNotNull(operatorChain);
 	}
 
 	@Override
@@ -67,7 +62,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 		InputStatus status = input.emitNext(output);
 
 		if (status == InputStatus.END_OF_INPUT) {
-			operatorChain.endMainOperatorInput(1);
+			output.endOutput();
 		}
 
 		return status;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
-import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,11 +41,11 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	private static final Logger LOG = LoggerFactory.getLogger(StreamOneInputProcessor.class);
 
 	private final StreamTaskInput<IN> input;
-	private final DataOutput<IN> output;
+	private final EndOfInputAwareDataOutput<IN> output;
 
 	public StreamOneInputProcessor(
 			StreamTaskInput<IN> input,
-			DataOutput<IN> output) {
+			EndOfInputAwareDataOutput<IN> output) {
 
 		this.input = checkNotNull(input);
 		this.output = checkNotNull(output);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -231,11 +231,23 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		try {
 			input1.close();
 		} catch (IOException e) {
-			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+			ex = e;
 		}
 
 		try {
 			input2.close();
+		} catch (IOException e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		try {
+			output1.close();
+		} catch (IOException e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		try {
+			output2.close();
 		} catch (IOException e) {
 			ex = ExceptionUtils.firstOrSuppressed(e, ex);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -376,17 +376,6 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 	}
 
 	/**
-	 * Ends the main operator input specified by {@code inputId}).
-	 *
-	 * @param inputId the input ID starts from 1 which indicates the first input.
-	 */
-	public void endMainOperatorInput(int inputId) throws Exception {
-		if (mainOperatorWrapper != null) {
-			mainOperatorWrapper.endOperatorInput(inputId);
-		}
-	}
-
-	/**
 	 * Initialize state and open all operators in the chain from <b>tail to heads</b>,
 	 * contrary to {@link StreamOperator#close()} which happens <b>heads to tail</b>
 	 * (see {@link #closeOperators(StreamTaskActionExecutor)}).

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.AbstractDataOutput;
+import org.apache.flink.streaming.runtime.io.EndOfInputAwareDataOutput;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
@@ -47,7 +48,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 	@Override
 	public void init() {
 		StreamTaskInput<T> input = new StreamTaskSourceInput<>(mainOperator, 0);
-		DataOutput<T> output = new AsyncDataOutputToOutput<>(
+		EndOfInputAwareDataOutput<T> output = new AsyncDataOutputToOutput<>(
 			operatorChain.getMainOperatorOutput(),
 			getStreamStatusMaintainer());
 
@@ -85,6 +86,11 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 		@Override
 		public void emitWatermark(Watermark watermark) {
 			output.emitWatermark(watermark);
+		}
+
+		@Override
+		public void endOutput() throws Exception {
+
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -53,8 +53,8 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 
 		inputProcessor = new StreamOneInputProcessor<>(
 			input,
-			output,
-			operatorChain);
+			output
+		);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
@@ -94,7 +94,7 @@ public class StreamOperatorWrapper<OUT, OP extends StreamOperator<OUT>> {
 	 *
 	 * @param inputId the input ID starts from 1 which indicates the first input.
 	 */
-	public void endOperatorInput(int inputId) throws Exception {
+	private void endOperatorInput(int inputId) throws Exception {
 		if (wrapped instanceof BoundedOneInput) {
 			((BoundedOneInput) wrapped).endInput();
 		} else if (wrapped instanceof BoundedMultiInput) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -76,7 +76,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			twoInputSelectionHandler,
 			input1WatermarkGauge,
 			input2WatermarkGauge,
-			operatorChain,
 			setupNumRecordsInCounter(mainOperator));
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -37,7 +37,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
-import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.SourceStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskTest;
@@ -237,10 +236,9 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		@Override
 		public void run(Object lockingObject,
 						StreamStatusMaintainer streamStatusMaintainer,
-						Output<StreamRecord<OUT>> collector,
-						OperatorChain<?, ?> operatorChain) throws Exception {
+						Output<StreamRecord<OUT>> collector) throws Exception {
 			ACTUAL_ORDER_TRACKING.add("OPERATOR::run");
-			super.run(lockingObject, streamStatusMaintainer, collector, operatorChain);
+			super.run(lockingObject, streamStatusMaintainer, collector);
 			runStarted.trigger();
 			runFinish.await();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -169,7 +169,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 			operator.getContainingTask(),
 			StreamTask.createRecordWriterDelegate(operator.getOperatorConfig(), new MockEnvironmentBuilder().build()));
 		try {
-			operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<>(output), operatorChain);
+			operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<>(output));
 			operator.close();
 		} finally {
 			operatorChain.releaseOutputs();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1460,8 +1460,7 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public void run(Object lockingObject,
 						StreamStatusMaintainer streamStatusMaintainer,
-						Output<StreamRecord<Long>> collector,
-						OperatorChain<?, ?> operatorChain) throws Exception {
+						Output<StreamRecord<Long>> collector) throws Exception {
 			while (!canceled) {
 				try {
 					Thread.sleep(500);


### PR DESCRIPTION

## What is the purpose of the change

In this PR PushingAsyncDataInput.DataOutput is notified
about the end of input. It also moves the propagation to the bounded
operators of that signal from OperatorChain to the DataOutputs.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
