### PR TITLE
[FLINK-17767][table-planner-blink]Tumbling/Sliding window aggregate support window start offset in batch and streaming mode

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
@@ -109,6 +109,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import scala.Option;
 import scala.Some;
 
 import static java.util.Arrays.asList;
@@ -542,13 +543,15 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 			DataType windowType = window.getTimeAttribute().getOutputDataType();
 			PlannerWindowReference windowReference = new PlannerWindowReference(window.getAlias(),
 					new Some<>(fromDataToLogicalType(windowType)));
+			// TODO: Support window offset
 			switch (window.getType()) {
 				case SLIDE:
 					return new SlidingGroupWindow(
 							windowReference,
 							window.getTimeAttribute(),
 							window.getSize().orElseThrow(() -> new TableException("missed size parameters!")),
-							window.getSlide().orElseThrow(() -> new TableException("missed slide parameters!"))
+							window.getSlide().orElseThrow(() -> new TableException("missed slide parameters!")),
+							Option.empty()
 					);
 				case SESSION:
 					return new SessionGroupWindow(
@@ -560,7 +563,8 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
 					return new TumblingGroupWindow(
 							windowReference,
 							window.getTimeAttribute(),
-							window.getSize().orElseThrow(() -> new TableException("missed size parameters!"))
+							window.getSize().orElseThrow(() -> new TableException("missed size parameters!")),
+							Option.empty()
 					);
 				default:
 					throw new TableException("Unknown window type");

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortWindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortWindowCodeGenerator.scala
@@ -108,6 +108,7 @@ class SortWindowCodeGenerator(
     val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
       enablePreAcc,
       ctx,
+      windowStart,
       windowSize,
       slideSize,
       windowsGrouping,
@@ -190,6 +191,7 @@ class SortWindowCodeGenerator(
     val (triggerWindowAgg, endWindowAgg) = genWindowAggCodes(
       enablePreAcc,
       ctx,
+      windowStart,
       windowSize,
       slideSize,
       windowsGrouping,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/logical/groupWindows.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/logical/groupWindows.scala
@@ -41,12 +41,17 @@ abstract class LogicalWindow(
 case class TumblingGroupWindow(
     alias: PlannerWindowReference,
     timeField: FieldReferenceExpression,
-    size: ValueLiteralExpression)
+    size: ValueLiteralExpression,
+    offset: Option[ValueLiteralExpression])
   extends LogicalWindow(
     alias,
     timeField) {
 
-  override def toString: String = s"TumblingGroupWindow($alias, $timeField, $size)"
+  override def toString: String = if (offset.isEmpty) {
+    s"TumblingGroupWindow($alias, $timeField, $size)"
+  } else {
+    s"TumblingGroupWindow($alias, $timeField, $size, ${offset.get})"
+  }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -57,12 +62,17 @@ case class SlidingGroupWindow(
     alias: PlannerWindowReference,
     timeField: FieldReferenceExpression,
     size: ValueLiteralExpression,
-    slide: ValueLiteralExpression)
+    slide: ValueLiteralExpression,
+    offset: Option[ValueLiteralExpression])
   extends LogicalWindow(
     alias,
     timeField) {
 
-  override def toString: String = s"SlidingGroupWindow($alias, $timeField, $size, $slide)"
+  override def toString: String = if (offset.isEmpty) {
+    s"SlidingGroupWindow($alias, $timeField, $size, $slide)"
+  } else {
+    s"SlidingGroupWindow($alias, $timeField, $size, $slide, ${offset.get})"
+  }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
@@ -221,9 +221,9 @@ class FlinkRelMdRowCount private extends MetadataHandler[BuiltInMetadata.RowCoun
       val expandFactorOfOverLapSlidingWindow = 4D
       val expandFactorOfSessionWindow = 2D
       window match {
-        case TumblingGroupWindow(_, _, size) if hasTimeIntervalType(size) =>
+        case TumblingGroupWindow(_, _, size, _) if hasTimeIntervalType(size) =>
           Math.min(expandFactorOfTumblingWindow * ndv, inputRowCount)
-        case SlidingGroupWindow(_, _, size, slide) if hasTimeIntervalType(size) =>
+        case SlidingGroupWindow(_, _, size, slide, _) if hasTimeIntervalType(size) =>
           val sizeValue = toLong(size)
           val slideValue = toLong(slide)
           if (sizeValue > slideValue) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashWindowAggregateBase.scala
@@ -130,13 +130,14 @@ abstract class BatchExecHashWindowAggregateBase(
     val groupBufferLimitSize = config.getConfiguration.getInteger(
       ExecutionConfigOptions.TABLE_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT)
 
-    val (windowSize: Long, slideSize: Long) = WindowCodeGenerator.getWindowDef(window)
+    val (windowSize: Long, slideSize: Long, windowStart: Long) =
+      WindowCodeGenerator.getWindowDef(window)
 
     val generatedOperator = new HashWindowCodeGenerator(
       ctx, relBuilder, window, inputTimeFieldIndex,
       inputTimeIsDate, namedProperties,
       aggInfos, inputRowType, grouping, auxGrouping, enableAssignPane, isMerge, isFinal).gen(
-      inputType, outputType, groupBufferLimitSize, 0,
+      inputType, outputType, groupBufferLimitSize, windowStart,
       windowSize, slideSize)
     val operator = new CodeGenOperatorFactory[RowData](generatedOperator)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortWindowAggregateBase.scala
@@ -118,13 +118,14 @@ abstract class BatchExecSortWindowAggregateBase(
     val groupBufferLimitSize = planner.getTableConfig.getConfiguration.getInteger(
       ExecutionConfigOptions.TABLE_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT)
 
-    val (windowSize: Long, slideSize: Long) = WindowCodeGenerator.getWindowDef(window)
+    val (windowSize: Long, slideSize: Long, windowStart: Long) =
+      WindowCodeGenerator.getWindowDef(window)
 
     val generator = new SortWindowCodeGenerator(
       ctx, relBuilder, window, inputTimeFieldIndex,
       inputTimeIsDate, namedProperties,
       aggInfos, inputRowType, inputType, outputType,
-      groupBufferLimitSize, 0L, windowSize, slideSize,
+      groupBufferLimitSize, windowStart, windowSize, slideSize,
       grouping, auxGrouping, enableAssignPane, isMerge, isFinal)
     val generatedOperator = if (grouping.isEmpty) {
       generator.genWithoutKeys()

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
@@ -23,12 +23,12 @@ import org.apache.flink.table.expressions.FieldReferenceExpression
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory.toLogicalType
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
-
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex._
-
 import _root_.java.math.{BigDecimal => JBigDecimal}
+
+import org.apache.calcite.sql.`type`.SqlTypeFamily
 
 /**
   * Planner rule that transforms simple [[LogicalAggregate]] on a [[LogicalProject]]
@@ -73,7 +73,10 @@ class BatchLogicalWindowAggregateRule
 
   def getOperandAsLong(call: RexCall, idx: Int): Long =
     call.getOperands.get(idx) match {
-      case v: RexLiteral => v.getValue.asInstanceOf[JBigDecimal].longValue()
+      case v: RexLiteral if v.getTypeName.getFamily == SqlTypeFamily.INTERVAL_DAY_TIME =>
+        v.getValue.asInstanceOf[JBigDecimal].longValue()
+      case v: RexLiteral if v.getTypeName.getFamily == SqlTypeFamily.TIME =>
+        v.getValue2.asInstanceOf[Integer].intValue()
       case _ => throw new TableException("Only constant window descriptors are supported")
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
@@ -87,6 +87,8 @@ class StreamLogicalWindowAggregateRule
     call.getOperands.get(idx) match {
       case v: RexLiteral if v.getTypeName.getFamily == SqlTypeFamily.INTERVAL_DAY_TIME =>
         v.getValue.asInstanceOf[JBigDecimal].longValue()
+      case v: RexLiteral if v.getTypeName.getFamily == SqlTypeFamily.TIME =>
+        v.getValue2.asInstanceOf[Integer].intValue()
       case _: RexLiteral => throw new TableException(
         "Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit. " +
           "MONTH and YEAR time unit are not supported yet.")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecWindowAggregateRule.scala
@@ -106,7 +106,7 @@ class BatchExecWindowAggregateRule
     val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
 
     window match {
-      case TumblingGroupWindow(_, _, size) if hasTimeIntervalType(size) =>
+      case TumblingGroupWindow(_, _, size, _) if hasTimeIntervalType(size) =>
         val sizeInLong = size.getValueAs(classOf[java.lang.Long]).get()
         transformTimeSlidingWindow(
           call,
@@ -120,7 +120,7 @@ class BatchExecWindowAggregateRule
           enableAssignPane = false,
           supportLocalWindowAgg(call, tableConfig, aggregates, sizeInLong, sizeInLong))
 
-      case SlidingGroupWindow(_, _, size, slide) if hasTimeIntervalType(size) =>
+      case SlidingGroupWindow(_, _, size, slide, _) if hasTimeIntervalType(size) =>
         val (sizeInLong, slideInLong) = (
           size.getValueAs(classOf[java.lang.Long]).get(),
           slide.getValueAs(classOf[java.lang.Long]).get())

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.xml
@@ -315,6 +315,137 @@ Calc(select=[EXPR$0, w$start AS EXPR$1, w$end AS EXPR$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTumbleWindowWithOffset[aggStrategy=AUTO]">
+	<Resource name="sql">
+	  <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 GROUP BY TUMBLE(ts, INTERVAL '1' HOUR, TIME '10:00:00')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[$TUMBLE($4, 3600000:INTERVAL HOUR, 10:00:00)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+HashWindowAggregate(window=[TumblingGroupWindow('w$, ts, 3600000, 36000000)], select=[Final_SUM(sum$0) AS sumA, Final_COUNT(count$1) AS cntB])
++- Exchange(distribution=[single])
+   +- LocalHashWindowAggregate(window=[TumblingGroupWindow('w$, ts, 3600000, 36000000)], select=[Partial_SUM(a) AS sum$0, Partial_COUNT(b) AS count$1])
+      +- Calc(select=[ts, a, b])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]], fields=[a, b, c, d, ts])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testTumbleWindowWithOffset[aggStrategy=ONE_PHASE]">
+	<Resource name="sql">
+	  <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 GROUP BY TUMBLE(ts, INTERVAL '1' HOUR, TIME '10:00:00')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[$TUMBLE($4, 3600000:INTERVAL HOUR, 10:00:00)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+HashWindowAggregate(window=[TumblingGroupWindow('w$, ts, 3600000, 36000000)], select=[SUM(a) AS sumA, COUNT(b) AS cntB])
++- Exchange(distribution=[single])
+   +- Calc(select=[ts, a, b])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]], fields=[a, b, c, d, ts])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testTumbleWindowWithOffset[aggStrategy=TWO_PHASE]">
+	<Resource name="sql">
+	  <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 GROUP BY TUMBLE(ts, INTERVAL '1' HOUR, TIME '10:00:00')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[$TUMBLE($4, 3600000:INTERVAL HOUR, 10:00:00)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+HashWindowAggregate(window=[TumblingGroupWindow('w$, ts, 3600000, 36000000)], select=[Final_SUM(sum$0) AS sumA, Final_COUNT(count$1) AS cntB])
++- Exchange(distribution=[single])
+   +- LocalHashWindowAggregate(window=[TumblingGroupWindow('w$, ts, 3600000, 36000000)], select=[Partial_SUM(a) AS sum$0, Partial_COUNT(b) AS count$1])
+      +- Calc(select=[ts, a, b])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]], fields=[a, b, c, d, ts])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testHopWindowWithOffset[aggStrategy=AUTO]">
+	<Resource name="sql">
+	  <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 GROUP BY HOP(ts, INTERVAL '1' HOUR, INTERVAL '2' HOUR, TIME '10:00:00')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[HOP($4, 3600000:INTERVAL HOUR, 7200000:INTERVAL HOUR, 10:00:00)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+HashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 7200000, 3600000, 36000000)], select=[Final_SUM(sum$0) AS sumA, Final_COUNT(count$1) AS cntB])
++- Exchange(distribution=[single])
+   +- LocalHashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 7200000, 3600000, 36000000)], select=[Partial_SUM(a) AS sum$0, Partial_COUNT(b) AS count$1])
+      +- Calc(select=[ts, a, b])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]], fields=[a, b, c, d, ts])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testHopWindowWithOffset[aggStrategy=ONE_PHASE]">
+	<Resource name="sql">
+	  <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 GROUP BY HOP(ts, INTERVAL '1' HOUR, INTERVAL '2' HOUR, TIME '10:00:00')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[HOP($4, 3600000:INTERVAL HOUR, 7200000:INTERVAL HOUR, 10:00:00)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+SortWindowAggregate(window=[SlidingGroupWindow('w$, ts, 7200000, 3600000, 36000000)], select=[SUM(a) AS sumA, COUNT(b) AS cntB])
++- Sort(orderBy=[ts ASC])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[ts, a, b])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]], fields=[a, b, c, d, ts])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testHopWindowWithOffset[aggStrategy=TWO_PHASE]">
+	<Resource name="sql">
+	  <![CDATA[SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 GROUP BY HOP(ts, INTERVAL '1' HOUR, INTERVAL '2' HOUR, TIME '10:00:00')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(sumA=[$1], cntB=[$2])
++- LogicalAggregate(group=[{0}], sumA=[SUM($1)], cntB=[COUNT($2)])
+   +- LogicalProject($f0=[HOP($4, 3600000:INTERVAL HOUR, 7200000:INTERVAL HOUR, 10:00:00)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+HashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 7200000, 3600000, 36000000)], select=[Final_SUM(sum$0) AS sumA, Final_COUNT(count$1) AS cntB])
++- Exchange(distribution=[single])
+   +- LocalHashWindowAggregate(window=[SlidingGroupWindow('w$, ts, 7200000, 3600000, 36000000)], select=[Partial_SUM(a) AS sum$0, Partial_COUNT(b) AS count$1])
+      +- Calc(select=[ts, a, b])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c, d, ts)]]], fields=[a, b, c, d, ts])
+]]>
+	</Resource>
+  </TestCase>
   <TestCase name="testNoGroupingTumblingWindow[aggStrategy=AUTO]">
     <Resource name="sql">
       <![CDATA[SELECT AVG(c), SUM(a) FROM MyTable GROUP BY TUMBLE(b, INTERVAL '3' SECOND)]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -619,6 +619,46 @@ GroupWindowAggregate(window=[TumblingGroupWindow('w$, $f2, 1000)], select=[SUM(a
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTumblingWindowWithOffset">
+	<Resource name="sql">
+	  <![CDATA[select sum(a), max(b) from MyTable1 group by TUMBLE(c, INTERVAL '4' SECOND, TIME '00:00:03')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)], EXPR$1=[MAX($2)])
+   +- LogicalProject($f0=[$TUMBLE(PROCTIME(), 4000:INTERVAL SECOND, 00:00:03)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+GroupWindowAggregate(window=[TumblingGroupWindow('w$, $f2, 4000, 3000)], select=[SUM(a) AS EXPR$0, MAX(b) AS EXPR$1])
++- Exchange(distribution=[single])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testHopWindowWithOffset">
+	<Resource name="sql">
+	  <![CDATA[select sum(a), max(b) FROM MyTable1 GROUP BY HOP(c, INTERVAL '4' SECOND, INTERVAL '5' SECOND, TIME '00:00:03')]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)], EXPR$1=[MAX($2)])
+   +- LogicalProject($f0=[HOP(PROCTIME(), 4000:INTERVAL SECOND, 5000:INTERVAL SECOND, 00:00:03)], a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+GroupWindowAggregate(window=[SlidingGroupWindow('w$, $f2, 5000, 4000, 3000)], select=[SUM(a) AS EXPR$0, MAX(b) AS EXPR$1])
++- Exchange(distribution=[single])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+	</Resource>
+  </TestCase>
   <TestCase name="testWindowAggregateWithAllowLatenessOnly">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.scala
@@ -58,16 +58,6 @@ class WindowAggregateTest(aggStrategy: AggregatePhaseStrategy) extends TableTest
   }
 
   @Test
-  def testHopWindowNoOffset(): Unit = {
-    val sqlQuery =
-      "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 " +
-        "GROUP BY HOP(ts, INTERVAL '1' HOUR, INTERVAL '2' HOUR, TIME '10:00:00')"
-    expectedException.expect(classOf[TableException])
-    expectedException.expectMessage("HOP window with alignment is not supported yet.")
-    util.verifyPlan(sqlQuery)
-  }
-
-  @Test
   def testSessionWindowNoOffset(): Unit = {
     val sqlQuery =
       "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 " +
@@ -120,6 +110,22 @@ class WindowAggregateTest(aggStrategy: AggregatePhaseStrategy) extends TableTest
       |    GROUP BY rollup(TUMBLE(ts, INTERVAL '15' MINUTE), b)
     """.stripMargin
     util.verifyPlanNotExpected(sql, "TUMBLE(ts")
+  }
+
+  @Test
+  def testTumbleWindowWithOffset(): Unit = {
+    val sqlQuery =
+      "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 " +
+        "GROUP BY TUMBLE(ts, INTERVAL '1' HOUR, TIME '10:00:00')"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testHopWindowWithOffset(): Unit = {
+    val sqlQuery =
+      "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable2 " +
+        "GROUP BY HOP(ts, INTERVAL '1' HOUR, INTERVAL '2' HOUR, TIME '10:00:00')"
+    util.verifyPlan(sqlQuery)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -1130,7 +1130,8 @@ class FlinkRelMdHandlerTestBase {
         new AtomicDataType(new TimestampType(true, TimestampKind.ROWTIME, 3)),
         0,
         4),
-      intervalOfMillis(900000)
+      intervalOfMillis(900000),
+      None
     )
 
   protected lazy val namedPropertiesOfWindowAgg: Seq[PlannerNamedWindowProperty] =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
@@ -45,22 +45,6 @@ class WindowAggregateTest extends TableTestBase {
        |""".stripMargin)
 
   @Test(expected = classOf[TableException])
-  def testTumbleWindowNoOffset(): Unit = {
-    val sqlQuery =
-      "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable " +
-        "GROUP BY TUMBLE(proctime, INTERVAL '2' HOUR, TIME '10:00:00')"
-    util.verifyPlan(sqlQuery)
-  }
-
-  @Test(expected = classOf[TableException])
-  def testHopWindowNoOffset(): Unit = {
-    val sqlQuery =
-      "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable " +
-        "GROUP BY HOP(proctime, INTERVAL '1' HOUR, INTERVAL '2' HOUR, TIME '10:00:00')"
-    util.verifyPlan(sqlQuery)
-  }
-
-  @Test(expected = classOf[TableException])
   def testSessionWindowNoOffset(): Unit = {
     val sqlQuery =
       "SELECT SUM(a) AS sumA, COUNT(b) AS cntB FROM MyTable " +
@@ -159,6 +143,21 @@ class WindowAggregateTest extends TableTestBase {
   @Test
   def testTumblingWindowWithProctime(): Unit = {
     val sql = "select sum(a), max(b) from MyTable1 group by TUMBLE(c, INTERVAL '1' SECOND)"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testTumblingWindowWithOffset(): Unit = {
+    val sql =
+      "select sum(a), max(b) from MyTable1 group by TUMBLE(c, INTERVAL '4' SECOND, TIME '00:00:03')"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testHopWindowWithOffset(): Unit = {
+    val sql =
+      "select sum(a), max(b) FROM MyTable1 " +
+      "GROUP BY HOP(c, INTERVAL '4' SECOND, INTERVAL '5' SECOND, TIME '00:00:03')"
     util.verifyPlan(sql)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/WindowAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/WindowAggregateITCase.scala
@@ -623,6 +623,181 @@ class WindowAggregateITCase extends BatchTestBase {
         localDateTime("1970-01-01 00:00:24.999"))))
   }
 
+  @Test
+  def testTumblingWindowWithOffset(): Unit = {
+    // sort; keyed; 2-phase;
+    checkResult(
+      "SELECT a, countFun(a), " +
+        "TUMBLE_START(ts, INTERVAL '3' SECOND, TIME '00:00:02'), " +
+        "TUMBLE_END(ts, INTERVAL '3' SECOND, TIME '00:00:02') " +
+        "FROM Table3WithTimestamp " +
+        "GROUP BY a, TUMBLE(ts, INTERVAL '3' SECOND, TIME '00:00:02')",
+      Seq(
+        row(1, 1,
+          localDateTime("1969-12-31 23:59:59.0"), localDateTime("1970-01-01 00:00:02.0")),
+        row(2, 1,
+          localDateTime("1970-01-01 00:00:02.0"), localDateTime("1970-01-01 00:00:05.0")),
+        row(3, 1,
+          localDateTime("1970-01-01 00:00:02.0"), localDateTime("1970-01-01 00:00:05.0")),
+        row(4, 1,
+          localDateTime("1970-01-01 00:00:02.0"), localDateTime("1970-01-01 00:00:05.0")),
+        row(5, 1,
+          localDateTime("1970-01-01 00:00:05.0"), localDateTime("1970-01-01 00:00:08.0")),
+        row(6, 1,
+          localDateTime("1970-01-01 00:00:05.0"), localDateTime("1970-01-01 00:00:08.0")),
+        row(7, 1,
+          localDateTime("1970-01-01 00:00:05.0"), localDateTime("1970-01-01 00:00:08.0")),
+        row(8, 1,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:11.0")),
+        row(9, 1,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:11.0")),
+        row(10, 1,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:11.0")),
+        row(11, 1,
+          localDateTime("1970-01-01 00:00:11.0"), localDateTime("1970-01-01 00:00:14.0")),
+        row(12, 1,
+          localDateTime("1970-01-01 00:00:11.0"), localDateTime("1970-01-01 00:00:14.0")),
+        row(13, 1,
+          localDateTime("1970-01-01 00:00:11.0"), localDateTime("1970-01-01 00:00:14.0")),
+        row(14, 1,
+          localDateTime("1970-01-01 00:00:14.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(15, 1,
+          localDateTime("1970-01-01 00:00:14.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(16, 1,
+          localDateTime("1970-01-01 00:00:14.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(17, 1,
+          localDateTime("1970-01-01 00:00:17.0"), localDateTime("1970-01-01 00:00:20.0")),
+        row(18, 1,
+          localDateTime("1970-01-01 00:00:17.0"), localDateTime("1970-01-01 00:00:20.0")),
+        row(19, 1,
+          localDateTime("1970-01-01 00:00:17.0"), localDateTime("1970-01-01 00:00:20.0")),
+        row(20, 1,
+          localDateTime("1970-01-01 00:00:20.0"), localDateTime("1970-01-01 00:00:23.0")),
+        row(21, 1,
+          localDateTime("1970-01-01 00:00:20.0"), localDateTime("1970-01-01 00:00:23.0"))
+      )
+    )
+
+    // hash; keyed; 2-phase;
+    checkResult(
+      "SELECT a, avg(b), min(b), TUMBLE_START(f, INTERVAL '10' SECOND, TIME '00:00:02'), " +
+        "TUMBLE_END(f, INTERVAL '10' SECOND, TIME '00:00:02') " +
+        "FROM Table6 " +
+        "GROUP BY a, TUMBLE(f, INTERVAL '10' SECOND, TIME '00:00:02')",
+      Seq(
+        row(1, 1.1, 1.1,
+          localDateTime("2015-05-20 09:59:52.0"), localDateTime("2015-05-20 10:00:02")),
+        row(2, -2.4, -2.4,
+          localDateTime("2016-09-01 23:07:02.0"), localDateTime("2016-09-01 23:07:12.0")),
+        row(2, 2.5, 2.5,
+          localDateTime("2019-09-19 08:03:02.0"), localDateTime("2019-09-19 08:03:12.0")),
+        row(3, -9.77, -9.77,
+          localDateTime("1999-12-12 10:00:02.0"), localDateTime("1999-12-12 10:00:12.0")),
+        row(3, 0.0, 0.0,
+          localDateTime("1999-12-12 09:59:52.0"), localDateTime("1999-12-12 10:00:02.0")),
+        row(3, 0.08, 0.08,
+          localDateTime("1999-12-12 10:02:52.0"), localDateTime("1999-12-12 10:03:02.0")),
+        row(4, 3.14, 3.14,
+          localDateTime("2017-11-20 08:59:52.0"), localDateTime("2017-11-20 09:00:02.0")),
+        row(4, 3.145, 3.14,
+          localDateTime("2015-11-19 09:59:52.0"), localDateTime("2015-11-19 10:00:02.0")),
+        row(4, 3.16, 3.16,
+          localDateTime("2015-11-20 08:59:52.0"), localDateTime("2015-11-20 09:00:02.0")),
+        row(5, -5.9, -5.9,
+          localDateTime("1989-06-04 09:59:52.0"), localDateTime("1989-06-04 10:00:02.0")),
+        row(5, -2.8, -2.8,
+          localDateTime("1937-07-07 08:08:02.0"), localDateTime("1937-07-07 08:08:12.0")),
+        row(5, 0.7, 0.7,
+          localDateTime("2010-06-01 09:59:52.0"), localDateTime("2010-06-01 10:00:02.0")),
+        row(5, 2.71, 2.71,
+          localDateTime("1997-07-01 08:59:52.0"), localDateTime("1997-07-01 09:00:02.0")),
+        row(5, 3.9, 3.9,
+          localDateTime("1999-12-31 23:59:52.0"), localDateTime("2000-01-01 00:00:02.0"))
+      )
+    )
+  }
+
+  @Test
+  def testSlidingWindowWithOffset(): Unit = {
+    // sort; keyed; 2-phase;
+    checkResult(
+      "SELECT b, sumFun(a), " +
+        "HOP_START(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND, TIME '00:00:03'), " +
+        "HOP_END(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND, TIME '00:00:03') " +
+        "FROM Table3WithTimestamp " +
+        "GROUP BY b, HOP(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND, TIME '00:00:03')",
+      Seq(
+        row(1, 1,
+          localDateTime("1969-12-31 23:59:53.0"), localDateTime("1970-01-01 00:00:02.0")),
+        row(1, 1,
+          localDateTime("1969-12-31 23:59:58.0"), localDateTime("1970-01-01 00:00:07.0")),
+        row(2, 3,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(2, 5,
+          localDateTime("1969-12-31 23:59:58.0"), localDateTime("1970-01-01 00:00:07.0")),
+        row(3, 15,
+          localDateTime("1969-12-31 23:59:58.0"), localDateTime("1970-01-01 00:00:07.0")),
+        row(3, 15,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(4, 27,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(4, 34,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(5, 11,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(5, 42,
+          localDateTime("1970-01-01 00:00:13.0"), localDateTime("1970-01-01 00:00:22.0")),
+        row(5, 65,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(6, 111,
+          localDateTime("1970-01-01 00:00:13.0"), localDateTime("1970-01-01 00:00:22.0")),
+        row(6, 16,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(6, 78,
+          localDateTime("1970-01-01 00:00:18.0"), localDateTime("1970-01-01 00:00:27.0"))
+      )
+    )
+
+    // hash; keyed; 2-phase;
+    checkResult(
+      "SELECT b, sum(a), " +
+        "HOP_START(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND, TIME '00:00:03'), " +
+        "HOP_END(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND, TIME '00:00:03') " +
+        "FROM Table3WithTimestamp " +
+        "GROUP BY b, HOP(ts, INTERVAL '5' SECOND, INTERVAL '9' SECOND,TIME '00:00:03')",
+      Seq(
+        row(1, 1,
+          localDateTime("1969-12-31 23:59:53.0"), localDateTime("1970-01-01 00:00:02.0")),
+        row(1, 1,
+          localDateTime("1969-12-31 23:59:58.0"), localDateTime("1970-01-01 00:00:07.0")),
+        row(2, 3,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(2, 5,
+          localDateTime("1969-12-31 23:59:58.0"), localDateTime("1970-01-01 00:00:07.0")),
+        row(3, 15,
+          localDateTime("1969-12-31 23:59:58.0"), localDateTime("1970-01-01 00:00:07.0")),
+        row(3, 15,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(4, 27,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(4, 34,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(5, 11,
+          localDateTime("1970-01-01 00:00:03.0"), localDateTime("1970-01-01 00:00:12.0")),
+        row(5, 42,
+          localDateTime("1970-01-01 00:00:13.0"), localDateTime("1970-01-01 00:00:22.0")),
+        row(5, 65,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(6, 111,
+          localDateTime("1970-01-01 00:00:13.0"), localDateTime("1970-01-01 00:00:22.0")),
+        row(6, 16,
+          localDateTime("1970-01-01 00:00:08.0"), localDateTime("1970-01-01 00:00:17.0")),
+        row(6, 78,
+          localDateTime("1970-01-01 00:00:18.0"), localDateTime("1970-01-01 00:00:27.0"))
+      )
+    )
+  }
+
   @Test(expected = classOf[RuntimeException])
   def testSessionWindowWithProperties(): Unit = {
     registerCollection(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
@@ -87,9 +87,23 @@ public class WindowOperatorBuilder {
 		return this;
 	}
 
+	public WindowOperatorBuilder tumble(Duration size, Duration offset) {
+		checkArgument(this.windowAssigner == null);
+		checkArgument(offset.toMillis() > 0);
+		this.windowAssigner = TumblingWindowAssigner.of(size).withOffset(offset);
+		return this;
+	}
+
 	public WindowOperatorBuilder sliding(Duration size, Duration slide) {
 		checkArgument(windowAssigner == null);
 		this.windowAssigner = SlidingWindowAssigner.of(size, slide);
+		return this;
+	}
+
+	public WindowOperatorBuilder sliding(Duration size, Duration slide, Duration offset) {
+		checkArgument(this.windowAssigner == null);
+		checkArgument(offset.toMillis() > 0);
+		this.windowAssigner = SlidingWindowAssigner.of(size, slide).withOffset(offset);
 		return this;
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

Tumbling/Sliding window aggregate support window start offset in batch and streaming mode.

## Brief change log
1. TumblingGroupWindow and SlidingGroupWindow add a option offset field.
2. Modify StreamExecGroupWindowAggregate and  BatchExecGroupWindowAggregate physical node.

## Verifying this change

This change added tests and can be verified as follows:
1. WindowAggregateTest#testTumbleWindowWithOffset and WindowAggregateTest#testHopWindowWithOffset
2. WindowAggregateITCase#testTumblingWindowWithOffset and testSlidingWindowWithOffset

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
