### PR TITLE
[FLINK-19372][python] Support Pandas Batch Over Window Aggregation

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -587,19 +587,19 @@ class OverWindowArrowCoderImpl(StreamCoderImpl):
 
     def decode_from_stream(self, in_stream, nested):
         while in_stream.size():
-            all_size = in_stream.read_var_int64()
+            remaining_size = in_stream.read_var_int64()
             window_num = self._int_coder.decode_from_stream(in_stream, nested)
-            all_size -= 4
+            remaining_size -= 4
             window_boundaries_and_arrow_data = []
             for _ in range(window_num):
                 window_size = self._int_coder.decode_from_stream(in_stream, nested)
-                all_size -= 4
+                remaining_size -= 4
                 window_boundaries_and_arrow_data.append(
                     [self._int_coder.decode_from_stream(in_stream, nested)
                      for _ in range(window_size)])
-                all_size -= 4 * window_size
+                remaining_size -= 4 * window_size
             window_boundaries_and_arrow_data.append(
-                self._arrow_coder._decode_one_batch_from_stream(in_stream, all_size))
+                self._arrow_coder._decode_one_batch_from_stream(in_stream, remaining_size))
             yield window_boundaries_and_arrow_data
 
     def __repr__(self):

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -560,7 +560,7 @@ class ArrowCoderImpl(StreamCoderImpl):
 
     def decode_from_stream(self, in_stream, nested):
         while in_stream.size() > 0:
-            yield self._decode_one_batch_from_stream(in_stream)
+            yield self._decode_one_batch_from_stream(in_stream, in_stream.read_var_int64())
 
     @staticmethod
     def _load_from_stream(stream):
@@ -568,13 +568,42 @@ class ArrowCoderImpl(StreamCoderImpl):
         for batch in reader:
             yield batch
 
-    def _decode_one_batch_from_stream(self, in_stream: create_InputStream) -> List:
-        self._resettable_io.set_input_bytes(in_stream.read_all(True))
+    def _decode_one_batch_from_stream(self, in_stream: create_InputStream, size: int) -> List:
+        self._resettable_io.set_input_bytes(in_stream.read(size))
         # there is only one arrow batch in the underlying input stream
         return arrow_to_pandas(self._timezone, self._field_types, [next(self._batch_reader)])
 
     def __repr__(self):
         return 'ArrowCoderImpl[%s]' % self._schema
+
+
+class OverWindowArrowCoderImpl(StreamCoderImpl):
+    def __init__(self, arrow_coder):
+        self._arrow_coder = arrow_coder
+        self._int_coder = IntCoderImpl()
+
+    def encode_to_stream(self, value, stream, nested):
+        self._arrow_coder.encode_to_stream(value, stream, nested)
+
+    def decode_from_stream(self, in_stream, nested):
+        while in_stream.size():
+            all_size = in_stream.read_var_int64()
+            window_num = self._int_coder.decode_from_stream(in_stream, nested)
+            all_size -= 4
+            window_boundaries_and_arrow_data = []
+            for _ in range(window_num):
+                window_size = self._int_coder.decode_from_stream(in_stream, nested)
+                all_size -= 4
+                window_boundaries_and_arrow_data.append(
+                    [self._int_coder.decode_from_stream(in_stream, nested)
+                     for _ in range(window_size)])
+                all_size -= 4 * window_size
+            window_boundaries_and_arrow_data.append(
+                self._arrow_coder._decode_one_batch_from_stream(in_stream, all_size))
+            yield window_boundaries_and_arrow_data
+
+    def __repr__(self):
+        return 'OverWindowArrowCoderImpl[%s]' % self._arrow_coder
 
 
 class PassThroughLengthPrefixCoderImpl(StreamCoderImpl):

--- a/flink-python/pyflink/fn_execution/beam/beam_coders.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coders.py
@@ -215,6 +215,30 @@ class ArrowCoder(FastCoder):
         return 'ArrowCoder[%s]' % self._schema
 
 
+class OverWindowArrowCoder(FastCoder):
+    """
+    Coder for batch pandas over window aggregation.
+    """
+    def __init__(self, arrow_coder):
+        self._arrow_coder = arrow_coder
+
+    def _create_impl(self):
+        return beam_coder_impl_slow.OverWindowArrowCoderImpl(
+            self._arrow_coder._create_impl())
+
+    def to_type_hint(self):
+        return typehints.List
+
+    @Coder.register_urn(coders.FLINK_OVER_WINDOW_ARROW_CODER_URN, flink_fn_execution_pb2.Schema)
+    def _pickle_from_runner_api_parameter(schema_proto, unused_components, unused_context):
+        return OverWindowArrowCoder(
+            ArrowCoder._pickle_from_runner_api_parameter(
+                schema_proto, unused_components, unused_context))
+
+    def __repr__(self):
+        return 'OverWindowArrowCoder[%s]' % self._arrow_coder
+
+
 class BeamDataStreamStatelessMapCoder(FastCoder):
 
     def __init__(self, field_coder):

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -48,7 +48,7 @@ cdef class PandasAggregateFunctionOperation(BeamStatelessFunctionOperation):
 
 cdef class PandasBatchOverWindowAggregateFunctionOperation(BeamStatelessFunctionOperation):
     cdef list windows
-    cdef list window_to_bounded_range_window_index
-    cdef list window_is_bounded_range_type
+    cdef list bounded_range_window_index
+    cdef list is_bounded_range_window
     cdef list window_indexes
     cdef list mapper

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -45,3 +45,10 @@ cdef class DataStreamStatelessFunctionOperation(BeamStatelessFunctionOperation):
 
 cdef class PandasAggregateFunctionOperation(BeamStatelessFunctionOperation):
     pass
+
+cdef class PandasBatchOverWindowAggregateFunctionOperation(BeamStatelessFunctionOperation):
+    cdef list windows
+    cdef list window_to_bounded_range_window_index
+    cdef list window_is_bounded_range_type
+    cdef list window_indexes
+    cdef list mapper

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -45,9 +45,11 @@ cdef class BeamStatelessFunctionOperation(Operation):
         super(BeamStatelessFunctionOperation, self).__init__(name, spec, counter_factory, sampler)
         self.consumer = consumers['output'][0]
         self._value_coder_impl = self.consumer.windowed_coder.wrapped_value_coder.get_impl()._value_coder
-        from pyflink.fn_execution.beam.beam_coder_impl_slow import ArrowCoderImpl
+        from pyflink.fn_execution.beam.beam_coder_impl_slow import ArrowCoderImpl, \
+            OverWindowArrowCoderImpl
 
-        if isinstance(self._value_coder_impl, ArrowCoderImpl):
+        if isinstance(self._value_coder_impl, ArrowCoderImpl) or \
+                isinstance(self._value_coder_impl, OverWindowArrowCoderImpl):
             self._is_python_coder = True
         else:
             self._is_python_coder = False
@@ -192,6 +194,108 @@ cdef class PandasAggregateFunctionOperation(BeamStatelessFunctionOperation):
         return generate_func, user_defined_funcs
 
 
