### PR TITLE
[FLINK-18906][task] Support checkpointing with multiple input operator chained with sources

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/AvailabilityProvider.java
@@ -66,6 +66,28 @@ public interface AvailabilityProvider {
 		return getAvailableFuture() == AVAILABLE;
 	}
 
+	static CompletableFuture<?> and(CompletableFuture<?> first, CompletableFuture<?> second) {
+		if (first == AVAILABLE && second == AVAILABLE) {
+			return AVAILABLE;
+		}
+		else if (first == AVAILABLE) {
+			return second;
+		}
+		else if (second == AVAILABLE) {
+			return first;
+		}
+		else {
+			return CompletableFuture.allOf(first, second);
+		}
+	}
+
+	static CompletableFuture<?> or(CompletableFuture<?> first, CompletableFuture<?> second) {
+		if (first == AVAILABLE || second == AVAILABLE) {
+			return AVAILABLE;
+		}
+		return CompletableFuture.anyOf(first, second);
+	}
+
 	/**
 	 * A availability implementation for providing the helpful functions of resetting the
 	 * available/unavailable states.
@@ -73,6 +95,22 @@ public interface AvailabilityProvider {
 	final class AvailabilityHelper implements AvailabilityProvider {
 
 		private CompletableFuture<?> availableFuture = new CompletableFuture<>();
+
+		public CompletableFuture<?> and(CompletableFuture<?> other) {
+			return AvailabilityProvider.and(availableFuture, other);
+		}
+
+		public CompletableFuture<?> and(AvailabilityProvider other) {
+			return and(other.getAvailableFuture());
+		}
+
+		public CompletableFuture<?> or(CompletableFuture<?> other) {
+			return AvailabilityProvider.or(availableFuture, other);
+		}
+
+		public CompletableFuture<?> or(AvailabilityProvider other) {
+			return or(other.getAvailableFuture());
+		}
 
 		/**
 		 * Judges to reset the current available state as unavailable.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -496,11 +496,8 @@ class LocalBufferPool implements BufferPool {
 	public CompletableFuture<?> getAvailableFuture() {
 		if (numberOfRequestedMemorySegments >= currentPoolSize || unavailableSubpartitionsCount > 0) {
 			return availabilityHelper.getAvailableFuture();
-		} else if (availabilityHelper.isApproximatelyAvailable() || networkBufferPool.isApproximatelyAvailable()) {
-			return AVAILABLE;
-		} else {
-			return CompletableFuture.anyOf(availabilityHelper.getAvailableFuture(), networkBufferPool.getAvailableFuture());
 		}
+		return availabilityHelper.or(networkBufferPool);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
@@ -26,9 +26,12 @@ import java.util.List;
 
 /**
  * Input, with just basic methods for blocking and resuming consumption. It can be for example an {@link InputGate}
+ * or a chained source.
  */
 @Internal
 public interface CheckpointableInput {
+	void blockConsumption(int inputChannelIdx);
+
 	void resumeConsumption(int channelIndex) throws IOException;
 
 	List<InputChannelInfo> getChannelInfos();
@@ -38,4 +41,6 @@ public interface CheckpointableInput {
 	void checkpointStarted(CheckpointBarrier barrier);
 
 	void checkpointStopped(long cancelledCheckpointId);
+
+	int getInputGateIndex();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
@@ -17,28 +17,25 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
- * An {@link InputGate} with a specific index.
+ * Input, with just basic methods for blocking and resuming consumption. It can be for example an {@link InputGate}
  */
-public abstract class IndexedInputGate extends InputGate implements CheckpointableInput {
-	/**
-	 * Returns the index of this input gate. Only supported on
-	 */
-	public abstract int getGateIndex();
+@Internal
+public interface CheckpointableInput {
+	void resumeConsumption(int channelIndex) throws IOException;
 
-	@Override
-	public void checkpointStarted(CheckpointBarrier barrier) {
-		for (int index = 0, numChannels = getNumberOfInputChannels(); index < numChannels; index++) {
-			getChannel(index).checkpointStarted(barrier);
-		}
-	}
+	List<InputChannelInfo> getChannelInfos();
 
-	@Override
-	public void checkpointStopped(long cancelledCheckpointId) {
-		for (int index = 0, numChannels = getNumberOfInputChannels(); index < numChannels; index++) {
-			getChannel(index).checkpointStopped(cancelledCheckpointId);
-		}
-	}
+	int getNumberOfInputChannels();
+
+	void checkpointStarted(CheckpointBarrier barrier);
+
+	void checkpointStopped(long cancelledCheckpointId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -41,4 +41,14 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
 			getChannel(index).checkpointStopped(cancelledCheckpointId);
 		}
 	}
+
+	@Override
+	public int getInputGateIndex() {
+		return getGateIndex();
+	}
+
+	@Override
+	public void blockConsumption(int inputChannelIdx) {
+		// Unused. Network stack is blocking consumption automatically by revoking credits.
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -776,6 +776,7 @@ public class SingleInputGate extends IndexedInputGate {
 
 	@Override
 	public void resumeConsumption(int channelIndex) throws IOException {
+		checkState(!isFinished(), "InputGate already finished.");
 		// BEWARE: consumption resumption only happens for streaming jobs in which all slots
 		// are allocated together so there should be no UnknownInputChannel. As a result, it
 		// is safe to not synchronize the requestLock here. We will refactor the code to not

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -220,7 +220,7 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 	protected void onBarrier(InputChannelInfo channelInfo) throws IOException {
 		if (!blockedChannels.get(channelInfo)) {
 			blockedChannels.put(channelInfo, true);
-
+			blockConsumption(channelInfo);
 			numBarriersReceived++;
 
 			if (LOG.isDebugEnabled()) {
@@ -339,6 +339,11 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 	private void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
 		CheckpointableInput input = inputs[channelInfo.getGateIdx()];
 		input.resumeConsumption(channelInfo.getInputChannelIdx());
+	}
+
+	private void blockConsumption(InputChannelInfo channelInfo) {
+		CheckpointableInput input = inputs[channelInfo.getGateIdx()];
+		input.blockConsumption(channelInfo.getInputChannelIdx());
 	}
 
 	@VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 
 import org.slf4j.Logger;
@@ -73,17 +73,17 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 	/** The time (in nanoseconds) that the latest alignment took. */
 	private long latestAlignmentDurationNanos;
 
-	private final InputGate[] inputGates;
+	private final CheckpointableInput[] inputs;
 
 	CheckpointBarrierAligner(
 			String taskName,
 			AbstractInvokable toNotifyOnCheckpoint,
-			InputGate... inputGates) {
+			CheckpointableInput... inputs) {
 		super(toNotifyOnCheckpoint);
 
 		this.taskName = taskName;
-		this.inputGates = inputGates;
-		blockedChannels = Arrays.stream(inputGates)
+		this.inputs = inputs;
+		blockedChannels = Arrays.stream(inputs)
 			.flatMap(gate -> gate.getChannelInfos().stream())
 			.collect(Collectors.toMap(Function.identity(), info -> false));
 		totalNumberOfInputChannels = blockedChannels.size();
@@ -337,8 +337,8 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 	}
 
 	private void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
-		InputGate inputGate = inputGates[channelInfo.getGateIdx()];
-		inputGate.resumeConsumption(channelInfo.getInputChannelIdx());
+		CheckpointableInput input = inputs[channelInfo.getGateIdx()];
+		input.resumeConsumption(channelInfo.getInputChannelIdx());
 	}
 
 	@VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -37,8 +37,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.util.Preconditions.checkState;
-
 /**
  * {@link CheckpointBarrierAligner} keep tracks of received {@link CheckpointBarrier} on given
  * channels and controls the alignment, by deciding which channels should be blocked and when to
@@ -340,8 +338,6 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 
 	private void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
 		InputGate inputGate = inputGates[channelInfo.getGateIdx()];
-		checkState(!inputGate.isFinished(), "InputGate already finished.");
-
 		inputGate.resumeConsumption(channelInfo.getInputChannelIdx());
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -61,7 +61,7 @@ public class InputProcessorUtil {
 	}
 
 	/**
-	 * @return a pair of {@link CheckpointedInputGate} created for two corresponding
+	 * @return an array of {@link CheckpointedInputGate} created for corresponding
 	 * {@link InputGate}s supplied as parameters.
 	 */
 	public static CheckpointedInputGate[] createCheckpointedMultipleInputGate(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -73,13 +74,13 @@ public class InputProcessorUtil {
 			MailboxExecutor mailboxExecutor,
 			List<IndexedInputGate>... inputGates) {
 
-		IndexedInputGate[] sortedInputGates = Arrays.stream(inputGates)
+		CheckpointableInput[] sortedInputs = Arrays.stream(inputGates)
 			.flatMap(Collection::stream)
 			.sorted(Comparator.comparing(IndexedInputGate::getGateIndex))
-			.toArray(IndexedInputGate[]::new);
+			.toArray(CheckpointableInput[]::new);
 		CheckpointBarrierHandler barrierHandler = createCheckpointBarrierHandler(
 			config,
-			sortedInputGates,
+			sortedInputs,
 			checkpointCoordinator,
 			taskName,
 			toNotifyOnCheckpoint);
@@ -96,7 +97,7 @@ public class InputProcessorUtil {
 
 	private static CheckpointBarrierHandler createCheckpointBarrierHandler(
 			StreamConfig config,
-			InputGate[] inputGates,
+			CheckpointableInput[] inputs,
 			SubtaskCheckpointCoordinator checkpointCoordinator,
 			String taskName,
 			AbstractInvokable toNotifyOnCheckpoint) {
@@ -104,17 +105,17 @@ public class InputProcessorUtil {
 			case EXACTLY_ONCE:
 				if (config.isUnalignedCheckpointsEnabled()) {
 					return new AlternatingCheckpointBarrierHandler(
-						new CheckpointBarrierAligner(taskName, toNotifyOnCheckpoint, inputGates),
-						new CheckpointBarrierUnaligner(checkpointCoordinator, taskName, toNotifyOnCheckpoint, inputGates),
+						new CheckpointBarrierAligner(taskName, toNotifyOnCheckpoint, inputs),
+						new CheckpointBarrierUnaligner(checkpointCoordinator, taskName, toNotifyOnCheckpoint, inputs),
 						toNotifyOnCheckpoint);
 				}
-				return new CheckpointBarrierAligner(taskName, toNotifyOnCheckpoint, inputGates);
+				return new CheckpointBarrierAligner(taskName, toNotifyOnCheckpoint, inputs);
 			case AT_LEAST_ONCE:
 				if (config.isUnalignedCheckpointsEnabled()) {
 					throw new IllegalStateException("Cannot use unaligned checkpoints with AT_LEAST_ONCE " +
 						"checkpointing mode");
 				}
-				int numInputChannels = Arrays.stream(inputGates).mapToInt(InputGate::getNumberOfInputChannels).sum();
+				int numInputChannels = Arrays.stream(inputs).mapToInt(CheckpointableInput::getNumberOfInputChannels).sum();
 				return new CheckpointBarrierTracker(numInputChannels, toNotifyOnCheckpoint);
 			default:
 				throw new UnsupportedOperationException("Unrecognized Checkpointing Mode: " + config.getCheckpointMode());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -30,7 +30,6 @@ import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
@@ -118,11 +117,11 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 			else if (configuredInput instanceof SourceInputConfig) {
 				SourceInputConfig sourceInput = (SourceInputConfig) configuredInput;
 				Output<StreamRecord<?>> chainedSourceOutput = operatorChain.getChainedSourceOutput(sourceInput);
-				SourceOperator<?, ?> sourceOperator = operatorChain.getSourceOperator(sourceInput);
+				StreamTaskSourceInput<?> sourceTaskInput = operatorChain.getSourceTaskInput(sourceInput);
 
 				inputProcessors[i] = new SourceInputProcessor(
 					new AsyncDataOutputToOutput(chainedSourceOutput, operatorChain),
-					new StreamTaskSourceInput(sourceOperator));
+					sourceTaskInput);
 			}
 			else {
 				throw new UnsupportedOperationException("Unknown input type: " + configuredInput);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.util.IOUtils;
 
@@ -70,6 +71,10 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T> {
 			ChannelStateWriter channelStateWriter,
 			long checkpointId) {
 		return CompletableFuture.completedFuture(null);
+	}
+
+	public OperatorID getOperatorID() {
+		return operator.getOperatorID();
 	}
 }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -21,10 +21,15 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.util.IOUtils;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -35,22 +40,90 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * unavailable or finished.
  */
 @Internal
-public final class StreamTaskSourceInput<T> implements StreamTaskInput<T> {
+public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, CheckpointableInput {
 
 	private final SourceOperator<T, ?> operator;
+	private final int inputGateIndex;
+	private final AvailabilityHelper isBlockedAvailability = new AvailabilityHelper();
+	private final List<InputChannelInfo> inputChannelInfos;
 
-	public StreamTaskSourceInput(SourceOperator<T, ?> operator) {
+	public StreamTaskSourceInput(SourceOperator<T, ?> operator, int inputGateIndex) {
 		this.operator = checkNotNull(operator);
+		this.inputGateIndex = inputGateIndex;
+		inputChannelInfos = Collections.singletonList(new InputChannelInfo(inputGateIndex, 0));
+		isBlockedAvailability.resetAvailable();
 	}
 
 	@Override
 	public InputStatus emitNext(DataOutput<T> output) throws Exception {
-		return operator.emitNext(output);
+		/**
+		 * Safe guard against best efforts availability checks. If despite being unavailable someone
+		 * polls the data from this source while it's blocked, it should return {@link InputStatus.NOTHING_AVAILABLE}.
+ 		 */
+		if (isBlockedAvailability.isApproximatelyAvailable()) {
+			return operator.emitNext(output);
+		}
+		return InputStatus.NOTHING_AVAILABLE;
 	}
 
 	@Override
 	public CompletableFuture<?> getAvailableFuture() {
-		return operator.getAvailableFuture();
+		return isBlockedAvailability.and(operator);
+	}
+
+	@Override
+	public void blockConsumption(int channelIndex) {
+		isBlockedAvailability.resetUnavailable();
+	}
+
+	@Override
+	public void resumeConsumption(int channelIndex) {
+		isBlockedAvailability.getUnavailableToResetAvailable().complete(null);
+	}
+
+	@Override
+	public List<InputChannelInfo> getChannelInfos() {
+		return inputChannelInfos;
+	}
+
+	@Override
+	public int getNumberOfInputChannels() {
+		return inputChannelInfos.size();
+	}
+
+	/**
+	 * This method is used with unaligned checkpoints to mark the arrival of a first {@link CheckpointBarrier}.
+	 * For chained sources, there is no {@link CheckpointBarrier} per se flowing through the job graph.
+	 * We can assume that an imaginary {@link CheckpointBarrier} was produced by the source, at any
+	 * point of time of our choosing.
+	 *
+	 * <p>We are choosing to interpret it, that {@link CheckpointBarrier} for sources was received immediately
+	 * as soon as we receive either checkpoint start RPC, or {@link CheckpointBarrier} from a network input.
+	 * So that we can checkpoint state of the source and all of the other operators at the same time.
+	 *
+	 * <p>Also we are choosing to block the source, as a best effort optimisation as:
+	 * - either there is no backpressure and the checkpoint "alignment" will happen very quickly anyway
+	 * - or there is a backpressure, and it's better to prioritize processing data from the network to
+	 * speed up checkpointing. From the cluster resource utilisation perspective, by blocking chained source
+	 * doesn't block any resources from being used, as this task running the source has a backlog of buffered
+	 * input data waiting to be processed.
+	 *
+	 * <p>However from the correctness point of view, {@link #checkpointStarted(CheckpointBarrier)}
+	 * and {@link #checkpointStopped(long)} methods could be empty no-op.
+	 */
+	@Override
+	public void checkpointStarted(CheckpointBarrier barrier) {
+		blockConsumption(-1);
+	}
+
+	@Override
+	public void checkpointStopped(long cancelledCheckpointId) {
+		resumeConsumption(-1);
+	}
+
+	@Override
+	public int getInputGateIndex() {
+		return inputGateIndex;
 	}
 
 	/**
@@ -58,7 +131,7 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T> {
 	 */
 	@Override
 	public int getInputIndex() {
-		return -1;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
@@ -317,8 +318,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 			return input1.getAvailableFuture();
 		}
 
-		return (input1.isApproximatelyAvailable() || input2.isApproximatelyAvailable()) ?
-			AVAILABLE : CompletableFuture.anyOf(input1.getAvailableFuture(), input2.getAvailableFuture());
+		return AvailabilityProvider.or(input1.getAvailableFuture(), input2.getAvailableFuture());
 	}
 
 	private StreamTaskInput getInput(int inputIndex) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -46,7 +46,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 
 	@Override
 	public void init() {
-		StreamTaskInput<T> input = new StreamTaskSourceInput<>(mainOperator);
+		StreamTaskInput<T> input = new StreamTaskSourceInput<>(mainOperator, 0);
 		DataOutput<T> output = new AsyncDataOutputToOutput<>(
 			operatorChain.getMainOperatorOutput(),
 			getStreamStatusMaintainer());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -585,6 +585,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		return mailboxProcessor.runMailboxStep();
 	}
 
+	@VisibleForTesting
+	public boolean isMailboxLoopRunning() {
+		return mailboxProcessor.isMailboxLoopRunning();
+	}
+
 	private void runMailboxLoop() throws Exception {
 		mailboxProcessor.runMailboxLoop();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessor;
 import org.apache.flink.streaming.runtime.io.TwoInputSelectionHandler;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -61,8 +62,8 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
 			getTaskNameWithSubtaskAndId(),
 			mainMailboxExecutor,
-			inputGates1,
-			inputGates2);
+			new List[]{ inputGates1, inputGates2 },
+			Collections.emptyList());
 		checkState(checkpointedInputGates.length == 2);
 
 		inputProcessor = new StreamTwoInputProcessor<>(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
@@ -26,8 +26,8 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 
@@ -130,7 +130,7 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 		}
 	}
 
-	private static class RandomGeneratingInputGate extends InputGate {
+	private static class RandomGeneratingInputGate extends IndexedInputGate {
 
 		private final int numberOfChannels;
 		private final BufferPool[] bufferPools;
@@ -239,6 +239,11 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 
 		@Override
 		public void close() {
+		}
+
+		@Override
+		public int getGateIndex() {
+			return 0;
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
@@ -91,7 +91,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 		return createCheckpointedInputGate(numberOfChannels, sequence, new DummyCheckpointInvokable());
 	}
 
-	abstract CheckpointedInputGate createCheckpointedInputGate(InputGate gate, AbstractInvokable toNotify) throws IOException;
+	abstract CheckpointedInputGate createCheckpointedInputGate(IndexedInputGate gate, AbstractInvokable toNotify) throws IOException;
 
 	@After
 	public void ensureEmpty() throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -79,19 +79,19 @@ public abstract class CheckpointBarrierAlignerTestBase {
 		testStartTimeNanos = System.nanoTime();
 	}
 
-	protected CheckpointedInputGate createBarrierBuffer(
-		int numberOfChannels,
-		BufferOrEvent[] sequence,
-		AbstractInvokable toNotify) throws IOException {
+	protected CheckpointedInputGate createCheckpointedInputGate(
+			int numberOfChannels,
+			BufferOrEvent[] sequence,
+			AbstractInvokable toNotify) throws IOException {
 		mockInputGate = new MockInputGate(numberOfChannels, Arrays.asList(sequence));
-		return createBarrierBuffer(mockInputGate, toNotify);
+		return createCheckpointedInputGate(mockInputGate, toNotify);
 	}
 
-	protected CheckpointedInputGate createBarrierBuffer(int numberOfChannels, BufferOrEvent[] sequence) throws IOException {
-		return createBarrierBuffer(numberOfChannels, sequence, new DummyCheckpointInvokable());
+	protected CheckpointedInputGate createCheckpointedInputGate(int numberOfChannels, BufferOrEvent[] sequence) throws IOException {
+		return createCheckpointedInputGate(numberOfChannels, sequence, new DummyCheckpointInvokable());
 	}
 
-	abstract CheckpointedInputGate createBarrierBuffer(InputGate gate, AbstractInvokable toNotify) throws IOException;
+	abstract CheckpointedInputGate createCheckpointedInputGate(InputGate gate, AbstractInvokable toNotify) throws IOException;
 
 	@After
 	public void ensureEmpty() throws Exception {
@@ -115,7 +115,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createBuffer(0), createBuffer(0),
 			createBuffer(0), createEndOfPartition(0)
 		};
-		inputGate = createBarrierBuffer(1, sequence);
+		inputGate = createCheckpointedInputGate(1, sequence);
 
 		for (BufferOrEvent boe : sequence) {
 			assertEquals(boe, inputGate.pollNext().get());
@@ -136,7 +136,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createBuffer(3), createBuffer(1), createEndOfPartition(3),
 			createBuffer(1), createEndOfPartition(1), createBuffer(2), createEndOfPartition(2)
 		};
-		inputGate = createBarrierBuffer(4, sequence);
+		inputGate = createCheckpointedInputGate(4, sequence);
 
 		for (BufferOrEvent boe : sequence) {
 			assertEquals(boe, inputGate.pollNext().get());
@@ -161,7 +161,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createBuffer(0), createEndOfPartition(0)
 		};
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(1, sequence, handler);
+		inputGate = createCheckpointedInputGate(1, sequence, handler);
 
 		handler.setNextExpectedCheckpointId(1L);
 
@@ -201,7 +201,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createEndOfPartition(0), createEndOfPartition(1), createEndOfPartition(2)
 		};
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(3, sequence, handler);
+		inputGate = createCheckpointedInputGate(3, sequence, handler);
 
 		handler.setNextExpectedCheckpointId(1L);
 
@@ -298,7 +298,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createBuffer(1), createEndOfPartition(1)
 		};
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(3, sequence, handler);
+		inputGate = createCheckpointedInputGate(3, sequence, handler);
 
 		handler.setNextExpectedCheckpointId(1L);
 
@@ -366,7 +366,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createBuffer(0)
 		};
 		AbstractInvokable validator = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(2, sequence, validator);
+		inputGate = createCheckpointedInputGate(2, sequence, validator);
 
 		for (BufferOrEvent boe : sequence) {
 			assertEquals(boe, inputGate.pollNext().get());
@@ -399,7 +399,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createBuffer(3),
 			createEndOfPartition(3)
 		};
-		inputGate = createBarrierBuffer(4, sequence);
+		inputGate = createCheckpointedInputGate(4, sequence);
 
 		// pre checkpoint 2
 		check(sequence[0], inputGate.pollNext().get(), PAGE_SIZE);
@@ -459,7 +459,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			// final end of stream
 			createEndOfPartition(0)
 		};
-		inputGate = createBarrierBuffer(3, sequence);
+		inputGate = createCheckpointedInputGate(3, sequence);
 
 		// data after first checkpoint
 		check(sequence[0], inputGate.pollNext().get(), PAGE_SIZE);
@@ -504,7 +504,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			createBuffer(0)
 		};
 		ValidatingCheckpointHandler toNotify = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(1, sequence, toNotify);
+		inputGate = createCheckpointedInputGate(1, sequence, toNotify);
 
 		toNotify.setNextExpectedCheckpointId(1);
 		check(sequence[0], inputGate.pollNext().get(), PAGE_SIZE);
@@ -583,7 +583,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			/* 35 */ createBuffer(0)
 		};
 		ValidatingCheckpointHandler toNotify = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(3, sequence, toNotify);
+		inputGate = createCheckpointedInputGate(3, sequence, toNotify);
 
 		long startTs;
 
@@ -715,7 +715,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			/* 14 */ createBuffer(0), createBuffer(1), createBuffer(2)
 		};
 		ValidatingCheckpointHandler toNotify = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(3, sequence, toNotify);
+		inputGate = createCheckpointedInputGate(3, sequence, toNotify);
 
 		long startTs;
 
@@ -795,7 +795,7 @@ public abstract class CheckpointBarrierAlignerTestBase {
 			/* 12 */ createBuffer(0), createBuffer(1), createBuffer(2)
 		};
 		ValidatingCheckpointHandler toNotify = new ValidatingCheckpointHandler();
-		inputGate = createBarrierBuffer(3, sequence, toNotify);
+		inputGate = createCheckpointedInputGate(3, sequence, toNotify);
 
 		long startTs;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerCancellationTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.event.RuntimeEvent;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
@@ -81,7 +81,7 @@ public class CheckpointBarrierUnalignerCancellationTest {
 	@Test
 	public void test() throws Exception {
 		TestInvokable invokable = new TestInvokable();
-		final InputGate inputGate = new SingleInputGateBuilder()
+		final SingleInputGate inputGate = new SingleInputGateBuilder()
 			.setNumberOfChannels(numChannels)
 			.setChannelFactory(InputChannelBuilder::buildLocalChannel)
 			.build();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
@@ -517,7 +516,7 @@ public class CheckpointBarrierUnalignerTest {
 	@Test
 	public void testProcessCancellationBarrierAfterProcessBarrier() throws Exception {
 		final ValidatingCheckpointInvokable invokable = new ValidatingCheckpointInvokable();
-		final InputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(2).setChannelFactory(InputChannelBuilder::buildLocalChannel).build();
+		final SingleInputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(2).setChannelFactory(InputChannelBuilder::buildLocalChannel).build();
 		final CheckpointBarrierUnaligner handler = new CheckpointBarrierUnaligner(TestSubtaskCheckpointCoordinator.INSTANCE, "test", invokable, inputGate);
 
 		// should trigger respective checkpoint
@@ -532,7 +531,7 @@ public class CheckpointBarrierUnalignerTest {
 	@Test
 	public void testProcessCancellationBarrierBeforeProcessAndReceiveBarrier() throws Exception {
 		final ValidatingCheckpointInvokable invokable = new ValidatingCheckpointInvokable();
-		final InputGate inputGate = new SingleInputGateBuilder().setChannelFactory(InputChannelBuilder::buildLocalChannel).build();
+		final SingleInputGate inputGate = new SingleInputGateBuilder().setChannelFactory(InputChannelBuilder::buildLocalChannel).build();
 		final CheckpointBarrierUnaligner handler = new CheckpointBarrierUnaligner(TestSubtaskCheckpointCoordinator.INSTANCE, "test", invokable, inputGate);
 
 		handler.processCancellationBarrier(new CancelCheckpointMarker(DEFAULT_CHECKPOINT_ID));
@@ -574,7 +573,7 @@ public class CheckpointBarrierUnalignerTest {
 	public void testEndOfStreamWithPendingCheckpoint() throws Exception {
 		final int numberOfChannels = 2;
 		final ValidatingCheckpointInvokable invokable = new ValidatingCheckpointInvokable();
-		final InputGate inputGate = new SingleInputGateBuilder().setChannelFactory(InputChannelBuilder::buildLocalChannel).setNumberOfChannels(numberOfChannels).build();
+		final SingleInputGate inputGate = new SingleInputGateBuilder().setChannelFactory(InputChannelBuilder::buildLocalChannel).setNumberOfChannels(numberOfChannels).build();
 		final CheckpointBarrierUnaligner handler = new CheckpointBarrierUnaligner(TestSubtaskCheckpointCoordinator.INSTANCE, "test", invokable, inputGate);
 
 		// should trigger respective checkpoint

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedCheckpointBarrierAlignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedCheckpointBarrierAlignerTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.runtime.io;
 
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 public class CreditBasedCheckpointBarrierAlignerTest extends CheckpointBarrierAlignerTestBase {
 
 	@Override
-	CheckpointedInputGate createCheckpointedInputGate(InputGate gate, AbstractInvokable toNotify) {
+	CheckpointedInputGate createCheckpointedInputGate(IndexedInputGate gate, AbstractInvokable toNotify) {
 		return new CheckpointedInputGate(
 			gate,
 			new CheckpointBarrierAligner("Testing", toNotify, gate),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedCheckpointBarrierAlignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedCheckpointBarrierAlignerTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 public class CreditBasedCheckpointBarrierAlignerTest extends CheckpointBarrierAlignerTestBase {
 
 	@Override
-	CheckpointedInputGate createBarrierBuffer(InputGate gate, AbstractInvokable toNotify) {
+	CheckpointedInputGate createCheckpointedInputGate(InputGate gate, AbstractInvokable toNotify) {
 		return new CheckpointedInputGate(
 			gate,
 			new CheckpointBarrierAligner("Testing", toNotify, gate),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
@@ -72,7 +72,8 @@ public class InputProcessorUtilTest {
 				environment.getMetricGroup().getIOMetricGroup(),
 				streamTask.getName(),
 				new SyncMailboxExecutor(),
-				inputGates);
+				inputGates,
+				Collections.emptyList());
 			for (CheckpointedInputGate checkpointedInputGate : checkpointedMultipleInputGate) {
 				registry.registerCloseable(checkpointedInputGate);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
@@ -39,7 +40,7 @@ import java.util.stream.IntStream;
 /**
  * Mock {@link InputGate}.
  */
-public class MockInputGate extends InputGate {
+public class MockInputGate extends IndexedInputGate {
 
 	private final int numberOfChannels;
 
@@ -145,5 +146,10 @@ public class MockInputGate extends InputGate {
 
 	@Override
 	public void close() {
+	}
+
+	@Override
+	public int getGateIndex() {
+		return 0;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.mocks.MockSource;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.MapToStringMultipleInputOperatorFactory;
+
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskChainedSourcesTest.addSourceRecords;
+import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskChainedSourcesTest.buildTestHarness;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link MultipleInputStreamTask} combined with {@link org.apache.flink.streaming.api.operators.SourceOperator} chaining.
+ */
+public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
+	private static final int MAX_STEPS = 100;
+
+	private final CheckpointMetaData metaData = new CheckpointMetaData(1L, System.currentTimeMillis());
+	private final CheckpointOptions options = CheckpointOptions.forCheckpointWithDefaultLocation();
+	private final CheckpointBarrier checkpointBarrier = new CheckpointBarrier(metaData.getCheckpointId(), metaData.getTimestamp(), options);
+
+	/**
+	 * In this scenario:
+	 * 1. checkpoint is triggered via RPC and source is blocked
+	 * 2. network inputs are processed until CheckpointBarriers are processed
+	 * 3. aligned checkpoint is performed
+	 */
+	@Test
+	public void testSourceCheckpointFirst() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness()) {
+			testHarness.setAutoProcess(false);
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+			addRecordsAndBarriers(testHarness);
+
+			Future<Boolean> checkpointFuture = testHarness.getStreamTask().triggerCheckpointAsync(metaData, options, false);
+			processSingleStepUntil(testHarness, checkpointFuture::isDone);
+
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+
+			ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
+
+			assertThat(actualOutput.subList(0, expectedOutput.size()), containsInAnyOrder(expectedOutput.toArray()));
+			assertThat(actualOutput.get(expectedOutput.size()), equalTo(checkpointBarrier));
+		}
+	}
+
+	/**
+	 * In this scenario:
+	 * 1. checkpoint is triggered via RPC and source is blocked
+	 * 2. unaligned checkpoint is performed
+	 * 3. all data from network inputs are processed
+	 */
+	@Test
+	public void testSourceCheckpointFirstUnaligned() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(true)) {
+			testHarness.setAutoProcess(false);
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+			addRecords(testHarness);
+
+			Future<Boolean> checkpointFuture = testHarness.getStreamTask().triggerCheckpointAsync(metaData, options, false);
+			processSingleStepUntil(testHarness, checkpointFuture::isDone);
+
+			assertThat(testHarness.getOutput(), contains(checkpointBarrier));
+
+			testHarness.processWhileAvailable();
+
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+
+			ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
+			assertThat(actualOutput.subList(1, expectedOutput.size() + 1), containsInAnyOrder(expectedOutput.toArray()));
+		}
+	}
+
+	/**
+	 * In this scenario:
+	 * 1a. network inputs are processed until CheckpointBarriers are processed
+	 * 1b. source records are processed at the same time
+	 * 2. checkpoint is triggered via RPC
+	 * 3. aligned checkpoint is performed
+	 */
+	@Test
+	public void testSourceCheckpointLast() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness()) {
+			testHarness.setAutoProcess(false);
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+			addRecordsAndBarriers(testHarness);
+
+			testHarness.processWhileAvailable();
+
+			Future<Boolean> checkpointFuture = testHarness.getStreamTask().triggerCheckpointAsync(metaData, options, false);
+			processSingleStepUntil(testHarness, checkpointFuture::isDone);
+
+			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+
+			ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
+
+			assertThat(actualOutput.subList(0, expectedOutput.size()), containsInAnyOrder(expectedOutput.toArray()));
+			assertThat(actualOutput.get(expectedOutput.size()), equalTo(checkpointBarrier));
+		}
+	}
+
+	/**
+	 * In this scenario:
+	 * 1. network inputs are processed until CheckpointBarriers are processed
+	 * 2. there are no source records to be processed
+	 * 3. checkpoint is triggered on first received CheckpointBarrier
+	 * 4. unaligned checkpoint is performed at some point of time blocking the source
+	 * 5. more source records are added, that shouldn't be processed
+	 */
+	@Test
+	public void testSourceCheckpointLastUnaligned() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(true)) {
+			testHarness.setAutoProcess(false);
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+
+			addNetworkRecords(testHarness);
+			addBarriers(testHarness);
+
+			testHarness.processWhileAvailable();
+			addSourceRecords(testHarness, 1, 1337, 1337, 1337);
+			testHarness.processWhileAvailable();
+
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(checkpointBarrier);
+
+			assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+		}
+	}
+
+	@Test
+	public void testOnlyOneSource() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+				new StreamTaskMailboxTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+					.modifyExecutionConfig(config -> config.enableObjectReuse())
+					.addSourceInput(
+						new SourceOperatorFactory<>(
+							new MockSource(Boundedness.BOUNDED, 1),
+							WatermarkStrategy.noWatermarks()))
+					.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperatorFactory(1))
+					.build()) {
+			testHarness.setAutoProcess(false);
+
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+
+			addSourceRecords(testHarness, 0, 42, 43, 44);
+			processSingleStepUntil(testHarness, () -> !testHarness.getOutput().isEmpty());
+			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
+
+			Future<Boolean> checkpointFuture = testHarness.getStreamTask().triggerCheckpointAsync(metaData, options, false);
+			processSingleStepUntil(testHarness, checkpointFuture::isDone);
+
+			ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
+			assertThat(actualOutput.subList(0, expectedOutput.size()), containsInAnyOrder(expectedOutput.toArray()));
+			assertThat(actualOutput.get(expectedOutput.size()), equalTo(checkpointBarrier));
+		}
+	}
+
+	private void addRecordsAndBarriers(StreamTaskMailboxTestHarness<String> testHarness) throws Exception {
+		addRecords(testHarness);
+		addBarriers(testHarness);
+	}
+
+	private void addBarriers(StreamTaskMailboxTestHarness<String> testHarness) throws Exception {
+		testHarness.processEvent(checkpointBarrier, 0);
+		testHarness.processEvent(checkpointBarrier, 1);
+	}
+
+	private void addRecords(StreamTaskMailboxTestHarness<String> testHarness) throws Exception {
+		addSourceRecords(testHarness, 1, 42, 42, 42);
+		addNetworkRecords(testHarness);
+	}
+
+	private void addNetworkRecords(StreamTaskMailboxTestHarness<String> testHarness) throws Exception {
+		testHarness.processElement(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP), 0);
+		testHarness.processElement(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP), 0);
+		testHarness.processElement(new StreamRecord<>(47d, TimestampAssigner.NO_TIMESTAMP), 1);
+		testHarness.processElement(new StreamRecord<>(47d, TimestampAssigner.NO_TIMESTAMP), 1);
+	}
+
+	private void processSingleStepUntil(StreamTaskMailboxTestHarness<String> testHarness, Supplier<Boolean> condition) throws Exception {
+		assertFalse(condition.get());
+		for (int i = 0; i < MAX_STEPS && !condition.get(); i++) {
+			testHarness.processSingleStep();
+		}
+		assertTrue(condition.get());
+	}
+}
+

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesTest.java
@@ -134,7 +134,7 @@ public class MultipleInputStreamTaskChainedSourcesTest {
 			int... records) throws Exception {
 		InputConfig[] inputs = testHarness.getStreamTask().getConfiguration().getInputs(testHarness.getClass().getClassLoader());
 		SourceInputConfig input = (SourceInputConfig) inputs[sourceId];
-		OperatorID sourceOperatorID = testHarness.getStreamTask().operatorChain.getSourceOperator(input).getOperatorID();
+		OperatorID sourceOperatorID = testHarness.getStreamTask().operatorChain.getSourceTaskInput(input).getOperatorID();
 
 		// Prepare the source split and assign it to the source reader.
 		MockSourceSplit split = new MockSourceSplit(0, 0, records.length);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -296,14 +296,14 @@ public class MultipleInputStreamTaskTest {
 		try {
 			testHarness.processElement(new StreamRecord<>("Hello-1"), 0);
 			testHarness.endInput(0);
-			testHarness.process();
+			testHarness.processWhileAvailable();
 
 			testHarness.processElement(new StreamRecord<>("Hello-2"), 1);
 			testHarness.processElement(new StreamRecord<>("Hello-3"), 2);
 			testHarness.endInput(1);
-			testHarness.process();
+			testHarness.processWhileAvailable();
 			testHarness.endInput(2);
-			testHarness.process();
+			testHarness.processWhileAvailable();
 			assertEquals(
 				true,
 				testHarness.getStreamTask().getInputOutputJointFuture(InputStatus.NOTHING_AVAILABLE).isDone());
@@ -347,7 +347,7 @@ public class MultipleInputStreamTaskTest {
 			testHarness.processElement(new StreamRecord<>("0"), 2);
 			testHarness.processElement(new StreamRecord<>("1"), 2);
 
-			testHarness.process();
+			testHarness.processWhileAvailable();
 
 			// We do not know which of the input will be picked first, but we are expecting them
 			// to alternate

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -107,21 +107,27 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 
 	private void maybeProcess() throws Exception {
 		if (autoProcess) {
-			process();
+			processWhileAvailable();
 		}
 	}
 
-	public void process() throws Exception {
-		while (processSingleStep()) {
+	public void processWhileAvailable() throws Exception {
+		while (processIfAvailable()) {
 		}
 	}
 
-	public boolean processSingleStep() throws Exception {
+	public boolean processIfAvailable() throws Exception {
 		if (streamTask.inputProcessor.isAvailable() && streamTask.mailboxProcessor.isMailboxLoopRunning()) {
 			streamTask.runMailboxStep();
 			return true;
 		}
 		return false;
+	}
+
+	public void processSingleStep() throws Exception {
+		if (streamTask.mailboxProcessor.isMailboxLoopRunning()) {
+			streamTask.runMailboxStep();
+		}
 	}
 
 	public void endInput() {
@@ -139,7 +145,8 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 
 	public void waitForTaskCompletion() throws Exception {
 		endInput();
-		while (streamTask.runMailboxStep()) {
+		while (streamTask.isMailboxLoopRunning()) {
+			streamTask.runMailboxStep();
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -100,6 +100,11 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
 		return this;
 	}
 
+	public <T> StreamTaskMailboxTestHarnessBuilder<OUT> modifyStreamConfig(Consumer<StreamConfig> action) {
+		action.accept(streamConfig);
+		return this;
+	}
+
 	public StreamTaskMailboxTestHarnessBuilder<OUT> addInput(TypeInformation<?> inputType) {
 		return addInput(inputType, 1);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
@@ -157,7 +157,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
 			testHarness.endInput();
 
 			if (!autoProcess) {
-				testHarness.process();
+				testHarness.processWhileAvailable();
 			}
 			testHarness.waitForTaskCompletion();
 
@@ -187,7 +187,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
 
 			testHarness.setAutoProcess(false);
 			// StreamMultipleInputProcessor starts with all inputs available. Let it rotate and refresh properly.
-			testHarness.processSingleStep();
+			testHarness.processIfAvailable();
 			assertTrue(testHarness.getOutput().isEmpty());
 
 			testHarness.processElement(new StreamRecord<>("NOT_SELECTED"), 0);
@@ -197,16 +197,16 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
 			testHarness.processElement(new StreamRecord<>("3"), 1);
 			testHarness.processElement(new StreamRecord<>("4"), 1);
 
-			testHarness.processSingleStep();
+			testHarness.processIfAvailable();
 			expectedOutput.add(new StreamRecord<>("[2]: 1"));
-			testHarness.processSingleStep();
+			testHarness.processIfAvailable();
 			expectedOutput.add(new StreamRecord<>("[2]: 2"));
 			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
 
 			// InputGate 2 was not available in previous steps, so let's check if we are not starving it
 			testHarness.processElement(new StreamRecord<>("1"), 2);
-			testHarness.processSingleStep();
-			testHarness.processSingleStep();
+			testHarness.processIfAvailable();
+			testHarness.processIfAvailable();
 
 			// One of those processing single step should pick up InputGate 2, however it's not
 			// important which one. We just must avoid starvation.


### PR DESCRIPTION
~This PR depends on https://github.com/apache/flink/pull/13228 and large bunch of commits is coming from there. Please ignore them in this PR.~

This PR adds support for checkpointing with multiple input operator chained with sources. It's doing it via hooking in `StreamTaskSourceInput` to `CheckpointBarrierHandler`s. Please check individual commits for the changelog.

## Verifying this change

This change is covered by the existing tests and is also adding `MultipleInputStreamTaskChainedSourcesCheckpointingTest` to cover for the new features (checkpointing with chained sources).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
