### PR TITLE
[FLINK-19273][sql-parser] Support METADATA syntax in SQL parser

### DIFF
--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.hive.ddl;
 
 import org.apache.flink.sql.parser.SqlProperty;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.hive.impl.ParseException;
 import org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec;
@@ -166,13 +167,13 @@ public class HiveDDLUtils {
 	public static void convertDataTypes(SqlNodeList columns) throws ParseException {
 		if (columns != null) {
 			for (SqlNode node : columns) {
-				convertDataTypes((SqlTableColumn) node);
+				convertDataTypes((SqlRegularColumn) node);
 			}
 		}
 	}
 
 	// Check and convert data types to comply with HiveQL, e.g. TIMESTAMP and BINARY
-	public static void convertDataTypes(SqlTableColumn column) throws ParseException {
+	public static void convertDataTypes(SqlRegularColumn column) throws ParseException {
 		column.setType(convertDataTypes(column.getType()));
 	}
 
@@ -311,18 +312,18 @@ public class HiveDDLUtils {
 	public static SqlNodeList deepCopyColList(SqlNodeList colList) {
 		SqlNodeList res = new SqlNodeList(colList.getParserPosition());
 		for (SqlNode node : colList) {
-			res.add(deepCopyTableColumn((SqlTableColumn) node));
+			res.add(deepCopyTableColumn((SqlRegularColumn) node));
 		}
 		return res;
 	}
 
-	public static SqlTableColumn deepCopyTableColumn(SqlTableColumn column) {
-		return new SqlTableColumn(
-				column.getName(),
-				column.getType(),
-				column.getConstraint().orElse(null),
-				column.getComment().orElse(null),
-				column.getParserPosition()
+	public static SqlRegularColumn deepCopyTableColumn(SqlRegularColumn column) {
+		return new SqlTableColumn.SqlRegularColumn(
+			column.getParserPosition(),
+			column.getName(),
+			column.getComment().orElse(null),
+			column.getType(),
+			column.getConstraint().orElse(null)
 		);
 	}
 

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTableChangeColumn.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTableChangeColumn.java
@@ -19,7 +19,7 @@
 package org.apache.flink.sql.parser.hive.ddl;
 
 import org.apache.flink.sql.parser.ddl.SqlChangeColumn;
-import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.hive.impl.ParseException;
 
 import org.apache.calcite.sql.SqlIdentifier;
@@ -32,11 +32,11 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  */
 public class SqlAlterHiveTableChangeColumn extends SqlChangeColumn {
 
-	private final SqlTableColumn origNewColumn;
+	private final SqlRegularColumn origNewColumn;
 	private final boolean cascade;
 
 	public SqlAlterHiveTableChangeColumn(SqlParserPos pos, SqlIdentifier tableName, boolean cascade,
-			SqlIdentifier oldName, SqlTableColumn newColumn, boolean first, SqlIdentifier after) throws ParseException {
+			SqlIdentifier oldName, SqlRegularColumn newColumn, boolean first, SqlIdentifier after) throws ParseException {
 		super(pos, tableName, oldName, newColumn, after, first, new SqlNodeList(pos));
 		this.origNewColumn = HiveDDLUtils.deepCopyTableColumn(newColumn);
 		HiveDDLUtils.convertDataTypes(newColumn);

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.hive.ddl;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.hive.impl.ParseException;
@@ -307,7 +308,7 @@ public class SqlCreateHiveTable extends SqlCreateTable {
 		int traitIndex = 0;
 		for (SqlNode node : columns) {
 			printIndent(writer);
-			SqlTableColumn column = (SqlTableColumn) node;
+			SqlRegularColumn column = (SqlRegularColumn) node;
 			column.getName().unparse(writer, leftPrec, rightPrec);
 			writer.print(" ");
 			column.getType().unparse(writer, leftPrec, rightPrec);

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -340,24 +340,24 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
 	@Test
 	public void testChangeColumn() {
 		sql("alter table tbl change c c1 struct<f0:timestamp,f1:array<char(5)>> restrict")
-				.ok("ALTER TABLE `TBL` CHANGE COLUMN `C` `C1`  STRUCT< `F0` TIMESTAMP, `F1` ARRAY< CHAR(5) > > RESTRICT");
+				.ok("ALTER TABLE `TBL` CHANGE COLUMN `C` `C1` STRUCT< `F0` TIMESTAMP, `F1` ARRAY< CHAR(5) > > RESTRICT");
 		sql("alter table tbl change column c c decimal(5,2) comment 'new comment' first cascade")
-				.ok("ALTER TABLE `TBL` CHANGE COLUMN `C` `C`  DECIMAL(5, 2)  COMMENT 'new comment' FIRST CASCADE");
+				.ok("ALTER TABLE `TBL` CHANGE COLUMN `C` `C` DECIMAL(5, 2) COMMENT 'new comment' FIRST CASCADE");
 	}
 
 	@Test
 	public void testAddReplaceColumn() {
 		sql("alter table tbl add columns (a float,b timestamp,c binary) cascade")
 				.ok("ALTER TABLE `TBL` ADD COLUMNS (\n" +
-						"  `A`  FLOAT,\n" +
-						"  `B`  TIMESTAMP,\n" +
-						"  `C`  BINARY\n" +
+						"  `A` FLOAT,\n" +
+						"  `B` TIMESTAMP,\n" +
+						"  `C` BINARY\n" +
 						") CASCADE");
 		sql("alter table tbl replace columns (a char(100),b tinyint comment 'tiny comment',c smallint) restrict")
 				.ok("ALTER TABLE `TBL` REPLACE COLUMNS (\n" +
-						"  `A`  CHAR(100),\n" +
-						"  `B`  TINYINT  COMMENT 'tiny comment',\n" +
-						"  `C`  SMALLINT\n" +
+						"  `A` CHAR(100),\n" +
+						"  `B` TINYINT COMMENT 'tiny comment',\n" +
+						"  `C` SMALLINT\n" +
 						") RESTRICT");
 	}
 

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -91,6 +91,7 @@
     "EXTENDED"
     "FUNCTIONS"
     "IF"
+    "METADATA"
     "OVERWRITE"
     "OVERWRITING"
     "PARTITIONED"
@@ -103,6 +104,7 @@
     "TABLES"
     "USE"
     "VIEWS"
+    "VIRTUAL"
     "WATERMARK"
     "WATERMARKS"
   ]
@@ -429,10 +431,12 @@
     # not in core, added in Flink
     "ENFORCED"
     "IF"
+    "METADATA"
     "OVERWRITE"
     "OVERWRITING"
     "PARTITIONED"
     "PARTITIONS"
+    "VIRTUAL"
   ]
 
   # List of non-reserved keywords to remove;

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -480,8 +480,9 @@ void TableColumn(TableCreationContext context) :
     SqlTableConstraint constraint;
 }
 {
-    (LOOKAHEAD(2)
-        TableColumn2(context.columnList)
+    (
+        LOOKAHEAD(2)
+        TypedColumn(context)
     |
         constraint = TableConstraint() {
             context.constraints.add(constraint);
@@ -513,50 +514,105 @@ void Watermark(TableCreationContext context) :
     }
 }
 
-void ComputedColumn(TableCreationContext context) :
+/** Parses {@code column_name column_data_type [...]}. */
+void TypedColumn(TableCreationContext context) :
 {
-    SqlIdentifier identifier;
-    SqlNode expr;
+    SqlIdentifier name;
     SqlParserPos pos;
-    SqlCharStringLiteral comment = null;
+    SqlDataTypeSpec type;
 }
 {
-    identifier = SimpleIdentifier() {pos = getPos();}
-    <AS>
-    expr = Expression(ExprContext.ACCEPT_NON_QUERY)
-    [ <COMMENT> <QUOTED_STRING> {
-            String p = SqlParserUtil.parseString(token.image);
-            comment = SqlLiteral.createCharString(p, getPos());
-        }
-     ]
-     {
-            SqlTableColumn computedColumn = new SqlTableColumn(identifier, expr, comment, getPos());
-            context.columnList.add(computedColumn);
-      }
+    name = SimpleIdentifier() {pos = getPos();}
+    type = ExtendedDataType()
+    (
+        MetadataColumn(context, name, type)
+    |
+        RegularColumn(context, name, type)
+    )
 }
 
-void TableColumn2(List<SqlNode> list) :
+/** Parses {@code column_name AS expr [COMMENT 'comment']}. */
+void ComputedColumn(TableCreationContext context) :
 {
-    SqlParserPos pos;
     SqlIdentifier name;
-    SqlDataTypeSpec type;
-    SqlTableConstraint constraint = null;
-    SqlCharStringLiteral comment = null;
+    SqlParserPos pos;
+    SqlNode expr;
+    SqlNode comment = null;
 }
 {
-    name = SimpleIdentifier()
-    type = ExtendedDataType()
+    name = SimpleIdentifier() {pos = getPos();}
+    <AS>
+    expr = Expression(ExprContext.ACCEPT_NON_QUERY)
+    [
+        <COMMENT>
+        comment = StringLiteral()
+    ]
+    {
+        SqlTableColumn computedColumn = new SqlTableColumn.SqlComputedColumn(
+            getPos(),
+            name,
+            comment,
+            expr);
+        context.columnList.add(computedColumn);
+    }
+}
+
+/** Parses {@code column_name column_data_type METADATA [FROM 'alias_name'] [VIRTUAL] [COMMENT 'comment']}. */
+void MetadataColumn(TableCreationContext context, SqlIdentifier name, SqlDataTypeSpec type) :
+{
+    SqlNode metadataAlias = null;
+    boolean isVirtual = false;
+    SqlNode comment = null;
+}
+{
+    <METADATA>
+    [
+        <FROM>
+        metadataAlias = StringLiteral()
+    ]
+    [
+        <VIRTUAL> {
+            isVirtual = true;
+        }
+    ]
+    [
+        <COMMENT>
+        comment = StringLiteral()
+    ]
+    {
+        SqlTableColumn metadataColumn = new SqlTableColumn.SqlMetadataColumn(
+            getPos(),
+            name,
+            comment,
+            type,
+            metadataAlias,
+            isVirtual);
+        context.columnList.add(metadataColumn);
+    }
+}
+
+/** Parses {@code column_name column_data_type [constraint] [COMMENT 'comment']}. */
+void RegularColumn(TableCreationContext context, SqlIdentifier name, SqlDataTypeSpec type) :
+{
+    SqlTableConstraint constraint = null;
+    SqlNode comment = null;
+}
+{
     [
         constraint = ColumnConstraint(name)
     ]
-    [ <COMMENT> <QUOTED_STRING> {
-            String p = SqlParserUtil.parseString(token.image);
-            comment = SqlLiteral.createCharString(p, getPos());
-        }
+    [
+        <COMMENT>
+        comment = StringLiteral()
     ]
     {
-        SqlTableColumn tableColumn = new SqlTableColumn(name, type, constraint, comment, getPos());
-        list.add(tableColumn);
+        SqlTableColumn regularColumn = new SqlTableColumn.SqlRegularColumn(
+            getPos(),
+            name,
+            comment,
+            type,
+            constraint);
+        context.columnList.add(regularColumn);
     }
 }
 
@@ -837,6 +893,8 @@ SqlTableLikeOption SqlTableLikeOption():
         <CONSTRAINTS> { featureOption = FeatureOption.CONSTRAINTS;}
     |
         <GENERATED> { featureOption = FeatureOption.GENERATED;}
+    |
+        <METADATA> { featureOption = FeatureOption.METADATA;}
     |
         <OPTIONS> { featureOption = FeatureOption.OPTIONS;}
     |

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
@@ -19,6 +19,8 @@
 package org.apache.flink.sql.parser.ddl;
 
 import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlComputedColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
@@ -37,6 +39,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.util.ImmutableNullableList;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -98,12 +101,12 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 	}
 
 	@Override
-	public SqlOperator getOperator() {
+	public @Nonnull SqlOperator getOperator() {
 		return OPERATOR;
 	}
 
 	@Override
-	public List<SqlNode> getOperandList() {
+	public @Nonnull List<SqlNode> getOperandList() {
 		return ImmutableNullableList.of(tableName,
 				columnList,
 				new SqlNodeList(tableConstraints, SqlParserPos.ZERO),
@@ -171,9 +174,11 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 
 			for (SqlNode column : columnList) {
 				SqlTableColumn tableColumn = (SqlTableColumn) column;
-				if (!tableColumn.isGenerated() && primaryKeyColumns.contains(tableColumn.getName().getSimple())) {
-					SqlDataTypeSpec notNullType = tableColumn.getType().withNullable(false);
-					tableColumn.setType(notNullType);
+				if (tableColumn instanceof SqlRegularColumn &&
+						primaryKeyColumns.contains(tableColumn.getName().getSimple())) {
+					SqlRegularColumn regularColumn = (SqlRegularColumn) column;
+					SqlDataTypeSpec notNullType = regularColumn.getType().withNullable(false);
+					regularColumn.setType(notNullType);
 				}
 			}
 		}
@@ -183,13 +188,14 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 		}
 	}
 
-	public boolean containsComputedColumn() {
+	public boolean hasRegularColumnsOnly() {
 		for (SqlNode column : columnList) {
-			if (((SqlTableColumn) column).isGenerated()) {
-				return true;
+			final SqlTableColumn tableColumn = (SqlTableColumn) column;
+			if (!(tableColumn instanceof SqlRegularColumn)) {
+				return false;
 			}
 		}
-		return false;
+		return true;
 	}
 
 	/** Returns the column constraints plus the table constraints. */
@@ -197,8 +203,9 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 		List<SqlTableConstraint> ret = new ArrayList<>();
 		this.columnList.forEach(column -> {
 			SqlTableColumn tableColumn = (SqlTableColumn) column;
-			if (!tableColumn.isGenerated()) {
-				tableColumn.getConstraint().map(ret::add);
+			if (tableColumn instanceof SqlRegularColumn) {
+				SqlRegularColumn regularColumn = (SqlRegularColumn) tableColumn;
+				regularColumn.getConstraint().map(ret::add);
 			}
 		});
 		ret.addAll(this.tableConstraints);
@@ -233,8 +240,9 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 		for (SqlNode column : columnList) {
 			writer.sep(",");
 			SqlTableColumn tableColumn = (SqlTableColumn) column;
-			if (tableColumn.isGenerated()) {
-				tableColumn.getExpr().get().unparse(writer, 0, 0);
+			if (tableColumn instanceof SqlComputedColumn) {
+				SqlComputedColumn computedColumn = (SqlComputedColumn) tableColumn;
+				computedColumn.getExpr().unparse(writer, 0, 0);
 				writer.keyword("AS");
 			}
 			tableColumn.getName().unparse(writer, 0, 0);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
@@ -21,7 +21,6 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 
 import org.apache.calcite.sql.SqlCall;
-import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -32,6 +31,7 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.List;
@@ -42,114 +42,185 @@ import static java.util.Objects.requireNonNull;
 /**
  * Table column of a CREATE TABLE DDL.
  */
-public class SqlTableColumn extends SqlCall {
+public abstract class SqlTableColumn extends SqlCall {
+
 	private static final SqlSpecialOperator OPERATOR =
 		new SqlSpecialOperator("COLUMN_DECL", SqlKind.COLUMN_DECL);
 
-	private SqlIdentifier name;
+	protected final SqlIdentifier name;
 
-	private SqlDataTypeSpec type;
-	private SqlTableConstraint constraint;
+	protected final SqlNode comment;
 
-	private SqlNode expr;
-
-	private SqlCharStringLiteral comment;
-
-	public SqlTableColumn(SqlIdentifier name,
-			SqlDataTypeSpec type,
-			@Nullable SqlTableConstraint constraint,
-			@Nullable SqlCharStringLiteral comment,
-			SqlParserPos pos) {
+	private SqlTableColumn(
+			SqlParserPos pos,
+			SqlIdentifier name,
+			@Nullable SqlNode comment) {
 		super(pos);
 		this.name = requireNonNull(name, "Column name should not be null");
-		this.type = requireNonNull(type, "Column type should not be null");
-		this.constraint = constraint;
 		this.comment = comment;
 	}
 
-	public SqlTableColumn(SqlIdentifier name,
-			SqlNode expr,
-			@Nullable SqlCharStringLiteral comment,
-			SqlParserPos pos) {
-		super(pos);
-		this.name = requireNonNull(name, "Column name should not be null");
-		this.expr = requireNonNull(expr, "Column expression should not be null");
-		this.comment = comment;
-	}
+	protected abstract void unparseColumn(SqlWriter writer, int leftPrec, int rightPrec);
 
 	@Override
-	public SqlOperator getOperator() {
+	public @Nonnull SqlOperator getOperator() {
 		return OPERATOR;
 	}
 
 	@Override
-	public List<SqlNode> getOperandList() {
-		return isGenerated() ?
-			ImmutableNullableList.of(name, expr, comment) :
-			ImmutableNullableList.of(name, type, comment);
-	}
-
-	@Override
 	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-		this.name.unparse(writer, leftPrec, rightPrec);
-		if (isGenerated()) {
-			writer.keyword("AS");
-			this.expr.unparse(writer, leftPrec, rightPrec);
-		} else {
-			writer.print(" ");
-			this.type.unparse(writer, leftPrec, rightPrec);
-			if (!this.type.getNullable()) {
-				// Default is nullable.
-				writer.keyword("NOT NULL");
-			}
-			if (this.constraint != null) {
-				this.constraint.unparse(writer, leftPrec, rightPrec);
-			}
-		}
-		if (this.comment != null) {
-			writer.print(" COMMENT ");
-			this.comment.unparse(writer, leftPrec, rightPrec);
-		}
-	}
+		name.unparse(writer, leftPrec, rightPrec);
 
-	/**
-	 * Returns if this column is a computed column that is generated from an expression.
-	 *
-	 * @return true if this column is generated
-	 */
-	public boolean isGenerated() {
-		return expr != null;
+		unparseColumn(writer, leftPrec, rightPrec);
+
+		if (comment != null) {
+			writer.keyword("COMMENT");
+			comment.unparse(writer, leftPrec, rightPrec);
+		}
 	}
 
 	public SqlIdentifier getName() {
 		return name;
 	}
 
-	public void setName(SqlIdentifier name) {
-		this.name = name;
-	}
-
-	public SqlDataTypeSpec getType() {
-		return type;
-	}
-
-	public void setType(SqlDataTypeSpec type) {
-		this.type = type;
-	}
-
-	public Optional<SqlNode> getExpr() {
-		return Optional.ofNullable(expr);
-	}
-
-	public Optional<SqlTableConstraint> getConstraint() {
-		return Optional.ofNullable(constraint);
-	}
-
-	public Optional<SqlCharStringLiteral> getComment() {
+	public Optional<SqlNode> getComment() {
 		return Optional.ofNullable(comment);
 	}
 
-	public void setComment(SqlCharStringLiteral comment) {
-		this.comment = comment;
+	/**
+	 * A regular, physical column.
+	 */
+	public static class SqlRegularColumn extends SqlTableColumn {
+
+		private SqlDataTypeSpec type;
+
+		private final @Nullable SqlTableConstraint constraint;
+
+		public SqlRegularColumn(
+				SqlParserPos pos,
+				SqlIdentifier name,
+				@Nullable SqlNode comment,
+				SqlDataTypeSpec type,
+				@Nullable SqlTableConstraint constraint) {
+			super(pos, name, comment);
+			this.type = requireNonNull(type, "Column type should not be null");
+			this.constraint = constraint;
+		}
+
+		public SqlDataTypeSpec getType() {
+			return type;
+		}
+
+		public void setType(SqlDataTypeSpec type) {
+			this.type = type;
+		}
+
+		public Optional<SqlTableConstraint> getConstraint() {
+			return Optional.ofNullable(constraint);
+		}
+
+		@Override
+		protected void unparseColumn(SqlWriter writer, int leftPrec, int rightPrec) {
+			type.unparse(writer, leftPrec, rightPrec);
+			if (!type.getNullable()) {
+				// Default is nullable.
+				writer.keyword("NOT NULL");
+			}
+			if (constraint != null) {
+				constraint.unparse(writer, leftPrec, rightPrec);
+			}
+		}
+
+		@Override
+		public @Nonnull List<SqlNode> getOperandList() {
+			return ImmutableNullableList.of(name, type, constraint, comment);
+		}
+	}
+
+	/**
+	 * A column derived from metadata.
+	 */
+	public static class SqlMetadataColumn extends SqlTableColumn {
+
+		private final SqlDataTypeSpec type;
+
+		private final @Nullable SqlNode metadataAlias;
+
+		private final boolean isVirtual;
+
+		public SqlMetadataColumn(
+				SqlParserPos pos,
+				SqlIdentifier name,
+				@Nullable SqlNode comment,
+				SqlDataTypeSpec type,
+				@Nullable SqlNode metadataAlias,
+				boolean isVirtual) {
+			super(pos, name, comment);
+			this.type = requireNonNull(type, "Column type should not be null");
+			this.metadataAlias = metadataAlias;
+			this.isVirtual = isVirtual;
+		}
+
+		public Optional<SqlNode> getMetadataAlias() {
+			return Optional.ofNullable(metadataAlias);
+		}
+
+		public boolean isVirtual() {
+			return isVirtual;
+		}
+
+		@Override
+		protected void unparseColumn(SqlWriter writer, int leftPrec, int rightPrec) {
+			type.unparse(writer, leftPrec, rightPrec);
+			if (!type.getNullable()) {
+				// Default is nullable.
+				writer.keyword("NOT NULL");
+			}
+			writer.keyword("METADATA");
+			if (metadataAlias != null) {
+				writer.keyword("FROM");
+				metadataAlias.unparse(writer, leftPrec, rightPrec);
+			}
+			if (isVirtual) {
+				writer.keyword("VIRTUAL");
+			}
+		}
+
+		@Override
+		public @Nonnull List<SqlNode> getOperandList() {
+			return ImmutableNullableList.of(name, type, comment);
+		}
+	}
+
+	/**
+	 * A column derived from an expression.
+	 */
+	public static class SqlComputedColumn extends SqlTableColumn {
+
+		private final SqlNode expr;
+
+		public SqlComputedColumn(
+				SqlParserPos pos,
+				SqlIdentifier name,
+				@Nullable SqlNode comment,
+				SqlNode expr) {
+			super(pos, name, comment);
+			this.expr = requireNonNull(expr, "Column expression should not be null");
+		}
+
+		public SqlNode getExpr() {
+			return expr;
+		}
+
+		@Override
+		protected void unparseColumn(SqlWriter writer, int leftPrec, int rightPrec) {
+			writer.keyword("AS");
+			expr.unparse(writer, leftPrec, rightPrec);
+		}
+
+		@Override
+		public @Nonnull List<SqlNode> getOperandList() {
+			return ImmutableNullableList.of(name, expr, comment);
+		}
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
@@ -115,9 +115,10 @@ public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
 	 *     <li>ALL - a shortcut to change the default merging strategy if none provided</li>
 	 *     <li>CONSTRAINTS - constraints such as primary and unique keys</li>
 	 *     <li>GENERATED - computed columns</li>
+	 *     <li>METADATA - metadata columns</li>
 	 *     <li>WATERMARKS - watermark declarations</li>
 	 *     <li>PARTITIONS - partition of the tables</li>
-	 *     <li>OPTIONS - connector options that decribed connector and format properties</li>
+	 *     <li>OPTIONS - connector options that described connector and format properties</li>
 	 * </ul>
 	 *
 	 * <p>Example:
@@ -142,6 +143,7 @@ public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
 		ALL,
 		CONSTRAINTS,
 		GENERATED,
+		METADATA,
 		OPTIONS,
 		PARTITIONS,
 		WATERMARKS

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.sql.parser;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
-import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 
 import org.apache.calcite.avatica.util.Casing;
@@ -410,7 +410,7 @@ public class FlinkDDLDataTypeTest {
 			final SqlCreateTable sqlCreateTable = (SqlCreateTable) sqlNode;
 			SqlNodeList columns = sqlCreateTable.getColumnList();
 			assert columns.size() == 1;
-			RelDataType columnType = ((SqlTableColumn) columns.get(0)).getType()
+			RelDataType columnType = ((SqlRegularColumn) columns.get(0)).getType()
 				.deriveType(factory.getValidator());
 			assertEquals(type, columnType);
 		}
@@ -447,7 +447,7 @@ public class FlinkDDLDataTypeTest {
 			final SqlCreateTable sqlCreateTable = (SqlCreateTable) sqlNode;
 			SqlNodeList columns = sqlCreateTable.getColumnList();
 			assert columns.size() == 1;
-			SqlDataTypeSpec dataTypeSpec = ((SqlTableColumn) columns.get(0)).getType();
+			SqlDataTypeSpec dataTypeSpec = ((SqlRegularColumn) columns.get(0)).getType();
 			SqlWriter sqlWriter = new SqlPrettyWriter(factory.createSqlDialect(), false);
 			dataTypeSpec.unparse(sqlWriter, 0, 0);
 			// SqlDataTypeSpec does not take care of the nullable attribute unparse,

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -225,6 +225,10 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'), \n" +
 				"  b varchar,\n" +
 				"  proc as PROCTIME(), \n" +
+				"  meta STRING METADATA, \n" +
+				"  my_meta STRING METADATA FROM 'meta', \n" +
+				"  my_meta STRING METADATA FROM 'meta' VIRTUAL, \n" +
+				"  meta STRING METADATA VIRTUAL, \n" +
 				"  PRIMARY KEY (a, b)\n" +
 				")\n" +
 				"PARTITIONED BY (a, h)\n" +
@@ -233,12 +237,16 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-				"  `A`  BIGINT,\n" +
-				"  `H`  VARCHAR,\n" +
+				"  `A` BIGINT,\n" +
+				"  `H` VARCHAR,\n" +
 				"  `G` AS (2 * (`A` + 1)),\n" +
 				"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  `B`  VARCHAR,\n" +
+				"  `B` VARCHAR,\n" +
 				"  `PROC` AS `PROCTIME`(),\n" +
+				"  `META` STRING METADATA,\n" +
+				"  `MY_META` STRING METADATA FROM 'meta',\n" +
+				"  `MY_META` STRING METADATA FROM 'meta' VIRTUAL,\n" +
+				"  `META` STRING METADATA VIRTUAL,\n" +
 				"  PRIMARY KEY (`A`, `B`)\n" +
 				")\n" +
 				"PARTITIONED BY (`A`, `H`)\n" +
@@ -266,11 +274,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final String expected = "CREATE TABLE IF NOT EXISTS `TBL1` (\n" +
-			"  `A`  BIGINT,\n" +
-			"  `H`  VARCHAR,\n" +
+			"  `A` BIGINT,\n" +
+			"  `H` VARCHAR,\n" +
 			"  `G` AS (2 * (`A` + 1)),\n" +
 			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-			"  `B`  VARCHAR,\n" +
+			"  `B` VARCHAR,\n" +
 			"  `PROC` AS `PROCTIME`(),\n" +
 			"  PRIMARY KEY (`A`, `B`)\n" +
 			")\n" +
@@ -291,6 +299,10 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'), \n" +
 				"  b varchar,\n" +
 				"  proc as PROCTIME(), \n" +
+				"  meta STRING METADATA COMMENT 'c1', \n" +
+				"  my_meta STRING METADATA FROM 'meta' COMMENT 'c2', \n" +
+				"  my_meta STRING METADATA FROM 'meta' VIRTUAL COMMENT 'c3', \n" +
+				"  meta STRING METADATA VIRTUAL COMMENT 'c4', \n" +
 				"  PRIMARY KEY (a, b)\n" +
 				")\n" +
 				"comment 'test table comment ABC.'\n" +
@@ -300,12 +312,16 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-				"  `A`  BIGINT  COMMENT 'test column comment AAA.',\n" +
-				"  `H`  VARCHAR,\n" +
+				"  `A` BIGINT COMMENT 'test column comment AAA.',\n" +
+				"  `H` VARCHAR,\n" +
 				"  `G` AS (2 * (`A` + 1)),\n" +
 				"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  `B`  VARCHAR,\n" +
+				"  `B` VARCHAR,\n" +
 				"  `PROC` AS `PROCTIME`(),\n" +
+				"  `META` STRING METADATA COMMENT 'c1',\n" +
+				"  `MY_META` STRING METADATA FROM 'meta' COMMENT 'c2',\n" +
+				"  `MY_META` STRING METADATA FROM 'meta' VIRTUAL COMMENT 'c3',\n" +
+				"  `META` STRING METADATA VIRTUAL COMMENT 'c4',\n" +
 				"  PRIMARY KEY (`A`, `B`)\n" +
 				")\n" +
 				"COMMENT 'test table comment ABC.'\n" +
@@ -335,11 +351,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-			"  `A`  BIGINT  COMMENT 'test column comment AAA.',\n" +
-			"  `H`  VARCHAR,\n" +
-			"  `G` AS (2 * (`A` + 1))  COMMENT 'test computed column.',\n" +
+			"  `A` BIGINT COMMENT 'test column comment AAA.',\n" +
+			"  `H` VARCHAR,\n" +
+			"  `G` AS (2 * (`A` + 1)) COMMENT 'test computed column.',\n" +
 			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-			"  `B`  VARCHAR,\n" +
+			"  `B` VARCHAR,\n" +
 			"  `PROC` AS `PROCTIME`(),\n" +
 			"  PRIMARY KEY (`A`, `B`)\n" +
 			")\n" +
@@ -368,11 +384,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-			"  `A`  BIGINT,\n" +
-			"  `H`  VARCHAR,\n" +
+			"  `A` BIGINT,\n" +
+			"  `H` VARCHAR,\n" +
 			"  `G` AS (2 * (`A` + 1)),\n" +
 			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-			"  `B`  VARCHAR,\n" +
+			"  `B` VARCHAR,\n" +
 			"  `PROC` AS `PROCTIME`(),\n" +
 			"  PRIMARY KEY (`A`, `B`),\n" +
 			"  UNIQUE (`H`, `G`)\n" +
@@ -399,11 +415,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-			"  `A`  BIGINT NOT NULL,\n" +
-			"  `H`  VARCHAR,\n" +
+			"  `A` BIGINT NOT NULL,\n" +
+			"  `H` VARCHAR,\n" +
 			"  `G` AS (2 * (`A` + 1)),\n" +
 			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-			"  `B`  VARCHAR NOT NULL,\n" +
+			"  `B` VARCHAR NOT NULL,\n" +
 			"  `PROC` AS `PROCTIME`(),\n" +
 			"  PRIMARY KEY (`A`, `B`),\n" +
 			"  UNIQUE (`H`, `G`)\n" +
@@ -429,11 +445,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-			"  `A`  BIGINT PRIMARY KEY ENFORCED  COMMENT 'test column comment AAA.',\n" +
-			"  `H`  VARCHAR CONSTRAINT `CT1` UNIQUE NOT ENFORCED,\n" +
+			"  `A` BIGINT PRIMARY KEY ENFORCED COMMENT 'test column comment AAA.',\n" +
+			"  `H` VARCHAR CONSTRAINT `CT1` UNIQUE NOT ENFORCED,\n" +
 			"  `G` AS (2 * (`A` + 1)),\n" +
 			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-			"  `B`  VARCHAR CONSTRAINT `CT2` UNIQUE,\n" +
+			"  `B` VARCHAR CONSTRAINT `CT2` UNIQUE,\n" +
 			"  `PROC` AS `PROCTIME`(),\n" +
 			"  UNIQUE (`G`, `TS`) NOT ENFORCED\n" +
 			") WITH (\n" +
@@ -473,8 +489,8 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-				"  `TS`  TIMESTAMP(3),\n" +
-				"  `ID`  VARCHAR,\n" +
+				"  `TS` TIMESTAMP(3),\n" +
+				"  `ID` VARCHAR,\n" +
 				"  WATERMARK FOR `TS` AS (`TS` - INTERVAL '3' SECOND)\n" +
 				") WITH (\n" +
 				"  'connector' = 'kafka',\n" +
@@ -495,7 +511,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-				"  `LOG_TS`  VARCHAR,\n" +
+				"  `LOG_TS` VARCHAR,\n" +
 				"  `TS` AS `TO_TIMESTAMP`(`LOG_TS`),\n" +
 				"  WATERMARK FOR `TS` AS (`TS` + INTERVAL '1' SECOND)\n" +
 				") WITH (\n" +
@@ -516,7 +532,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-				"  `F1`  ROW< `Q1` BIGINT, `Q2` ROW< `T1` TIMESTAMP, `T2` VARCHAR >, `Q3` BOOLEAN >,\n" +
+				"  `F1` ROW< `Q1` BIGINT, `Q2` ROW< `T1` TIMESTAMP, `T2` VARCHAR >, `Q3` BOOLEAN >,\n" +
 				"  WATERMARK FOR `F1`.`Q2`.`T1` AS `NOW`()\n" +
 				") WITH (\n" +
 				"  'connector' = 'kafka',\n" +
@@ -571,10 +587,10 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  'asd' = 'data'\n" +
 				")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-				"  `A`  ARRAY< BIGINT >,\n" +
-				"  `B`  MAP< INTEGER, VARCHAR >,\n" +
-				"  `C`  ROW< `CC0` INTEGER, `CC1` FLOAT, `CC2` VARCHAR >,\n" +
-				"  `D`  MULTISET< VARCHAR >,\n" +
+				"  `A` ARRAY< BIGINT >,\n" +
+				"  `B` MAP< INTEGER, VARCHAR >,\n" +
+				"  `C` ROW< `CC0` INTEGER, `CC1` FLOAT, `CC2` VARCHAR >,\n" +
+				"  `D` MULTISET< VARCHAR >,\n" +
 				"  PRIMARY KEY (`A`, `B`)\n" +
 				") WITH (\n" +
 				"  'x' = 'y',\n" +
@@ -596,10 +612,10 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  'asd' = 'data'\n" +
 				")\n";
 		final String expected = "CREATE TABLE `TBL1` (\n" +
-				"  `A`  ARRAY< ARRAY< BIGINT > >,\n" +
-				"  `B`  MAP< MAP< INTEGER, VARCHAR >, ARRAY< VARCHAR > >,\n" +
-				"  `C`  ROW< `CC0` ARRAY< INTEGER >, `CC1` FLOAT, `CC2` VARCHAR >,\n" +
-				"  `D`  MULTISET< ARRAY< INTEGER > >,\n" +
+				"  `A` ARRAY< ARRAY< BIGINT > >,\n" +
+				"  `B` MAP< MAP< INTEGER, VARCHAR >, ARRAY< VARCHAR > >,\n" +
+				"  `C` ROW< `CC0` ARRAY< INTEGER >, `CC1` FLOAT, `CC2` VARCHAR >,\n" +
+				"  `D` MULTISET< ARRAY< INTEGER > >,\n" +
 				"  PRIMARY KEY (`A`, `B`)\n" +
 				") WITH (\n" +
 				"  'x' = 'y',\n" +
@@ -618,8 +634,8 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  'k2' = 'v2'\n" +
 			")";
 		final String expected = "CREATE TABLE `T` (\n" +
-			"  `A`  `CATALOG1`.`DB1`.`MYTYPE1`,\n" +
-			"  `B`  `DB2`.`MYTYPE2`\n" +
+			"  `A` `CATALOG1`.`DB1`.`MYTYPE1`,\n" +
+			"  `B` `DB2`.`MYTYPE2`\n" +
 			") WITH (\n" +
 			"  'k1' = 'v1',\n" +
 			"  'k2' = 'v2'\n" +
@@ -692,9 +708,9 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  'a.b-c-d.e-1231.g' = 'ada',\n" +
 			"  'a.b-c-d.*' = 'adad')\n";
 		final String expected = "CREATE TABLE `SOURCE_TABLE` (\n" +
-			"  `A`  INTEGER,\n" +
-			"  `B`  BIGINT,\n" +
-			"  `C`  STRING\n" +
+			"  `A` INTEGER,\n" +
+			"  `B` BIGINT,\n" +
+			"  `C` STRING\n" +
 			") WITH (\n" +
 			"  'a-b-c-d124' = 'ab',\n" +
 			"  'a.b.1.c' = 'aabb',\n" +
@@ -729,17 +745,19 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"   OVERWRITING OPTIONS\n" +
 			"   EXCLUDING PARTITIONS\n" +
 			"   INCLUDING GENERATED\n" +
+			"   INCLUDING METADATA\n" +
 			")";
 		final String expected = "CREATE TABLE `SOURCE_TABLE` (\n" +
-			"  `A`  INTEGER,\n" +
-			"  `B`  BIGINT,\n" +
-			"  `C`  STRING\n" +
+			"  `A` INTEGER,\n" +
+			"  `B` BIGINT,\n" +
+			"  `C` STRING\n" +
 			")\n" +
 			"LIKE `PARENT_TABLE` (\n" +
 			"  INCLUDING ALL\n" +
 			"  OVERWRITING OPTIONS\n" +
 			"  EXCLUDING PARTITIONS\n" +
 			"  INCLUDING GENERATED\n" +
+			"  INCLUDING METADATA\n" +
 			")";
 		sql(sql).ok(expected);
 	}
@@ -755,9 +773,9 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  'abc' = 'def'\n" +
 			")";
 		final String expected = "CREATE TEMPORARY TABLE `SOURCE_TABLE` (\n" +
-			"  `A`  INTEGER,\n" +
-			"  `B`  BIGINT,\n" +
-			"  `C`  STRING\n" +
+			"  `A` INTEGER,\n" +
+			"  `B` BIGINT,\n" +
+			"  `C` STRING\n" +
 			") WITH (\n" +
 			"  'x' = 'y',\n" +
 			"  'abc' = 'def'\n" +

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
@@ -21,8 +21,10 @@ package org.apache.flink.table.planner.utils;
 import org.apache.flink.sql.parser.ddl.SqlAddReplaceColumns;
 import org.apache.flink.sql.parser.ddl.SqlChangeColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.WatermarkSpec;
@@ -164,9 +166,13 @@ public class OperationConverterUtils {
 		// TODO: handle watermark and constraints
 	}
 
-	private static TableColumn toTableColumn(SqlTableColumn sqlTableColumn, SqlValidator sqlValidator) {
-		String name = sqlTableColumn.getName().getSimple();
-		SqlDataTypeSpec typeSpec = sqlTableColumn.getType();
+	private static TableColumn toTableColumn(SqlTableColumn tableColumn, SqlValidator sqlValidator) {
+		if (!(tableColumn instanceof SqlRegularColumn)) {
+			throw new TableException("Only regular columns are supported for this operation yet.");
+		}
+		SqlRegularColumn regularColumn = (SqlRegularColumn) tableColumn;
+		String name = regularColumn.getName().getSimple();
+		SqlDataTypeSpec typeSpec = regularColumn.getType();
 		LogicalType logicalType = FlinkTypeFactory.toLogicalType(
 				typeSpec.deriveType(sqlValidator, typeSpec.getNullable()));
 		DataType dataType = TypeConversions.fromLogicalToDataType(logicalType);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.table.planner.operations;
 
-import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlComputedColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableLike.FeatureOption;
 import org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy;
 import org.apache.flink.sql.parser.ddl.SqlTableLike.SqlTableLikeOption;
@@ -84,8 +85,8 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Arrays.asList(
-				tableColumn("three", DataTypes.INT()),
-				tableColumn("four", DataTypes.STRING()));
+				regularColumn("three", DataTypes.INT()),
+				regularColumn("four", DataTypes.STRING()));
 
 		TableSchema mergedSchema = util.mergeTables(
 				getDefaultMergingStrategies(),
@@ -111,8 +112,8 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Arrays.asList(
-				tableColumn("one", DataTypes.INT()),
-				tableColumn("four", DataTypes.STRING()));
+				regularColumn("one", DataTypes.INT()),
+				regularColumn("four", DataTypes.STRING()));
 
 		thrown.expect(ValidationException.class);
 		thrown.expectMessage("A column named 'one' already exists in the base table.");
@@ -132,8 +133,8 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Arrays.asList(
-				tableColumn("three", DataTypes.INT()),
-				tableColumn("four", plus("one", "3")));
+				regularColumn("three", DataTypes.INT()),
+				computedColumn("four", plus("one", "3")));
 
 		TableSchema mergedSchema = util.mergeTables(
 				getDefaultMergingStrategies(),
@@ -160,7 +161,7 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Collections.singletonList(
-				tableColumn("two", plus("one", "3")));
+				computedColumn("two", plus("one", "3")));
 
 		thrown.expect(ValidationException.class);
 		thrown.expectMessage("A generated column named 'two' already exists in the base table. You " +
@@ -181,7 +182,7 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Collections.singletonList(
-				tableColumn("two", plus("one", "3")));
+				computedColumn("two", plus("one", "3")));
 
 		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
 		mergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.EXCLUDING);
@@ -209,7 +210,7 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Collections.singletonList(
-				tableColumn("two", plus("one", "3")));
+				computedColumn("two", plus("one", "3")));
 
 		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
 		mergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.OVERWRITING);
@@ -237,7 +238,7 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Collections.singletonList(
-				tableColumn("two", plus("one", "3")));
+				computedColumn("two", plus("one", "3")));
 
 		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
 		mergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.OVERWRITING);
@@ -266,8 +267,8 @@ public class MergeTableLikeUtilTest {
 				.build();
 
 		List<SqlNode> derivedColumns = Arrays.asList(
-				tableColumn("three", DataTypes.INT()),
-				tableColumn("four", plus("one", "3")));
+				regularColumn("three", DataTypes.INT()),
+				computedColumn("four", plus("one", "3")));
 
 		TableSchema mergedSchema = util.mergeTables(
 				getDefaultMergingStrategies(),
@@ -698,24 +699,24 @@ public class MergeTableLikeUtilTest {
 		return util.computeMergingStrategies(Collections.emptyList());
 	}
 
-	private SqlNode tableColumn(String name, DataType type) {
+	private SqlNode regularColumn(String name, DataType type) {
 		LogicalType logicalType = type.getLogicalType();
-		return new SqlTableColumn(
-			new SqlIdentifier(name, SqlParserPos.ZERO),
+		return new SqlRegularColumn(
+			SqlParserPos.ZERO,
+			identifier(name),
+			null,
 			SqlTypeUtil.convertTypeToSpec(typeFactory.createFieldTypeFromLogicalType(logicalType))
 				.withNullable(logicalType.isNullable()),
-			null,
-			null,
-			SqlParserPos.ZERO
+			null
 		);
 	}
 
-	private SqlNode tableColumn(String name, SqlNode expression) {
-		return new SqlTableColumn (
+	private SqlNode computedColumn(String name, SqlNode expression) {
+		return new SqlComputedColumn(
+			SqlParserPos.ZERO,
 			identifier(name),
-			expression,
 			null,
-			SqlParserPos.ZERO
+			expression
 		);
 	}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -31,7 +31,7 @@ import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
 import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlDropView;
-import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
 import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
@@ -628,22 +628,23 @@ public class SqlToOperationConverter {
 		SqlNodeList columnList = sqlCreateTable.getColumnList();
 		TableSchema physicalSchema = null;
 		TableSchema.Builder builder = new TableSchema.Builder();
-		// collect the physical table schema first.
-		final List<SqlNode> physicalColumns = columnList.getList().stream()
-			.filter(n -> !((SqlTableColumn) n).isGenerated()).collect(Collectors.toList());
-		for (SqlNode node : physicalColumns) {
-			SqlTableColumn column = (SqlTableColumn) node;
-			final RelDataType relType = column.getType()
+		// collect the regular, physical table schema first.
+		final List<SqlRegularColumn> physicalColumns = columnList.getList().stream()
+			.filter(SqlRegularColumn.class::isInstance)
+			.map(SqlRegularColumn.class::cast)
+			.collect(Collectors.toList());
+		for (SqlRegularColumn regularColumn : physicalColumns) {
+			final RelDataType relType = regularColumn.getType()
 				.deriveType(
 					flinkPlanner.getOrCreateSqlValidator(),
-					column.getType().getNullable());
-			builder.field(column.getName().getSimple(),
+					regularColumn.getType().getNullable());
+			builder.field(regularColumn.getName().getSimple(),
 				TypeConversions.fromLegacyInfoToDataType(FlinkTypeFactory.toTypeInfo(relType)));
 			physicalSchema = builder.build();
 		}
 		assert physicalSchema != null;
-		if (sqlCreateTable.containsComputedColumn()) {
-			throw new SqlConversionException("Computed columns for DDL is not supported yet!");
+		if (!sqlCreateTable.hasRegularColumnsOnly()) {
+			throw new SqlConversionException("Only regular columns are supported in DDL.");
 		}
 		return physicalSchema;
 	}


### PR DESCRIPTION
## What is the purpose of the change

Updates the parser to accept `METADATA` syntax for columns and in the `LIKE` clause.

## Brief change log

- Reworks the class hierarchy of table columns.
- Introduces new keywords and grammar.

## Verifying this change

This change is already covered by unit tests, such as `FlinkSqlParserImplTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