+cdef class PandasBatchOverWindowAggregateFunctionOperation(BeamStatelessFunctionOperation):
+    def __init__(self, name, spec, counter_factory, sampler, consumers):
+        super(PandasBatchOverWindowAggregateFunctionOperation, self).__init__(
+            name, spec, counter_factory, sampler, consumers)
+        self.windows = [window for window in self.spec.serialized_fn.windows]
+        self.window_to_bounded_range_window_index = [-1 for _ in range(len(self.windows))]
+        self.window_is_bounded_range_type = []
+        window_types = flink_fn_execution_pb2.OverWindow
+        bounded_range_window_nums = 0
+        for i, window in enumerate(self.windows):
+            window_type = window.window_type
+            if (window_type is window_types.RANGE_UNBOUNDED_PRECEDING) or (
+                    window_type is window_types.RANGE_UNBOUNDED_FOLLOWING) or (
+                    window_type is window_types.RANGE_SLIDING):
+                self.window_to_bounded_range_window_index[i] = bounded_range_window_nums
+                self.window_is_bounded_range_type.append(True)
+                bounded_range_window_nums += 1
+            else:
+                self.window_is_bounded_range_type.append(False)
+
+    def generate_func(self, udfs):
+        user_defined_funcs = []
+        self.window_indexes = []
+        self.mapper = []
+        for udf in udfs:
+            pandas_agg_function, variable_dict, user_defined_func, window_index = \
+                operation_utils.extract_over_window_user_defined_function(udf)
+            user_defined_funcs.extend(user_defined_func)
+            self.window_indexes.append(window_index)
+            self.mapper.append(eval('lambda value: %s' % pandas_agg_function, variable_dict))
+        return self.wrap_over_window_function, user_defined_funcs
+
+    def wrap_over_window_function(self, it):
+        import pandas as pd
+        window_types = flink_fn_execution_pb2.OverWindow
+        for boundaries_series in it:
+            series = boundaries_series[len(boundaries_series) - 1]
+            rows_count = len(series[0])
+            results = []
+            # loop every agg func
+            for i in range(len(self.window_indexes)):
+                window_index = self.window_indexes[i]
+                window = self.windows[window_index]
+                window_type = window.window_type
+                func = self.mapper[i]
+                result = []
+                if self.window_is_bounded_range_type[window_index]:
+                    window_boundaries = boundaries_series[
+                        self.window_to_bounded_range_window_index[window_index]]
+                    if window_type is window_types.RANGE_UNBOUNDED_PRECEDING:
+                        # range unbounded preceding window
+                        for j in range(rows_count):
+                            end = window_boundaries[j]
+                            series_slices = [s.iloc[:end] for s in series]
+                            result.append(func(series_slices))
+                    elif window_type is window_types.RANGE_UNBOUNDED_FOLLOWING:
+                        # range unbounded following window
+                        for j in range(rows_count):
+                            start = window_boundaries[j]
+                            series_slices = [s.iloc[start:] for s in series]
+                            result.append(func(series_slices))
+                    else:
+                        # range sliding window
+                        for j in range(rows_count):
+                            start = window_boundaries[j * 2]
+                            end = window_boundaries[j * 2 + 1]
+                            series_slices = [s.iloc[start:end] for s in series]
+                            result.append(func(series_slices))
+                else:
+                    # unbounded range window or unbounded row window
+                    if (window_type is window_types.RANGE_UNBOUNDED) or (
+                            window_type is window_types.ROW_UNBOUNDED):
+                        series_slices = [s.iloc[:] for s in series]
+                        func_result = func(series_slices)
+                        result = [func_result for _ in range(rows_count)]
+                    elif window_type is window_types.ROW_UNBOUNDED_PRECEDING:
+                        # row unbounded preceding window
+                        window_end = window.upper_boundary
+                        for j in range(rows_count):
+                            end = min(j + window_end + 1, rows_count)
+                            series_slices = [s.iloc[: end] for s in series]
+                            result.append(func(series_slices))
+                    elif window_type is window_types.ROW_UNBOUNDED_FOLLOWING:
+                        # row unbounded following window
+                        window_start = window.lower_boundary
+                        for j in range(rows_count):
+                            start = max(j + window_start, 0)
+                            series_slices = [s.iloc[start: rows_count] for s in series]
+                            result.append(func(series_slices))
+                    else:
+                        # row sliding window
+                        window_start = window.lower_boundary
+                        window_end = window.upper_boundary
+                        for j in range(rows_count):
+                            start = max(j + window_start, 0)
+                            end = min(j + window_end + 1, rows_count)
+                            series_slices = [s.iloc[start: end] for s in series]
+                            result.append(func(series_slices))
+                results.append(pd.Series(result))
+            yield results
+
+
 @bundle_processor.BeamTransformFactory.register_urn(
     operation_utils.SCALAR_FUNCTION_URN, flink_fn_execution_pb2.UserDefinedFunctions)
 def create_scalar_function(factory, transform_id, transform_proto, parameter, consumers):
