### PR TITLE
[FLINK-19219] Run JobManager initialization in separate thread to make it cancellable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/InitializingJobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/InitializingJobManagerRunner.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.client.JobInitializationException;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Wrapper for an initializing JobManagerRunner.
+ */
+public class InitializingJobManagerRunner {
+	private final Logger log = LoggerFactory.getLogger(InitializingJobManagerRunner.class);
+
+	private final CompletableFuture<JobManagerRunner> jobManagerRunnerFuture = new CompletableFuture<>();
+
+	private final Thread initializationRunner;
+
+	private final Object lock = new Object();
+
+	@GuardedBy("lock")
+	private CompletableFuture<Acknowledge> cancellationFuture;
+
+	public InitializingJobManagerRunner(SupplierWithException<JobManagerRunner, JobInitializationException> initializationRunnable, JobID jobID) {
+		String threadName = "jobmanager-initialization-" + jobID;
+		this.initializationRunner = new Thread(() -> {
+			log.debug("Starting JobManager initialization thread: {}", threadName);
+			try {
+				runInitialization(initializationRunnable);
+			} catch (Throwable threadError) {
+				log.warn("Unexpected error in thread '{}'", threadName, threadError);
+			} finally {
+				log.debug("Stopping JobManager initialization thread: {}", threadName);
+			}
+		}, threadName);
+		this.initializationRunner.setDaemon(true); // this should not block the JVM from shutting down
+		this.initializationRunner.start();
+	}
+
+	private void runInitialization(SupplierWithException<JobManagerRunner, JobInitializationException> initializationRunnable) {
+		try {
+			JobManagerRunner runner = initializationRunnable.get();
+			synchronized (lock) {
+				if (cancellationFuture == null) {
+					jobManagerRunnerFuture.complete(runner);
+				} else {
+					// jobMaster has finished despite the interruption. Cancel job.
+					FutureUtils.forward(runner.getJobMasterGateway().thenCompose(gateway -> gateway.cancel(RpcUtils.INF_TIMEOUT)),
+						cancellationFuture);
+					jobManagerRunnerFuture.complete(runner);
+				}
+			}
+		} catch (JobInitializationException throwable) {
+			synchronized (lock) {
+				if (cancellationFuture == null) {
+					jobManagerRunnerFuture.completeExceptionally(throwable);
+				} else {
+					// an exception related to an interruption is expected here.
+					log.debug("Cancellation finished with (expected) exception", throwable);
+					jobManagerRunnerFuture.completeExceptionally(new JobInitializationCancelledException("Job initialization has been cancelled", throwable));
+					cancellationFuture.complete(Acknowledge.get());
+				}
+			}
+		}
+	}
+
+	public CompletableFuture<Acknowledge> cancelInitialization() {
+		synchronized (lock) {
+			initializationRunner.interrupt();
+			cancellationFuture = new CompletableFuture<>();
+			return cancellationFuture;
+		}
+	}
+
+	public CompletableFuture<JobManagerRunner> getJobManagerRunnerFuture() {
+		return jobManagerRunnerFuture;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobInitializationCancelledException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobInitializationCancelledException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+/**
+ * An exception signaling that the initialization of the job has been cancelled.
+ */
+public class JobInitializationCancelledException extends DispatcherException {
+	private static final long serialVersionUID = -9118443543892042001L;
+
+	public JobInitializationCancelledException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -416,7 +416,7 @@ public class DispatcherTest extends TestLogger {
 		jobMasterLeaderElectionService.isLeader(UUID.randomUUID());
 		DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
 
-		// create a job graph of a job that blocks forever
+		// create a job graph of a job that blocks forever, and will be interrupted
 		Tuple2<JobGraph, BlockingJobVertex> blockingJobGraph = getBlockingJobGraphAndVertex();
 		JobID jobID = blockingJobGraph.f0.getJobID();
 
@@ -428,8 +428,7 @@ public class DispatcherTest extends TestLogger {
 		CompletableFuture<Acknowledge> cancellationFuture = dispatcherGateway.cancelJob(jobID, TIMEOUT);
 		assertThat(dispatcherGateway.requestJobStatus(jobID, TIMEOUT).get(), is(JobStatus.CANCELLING));
 		assertThat(cancellationFuture.isDone(), is(false));
-		// unblock
-		blockingJobGraph.f1.unblock();
+
 		// wait until cancelled
 		cancellationFuture.get();
 		assertThat(dispatcherGateway.requestJobResult(jobID, TIMEOUT).get().getApplicationStatus(), is(ApplicationStatus.CANCELED));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -182,6 +182,11 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
 				LOG.info("Cancel recovered job {}.", jobGraph.getJobID());
 				// cancellation of the job should remove everything
 				final CompletableFuture<JobResult> jobResultFuture = dispatcherGateway.requestJobResult(jobGraph.getJobID(), TESTING_TIMEOUT);
+
+				// wait until job is initialized, otherwise we would cancel the initialization
+				final DispatcherGateway currentGateway = dispatcherGateway;
+				CommonTestUtils.waitUntilJobManagerIsInitialized(() -> currentGateway.requestJobStatus(jobGraph.getJobID(), TESTING_TIMEOUT).get());
+
 				dispatcherGateway.cancelJob(jobGraph.getJobID(), TESTING_TIMEOUT).get();
 
 				// a successful cancellation should eventually remove all job information


### PR DESCRIPTION

## What is the purpose of the change

If a job gets stuck in the INITIALIZING state, we can not properly cancel it in this stage.
What effectively happens is that we are waiting for the initialization to be over before cancelling the job.

This change runs the initialization in a separate thread, that we can interrupt in case the user issues a cancel call.

This approach does not guarantee that the initialization is cooperatively aborting the current operation. If it is not cooperating, we will wait and follow the old approach of cancelling.


## Brief change log

- Introduce `InitializingJobManagerRunner` class that hides the thread handling
- adjusted `Dispatcher` and `DispatcherJob` to cooperate with the new class 


## Verifying this change

I adjusted some existing tests. 
This is a draft PR, once it seems to be ok, I'll add a test for `InitializingJobManagerRunner`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / *no*)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / *no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (*no* / no / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / *no*)
  - If yes, how is the feature documented? (not applicable / docs / *JavaDocs* / not documented)
