### PR TITLE
[FLINK-19280][connectors] fix the bug of the option "sink.buffer-flush.max-rows" for JDBC can't be disabled by set to zero

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
@@ -152,7 +152,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 		try {
 			addToBatch(record, jdbcRecordExtractor.apply(record));
 			batchCount++;
-			if (batchCount >= executionOptions.getBatchSize()) {
+			if (executionOptions.getBatchSize() > 0 && batchCount >= executionOptions.getBatchSize()) {
 				flush();
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

*Fix the bug of the option "sink.buffer-flush.max-rows" for JDBC can't be disabled by set to zero*


## Brief change log

  - *Fix the bug of the option "sink.buffer-flush.max-rows" for JDBC can't be disabled by set to zero*


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added JdbcDynamicOutputFormatTest#testFlushWithBatchSizeEqualsZero test validate it

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