@@ -215,6 +319,15 @@ def create_data_stream_function(factory, transform_id, transform_proto, paramete
 def create_pandas_aggregate_function(factory, transform_id, transform_proto, parameter, consumers):
     return _create_user_defined_function_operation(
         factory, transform_proto, consumers, parameter, PandasAggregateFunctionOperation)
+
+@bundle_processor.BeamTransformFactory.register_urn(
+    operation_utils.PANDAS_BATCH_OVER_WINDOW_AGGREGATE_FUNCTION_URN,
+    flink_fn_execution_pb2.UserDefinedFunctions)
+def create_pandas_over_window_aggregate_function(
+        factory, transform_id, transform_proto, parameter, consumers):
+    return _create_user_defined_function_operation(
+        factory, transform_proto, consumers, parameter,
+        PandasBatchOverWindowAggregateFunctionOperation)
 
 def _create_user_defined_function_operation(factory, transform_proto, consumers, udfs_proto,
                                             operation_cls):

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -199,8 +199,8 @@ cdef class PandasBatchOverWindowAggregateFunctionOperation(BeamStatelessFunction
         super(PandasBatchOverWindowAggregateFunctionOperation, self).__init__(
             name, spec, counter_factory, sampler, consumers)
         self.windows = [window for window in self.spec.serialized_fn.windows]
-        self.window_to_bounded_range_window_index = [-1 for _ in range(len(self.windows))]
-        self.window_is_bounded_range_type = []
+        self.bounded_range_window_index = [-1 for _ in range(len(self.windows))]
+        self.is_bounded_range_window = []
         window_types = flink_fn_execution_pb2.OverWindow
         bounded_range_window_nums = 0
         for i, window in enumerate(self.windows):
@@ -208,11 +208,11 @@ cdef class PandasBatchOverWindowAggregateFunctionOperation(BeamStatelessFunction
             if (window_type is window_types.RANGE_UNBOUNDED_PRECEDING) or (
                     window_type is window_types.RANGE_UNBOUNDED_FOLLOWING) or (
                     window_type is window_types.RANGE_SLIDING):
-                self.window_to_bounded_range_window_index[i] = bounded_range_window_nums
-                self.window_is_bounded_range_type.append(True)
+                self.bounded_range_window_index[i] = bounded_range_window_nums
+                self.is_bounded_range_window.append(True)
                 bounded_range_window_nums += 1
             else:
-                self.window_is_bounded_range_type.append(False)
+                self.is_bounded_range_window.append(False)
 
     def generate_func(self, udfs):
         user_defined_funcs = []
@@ -224,14 +224,14 @@ cdef class PandasBatchOverWindowAggregateFunctionOperation(BeamStatelessFunction
             user_defined_funcs.extend(user_defined_func)
             self.window_indexes.append(window_index)
             self.mapper.append(eval('lambda value: %s' % pandas_agg_function, variable_dict))
-        return self.wrap_over_window_function, user_defined_funcs
+        return self.wrapped_over_window_function, user_defined_funcs
 
-    def wrap_over_window_function(self, it):
+    def wrapped_over_window_function(self, it):
         import pandas as pd
-        window_types = flink_fn_execution_pb2.OverWindow
+        OverWindow = flink_fn_execution_pb2.OverWindow
         for boundaries_series in it:
-            series = boundaries_series[len(boundaries_series) - 1]
-            rows_count = len(series[0])
+            input_series = boundaries_series[len(boundaries_series) - 1]
+            input_cnt = len(input_series[0])
             results = []
             # loop every agg func
             for i in range(len(self.window_indexes)):
@@ -240,57 +240,57 @@ cdef class PandasBatchOverWindowAggregateFunctionOperation(BeamStatelessFunction
                 window_type = window.window_type
                 func = self.mapper[i]
                 result = []
-                if self.window_is_bounded_range_type[window_index]:
+                if self.is_bounded_range_window[window_index]:
                     window_boundaries = boundaries_series[
-                        self.window_to_bounded_range_window_index[window_index]]
-                    if window_type is window_types.RANGE_UNBOUNDED_PRECEDING:
+                        self.bounded_range_window_index[window_index]]
+                    if window_type is OverWindow.RANGE_UNBOUNDED_PRECEDING:
                         # range unbounded preceding window
-                        for j in range(rows_count):
+                        for j in range(input_cnt):
                             end = window_boundaries[j]
-                            series_slices = [s.iloc[:end] for s in series]
+                            series_slices = [s.iloc[:end] for s in input_series]
                             result.append(func(series_slices))
-                    elif window_type is window_types.RANGE_UNBOUNDED_FOLLOWING:
+                    elif window_type is OverWindow.RANGE_UNBOUNDED_FOLLOWING:
                         # range unbounded following window
-                        for j in range(rows_count):
+                        for j in range(input_cnt):
                             start = window_boundaries[j]
-                            series_slices = [s.iloc[start:] for s in series]
+                            series_slices = [s.iloc[start:] for s in input_series]
                             result.append(func(series_slices))
                     else:
                         # range sliding window
-                        for j in range(rows_count):
+                        for j in range(input_cnt):
                             start = window_boundaries[j * 2]
                             end = window_boundaries[j * 2 + 1]
-                            series_slices = [s.iloc[start:end] for s in series]
+                            series_slices = [s.iloc[start:end] for s in input_series]
                             result.append(func(series_slices))
                 else:
                     # unbounded range window or unbounded row window
-                    if (window_type is window_types.RANGE_UNBOUNDED) or (
-                            window_type is window_types.ROW_UNBOUNDED):
-                        series_slices = [s.iloc[:] for s in series]
+                    if (window_type is OverWindow.RANGE_UNBOUNDED) or (
+                            window_type is OverWindow.ROW_UNBOUNDED):
+                        series_slices = [s.iloc[:] for s in input_series]
                         func_result = func(series_slices)
-                        result = [func_result for _ in range(rows_count)]
-                    elif window_type is window_types.ROW_UNBOUNDED_PRECEDING:
+                        result = [func_result for _ in range(input_cnt)]
+                    elif window_type is OverWindow.ROW_UNBOUNDED_PRECEDING:
                         # row unbounded preceding window
                         window_end = window.upper_boundary
-                        for j in range(rows_count):
-                            end = min(j + window_end + 1, rows_count)
-                            series_slices = [s.iloc[: end] for s in series]
+                        for j in range(input_cnt):
+                            end = min(j + window_end + 1, input_cnt)
+                            series_slices = [s.iloc[: end] for s in input_series]
                             result.append(func(series_slices))
-                    elif window_type is window_types.ROW_UNBOUNDED_FOLLOWING:
+                    elif window_type is OverWindow.ROW_UNBOUNDED_FOLLOWING:
                         # row unbounded following window
                         window_start = window.lower_boundary
-                        for j in range(rows_count):
+                        for j in range(input_cnt):
                             start = max(j + window_start, 0)
-                            series_slices = [s.iloc[start: rows_count] for s in series]
+                            series_slices = [s.iloc[start: input_cnt] for s in input_series]
                             result.append(func(series_slices))
                     else:
                         # row sliding window
                         window_start = window.lower_boundary
                         window_end = window.upper_boundary
-                        for j in range(rows_count):
+                        for j in range(input_cnt):
                             start = max(j + window_start, 0)
-                            end = min(j + window_end + 1, rows_count)
-                            series_slices = [s.iloc[start: end] for s in series]
+                            end = min(j + window_end + 1, input_cnt)
+                            series_slices = [s.iloc[start: end] for s in input_series]
                             result.append(func(series_slices))
                 results.append(pd.Series(result))
             yield results

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -172,6 +172,113 @@ class PandasAggregateFunctionOperation(StatelessFunctionOperation):
         return lambda it: map(mapper, it), user_defined_funcs
 
 
+class PandasBatchOverWindowAggregateFunctionOperation(StatelessFunctionOperation):
+    def __init__(self, name, spec, counter_factory, sampler, consumers):
+        super(PandasBatchOverWindowAggregateFunctionOperation, self).__init__(
+            name, spec, counter_factory, sampler, consumers)
+        self.windows = [window for window in self.spec.serialized_fn.windows]
+        # Set a serial number for each over window to indicate which bounded range over window
+        # it is.
+        self.window_to_bounded_range_window_index = [-1 for _ in range(len(self.windows))]
+        # Whether the specified position window is a bounded range window.
+        self.window_is_bounded_range_type = []
+        window_types = flink_fn_execution_pb2.OverWindow
+
+        bounded_range_window_nums = 0
+        for i, window in enumerate(self.windows):
+            window_type = window.window_type
+            if (window_type is window_types.RANGE_UNBOUNDED_PRECEDING) or (
+                    window_type is window_types.RANGE_UNBOUNDED_FOLLOWING) or (
+                    window_type is window_types.RANGE_SLIDING):
+                self.window_to_bounded_range_window_index[i] = bounded_range_window_nums
+                self.window_is_bounded_range_type.append(True)
+                bounded_range_window_nums += 1
+            else:
+                self.window_is_bounded_range_type.append(False)
+
+    def generate_func(self, udfs):
+        user_defined_funcs = []
+        self.window_indexes = []
+        self.mapper = []
+        for udf in udfs:
+            pandas_agg_function, variable_dict, user_defined_func, window_index = \
+                operation_utils.extract_over_window_user_defined_function(udf)
+            user_defined_funcs.extend(user_defined_func)
+            self.window_indexes.append(window_index)
+            self.mapper.append(eval('lambda value: %s' % pandas_agg_function, variable_dict))
+        return self.wrap_over_window_function, user_defined_funcs
+
+    def wrap_over_window_function(self, it):
+        import pandas as pd
+        window_types = flink_fn_execution_pb2.OverWindow
+        for boundaries_series in it:
+            series = boundaries_series[-1]
+            # the row number of the arrow format data
+            rows_count = len(series[0])
+            results = []
+            # loop every agg func
+            for i in range(len(self.window_indexes)):
+                window_index = self.window_indexes[i]
+                # the over window which the agg function belongs to
+                window = self.windows[window_index]
+                window_type = window.window_type
+                func = self.mapper[i]
+                result = []
+                if self.window_is_bounded_range_type[window_index]:
+                    window_boundaries = boundaries_series[
+                        self.window_to_bounded_range_window_index[window_index]]
+                    if window_type is window_types.RANGE_UNBOUNDED_PRECEDING:
+                        # range unbounded preceding window
+                        for j in range(rows_count):
+                            end = window_boundaries[j]
+                            series_slices = [s.iloc[:end] for s in series]
+                            result.append(func(series_slices))
+                    elif window_type is window_types.RANGE_UNBOUNDED_FOLLOWING:
+                        # range unbounded following window
+                        for j in range(rows_count):
+                            start = window_boundaries[j]
+                            series_slices = [s.iloc[start:] for s in series]
+                            result.append(func(series_slices))
+                    else:
+                        # range sliding window
+                        for j in range(rows_count):
+                            start = window_boundaries[j * 2]
+                            end = window_boundaries[j * 2 + 1]
+                            series_slices = [s.iloc[start:end] for s in series]
+                            result.append(func(series_slices))
+                else:
+                    # unbounded range window or unbounded row window
+                    if (window_type is window_types.RANGE_UNBOUNDED) or (
+                            window_type is window_types.ROW_UNBOUNDED):
+                        series_slices = [s.iloc[:] for s in series]
+                        func_result = func(series_slices)
+                        result = [func_result for _ in range(rows_count)]
+                    elif window_type is window_types.ROW_UNBOUNDED_PRECEDING:
+                        # row unbounded preceding window
+                        window_end = window.upper_boundary
+                        for j in range(rows_count):
+                            end = min(j + window_end + 1, rows_count)
+                            series_slices = [s.iloc[: end] for s in series]
+                            result.append(func(series_slices))
+                    elif window_type is window_types.ROW_UNBOUNDED_FOLLOWING:
+                        # row unbounded following window
+                        window_start = window.lower_boundary
+                        for j in range(rows_count):
+                            start = max(j + window_start, 0)
+                            series_slices = [s.iloc[start: rows_count] for s in series]
+                            result.append(func(series_slices))
+                    else:
+                        # row sliding window
+                        window_start = window.lower_boundary
+                        window_end = window.upper_boundary
+                        for j in range(rows_count):
+                            start = max(j + window_start, 0)
+                            end = min(j + window_end + 1, rows_count)
+                            series_slices = [s.iloc[start: end] for s in series]
+                            result.append(func(series_slices))
+                results.append(pd.Series(result))
+            yield results
+
 @bundle_processor.BeamTransformFactory.register_urn(
     operation_utils.SCALAR_FUNCTION_URN, flink_fn_execution_pb2.UserDefinedFunctions)
 def create_scalar_function(factory, transform_id, transform_proto, parameter, consumers):
@@ -199,6 +306,16 @@ def create_data_stream_function(factory, transform_id, transform_proto, paramete
 def create_pandas_aggregate_function(factory, transform_id, transform_proto, parameter, consumers):
     return _create_user_defined_function_operation(
         factory, transform_proto, consumers, parameter, PandasAggregateFunctionOperation)
+
+
+@bundle_processor.BeamTransformFactory.register_urn(
+    operation_utils.PANDAS_BATCH_OVER_WINDOW_AGGREGATE_FUNCTION_URN,
+    flink_fn_execution_pb2.UserDefinedFunctions)
+def create_pandas_over_window_aggregate_function(
+        factory, transform_id, transform_proto, parameter, consumers):
+    return _create_user_defined_function_operation(
+        factory, transform_proto, consumers, parameter,
+        PandasBatchOverWindowAggregateFunctionOperation)
 
 
 def _create_user_defined_function_operation(factory, transform_proto, consumers, udfs_proto,

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -40,6 +40,7 @@ FLINK_SCALAR_FUNCTION_SCHEMA_ARROW_CODER_URN = "flink:coder:schema:scalar_functi
 FLINK_SCHEMA_ARROW_CODER_URN = "flink:coder:schema:arrow:v1"
 FLINK_MAP_FUNCTION_DATA_STREAM_CODER_URN = "flink:coder:datastream:map_function:v1"
 FLINK_FLAT_MAP_FUNCTION_DATA_STREAM_CODER_URN = "flink:coder:datastream:flatmap_function:v1"
+FLINK_OVER_WINDOW_ARROW_CODER_URN = "flink:coder:schema:batch_over_window:arrow:v1"
 
 
 class BaseCoder(ABC):

--- a/flink-python/pyflink/fn_execution/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/operation_utils.py
@@ -29,6 +29,8 @@ SCALAR_FUNCTION_URN = "flink:transform:scalar_function:v1"
 TABLE_FUNCTION_URN = "flink:transform:table_function:v1"
 DATA_STREAM_STATELESS_FUNCTION_URN = "flink:transform:datastream_stateless_function:v1"
 PANDAS_AGGREGATE_FUNCTION_URN = "flink:transform:aggregate_function:arrow:v1"
+PANDAS_BATCH_OVER_WINDOW_AGGREGATE_FUNCTION_URN = \
+    "flink:transform:batch_over_window_aggregate_function:arrow:v1"
 
 _func_num = 0
 _constant_num = 0
@@ -37,6 +39,11 @@ _constant_num = 0
 def wrap_pandas_result(it):
     import pandas as pd
     return [pd.Series([result]) for result in it]
+
+
+def extract_over_window_user_defined_function(user_defined_function_proto):
+    window_index = user_defined_function_proto.window_index
+    return (*extract_user_defined_function(user_defined_function_proto, True), window_index)
 
 
 def extract_user_defined_function(user_defined_function_proto, pandas_udaf=False)\

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -189,6 +189,75 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
                             "3,2018-03-11 03:00:00.0,2018-03-11 04:00:00.0,2.0,7",
                             "3,2018-03-11 02:30:00.0,2018-03-11 03:30:00.0,2.0,7"])
 
+    def test_over_window_aggregate_function(self):
+        import datetime
+        t = self.t_env.from_elements(
+            [
+                (1, 2, 3, datetime.datetime(2018, 3, 11, 3, 10, 0, 0)),
+                (3, 2, 1, datetime.datetime(2018, 3, 11, 3, 10, 0, 0)),
+                (2, 1, 2, datetime.datetime(2018, 3, 11, 3, 10, 0, 0)),
+                (1, 3, 1, datetime.datetime(2018, 3, 11, 3, 10, 0, 0)),
+                (1, 8, 5, datetime.datetime(2018, 3, 11, 4, 20, 0, 0)),
+                (2, 3, 6, datetime.datetime(2018, 3, 11, 3, 30, 0, 0))
+            ],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT()),
+                 DataTypes.FIELD("rowtime", DataTypes.TIMESTAMP(3))]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+            [DataTypes.TINYINT(), DataTypes.FLOAT(), DataTypes.INT(), DataTypes.FLOAT(),
+             DataTypes.FLOAT(), DataTypes.FLOAT(), DataTypes.FLOAT(), DataTypes.FLOAT(),
+             DataTypes.FLOAT(), DataTypes.FLOAT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        self.t_env.create_temporary_system_function("mean_udaf", mean_udaf)
+        self.t_env.register_function("max_add", udaf(MaxAdd(),
+                                                     result_type=DataTypes.INT(),
+                                                     func_type="pandas"))
+        self.t_env.register_table("T", t)
+        self.t_env.execute_sql("""
+            insert into Results
+            select a,
+             mean_udaf(b)
+             over (PARTITION BY a ORDER BY rowtime
+             ROWS BETWEEN UNBOUNDED preceding AND UNBOUNDED FOLLOWING),
+             max_add(b, c)
+             over (PARTITION BY a ORDER BY rowtime
+             ROWS BETWEEN UNBOUNDED preceding AND 0 FOLLOWING),
+             mean_udaf(b)
+             over (PARTITION BY a ORDER BY rowtime
+             ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING),
+             mean_udaf(c)
+             over (PARTITION BY a ORDER BY rowtime
+             ROWS BETWEEN 1 PRECEDING AND 0 FOLLOWING),
+             mean_udaf(c)
+             over (PARTITION BY a ORDER BY rowtime
+             RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+             mean_udaf(b)
+             over (PARTITION BY a ORDER BY rowtime
+             RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+             mean_udaf(b)
+             over (PARTITION BY a ORDER BY rowtime
+             RANGE BETWEEN INTERVAL '20' MINUTE PRECEDING AND UNBOUNDED FOLLOWING),
+             mean_udaf(c)
+             over (PARTITION BY a ORDER BY rowtime
+             RANGE BETWEEN INTERVAL '20' MINUTE PRECEDING AND UNBOUNDED FOLLOWING),
+             mean_udaf(c)
+             over (PARTITION BY a ORDER BY rowtime
+             RANGE BETWEEN INTERVAL '20' MINUTE PRECEDING AND CURRENT ROW)
+            from T
+        """).wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual,
+                           ["1,4.3333335,5,4.3333335,3.0,3.0,2.5,4.3333335,3.0,2.0",
+                            "1,4.3333335,13,5.5,3.0,3.0,4.3333335,8.0,5.0,5.0",
+                            "1,4.3333335,6,4.3333335,2.0,3.0,2.5,4.3333335,3.0,2.0",
+                            "2,2.0,9,2.0,4.0,4.0,2.0,2.0,4.0,4.0",
+                            "2,2.0,3,2.0,2.0,4.0,1.0,2.0,4.0,2.0",
+                            "3,2.0,3,2.0,1.0,1.0,2.0,2.0,1.0,1.0"])
+
 
 @udaf(result_type=DataTypes.FLOAT(), func_type="pandas")
 def mean_udaf(v):

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
@@ -180,6 +180,10 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
 			ListIterator<RowData> iter = forwardedInputQueue.listIterator(lastKeyDataStartPos);
 			int[] lowerBoundaryPos = new int[boundedRangeWindowIndex.size()];
 			int[] upperBoundaryPos = new int[boundedRangeWindowIndex.size()];
+			for (int i = 0; i < lowerBoundaryPos.length; i++) {
+				lowerBoundaryPos[i] = lastKeyDataStartPos;
+				upperBoundaryPos[i] = lastKeyDataStartPos;
+			}
 			while (iter.hasNext()) {
 				RowData curData = iter.next();
 				// loop every bounded range window
@@ -195,7 +199,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
 							curLowerBoundaryPos += 1;
 						}
 						lowerBoundaryPos[j] = curLowerBoundaryPos;
-						curWindowBoundary.add(curLowerBoundaryPos);
+						curWindowBoundary.add(curLowerBoundaryPos - lastKeyDataStartPos);
 					}
 					// bounded following
 					if (upperBoundary[windowPos] != Long.MAX_VALUE) {
@@ -206,7 +210,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
 							curUpperBoundaryPos += 1;
 						}
 						upperBoundaryPos[j] = curUpperBoundaryPos;
-						curWindowBoundary.add(curUpperBoundaryPos);
+						curWindowBoundary.add(curUpperBoundaryPos - lastKeyDataStartPos);
 					}
 				}
 			}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregate.scala
