### PR TITLE
[FLINK-19307][coordination] Add ResourceTracker

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.slots.ResourceCounter;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -64,14 +65,14 @@ class BiDirectionalResourceToRequirementMapping {
 			});
 	}
 
-	public ResourceCounter getFulfillingResourcesFor(ResourceProfile requirement) {
+	public Map<ResourceProfile, Integer> getResourcesFulfilling(ResourceProfile requirement) {
 		Preconditions.checkNotNull(requirement);
-		return requirementToFulfillingResources.getOrDefault(requirement, ResourceCounter.EMPTY);
+		return requirementToFulfillingResources.getOrDefault(requirement, ResourceCounter.EMPTY).getResourceProfilesWithCount();
 	}
 
-	public ResourceCounter getFulfilledRequirementsBy(ResourceProfile resource) {
+	public Map<ResourceProfile, Integer> getRequirementsFulfilledBy(ResourceProfile resource) {
 		Preconditions.checkNotNull(resource);
-		return resourceToFulfilledRequirement.getOrDefault(resource, ResourceCounter.EMPTY);
+		return resourceToFulfilledRequirement.getOrDefault(resource, ResourceCounter.EMPTY).getResourceProfilesWithCount();
 	}
 
 	public Set<ResourceProfile> getAllResourceProfiles() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
@@ -57,9 +57,10 @@ class BiDirectionalResourceToRequirementMapping {
 	}
 
 	private static void internalDecrementCount(Map<ResourceProfile, ResourceCounter> primaryMap, ResourceProfile primaryKey, ResourceProfile secondaryKey, int decrement) {
-		primaryMap.computeIfPresent(
+		primaryMap.compute(
 			primaryKey,
 			(resourceProfile, resourceCounter) -> {
+				Preconditions.checkState(resourceCounter != null, "Attempting to decrement count of %s->%s, but primary key was unknown.", resourceProfile, secondaryKey);
 				resourceCounter.decrementCount(secondaryKey, decrement);
 				return resourceCounter.isEmpty() ? null : resourceCounter;
 			});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.slots.ResourceCounter;
 import org.apache.flink.util.Preconditions;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMapping.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.slots.ResourceCounter;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A bi-directional mapping between required and acquired resources.
+ */
+class BiDirectionalResourceToRequirementMapping {
+	private final Map<ResourceProfile, ResourceCounter> requirementToFulfillingResources = new HashMap<>();
+	private final Map<ResourceProfile, ResourceCounter> resourceToFulfilledRequirement = new HashMap<>();
+
+	public void incrementCount(ResourceProfile requirement, ResourceProfile resource, int increment) {
+		Preconditions.checkNotNull(requirement);
+		Preconditions.checkNotNull(resource);
+		Preconditions.checkArgument(increment > 0);
+		internalIncrementCount(requirementToFulfillingResources, requirement, resource, increment);
+		internalIncrementCount(resourceToFulfilledRequirement, resource, requirement, increment);
+	}
+
+	public void decrementCount(ResourceProfile requirement, ResourceProfile resource, int decrement) {
+		Preconditions.checkNotNull(requirement);
+		Preconditions.checkNotNull(resource);
+		Preconditions.checkArgument(decrement > 0);
+		internalDecrementCount(requirementToFulfillingResources, requirement, resource, decrement);
+		internalDecrementCount(resourceToFulfilledRequirement, resource, requirement, decrement);
+	}
+
+	private static void internalIncrementCount(Map<ResourceProfile, ResourceCounter> primaryMap, ResourceProfile primaryKey, ResourceProfile secondaryKey, int increment) {
+		primaryMap
+			.computeIfAbsent(primaryKey, ignored -> new ResourceCounter())
+			.incrementCount(secondaryKey, increment);
+	}
+
+	private static void internalDecrementCount(Map<ResourceProfile, ResourceCounter> primaryMap, ResourceProfile primaryKey, ResourceProfile secondaryKey, int decrement) {
+		primaryMap.computeIfPresent(
+			primaryKey,
+			(resourceProfile, resourceCounter) -> {
+				resourceCounter.decrementCount(secondaryKey, decrement);
+				return resourceCounter.isEmpty() ? null : resourceCounter;
+			});
+	}
+
+	public ResourceCounter getFulfillingResourcesFor(ResourceProfile requirement) {
+		Preconditions.checkNotNull(requirement);
+		return requirementToFulfillingResources.getOrDefault(requirement, ResourceCounter.EMPTY);
+	}
+
+	public ResourceCounter getFulfilledRequirementsBy(ResourceProfile resource) {
+		Preconditions.checkNotNull(resource);
+		return resourceToFulfilledRequirement.getOrDefault(resource, ResourceCounter.EMPTY);
+	}
+
+	public Set<ResourceProfile> getAllResourceProfiles() {
+		return resourceToFulfilledRequirement.keySet();
+	}
+
+	public Set<ResourceProfile> getAllRequirementProfiles() {
+		return requirementToFulfillingResources.keySet();
+	}
+
+	public int getNumFulfillingResources(ResourceProfile requirement) {
+		Preconditions.checkNotNull(requirement);
+		return requirementToFulfillingResources
+			.getOrDefault(requirement, ResourceCounter.EMPTY)
+			.getResourceCount();
+	}
+
+	public int getNumFulfilledRequirements(ResourceProfile resource) {
+		Preconditions.checkNotNull(resource);
+		return resourceToFulfilledRequirement
+			.getOrDefault(resource, ResourceCounter.EMPTY)
+			.getResourceCount();
+	}
+
+	@VisibleForTesting
+	boolean isEmpty() {
+		return requirementToFulfillingResources.isEmpty() && resourceToFulfilledRequirement.isEmpty();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTracker.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Default {@link ResourceTracker} implementation.
+ */
+public class DefaultResourceTracker implements ResourceTracker {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultResourceTracker.class);
+
+	private final Map<JobID, JobScopedResourceTracker> trackers = new LinkedHashMap<>();
+
+	@Override
+	public void notifyResourceRequirements(JobID jobId, Collection<ResourceRequirement> resourceRequirements) {
+		Preconditions.checkNotNull(jobId);
+		Preconditions.checkNotNull(resourceRequirements);
+		LOG.trace("Received notification for job {} having new resource requirements {}.", jobId, resourceRequirements);
+		getOrCreateTracker(jobId).notifyResourceRequirements(resourceRequirements);
+
+		if (resourceRequirements.isEmpty()) {
+			checkWhetherTrackerCanBeRemoved(jobId, trackers.get(jobId));
+		}
+	}
+
+	private void checkWhetherTrackerCanBeRemoved(JobID jobId, JobScopedResourceTracker tracker) {
+		if (tracker.isEmpty()) {
+			LOG.debug("Stopping tracking of resources for job {}.", jobId);
+			trackers.remove(jobId);
+		}
+	}
+
+	@Override
+	public void notifyAcquiredResource(JobID jobId, ResourceProfile resourceProfile) {
+		Preconditions.checkNotNull(jobId);
+		Preconditions.checkNotNull(resourceProfile);
+		LOG.trace("Received notification for job {} having acquired resource {}.", jobId, resourceProfile);
+		getOrCreateTracker(jobId).notifyAcquiredResource(resourceProfile);
+	}
+
+	private JobScopedResourceTracker getOrCreateTracker(JobID jobId) {
+		return trackers.computeIfAbsent(jobId, ignored -> {
+			LOG.debug("Initiating tracking of resources for job {}.", jobId);
+			return new JobScopedResourceTracker(jobId);
+		});
+	}
+
+	@Override
+	public void notifyLostResource(JobID jobId, ResourceProfile resourceProfile) {
+		Preconditions.checkNotNull(jobId);
+		Preconditions.checkNotNull(resourceProfile);
+		JobScopedResourceTracker tracker = trackers.get(jobId);
+
+		// during shutdown the tracker is cleared before task executors are unregistered,
+		// to prevent the loss of resources triggering new allocations
+		if (tracker != null) {
+			LOG.trace("Received notification for job {} having lost resource {}.", jobId, resourceProfile);
+			tracker.notifyLostResource(resourceProfile);
+
+			checkWhetherTrackerCanBeRemoved(jobId, tracker);
+		} else {
+			LOG.trace("Received notification for job {} having lost resource {}, but no such job was tracked.", jobId, resourceProfile);
+		}
+	}
+
+	@Override
+	public void clear() {
+		trackers.clear();
+	}
+
+	@Override
+	public Map<JobID, Collection<ResourceRequirement>> getRequiredResources() {
+		Map<JobID, Collection<ResourceRequirement>> requiredResources = new LinkedHashMap<>();
+		for (Map.Entry<JobID, JobScopedResourceTracker> jobIDJobScopedRequirementsTrackerEntry : trackers.entrySet()) {
+			Collection<ResourceRequirement> exceedingOrRequiredResources = jobIDJobScopedRequirementsTrackerEntry.getValue().getRequiredResources();
+			if (!exceedingOrRequiredResources.isEmpty()) {
+				requiredResources.put(jobIDJobScopedRequirementsTrackerEntry.getKey(), exceedingOrRequiredResources);
+			}
+		}
+		return requiredResources;
+	}
+
+	@Override
+	public Collection<ResourceRequirement> getAcquiredResources(JobID jobId) {
+		Preconditions.checkNotNull(jobId);
+		JobScopedResourceTracker tracker = trackers.get(jobId);
+		return tracker == null
+			? Collections.emptyList()
+			: tracker.getAcquiredResources();
+	}
+
+	@VisibleForTesting
+	boolean isEmpty() {
+		return trackers.isEmpty();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTracker.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -39,7 +39,7 @@ public class DefaultResourceTracker implements ResourceTracker {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DefaultResourceTracker.class);
 
-	private final Map<JobID, JobScopedResourceTracker> trackers = new LinkedHashMap<>();
+	private final Map<JobID, JobScopedResourceTracker> trackers = new HashMap<>();
 
 	@Override
 	public void notifyResourceRequirements(JobID jobId, Collection<ResourceRequirement> resourceRequirements) {
@@ -100,7 +100,7 @@ public class DefaultResourceTracker implements ResourceTracker {
 
 	@Override
 	public Map<JobID, Collection<ResourceRequirement>> getMissingResources() {
-		Map<JobID, Collection<ResourceRequirement>> allMissingResources = new LinkedHashMap<>();
+		Map<JobID, Collection<ResourceRequirement>> allMissingResources = new HashMap<>();
 		for (Map.Entry<JobID, JobScopedResourceTracker> tracker : trackers.entrySet()) {
 			Collection<ResourceRequirement> missingResources = tracker.getValue().getMissingResources();
 			if (!missingResources.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTracker.java
@@ -99,15 +99,15 @@ public class DefaultResourceTracker implements ResourceTracker {
 	}
 
 	@Override
-	public Map<JobID, Collection<ResourceRequirement>> getRequiredResources() {
-		Map<JobID, Collection<ResourceRequirement>> requiredResources = new LinkedHashMap<>();
-		for (Map.Entry<JobID, JobScopedResourceTracker> jobIDJobScopedRequirementsTrackerEntry : trackers.entrySet()) {
-			Collection<ResourceRequirement> exceedingOrRequiredResources = jobIDJobScopedRequirementsTrackerEntry.getValue().getRequiredResources();
-			if (!exceedingOrRequiredResources.isEmpty()) {
-				requiredResources.put(jobIDJobScopedRequirementsTrackerEntry.getKey(), exceedingOrRequiredResources);
+	public Map<JobID, Collection<ResourceRequirement>> getMissingResources() {
+		Map<JobID, Collection<ResourceRequirement>> allMissingResources = new LinkedHashMap<>();
+		for (Map.Entry<JobID, JobScopedResourceTracker> tracker : trackers.entrySet()) {
+			Collection<ResourceRequirement> missingResources = tracker.getValue().getMissingResources();
+			if (!missingResources.isEmpty()) {
+				allMissingResources.put(tracker.getKey(), missingResources);
 			}
 		}
-		return requiredResources;
+		return allMissingResources;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
@@ -75,7 +75,7 @@ class JobScopedResourceTracker {
 	}
 
 	private Optional<ResourceProfile> findMatchingRequirement(ResourceProfile resourceProfile) {
-		for (Map.Entry<ResourceProfile, Integer> requirementCandidate : resourceRequirements.getResourceProfilesWithCount()) {
+		for (Map.Entry<ResourceProfile, Integer> requirementCandidate : resourceRequirements.getResourceProfilesWithCount().entrySet()) {
 			ResourceProfile requirementProfile = requirementCandidate.getKey();
 
 			// beware the order when matching resources to requirements, because ResourceProfile.UNKNOWN (which only
@@ -95,7 +95,7 @@ class JobScopedResourceTracker {
 			return;
 		}
 
-		Set<ResourceProfile> fulfilledRequirements = resourceToRequirementMapping.getFulfilledRequirementsBy(resourceProfile).getResourceProfiles();
+		Set<ResourceProfile> fulfilledRequirements = resourceToRequirementMapping.getRequirementsFulfilledBy(resourceProfile).keySet();
 
 		if (!fulfilledRequirements.isEmpty()) {
 			// determine for which of the requirements, that the resource could be used for, the resource count should be reduced for
@@ -125,7 +125,7 @@ class JobScopedResourceTracker {
 
 	public Collection<ResourceRequirement> getRequiredResources() {
 		final Collection<ResourceRequirement> requiredResources = new ArrayList<>();
-		for (Map.Entry<ResourceProfile, Integer> requirement : resourceRequirements.getResourceProfilesWithCount()) {
+		for (Map.Entry<ResourceProfile, Integer> requirement : resourceRequirements.getResourceProfilesWithCount().entrySet()) {
 			ResourceProfile requirementProfile = requirement.getKey();
 
 			int numRequiredResources = requirement.getValue();
@@ -168,7 +168,7 @@ class JobScopedResourceTracker {
 			if (numTotalAcquiredResources > numTotalRequiredResources) {
 				int numExcessResources = numTotalAcquiredResources - numTotalRequiredResources;
 
-				for (Map.Entry<ResourceProfile, Integer> acquiredResource : resourceToRequirementMapping.getFulfillingResourcesFor(requirementProfile).getResourceProfilesWithCount()) {
+				for (Map.Entry<ResourceProfile, Integer> acquiredResource : resourceToRequirementMapping.getResourcesFulfilling(requirementProfile).entrySet()) {
 					ResourceProfile acquiredResourceProfile = acquiredResource.getKey();
 					int numAcquiredResources = acquiredResource.getValue();
 
@@ -198,7 +198,7 @@ class JobScopedResourceTracker {
 		// this is a quick-and-dirty solution; in the worse case we copy the excessResources map twice
 		ResourceCounter copy = excessResources.copy();
 		excessResources.clear();
-		for (Map.Entry<ResourceProfile, Integer> resourceProfileIntegerEntry : copy.getResourceProfilesWithCount()) {
+		for (Map.Entry<ResourceProfile, Integer> resourceProfileIntegerEntry : copy.getResourceProfilesWithCount().entrySet()) {
 			for (int x = 0; x < resourceProfileIntegerEntry.getValue(); x++) {
 				// try making use of this resource again; any excess resources will be added again to excessResources
 				notifyAcquiredResource(resourceProfileIntegerEntry.getKey());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
@@ -104,7 +104,8 @@ class JobScopedResourceTracker {
 			for (ResourceProfile requirementProfile : fulfilledRequirements) {
 				assignedRequirement = requirementProfile;
 
-				// try finding a requirement that has too many resources, otherwise use any
+				// try finding a requirement that has too many resources; if non are exceeding the requirements we deduct
+				// the resource from any requirement having such a resource
 				if (resourceRequirements.getResourceCount(requirementProfile) < resourceToRequirementMapping.getNumFulfillingResources(requirementProfile)) {
 					break;
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.slots.ResourceCounter;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Tracks resource for a single job.
+ */
+class JobScopedResourceTracker {
+
+	private static final Logger LOG = LoggerFactory.getLogger(JobScopedResourceTracker.class);
+
+	// only for logging purposes
+	private final JobID jobId;
+
+	private final ResourceCounter resourceRequirements = new ResourceCounter();
+	private final BiDirectionalResourceToRequirementMapping resourceToRequirementMapping = new BiDirectionalResourceToRequirementMapping();
+	private final ResourceCounter excessResources = new ResourceCounter();
+
+	JobScopedResourceTracker(JobID jobId) {
+		this.jobId = Preconditions.checkNotNull(jobId);
+	}
+
+	public void notifyResourceRequirements(Collection<ResourceRequirement> newResourceRequirements) {
+		Preconditions.checkNotNull(newResourceRequirements);
+
+		resourceRequirements.clear();
+		for (ResourceRequirement newResourceRequirement : newResourceRequirements) {
+			resourceRequirements.incrementCount(newResourceRequirement.getResourceProfile(), newResourceRequirement.getNumberOfRequiredSlots());
+		}
+		findExcessSlots();
+		tryAssigningExcessSlots();
+	}
+
+	public void notifyAcquiredResource(ResourceProfile resourceProfile) {
+		Preconditions.checkNotNull(resourceProfile);
+		final Optional<ResourceProfile> matchingRequirement = findMatchingRequirement(resourceProfile);
+		if (matchingRequirement.isPresent()) {
+			resourceToRequirementMapping.incrementCount(matchingRequirement.get(), resourceProfile, 1);
+		} else {
+			LOG.debug("Job {} acquired excess resource {}.", resourceProfile, jobId);
+			excessResources.incrementCount(resourceProfile, 1);
+		}
+	}
+
+	private Optional<ResourceProfile> findMatchingRequirement(ResourceProfile resourceProfile) {
+		for (Map.Entry<ResourceProfile, Integer> requirementCandidate : resourceRequirements.getResourceProfilesWithCount()) {
+			ResourceProfile requirementProfile = requirementCandidate.getKey();
+
+			// beware the order when matching resources to requirements, because ResourceProfile.UNKNOWN (which only
+			// occurs as a requirement) does not match any resource!
+			if (resourceProfile.isMatching(requirementProfile) && requirementCandidate.getValue() > resourceToRequirementMapping.getNumFulfillingResources(requirementProfile)) {
+				return Optional.of(requirementProfile);
+			}
+		}
+		return Optional.empty();
+	}
+
+	public void notifyLostResource(ResourceProfile resourceProfile) {
+		Preconditions.checkNotNull(resourceProfile);
+		if (excessResources.getResourceCount(resourceProfile) > 0) {
+			LOG.trace("Job {} lost excess resource {}.", jobId, resourceProfile);
+			excessResources.decrementCount(resourceProfile, 1);
+			return;
+		}
+
+		Set<ResourceProfile> fulfilledRequirements = resourceToRequirementMapping.getFulfilledRequirementsBy(resourceProfile).getResourceProfiles();
+
+		if (!fulfilledRequirements.isEmpty()) {
+			// determine for which of the requirements, that the resource could be used for, the resource count should be reduced for
+			ResourceProfile assignedRequirement = null;
+
+			for (ResourceProfile requirementProfile : fulfilledRequirements) {
+				assignedRequirement = requirementProfile;
+
+				// try finding a requirement that has too many resources, otherwise use any
+				if (resourceRequirements.getResourceCount(requirementProfile) < resourceToRequirementMapping.getNumFulfillingResources(requirementProfile)) {
+					break;
+				}
+			}
+
+			if (assignedRequirement == null) {
+				// safeguard against programming errors
+				throw new IllegalStateException(String.format("Job %s lost a (non-excess) resource %s but no requirement was assigned to it.", jobId, resourceProfile));
+			}
+
+			resourceToRequirementMapping.decrementCount(assignedRequirement, resourceProfile, 1);
+
+			tryAssigningExcessSlots();
+		} else {
+			LOG.warn("Job {} lost a resource {} but no such resource was tracked.", jobId, resourceProfile);
+		}
+	}
+
+	public Collection<ResourceRequirement> getRequiredResources() {
+		final Collection<ResourceRequirement> requiredResources = new ArrayList<>();
+		for (Map.Entry<ResourceProfile, Integer> requirement : resourceRequirements.getResourceProfilesWithCount()) {
+			ResourceProfile requirementProfile = requirement.getKey();
+
+			int numRequiredResources = requirement.getValue();
+			int numAcquiredResources = resourceToRequirementMapping.getNumFulfillingResources(requirementProfile);
+
+			if (numAcquiredResources < numRequiredResources) {
+				requiredResources.add(ResourceRequirement.create(requirementProfile, numRequiredResources - numAcquiredResources));
+			}
+
+		}
+		return requiredResources;
+	}
+
+	public Collection<ResourceRequirement> getAcquiredResources() {
+		final Set<ResourceProfile> knownResourceProfiles = new HashSet<>();
+		knownResourceProfiles.addAll(resourceToRequirementMapping.getAllResourceProfiles());
+		knownResourceProfiles.addAll(excessResources.getResourceProfiles());
+
+		final List<ResourceRequirement> acquiredResources = new ArrayList<>();
+		for (ResourceProfile knownResourceProfile : knownResourceProfiles) {
+			int numTotalAcquiredResources = resourceToRequirementMapping.getNumFulfilledRequirements(knownResourceProfile) + excessResources.getResourceCount(knownResourceProfile);
+			ResourceRequirement resourceRequirement = ResourceRequirement.create(knownResourceProfile, numTotalAcquiredResources);
+			acquiredResources.add(resourceRequirement);
+		}
+
+		return acquiredResources;
+	}
+
+	public boolean isEmpty() {
+		return resourceRequirements.isEmpty() && excessResources.isEmpty();
+	}
+
+	private void findExcessSlots() {
+		final Collection<ExcessResource> excessResources = new ArrayList<>();
+
+		for (ResourceProfile requirementProfile : resourceToRequirementMapping.getAllRequirementProfiles()) {
+			int numTotalRequiredResources = resourceRequirements.getResourceCount(requirementProfile);
+			int numTotalAcquiredResources = resourceToRequirementMapping.getNumFulfillingResources(requirementProfile);
+
+			if (numTotalAcquiredResources > numTotalRequiredResources) {
+				int numExcessResources = numTotalAcquiredResources - numTotalRequiredResources;
+
+				for (Map.Entry<ResourceProfile, Integer> acquiredResource : resourceToRequirementMapping.getFulfillingResourcesFor(requirementProfile).getResourceProfilesWithCount()) {
+					ResourceProfile acquiredResourceProfile = acquiredResource.getKey();
+					int numAcquiredResources = acquiredResource.getValue();
+
+					if (numAcquiredResources <= numExcessResources) {
+						excessResources.add(new ExcessResource(requirementProfile, acquiredResourceProfile, numAcquiredResources));
+
+						numExcessResources -= numAcquiredResources;
+					} else {
+						excessResources.add(new ExcessResource(requirementProfile, acquiredResourceProfile, numExcessResources));
+						break;
+					}
+				}
+			}
+		}
+
+		LOG.debug("Detected excess resources for job {}: {}", jobId, excessResources);
+		for (ExcessResource excessResource : excessResources) {
+			resourceToRequirementMapping.decrementCount(excessResource.requirementProfile, excessResource.resourceProfile, excessResource.numExcessResources);
+			this.excessResources.incrementCount(excessResource.resourceProfile, excessResource.numExcessResources);
+		}
+	}
+
+	private void tryAssigningExcessSlots() {
+		if (LOG.isTraceEnabled()) {
+			LOG.trace("There are {} excess resources for job {} before re-assignment.", jobId, excessResources.getResourceCount());
+		}
+		// this is a quick-and-dirty solution; in the worse case we copy the excessResources map twice
+		ResourceCounter copy = excessResources.copy();
+		excessResources.clear();
+		for (Map.Entry<ResourceProfile, Integer> resourceProfileIntegerEntry : copy.getResourceProfilesWithCount()) {
+			for (int x = 0; x < resourceProfileIntegerEntry.getValue(); x++) {
+				// try making use of this resource again; any excess resources will be added again to excessResources
+				notifyAcquiredResource(resourceProfileIntegerEntry.getKey());
+			}
+		}
+		if (LOG.isTraceEnabled()) {
+			LOG.trace("There are {} excess resources for job {} after re-assignment.", jobId, excessResources.getResourceCount());
+		}
+	}
+
+	private static class ExcessResource {
+		private final ResourceProfile requirementProfile;
+		private final ResourceProfile resourceProfile;
+		private final int numExcessResources;
+
+		private ExcessResource(ResourceProfile requirementProfile, ResourceProfile resourceProfile, int numExcessResources) {
+			this.requirementProfile = requirementProfile;
+			this.resourceProfile = resourceProfile;
+			this.numExcessResources = numExcessResources;
+		}
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceTracker.java
@@ -56,11 +56,11 @@ public interface ResourceTracker {
 
 	/**
 	 * Returns a collection of {@link ResourceRequirements} that describe which resources the corresponding job is
-	 * in need/excess of.
+	 * missing.
 	 *
-	 * @return required/exceeding resources for each jobs
+	 * @return missing resources for each jobs
 	 */
-	Map<JobID, Collection<ResourceRequirement>> getRequiredResources();
+	Map<JobID, Collection<ResourceRequirement>> getMissingResources();
 
 	/**
 	 * Returns a collection of {@link ResourceRequirement}s that describe which resources have been assigned to a job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceTracker.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A tracker for required/acquired resources of a job.
+ */
+public interface ResourceTracker {
+
+	/**
+	 * Notifies the tracker about a new or updated {@link ResourceRequirements}.
+	 *
+	 * @param jobId the job that that the resource requirements belongs to
+	 * @param resourceRequirements new resource requirements
+	 */
+	void notifyResourceRequirements(JobID jobId, Collection<ResourceRequirement> resourceRequirements);
+
+	/**
+	 * Notifies the tracker about the acquisition of a resource with the given resource profile, for the given job.
+	 *
+	 * @param jobId the job that acquired the resource
+	 * @param resourceProfile profile of the resource
+	 */
+	void notifyAcquiredResource(JobID jobId, ResourceProfile resourceProfile);
+
+	/**
+	 * Notifies the tracker about the loss of a resource with the given resource profile, for the given job.
+	 *
+	 * @param jobId the job that lost the resource
+	 * @param resourceProfile profile of the resource
+	 */
+	void notifyLostResource(JobID jobId, ResourceProfile resourceProfile);
+
+	/**
+	 * Returns a collection of {@link ResourceRequirements} that describe which resources the corresponding job is
+	 * in need/excess of.
+	 *
+	 * @return required/exceeding resources for each jobs
+	 */
+	Map<JobID, Collection<ResourceRequirement>> getRequiredResources();
+
+	/**
+	 * Returns a collection of {@link ResourceRequirement}s that describe which resources have been assigned to a job.
+	 *
+	 * @param jobId job ID
+	 * @return required/exceeding resources for each jobs
+	 */
+	Collection<ResourceRequirement> getAcquiredResources(JobID jobId);
+
+	/**
+	 * Removes all state from the tracker.
+	 */
+	void clear();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceTracker.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * A tracker for required/acquired resources of a job.
+ * Tracks for each job how many resource are required/acquired.
  */
 public interface ResourceTracker {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.slots;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.util.Preconditions;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,8 +61,8 @@ public class ResourceCounter {
 		return count;
 	}
 
-	public Collection<Map.Entry<ResourceProfile, Integer>> getResourceProfilesWithCount() {
-		return Collections.unmodifiableMap(resources).entrySet();
+	public Map<ResourceProfile, Integer> getResourceProfilesWithCount() {
+		return Collections.unmodifiableMap(resources);
 	}
 
 	public Set<ResourceProfile> getResourceProfiles() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.slots;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A counter for resources.
+ *
+ * <p>ResourceCounter contains a set of {@link ResourceProfile ResourceProfiles} and their
+ * associated counts. The counts are always positive (> 0).
+ */
+public class ResourceCounter {
+	public static final ResourceCounter EMPTY = new ResourceCounter(Collections.emptyMap());
+
+	private final Map<ResourceProfile, Integer> resources;
+
+	public ResourceCounter() {
+		this(new HashMap<>());
+	}
+
+	private ResourceCounter(Map<ResourceProfile, Integer> resources) {
+		this.resources = resources;
+	}
+
+	public void incrementCount(ResourceProfile profile, int increment) {
+		Preconditions.checkArgument(increment > 0);
+		resources.compute(profile, (ignored, currentCount) -> currentCount == null ? increment : currentCount + increment);
+	}
+
+	public void decrementCount(ResourceProfile profile, int decrement) {
+		Preconditions.checkArgument(decrement > 0);
+		resources.computeIfPresent(profile, (ignored, currentCount) -> currentCount == decrement ? null : guardAgainstNegativeCount(currentCount - decrement));
+	}
+
+	private static int guardAgainstNegativeCount(int count) {
+		if (count < 0) {
+			throw new IllegalStateException("Count is negative.");
+		}
+		return count;
+	}
+
+	public Collection<Map.Entry<ResourceProfile, Integer>> getResourceProfilesWithCount() {
+		return Collections.unmodifiableMap(resources).entrySet();
+	}
+
+	public Set<ResourceProfile> getResourceProfiles() {
+		return resources.keySet();
+	}
+
+	public int getResourceCount(ResourceProfile profile) {
+		return resources.getOrDefault(profile, 0);
+	}
+
+	public int getResourceCount() {
+		return resources.isEmpty()
+			? 0
+			: resources.values().stream().reduce(0, Integer::sum);
+	}
+
+	public ResourceCounter copy() {
+		return new ResourceCounter(new HashMap<>(resources));
+	}
+
+	public boolean isEmpty() {
+		return resources.isEmpty();
+	}
+
+	public void clear() {
+		resources.clear();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
@@ -51,7 +51,10 @@ public class ResourceCounter {
 
 	public void decrementCount(ResourceProfile profile, int decrement) {
 		Preconditions.checkArgument(decrement > 0);
-		resources.computeIfPresent(profile, (ignored, currentCount) -> currentCount == decrement ? null : guardAgainstNegativeCount(currentCount - decrement));
+		resources.compute(profile, (p, currentCount) -> {
+			Preconditions.checkState(currentCount != null, "Attempting to decrement count of profile %s, but no count was present.", p);
+			return currentCount == decrement ? null : guardAgainstNegativeCount(currentCount - decrement);
+		});
 	}
 
 	private static int guardAgainstNegativeCount(int count) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMappingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMappingTest.java
@@ -41,8 +41,8 @@ public class BiDirectionalResourceToRequirementMappingTest extends TestLogger {
 
 		mapping.incrementCount(requirement, resource, 1);
 
-		assertThat(mapping.getFulfilledRequirementsBy(resource).getResourceCount(requirement), is(1));
-		assertThat(mapping.getFulfillingResourcesFor(requirement).getResourceCount(resource), is(1));
+		assertThat(mapping.getRequirementsFulfilledBy(resource).get(requirement), is(1));
+		assertThat(mapping.getResourcesFulfilling(requirement).get(resource), is(1));
 
 		assertThat(mapping.getAllRequirementProfiles(), contains(requirement));
 		assertThat(mapping.getAllResourceProfiles(), contains(resource));
@@ -58,8 +58,8 @@ public class BiDirectionalResourceToRequirementMappingTest extends TestLogger {
 		mapping.incrementCount(requirement, resource, 1);
 		mapping.decrementCount(requirement, resource, 1);
 
-		assertThat(mapping.getFulfilledRequirementsBy(resource).getResourceCount(requirement), is(0));
-		assertThat(mapping.getFulfillingResourcesFor(requirement).getResourceCount(resource), is(0));
+		assertThat(mapping.getRequirementsFulfilledBy(resource).getOrDefault(requirement, 0), is(0));
+		assertThat(mapping.getResourcesFulfilling(requirement).getOrDefault(resource, 0), is(0));
 
 		assertThat(mapping.getAllRequirementProfiles(), empty());
 		assertThat(mapping.getAllResourceProfiles(), empty());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMappingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/BiDirectionalResourceToRequirementMappingTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for the {@link BiDirectionalResourceToRequirementMapping}.
+ */
+public class BiDirectionalResourceToRequirementMappingTest extends TestLogger {
+
+	@Test
+	public void testIncrement() {
+		BiDirectionalResourceToRequirementMapping mapping = new BiDirectionalResourceToRequirementMapping();
+
+		ResourceProfile requirement = ResourceProfile.UNKNOWN;
+		ResourceProfile resource = ResourceProfile.ANY;
+
+		mapping.incrementCount(requirement, resource, 1);
+
+		assertThat(mapping.getFulfilledRequirementsBy(resource).getResourceCount(requirement), is(1));
+		assertThat(mapping.getFulfillingResourcesFor(requirement).getResourceCount(resource), is(1));
+
+		assertThat(mapping.getAllRequirementProfiles(), contains(requirement));
+		assertThat(mapping.getAllResourceProfiles(), contains(resource));
+	}
+
+	@Test
+	public void testDecrement() {
+		BiDirectionalResourceToRequirementMapping mapping = new BiDirectionalResourceToRequirementMapping();
+
+		ResourceProfile requirement = ResourceProfile.UNKNOWN;
+		ResourceProfile resource = ResourceProfile.ANY;
+
+		mapping.incrementCount(requirement, resource, 1);
+		mapping.decrementCount(requirement, resource, 1);
+
+		assertThat(mapping.getFulfilledRequirementsBy(resource).getResourceCount(requirement), is(0));
+		assertThat(mapping.getFulfillingResourcesFor(requirement).getResourceCount(resource), is(0));
+
+		assertThat(mapping.getAllRequirementProfiles(), empty());
+		assertThat(mapping.getAllResourceProfiles(), empty());
+
+		assertThat(mapping.isEmpty(), is(true));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTrackerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.util.TestLogger;
+
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link DefaultResourceTracker}.
+ *
+ * <p>Note: The majority is of the tracking logic is covered by the {@link JobScopedResourceTrackerTest}.
+ */
+public class DefaultResourceTrackerTest extends TestLogger {
+
+	@Test
+	public void testInitialBehavior() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+
+		assertThat(tracker.isEmpty(), is(true));
+		tracker.notifyLostResource(JobID.generate(), ResourceProfile.ANY);
+		tracker.clear();
+	}
+
+	@Test
+	public void testGetRequiredResources() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+		JobID jobId1 = JobID.generate();
+		JobID jobId2 = JobID.generate();
+
+		ResourceRequirement requirement1 = ResourceRequirement.create(ResourceProfile.ANY, 1);
+		ResourceRequirement requirement2 = ResourceRequirement.create(ResourceProfile.ANY, 2);
+
+		tracker.notifyResourceRequirements(jobId1, Collections.singletonList(requirement1));
+		tracker.notifyResourceRequirements(jobId2, Collections.singletonList(requirement2));
+
+		Map<JobID, Collection<ResourceRequirement>> requiredResources = tracker.getRequiredResources();
+		assertThat(requiredResources, IsMapContaining.hasEntry(is(jobId1), contains(requirement1)));
+		assertThat(requiredResources, IsMapContaining.hasEntry(is(jobId2), contains(requirement2)));
+	}
+
+	@Test
+	public void testGetAcquiredResources() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+		JobID jobId1 = JobID.generate();
+		JobID jobId2 = JobID.generate();
+
+		ResourceRequirement requirement1 = ResourceRequirement.create(ResourceProfile.ANY, 1);
+		ResourceRequirement requirement2 = ResourceRequirement.create(ResourceProfile.ANY, 2);
+
+		tracker.notifyAcquiredResource(jobId1, requirement1.getResourceProfile());
+		for (int x = 0; x < requirement2.getNumberOfRequiredSlots(); x++) {
+			tracker.notifyAcquiredResource(jobId2, requirement2.getResourceProfile());
+		}
+
+		assertThat(tracker.getAcquiredResources(jobId1), contains(requirement1));
+		assertThat(tracker.getAcquiredResources(jobId2), contains(requirement2));
+
+		tracker.notifyLostResource(jobId1, requirement1.getResourceProfile());
+		assertThat(tracker.getAcquiredResources(jobId1), empty());
+	}
+
+	@Test
+	public void testTrackerRemovedOnRequirementReset() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+		JobID jobId1 = JobID.generate();
+
+		tracker.notifyResourceRequirements(jobId1, Collections.singletonList(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+		assertThat(tracker.isEmpty(), is(false));
+
+		tracker.notifyResourceRequirements(jobId1, Collections.emptyList());
+		assertThat(tracker.isEmpty(), is(true));
+	}
+
+	@Test
+	public void testTrackerRemovedOnResourceLoss() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+		JobID jobId1 = JobID.generate();
+
+		tracker.notifyAcquiredResource(jobId1, ResourceProfile.ANY);
+		assertThat(tracker.isEmpty(), is(false));
+
+		tracker.notifyLostResource(jobId1, ResourceProfile.ANY);
+		assertThat(tracker.isEmpty(), is(true));
+	}
+
+	@Test
+	public void testTrackerRetainedOnResourceLossIfRequirementExists() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+		JobID jobId1 = JobID.generate();
+
+		tracker.notifyAcquiredResource(jobId1, ResourceProfile.ANY);
+		tracker.notifyResourceRequirements(jobId1, Collections.singletonList(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+
+		tracker.notifyLostResource(jobId1, ResourceProfile.ANY);
+		assertThat(tracker.isEmpty(), is(false));
+
+		tracker.notifyResourceRequirements(jobId1, Collections.emptyList());
+		assertThat(tracker.isEmpty(), is(true));
+	}
+
+	@Test
+	public void testTrackerRetainedOnRequirementResetIfResourceExists() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+		JobID jobId1 = JobID.generate();
+
+		tracker.notifyAcquiredResource(jobId1, ResourceProfile.ANY);
+		tracker.notifyResourceRequirements(jobId1, Collections.singletonList(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+
+		tracker.notifyResourceRequirements(jobId1, Collections.emptyList());
+		assertThat(tracker.isEmpty(), is(false));
+
+		tracker.notifyLostResource(jobId1, ResourceProfile.ANY);
+		assertThat(tracker.isEmpty(), is(true));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceTrackerTest.java
@@ -50,6 +50,12 @@ public class DefaultResourceTrackerTest extends TestLogger {
 
 		assertThat(tracker.isEmpty(), is(true));
 		tracker.notifyLostResource(JobID.generate(), ResourceProfile.ANY);
+	}
+
+	@Test
+	public void testClearDoesNotThrowException() {
+		DefaultResourceTracker tracker = new DefaultResourceTracker();
+
 		tracker.clear();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTrackerTest.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link JobScopedResourceTracker}.
+ */
+public class JobScopedResourceTrackerTest extends TestLogger {
+
+	private static final ResourceProfile PROFILE_1 = ResourceProfile.newBuilder().setCpuCores(1).build();
+	private static final ResourceProfile PROFILE_2 = ResourceProfile.newBuilder().setCpuCores(2).build();
+
+	@Test
+	public void testInitialBehavior() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		assertThat(tracker.isEmpty(), is(true));
+		assertThat(tracker.getAcquiredResources(), empty());
+		assertThat(tracker.getRequiredResources(), empty());
+
+		// should not throw an exception
+		tracker.notifyLostResource(ResourceProfile.UNKNOWN);
+	}
+
+	@Test
+	public void testIsEmpty() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		tracker.notifyResourceRequirements(Collections.singleton(ResourceRequirement.create(ResourceProfile.UNKNOWN, 1)));
+		assertThat(tracker.isEmpty(), is(false));
+		tracker.notifyResourceRequirements(Collections.emptyList());
+		assertThat(tracker.isEmpty(), is(true));
+
+		tracker.notifyAcquiredResource(ResourceProfile.ANY);
+		assertThat(tracker.isEmpty(), is(false));
+		tracker.notifyLostResource(ResourceProfile.ANY);
+		assertThat(tracker.isEmpty(), is(true));
+	}
+
+	@Test
+	public void testRequirementsNotificationWithoutResources() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		ResourceRequirement[][] resourceRequirements = new ResourceRequirement[][]{
+			new ResourceRequirement[]{
+				ResourceRequirement.create(PROFILE_1, 4),
+				ResourceRequirement.create(PROFILE_2, 2)},
+			new ResourceRequirement[]{
+				ResourceRequirement.create(PROFILE_1, 8),
+				ResourceRequirement.create(PROFILE_2, 2)},
+			new ResourceRequirement[]{
+				ResourceRequirement.create(PROFILE_1, 4),
+				ResourceRequirement.create(PROFILE_2, 2)}};
+
+		for (ResourceRequirement[] resourceRequirement : resourceRequirements) {
+			tracker.notifyResourceRequirements(Arrays.asList(resourceRequirement));
+
+			assertThat(tracker.isEmpty(), is(false));
+			assertThat(tracker.getAcquiredResources(), empty());
+			assertThat(tracker.getRequiredResources(), containsInAnyOrder(resourceRequirement));
+		}
+
+		tracker.notifyResourceRequirements(Collections.emptyList());
+
+		assertThat(tracker.getAcquiredResources(), empty());
+		assertThat(tracker.getRequiredResources(), empty());
+	}
+
+	@Test
+	public void testRequirementsNotificationWithResources() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		ResourceRequirement[][] resourceRequirements = new ResourceRequirement[][]{
+			new ResourceRequirement[]{
+				ResourceRequirement.create(PROFILE_1, 4),
+				ResourceRequirement.create(PROFILE_2, 2)},
+			new ResourceRequirement[]{
+				ResourceRequirement.create(PROFILE_1, 8),
+				ResourceRequirement.create(PROFILE_2, 2)},
+			new ResourceRequirement[]{
+				ResourceRequirement.create(PROFILE_1, 4),
+				ResourceRequirement.create(PROFILE_2, 2)}};
+
+		int numAcquiredSlotsP1 = resourceRequirements[0][0].getNumberOfRequiredSlots() - 1;
+		int numAcquiredSlotsP2 = resourceRequirements[0][1].getNumberOfRequiredSlots();
+
+		for (int x = 0; x < numAcquiredSlotsP1; x++) {
+			tracker.notifyAcquiredResource(PROFILE_1);
+		}
+		for (int x = 0; x < numAcquiredSlotsP2; x++) {
+			tracker.notifyAcquiredResource(PROFILE_2);
+		}
+
+		for (ResourceRequirement[] resourceRequirement : resourceRequirements) {
+			tracker.notifyResourceRequirements(Arrays.asList(resourceRequirement));
+
+			assertThat(tracker.getAcquiredResources(), containsInAnyOrder(ResourceRequirement.create(PROFILE_1, numAcquiredSlotsP1), ResourceRequirement.create(PROFILE_2, numAcquiredSlotsP2)));
+			assertThat(tracker.getRequiredResources(), contains(ResourceRequirement.create(PROFILE_1, resourceRequirement[0].getNumberOfRequiredSlots() - numAcquiredSlotsP1)));
+		}
+
+		tracker.notifyResourceRequirements(Collections.emptyList());
+
+		assertThat(tracker.getAcquiredResources(), containsInAnyOrder(ResourceRequirement.create(PROFILE_1, numAcquiredSlotsP1), ResourceRequirement.create(PROFILE_2, numAcquiredSlotsP2)));
+		assertThat(tracker.getRequiredResources(), empty());
+	}
+
+	@Test
+	public void testMatchingWithResourceExceedingRequirement() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		tracker.notifyResourceRequirements(Arrays.asList(ResourceRequirement.create(PROFILE_1, 1)));
+
+		tracker.notifyAcquiredResource(PROFILE_2);
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(PROFILE_2, 1)));
+	}
+
+	@Test
+	public void testMatchingWithResourceLessThanRequirement() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		tracker.notifyResourceRequirements(Arrays.asList(ResourceRequirement.create(PROFILE_2, 1)));
+
+		tracker.notifyAcquiredResource(PROFILE_1);
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(PROFILE_1, 1)));
+		assertThat(tracker.getRequiredResources(), contains(ResourceRequirement.create(PROFILE_2, 1)));
+	}
+
+	@Test
+	public void testResourceNotificationsWithoutRequirements() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		tracker.notifyAcquiredResource(ResourceProfile.ANY);
+
+		assertThat(tracker.isEmpty(), is(false));
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+		assertThat(tracker.getRequiredResources(), empty());
+
+		tracker.notifyAcquiredResource(ResourceProfile.ANY);
+
+		assertThat(tracker.isEmpty(), is(false));
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(ResourceProfile.ANY, 2)));
+		assertThat(tracker.getRequiredResources(), empty());
+
+		tracker.notifyLostResource(ResourceProfile.ANY);
+
+		assertThat(tracker.isEmpty(), is(false));
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+		assertThat(tracker.getRequiredResources(), empty());
+
+		tracker.notifyLostResource(ResourceProfile.ANY);
+
+		assertThat(tracker.isEmpty(), is(true));
+		assertThat(tracker.getAcquiredResources(), empty());
+		assertThat(tracker.getRequiredResources(), empty());
+	}
+
+	@Test
+	public void testResourceNotificationsWithRequirements() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		ResourceRequirement[] resourceRequirementsArray = new ResourceRequirement[]{
+			ResourceRequirement.create(PROFILE_1, 2),
+			ResourceRequirement.create(PROFILE_2, 1)
+		};
+
+		tracker.notifyResourceRequirements(Arrays.asList(resourceRequirementsArray));
+
+		for (int x = 0; x < 2; x++) {
+			tracker.notifyAcquiredResource(PROFILE_1);
+		}
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(PROFILE_1, 2)));
+		assertThat(tracker.getRequiredResources(), contains(ResourceRequirement.create(PROFILE_2, 1)));
+
+		tracker.notifyLostResource(PROFILE_1);
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(PROFILE_1, 1)));
+		assertThat(tracker.getRequiredResources(), containsInAnyOrder(ResourceRequirement.create(PROFILE_1, 1), ResourceRequirement.create(PROFILE_2, 1)));
+	}
+
+	@Test
+	public void testRequirementReductionRetainsExceedingResources() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		tracker.notifyResourceRequirements(Collections.singleton(ResourceRequirement.create(ResourceProfile.UNKNOWN, 1)));
+
+		tracker.notifyAcquiredResource(ResourceProfile.ANY);
+
+		tracker.notifyResourceRequirements(Collections.emptyList());
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+		assertThat(tracker.getRequiredResources(), empty());
+
+		tracker.notifyResourceRequirements(Collections.singleton(ResourceRequirement.create(ResourceProfile.UNKNOWN, 1)));
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+		assertThat(tracker.getRequiredResources(), empty());
+	}
+
+	@Test
+	public void testExcessResourcesAreAssignedOnRequirementIncrease() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		tracker.notifyAcquiredResource(ResourceProfile.ANY);
+
+		tracker.notifyResourceRequirements(Collections.singleton(ResourceRequirement.create(ResourceProfile.UNKNOWN, 1)));
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+	}
+
+	@Test
+	public void testExcessResourcesAreAssignedOnResourceLoss() {
+		JobScopedResourceTracker tracker = new JobScopedResourceTracker(JobID.generate());
+
+		tracker.notifyAcquiredResource(ResourceProfile.ANY);
+		tracker.notifyAcquiredResource(ResourceProfile.ANY);
+
+		tracker.notifyResourceRequirements(Collections.singleton(ResourceRequirement.create(ResourceProfile.UNKNOWN, 1)));
+
+		tracker.notifyLostResource(ResourceProfile.ANY);
+
+		assertThat(tracker.getAcquiredResources(), contains(ResourceRequirement.create(ResourceProfile.ANY, 1)));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/slots/ResourceCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/slots/ResourceCounterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.slots;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link ResourceCounter}.
+ */
+public class ResourceCounterTest extends TestLogger {
+
+	@Test
+	public void testIncrement() {
+		ResourceCounter counter = new ResourceCounter();
+
+		counter.incrementCount(ResourceProfile.ANY, 1);
+		assertThat(counter.getResourceCount(ResourceProfile.ANY), is(1));
+	}
+
+	@Test
+	public void testDecrement() {
+		ResourceCounter counter = new ResourceCounter();
+
+		counter.incrementCount(ResourceProfile.ANY, 1);
+		counter.decrementCount(ResourceProfile.ANY, 1);
+		assertThat(counter.getResourceCount(ResourceProfile.ANY), is(0));
+
+		assertThat(counter.isEmpty(), is(true));
+	}
+
+	@Test
+	public void testCopy() {
+		ResourceCounter counter = new ResourceCounter();
+		counter.incrementCount(ResourceProfile.ANY, 1);
+
+		ResourceCounter copy = counter.copy();
+		counter.decrementCount(ResourceProfile.ANY, 0);
+
+		// check that copy is independent from original
+		assertThat(copy.getResourceCount(ResourceProfile.ANY), is(1));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/slots/ResourceCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/slots/ResourceCounterTest.java
@@ -55,7 +55,7 @@ public class ResourceCounterTest extends TestLogger {
 		counter.incrementCount(ResourceProfile.ANY, 1);
 
 		ResourceCounter copy = counter.copy();
-		counter.decrementCount(ResourceProfile.ANY, 0);
+		counter.decrementCount(ResourceProfile.ANY, 1);
 
 		// check that copy is independent from original
 		assertThat(copy.getResourceCount(ResourceProfile.ANY), is(1));


### PR DESCRIPTION
Adds the `ResourceTracker` one of the components of the new declarative slot manager.

The purpose of this tracker is to answer questions such as "How many resources does this job have?" or "How many resources does job still need?".

To that end the tracker will be informed by the slot manager whenever the JobMaster has updated its `ResourceRequirements`, a resource was acquired (==TaskExecutor confirmed slot allocation) or a resource was lost (==JobMaster released slot or TaskExecutor failed).

The default implementation is the `DefaultResourceTracker` which mostly delegates tracking work to the `JobScopedResourceTracker`.

This tracker tracks the requirements and acquired resources for a single job. It heavily relies on 2 new data-structures:
1) `ResourceCounter`: Essentially a wrapper around `Map<ResourceProfile, Integer>, tracking the number of instances of a particular resource profile. This structure is used for tracking the requirements for a job, and acquired resources that exceed the requirements. It ensures that the counts are always positive.
2) `BiDirectionalResourceToRequirementMapping`: This structure tracks which resources are being used for which requirement, and which requirement is being (potentially partially) fulfilled by which resources. Essentially, this structure exists so that we can easily figure out which resources are no longer needed if requirements change, or inversely, which requirements require new slots if we lost one.
