### PR TITLE
[DRAFT] Stubs for formats implementation for the new File Source (ORC, Avro, CSV)

### DIFF
--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -46,6 +46,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
 			<!-- managed version -->

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileFormat.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileFormat.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.StreamFormat;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.formats.avro.utils.AvroUtils;
+import org.apache.flink.formats.avro.utils.FSDataInputStreamWrapper;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.SeekableInput;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * A File Format for reading Avro files via the unified batch/streaming file source
+ * ({@link org.apache.flink.connector.file.src.FileSource}).
+ *
+ * @param <E> The type of the records read by this reader.
+ */
+public class AvroFileFormat<E> implements StreamFormat<E> {
+
+	private static final long serialVersionUID = 1L;
+
+	static final Logger LOG = LoggerFactory.getLogger(AvroFileFormat.class);
+
+	// ------------------------------------------------------------------------
+	//  factories
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new Avro File Format that reads Avro {@link org.apache.avro.specific.SpecificData specific records}
+	 * or records via Avro's {@link org.apache.avro.reflect.ReflectData reflection reader}.
+	 *
+	 * <p>To read into Avro {@link GenericRecord} types, use the {@link #forGenericType(Schema)} method.
+	 *
+	 * @see #forGenericType(Schema)
+	 */
+	public static <T> AvroFileFormat<T> forSpecificOrReflectType(final Class<T> typeClass) {
+		final TypeInformation<T> typeInfo;
+		if (SpecificRecordBase.class.isAssignableFrom(typeClass)) {
+			final TypeInformation<? extends SpecificRecordBase> specTypeInfo =
+					new AvroTypeInfo<>(typeClass.asSubclass(SpecificRecordBase.class));
+
+			// juggle a bit with the generic casting
+			@SuppressWarnings("unchecked")
+			final TypeInformation<T> castedInfo = (TypeInformation<T>) specTypeInfo;
+			typeInfo = castedInfo;
+		} else if (GenericRecord.class.isAssignableFrom(typeClass)) {
+			throw new IllegalArgumentException(
+					"Cannot read and create Avro GenericRecord without specifying the Avro Schema. " +
+					"That is because Flink needs to be able serialize the results in its data flow, which is" +
+					"very inefficient without the schema. And while the Schema is stored in the Avro file header," +
+					"Flink needs this schema during 'pre-flight' time when the data flow is set up and wired," +
+					"which is before there is access to the files");
+		} else {
+			// this is a PoJo that Avo will reader via reflect de-serialization
+			// for Flink, this is just a plain PoJo type
+			typeInfo = TypeExtractor.createTypeInfo(typeClass);
+		}
+
+		return new AvroFileFormat<>(typeInfo);
+	}
+
+	/**
+	 * Creates a new Avro File Format that reads the file into Avro {@link GenericRecord}s.
+	 *
+	 * <p>To read into {@code GenericRecords}, this method needs an Avro Schema.
+	 * That is because Flink needs to be able serialize the results in its data flow, which is
+	 * very inefficient without the schema. And while the Schema is stored in the Avro file header,
+	 * Flink needs this schema during 'pre-flight' time when the data flow is set up and wired," +
+	 * which is before there is access to the files.
+	 */
+	public static AvroFileFormat<GenericRecord> forGenericType(final Schema schema) {
+		final GenericRecordAvroTypeInfo type = new GenericRecordAvroTypeInfo(schema);
+		return new AvroFileFormat<>(type);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Stream File Format
+	// ------------------------------------------------------------------------
+
+	private final TypeInformation<E> type;
+
+	private AvroFileFormat(TypeInformation<E> type) {
+		this.type = type;
+	}
+
+	@Override
+	public TypeInformation<E> getProducedType() {
+		return type;
+	}
+
+	@Override
+	public boolean isSplittable() {
+		return true;
+	}
+
+	@Override
+	public Reader<E> createReader(
+			final Configuration config,
+			final FSDataInputStream stream,
+			final long fileLen,
+			final long splitEnd) throws IOException {
+
+		// creating the reader will sync to 0, so we need to remember the position and sync back
+		// to this position at the end.
+		final long startPos = stream.getPos();
+
+		final DatumReader<E> datumReader = AvroUtils.createDatumReader(type);
+		final SeekableInput in = new FSDataInputStreamWrapper(stream, fileLen);
+		final DataFileReader<E> avroDataFileReader = (DataFileReader<E>) DataFileReader.openReader(in, datumReader);
+
+		LOG.debug("Loaded Avro Schema: {}", avroDataFileReader.getSchema());
+
+		avroDataFileReader.sync(startPos);
+		final long lastSync = avroDataFileReader.previousSync();
+
+		return new AvroReader<>(avroDataFileReader, splitEnd, lastSync);
+	}
+
+	@Override
+	public Reader<E> restoreReader(
+			final Configuration config,
+			final FSDataInputStream stream,
+			final long restoredOffset,
+			final long fileLen,
+			final long splitEnd) throws IOException {
+
+		// Restoring a reader is here in fact identical to creating a reader, from the appropriate
+		// position in the stream
+		// Avro advances to the next sync marker from the offset, and if the offset happened
+		// to be an exact sync marker (like when the position comes from a checkpoint), the position
+		// will remain unchanged
+		stream.seek(restoredOffset);
+		return createReader(config, stream, fileLen, splitEnd);
+	}
+
+	// ------------------------------------------------------------------------
+	//  reader implementation
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A reader for file sources that reads records via an Avro {@link DataFileReader}.
+	 *
+	 * @param <E> The type of the records read by this reader.
+	 */
+	public static class AvroReader<E> implements StreamFormat.Reader<E> {
+
+		private final DataFileReader<E> avroDataFileReader;
+		private final long splitEnd;
+		private long checkpointSyncOffset;
+		private long numRecordsSinceSyncOffset;
+
+		public AvroReader(DataFileReader<E> avroDataFileReader, long splitEnd, long checkpointSyncOffset) {
+			this.avroDataFileReader = avroDataFileReader;
+			this.splitEnd = splitEnd;
+			this.checkpointSyncOffset = checkpointSyncOffset;
+			this.numRecordsSinceSyncOffset = 0;
+		}
+
+		@Nullable
+		@Override
+		public E read() throws IOException {
+			if (avroDataFileReader.pastSync(splitEnd) || !avroDataFileReader.hasNext()) {
+				return null;
+			}
+
+			final E next = avroDataFileReader.next();
+
+			// When the call to 'getCheckpointedPosition()' comes, we need to give the position
+			// where the reader is then, i.e., after the current record. That's why we only build
+			// the position information after we read the record.
+			final long currentSync = avroDataFileReader.previousSync();
+			if (currentSync != checkpointSyncOffset) {
+				checkpointSyncOffset = currentSync;
+				numRecordsSinceSyncOffset = 0;
+			} else {
+				numRecordsSinceSyncOffset++;
+			}
+
+			return next;
+		}
+
+		@Override
+		public void close() throws IOException {
+			avroDataFileReader.close();
+		}
+
+		@Override
+		public CheckpointedPosition getCheckpointedPosition() {
+			return new CheckpointedPosition(checkpointSyncOffset, numRecordsSinceSyncOffset);
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/AvroUtils.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/AvroUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.utils;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificRecordBase;
+
+/**
+ * A collection of utilities around Avro.
+ */
+public final class AvroUtils {
+
+	public static <E>DatumReader<E> createDatumReader(TypeInformation<E> type) {
+		return createDatumReader(type.getTypeClass());
+	}
+
+	public static <E>DatumReader<E> createDatumReader(Class<E> type) {
+		if (type == org.apache.avro.generic.GenericRecord.class) {
+			return new GenericDatumReader<>();
+		} else if (SpecificRecordBase.class.isAssignableFrom(type)) {
+			return new SpecificDatumReader<>(type);
+		} else {
+			return new ReflectDatumReader<>(type);
+		}
+	}
+}

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -58,6 +58,13 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<!-- CSV table descriptor testing -->

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowFormat.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowFormat.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.csv;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
+import org.apache.flink.connector.file.src.reader.StreamFormat;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.types.Row;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.MappingIterator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvSchema;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A reader format for the {@link org.apache.flink.connector.file.src.FileSource} that reads
+ * CSV files into {@link Row Rows}.
+ *
+ * <p>Internally, this format uses the Jackson Library's CSV decoder.
+ */
+public class CsvRowFormat extends SimpleStreamFormat<Row> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final CsvSchema csvSchema;
+
+	private final String[] selectedFieldNames;
+
+	private final RowTypeInfo rowType;
+
+	private final boolean ignoreParseErrors;
+
+	/**
+	 * Creates a new {@code CsvRowFormat}. This constructor cannot be called directly, construction
+	 * should go through the builder, for example via the {@link #builder(RowTypeInfo)} method.
+	 */
+	private CsvRowFormat(
+			final CsvSchema csvSchema,
+			final String[] selectedFieldNames,
+			final RowTypeInfo rowType,
+			boolean ignoreParseErrors) {
+
+		this.csvSchema = checkNotNull(csvSchema);
+		this.selectedFieldNames = checkNotNull(selectedFieldNames);
+		this.rowType = checkNotNull(rowType);
+		this.ignoreParseErrors = ignoreParseErrors;
+		checkArgument(selectedFieldNames.length == rowType.getArity());
+	}
+
+	@Override
+	public Reader createReader(Configuration config, FSDataInputStream inputStream) throws IOException {
+		final CsvRowDeserializationSchema.RuntimeConverter[] fieldConvertes =
+				CsvRowDeserializationSchema.createFieldRuntimeConverters(ignoreParseErrors, rowType.getFieldTypes());
+
+		final MappingIterator<JsonNode> iterator = new CsvMapper()
+			.readerFor(JsonNode.class)
+			.with(csvSchema)
+			.readValues(inputStream);
+
+		return new Reader(iterator, selectedFieldNames, fieldConvertes, ignoreParseErrors);
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		return rowType;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Builder / Factory
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Starts building a {@link CsvRowFormat} based on a row type information.
+	 */
+	public static Builder builder(RowTypeInfo rowType) {
+		return new Builder(rowType);
+	}
+
+	/**
+	 * A builder for creating a {@link RowCsvInputFormat}.
+	 */
+	public static final class Builder {
+
+		private final RowTypeInfo rowType;
+		private int[] selectedFields;
+		private CsvSchema csvSchema;
+		private boolean ignoreParseErrors;
+
+		/**
+		 * Creates a row CSV input format for the given {@link TypeInformation} and file paths
+		 * with optional parameters.
+		 */
+		private Builder(RowTypeInfo rowTypeInfo) {
+			this.rowType = checkNotNull(rowTypeInfo, "Type information must not be null.");
+			this.csvSchema = CsvRowSchemaConverter.convert(rowTypeInfo);
+		}
+
+		public Builder setFieldDelimiter(char delimiter) {
+			this.csvSchema = this.csvSchema.rebuild().setColumnSeparator(delimiter).build();
+			return this;
+		}
+
+		public Builder setAllowComments(boolean allowComments) {
+			this.csvSchema = this.csvSchema.rebuild().setAllowComments(allowComments).build();
+			return this;
+		}
+
+		public Builder setArrayElementDelimiter(String delimiter) {
+			checkNotNull(delimiter, "Array element delimiter must not be null.");
+			this.csvSchema = this.csvSchema.rebuild().setArrayElementSeparator(delimiter).build();
+			return this;
+		}
+
+		public Builder setQuoteCharacter(char c) {
+			this.csvSchema = this.csvSchema.rebuild().setQuoteChar(c).build();
+			return this;
+		}
+
+		public Builder setEscapeCharacter(char c) {
+			this.csvSchema = this.csvSchema.rebuild().setEscapeChar(c).build();
+			return this;
+		}
+
+		public Builder setNullLiteral(String nullLiteral) {
+			checkNotNull(nullLiteral, "Null literal must not be null.");
+			this.csvSchema = this.csvSchema.rebuild().setNullValue(nullLiteral).build();
+			return this;
+		}
+
+		public Builder setIgnoreParseErrors(boolean ignoreParseErrors) {
+			this.ignoreParseErrors = ignoreParseErrors;
+			return this;
+		}
+
+		public Builder setSelectedFields(int... selectedFields) {
+			this.selectedFields = selectedFields;
+			return this;
+		}
+
+		public CsvRowFormat build() {
+			final TypeInformation<?>[] fieldTypes = rowType.getFieldTypes();
+
+			if (selectedFields == null) {
+				selectedFields = new int[fieldTypes.length];
+				for (int i = 0; i < fieldTypes.length; i++) {
+					selectedFields[i] = i;
+				}
+			}
+
+			final String[] selectedFieldNames = Arrays.stream(selectedFields)
+				.mapToObj(csvSchema::columnName)
+				.toArray(String[]::new);
+
+			return new CsvRowFormat(
+				csvSchema,
+				selectedFieldNames,
+				rowType,
+				ignoreParseErrors);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//   Reader Implementation
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The reader implementation that reads from the stream and decodes the CSV rows.
+	 */
+	public static class Reader implements StreamFormat.Reader<Row> {
+
+		private final MappingIterator<JsonNode> iterator;
+
+		private final String[] selectedFieldNames;
+
+		private final CsvRowDeserializationSchema.RuntimeConverter[] fieldConverters;
+
+		private final boolean ignoreParseErrors;
+
+		protected Reader(
+				final MappingIterator<JsonNode> iterator,
+				final String[] selectedFieldNames,
+				final CsvRowDeserializationSchema.RuntimeConverter[] fieldConverters,
+				final boolean ignoreParseErrors) {
+
+			this.iterator = checkNotNull(iterator);
+			this.selectedFieldNames = selectedFieldNames;
+			this.fieldConverters = checkNotNull(fieldConverters);
+			this.ignoreParseErrors = ignoreParseErrors;
+		}
+
+		@Nullable
+		@Override
+		public Row read() throws IOException {
+			// we need to loop because we possibly skip records (ignored parse errors)
+			while (true) {
+
+				// the first step handles exceptions only for Jackson, because there
+				// we need to differentiate between forwarded IO Errors and parse exceptions
+				final JsonNode node;
+				try {
+					node = iterator.nextValue();
+				}
+				catch (NoSuchElementException e) {
+					return null;
+				}
+				catch (Exception e) {
+					if (isParseException(e) && ignoreParseErrors) {
+						continue;
+					} else {
+						throw e instanceof IOException
+								? (IOException) e
+								: new IOException("Failed to deserialize CSV row.", e);
+					}
+				}
+
+				if (!validateArity(node)) {
+					continue;
+				}
+
+				try {
+					return decodeToRow(node);
+				}
+				catch (Exception e) {
+					if (!(isParseException(e) && ignoreParseErrors)) {
+						throw e instanceof IOException
+							? (IOException) e
+							: new IOException("Failed to deserialize CSV row.", e);
+					}
+				}
+			}
+		}
+
+		@Override
+		public void close() throws IOException {
+			iterator.close();
+		}
+
+		private Row decodeToRow(JsonNode node) {
+			final int nodeSize = node.size();
+			final Row row = new Row(selectedFieldNames.length);
+
+			for (int i = 0; i < Math.min(selectedFieldNames.length, nodeSize); i++) {
+				// Jackson only supports mapping by name in the first level
+				row.setField(i, fieldConverters[i].convert(node.get(selectedFieldNames[i])));
+			}
+			return row;
+		}
+
+		private boolean validateArity(JsonNode node) throws IOException {
+			if (selectedFieldNames.length == node.size()) {
+				return true;
+			}
+			else if (ignoreParseErrors) {
+				return false;
+			} else {
+				throw new IOException(String.format("Row length mismatch: %d fields expected but was %d.",
+						selectedFieldNames.length, node.size()));
+			}
+		}
+
+		private static boolean isParseException(Exception e) {
+			// TODO: this needs proper logic
+			return true;
+		}
+	}
+}

--- a/flink-formats/flink-orc-nohive/pom.xml
+++ b/flink-formats/flink-orc-nohive/pom.xml
@@ -69,7 +69,7 @@ under the License.
 				</exclusion>
 			</exclusions>
 		</dependency>
-		
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -45,6 +45,20 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- File connector for file input/output formats -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- Table ecosystem -->
 		<!-- Projects depending on this project won't depend on flink-table-*. -->
 		<dependency>

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/AbstractOrcFileInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/AbstractOrcFileInputFormat.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.orc.shim.OrcShim;
+import org.apache.flink.orc.util.SerializableHadoopConfigWrapper;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.RecordReader;
+import org.apache.orc.TypeDescription;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The base for ORC readers for the {@link org.apache.flink.connector.file.src.FileSource}.
+ * Implements the reader initialization, vectorized reading, and pooling of column vector objects.
+ *
+ * <p>Subclasses implement the conversion to the specific result record(s) that they return by creating
+ * via extending {@link AbstractOrcFileInputFormat.OrcReaderBatch}.
+ *
+ * @param <T> The type of records produced by this reader format.
+ */
+public abstract class AbstractOrcFileInputFormat<T> implements BulkFormat<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	protected final SerializableHadoopConfigWrapper hadoopConfigWrapper;
+
+	protected final TypeDescription schema;
+
+	protected final int[] selectedFields;
+
+	protected final List<OrcSplitReader.Predicate> conjunctPredicates;
+
+	protected final int batchSize;
+
+	protected AbstractOrcFileInputFormat(
+			final org.apache.hadoop.conf.Configuration hadoopConfig,
+			final TypeDescription schema,
+			final int[] selectedFields,
+			final List<OrcSplitReader.Predicate> conjunctPredicates,
+			final int batchSize) {
+
+		this.hadoopConfigWrapper = new SerializableHadoopConfigWrapper(checkNotNull(hadoopConfig));
+		this.schema = checkNotNull(schema);
+		this.selectedFields = checkNotNull(selectedFields);
+		this.conjunctPredicates = checkNotNull(conjunctPredicates);
+		this.batchSize = batchSize;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public OrcVectorizedReader<T> createReader(
+			final Configuration config,
+			final Path filePath,
+			final long splitOffset,
+			final long splitLength) throws IOException {
+
+		final int numBatchesToCirculate = config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY) + 1;
+		final Pool<OrcReaderBatch<T>> poolOfBatches = createPoolOfBatches(numBatchesToCirculate);
+
+		final RecordReader orcReader = OrcShim.defaultShim().createRecordReader(
+				hadoopConfigWrapper.getHadoopConfig(),
+				schema,
+				selectedFields,
+				conjunctPredicates,
+				filePath, splitOffset, splitLength);
+
+		return new OrcVectorizedReader<>(orcReader, poolOfBatches);
+	}
+
+	@Override
+	public OrcVectorizedReader<T> restoreReader(
+			final Configuration config,
+			final Path filePath,
+			final long splitOffset,
+			final long splitLength,
+			final CheckpointedPosition checkpointedPosition) throws IOException {
+
+		final OrcVectorizedReader<T> reader = createReader(config, filePath, splitOffset, splitLength);
+		reader.seek(checkpointedPosition);
+		return reader;
+	}
+
+	@Override
+	public boolean isSplittable() {
+		return true;
+	}
+
+	/**
+	 * Creates the {@link OrcReaderBatch} structure, which is responsible for holding the data structures
+	 * that hold the batch data (column vectors, row arrays, ...) and the batch conversion from the
+	 * ORC representation to the result format.
+	 */
+	public abstract OrcReaderBatch<T> createReaderBatch(
+			VectorizedRowBatch orcVectorizedRowBatch,
+			Pool.Recycler<OrcReaderBatch<T>> recycler,
+			int batchSize);
+
+	/**
+	 * Gets the type produced by this format.
+	 */
+	@Override
+	public abstract TypeInformation<T> getProducedType();
+
+	// ------------------------------------------------------------------------
+
+	private Pool<OrcReaderBatch<T>> createPoolOfBatches(final int numBatches) {
+		final Pool<OrcReaderBatch<T>> pool = new Pool<>(numBatches);
+
+		for (int i = 0; i < numBatches; i++) {
+			final VectorizedRowBatch orcVectorizedRowBatch = schema.createRowBatch(batchSize);
+			final OrcReaderBatch<T> batch = createReaderBatch(orcVectorizedRowBatch, pool.recycler(), batchSize);
+			pool.add(batch);
+		}
+
+		return pool;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The {@code OrcReaderBatch} class holds the data structures containing the batch data
+	 * (column vectors, row arrays, ...) and performs the batch conversion from the ORC
+	 * representation to the result format.
+	 *
+	 * <p>This base class only holds the ORC Column Vectors, subclasses hold additionally the result
+	 * structures and implement the conversion in
+	 * {@link OrcReaderBatch#convertAndGetIterator(VectorizedRowBatch, long)}.
+	 */
+	protected abstract static class OrcReaderBatch<T> {
+
+		private final VectorizedRowBatch orcVectorizedRowBatch;
+		private final Pool.Recycler<OrcReaderBatch<T>> recycler;
+
+		protected OrcReaderBatch(
+				final VectorizedRowBatch orcVectorizedRowBatch,
+				final Pool.Recycler<OrcReaderBatch<T>> recycler) {
+			this.orcVectorizedRowBatch = checkNotNull(orcVectorizedRowBatch);
+			this.recycler = checkNotNull(recycler);
+		}
+
+		/**
+		 * Puts this batch back into the pool. This should be called after all records from the
+		 * batch have been returned, typically in the {@link RecordIterator#releaseBatch()} method.
+		 */
+		public void recycle() {
+			recycler.recycle(this);
+		}
+
+		/**
+		 * Gets the ORC VectorizedRowBatch structure from this batch.
+		 */
+		public VectorizedRowBatch orcVectorizedRowBatch() {
+			return orcVectorizedRowBatch;
+		}
+
+		/**
+		 * Converts the ORC VectorizedRowBatch into the result structure and returns an iterator
+		 * over the entries.
+		 *
+		 * <p>This method may, for example, return a single element iterator that returns the entire
+		 * batch as one, or (as another example) return an iterator over the rows projected from this
+		 * column batch.
+		 *
+		 * <p>The position information in the result needs to be constructed as follows: The
+		 * value of {@code startingOffset} is the offset value ({@link RecordAndPosition#getOffset()})
+		 * for all rows in the batch. Each row then increments the records-to-skip value
+		 * ({@link RecordAndPosition#getRecordSkipCount()}).
+		 */
+		public abstract RecordIterator<T> convertAndGetIterator(
+				final VectorizedRowBatch orcVectorizedRowBatch,
+				final long startingOffset) throws IOException;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A vectorized ORC reader. This reader reads an ORC {@link VectorizedRowBatch} at a time and
+	 * converts it to one or more records to be returned. An ORC Row-wise reader would convert the
+	 * batch into a set of rows, while a reader for a vectorized query processor might return
+	 * the whole batch as one record.
+	 *
+	 * <p>The conversion of the {@code VectorizedRowBatch} happens in the specific {@link OrcReaderBatch}
+	 * implementation.
+	 *
+	 * <p>The reader tracks its current position using ORC's <i>row numbers</i>. Each record in a
+	 * batch is addressed by the starting row number of the batch, plus the number of records to
+	 * be skipped before.
+	 *
+	 * @param <T> The type of the records returned by the reader.
+	 */
+	protected static final class OrcVectorizedReader<T> implements BulkFormat.Reader<T> {
+
+		private final RecordReader orcReader;
+		private final Pool<OrcReaderBatch<T>> pool;
+		private long recordsToSkip;
+
+		protected OrcVectorizedReader(
+				final RecordReader orcReader,
+				final Pool<OrcReaderBatch<T>> pool) {
+
+			this.orcReader = checkNotNull(orcReader, "orcReader");
+			this.pool = checkNotNull(pool, "pool");
+		}
+
+		@Nullable
+		@Override
+		public RecordIterator<T> readBatch() throws IOException {
+			final OrcReaderBatch<T> batch = getCachedEntry();
+			final VectorizedRowBatch orcVectorBatch = batch.orcVectorizedRowBatch();
+
+			final long orcRowNumber = orcReader.getRowNumber();
+			if (!orcReader.nextBatch(orcVectorBatch)) {
+				batch.recycle();
+				return null;
+			}
+
+			final RecordIterator<T> records = batch.convertAndGetIterator(orcVectorBatch, orcRowNumber);
+			if (recordsToSkip > 0) {
+				// this may leave an exhausted iterator, which is a valid result for this method
+				// and is not interpreted as end-of-input or anything
+				skipRecord(records);
+			}
+			return records;
+		}
+
+		@Override
+		public void close() throws IOException {
+			orcReader.close();
+		}
+
+		public void seek(CheckpointedPosition position) throws IOException {
+			orcReader.seekToRow(position.getOffset());
+			recordsToSkip = position.getRecordsAfterOffset();
+		}
+
+		private OrcReaderBatch<T> getCachedEntry() throws IOException {
+			try {
+				return pool.pollEntry();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IOException("Interrupted");
+			}
+		}
+
+		private void skipRecord(RecordIterator<T> records) {
+			while (recordsToSkip > 0 && records.next() != null) {
+				recordsToSkip--;
+			}
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcRowFileInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcRowFileInputFormat.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.file.src.util.ArrayResultIterator;
+import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.TypeDescription;
+
+import java.util.List;
+
+/**
+ * An ORC file input format that reads an ORC file and produces a stream of {@link Row} records.
+ */
+public class OrcRowFileInputFormat extends AbstractOrcFileInputFormat<Row> {
+
+	private static final long serialVersionUID = 1L;
+
+	protected OrcRowFileInputFormat(
+			final Configuration hadoopConfig,
+			final TypeDescription schema,
+			final int[] selectedFields,
+			final List<OrcSplitReader.Predicate> conjunctPredicates,
+			final int batchSize) {
+		super(hadoopConfig, schema, selectedFields, conjunctPredicates, batchSize);
+	}
+
+	@Override
+	public OrcReaderBatch<Row> createReaderBatch(
+			final VectorizedRowBatch orcVectorizedRowBatch,
+			final Pool.Recycler<OrcReaderBatch<Row>> recycler,
+			final int batchSize) {
+
+		final int[] selectedFields = this.selectedFields;
+		final Row[] rows = new Row[batchSize];
+
+		for (int i = 0; i < batchSize; i++) {
+			rows[i] = new Row(selectedFields.length);
+		}
+		return new RowReaderBatch(schema, selectedFields, rows, orcVectorizedRowBatch, recycler);
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		// TODO
+		return null;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * One batch of ORC columnar vectors and Flink Rows, plus the conversion between them.
+	 */
+	private static final class RowReaderBatch extends OrcReaderBatch<Row> {
+
+		private final TypeDescription schema;
+
+		private final int[] selectedFields;
+
+		private final Row[] rows;
+
+		private final ArrayResultIterator<Row> result;
+
+		RowReaderBatch(
+				final TypeDescription schema,
+				final int[] selectedFields,
+				final Row[] rows,
+				final VectorizedRowBatch orcVectorizedRowBatch,
+				final Pool.Recycler<OrcReaderBatch<Row>> recycler) {
+
+			super(orcVectorizedRowBatch, recycler);
+			this.schema = schema;
+			this.selectedFields = selectedFields;
+			this.rows = rows;
+			this.result = new ArrayResultIterator<>(this::recycle);
+		}
+
+		@Override
+		public RecordIterator<Row> convertAndGetIterator(
+				final VectorizedRowBatch orcVectorizedRowBatch,
+				final long startingOffset) {
+
+			OrcBatchReader.fillRows(rows, schema, orcVectorizedRowBatch, selectedFields);
+			result.set(rows, orcVectorizedRowBatch.size, startingOffset, 0L);
+			return result;
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcVectorizedColumnarFileInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcVectorizedColumnarFileInputFormat.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.flink.connector.file.src.util.SingletonResultIterator;
+import org.apache.flink.table.data.vector.VectorizedColumnBatch;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.TypeDescription;
+
+import java.util.List;
+
+/**
+ * An ORC reader that produces a stream of {@link VectorizedColumnBatch} records.
+ * Used in vectorized query processing.
+ */
+public class OrcVectorizedColumnarFileInputFormat extends AbstractOrcFileInputFormat<VectorizedColumnBatch> {
+
+	private static final long serialVersionUID = 1L;
+
+	protected OrcVectorizedColumnarFileInputFormat(
+			final Configuration hadoopConfig,
+			final TypeDescription schema,
+			final int[] selectedFields,
+			final List<OrcSplitReader.Predicate> conjunctPredicates,
+			final int batchSize) {
+		super(hadoopConfig, schema, selectedFields, conjunctPredicates, batchSize);
+	}
+
+	@Override
+	public OrcReaderBatch<VectorizedColumnBatch> createReaderBatch(
+			final VectorizedRowBatch orcVectorizedRowBatch,
+			final Pool.Recycler<OrcReaderBatch<VectorizedColumnBatch>> recycler,
+			final int batchSize) {
+
+		final VectorizedColumnBatch flinkColumnBatch = createFlinkColumnBatchFromOrcColumnBatch(orcVectorizedRowBatch);
+		return new VectorizedColumnReaderBatch(orcVectorizedRowBatch, flinkColumnBatch, recycler);
+	}
+
+	@Override
+	public TypeInformation<VectorizedColumnBatch> getProducedType() {
+		// TODO
+		return null;
+	}
+
+	private VectorizedColumnBatch createFlinkColumnBatchFromOrcColumnBatch(VectorizedRowBatch orcVectorizedRowBatch) {
+		// TODO
+		return null;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * One batch of ORC columnar vectors and Flink column vectors.
+	 */
+	private static final class VectorizedColumnReaderBatch extends AbstractOrcFileInputFormat.OrcReaderBatch<VectorizedColumnBatch> {
+
+		private final VectorizedColumnBatch flinkColumnBatch;
+
+		private final SingletonResultIterator<VectorizedColumnBatch> result;
+
+		VectorizedColumnReaderBatch(
+				final VectorizedRowBatch orcVectorizedRowBatch,
+				final VectorizedColumnBatch flinkColumnBatch,
+				final Pool.Recycler<AbstractOrcFileInputFormat.OrcReaderBatch<VectorizedColumnBatch>> recycler) {
+
+			super(orcVectorizedRowBatch, recycler);
+			this.flinkColumnBatch = flinkColumnBatch;
+			this.result = new SingletonResultIterator<>(this::recycle);
+		}
+
+		@Override
+		public RecordIterator<VectorizedColumnBatch> convertAndGetIterator(
+				final VectorizedRowBatch orcVectorizedRowBatch,
+				final long startingOffset) {
+			// no copying from the ORC column vectors to the Flink columns vectors necessary,
+			// because they point to the same data arrays internally design
+			final int numRowsInBatch = orcVectorizedRowBatch.size;
+			flinkColumnBatch.setNumRows(numRowsInBatch);
+			result.set(flinkColumnBatch, startingOffset, 1);
+			return result;
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/SerializableHadoopConfigWrapper.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/SerializableHadoopConfigWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.util;
+
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility class to make a {@link Configuration Hadoop Configuration} serializable.
+ */
+public final class SerializableHadoopConfigWrapper implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private transient Configuration hadoopConfig;
+
+	public SerializableHadoopConfigWrapper(Configuration hadoopConfig) {
+		this.hadoopConfig = checkNotNull(hadoopConfig);
+	}
+
+	public Configuration getHadoopConfig() {
+		return hadoopConfig;
+	}
+
+	// ------------------------------------------------------------------------
+
+	private void writeObject(ObjectOutputStream out) throws IOException {
+		out.defaultWriteObject();
+
+		// we write the Hadoop config through a separate serializer to avoid cryptic exceptions when it
+		// corrupts the serialization stream
+		final DataOutputSerializer ser = new DataOutputSerializer(256);
+		hadoopConfig.write(ser);
+		out.writeInt(ser.length());
+		out.write(ser.getSharedBuffer(), 0, ser.length());
+	}
+
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+
+		final byte[] data = new byte[in.readInt()];
+		in.readFully(data);
+		final DataInputDeserializer deser = new DataInputDeserializer(data);
+		this.hadoopConfig = new Configuration();
+
+		try {
+			this.hadoopConfig.readFields(deser);
+		} catch (IOException e) {
+			throw new IOException(
+				"Could not deserialize Hadoop Configuration, the serialized and de-serialized don't match.", e);
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/util/SerializableHadoopConfigWrapperTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/util/SerializableHadoopConfigWrapperTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.util;
+
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for the {@link SerializableHadoopConfigWrapper}.
+ */
+public class SerializableHadoopConfigWrapperTest {
+
+	@Test
+	public void testSerializationRoundTrip() throws Exception {
+		final Configuration hadoopConf = new Configuration();
+		hadoopConf.set("test-key", "test-value");
+		final SerializableHadoopConfigWrapper wrapper = new SerializableHadoopConfigWrapper(hadoopConf);
+
+		final SerializableHadoopConfigWrapper copy = CommonTestUtils.createCopySerializable(wrapper);
+
+		assertEquals("test-value", copy.getHadoopConfig().get("test-key"));
+	}
+}


### PR DESCRIPTION
Some stubs for implementing file formats for the new source API.

The readers are fairly complete in their implementation, what is usually missing is the construction of the reader schema/conversion-logic/etc from the type or schema definitions.

These illustrate the following concepts:
  - ORC: A very performance sensitive `BulkFormat`, concerned with avoiding object allocations (splittable).
  - Avro: A stream format that is splittable.
  - CSV: A simple stream format that is not splittable.
