### PR TITLE
[hotfix][typos]Add @link for BinaryRowData in RowData javadoc

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.data;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -51,7 +52,7 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getSc
  * <p>The {@link RowData} interface has different implementations which are designed for different
  * scenarios:
  * <ul>
- *     <li>The binary-oriented implementation {@code BinaryRowData} is backed by references to {@link MemorySegment}
+ *     <li>The binary-oriented implementation {@link BinaryRowData} is backed by references to {@link MemorySegment}
  *     instead of using Java objects to reduce the serialization/deserialization overhead.</li>
  *     <li>The object-oriented implementation {@link GenericRowData} is backed by an array of Java {@link Object}
  *     which is easy to construct and efficient to update.</li>


### PR DESCRIPTION
## What is the purpose of the change

Add @link for BinaryRowData in RowData javadoc

## Brief change log

Add @link for BinaryRowData in RowData javadoc

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
