### PR TITLE
[FLINK-19244] CsvRowDataDeserializationSchema throws cast exception : Row length mismatch.

### DIFF
--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -241,7 +241,11 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
 		return jsonNode -> {
 			int nodeSize = jsonNode.size();
 
-			validateArity(arity, nodeSize, ignoreParseErrors);
+			if (nodeSize != 0) {
+				validateArity(arity, nodeSize, ignoreParseErrors);
+			} else {
+				return null;
+			}
 
 			GenericRowData row = new GenericRowData(arity);
 			for (int i = 0; i < arity; i++) {

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
@@ -248,7 +248,11 @@ public final class CsvRowDeserializationSchema implements DeserializationSchema<
 		return (node) -> {
 			final int nodeSize = node.size();
 
-			validateArity(rowArity, nodeSize, ignoreParseErrors);
+			if (nodeSize != 0) {
+				validateArity(rowArity, nodeSize, ignoreParseErrors);
+			} else {
+				return null;
+			}
 
 			final Row row = new Row(rowArity);
 			for (int i = 0; i < Math.min(rowArity, nodeSize); i++) {

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -365,9 +365,9 @@ public class CsvRowDataSerDeSchemaTest {
 	}
 
 	private void testSerDeConsistency(
-		RowData originalRow,
-		CsvRowDataSerializationSchema.Builder serSchemaBuilder,
-		CsvRowDataDeserializationSchema.Builder deserSchemaBuilder) throws Exception {
+			RowData originalRow,
+			CsvRowDataSerializationSchema.Builder serSchemaBuilder,
+			CsvRowDataDeserializationSchema.Builder deserSchemaBuilder) throws Exception {
 		RowData deserializedRow = deserialize(
 			deserSchemaBuilder,
 			new String(serialize(serSchemaBuilder, originalRow)));

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -395,5 +395,4 @@ public class CsvRowDataSerDeSchemaTest {
 	private static RowData rowData(String str1, int integer, String str2) {
 		return GenericRowData.of(fromString(str1), integer, fromString(str2));
 	}
-
 }

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -250,6 +250,39 @@ public class CsvRowDataSerDeSchemaTest {
 			new java.util.Date());
 	}
 
+	@Test
+	public void testSerializeDeserializeNestedTypes() throws Exception {
+		DataType subDataType0 = ROW(
+			FIELD("f0c0", STRING()),
+			FIELD("f0c1", INT()),
+			FIELD("f0c2", STRING()));
+		DataType subDataType1 = ROW(
+			FIELD("f1c0", STRING()),
+			FIELD("f1c1", INT()),
+			FIELD("f1c2", STRING()));
+		DataType dataType = ROW(
+			FIELD("f0", subDataType0),
+			FIELD("f1", subDataType1));
+		RowType rowType = (RowType) dataType.getLogicalType();
+
+		// serialization
+		CsvRowDataSerializationSchema.Builder serSchemaBuilder =
+			new CsvRowDataSerializationSchema.Builder(rowType);
+		// deserialization
+		CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =
+			new CsvRowDataDeserializationSchema.Builder(rowType, InternalTypeInfo.of(rowType));
+
+		RowData normalRow = GenericRowData.of(
+			rowData("hello", 1, "This is 1st top column"),
+			rowData("world", 2, "This is 2nd top column"));
+		testSerDeConsistency(normalRow, serSchemaBuilder, deserSchemaBuilder);
+
+		RowData nullRow = GenericRowData.of(
+			null,
+			rowData("world", 2, "This is 2nd top column after null"));
+		testSerDeConsistency(nullRow, serSchemaBuilder, deserSchemaBuilder);
+	}
+
 	private void testNullableField(DataType fieldType, String string, Object value) throws Exception {
 		testField(
 			fieldType,
@@ -331,6 +364,16 @@ public class CsvRowDataSerDeSchemaTest {
 			.toExternal(deserializedRow);
 	}
 
+	private void testSerDeConsistency(
+		RowData originalRow,
+		CsvRowDataSerializationSchema.Builder serSchemaBuilder,
+		CsvRowDataDeserializationSchema.Builder deserSchemaBuilder) throws Exception {
+		RowData deserializedRow = deserialize(
+			deserSchemaBuilder,
+			new String(serialize(serSchemaBuilder, originalRow)));
+		assertEquals(deserializedRow, originalRow);
+	}
+
 	private static byte[] serialize(CsvRowDataSerializationSchema.Builder serSchemaBuilder, RowData row) throws Exception {
 		// we serialize and deserialize the schema to test runtime behavior
 		// when the schema is shipped to the cluster
@@ -352,4 +395,5 @@ public class CsvRowDataSerDeSchemaTest {
 	private static RowData rowData(String str1, int integer, String str2) {
 		return GenericRowData.of(fromString(str1), integer, fromString(str2));
 	}
+
 }

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
@@ -207,6 +207,30 @@ public class CsvRowDeSerializationSchemaTest {
 		testNullableField(Types.GENERIC(java.util.Date.class), "FAIL", new java.util.Date());
 	}
 
+	@Test
+	public void testSerializeDeserializeNestedTypes() throws Exception {
+		final TypeInformation<Row> subDataType0 = Types.ROW(Types.STRING, Types.INT, Types.STRING);
+		final TypeInformation<Row> subDataType1 = Types.ROW(Types.STRING, Types.INT, Types.STRING);
+		final TypeInformation<Row> rowInfo = Types.ROW(subDataType0, subDataType1);
+
+		// serialization
+		CsvRowSerializationSchema.Builder serSchemaBuilder =
+			new CsvRowSerializationSchema.Builder(rowInfo);
+		// deserialization
+		CsvRowDeserializationSchema.Builder deserSchemaBuilder =
+			new CsvRowDeserializationSchema.Builder(rowInfo);
+
+		Row normalRow = Row.of(
+			Row.of("hello", 1, "This is 1st top column"),
+			Row.of("world", 2, "This is 2nd top column"));
+		testSerDeConsistency(normalRow, serSchemaBuilder, deserSchemaBuilder);
+
+		Row nullRow = Row.of(
+			null,
+			Row.of("world", 2, "This is 2nd top column after null"));
+		testSerDeConsistency(nullRow, serSchemaBuilder, deserSchemaBuilder);
+	}
+
 	private <T> void testNullableField(TypeInformation<T> fieldInfo, String string, T value) throws Exception {
 		testField(
 			fieldInfo,
@@ -267,6 +291,16 @@ public class CsvRowDeSerializationSchemaTest {
 			.setIgnoreParseErrors(allowParsingErrors)
 			.setAllowComments(allowComments);
 		return deserialize(deserSchemaBuilder, string);
+	}
+
+	private void testSerDeConsistency(
+		Row originalRow,
+		CsvRowSerializationSchema.Builder serSchemaBuilder,
+		CsvRowDeserializationSchema.Builder deserSchemaBuilder) throws Exception {
+		Row deserializedRow = deserialize(
+			deserSchemaBuilder,
+			new String(serialize(serSchemaBuilder, originalRow)));
+		assertEquals(deserializedRow, originalRow);
 	}
 
 	private static byte[] serialize(CsvRowSerializationSchema.Builder serSchemaBuilder, Row row) throws Exception {

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
@@ -294,9 +294,9 @@ public class CsvRowDeSerializationSchemaTest {
 	}
 
 	private void testSerDeConsistency(
-		Row originalRow,
-		CsvRowSerializationSchema.Builder serSchemaBuilder,
-		CsvRowDeserializationSchema.Builder deserSchemaBuilder) throws Exception {
+			Row originalRow,
+			CsvRowSerializationSchema.Builder serSchemaBuilder,
+			CsvRowDeserializationSchema.Builder deserSchemaBuilder) throws Exception {
 		Row deserializedRow = deserialize(
 			deserSchemaBuilder,
 			new String(serialize(serSchemaBuilder, originalRow)));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request fix cast exception when the nested row type is null.
Through csv is not a good format to handle nested types, but it's meaningful to make SerDe  consistent.

## Brief change log

If jsonNode.size equals zero, return a null Row/RowData directly.

## Verifying this change

This change added tests and can be verified as follows:
CsvRowDataSerDeSchemaTest.testSerializeDeserializeNestedTypes
CsvRowDeSerializationSchemaTest.testSerializeDeserializeNestedTypes


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
