### PR TITLE
[FLINK-19189][runtime] Enable pipelined scheduling by default

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -348,7 +348,7 @@ public class JobManagerOptions {
 	public static final ConfigOption<String> SCHEDULING_STRATEGY =
 		key("jobmanager.scheduler.scheduling-strategy")
 			.stringType()
-			.defaultValue("legacy")
+			.defaultValue("region")
 			.withDescription(Description.builder()
 				.text("Determines which scheduling strategy is used to schedule tasks. Accepted values are:")
 				.list(

--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.tpcds;
 
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
@@ -129,6 +130,8 @@ public class TpcdsTestProgram {
 		//config Optimizer parameters
 		tEnv.getConfig().getConfiguration()
 				.setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 4);
+		tEnv.getConfig().getConfiguration()
+				.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
 		tEnv.getConfig().getConfiguration()
 				.setLong(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD, 10 * 1024 * 1024);
 		tEnv.getConfig().getConfiguration()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -400,9 +400,15 @@ public class MiniClusterITCase extends TestLogger {
 		try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
 			miniCluster.start();
 
+			// putting sender and receiver vertex in the same slot sharing group is required
+			// to ensure all senders can be deployed. Otherwise this case can fail if the
+			// expected failing sender is not deployed.
+			final SlotSharingGroup group = new SlotSharingGroup();
+
 			final JobVertex sender = new JobVertex("Sender");
 			sender.setInvokableClass(SometimesExceptionSender.class);
 			sender.setParallelism(parallelism);
+			sender.setSlotSharingGroup(group);
 
 			// set failing senders
 			SometimesExceptionSender.configFailingSenders(parallelism);
@@ -410,6 +416,7 @@ public class MiniClusterITCase extends TestLogger {
 			final JobVertex receiver = new JobVertex("Receiver");
 			receiver.setInvokableClass(Receiver.class);
 			receiver.setParallelism(parallelism);
+			receiver.setSlotSharingGroup(group);
 
 			receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
 				ResultPartitionType.PIPELINED);
@@ -514,9 +521,15 @@ public class MiniClusterITCase extends TestLogger {
 		try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
 			miniCluster.start();
 
+			// putting sender and receiver vertex in the same slot sharing group is required
+			// to ensure all senders can be deployed. Otherwise this case can fail if the
+			// expected failing sender is not deployed.
+			final SlotSharingGroup group = new SlotSharingGroup();
+
 			final JobVertex sender = new JobVertex("Sender");
 			sender.setInvokableClass(SometimesInstantiationErrorSender.class);
 			sender.setParallelism(parallelism);
+			sender.setSlotSharingGroup(group);
 
 			// set failing senders
 			SometimesInstantiationErrorSender.configFailingSenders(parallelism);
@@ -524,6 +537,7 @@ public class MiniClusterITCase extends TestLogger {
 			final JobVertex receiver = new JobVertex("Receiver");
 			receiver.setInvokableClass(Receiver.class);
 			receiver.setParallelism(parallelism);
+			receiver.setSlotSharingGroup(group);
 
 			receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
 				ResultPartitionType.PIPELINED);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponentsFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponentsFactoryTest.java
@@ -62,9 +62,9 @@ public class DefaultSchedulerComponentsFactoryTest extends TestLogger {
 	}
 
 	@Test
-	public void testCreatingLegacySchedulingStrategyFactoryByDefault() {
+	public void testCreatingPipelinedRegionSchedulingStrategyFactoryByDefault() {
 		final DefaultSchedulerComponents components = createSchedulerComponents(new Configuration());
-		assertThat(components.getSchedulingStrategyFactory(), instanceOf(LazyFromSourcesSchedulingStrategy.Factory.class));
+		assertThat(components.getSchedulingStrategyFactory(), instanceOf(PipelinedRegionSchedulingStrategy.Factory.class));
 	}
 
 	private static DefaultSchedulerComponents createSchedulerComponents(final Configuration configuration) {

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -64,8 +64,8 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
 		config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("80m"));
-		config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.ofMebiBytes(25L));
-		config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.ofMebiBytes(25L));
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.ofMebiBytes(32L));
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.ofMebiBytes(32L));
 		return config;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR is to enable pipelined scheduling by default.
This change is based on #13422

## Verifying this change

  - *Stability tests passed*
  - *TPC-DS benchmark on 1T dataset passed with a slightly better performance over lazy-from-sources scheduling*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
