### PR TITLE
[FLINK-19304][coordination] Add FLIP-138 feature toggle

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -92,4 +92,15 @@ public class ClusterOptions {
 					"to a JVM deadlock. See %s for details.",
 				link("https://issues.apache.org/jira/browse/FLINK-16510", "FLINK-16510"))
 				.build());
+
+	@Documentation.ExcludeFromDocumentation
+	public static final ConfigOption<Boolean> ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT = ConfigOptions
+		.key("cluster.declarative-resource-management.enabled")
+		.booleanType()
+		.defaultValue(false)
+		.withDescription("Defines whether the cluster uses declarative resource management.");
+
+	public static boolean isDeclarativeResourceManagementEnabled(Configuration configuration) {
+		return configuration.get(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT) || System.getProperties().containsKey("flink.tests.enable-declarative");
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.DefaultSlotPoolFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -57,7 +56,7 @@ public enum DefaultJobManagerRunnerFactory implements JobManagerRunnerFactory {
 
 		final JobMasterConfiguration jobMasterConfiguration = JobMasterConfiguration.fromConfiguration(configuration);
 
-		final SlotPoolFactory slotPoolFactory = DefaultSlotPoolFactory.fromConfiguration(configuration);
+		final SlotPoolFactory slotPoolFactory = SlotPoolFactory.fromConfiguration(configuration);
 		final SchedulerNGFactory schedulerNGFactory = SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration);
 		final ShuffleMaster<?> shuffleMaster = ShuffleServiceLoader.loadShuffleServiceFactory(configuration).createShuffleMaster(configuration);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolFactory.java
@@ -20,11 +20,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.util.clock.Clock;
-import org.apache.flink.util.clock.SystemClock;
 
 import javax.annotation.Nonnull;
 
@@ -62,19 +58,6 @@ public class DefaultSlotPoolFactory implements SlotPoolFactory {
 		return new SlotPoolImpl(
 			jobId,
 			clock,
-			rpcTimeout,
-			slotIdleTimeout,
-			batchSlotTimeout);
-	}
-
-	public static DefaultSlotPoolFactory fromConfiguration(@Nonnull Configuration configuration) {
-
-		final Time rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
-		final Time slotIdleTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
-		final Time batchSlotTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
-
-		return new DefaultSlotPoolFactory(
-			SystemClock.getInstance(),
 			rpcTimeout,
 			slotIdleTimeout,
 			batchSlotTimeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolFactory.java
@@ -19,6 +19,12 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.util.clock.SystemClock;
 
 import javax.annotation.Nonnull;
 
@@ -29,4 +35,20 @@ public interface SlotPoolFactory {
 
 	@Nonnull
 	SlotPool createSlotPool(@Nonnull JobID jobId);
+
+	static SlotPoolFactory fromConfiguration(Configuration configuration) {
+		final Time rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
+		final Time slotIdleTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
+		final Time batchSlotTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
+
+		if (ClusterOptions.isDeclarativeResourceManagementEnabled(configuration)) {
+			throw new UnsupportedOperationException("Declarative slot pool is not yet implemented.");
+		} else {
+			return new DefaultSlotPoolFactory(
+				SystemClock.getInstance(),
+				rpcTimeout,
+				slotIdleTimeout,
+				batchSlotTimeout);
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -54,10 +54,7 @@ public class ResourceManagerRuntimeServices {
 			ScheduledExecutor scheduledExecutor,
 			SlotManagerMetricGroup slotManagerMetricGroup) {
 
-		final SlotManager slotManager = new SlotManagerImpl(
-			scheduledExecutor,
-			configuration.getSlotManagerConfiguration(),
-			slotManagerMetricGroup);
+		final SlotManager slotManager = createSlotManager(configuration, scheduledExecutor, slotManagerMetricGroup);
 
 		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
 			highAvailabilityServices,
@@ -65,5 +62,16 @@ public class ResourceManagerRuntimeServices {
 			configuration.getJobTimeout());
 
 		return new ResourceManagerRuntimeServices(slotManager, jobLeaderIdService);
+	}
+
+	private static SlotManager createSlotManager(ResourceManagerRuntimeServicesConfiguration configuration, ScheduledExecutor scheduledExecutor, SlotManagerMetricGroup slotManagerMetricGroup) {
+		if (configuration.isDeclarativeResourceManagementEnabled()) {
+			throw new UnsupportedOperationException("Declarative slot manager is not yet implemented.");
+		} else {
+			return new SlotManagerImpl(
+				scheduledExecutor,
+				configuration.getSlotManagerConfiguration(),
+				slotManagerMetricGroup);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
@@ -35,9 +36,12 @@ public class ResourceManagerRuntimeServicesConfiguration {
 
 	private final SlotManagerConfiguration slotManagerConfiguration;
 
-	public ResourceManagerRuntimeServicesConfiguration(Time jobTimeout, SlotManagerConfiguration slotManagerConfiguration) {
+	private final boolean enableDeclarativeResourceManagement;
+
+	public ResourceManagerRuntimeServicesConfiguration(Time jobTimeout, SlotManagerConfiguration slotManagerConfiguration, boolean enableDeclarativeResourceManagement) {
 		this.jobTimeout = Preconditions.checkNotNull(jobTimeout);
 		this.slotManagerConfiguration = Preconditions.checkNotNull(slotManagerConfiguration);
+		this.enableDeclarativeResourceManagement = enableDeclarativeResourceManagement;
 	}
 
 	public Time getJobTimeout() {
@@ -46,6 +50,10 @@ public class ResourceManagerRuntimeServicesConfiguration {
 
 	public SlotManagerConfiguration getSlotManagerConfiguration() {
 		return slotManagerConfiguration;
+	}
+
+	public boolean isDeclarativeResourceManagementEnabled() {
+		return enableDeclarativeResourceManagement;
 	}
 
 	// ---------------------------- Static methods ----------------------------------
@@ -68,6 +76,8 @@ public class ResourceManagerRuntimeServicesConfiguration {
 		final SlotManagerConfiguration slotManagerConfiguration =
 			SlotManagerConfiguration.fromConfiguration(configuration, defaultWorkerResourceSpec);
 
-		return new ResourceManagerRuntimeServicesConfiguration(jobTimeout, slotManagerConfiguration);
+		final boolean enableDeclarativeResourceManagement = ClusterOptions.isDeclarativeResourceManagementEnabled(configuration);
+
+		return new ResourceManagerRuntimeServicesConfiguration(jobTimeout, slotManagerConfiguration, enableDeclarativeResourceManagement);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -86,7 +86,6 @@ import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.DefaultSlotPoolFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
@@ -306,7 +305,7 @@ public class JobMasterTest extends TestLogger {
 				jmResourceId,
 				jobGraph,
 				haServices,
-				DefaultSlotPoolFactory.fromConfiguration(configuration),
+				SlotPoolFactory.fromConfiguration(configuration),
 				jobManagerSharedServices,
 				heartbeatServices,
 				UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
@@ -1658,7 +1657,7 @@ public class JobMasterTest extends TestLogger {
 			jmResourceId,
 			jobGraph,
 			haServices,
-			DefaultSlotPoolFactory.fromConfiguration(configuration),
+			SlotPoolFactory.fromConfiguration(configuration),
 			jobManagerSharedServices,
 			heartbeatServices,
 			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -38,7 +38,6 @@ import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerSharedServicesBuilder;
 import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.DefaultSlotPoolFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -167,7 +166,7 @@ public class JobMasterBuilder {
 			jmResourceId,
 			jobGraph,
 			highAvailabilityServices,
-			slotPoolFactory != null ? slotPoolFactory : DefaultSlotPoolFactory.fromConfiguration(configuration),
+			slotPoolFactory != null ? slotPoolFactory : SlotPoolFactory.fromConfiguration(configuration),
 			jobManagerSharedServices,
 			heartbeatServices,
 			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -67,6 +69,7 @@ public class ResourceManagerHATest extends TestLogger {
 
 		TestingHeartbeatServices heartbeatServices = new TestingHeartbeatServices();
 
+		final Configuration configuration = new Configuration();
 		ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration = new ResourceManagerRuntimeServicesConfiguration(
 			Time.seconds(5L),
 			new SlotManagerConfiguration(
@@ -78,7 +81,8 @@ public class ResourceManagerHATest extends TestLogger {
 				WorkerResourceSpec.ZERO,
 				1,
 				ResourceManagerOptions.MAX_SLOT_NUM.defaultValue(),
-				ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue()));
+				ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue()),
+			ClusterOptions.isDeclarativeResourceManagementEnabled(configuration));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,


### PR DESCRIPTION
Adds a feature toggle for declarative resource management. The new management scheme is encapsulated in the slot pool / slot manager; this PR adds the infrastructure for plugging in the new implementations of these components later on. Until the new components are added, and UnsupportedOperationException will be thrown if the feature is enabled.