### PR TITLE
[FLINK-19321][Table SQL / Runtime]CollectSinkFunction does not define serialVersionUID

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
@@ -122,6 +122,8 @@ import java.util.concurrent.locks.ReentrantLock;
 @Internal
 public class CollectSinkFunction<IN> extends RichSinkFunction<IN> implements CheckpointedFunction, CheckpointListener {
 
+	private static final long serialVersionUID = 1L;
+
 	private static final Logger LOG = LoggerFactory.getLogger(CollectSinkFunction.class);
 
 	private final TypeSerializer<IN> serializer;


### PR DESCRIPTION

## What is the purpose of the change

The org.apache.flink.streaming.api.operators.collect.CollectSinkFunction function does not define a serialVersionUID.

Function objects are serialized using Java Serialization and should define a serialVersionUID.

If no o serialVersionUID is defined, Java automatically generates IDs to check compatibility of objects during deserialization. However, the generation depends on the environment (JVM, class version, etc.) and can hence lead to java.io.InvalidClassException even if the classes are compatible.


## Brief change log

  - *add serialVersionUID to CollectSinkFunction*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
