### PR TITLE
[FLINK-19385] Request partitions for each InputGate independently

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -508,14 +508,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		// output can request more floating buffers from global firstly.
 		InputGate[] inputGates = getEnvironment().getAllInputGates();
 		if (inputGates != null && inputGates.length > 0) {
-			CompletableFuture[] futures = new CompletableFuture[inputGates.length];
-			for (int i = 0; i < inputGates.length; i++) {
-				futures[i] = inputGates[i].readRecoveredState(channelIOExecutor, reader);
+			for (InputGate inputGate : inputGates) {
+				inputGate
+					.readRecoveredState(channelIOExecutor, reader)
+					.thenRun(() -> mainMailboxExecutor.execute(inputGate::requestPartitions, "Input gate request partitions"));
 			}
-
-			// Note that we must request partition after all the single gates finished recovery.
-			CompletableFuture.allOf(futures).thenRun(() -> mainMailboxExecutor.execute(
-				this::requestPartitions, "Input gates request partitions"));
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Please see FLINK-19385 for motivation.

## Verifying this change

The issue is covered by `StreamTaskSelectiveReadingITCase`: #13351 fails without this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
