### PR TITLE
[FLINK-19272][table-common] Add metadata interfaces for FLIP-107

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/DecodingFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/DecodingFormat.java
@@ -20,7 +20,12 @@ package org.apache.flink.table.connector.format;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.types.DataType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A {@link Format} for a {@link DynamicTableSource} for reading rows.
@@ -34,4 +39,35 @@ public interface DecodingFormat<I> extends Format {
 	 * Creates runtime decoder implementation that is configured to produce data of the given data type.
 	 */
 	I createRuntimeDecoder(DynamicTableSource.Context context, DataType producedDataType);
+
+	/**
+	 * Returns the map of metadata keys and their corresponding data types that can be produced by this
+	 * format for reading. By default, this method returns an empty map.
+	 *
+	 * <p>Metadata columns add additional columns to the table's schema. A decoding format is responsible
+	 * to add requested metadata columns at the end of produced rows.
+	 *
+	 * <p>See {@link SupportsReadingMetadata} for more information.
+	 *
+	 * <p>Note: This method is only used if the outer {@link DynamicTableSource} implements {@link SupportsReadingMetadata}
+	 * and calls this method in {@link SupportsReadingMetadata#listReadableMetadata()}.
+	 */
+	default Map<String, DataType> listReadableMetadata() {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Provides a list of metadata keys that the produced row must contain as appended metadata columns.
+	 * By default, this method throws an exception if metadata keys are defined.
+	 *
+	 * <p>See {@link SupportsReadingMetadata} for more information.
+	 *
+	 * <p>Note: This method is only used if the outer {@link DynamicTableSource} implements {@link SupportsReadingMetadata}
+	 * and calls this method in {@link SupportsReadingMetadata#applyReadableMetadata(List, DataType)}.
+	 */
+	@SuppressWarnings("unused")
+	default void applyReadableMetadata(List<String> metadataKeys) {
+		throw new UnsupportedOperationException(
+			"A decoding format must override this method to apply metadata keys.");
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/EncodingFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/EncodingFormat.java
@@ -20,7 +20,12 @@ package org.apache.flink.table.connector.format;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.abilities.SupportsWritingMetadata;
 import org.apache.flink.table.types.DataType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A {@link Format} for a {@link DynamicTableSink} for writing rows.
@@ -34,4 +39,35 @@ public interface EncodingFormat<I> extends Format {
 	 * Creates runtime encoder implementation that is configured to consume data of the given data type.
 	 */
 	I createRuntimeEncoder(DynamicTableSink.Context context, DataType consumedDataType);
+
+	/**
+	 * Returns the map of metadata keys and their corresponding data types that can be consumed by this
+	 * format for writing. By default, this method returns an empty map.
+	 *
+	 * <p>Metadata columns add additional columns to the table's schema. An encoding format is responsible
+	 * to accept requested metadata columns at the end of consumed rows and persist them.
+	 *
+	 * <p>See {@link SupportsWritingMetadata} for more information.
+	 *
+	 * <p>Note: This method is only used if the outer {@link DynamicTableSink} implements {@link SupportsWritingMetadata}
+	 * and calls this method in {@link SupportsWritingMetadata#listWritableMetadata()}.
+	 */
+	default Map<String, DataType> listWritableMetadata() {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Provides a list of metadata keys that the consumed row will contain as appended metadata columns.
+	 * By default, this method throws an exception if metadata keys are defined.
+	 *
+	 * <p>See {@link SupportsWritingMetadata} for more information.
+	 *
+	 * <p>Note: This method is only used if the outer {@link DynamicTableSink} implements {@link SupportsWritingMetadata}
+	 * and calls this method in {@link SupportsWritingMetadata#applyWritableMetadata(List)}.
+	 */
+	@SuppressWarnings("unused")
+	default void applyWritableMetadata(List<String> metadataKeys) {
+		throw new UnsupportedOperationException(
+			"An encoding format must override this method to apply metadata keys.");
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.RuntimeConverter;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
+import org.apache.flink.table.connector.sink.abilities.SupportsWritingMetadata;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -64,6 +65,7 @@ import java.io.Serializable;
  * <ul>
  *     <li>{@link SupportsPartitioning}
  *     <li>{@link SupportsOverwrite}
+ *     <li>{@link SupportsWritingMetadata}
  * </ul>
  *
  * <p>In the last step, the planner will call {@link #getSinkRuntimeProvider(Context)} for obtaining a

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsWritingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsWritingMetadata.java
@@ -32,11 +32,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Enables to write metadata columns to a {@link DynamicTableSink}.
+ * Interface for {@link DynamicTableSink}s that support writing metadata columns.
  *
- * <p>Metadata columns add additional columns to the table's schema. A table sink is responsible to
- * accept requested metadata columns at the end of consumed rows and persist them. This includes potentially
- * forwarding metadata columns to contained formats.
+ * <p>Metadata columns add additional columns to the table's schema. A table sink is responsible for
+ * accepting requested metadata columns at the end of consumed rows and persist them. This includes
+ * potentially forwarding metadata columns to contained formats.
  *
  * <p>Examples in SQL look like:
  * <pre>{@code

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsWritingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsWritingMetadata.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Enables to write metadata columns to a {@link DynamicTableSink}.
+ *
+ * <p>Metadata columns add additional columns to the table's schema. A table sink is responsible to
+ * accept requested metadata columns at the end of consumed rows and persist them. This includes potentially
+ * forwarding metadata columns to contained formats.
+ *
+ * <p>Examples in SQL look like:
+ * <pre>{@code
+ *   // writes data to the corresponding metadata key `timestamp`
+ *   CREATE TABLE t1 (i INT, s STRING, timestamp TIMESTAMP(3) WITH LOCAL TIME ZONE METADATA, d DOUBLE)
+ *
+ *   // casts data from INT and writes to metadata key `timestamp`
+ *   CREATE TABLE t2 (i INT, s STRING, myTimestamp INT METADATA FROM 'timestamp', d DOUBLE)
+ *
+ *   // metadata is not persisted because metadata column is virtual
+ *   CREATE TABLE t3 (i INT, s STRING, timestamp TIMESTAMP(3) WITH LOCAL TIME ZONE METADATA VIRTUAL, d DOUBLE)
+ * }</pre>
+ *
+ * <p>By default, if this interface is not implemented, the statements above would fail because the
+ * table sink does not provide a metadata key called `timestamp`.
+ *
+ * <p>If this interface is implemented, {@link #listWritableMetadata()} lists all metadata keys and
+ * their corresponding data types that the sink exposes to the planner. The planner will use this
+ * information for validation and insertion of explicit casts if necessary.
+ *
+ * <p>The planner will select required metadata columns and will call {@link #applyWritableMetadata(List)}
+ * with a list of metadata keys. An implementation must ensure that metadata columns are accepted at
+ * the end of the physical row in the order of the provided list after the apply method has been called.
+ *
+ * <p>The metadata column's data type must match with {@link #listWritableMetadata()}. For the examples
+ * above, this means that a table sink for `t2` accepts a TIMESTAMP and not INT. The casting from INT
+ * will be performed by the planner in a preceding operation:
+ *
+ * <pre>{@code
+ *   // for t1 and t2
+ *   ROW < i INT, s STRING, d DOUBLE >                                              // physical input
+ *   ROW < i INT, s STRING, d DOUBLE, timestamp TIMESTAMP(3) WITH LOCAL TIME ZONE > // final input
+ *
+ *   // for t3
+ *   ROW < i INT, s STRING, d DOUBLE >                                              // physical input
+ *   ROW < i INT, s STRING, d DOUBLE >                                              // final input
+ * }</pre>
+ */
+@PublicEvolving
+public interface SupportsWritingMetadata {
+
+	/**
+	 * Returns the map of metadata keys and their corresponding data types that can be consumed by this
+	 * table sink for writing.
+	 *
+	 * <p>The returned map will be used by the planner for validation and insertion of explicit casts
+	 * (see {@link LogicalTypeCasts#supportsExplicitCast(LogicalType, LogicalType)}) if necessary.
+	 *
+	 * <p>The iteration order of the returned map determines the order of metadata keys in the list
+	 * passed in {@link #applyWritableMetadata(List)}. Therefore, it might be beneficial to return a
+	 * {@link LinkedHashMap} if a strict metadata column order is required.
+	 *
+	 * <p>If a sink forwards metadata to one or more formats, we recommend the following column
+	 * order for consistency:
+	 *
+	 * <pre>{@code
+	 *   KEY FORMAT METADATA COLUMNS + VALUE FORMAT METADATA COLUMNS + SINK METADATA COLUMNS
+	 * }</pre>
+	 *
+	 * <p>Metadata key names follow the same pattern as mentioned in {@link Factory}. In case of duplicate
+	 * names in format and sink keys, format keys shall have higher precedence.
+	 *
+	 * <p>Regardless of the returned {@link DataType}s, a metadata column is always represented using
+	 * internal data structures (see {@link RowData}).
+	 *
+	 * @see EncodingFormat#listWritableMetadata()
+	 */
+	Map<String, DataType> listWritableMetadata();
+
+	/**
+	 * Provides a list of metadata keys that the consumed {@link RowData} will contain as appended metadata
+	 * columns which must be persisted.
+	 *
+	 * @param metadataKeys a subset of the keys returned by {@link #listWritableMetadata()}, ordered
+	 *                     by the iteration order of returned map
+	 *
+	 * @see EncodingFormat#applyWritableMetadata(List)
+	 */
+	void applyWritableMetadata(List<String> metadataKeys);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsComputedColumnP
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.types.RowKind;
 
@@ -51,6 +52,7 @@ import java.io.Serializable;
  *     <li>{@link SupportsFilterPushDown}
  *     <li>{@link SupportsProjectionPushDown}
  *     <li>{@link SupportsPartitionPushDown}
+ *     <li>{@link SupportsReadingMetadata}
  * </ul>
  *
  * <p>In the last step, the planner will call {@link #getScanRuntimeProvider(ScanContext)} for obtaining a

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Enables to read metadata columns from a {@link ScanTableSource}.
+ *
+ * <p>Metadata columns add additional columns to the table's schema. A table source is responsible to
+ * add requested metadata columns at the end of produced rows. This includes potentially forwarding metadata
+ * columns from contained formats.
+ *
+ * <p>Examples in SQL look like:
+ * <pre>{@code
+ *   // reads the column from corresponding metadata key `timestamp`
+ *   CREATE TABLE t1 (i INT, s STRING, timestamp TIMESTAMP(3) WITH LOCAL TIME ZONE METADATA, d DOUBLE)
+ *
+ *   // reads the column from metadata key `timestamp` and casts to INT
+ *   CREATE TABLE t2 (i INT, s STRING, myTimestamp INT METADATA FROM 'timestamp', d DOUBLE)
+ * }</pre>
+ *
+ * <p>By default, if this interface is not implemented, the statements above would fail because the
+ * table source does not provide a metadata key called `timestamp`.
+ *
+ * <p>If this interface is implemented, {@link #listReadableMetadata()} lists all metadata keys and
+ * their corresponding data types that the source exposes to the planner. The planner will use this
+ * information for validation and insertion of explicit casts if necessary.
+ *
+ * <p>The planner will select required metadata columns (i.e. perform projection push down) and will
+ * call {@link #applyReadableMetadata(List, DataType)} with a list of metadata keys. An implementation
+ * must ensure that metadata columns are appended at the end of the physical row in the order of the
+ * provided list after the apply method has been called.
+ *
+ * <p>Note: The final output data type emitted by a source changes from the physically produced data
+ * type to a data type with metadata columns. {@link #applyReadableMetadata(List, DataType)} will pass
+ * the updated data type for convenience. If a source implements {@link SupportsProjectionPushDown},
+ * the projection must be applied to the physical data in the first step. The passed updated data type
+ * will have considered information from {@link SupportsProjectionPushDown} already.
+ *
+ * <p>The metadata column's data type must match with {@link #listReadableMetadata()}. For the examples
+ * above, this means that a table source for `t2` returns a TIMESTAMP and not INT. The casting to INT
+ * will be performed by the planner in a subsequent operation:
+ *
+ * <pre>{@code
+ *   // for t1 and t2
+ *   ROW < i INT, s STRING, d DOUBLE >                                              // physical output
+ *   ROW < i INT, s STRING, d DOUBLE, timestamp TIMESTAMP(3) WITH LOCAL TIME ZONE > // final output
+ * }</pre>
+ */
+@PublicEvolving
+public interface SupportsReadingMetadata {
+
+	/**
+	 * Returns the map of metadata keys and their corresponding data types that can be produced by this
+	 * table source for reading.
+	 *
+	 * <p>The returned map will be used by the planner for validation and insertion of explicit casts
+	 * (see {@link LogicalTypeCasts#supportsExplicitCast(LogicalType, LogicalType)}) if necessary.
+	 *
+	 * <p>The iteration order of the returned map determines the order of metadata keys in the list
+	 * passed in {@link #applyReadableMetadata(List, DataType)}. Therefore, it might be beneficial to
+	 * return a {@link LinkedHashMap} if a strict metadata column order is required.
+	 *
+	 * <p>If a source forwards metadata from one or more formats, we recommend the following column
+	 * order for consistency:
+	 *
+	 * <pre>{@code
+	 *   KEY FORMAT METADATA COLUMNS + VALUE FORMAT METADATA COLUMNS + SOURCE METADATA COLUMNS
+	 * }</pre>
+	 *
+	 * <p>Metadata key names follow the same pattern as mentioned in {@link Factory}. In case of duplicate
+	 * names in format and source keys, format keys shall have higher precedence.
+	 *
+	 * <p>Regardless of the returned {@link DataType}s, a metadata column is always represented using
+	 * internal data structures (see {@link RowData}).
+	 *
+	 * @see DecodingFormat#listReadableMetadata()
+	 */
+	Map<String, DataType> listReadableMetadata();
+
+	/**
+	 * Provides a list of metadata keys that the produced {@link RowData} must contain as appended
+	 * metadata columns.
+	 *
+	 * <p>Note: Use the passed data type instead of {@link TableSchema#toPhysicalRowDataType()} for
+	 * describing the final output data type when creating {@link TypeInformation}. If the source implements
+	 * {@link SupportsProjectionPushDown}, the projection is already considered in the given output
+	 * data type.
+	 *
+	 * @param metadataKeys a subset of the keys returned by {@link #listReadableMetadata()}, ordered
+	 *                     by the iteration order of returned map
+	 * @param outputDataType the final output type of the source
+	 *
+	 * @see DecodingFormat#applyReadableMetadata(List)
+	 */
+	void applyReadableMetadata(List<String> metadataKeys, DataType outputDataType);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
@@ -34,11 +34,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Enables to read metadata columns from a {@link ScanTableSource}.
+ * Interface for {@link ScanTableSource}s that support reading metadata columns.
  *
- * <p>Metadata columns add additional columns to the table's schema. A table source is responsible to
- * add requested metadata columns at the end of produced rows. This includes potentially forwarding metadata
- * columns from contained formats.
+ * <p>Metadata columns add additional columns to the table's schema. A table source is responsible for
+ * adding requested metadata columns at the end of produced rows. This includes potentially forwarding
+ * metadata columns from contained formats.
  *
  * <p>Examples in SQL look like:
  * <pre>{@code


### PR DESCRIPTION
## What is the purpose of the change

Adds all `@PublicEvolving` interfaces mentioned in FLIP-107.

## Brief change log

- Updated `EncodingFormat` and `DecodingFormat`
- Added `SupportsReadingMetadata` and `SupportsWritingMetadata`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
