### PR TITLE
[FLINK-19339] Support unions with logical types in Avro >= 1.9.x

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -144,7 +144,10 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
 
 		ClassLoader cl = Thread.currentThread().getContextClassLoader();
 		if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
-			SpecificData specificData = new SpecificData(cl);
+			@SuppressWarnings("unchecked")
+			SpecificData specificData = AvroFactory.getSpecificDataForClass(
+				(Class<? extends SpecificData>) recordClazz,
+				cl);
 			this.datumReader = new SpecificDatumReader<>(specificData);
 			this.reader = AvroFactory.extractAvroSpecificSchema(recordClazz, specificData);
 		} else {
@@ -163,7 +166,7 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public TypeInformation<T> getProducedType() {
 		if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
 			return new AvroTypeInfo(recordClazz);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
@@ -185,7 +185,8 @@ public class AvroSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
 			return null;
 		}
 		if (isSpecificRecord(runtimeType)) {
-			SpecificData d = new SpecificData(cl);
+			@SuppressWarnings("unchecked")
+			SpecificData d = AvroFactory.getSpecificDataForClass((Class<? extends SpecificData>) runtimeType, cl);
 			return AvroFactory.extractAvroSpecificSchema(runtimeType, d);
 		}
 		ReflectData d = new ReflectData(cl);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
@@ -20,11 +20,13 @@ package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.generated.UnionLogicalType;
 import org.apache.flink.formats.avro.utils.TestDataGenerator;
 
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Random;
 
 import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
@@ -52,11 +54,22 @@ public class AvroDeserializationSchemaTest {
 	}
 
 	@Test
-	public void testSpecificRecordWithConfluentSchemaRegistry() throws Exception {
+	public void testSpecificRecord() throws Exception {
 		DeserializationSchema<Address> deserializer = AvroDeserializationSchema.forSpecific(Address.class);
 
-		byte[] encodedAddress = writeRecord(address, Address.getClassSchema());
+		byte[] encodedAddress = writeRecord(address);
 		Address deserializedAddress = deserializer.deserialize(encodedAddress);
 		assertEquals(address, deserializedAddress);
+	}
+
+	@Test
+	public void testSpecificRecordWithUnionLogicalType() throws Exception {
+		Random rnd = new Random();
+		UnionLogicalType data = new UnionLogicalType(Instant.ofEpochMilli(rnd.nextLong()));
+		DeserializationSchema<UnionLogicalType> deserializer = AvroDeserializationSchema.forSpecific(UnionLogicalType.class);
+
+		byte[] encodedData = writeRecord(data);
+		UnionLogicalType deserializedData = deserializer.deserialize(encodedData);
+		assertEquals(data, deserializedData);
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSerializationSchemaTest.java
@@ -20,11 +20,13 @@ package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.generated.UnionLogicalType;
 import org.apache.flink.formats.avro.utils.TestDataGenerator;
 
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Random;
 
 import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
@@ -39,22 +41,33 @@ public class AvroSerializationSchemaTest {
 
 	@Test
 	public void testGenericRecord() throws Exception {
-		SerializationSchema<GenericRecord> deserializationSchema =
+		SerializationSchema<GenericRecord> serializationSchema =
 			AvroSerializationSchema.forGeneric(
 				address.getSchema()
 			);
 
 		byte[] encodedAddress = writeRecord(address, Address.getClassSchema());
-		byte[] dataSerialized = deserializationSchema.serialize(address);
+		byte[] dataSerialized = serializationSchema.serialize(address);
 		assertArrayEquals(encodedAddress, dataSerialized);
 	}
 
 	@Test
-	public void testSpecificRecordWithConfluentSchemaRegistry() throws Exception {
-		SerializationSchema<Address> deserializer = AvroSerializationSchema.forSpecific(Address.class);
+	public void testSpecificRecord() throws Exception {
+		SerializationSchema<Address> serializer = AvroSerializationSchema.forSpecific(Address.class);
 
 		byte[] encodedAddress = writeRecord(address, Address.getClassSchema());
-		byte[] serializedAddress = deserializer.serialize(address);
+		byte[] serializedAddress = serializer.serialize(address);
 		assertArrayEquals(encodedAddress, serializedAddress);
+	}
+
+	@Test
+	public void testSpecificRecordWithUnionLogicalType() throws Exception {
+		Random rnd = new Random();
+		UnionLogicalType data = new UnionLogicalType(Instant.ofEpochMilli(rnd.nextLong()));
+		AvroSerializationSchema<UnionLogicalType> serializer = AvroSerializationSchema.forSpecific(UnionLogicalType.class);
+
+		byte[] encodedData = writeRecord(data);
+		byte[] serializedData = serializer.serialize(data);
+		assertArrayEquals(encodedData, serializedData);
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroUnionLogicalSerializerTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroUnionLogicalSerializerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.typeutils;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.formats.avro.generated.UnionLogicalType;
+
+import java.time.Instant;
+import java.util.Random;
+
+/**
+ * Tests for the {@link AvroSerializer} that test specific avro types.
+ */
+public class AvroUnionLogicalSerializerTest extends SerializerTestBase<UnionLogicalType> {
+
+	@Override
+	protected TypeSerializer<UnionLogicalType> createSerializer() {
+		return new AvroSerializer<>(UnionLogicalType.class);
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<UnionLogicalType> getTypeClass() {
+		return UnionLogicalType.class;
+	}
+
+	@Override
+	protected UnionLogicalType[] getTestData() {
+		final Random rnd = new Random();
+		final UnionLogicalType[] data = new UnionLogicalType[20];
+
+		for (int i = 0; i < data.length; i++) {
+			data[i] = new UnionLogicalType(Instant.ofEpochMilli(rnd.nextLong()));
+		}
+
+		return data;
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -32,6 +32,7 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
 
 import java.io.ByteArrayOutputStream;
@@ -250,6 +251,22 @@ public final class AvroTestUtils {
 		BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(stream, null);
 
 		new GenericDatumWriter<>(schema).write(record, encoder);
+		encoder.flush();
+		return stream.toByteArray();
+	}
+
+	/**
+	 * Writes given specific record.
+	 * @param record record to serialize
+	 * @return serialized record
+	 */
+	public static <T extends SpecificRecord> byte[] writeRecord(T record) throws IOException {
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(stream, null);
+
+		@SuppressWarnings("unchecked")
+		SpecificDatumWriter<T> writer = new SpecificDatumWriter<>((Class<T>) record.getClass());
+		writer.write(record, encoder);
 		encoder.flush();
 		return stream.toByteArray();
 	}

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -1,6 +1,13 @@
 [
 {"namespace": "org.apache.flink.formats.avro.generated",
  "type": "record",
+ "name": "UnionLogicalType",
+ "fields": [
+     {"name": "nullableTimestamp", "type": [ "null", {"type": "long", "logicalType": "timestamp-millis"}]}
+  ]
+},
+{"namespace": "org.apache.flink.formats.avro.generated",
+ "type": "record",
  "name": "Address",
  "fields": [
      {"name": "num", "type": "int"},


### PR DESCRIPTION
## What is the purpose of the change

Avro 1.9.x introduced yet another mechanism for registering/looking up
conversions for logical types.

If a logical type is part of a union a static field MODEL$ of type SpecificData
is added to the generated Avro class with registered conversions for logical types.
In this commit we try to use that SpecificData in AvroSerializer and
Avro(De)SerializationSchema whenever available instead of instantiating a new
unrelated one.

The change is backwards compatible and if the field is not available we
fallback to the old ways.

## Verifying this change

This change added tests in respective test classes for AvroSerializer and Avro(De)SerializationSchema.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