@@ -20,28 +20,22 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.MemorySize
-import org.apache.flink.runtime.operators.DamBehavior
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.functions.UserDefinedFunction
-import org.apache.flink.table.planner.CalcitePair
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext
 import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator
 import org.apache.flink.table.planner.codegen.over.{MultiFieldRangeBoundComparatorCodeGenerator, RangeBoundComparatorCodeGenerator}
 import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator
 import org.apache.flink.table.planner.delegation.BatchPlanner
-import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
-import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
-import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
-import org.apache.flink.table.planner.plan.nodes.physical.batch.OverWindowMode.OverWindowMode
-import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecJoinRuleBase
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 import org.apache.flink.table.planner.plan.utils.AggregateUtil.transformToBatchAggregateInfoList
 import org.apache.flink.table.planner.plan.utils.OverAggregateUtil.getLongBoundary
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, OverAggregateUtil, RelExplainUtil}
+import org.apache.flink.table.planner.plan.utils.OverAggregateUtil
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator
 import org.apache.flink.table.runtime.operators.over.frame.OffsetOverFrame.CalcOffsetFunc
 import org.apache.flink.table.runtime.operators.over.frame._
@@ -50,22 +44,14 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.LogicalTypeRoot.{BIGINT, INTEGER, SMALLINT}
 
 import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelDistribution.Type._
 import org.apache.calcite.rel._
 import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.core.Window.Group
 import org.apache.calcite.rel.core.{AggregateCall, Window}
-import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rex.RexWindowBound
 import org.apache.calcite.sql.SqlKind
-import org.apache.calcite.sql.fun.SqlLeadLagAggFunction
 import org.apache.calcite.tools.RelBuilder
