### PR TITLE
[FLINK-19288] Make the InternalTimeServiceManager an interface

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/StateReaderOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/StateReaderOperator.java
@@ -32,7 +32,6 @@ import org.apache.flink.state.api.runtime.VoidTriggerable;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.KeyContext;
-import org.apache.flink.streaming.api.operators.TimerSerializer;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
@@ -95,8 +94,11 @@ public abstract class StateReaderOperator<F extends Function, KEY, N, OUT> imple
 	}
 
 	protected final InternalTimerService<N> getInternalTimerService(String name) {
-		TimerSerializer<KEY, N> timerSerializer = new TimerSerializer<>(keySerializer, namespaceSerializer);
-		return timerServiceManager.getInternalTimerService(name, timerSerializer, VoidTriggerable.instance());
+		return timerServiceManager.getInternalTimerService(
+			name,
+			keySerializer,
+			namespaceSerializer,
+			VoidTriggerable.instance());
 	}
 
 	public void open() throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -60,6 +60,8 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Optional;
 
+import static org.apache.flink.util.Preconditions.checkState;
+
 /**
  * Base class for all stream operators. Operators that contain a user function should extend the class
  * {@link AbstractUdfStreamOperator} instead (which is a specialized subclass of this class).
@@ -556,11 +558,13 @@ public abstract class AbstractStreamOperator<OUT>
 		}
 		@SuppressWarnings("unchecked")
 		InternalTimeServiceManager<K> keyedTimeServiceHandler = (InternalTimeServiceManager<K>) timeServiceManager;
+		KeyedStateBackend<K> keyedStateBackend = getKeyedStateBackend();
+		checkState(keyedStateBackend != null, "Timers can only be used on keyed operators.");
 		return keyedTimeServiceHandler.getInternalTimerService(
 			name,
+			keyedStateBackend.getKeySerializer(),
 			namespaceSerializer,
-			triggerable,
-			stateHandler.getKeyedStateBackend());
+			triggerable);
 	}
 
 	public void processWatermark(Watermark mark) throws Exception {
@@ -591,16 +595,6 @@ public abstract class AbstractStreamOperator<OUT>
 	@Override
 	public OperatorID getOperatorID() {
 		return config.getOperatorID();
-	}
-
-	@VisibleForTesting
-	public int numProcessingTimeTimers() {
-		return timeServiceManager == null ? 0 : timeServiceManager.numProcessingTimeTimers();
-	}
-
-	@VisibleForTesting
-	public int numEventTimeTimers() {
-		return timeServiceManager == null ? 0 : timeServiceManager.numEventTimeTimers();
 	}
 
 	protected Optional<InternalTimeServiceManager<?>> getTimeServiceManager() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -60,6 +60,8 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 
+import static org.apache.flink.util.Preconditions.checkState;
+
 /**
  * New base class for all stream operators, intended to eventually replace {@link AbstractStreamOperator}.
  * Currently intended to work smoothly just with {@link MultipleInputStreamOperator}.
@@ -455,12 +457,16 @@ public abstract class AbstractStreamOperatorV2<OUT> implements StreamOperator<OU
 		if (timeServiceManager == null) {
 			throw new RuntimeException("The timer service has not been initialized.");
 		}
+
+		@SuppressWarnings("unchecked")
 		InternalTimeServiceManager<K> keyedTimeServiceHandler = (InternalTimeServiceManager<K>) timeServiceManager;
+		KeyedStateBackend<K> keyedStateBackend = getKeyedStateBackend();
+		checkState(keyedStateBackend != null, "Timers can only be used on keyed operators.");
 		return keyedTimeServiceHandler.getInternalTimerService(
 			name,
+			keyedStateBackend.getKeySerializer(),
 			namespaceSerializer,
-			triggerable,
-			stateHandler.getKeyedStateBackend());
+			triggerable);
 	}
 
 	public void processWatermark(Watermark mark) throws Exception {
@@ -485,16 +491,6 @@ public abstract class AbstractStreamOperatorV2<OUT> implements StreamOperator<OU
 	@Override
 	public OperatorID getOperatorID() {
 		return config.getOperatorID();
-	}
-
-	@VisibleForTesting
-	public int numProcessingTimeTimers() {
-		return timeServiceManager == null ? 0 : timeServiceManager.numProcessingTimeTimers();
-	}
-
-	@VisibleForTesting
-	public int numEventTimeTimers() {
-		return timeServiceManager == null ? 0 : timeServiceManager.numEventTimeTimers();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -19,214 +19,61 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
-import org.apache.flink.runtime.state.KeyGroupsList;
-import org.apache.flink.runtime.state.KeyedStateBackend;
-import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
-import org.apache.flink.runtime.state.PriorityQueueSetFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.util.Preconditions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * An entity keeping all the time-related services available to all operators extending the
- * {@link AbstractStreamOperator}. Right now, this is only a
- * {@link InternalTimerServiceImpl timer services}.
+ * An entity keeping all the time-related services.
  *
  * <b>NOTE:</b> These services are only available to keyed operators.
  *
  * @param <K> The type of keys used for the timers and the registry.
  */
 @Internal
