### PR TITLE
[FLINK-19124][datastream] Some JobClient methods are not ergonomic, require ClassLoader argument

### DIFF
--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -231,7 +231,7 @@ just submitted. For instance, here is how to implement the semantics of
 {% highlight java %}
 final JobClient jobClient = env.executeAsync();
 
-final JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+final JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult().get();
 {% endhighlight %}
 
 That last part about program execution is crucial to understanding when and how

--- a/docs/dev/datastream_api.zh.md
+++ b/docs/dev/datastream_api.zh.md
@@ -231,7 +231,7 @@ just submitted. For instance, here is how to implement the semantics of
 {% highlight java %}
 final JobClient jobClient = env.executeAsync();
 
-final JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+final JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult().get();
 {% endhighlight %}
 
 That last part about program execution is crucial to understanding when and how

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -51,9 +51,12 @@ public class ClusterClientJobClientAdapter<ClusterID> implements JobClient, Coor
 
 	private final JobID jobID;
 
-	public ClusterClientJobClientAdapter(final ClusterClientProvider<ClusterID> clusterClientProvider, final JobID jobID) {
+	private final ClassLoader classLoader;
+
+	public ClusterClientJobClientAdapter(final ClusterClientProvider<ClusterID> clusterClientProvider, final JobID jobID, final ClassLoader classLoader) {
 		this.jobID = checkNotNull(jobID);
 		this.clusterClientProvider = checkNotNull(clusterClientProvider);
+		this.classLoader = classLoader;
 	}
 
 	@Override
@@ -92,7 +95,7 @@ public class ClusterClientJobClientAdapter<ClusterID> implements JobClient, Coor
 	}
 
 	@Override
