### PR TITLE
[FLINK-19391][network] Moved notification during subpartition request to the requester.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -92,6 +92,8 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 				throw new IllegalStateException("Subpartition already requested");
 			}
 		}
+
+		notifyDataAvailable();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -40,7 +40,7 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
 
 	@Override
 	public boolean isReleased() {
-		return true;
+		return false;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -73,8 +73,6 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 			subpartitionView = partition.createSubpartitionView(subpartitionIndex, availabilityListener);
 		}
 
-		availabilityListener.notifyDataAvailable();
-
 		return subpartitionView;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
@@ -47,7 +47,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
 	private static final int BUFFER_SIZE = 32 * 1024;
 
 	@Test
-	public void testInitiallyAvailable() throws Exception {
+	public void testInitiallyNotAvailable() throws Exception {
 		final ResultSubpartition subpartition = createPartitionWithData(10);
 		final CountingAvailabilityListener listener = new CountingAvailabilityListener();
 
@@ -55,7 +55,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
 		final ResultSubpartitionView subpartitionView = createView(subpartition, listener);
 
 		// assert
-		assertEquals(1, listener.numNotifications);
+		assertEquals(0, listener.numNotifications);
 
 		// cleanup
 		subpartitionView.releaseAllResources();
@@ -95,7 +95,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
 
 		// assert
 		assertTrue(reader.isAvailable(Integer.MAX_VALUE));
-		assertEquals(2, listener.numNotifications); // one initial, one for new availability
+		assertEquals(1, listener.numNotifications);
 
 		// cleanup
 		reader.releaseAllResources();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
@@ -132,10 +132,6 @@ public class FileChannelBoundedDataTest extends BoundedDataTestBase {
 
 		final VerifyNotificationBufferAvailabilityListener listener = new VerifyNotificationBufferAvailabilityListener();
 		final ResultSubpartitionView subpartitionView = createView(subpartition, listener);
-		// the notification is triggered while creating view
-		assertTrue(listener.isAvailable);
-
-		listener.resetAvailable();
 		assertFalse(listener.isAvailable);
 
 		final BufferAndBacklog buffer1 = subpartitionView.getNextBuffer();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -64,7 +64,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -240,19 +239,16 @@ public class SingleInputGateTest extends InputGateTestBase {
 			// check channel error during above partition request
 			gate.pollNext();
 
-			Collection<InputChannel> channels = gate.getInputChannels().values();
-			for (InputChannel channel: channels) {
-				if (channel.getChannelIndex() == 0) {
-					assertThat(channel, instanceOf(RemoteInputChannel.class));
-					assertNotNull(((RemoteInputChannel) channel).getPartitionRequestClient());
-					assertEquals(2, ((RemoteInputChannel) channel).getInitialCredit());
-				} else if (channel.getChannelIndex() == 1) {
-					assertThat(channel, instanceOf(LocalInputChannel.class));
-					assertNotNull(((LocalInputChannel) channel).getSubpartitionView());
-				} else if (channel.getChannelIndex() == 2) {
-					assertThat(channel, instanceOf(UnknownInputChannel.class));
-				}
-			}
+			final InputChannel remoteChannel = gate.getChannel(0);
+			assertThat(remoteChannel, instanceOf(RemoteInputChannel.class));
+			assertNotNull(((RemoteInputChannel) remoteChannel).getPartitionRequestClient());
+			assertEquals(2, ((RemoteInputChannel) remoteChannel).getInitialCredit());
+
+			final InputChannel localChannel = gate.getChannel(1);
+			assertThat(localChannel, instanceOf(LocalInputChannel.class));
+			assertNotNull(((LocalInputChannel) localChannel).getSubpartitionView());
+
+			assertThat(gate.getChannel(2), instanceOf(UnknownInputChannel.class));
 		} finally {
 			gate.close();
 			environment.close();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This change avoid a deadlock on requestLock that may happen with concurrent release via input gate.

The deadlock was introduced by the alternative fix for FLINK-12510 in FLINK-19026 .

The alternative fix avoided double lock acquisition in `SingleInputGate#waitAndGetNextData` by moving `notifyDataAvailable` from `ResultSubpartition#createReadView` to `ResultPartitionManager#createSubpartitionView`, which solved the circular deadlock of FLINK-12510 by not acquiring the `buffers` lock of `PipelinedSubpartition`.

However, that fix didn't go far enough. For local channels, it is still possible to create a similar deadlock. While `SingleInputGate` reads from `LocalInputChannel`, it holds the lock `inputChannelsWithData`. The channel may start requesting the partition and tries to acquire `requestLock`. 
At the same time there is an update of partition info, which acquires the `requestLock` and notifies the `SingleInputGate`, which needs to lock on `inputChannelsWithData`.

The solution is to first acquire the partition and release `requestLock` before notifying `SingleInputGate`.

## Brief change log

  - Moved notification during subpartition request to the requester.
  - Fixes the broken SingleInputGateTest#testPartitionRequestLogic, where pollNext was a no-op.

## Verifying this change

This is a bugfix for broken master cron job and is already covered by it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
