### PR TITLE
fix properties type cast error

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -98,7 +98,7 @@ public class Kafka extends ConnectorDescriptor {
 			this.kafkaProperties = new HashMap<>();
 		}
 		this.kafkaProperties.clear();
-		properties.forEach((k, v) -> this.kafkaProperties.put((String) k, (String) v));
+		properties.forEach((k, v) -> this.kafkaProperties.put(String.valueOf(k), String.valueOf(v) ));
 		return this;
 	}
 


### PR DESCRIPTION
Properties extends Hashtable<Object,Object> ，The key and value of the Properties class support object objects. If the user's value is a boolean type,  this code "(String) k, (String) v"  will occur an error.

such as :  java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String

