### PR TITLE
Single task add partial flag in buffer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -25,6 +25,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Closeable;
 
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.DATA_BUFFER;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilder.BUFFER_BUILDER_HEADER_SIZE;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -96,15 +98,43 @@ public class BufferConsumer implements Closeable {
 		return writerPosition.isFinished();
 	}
 
+	public boolean startOfDataBuffer() {
+		return buffer.getDataType() == DATA_BUFFER && currentReaderPosition == 0;
+	}
+
 	/**
+	 * BufferConsumer skips the buffer header before building buffer.
 	 * @return sliced {@link Buffer} containing the not yet consumed data. Returned {@link Buffer} shares the reference
 	 * counter with the parent {@link BufferConsumer} - in order to recycle memory both of them must be recycled/closed.
 	 */
 	public Buffer build() {
 		writerPosition.update();
 		int cachedWriterPosition = writerPosition.getCached();
-		Buffer slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+
+		Buffer slice = null;
+
+		// data buffer && starting from the beginning of the buffer
+		if (startOfDataBuffer()) {
+			// either do not have any data, or at least have 4 bytes (header + data)
+			checkState(
+				(cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE)
+					|| (currentReaderPosition == cachedWriterPosition)
+			);
+
+			// remove the header
+			if (cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE) {
+				slice = buffer.readOnlySlice(
+					currentReaderPosition + BUFFER_BUILDER_HEADER_SIZE,
+					cachedWriterPosition - currentReaderPosition - BUFFER_BUILDER_HEADER_SIZE);
+			}
+		}
+
+		if (slice == null) {
+			slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+		}
+
 		currentReaderPosition = cachedWriterPosition;
+
 		return slice.retainBuffer();
 	}
 
@@ -149,10 +179,6 @@ public class BufferConsumer implements Closeable {
 
 	public int getWrittenBytes() {
 		return writerPosition.getCached();
-	}
-
-	int getCurrentReaderPosition() {
-		return currentReaderPosition;
 	}
 
 	/**


### PR DESCRIPTION

## What is the purpose of the change
This PR adds a header to each BufferBuilder to indicate whether the first record in the buffer is partial or not. 
For each buffer builder, a header with a 4-byte integer is attached.

Since length can only be 0 or positive numbers, the first bit of the integer is used to identify whether the first record is partial (1) or not (0). The remaining 31 bits stand for the length of the first record remaining. When reading from the buffer through BufferConsumer, BufferConsumer.build() makes sure the header is removed off when returning a sliced buffer.

No header info is transmitted through network.
	 
## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
