### PR TITLE
handle partial flag when sub-partition is partial

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.DATA_BUFFER;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilder.BUFFER_BUILDER_HEADER_SIZE;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilder.Header;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -138,6 +139,62 @@ public class BufferConsumer implements Closeable {
 		return slice.retainBuffer();
 	}
 
+	public PartialRecordCleanupResult skipPartialRecord() {
+		writerPosition.update();
+		int cachedWriterPosition = writerPosition.getCached();
+
+		Buffer slice;
+		boolean cleanedUp;
+
+		// partial record can happen only at the beginning of a buffer
+		// because buffer slicer can end with either a full record or full buffer (partial record)
+		if (startOfDataBuffer()) {
+			// either do not have any data, or at least have 4 bytes (header + data)
+			checkState(
+				(cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE)
+					|| (currentReaderPosition == cachedWriterPosition)
+			);
+
+			if (cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE) {
+				int head = buffer.getMemorySegment().getIntBigEndian(0);
+				boolean partial = Header.isPartial(head);
+				int length = Header.length(head);
+
+				if (partial) {
+					// case 1: long record spanning multiple buffers, haven't yet cleaned up, skip the whole buffer
+					if (length == buffer.getMaxCapacity() - BUFFER_BUILDER_HEADER_SIZE) {
+						slice = buffer.readOnlySlice(currentReaderPosition, 0);
+						cleanedUp = false;
+					} else {
+						// case 2: partial record ends within the buffer, cleaned up successfully, skip the partial record
+						slice = buffer.readOnlySlice(
+							currentReaderPosition + BUFFER_BUILDER_HEADER_SIZE + length,
+							cachedWriterPosition - currentReaderPosition - BUFFER_BUILDER_HEADER_SIZE - length);
+						cleanedUp = true;
+					}
+				} else {
+					// case 3: the record is not a partial record, cleaned up successfully, skip the head
+					slice = buffer.readOnlySlice(
+						currentReaderPosition + BUFFER_BUILDER_HEADER_SIZE ,
+						cachedWriterPosition - currentReaderPosition - BUFFER_BUILDER_HEADER_SIZE);
+					cleanedUp = true;
+				}
+			} else {
+				// case 4: written data is not visible yet, haven't yet cleaned up, return an empty slicer
+				slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+				cleanedUp = false;
+			}
+		} else {
+			// case 5: read from the middle of the buffer or event buffer; no clean up needed,
+			// because buffer slicer can end with either a full record or full buffer (partial record)
+			slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+			cleanedUp = true;
+		}
+
+		currentReaderPosition = cachedWriterPosition;
+		return new PartialRecordCleanupResult(slice.retainBuffer(), cleanedUp);
+	}
+
 	/**
 	 * Returns a retained copy with separate indexes. This allows to read from the same {@link MemorySegment} twice.
 	 *
@@ -225,6 +282,24 @@ public class BufferConsumer implements Closeable {
 
 		private void update() {
 			this.cachedPosition = positionMarker.get();
+		}
+	}
+
+	public static class PartialRecordCleanupResult {
+		private final Buffer buffer;
+		private final boolean cleaned;
+
+		PartialRecordCleanupResult(Buffer buffer, boolean cleaned) {
+			this.buffer = checkNotNull(buffer);
+			this.cleaned = cleaned;
+		}
+
+		public Buffer getBuffer() {
+			return buffer;
+		}
+
+		public boolean getCleaned() {
+			return cleaned;
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR includes two parts
- the first commit is the same as #13456  (the one I sent yesterday); to attach the partial flag header to the buffer builder;
- the second commit does the real partial record clean-up logic when sub-partition is partial, handled in `skipPartialRecord()`; Notice that partial record can happen only at the beginning of a buffer because the buffer builder can end with either a full record or full buffer after each `bufferbuilder.commit()` and consequently each `bufferconsumer.build()` ; (or full record + full buffer, but that’s fine). 
Partial records occur only when bufferbuilder ends with a full buffer but not a full record;

Totally five cases:
- Read position starts from the beginning of a data buffer:
case 1: long record spanning over multiple buffers => clean up is not successful => we need to skip the whole buffer
case 2: partial record ends within the buffer => cleaned up successfully => skip the partial record
case 3: the record is not a partial record => cleaned up successfully => skip the head
case 4: written data is not visible yet => cleaned up is not successful => return an empty slicer

- Read position starts from the middle of a data buffer
// bufferbuilder can end with either a full record or full buffer (partial record) after each commit, so in this case, we are guaranteed to start with a complete record

case 5 no clean up needed


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