-	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
+	public CompletableFuture<Map<String, Object>> getAccumulators() {
 		checkNotNull(classLoader);
 
 		return bridgeClientRequest(
@@ -102,8 +105,8 @@ public class ClusterClientJobClientAdapter<ClusterID> implements JobClient, Coor
 	}
 
 	@Override
-	public CompletableFuture<JobExecutionResult> getJobExecutionResult(final ClassLoader userClassloader) {
-		checkNotNull(userClassloader);
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult() {
+		checkNotNull(classLoader);
 
 		return bridgeClientRequest(
 				clusterClientProvider,
@@ -111,7 +114,7 @@ public class ClusterClientJobClientAdapter<ClusterID> implements JobClient, Coor
 					.requestJobResult(jobID)
 					.thenApply((jobResult) -> {
 						try {
-							return jobResult.toJobExecutionResult(userClassloader);
+							return jobResult.toJobExecutionResult(classLoader);
 						} catch (Throwable t) {
 							throw new CompletionException(
 									new ProgramInvocationException("Job failed", jobID, t));

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
@@ -59,15 +59,19 @@ public class EmbeddedJobClient implements JobClient, CoordinationRequestGateway 
 
 	private final Time timeout;
 
+	private final ClassLoader classLoader;
+
 	public EmbeddedJobClient(
 			final JobID jobId,
 			final DispatcherGateway dispatcherGateway,
 			final ScheduledExecutor retryExecutor,
-			final Time rpcTimeout) {
+			final Time rpcTimeout,
+			final ClassLoader classLoader) {
 		this.jobId = checkNotNull(jobId);
 		this.dispatcherGateway = checkNotNull(dispatcherGateway);
 		this.retryExecutor = checkNotNull(retryExecutor);
 		this.timeout = checkNotNull(rpcTimeout);
+		this.classLoader = classLoader;
 	}
 
 	@Override
@@ -98,7 +102,7 @@ public class EmbeddedJobClient implements JobClient, CoordinationRequestGateway 
 	}
 
 	@Override
-	public CompletableFuture<Map<String, Object>> getAccumulators(final ClassLoader classLoader) {
+	public CompletableFuture<Map<String, Object>> getAccumulators() {
 		checkNotNull(classLoader);
 
 		return dispatcherGateway.requestJob(jobId, timeout)
@@ -113,14 +117,14 @@ public class EmbeddedJobClient implements JobClient, CoordinationRequestGateway 
 	}
 
 	@Override
-	public CompletableFuture<JobExecutionResult> getJobExecutionResult(final ClassLoader userClassloader) {
-		checkNotNull(userClassloader);
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult() {
+		checkNotNull(classLoader);
 
 		final Time retryPeriod = Time.milliseconds(100L);
 		return JobStatusPollingUtils.getJobResult(dispatcherGateway, jobId, retryExecutor, timeout, retryPeriod)
 				.thenApply((jobResult) -> {
 					try {
-						return jobResult.toJobExecutionResult(userClassloader);
+						return jobResult.toJobExecutionResult(classLoader);
 					} catch (Throwable t) {
 						throw new CompletionException(new Exception("Job " + jobId + " failed", t));
 					}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/WebSubmissionJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/WebSubmissionJobClient.java
@@ -43,7 +43,7 @@ public class WebSubmissionJobClient implements JobClient {
 
 	private final JobID jobId;
 
-	public WebSubmissionJobClient(final JobID jobId) {
+	public WebSubmissionJobClient(final JobID jobId, final ClassLoader userCodeClassloader) {
 		this.jobId = checkNotNull(jobId);
 	}
 
@@ -73,12 +73,12 @@ public class WebSubmissionJobClient implements JobClient {
 	}
 
 	@Override
-	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
+	public CompletableFuture<Map<String, Object>> getAccumulators() {
 		throw new FlinkRuntimeException("The Accumulators cannot be fetched through the Job Client when in Web Submission.");
 	}
 
 	@Override
-	public CompletableFuture<JobExecutionResult> getJobExecutionResult(ClassLoader userClassloader) {
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult() {
 		throw new FlinkRuntimeException("The Job Result cannot be fetched through the Job Client when in Web Submission.");
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/WebSubmissionJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/WebSubmissionJobClient.java
@@ -43,7 +43,7 @@ public class WebSubmissionJobClient implements JobClient {
 
 	private final JobID jobId;
 
-	public WebSubmissionJobClient(final JobID jobId, final ClassLoader userCodeClassloader) {
+	public WebSubmissionJobClient(final JobID jobId) {
 		this.jobId = checkNotNull(jobId);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
@@ -92,15 +92,15 @@ public class EmbeddedExecutor implements PipelineExecutor {
 				.map(JobID::fromHexString);
 
 		if (optJobId.isPresent() && submittedJobIds.contains(optJobId.get())) {
-			return getJobClientFuture(optJobId.get());
+			return getJobClientFuture(optJobId.get(), userCodeClassloader);
 		}
 
 		return submitAndGetJobClientFuture(pipeline, configuration, userCodeClassloader);
 	}
 
-	private CompletableFuture<JobClient> getJobClientFuture(final JobID jobId) {
+	private CompletableFuture<JobClient> getJobClientFuture(final JobID jobId, final ClassLoader userCodeClassloader) {
 		LOG.info("Job {} was recovered successfully.", jobId);
-		return CompletableFuture.completedFuture(jobClientCreator.getJobClient(jobId));
+		return CompletableFuture.completedFuture(jobClientCreator.getJobClient(jobId, userCodeClassloader));
 	}
 
 	private CompletableFuture<JobClient> submitAndGetJobClientFuture(final Pipeline pipeline, final Configuration configuration, final ClassLoader userCodeClassloader) throws MalformedURLException {
@@ -130,7 +130,7 @@ public class EmbeddedExecutor implements PipelineExecutor {
 						userCodeClassloader);
 					return jobId;
 				}))
-				.thenApplyAsync(jobID -> jobClientCreator.getJobClient(actualJobId));
+				.thenApplyAsync(jobID -> jobClientCreator.getJobClient(actualJobId, userCodeClassloader));
 	}
 
 	private static CompletableFuture<JobID> submitJob(

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
@@ -79,7 +79,7 @@ public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
 		return new EmbeddedExecutor(
 				submittedJobIds,
 				dispatcherGateway,
-			(jobId, userCodeClassloader) -> {
+				(jobId, userCodeClassloader) -> {
 					final Time timeout = Time.milliseconds(configuration.get(ClientOptions.CLIENT_TIMEOUT).toMillis());
 					return new EmbeddedJobClient(jobId, dispatcherGateway, retryExecutor, timeout, userCodeClassloader);
 				});

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
@@ -79,9 +79,9 @@ public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
 		return new EmbeddedExecutor(
 				submittedJobIds,
 				dispatcherGateway,
-				jobId -> {
+			(jobId, userCodeClassloader) -> {
 					final Time timeout = Time.milliseconds(configuration.get(ClientOptions.CLIENT_TIMEOUT).toMillis());
-					return new EmbeddedJobClient(jobId, dispatcherGateway, retryExecutor, timeout);
+					return new EmbeddedJobClient(jobId, dispatcherGateway, retryExecutor, timeout, userCodeClassloader);
 				});
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedJobClientCreator.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedJobClientCreator.java
@@ -31,7 +31,8 @@ public interface EmbeddedJobClientCreator {
 	/**
 	 * Creates a {@link JobClient} that is adequate for the context in which the job is executed.
 	 * @param jobId the job id of the job associated with the returned client.
+	 * @param userCodeClassloader the class loader to deserialize user code.
 	 * @return the job client.
 	 */
-	JobClient getJobClient(final JobID jobId);
+	JobClient getJobClient(final JobID jobId, final ClassLoader userCodeClassloader);
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/WebSubmissionExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/WebSubmissionExecutorFactory.java
@@ -75,6 +75,6 @@ public class WebSubmissionExecutorFactory implements PipelineExecutorFactory {
 		return new EmbeddedExecutor(
 				submittedJobIds,
 				dispatcherGateway,
-				WebSubmissionJobClient::new);
+				(jobId, userCodeClassloader) -> new WebSubmissionJobClient(jobId));
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractJobClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractJobClusterExecutor.java
@@ -71,7 +71,7 @@ public class AbstractJobClusterExecutor<ClusterID, ClientFactory extends Cluster
 			LOG.info("Job has been submitted with JobID " + jobGraph.getJobID());
 
 			return CompletableFuture.completedFuture(
-					new ClusterClientJobClientAdapter<>(clusterClientProvider, jobGraph.getJobID()));
+					new ClusterClientJobClientAdapter<>(clusterClientProvider, jobGraph.getJobID(), userCodeClassloader));
 		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
@@ -75,7 +75,8 @@ public class AbstractSessionClusterExecutor<ClusterID, ClientFactory extends Clu
 					}))
 					.thenApplyAsync(jobID -> (JobClient) new ClusterClientJobClientAdapter<>(
 							clusterClientProvider,
-							jobID))
+							jobID,
+							userCodeClassloader))
 					.whenComplete((ignored1, ignored2) -> clusterClient.close());
 		}
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -93,7 +93,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		JobExecutionResult jobExecutionResult;
 		if (getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {
 			CompletableFuture<JobExecutionResult> jobExecutionResultFuture =
-					jobClient.getJobExecutionResult(getUserCodeClassLoader());
+					jobClient.getJobExecutionResult();
 
 			if (getConfiguration().getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
 				Thread shutdownHook = ShutdownHookUtil.addShutdownHook(

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
@@ -97,7 +97,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 		JobExecutionResult jobExecutionResult;
 		if (getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {
 			CompletableFuture<JobExecutionResult> jobExecutionResultFuture =
-					jobClient.getJobExecutionResult(getUserClassloader());
+					jobClient.getJobExecutionResult();
 
 			if (getConfiguration().getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
 				Thread shutdownHook = ShutdownHookUtil.addShutdownHook(

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -340,7 +340,7 @@ public class ClientTest extends TestLogger {
 				env.fromElements(1, 2).output(new DiscardingOutputFormat<>());
 				JobClient jc = env.executeAsync();
 
-				jc.getJobExecutionResult(TestMultiExecute.class.getClassLoader());
+				jc.getJobExecutionResult();
 			}
 		}
 	}
@@ -429,7 +429,7 @@ public class ClientTest extends TestLogger {
 						jobGraph.setClasspaths(accessor.getClasspaths());
 
 						final JobID jobID = clusterClient.submitJob(jobGraph).get();
-						return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
+						return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID, classLoader));
 					};
 				}
 			};

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
@@ -61,10 +61,10 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
 
 		JobClient jobClient = perJobMiniClusterFactory.submitJob(getNoopJobGraph(), ClassLoader.getSystemClassLoader()).get();
 
-		JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult(getClass().getClassLoader()).get();
+		JobExecutionResult jobExecutionResult = jobClient.getJobExecutionResult().get();
 		assertThat(jobExecutionResult, is(notNullValue()));
 
-		Map<String, Object> actual = jobClient.getAccumulators(getClass().getClassLoader()).get();
+		Map<String, Object> actual = jobClient.getAccumulators().get();
 		assertThat(actual, is(notNullValue()));
 
 		assertThatMiniClusterIsShutdown();
@@ -87,7 +87,7 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
 		assertThrows(
 			"Job was cancelled.",
 			ExecutionException.class,
-			() -> jobClient.getJobExecutionResult(getClass().getClassLoader()).get()
+			() -> jobClient.getJobExecutionResult().get()
 		);
 
 		assertThatMiniClusterIsShutdown();
@@ -127,12 +127,12 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
 		PerJobMiniClusterFactory perJobMiniClusterFactory = initializeMiniCluster();
 		{
 			JobClient jobClient = perJobMiniClusterFactory.submitJob(getNoopJobGraph(), ClassLoader.getSystemClassLoader()).get();
-			jobClient.getJobExecutionResult(getClass().getClassLoader()).get();
+			jobClient.getJobExecutionResult().get();
 			assertThatMiniClusterIsShutdown();
 		}
 		{
 			JobClient jobClient = perJobMiniClusterFactory.submitJob(getNoopJobGraph(), ClassLoader.getSystemClassLoader()).get();
-			jobClient.getJobExecutionResult(getClass().getClassLoader()).get();
+			jobClient.getJobExecutionResult().get();
 			assertThatMiniClusterIsShutdown();
 		}
 	}
@@ -141,7 +141,7 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
 	public void testJobClientInteractionAfterShutdown() throws Exception {
 		PerJobMiniClusterFactory perJobMiniClusterFactory = initializeMiniCluster();
 		JobClient jobClient = perJobMiniClusterFactory.submitJob(getNoopJobGraph(), ClassLoader.getSystemClassLoader()).get();
-		jobClient.getJobExecutionResult(getClass().getClassLoader()).get();
+		jobClient.getJobExecutionResult().get();
 		assertThatMiniClusterIsShutdown();
 
 		assertThrows(

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
@@ -75,12 +75,10 @@ public interface JobClient {
 	 * Requests the accumulators of the associated job. Accumulators can be requested while it is running
 	 * or after it has finished. The class loader is used to deserialize the incoming accumulator results.
 	 */
-	CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader);
+	CompletableFuture<Map<String, Object>> getAccumulators();
 
 	/**
 	 * Returns the {@link JobExecutionResult result of the job execution} of the submitted job.
-	 *
-	 * @param userClassloader the classloader used to de-serialize the accumulators of the job.
 	 */
-	CompletableFuture<JobExecutionResult> getJobExecutionResult(final ClassLoader userClassloader);
+	CompletableFuture<JobExecutionResult> getJobExecutionResult();
 }

--- a/flink-end-to-end-tests/flink-batch-sql-test/src/main/java/org/apache/flink/sql/tests/BatchSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-batch-sql-test/src/main/java/org/apache/flink/sql/tests/BatchSQLTestProgram.java
@@ -70,7 +70,7 @@ public class BatchSQLTestProgram {
 
 		TableResult result = tEnv.executeSql(sqlStatement);
 		// wait job finish
-		result.getJobClient().get().getJobExecutionResult(Thread.currentThread().getContextClassLoader()).get();
+		result.getJobClient().get().getJobExecutionResult().get();
 	}
 
 	/**

--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
@@ -105,7 +105,7 @@ public class TpcdsTestProgram {
 			TableResult tableResult = resultTable.executeInsert(sinkTableName);
 			// wait job finish
 			tableResult.getJobClient().get()
-					.getJobExecutionResult(Thread.currentThread().getContextClassLoader())
+					.getJobExecutionResult()
 					.get();
 			System.out.println("[INFO]Run TPC-DS query " + queryId + " success.");
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -890,7 +890,7 @@ public class ExecutionEnvironment {
 
 		try {
 			if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
-				lastJobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+				lastJobExecutionResult = jobClient.getJobExecutionResult().get();
 			} else {
 				lastJobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
 			}

--- a/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
@@ -45,7 +45,7 @@ public class TestingJobClient implements JobClient {
 	}
 
 	@Override
-	public CompletableFuture<JobExecutionResult> getJobExecutionResult(ClassLoader userClassloader) {
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult() {
 		return CompletableFuture.completedFuture(new JobExecutionResult(new JobID(), 0L, Collections.emptyMap()));
 	}
 
@@ -65,7 +65,7 @@ public class TestingJobClient implements JobClient {
 	}
 
 	@Override
-	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
+	public CompletableFuture<Map<String, Object>> getAccumulators() {
 		return CompletableFuture.completedFuture(Collections.emptyMap());
 	}
 }

--- a/flink-python/pyflink/common/job_client.py
+++ b/flink-python/pyflink/common/job_client.py
@@ -19,7 +19,6 @@ from pyflink.common.completable_future import CompletableFuture
 from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.job_id import JobID
 from pyflink.common.job_status import JobStatus
-from pyflink.java_gateway import get_gateway
 
 __all__ = ['JobClient']
 
@@ -103,7 +102,7 @@ class JobClient(object):
         """
         return CompletableFuture(self._j_job_client.triggerSavepoint(savepoint_directory), str)
 
-    def get_accumulators(self, class_loader=None):
+    def get_accumulators(self):
         """
         Requests the accumulators of the associated job. Accumulators can be requested while it
         is running or after it has finished. The class loader is used to deserialize the incoming
@@ -115,21 +114,16 @@ class JobClient(object):
 
         .. versionadded:: 1.11.0
         """
-        if class_loader is None:
-            class_loader = get_gateway().jvm.Thread.currentThread().getContextClassLoader()
-        return CompletableFuture(self._j_job_client.getAccumulators(class_loader), dict)
+        return CompletableFuture(self._j_job_client.getAccumulators(), dict)
 
-    def get_job_execution_result(self, user_class_loader=None):
+    def get_job_execution_result(self):
         """
         Returns the JobExecutionResult result of the job execution of the submitted job.
 
-        :param user_class_loader: Class loader used to deserialize the accumulators of the job.
         :return: A CompletableFuture containing the JobExecutionResult result of the job execution.
         :rtype: pyflink.common.CompletableFuture
 
         .. versionadded:: 1.11.0
         """
-        if user_class_loader is None:
-            user_class_loader = get_gateway().jvm.Thread.currentThread().getContextClassLoader()
-        return CompletableFuture(self._j_job_client.getJobExecutionResult(user_class_loader),
+        return CompletableFuture(self._j_job_client.getJobExecutionResult(),
                                  JobExecutionResult)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1723,7 +1723,7 @@ public class StreamExecutionEnvironment {
 			final JobExecutionResult jobExecutionResult;
 
 			if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
-				jobExecutionResult = jobClient.getJobExecutionResult(userClassloader).get();
+				jobExecutionResult = jobClient.getJobExecutionResult().get();
 			} else {
 				jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
 			}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
@@ -169,7 +169,7 @@ public class CollectResultFetcher<T> {
 		JobExecutionResult executionResult;
 		try {
 			// this timeout is sort of hack, see comments in isJobTerminated for explanation
-			executionResult = jobClient.getJobExecutionResult(getClass().getClassLoader()).get(
+			executionResult = jobClient.getJobExecutionResult().get(
 				DEFAULT_ACCUMULATOR_GET_MILLIS, TimeUnit.MILLISECONDS);
 		} catch (InterruptedException | ExecutionException | TimeoutException e) {
 			throw new IOException("Failed to fetch job execution result", e);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestJobClient.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestJobClient.java
@@ -90,12 +90,12 @@ public class TestJobClient implements JobClient, CoordinationRequestGateway {
 	}
 
 	@Override
-	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
+	public CompletableFuture<Map<String, Object>> getAccumulators() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public CompletableFuture<JobExecutionResult> getJobExecutionResult(ClassLoader userClassloader) {
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult() {
 		return CompletableFuture.completedFuture(jobExecutionResult);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
@@ -45,7 +45,7 @@ public class TestingJobClient implements JobClient {
 	}
 
 	@Override
-	public CompletableFuture<JobExecutionResult> getJobExecutionResult(ClassLoader userClassloader) {
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult() {
 		return CompletableFuture.completedFuture(new JobExecutionResult(new JobID(), 0L, Collections.emptyMap()));
 	}
 
@@ -65,7 +65,7 @@ public class TestingJobClient implements JobClient {
 	}
 
 	@Override
-	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
+	public CompletableFuture<Map<String, Object>> getAccumulators() {
 		return CompletableFuture.completedFuture(Collections.emptyMap());
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -508,8 +508,7 @@ public class LocalExecutor implements Executor {
 		final DynamicResult<C> result = resultStore.createResult(
 				context.getEnvironment(),
 				removeTimeAttributes(table.getSchema()),
-				context.getExecutionConfig(),
-				context.getClassLoader());
+				context.getExecutionConfig());
 		final String jobName = sessionId + ": " + query;
 		final String tableName = String.format("_tmp_table_%s", Math.abs(query.hashCode()));
 		final Pipeline pipeline;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -59,8 +59,7 @@ public class ResultStore {
 	public <T> DynamicResult<T> createResult(
 			Environment env,
 			TableSchema schema,
-			ExecutionConfig config,
-			ClassLoader classLoader) {
+			ExecutionConfig config) {
 
 		if (env.getExecution().inStreamingMode()) {
 			// determine gateway address (and port if possible)
@@ -72,22 +71,20 @@ public class ResultStore {
 						schema,
 						config,
 						gatewayAddress,
-						gatewayPort,
-						classLoader);
+						gatewayPort);
 			} else {
 				return new MaterializedCollectStreamResult<>(
 						schema,
 						config,
 						gatewayAddress,
 						gatewayPort,
-						env.getExecution().getMaxTableResultRows(),
-						classLoader);
+						env.getExecution().getMaxTableResultRows());
 			}
 
 		} else {
 			// Batch Execution
 			if (env.getExecution().isTableMode() || env.getExecution().isTableauMode()) {
-				return new MaterializedCollectBatchResult<>(schema, config, classLoader);
+				return new MaterializedCollectBatchResult<>(schema, config);
 			} else {
 				throw new SqlExecutionException(
 						"Results of batch queries can only be served in table or tableau mode.");

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
@@ -42,9 +42,8 @@ public class ChangelogCollectStreamResult<C> extends CollectStreamResult<C> impl
 			TableSchema tableSchema,
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
-			int gatewayPort,
-			ClassLoader classLoader) {
-		super(tableSchema, config, gatewayAddress, gatewayPort, classLoader);
+			int gatewayPort) {
+		super(tableSchema, config, gatewayAddress, gatewayPort);
 
 		// prepare for changelog
 		changeRecordBuffer = new ArrayList<>();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -96,9 +96,8 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			InetAddress gatewayAddress,
 			int gatewayPort,
 			int maxRowCount,
-			int overcommitThreshold,
-			ClassLoader classLoader) {
-		super(tableSchema, config, gatewayAddress, gatewayPort, classLoader);
+			int overcommitThreshold) {
+		super(tableSchema, config, gatewayAddress, gatewayPort);
 
 		if (maxRowCount <= 0) {
 			this.maxRowCount = Integer.MAX_VALUE;
@@ -123,8 +122,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
 			int gatewayPort,
-			int maxRowCount,
-			ClassLoader classLoader) {
+			int maxRowCount) {
 
 		this(
 			tableSchema,
@@ -132,8 +130,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			gatewayAddress,
 			gatewayPort,
 			maxRowCount,
-			computeMaterializedTableOvercommit(maxRowCount),
-			classLoader);
+			computeMaterializedTableOvercommit(maxRowCount));
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -162,8 +162,7 @@ public class MaterializedCollectStreamResultTest {
 				gatewayAddress,
 				gatewayPort,
 				maxRowCount,
-				overcommitThreshold,
-				MaterializedCollectStreamResultTest.class.getClassLoader());
+				overcommitThreshold);
 		}
 
 		public TestMaterializedCollectStreamResult(
@@ -178,8 +177,7 @@ public class MaterializedCollectStreamResultTest {
 				config,
 				gatewayAddress,
 				gatewayPort,
-				maxRowCount,
-				MaterializedCollectStreamResultTest.class.getClassLoader());
+				maxRowCount);
 		}
 
 		@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/InsertResultIterator.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/InsertResultIterator.java
@@ -54,7 +54,7 @@ class InsertResultIterator implements CloseableIterator<Row> {
 	public boolean hasNext() {
 		if (hasNext == null) {
 			try {
-				jobClient.getJobExecutionResult(classLoader).get();
+				jobClient.getJobExecutionResult().get();
 			} catch (Exception e) {
 				throw new TableException("Failed to wait job finish", e);
 			}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/BatchSelectTableSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sinks/BatchSelectTableSink.java
@@ -99,8 +99,7 @@ public class BatchSelectTableSink implements BatchTableSink<Row> {
 	private CloseableIterator<Row> collectResult(JobClient jobClient) {
 		JobExecutionResult jobExecutionResult;
 		try {
-			jobExecutionResult = jobClient.getJobExecutionResult(
-					Thread.currentThread().getContextClassLoader())
+			jobExecutionResult = jobClient.getJobExecutionResult()
 					.get();
 		} catch (InterruptedException | ExecutionException e) {
 			throw new TableException("Failed to get job execution result.", e);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
@@ -316,7 +316,7 @@ abstract class BatchTableEnvImpl(
     try {
       val jobClient = executePipeline(plan)
       if (execEnv.getConfiguration.getBoolean(DeploymentOptions.ATTACHED)) {
-        jobClient.getJobExecutionResult(execEnv.getUserCodeClassLoader).get
+        jobClient.getJobExecutionResult().get
       } else {
         new DetachedJobExecutionResult(jobClient.getJobID)
       }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
@@ -108,7 +108,7 @@ public class UnalignedCheckpointCompatibilityITCase {
 	private Tuple2<String, Map<String, Object>> runAndTakeSavepoint() throws Exception {
 		JobClient jobClient = submitJobInitially(env(startAligned, 0, emptyMap()));
 		Thread.sleep(FIRST_RUN_EL_COUNT * FIRST_RUN_BACKPRESSURE_MS); // wait for all tasks to run and some backpressure from sink
-		Future<Map<String, Object>> accFuture = jobClient.getAccumulators(getClass().getClassLoader());
+		Future<Map<String, Object>> accFuture = jobClient.getAccumulators();
 		Future<String> savepointFuture = jobClient.stopWithSavepoint(false, tempFolder().toURI().toString());
 		return new Tuple2<>(savepointFuture.get(), accFuture.get());
 	}
@@ -141,7 +141,7 @@ public class UnalignedCheckpointCompatibilityITCase {
 	private void cancelJob(JobClient jobClient) throws InterruptedException, java.util.concurrent.ExecutionException {
 		jobClient.cancel().get();
 		try {
-			jobClient.getJobExecutionResult(getClass().getClassLoader()); // wait for cancellation
+			jobClient.getJobExecutionResult(); // wait for cancellation
 		} catch (Exception e) {
 			// ignore cancellation exception
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
@@ -82,7 +82,7 @@ public class LocalExecutorITCase extends TestLogger {
 			Plan wcPlan = getWordCountPlan(inFile, outFile, parallelism);
 			wcPlan.setExecutionConfig(new ExecutionConfig());
 			JobClient jobClient = executor.execute(wcPlan, config, ClassLoader.getSystemClassLoader()).get();
-			jobClient.getJobExecutionResult(getClass().getClassLoader()).get();
+			jobClient.getJobExecutionResult().get();
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail(e.getMessage());
@@ -104,7 +104,7 @@ public class LocalExecutorITCase extends TestLogger {
 		assertThrows(
 			"Job execution failed.",
 			Exception.class,
-			() -> jobClient.getJobExecutionResult(getClass().getClassLoader()).get());
+			() -> jobClient.getJobExecutionResult().get());
 
 		assertThat(miniCluster.isRunning(), is(false));
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
@@ -161,7 +161,7 @@ public class RemoteStreamEnvironmentTest extends TestLogger {
 						clusterClient = new TestClusterClient(configuration, jobID);
 
 						return CompletableFuture.completedFuture(
-								new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
+								new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID, classLoader));
 					};
 				}
 			};


### PR DESCRIPTION
## What is the purpose of the change

*Both `getAccumulators()` and `getJobExecutionResult()` result require the user to give a `ClassLoader`. `JobClient` created in a context could get the user-code `ClassLoader` by `PipelineExecutor`. `ClassLoader` parameter should be removed from those methods and require that users could give the user-code class loader when constructing a `JobClient` themselves for an already running job.*

## Brief change log

  - *`getAccumulators()` and `getJobExecutionResult()` of `JobClient` remove the user-code `ClassLoader` parameter.*
  - *Constructor of `ClusterClientJobClientAdapter`, `EmbeddedJobClient`, `PerJobMiniClusterJobClient` and `WebSubmissionJobClient` for`JobClient` implementations add `ClassLoader` parameter.*
  - *Caller of `getAccumulators()` and `getJobExecutionResult()` removes the user-code `ClassLoader` adapt to the modified API of `JobClient`.*  

## Verifying this change

  - *Test cases related to `getAccumulators()` and `getJobExecutionResult()` of `JobClient` could verify the case that removes the user-code `ClassLoader` parameter.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)