### PR TITLE
[FLINK-19281][Table SQL / API]LIKE cannot recognize full table path

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -140,8 +140,7 @@ class SqlCreateTableConverter {
 	}
 
 	private CatalogTable lookupLikeSourceTable(SqlTableLike sqlTableLike) {
-		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlTableLike.getSourceTable()
-			.names);
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlTableLike.getSourceTable().names);
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 		CatalogManager.TableLookupResult lookupResult = catalogManager.getTable(identifier)
 			.orElseThrow(() -> new ValidationException(String.format(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -141,7 +141,7 @@ class SqlCreateTableConverter {
 
 	private CatalogTable lookupLikeSourceTable(SqlTableLike sqlTableLike) {
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlTableLike.getSourceTable()
-			.toString());
+			.names);
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 		CatalogManager.TableLookupResult lookupResult = catalogManager.getTable(identifier)
 			.orElseThrow(() -> new ValidationException(String.format(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -527,6 +527,7 @@ public class SqlToOperationConverterTest {
 			)
 		);
 	}
+
 	@Test
 	public void testCreateTableLikeWithFullPath(){
 		Map<String, String> sourceProperties = new HashMap<>();

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -527,6 +527,40 @@ public class SqlToOperationConverterTest {
 			)
 		);
 	}
+	@Test
+	public void testCreateTableLikeWithFullPath(){
+		Map<String, String> sourceProperties = new HashMap<>();
+		sourceProperties.put("format.type", "json");
+		CatalogTableImpl catalogTable = new CatalogTableImpl(
+			TableSchema.builder()
+				.field("f0", DataTypes.INT().notNull())
+				.field("f1", DataTypes.TIMESTAMP(3))
+				.build(),
+			sourceProperties,
+			null
+		);
+		catalogManager.createTable(catalogTable, ObjectIdentifier.of("builtin", "default", "sourceTable"), false);
+		final String sql = "create table mytable like builtin.default.sourceTable";
+		Operation operation = parseAndConvert(sql);
+
+		assertThat(
+			operation,
+			isCreateTableOperation(
+			withSchema(
+				TableSchema.builder()
+					.field("f0", DataTypes.INT().notNull())
+					.field("f1", DataTypes.TIMESTAMP(3))
+					.build()
+			),
+			withOptions(
+				entry("connector.type", "kafka"),
+				entry("format.type", "json")
+			),
+			partitionedBy(
+				"a", "f0"
+			)
+		));
+	}
 
 	@Test
 	public void testMergingCreateTableLike() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -531,6 +531,7 @@ public class SqlToOperationConverterTest {
 	@Test
 	public void testCreateTableLikeWithFullPath(){
 		Map<String, String> sourceProperties = new HashMap<>();
+		sourceProperties.put("connector.type", "kafka");
 		sourceProperties.put("format.type", "json");
 		CatalogTableImpl catalogTable = new CatalogTableImpl(
 			TableSchema.builder()
@@ -541,7 +542,7 @@ public class SqlToOperationConverterTest {
 			null
 		);
 		catalogManager.createTable(catalogTable, ObjectIdentifier.of("builtin", "default", "sourceTable"), false);
-		final String sql = "create table mytable like builtin.default.sourceTable";
+		final String sql = "create table mytable like `builtin`.`default`.sourceTable";
 		Operation operation = parseAndConvert(sql);
 
 		assertThat(
@@ -556,9 +557,6 @@ public class SqlToOperationConverterTest {
 			withOptions(
 				entry("connector.type", "kafka"),
 				entry("format.type", "json")
-			),
-			partitionedBy(
-				"a", "f0"
 			)
 		));
 	}


### PR DESCRIPTION

## What is the purpose of the change

to support full table path in flink sql ddl
for example, if we have a table whose full path is default_catalog.default_database.my_table1, and the following DDL will fail

```
create table my_table2 
like default_catalog.default_database.my_table1
```


## Brief change log
  - to support full table path in flink sql ddl


## Verifying this change

This change added tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