-import org.apache.calcite.util.ImmutableIntList
-
-import java.util
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable.ArrayBuffer
 
 /**
   * Batch physical RelNode for sort-based over [[Window]] aggregate.
@@ -84,13 +70,19 @@ class BatchExecOverAggregate(
     windowGroupToAggCallToAggFunction: Seq[
       (Window.Group, Seq[(AggregateCall, UserDefinedFunction)])],
     logicWindow: Window)
-  extends SingleRel(cluster, traitSet, inputRel)
-  with BatchPhysicalRel
-  with BatchExecNode[RowData] {
-
-  private lazy val modeToGroupToAggCallToAggFunction:
-    Seq[(OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)])] =
-    splitOutOffsetOrInsensitiveGroup()
+  extends BatchExecOverAggregateBase(
+    cluster,
+    relBuilder,
+    traitSet,
+    inputRel,
+    outputRowType,
+    inputRowType,
+    grouping,
+    orderKeyIndices,
+    orders,
+    nullIsLasts,
+    windowGroupToAggCallToAggFunction,
+    logicWindow) {
 
   lazy val needBufferData: Boolean = {
     modeToGroupToAggCallToAggFunction.exists {
@@ -105,23 +97,6 @@ class BatchExecOverAggregate(
         }
     }
   }
-
-  private val constants = logicWindow.constants
-  private val inputTypeWithConstants = {
-    val constantTypes = constants.map(c => FlinkTypeFactory.toLogicalType(c.getType))
-    val inputTypeNamesWithConstants =
-      inputType.getFieldNames ++ constants.indices.map(i => "TMP" + i)
-    val inputTypesWithConstants = inputType.getChildren ++ constantTypes
-    cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
-        .buildRelNodeRowType(inputTypeNamesWithConstants, inputTypesWithConstants)
-  }
-
-  lazy val aggregateCalls: Seq[AggregateCall] =
-    windowGroupToAggCallToAggFunction.flatMap(_._2).map(_._1)
-
-  private lazy val inputType = FlinkTypeFactory.toLogicalRowType(inputRowType)
-
-  def getGrouping: Array[Int] = grouping
 
   override def deriveRowType: RelDataType = outputRowType
 
@@ -139,226 +114,6 @@ class BatchExecOverAggregate(
       nullIsLasts,
       windowGroupToAggCallToAggFunction,
       logicWindow)
-  }
-
-  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
-    // sort is done in the last sort operator.
-    val inputRows = mq.getRowCount(getInput())
-    if (inputRows == null) {
-      return null
-    }
-    val cpu = FlinkCost.FUNC_CPU_COST * inputRows *
-      modeToGroupToAggCallToAggFunction.flatMap(_._3).size
-    val averageRowSize: Double = mq.getAverageRowSize(this)
-    val memCost = averageRowSize
-    val costFactory = planner.getCostFactory.asInstanceOf[FlinkCostFactory]
-    costFactory.makeCost(mq.getRowCount(this), cpu, 0, 0, memCost)
-  }
-
-  override def explainTerms(pw: RelWriter): RelWriter = {
-    val partitionKeys: Array[Int] = grouping
-    val groups = modeToGroupToAggCallToAggFunction.map(_._2)
-    val writer = super.explainTerms(pw)
-      .itemIf("partitionBy", RelExplainUtil.fieldToString(partitionKeys, inputRowType),
-        partitionKeys.nonEmpty)
-      .itemIf("orderBy",
-        RelExplainUtil.collationToString(groups.head.orderKeys, inputRowType),
-        orderKeyIndices.nonEmpty)
-
-    var offset = inputRowType.getFieldCount
-    groups.zipWithIndex.foreach { case (group, index) =>
-      val namedAggregates = generateNamedAggregates(group)
-      val select = RelExplainUtil.overAggregationToString(
-        inputRowType,
-        outputRowType,
-        constants,
-        namedAggregates,
-        outputInputName = false,
-        rowTypeOffset = offset)
-      offset += namedAggregates.size
-      val windowRange = RelExplainUtil.windowRangeToString(logicWindow, group)
-      writer.item("window#" + index, select + windowRange)
-    }
-    writer.item("select", getRowType.getFieldNames.mkString(", "))
-  }
-
-  private def generateNamedAggregates(
-      groupWindow: Group): Seq[CalcitePair[AggregateCall, String]] = {
-    val aggregateCalls = groupWindow.getAggregateCalls(logicWindow)
-    for (i <- 0 until aggregateCalls.size())
-      yield new CalcitePair[AggregateCall, String](aggregateCalls.get(i), "windowAgg$" + i)
-  }
-
-  private def splitOutOffsetOrInsensitiveGroup()
-  : Seq[(OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)])] = {
-
-    def compareTo(o1: Window.RexWinAggCall, o2: Window.RexWinAggCall): Boolean = {
-      val allowsFraming1 = o1.getOperator.allowsFraming
-      val allowsFraming2 = o2.getOperator.allowsFraming
-      if (!allowsFraming1 && !allowsFraming2) {
-        o1.getOperator.getClass == o2.getOperator.getClass
-      } else {
-        allowsFraming1 == allowsFraming2
-      }
-    }
-
-    def inferGroupMode(group: Window.Group): OverWindowMode = {
-      val aggCall = group.aggCalls(0)
-      if (aggCall.getOperator.allowsFraming()) {
-        if (group.isRows) OverWindowMode.Row else OverWindowMode.Range
-      } else {
-        if (aggCall.getOperator.isInstanceOf[SqlLeadLagAggFunction]) {
-          OverWindowMode.Offset
-        } else {
-          OverWindowMode.Insensitive
-        }
-      }
-    }
-
-    def createNewGroup(
-        group: Window.Group,
-        aggCallsBuffer: Seq[(Window.RexWinAggCall, (AggregateCall, UserDefinedFunction))])
-    : (OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)]) = {
-      val newGroup = new Window.Group(
-        group.keys,
-        group.isRows,
-        group.lowerBound,
-        group.upperBound,
-        group.orderKeys,
-        aggCallsBuffer.map(_._1))
-      val mode = inferGroupMode(newGroup)
-      (mode, group, aggCallsBuffer.map(_._2))
-    }
-
-    val windowGroupInfo =
-      ArrayBuffer[(OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)])]()
-    windowGroupToAggCallToAggFunction.foreach { case (group, aggCallToAggFunction) =>
-      var lastAggCall: Window.RexWinAggCall = null
-      val aggCallsBuffer =
-        ArrayBuffer[(Window.RexWinAggCall, (AggregateCall, UserDefinedFunction))]()
-      group.aggCalls.zip(aggCallToAggFunction).foreach { case (aggCall, aggFunction) =>
-        if (lastAggCall != null && !compareTo(lastAggCall, aggCall)) {
-          windowGroupInfo.add(createNewGroup(group, aggCallsBuffer))
-          aggCallsBuffer.clear()
-        }
-        aggCallsBuffer.add((aggCall, aggFunction))
-        lastAggCall = aggCall
-      }
-      if (aggCallsBuffer.nonEmpty) {
-        windowGroupInfo.add(createNewGroup(group, aggCallsBuffer))
-        aggCallsBuffer.clear()
-      }
-    }
-    windowGroupInfo
-  }
-
-  override def satisfyTraits(requiredTraitSet: RelTraitSet): Option[RelNode] = {
-    val requiredDistribution = requiredTraitSet.getTrait(FlinkRelDistributionTraitDef.INSTANCE)
-    val requiredCollation = requiredTraitSet.getTrait(RelCollationTraitDef.INSTANCE)
-    if (requiredDistribution.getType == ANY && requiredCollation.getFieldCollations.isEmpty) {
-      return None
-    }
-
-    val selfProvidedTraitSet = inferProvidedTraitSet()
-    if (selfProvidedTraitSet.satisfies(requiredTraitSet)) {
-      // Current node can satisfy the requiredTraitSet,return the current node with ProvidedTraitSet
-      return Some(copy(selfProvidedTraitSet, Seq(getInput)))
-    }
-
-    val inputFieldCnt = getInput.getRowType.getFieldCount
-    val canSatisfy = if (requiredDistribution.getType == ANY) {
-      true
-    } else {
-      if (!grouping.isEmpty) {
-        if (requiredDistribution.requireStrict) {
-          requiredDistribution.getKeys == ImmutableIntList.of(grouping: _*)
-        } else {
-          val isAllFieldsFromInput = requiredDistribution.getKeys.forall(_ < inputFieldCnt)
-          if (isAllFieldsFromInput) {
-            val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
-            if (tableConfig.getConfiguration.getBoolean(
-              BatchExecJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)) {
-              ImmutableIntList.of(grouping: _*).containsAll(requiredDistribution.getKeys)
-            } else {
-              requiredDistribution.getKeys == ImmutableIntList.of(grouping: _*)
-            }
-          } else {
-            // If requirement distribution keys are not all comes from input directly,
-            // cannot satisfy requirement distribution and collations.
-            false
-          }
-        }
-      } else {
-        requiredDistribution.getType == SINGLETON
-      }
-    }
-    // If OverAggregate can provide distribution, but it's traits cannot satisfy required
-    // distribution, cannot push down distribution and collation requirement (because later
-    // shuffle will destroy previous collation.
-    if (!canSatisfy) {
-      return None
-    }
-
-    var inputRequiredTraits = getInput.getTraitSet
-    var providedTraits = selfProvidedTraitSet
-    val providedCollation = selfProvidedTraitSet.getTrait(RelCollationTraitDef.INSTANCE)
-    if (!requiredDistribution.isTop) {
-      inputRequiredTraits = inputRequiredTraits.replace(requiredDistribution)
-      providedTraits = providedTraits.replace(requiredDistribution)
-    }
-
-    if (providedCollation.satisfies(requiredCollation)) {
-      // the providedCollation can satisfy the requirement,
-      // so don't push down the sort into it's input.
-    } else if (providedCollation.getFieldCollations.isEmpty &&
-      requiredCollation.getFieldCollations.nonEmpty) {
-      // If OverAgg cannot provide collation itself, try to push down collation requirements into
-      // it's input if collation fields all come from input node.
-      val canPushDownCollation = requiredCollation.getFieldCollations
-          .forall(_.getFieldIndex < inputFieldCnt)
-      if (canPushDownCollation) {
-        inputRequiredTraits = inputRequiredTraits.replace(requiredCollation)
-        providedTraits = providedTraits.replace(requiredCollation)
-      }
-    } else {
-      // Don't push down the sort into it's input,
-      // due to the provided collation will destroy the input's provided collation.
-    }
-    val newInput = RelOptRule.convert(getInput, inputRequiredTraits)
-    Some(copy(providedTraits, Seq(newInput)))
-  }
-
-  private def inferProvidedTraitSet(): RelTraitSet = {
-    var selfProvidedTraitSet = getTraitSet
-    // provided distribution
-    val providedDistribution = if (grouping.nonEmpty) {
-      FlinkRelDistribution.hash(grouping.map(Integer.valueOf).toList, requireStrict = false)
-    } else {
-      FlinkRelDistribution.SINGLETON
-    }
-    selfProvidedTraitSet = selfProvidedTraitSet.replace(providedDistribution)
-    // provided collation
-    val firstGroup = windowGroupToAggCallToAggFunction.head._1
-    if (OverAggregateUtil.needCollationTrait(logicWindow, firstGroup)) {
-      val collation = OverAggregateUtil.createCollation(firstGroup)
-      if (!collation.equals(RelCollations.EMPTY)) {
-        selfProvidedTraitSet = selfProvidedTraitSet.replace(collation)
-      }
-    }
-    selfProvidedTraitSet
-  }
-
-  //~ ExecNode methods -----------------------------------------------------------
-
-  override def getDamBehavior = DamBehavior.PIPELINED
-
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
-
-  override def replaceInputNode(
-      ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
-    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 
   override protected def translateToPlanInternal(
@@ -428,18 +183,6 @@ class BatchExecOverAggregate(
   }
 
   def createOverWindowFrames(config: TableConfig): Array[OverWindowFrame] = {
-
-    def isUnboundedWindow(group: Window.Group) =
-      group.lowerBound.isUnbounded && group.upperBound.isUnbounded
-
-    def isUnboundedPrecedingWindow(group: Window.Group) =
-      group.lowerBound.isUnbounded && !group.upperBound.isUnbounded
-
-    def isUnboundedFollowingWindow(group: Window.Group) =
-      !group.lowerBound.isUnbounded && group.upperBound.isUnbounded
-
-    def isSlidingWindow(group: Window.Group) =
-      !group.lowerBound.isUnbounded && !group.upperBound.isUnbounded
 
     modeToGroupToAggCallToAggFunction.flatMap { case (mode, windowGroup, aggCallToAggFunction) =>
       mode match {
@@ -621,13 +364,4 @@ class BatchExecOverAggregate(
         isLowerBound).generateBoundComparator("MultiFieldRangeBoundComparator")
     }
   }
-}
-
-object OverWindowMode extends Enumeration {
-  type OverWindowMode = Value
-  val Row: OverWindowMode = Value
-  val Range: OverWindowMode = Value
-  //Then it is a special kind of Window when the agg is LEAD&LAG.
-  val Offset: OverWindowMode = Value
-  val Insensitive: OverWindowMode = Value
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregateBase.scala
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.batch
+
+import java.util
+
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.planner.CalcitePair
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.delegation.BatchPlanner
+import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
+import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
+import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.OverWindowMode.OverWindowMode
+import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecJoinRuleBase
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, OverAggregateUtil, RelExplainUtil}
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelDistribution.Type._
+import org.apache.calcite.rel._
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Window.Group
+import org.apache.calcite.rel.core.{AggregateCall, Window}
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.rex.RexLiteral
+import org.apache.calcite.sql.fun.SqlLeadLagAggFunction
+import org.apache.calcite.tools.RelBuilder
+import org.apache.calcite.util.ImmutableIntList
+
+import com.google.common.collect.ImmutableList
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Batch physical RelNode for sort-based over [[Window]] aggregate.
+  */
+abstract class BatchExecOverAggregateBase(
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    orderKeyIndices: Array[Int],
+    orders: Array[Boolean],
+    nullIsLasts: Array[Boolean],
+    windowGroupToAggCallToAggFunction: Seq[
+      (Window.Group, Seq[(AggregateCall, UserDefinedFunction)])],
+    logicWindow: Window)
+  extends SingleRel(cluster, traitSet, inputRel)
+  with BatchPhysicalRel
+  with BatchExecNode[RowData] {
+
+  protected lazy val modeToGroupToAggCallToAggFunction:
+    Seq[(OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)])] =
+    splitOutOffsetOrInsensitiveGroup()
+
+  protected val constants: ImmutableList[RexLiteral] = logicWindow.constants
+  protected val inputTypeWithConstants: RelDataType = {
+    val constantTypes = constants.map(c => FlinkTypeFactory.toLogicalType(c.getType))
+    val inputTypeNamesWithConstants =
+      inputType.getFieldNames ++ constants.indices.map(i => "TMP" + i)
+    val inputTypesWithConstants = inputType.getChildren ++ constantTypes
+    cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+      .buildRelNodeRowType(inputTypeNamesWithConstants, inputTypesWithConstants)
+  }
+
+  lazy val aggregateCalls: Seq[AggregateCall] =
+    windowGroupToAggCallToAggFunction.flatMap(_._2).map(_._1)
+
+  protected lazy val inputType = FlinkTypeFactory.toLogicalRowType(inputRowType)
+
+  protected def isUnboundedWindow(group: Window.Group) =
+    group.lowerBound.isUnbounded && group.upperBound.isUnbounded
+
+  protected def isUnboundedPrecedingWindow(group: Window.Group) =
+    group.lowerBound.isUnbounded && !group.upperBound.isUnbounded
+
+  protected def isUnboundedFollowingWindow(group: Window.Group) =
+    !group.lowerBound.isUnbounded && group.upperBound.isUnbounded
+
+  protected def isSlidingWindow(group: Window.Group) =
+    !group.lowerBound.isUnbounded && !group.upperBound.isUnbounded
+
+  def getGrouping: Array[Int] = grouping
+
+  override def deriveRowType: RelDataType = outputRowType
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    // sort is done in the last sort operator.
+    val inputRows = mq.getRowCount(getInput())
+    if (inputRows == null) {
+      return null
+    }
+    val cpu = FlinkCost.FUNC_CPU_COST * inputRows *
+      modeToGroupToAggCallToAggFunction.flatMap(_._3).size
+    val averageRowSize: Double = mq.getAverageRowSize(this)
+    val memCost = averageRowSize
+    val costFactory = planner.getCostFactory.asInstanceOf[FlinkCostFactory]
+    costFactory.makeCost(mq.getRowCount(this), cpu, 0, 0, memCost)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val partitionKeys: Array[Int] = grouping
+    val groups = modeToGroupToAggCallToAggFunction.map(_._2)
+    val writer = super.explainTerms(pw)
+      .itemIf("partitionBy", RelExplainUtil.fieldToString(partitionKeys, inputRowType),
+        partitionKeys.nonEmpty)
+      .itemIf("orderBy",
+        RelExplainUtil.collationToString(groups.head.orderKeys, inputRowType),
+        orderKeyIndices.nonEmpty)
+
+    var offset = inputRowType.getFieldCount
+    groups.zipWithIndex.foreach { case (group, index) =>
+      val namedAggregates = generateNamedAggregates(group)
+      val select = RelExplainUtil.overAggregationToString(
+        inputRowType,
+        outputRowType,
+        constants,
+        namedAggregates,
+        outputInputName = false,
+        rowTypeOffset = offset)
+      offset += namedAggregates.size
+      val windowRange = RelExplainUtil.windowRangeToString(logicWindow, group)
+      writer.item("window#" + index, select + windowRange)
+                                }
+    writer.item("select", getRowType.getFieldNames.mkString(", "))
+  }
+
+  private def generateNamedAggregates(
+      groupWindow: Group): Seq[CalcitePair[AggregateCall, String]] = {
+    val aggregateCalls = groupWindow.getAggregateCalls(logicWindow)
+    for (i <- 0 until aggregateCalls.size())
+      yield new CalcitePair[AggregateCall, String](aggregateCalls.get(i), "windowAgg$" + i)
+  }
+
+  private def splitOutOffsetOrInsensitiveGroup()
+  : Seq[(OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)])] = {
+
+    def compareTo(o1: Window.RexWinAggCall, o2: Window.RexWinAggCall): Boolean = {
+      val allowsFraming1 = o1.getOperator.allowsFraming
+      val allowsFraming2 = o2.getOperator.allowsFraming
+      if (!allowsFraming1 && !allowsFraming2) {
+        o1.getOperator.getClass == o2.getOperator.getClass
+      } else {
+        allowsFraming1 == allowsFraming2
+      }
+    }
+
+    def inferGroupMode(group: Window.Group): OverWindowMode = {
+      val aggCall = group.aggCalls(0)
+      if (aggCall.getOperator.allowsFraming()) {
+        if (group.isRows) OverWindowMode.Row else OverWindowMode.Range
+      } else {
+        if (aggCall.getOperator.isInstanceOf[SqlLeadLagAggFunction]) {
+          OverWindowMode.Offset
+        } else {
+          OverWindowMode.Insensitive
+        }
+      }
+    }
+
+    def createNewGroup(
+        group: Window.Group,
+        aggCallsBuffer: Seq[(Window.RexWinAggCall, (AggregateCall, UserDefinedFunction))])
+    : (OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)]) = {
+      val newGroup = new Window.Group(
+        group.keys,
+        group.isRows,
+        group.lowerBound,
+        group.upperBound,
+        group.orderKeys,
+        aggCallsBuffer.map(_._1))
+      val mode = inferGroupMode(newGroup)
+      (mode, group, aggCallsBuffer.map(_._2))
+    }
+
+    val windowGroupInfo =
+      ArrayBuffer[(OverWindowMode, Window.Group, Seq[(AggregateCall, UserDefinedFunction)])]()
+    windowGroupToAggCallToAggFunction.foreach { case (group, aggCallToAggFunction) =>
+      var lastAggCall: Window.RexWinAggCall = null
+      val aggCallsBuffer =
+        ArrayBuffer[(Window.RexWinAggCall, (AggregateCall, UserDefinedFunction))]()
+      group.aggCalls.zip(aggCallToAggFunction).foreach { case (aggCall, aggFunction) =>
+        if (lastAggCall != null && !compareTo(lastAggCall, aggCall)) {
+          windowGroupInfo.add(createNewGroup(group, aggCallsBuffer))
+          aggCallsBuffer.clear()
+        }
+        aggCallsBuffer.add((aggCall, aggFunction))
+        lastAggCall = aggCall
+                                                       }
+      if (aggCallsBuffer.nonEmpty) {
+        windowGroupInfo.add(createNewGroup(group, aggCallsBuffer))
+        aggCallsBuffer.clear()
+      }
+                                              }
+    windowGroupInfo
+  }
+
+  override def satisfyTraits(requiredTraitSet: RelTraitSet): Option[RelNode] = {
+    val requiredDistribution = requiredTraitSet.getTrait(FlinkRelDistributionTraitDef.INSTANCE)
+    val requiredCollation = requiredTraitSet.getTrait(RelCollationTraitDef.INSTANCE)
+    if (requiredDistribution.getType == ANY && requiredCollation.getFieldCollations.isEmpty) {
+      return None
+    }
+
+    val selfProvidedTraitSet = inferProvidedTraitSet()
+    if (selfProvidedTraitSet.satisfies(requiredTraitSet)) {
+      // Current node can satisfy the requiredTraitSet,return the current node with ProvidedTraitSet
+      return Some(copy(selfProvidedTraitSet, Seq(getInput)))
+    }
+
+    val inputFieldCnt = getInput.getRowType.getFieldCount
+    val canSatisfy = if (requiredDistribution.getType == ANY) {
+      true
+    } else {
+      if (!grouping.isEmpty) {
+        if (requiredDistribution.requireStrict) {
+          requiredDistribution.getKeys == ImmutableIntList.of(grouping: _*)
+        } else {
+          val isAllFieldsFromInput = requiredDistribution.getKeys.forall(_ < inputFieldCnt)
+          if (isAllFieldsFromInput) {
+            val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
+            if (tableConfig.getConfiguration.getBoolean(
+              BatchExecJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)) {
+              ImmutableIntList.of(grouping: _*).containsAll(requiredDistribution.getKeys)
+            } else {
+              requiredDistribution.getKeys == ImmutableIntList.of(grouping: _*)
+            }
+          } else {
+            // If requirement distribution keys are not all comes from input directly,
+            // cannot satisfy requirement distribution and collations.
+            false
+          }
+        }
+      } else {
+        requiredDistribution.getType == SINGLETON
+      }
+    }
+    // If OverAggregate can provide distribution, but it's traits cannot satisfy required
+    // distribution, cannot push down distribution and collation requirement (because later
+    // shuffle will destroy previous collation.
+    if (!canSatisfy) {
+      return None
+    }
+
+    var inputRequiredTraits = getInput.getTraitSet
+    var providedTraits = selfProvidedTraitSet
+    val providedCollation = selfProvidedTraitSet.getTrait(RelCollationTraitDef.INSTANCE)
+    if (!requiredDistribution.isTop) {
+      inputRequiredTraits = inputRequiredTraits.replace(requiredDistribution)
+      providedTraits = providedTraits.replace(requiredDistribution)
+    }
+
+    if (providedCollation.satisfies(requiredCollation)) {
+      // the providedCollation can satisfy the requirement,
+      // so don't push down the sort into it's input.
+    } else if (providedCollation.getFieldCollations.isEmpty &&
+      requiredCollation.getFieldCollations.nonEmpty) {
+      // If OverAgg cannot provide collation itself, try to push down collation requirements into
+      // it's input if collation fields all come from input node.
+      val canPushDownCollation = requiredCollation.getFieldCollations
+        .forall(_.getFieldIndex < inputFieldCnt)
+      if (canPushDownCollation) {
+        inputRequiredTraits = inputRequiredTraits.replace(requiredCollation)
+        providedTraits = providedTraits.replace(requiredCollation)
+      }
+    } else {
+      // Don't push down the sort into it's input,
+      // due to the provided collation will destroy the input's provided collation.
+    }
+    val newInput = RelOptRule.convert(getInput, inputRequiredTraits)
+    Some(copy(providedTraits, Seq(newInput)))
+  }
+
+  private def inferProvidedTraitSet(): RelTraitSet = {
+    var selfProvidedTraitSet = getTraitSet
+    // provided distribution
+    val providedDistribution = if (grouping.nonEmpty) {
+      FlinkRelDistribution.hash(grouping.map(Integer.valueOf).toList, requireStrict = false)
+    } else {
+      FlinkRelDistribution.SINGLETON
+    }
+    selfProvidedTraitSet = selfProvidedTraitSet.replace(providedDistribution)
+    // provided collation
+    val firstGroup = windowGroupToAggCallToAggFunction.head._1
+    if (OverAggregateUtil.needCollationTrait(logicWindow, firstGroup)) {
+      val collation = OverAggregateUtil.createCollation(firstGroup)
+      if (!collation.equals(RelCollations.EMPTY)) {
+        selfProvidedTraitSet = selfProvidedTraitSet.replace(collation)
+      }
+    }
+    selfProvidedTraitSet
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getDamBehavior = DamBehavior.PIPELINED
+
+  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
+    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+
+  override def replaceInputNode(
+      ordinalInParent: Int,
+      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
+  }
+}
+
+object OverWindowMode extends Enumeration {
+  type OverWindowMode = Value
+  val Row: OverWindowMode = Value
+  val Range: OverWindowMode = Value
+  //Then it is a special kind of Window when the agg is LEAD&LAG.
+  val Offset: OverWindowMode = Value
+  val Insensitive: OverWindowMode = Value
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonOverAggregate.scala
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.batch
+
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.functions.python.PythonFunctionInfo
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.delegation.BatchPlanner
+import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecPythonOverAggregate.ARROW_PYTHON_OVER_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME
+import org.apache.flink.table.planner.plan.utils.OverAggregateUtil.getLongBoundary
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.flink.table.types.logical.RowType
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel._
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{AggregateCall, Window}
+import org.apache.calcite.tools.RelBuilder
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Batch physical RelNode for sort-based over [[Window]] aggregate (Python user defined aggregate
+  * function).
+  */
+class BatchExecPythonOverAggregate(
+    cluster: RelOptCluster,
+    relBuilder: RelBuilder,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    orderKeyIndices: Array[Int],
+    orders: Array[Boolean],
+    nullIsLasts: Array[Boolean],
+    windowGroupToAggCallToAggFunction: Seq[
+      (Window.Group, Seq[(AggregateCall, UserDefinedFunction)])],
+    logicWindow: Window)
+  extends BatchExecOverAggregateBase(
+    cluster,
+    relBuilder,
+    traitSet,
+    inputRel,
+    outputRowType,
+    inputRowType,
+    grouping,
+    orderKeyIndices,
+    orders,
+    nullIsLasts,
+    windowGroupToAggCallToAggFunction,
+    logicWindow)
+  with CommonPythonAggregate {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new BatchExecPythonOverAggregate(
+      cluster,
+      relBuilder,
+      traitSet,
+      inputs.get(0),
+      outputRowType,
+      inputRowType,
+      grouping,
+      orderKeyIndices,
+      orders,
+      nullIsLasts,
+      windowGroupToAggCallToAggFunction,
+      logicWindow)
+  }
+
+  override protected def translateToPlanInternal(
+      planner: BatchPlanner): Transformation[RowData] = {
+    val input = getInputNodes.get(0).translateToPlan(planner)
+      .asInstanceOf[Transformation[RowData]]
+    val outputType = FlinkTypeFactory.toLogicalRowType(getRowType)
+    val inputType = FlinkTypeFactory.toLogicalRowType(inputRowType)
+    val windowBoundary = ArrayBuffer[(Long, Long, Boolean)]()
+    val aggFunctions = modeToGroupToAggCallToAggFunction.zipWithIndex.flatMap {
+      case ((mode, windowGroup, aggCallToAggFunction), index) =>
+        val boundary = mode match {
+          case OverWindowMode.Row if isUnboundedWindow(windowGroup) =>
+            (Long.MinValue, Long.MaxValue, false)
+          case OverWindowMode.Row if isUnboundedPrecedingWindow(windowGroup) =>
+            (Long.MinValue, getLongBoundary(logicWindow, windowGroup.upperBound), false)
+          case OverWindowMode.Row if isUnboundedFollowingWindow(windowGroup) =>
+            (getLongBoundary(logicWindow, windowGroup.lowerBound), Long.MaxValue, false)
+          case OverWindowMode.Row if isSlidingWindow(windowGroup) =>
+            (getLongBoundary(logicWindow, windowGroup.lowerBound),
+              getLongBoundary(logicWindow, windowGroup.upperBound), false)
+          case OverWindowMode.Range if isUnboundedWindow(windowGroup) =>
+            (Long.MinValue, Long.MaxValue, true)
+          case OverWindowMode.Range if isUnboundedPrecedingWindow(windowGroup) =>
+            (Long.MinValue, getLongBoundary(logicWindow, windowGroup.upperBound), true)
+          case OverWindowMode.Range if isUnboundedFollowingWindow(windowGroup) =>
+            (getLongBoundary(logicWindow, windowGroup.lowerBound), Long.MaxValue, true)
+          case OverWindowMode.Range if isSlidingWindow(windowGroup) =>
+            (getLongBoundary(logicWindow, windowGroup.lowerBound),
+              getLongBoundary(logicWindow, windowGroup.upperBound), true)
+        }
+        windowBoundary.append(boundary)
+        aggCallToAggFunction.map((_, index))
+    }
+    val ret = createPythonOneInputTransformation(
+      input,
+      aggFunctions,
+      windowBoundary.toArray,
+      inputType,
+      outputType,
+      grouping,
+      getConfig(planner.getExecEnv, planner.getTableConfig))
+
+    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+      ExecNode.setManagedMemoryWeight(
+        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+    }
+    ret
+  }
+
+  private[this] def createPythonOneInputTransformation(
+      inputTransform: Transformation[RowData],
+      aggCallToAggFunctionToWindowIndex: Seq[((AggregateCall, UserDefinedFunction), Int)],
+      windowBoundary: Array[(Long, Long, Boolean)],
+      inputRowType: RowType,
+      outputRowType: RowType,
+      groupingSet: Array[Int],
+      config: Configuration): OneInputTransformation[RowData, RowData] = {
+    val (pythonUdafInputOffsets, pythonFunctionInfos) =
+      extractPythonAggregateFunctionInfos(aggCallToAggFunctionToWindowIndex.map(_._1._1))
+    val pythonOperator = getPythonOverWindowAggregateFunctionOperator(
+      config,
+      inputRowType,
+      outputRowType,
+      windowBoundary.map(_._1),
+      windowBoundary.map(_._2),
+      windowBoundary.map(_._3),
+      aggCallToAggFunctionToWindowIndex.map(_._2).toArray,
+      pythonUdafInputOffsets,
+      pythonFunctionInfos)
+
+    new OneInputTransformation(
+      inputTransform,
+      "BatchExecPythonOverAggregate",
+      pythonOperator,
+      InternalTypeInfo.of(outputRowType),
+      inputTransform.getParallelism)
+  }
+
+  private[this] def getPythonOverWindowAggregateFunctionOperator(
+      config: Configuration,
+      inputRowType: RowType,
+      outputRowType: RowType,
+      lowerBinary: Array[Long],
+      upperBinary: Array[Long],
+      windowType: Array[Boolean],
+      aggWindowIndex: Array[Int],
+      udafInputOffsets: Array[Int],
+      pythonFunctionInfos: Array[PythonFunctionInfo]): OneInputStreamOperator[RowData, RowData] = {
+    val clazz = loadClass(ARROW_PYTHON_OVER_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME)
+
+    val ctor = clazz.getConstructor(
+      classOf[Configuration],
+      classOf[Array[PythonFunctionInfo]],
+      classOf[RowType],
+      classOf[RowType],
+      classOf[Array[Long]],
+      classOf[Array[Long]],
+      classOf[Array[Boolean]],
+      classOf[Array[Int]],
+      classOf[Array[Int]],
+      classOf[Array[Int]],
+      classOf[Array[Int]],
+      classOf[Int],
+      classOf[Boolean])
+
+    ctor.newInstance(
+      config,
+      pythonFunctionInfos,
+      inputRowType,
+      outputRowType,
+      lowerBinary,
+      upperBinary,
+      windowType,
+      aggWindowIndex,
+      grouping,
+      grouping,
+      udafInputOffsets,
+      java.lang.Integer.valueOf(orderKeyIndices(0)),
+      java.lang.Boolean.valueOf(orders(0)))
+      .asInstanceOf[OneInputStreamOperator[RowData, RowData]]
+  }
+}
+
+object BatchExecPythonOverAggregate {
+  val ARROW_PYTHON_OVER_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME: String =
+    "org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch." +
+      "BatchArrowPythonOverWindowAggregateFunctionOperator"
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testPandasRangeOverWindowAggregate">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$1], _c1=[AS(org$apache$flink$table$planner$runtime$utils$JavaUserDefinedAggFunctions$PandasAggregateFunction$2d00a4b7889c065a728bf23f9cf0f0d2($0, $2) OVER (PARTITION BY $1 ORDER BY $3 NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), _UTF-16LE'_c1')])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+	</Resource>
+    <Resource name="planAfter">
+	  <![CDATA[
+Calc(select=[b, w0$o0 AS _c1])
++- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window#0=[PandasAggregateFunction(a, c) AS w0$o0 RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, w0$o0])
+   +- Sort(orderBy=[b ASC, rowtime ASC])
+      +- Exchange(distribution=[hash[b]])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testPandasRowsOverWindowAggregate">
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(b=[$1], _c1=[AS(org$apache$flink$table$planner$runtime$utils$JavaUserDefinedAggFunctions$PandasAggregateFunction$2d00a4b7889c065a728bf23f9cf0f0d2($0, $2) OVER (PARTITION BY $1 ORDER BY $3 NULLS FIRST ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), _UTF-16LE'_c1')])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+Calc(select=[b, w0$o0 AS _c1])
++- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window#0=[PandasAggregateFunction(a, c) AS w0$o0 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, w0$o0])
+   +- Sort(orderBy=[b ASC, rowtime ASC])
+      +- Exchange(distribution=[hash[b]])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+	</Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.batch.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api._
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.PandasAggregateFunction
+import org.apache.flink.table.planner.utils.TableTestBase
+import org.junit.Test
+
+class PythonOverWindowAggregateTest extends TableTestBase {
+
+  @Test
+  def testPandasRangeOverWindowAggregate(): Unit = {
+    val util = batchTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new PandasAggregateFunction
+
+    val resultTable = sourceTable
+      .window(
+        Over
+          partitionBy 'b
+          orderBy 'rowtime
+          preceding UNBOUNDED_RANGE
+          as 'w)
+      .select('b, func('a, 'c) over 'w)
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test
+  def testPandasRowsOverWindowAggregate(): Unit = {
+    val util = batchTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new PandasAggregateFunction
+
+    val resultTable = sourceTable
+      .window(
+        Over
+          partitionBy 'b
+          orderBy 'rowtime
+          preceding 10.rows
+          as 'w)
+      .select('b, func('a, 'c) over 'w)
+
+    util.verifyPlan(resultTable)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support Pandas Batch Over Window Aggregation*


## Brief change log

  - *Add Batch Physical Pandas Over Window RelNode*
  - *Add PandasBatchOverWindowAggregateFunctionOperation*
  - *Add OverWindowArrowCoder*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add UT test to test plan in PythonOverWindowAggregateTest*
  - *Add IT test_over_window_aggregate_function*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