-public class InternalTimeServiceManager<K> {
-	protected static final Logger LOG = LoggerFactory.getLogger(InternalTimeServiceManager.class);
+public interface InternalTimeServiceManager<K> {
+	/**
+	 * Creates an {@link InternalTimerService} for handling a group of timers identified by
+	 * the given {@code name}. The timers are scoped to a key and namespace.
+	 *
+	 * <p>When a timer fires the given {@link Triggerable} will be invoked.
+	 */
+	<N> InternalTimerService<N> getInternalTimerService(
+		String name,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer,
+		Triggerable<K, N> triggerable);
 
-	@VisibleForTesting
-	static final String TIMER_STATE_PREFIX = "_timer_state";
-	@VisibleForTesting
-	static final String PROCESSING_TIMER_PREFIX = TIMER_STATE_PREFIX + "/processing_";
-	@VisibleForTesting
-	static final String EVENT_TIMER_PREFIX = TIMER_STATE_PREFIX + "/event_";
+	/**
+	 * Advances the Watermark of all managed {@link InternalTimerService timer services},
+	 * potentially firing event time timers.
+	 */
+	void advanceWatermark(Watermark watermark) throws Exception;
 
-	private final KeyGroupRange localKeyGroupRange;
-	private final KeyContext keyContext;
+	/**
+	 * Snapshots the timers to keyed state.
+	 *
+	 * <p><b>TODO:</b> This can be removed once heap-based timers are integrated with RocksDB
+	 * incremental snapshots.
+	 */
+	void snapshotState(
+		StateSnapshotContext context,
+		String operatorName) throws Exception;
 
-	private final PriorityQueueSetFactory priorityQueueSetFactory;
-	private final ProcessingTimeService processingTimeService;
-
-	private final Map<String, InternalTimerServiceImpl<K, ?>> timerServices;
-
-	private final boolean useLegacySynchronousSnapshots;
-
-	InternalTimeServiceManager(
-			KeyGroupRange localKeyGroupRange,
+	/**
+	 * A provider pattern for creating an instance of a {@link InternalTimeServiceManager}.
+	 * Allows substituting the manager that will be used at the runtime.
+	 */
+	@FunctionalInterface
+	interface Provider {
+		<K> InternalTimeServiceManager<K> create(
+			CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+			ClassLoader userClassloader,
 			KeyContext keyContext,
-			PriorityQueueSetFactory priorityQueueSetFactory,
 			ProcessingTimeService processingTimeService,
-			boolean useLegacySynchronousSnapshots) {
-
-		this.localKeyGroupRange = Preconditions.checkNotNull(localKeyGroupRange);
-		this.priorityQueueSetFactory = Preconditions.checkNotNull(priorityQueueSetFactory);
-		this.keyContext = Preconditions.checkNotNull(keyContext);
-		this.processingTimeService = Preconditions.checkNotNull(processingTimeService);
-		this.useLegacySynchronousSnapshots = useLegacySynchronousSnapshots;
-
-		this.timerServices = new HashMap<>();
-	}
-
-	public <N> InternalTimerService<N> getInternalTimerService(
-			String name,
-			TypeSerializer<N> namespaceSerializer,
-			Triggerable<K, N> triggerable,
-			KeyedStateBackend<K> keyedStateBackend) {
-		checkNotNull(keyedStateBackend, "Timers can only be used on keyed operators.");
-
-		TypeSerializer<K> keySerializer = keyedStateBackend.getKeySerializer();
-		// the following casting is to overcome type restrictions.
-		TimerSerializer<K, N> timerSerializer = new TimerSerializer<>(keySerializer, namespaceSerializer);
-		return getInternalTimerService(name, timerSerializer, triggerable);
-	}
-
-	public <N> InternalTimerService<N> getInternalTimerService(
-		String name,
-		TimerSerializer<K, N> timerSerializer,
-		Triggerable<K, N> triggerable) {
-
-		InternalTimerServiceImpl<K, N> timerService = registerOrGetTimerService(name, timerSerializer);
-
-		timerService.startTimerService(
-			timerSerializer.getKeySerializer(),
-			timerSerializer.getNamespaceSerializer(),
-			triggerable);
-
-		return timerService;
-	}
-
-	@SuppressWarnings("unchecked")
-	<N> InternalTimerServiceImpl<K, N> registerOrGetTimerService(String name, TimerSerializer<K, N> timerSerializer) {
-		InternalTimerServiceImpl<K, N> timerService = (InternalTimerServiceImpl<K, N>) timerServices.get(name);
-		if (timerService == null) {
-
-			timerService = new InternalTimerServiceImpl<>(
-				localKeyGroupRange,
-				keyContext,
-				processingTimeService,
-				createTimerPriorityQueue(PROCESSING_TIMER_PREFIX + name, timerSerializer),
-				createTimerPriorityQueue(EVENT_TIMER_PREFIX + name, timerSerializer));
-
-			timerServices.put(name, timerService);
-		}
-		return timerService;
-	}
-
-	Map<String, InternalTimerServiceImpl<K, ?>> getRegisteredTimerServices() {
-		return Collections.unmodifiableMap(timerServices);
-	}
-
-	private <N> KeyGroupedInternalPriorityQueue<TimerHeapInternalTimer<K, N>> createTimerPriorityQueue(
-		String name,
-		TimerSerializer<K, N> timerSerializer) {
-		return priorityQueueSetFactory.create(
-			name,
-			timerSerializer);
-	}
-
-	public void advanceWatermark(Watermark watermark) throws Exception {
-		for (InternalTimerServiceImpl<?, ?> service : timerServices.values()) {
-			service.advanceWatermark(watermark.getTimestamp());
-		}
-	}
-
-	//////////////////				Fault Tolerance Methods				///////////////////
-
-	public void snapshotState(StateSnapshotContext context, String operatorName) throws Exception {
-		//TODO all of this can be removed once heap-based timers are integrated with RocksDB incremental snapshots
-		if (useLegacySynchronousSnapshots) {
-			KeyedStateCheckpointOutputStream out;
-			try {
-				out = context.getRawKeyedOperatorStateOutput();
-			} catch (Exception exception) {
-				throw new Exception("Could not open raw keyed operator state stream for " +
-					operatorName + '.', exception);
-			}
-
-			try {
-				KeyGroupsList allKeyGroups = out.getKeyGroupList();
-				for (int keyGroupIdx : allKeyGroups) {
-					out.startNewKeyGroup(keyGroupIdx);
-
-					snapshotStateForKeyGroup(
-						new DataOutputViewStreamWrapper(out), keyGroupIdx);
-				}
-			} catch (Exception exception) {
-				throw new Exception("Could not write timer service of " + operatorName +
-					" to checkpoint state stream.", exception);
-			} finally {
-				try {
-					out.close();
-				} catch (Exception closeException) {
-					LOG.warn("Could not close raw keyed operator state stream for {}. This " +
-						"might have prevented deleting some state data.", operatorName, closeException);
-				}
-			}
-		}
-	}
-
-	private void snapshotStateForKeyGroup(DataOutputView stream, int keyGroupIdx) throws IOException {
-		InternalTimerServiceSerializationProxy<K> serializationProxy =
-			new InternalTimerServiceSerializationProxy<>(this, keyGroupIdx);
-
-		serializationProxy.write(stream);
-	}
-
-	public void restoreStateForKeyGroup(
-			InputStream stream,
-			int keyGroupIdx,
-			ClassLoader userCodeClassLoader) throws IOException {
-
-		InternalTimerServiceSerializationProxy<K> serializationProxy =
-			new InternalTimerServiceSerializationProxy<>(
-				this,
-				userCodeClassLoader,
-				keyGroupIdx);
-
-		serializationProxy.read(stream);
-	}
-
-	////////////////////			Methods used ONLY IN TESTS				////////////////////
-
-	@VisibleForTesting
-	public int numProcessingTimeTimers() {
-		int count = 0;
-		for (InternalTimerServiceImpl<?, ?> timerService : timerServices.values()) {
-			count += timerService.numProcessingTimeTimers();
-		}
-		return count;
-	}
-
-	@VisibleForTesting
-	public int numEventTimeTimers() {
-		int count = 0;
-		for (InternalTimerServiceImpl<?, ?> timerService : timerServices.values()) {
-			count += timerService.numEventTimeTimers();
-		}
-		return count;
+			Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.KeyGroupsList;
+import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An entity keeping all the time-related services. Right now, this is only a
+ * {@link InternalTimerServiceImpl timer services}.
+ *
+ * <b>NOTE:</b> These services are only available to keyed operators.
+ *
+ * @param <K> The type of keys used for the timers and the registry.
+ */
+@Internal
+public class InternalTimeServiceManagerImpl<K> implements InternalTimeServiceManager<K> {
+	protected static final Logger LOG = LoggerFactory.getLogger(InternalTimeServiceManagerImpl.class);
+
+	@VisibleForTesting
+	static final String TIMER_STATE_PREFIX = "_timer_state";
+	@VisibleForTesting
+	static final String PROCESSING_TIMER_PREFIX = TIMER_STATE_PREFIX + "/processing_";
+	@VisibleForTesting
+	static final String EVENT_TIMER_PREFIX = TIMER_STATE_PREFIX + "/event_";
+
+	private final KeyGroupRange localKeyGroupRange;
+	private final KeyContext keyContext;
+
+	private final PriorityQueueSetFactory priorityQueueSetFactory;
+	private final ProcessingTimeService processingTimeService;
+
+	private final Map<String, InternalTimerServiceImpl<K, ?>> timerServices;
+
+	private final boolean useLegacySynchronousSnapshots;
+
+	private InternalTimeServiceManagerImpl(
+		KeyGroupRange localKeyGroupRange,
+		KeyContext keyContext,
+		PriorityQueueSetFactory priorityQueueSetFactory,
+		ProcessingTimeService processingTimeService, boolean useLegacySynchronousSnapshots) {
+
+		this.localKeyGroupRange = Preconditions.checkNotNull(localKeyGroupRange);
+		this.priorityQueueSetFactory = Preconditions.checkNotNull(priorityQueueSetFactory);
+		this.keyContext = Preconditions.checkNotNull(keyContext);
+		this.processingTimeService = Preconditions.checkNotNull(processingTimeService);
+		this.useLegacySynchronousSnapshots = useLegacySynchronousSnapshots;
+
+		this.timerServices = new HashMap<>();
+	}
+
+	/**
+	 * A factory method for creating the {@link InternalTimeServiceManagerImpl}.
+	 *
+	 * <p><b>IMPORTANT:</b> Keep in sync with {@link InternalTimeServiceManager.Provider}.
+	 */
+	public static <K> InternalTimeServiceManagerImpl<K> create(
+			CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+			ClassLoader userClassloader,
+			KeyContext keyContext,
+			ProcessingTimeService processingTimeService,
+			Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+
+		if (keyedStatedBackend == null) {
+			return null;
+		}
+
+		final KeyGroupRange keyGroupRange = keyedStatedBackend.getKeyGroupRange();
+		final boolean requiresSnapshotLegacyTimers = keyedStatedBackend instanceof AbstractKeyedStateBackend &&
+			((AbstractKeyedStateBackend<K>) keyedStatedBackend).requiresLegacySynchronousTimerSnapshots();
+
+		final InternalTimeServiceManagerImpl<K> timeServiceManager = new InternalTimeServiceManagerImpl<>(
+			keyGroupRange,
+			keyContext,
+			keyedStatedBackend,
+			processingTimeService,
+			requiresSnapshotLegacyTimers);
+
+		// and then initialize the timer services
+		for (KeyGroupStatePartitionStreamProvider streamProvider : rawKeyedStates) {
+			int keyGroupIdx = streamProvider.getKeyGroupId();
+
+			Preconditions.checkArgument(keyGroupRange.contains(keyGroupIdx),
+				"Key Group " + keyGroupIdx + " does not belong to the local range.");
+
+			timeServiceManager.restoreStateForKeyGroup(
+				streamProvider.getStream(),
+				keyGroupIdx,
+				userClassloader);
+		}
+
+		return timeServiceManager;
+	}
+
+	@Override
+	public <N> InternalTimerService<N> getInternalTimerService(
+			String name,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			Triggerable<K, N> triggerable) {
+		checkNotNull(keySerializer, "Timers can only be used on keyed operators.");
+
+		// the following casting is to overcome type restrictions.
+		TimerSerializer<K, N> timerSerializer = new TimerSerializer<>(keySerializer, namespaceSerializer);
+
+		InternalTimerServiceImpl<K, N> timerService = registerOrGetTimerService(name, timerSerializer);
+
+		timerService.startTimerService(
+			timerSerializer.getKeySerializer(),
+			timerSerializer.getNamespaceSerializer(),
+			triggerable);
+
+		return timerService;
+	}
+
+	@SuppressWarnings("unchecked")
+	<N> InternalTimerServiceImpl<K, N> registerOrGetTimerService(String name, TimerSerializer<K, N> timerSerializer) {
+		InternalTimerServiceImpl<K, N> timerService = (InternalTimerServiceImpl<K, N>) timerServices.get(name);
+		if (timerService == null) {
+
+			timerService = new InternalTimerServiceImpl<>(
+				localKeyGroupRange,
+				keyContext,
+				processingTimeService,
+				createTimerPriorityQueue(PROCESSING_TIMER_PREFIX + name, timerSerializer),
+				createTimerPriorityQueue(EVENT_TIMER_PREFIX + name, timerSerializer));
+
+			timerServices.put(name, timerService);
+		}
+		return timerService;
+	}
+
+	Map<String, InternalTimerServiceImpl<K, ?>> getRegisteredTimerServices() {
+		return Collections.unmodifiableMap(timerServices);
+	}
+
+	private <N> KeyGroupedInternalPriorityQueue<TimerHeapInternalTimer<K, N>> createTimerPriorityQueue(
+			String name,
+			TimerSerializer<K, N> timerSerializer) {
+		return priorityQueueSetFactory.create(name, timerSerializer);
+	}
+
+	@Override
+	public void advanceWatermark(Watermark watermark) throws Exception {
+		for (InternalTimerServiceImpl<?, ?> service : timerServices.values()) {
+			service.advanceWatermark(watermark.getTimestamp());
+		}
+	}
+
+	//////////////////				Fault Tolerance Methods				///////////////////
+
+	@Override
+	public void snapshotState(StateSnapshotContext context, String operatorName) throws Exception {
+		//TODO all of this can be removed once heap-based timers are integrated with RocksDB incremental snapshots
+		if (useLegacySynchronousSnapshots) {
+
+			KeyedStateCheckpointOutputStream out;
+			try {
+				out = context.getRawKeyedOperatorStateOutput();
+			} catch (Exception exception) {
+				throw new Exception("Could not open raw keyed operator state stream for " +
+					operatorName + '.', exception);
+			}
+
+			try {
+				KeyGroupsList allKeyGroups = out.getKeyGroupList();
+				for (int keyGroupIdx : allKeyGroups) {
+					out.startNewKeyGroup(keyGroupIdx);
+
+					snapshotStateForKeyGroup(
+						new DataOutputViewStreamWrapper(out), keyGroupIdx);
+				}
+			} catch (Exception exception) {
+				throw new Exception("Could not write timer service of " + operatorName +
+					" to checkpoint state stream.", exception);
+			} finally {
+				try {
+					out.close();
+				} catch (Exception closeException) {
+					LOG.warn("Could not close raw keyed operator state stream for {}. This " +
+						"might have prevented deleting some state data.", operatorName, closeException);
+				}
+			}
+		}
+	}
+
+	private void snapshotStateForKeyGroup(DataOutputView stream, int keyGroupIdx) throws IOException {
+		InternalTimerServiceSerializationProxy<K> serializationProxy =
+			new InternalTimerServiceSerializationProxy<>(this, keyGroupIdx);
+
+		serializationProxy.write(stream);
+	}
+
+	private void restoreStateForKeyGroup(
+			InputStream stream,
+			int keyGroupIdx,
+			ClassLoader userCodeClassLoader) throws IOException {
+
+		InternalTimerServiceSerializationProxy<K> serializationProxy =
+			new InternalTimerServiceSerializationProxy<>(
+				this,
+				userCodeClassLoader,
+				keyGroupIdx);
+
+		serializationProxy.read(stream);
+	}
+
+	////////////////////			Methods used ONLY IN TESTS				////////////////////
+
+	@VisibleForTesting
+	public int numProcessingTimeTimers() {
+		int count = 0;
+		for (InternalTimerServiceImpl<?, ?> timerService : timerServices.values()) {
+			count += timerService.numProcessingTimeTimers();
+		}
+		return count;
+	}
+
+	@VisibleForTesting
+	public int numEventTimeTimers() {
+		int count = 0;
+		for (InternalTimerServiceImpl<?, ?> timerService : timerServices.values()) {
+			count += timerService.numEventTimeTimers();
+		}
+		return count;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
@@ -38,7 +38,7 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 	public static final int VERSION = 2;
 
 	/** The key-group timer services to write / read. */
-	private final InternalTimeServiceManager<K> timerServicesManager;
+	private final InternalTimeServiceManagerImpl<K> timerServicesManager;
 
 	/** The user classloader; only relevant if the proxy is used to restore timer services. */
 	private ClassLoader userCodeClassLoader;
@@ -51,7 +51,7 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 	 * Constructor to use when restoring timer services.
 	 */
 	public InternalTimerServiceSerializationProxy(
-		InternalTimeServiceManager<K> timerServicesManager,
+		InternalTimeServiceManagerImpl<K> timerServicesManager,
 		ClassLoader userCodeClassLoader,
 		int keyGroupIdx) {
 		this.timerServicesManager = checkNotNull(timerServicesManager);
@@ -63,7 +63,7 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 	 * Constructor to use when writing timer services.
 	 */
 	public InternalTimerServiceSerializationProxy(
-		InternalTimeServiceManager<K> timerServicesManager,
+		InternalTimeServiceManagerImpl<K> timerServicesManager,
 		int keyGroupIdx) {
 		this.timerServicesManager = checkNotNull(timerServicesManager);
 		this.keyGroupIdx = keyGroupIdx;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImplTest.java
@@ -24,9 +24,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for {@link InternalTimeServiceManager}.
+ * Tests for {@link InternalTimeServiceManagerImpl}.
  */
-public class InternalTimeServiceManagerTest extends TestLogger {
+public class InternalTimeServiceManagerImplTest extends TestLogger {
 
 	/**
 	 * This test fixes some constants, because changing them can harm backwards compatibility.
@@ -34,8 +34,8 @@ public class InternalTimeServiceManagerTest extends TestLogger {
 	@Test
 	public void fixConstants() {
 		String expectedTimerStatePrefix = "_timer_state";
-		Assert.assertEquals(expectedTimerStatePrefix, InternalTimeServiceManager.TIMER_STATE_PREFIX);
-		Assert.assertEquals(expectedTimerStatePrefix + "/processing_", InternalTimeServiceManager.PROCESSING_TIMER_PREFIX);
-		Assert.assertEquals(expectedTimerStatePrefix + "/event_", InternalTimeServiceManager.EVENT_TIMER_PREFIX);
+		Assert.assertEquals(expectedTimerStatePrefix, InternalTimeServiceManagerImpl.TIMER_STATE_PREFIX);
+		Assert.assertEquals(expectedTimerStatePrefix + "/processing_", InternalTimeServiceManagerImpl.PROCESSING_TIMER_PREFIX);
+		Assert.assertEquals(expectedTimerStatePrefix + "/event_", InternalTimeServiceManagerImpl.EVENT_TIMER_PREFIX);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -283,16 +283,19 @@ public class StreamTaskStateInitializerImplTest {
 		} else {
 			return new StreamTaskStateInitializerImpl(
 				dummyEnvironment,
-				stateBackend) {
-				@Override
-				protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
-					CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-					KeyContext keyContext,
-					ProcessingTimeService processingTimeService,
-					Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
-					return null;
-				}
-			};
+				stateBackend,
+				TtlTimeProvider.DEFAULT,
+				new InternalTimeServiceManager.Provider() {
+					@Override
+					public <K> InternalTimeServiceManager<K> create(
+							CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+							ClassLoader userClassloader,
+							KeyContext keyContext,
+							ProcessingTimeService processingTimeService,
+							Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+						return null;
+					}
+				});
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -237,17 +237,21 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 				StateBackend stateBackend,
 				TtlTimeProvider ttlTimeProvider) {
 
-				return new StreamTaskStateInitializerImpl(env, stateBackend) {
-					@Override
-					protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
-						CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-						KeyContext keyContext,
-						ProcessingTimeService processingTimeService,
-						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) {
-
-						return null;
-					}
-				};
+				return new StreamTaskStateInitializerImpl(
+						env,
+						stateBackend,
+						ttlTimeProvider,
+						new InternalTimeServiceManager.Provider() {
+							@Override
+							public <K> InternalTimeServiceManager<K> create(
+								CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+								ClassLoader userClassloader,
+								KeyContext keyContext,
+								ProcessingTimeService processingTimeService,
+								Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+								return null;
+							}
+						});
 			}
 		};
 


### PR DESCRIPTION
## What is the purpose of the change

This refactoring allows to replace the InternalTimerService with a
different implementation.

Moreover it removes methods for retrieving the number of registered
timers from AbstractStreamOperator(s) which were introduced for tests.

## Verifying this change

This change is a refactoring that should be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
