### PR TITLE
[FLINK-19411][task] Fix construction of MultipleInputStreamTask with union inputs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Input processor for {@link MultipleInputStreamOperator}.
@@ -100,6 +101,11 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 		this.mainOperatorRecordsIn = mainOperatorRecordsIn;
 		ioMetricGroup.reuseRecordsInputCounter(networkRecordsIn);
 
+		checkState(
+			configuredInputs.length == inputsCount,
+			"Number of configured inputs in StreamConfig [%s] doesn't match the main operator's number of inputs [%s]",
+			configuredInputs.length,
+			inputsCount);
 		for (int i = 0; i < inputsCount; i++) {
 			InputConfig configuredInput = configuredInputs[i];
 			streamStatuses[i] = StreamStatus.ACTIVE;

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.test.streaming.runtime.util.TestListResultSink;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
@@ -54,31 +56,52 @@ import static org.junit.Assert.assertEquals;
  */
 @SuppressWarnings("serial")
 public class MultipleInputITCase extends AbstractTestBase {
-	@Test
-	public void test() throws Exception {
 
+	@Test
+	public void testBasicProcessing() throws Exception {
+		testNonKeyed(false);
+	}
+
+	@Test
+	public void testUnion() throws Exception {
+		testNonKeyed(true);
+	}
+
+	public void testNonKeyed(boolean withUnion) throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 
 		TestListResultSink<Long> resultSink = new TestListResultSink<>();
 
-		DataStream<Integer> source1 = env.fromElements(1, 10);
+		DataStream<Long> source1 = env.fromElements(1L, 10L);
 		DataStream<Long> source2 = env.fromElements(2L, 11L);
 		DataStream<String> source3 = env.fromElements("42", "44");
 
-		MultipleInputTransformation<Long> transform = new MultipleInputTransformation<>(
+		MultipleInputTransformation<Long> multipleInput = new MultipleInputTransformation<>(
 			"My Operator",
-			new SumAllInputOperatorFactory(),
+			new SumAllInputOperatorFactory(withUnion ? 2 : 3),
 			BasicTypeInfo.LONG_TYPE_INFO,
 			1);
 
-		env.addOperator(transform
-			.addInput(source1.getTransformation())
-			.addInput(source2.getTransformation())
+		MultipleInputTransformation<Long> multipleInputTransformation;
+		if (withUnion) {
+			UnionTransformation<Long> union = new UnionTransformation<>(
+				Arrays.asList(source1.getTransformation(), source2.getTransformation()));
+
+			multipleInputTransformation = multipleInput
+				.addInput(union);
+		}
+		else {
+			multipleInputTransformation = multipleInput
+				.addInput(source1.getTransformation())
+				.addInput(source2.getTransformation());
+		}
+
+		env.addOperator(multipleInputTransformation
 			.addInput(source3.getTransformation()));
 
 		new MultipleConnectedStreams(env)
-			.transform(transform)
+			.transform(multipleInput)
 			.addSink(resultSink);
 
 		env.execute();
@@ -183,18 +206,21 @@ public class MultipleInputITCase extends AbstractTestBase {
 	 * 3 input operator that sums all of it inputs.
 	 */
 	public static class SumAllInputOperator extends AbstractStreamOperatorV2<Long> implements MultipleInputStreamOperator<Long> {
+		private final int numberOfInputs;
 		private long sum;
 
-		public SumAllInputOperator(StreamOperatorParameters<Long> parameters) {
-			super(parameters, 3);
+		public SumAllInputOperator(StreamOperatorParameters<Long> parameters, int numberOfInputs) {
+			super(parameters, numberOfInputs);
+			this.numberOfInputs = numberOfInputs;
 		}
 
 		@Override
 		public List<Input> getInputs() {
-			return Arrays.asList(
+			checkState(numberOfInputs <= 3);
+			return Arrays.<Input>asList(
 				new SumInput<Integer>(this, 1),
 				new SumInput<Long>(this, 2),
-				new SumInput<String>(this, 3));
+				new SumInput<String>(this, 3)).subList(0, numberOfInputs);
 		}
 
 		/**
@@ -217,9 +243,15 @@ public class MultipleInputITCase extends AbstractTestBase {
 	 * Factory for {@link SumAllInputOperator}.
 	 */
 	public static class SumAllInputOperatorFactory extends AbstractStreamOperatorFactory<Long> {
+		private int numberOfInputs;
+
+		public SumAllInputOperatorFactory(int numberOfInputs) {
+			this.numberOfInputs = numberOfInputs;
+		}
+
 		@Override
 		public <T extends StreamOperator<Long>> T createStreamOperator(StreamOperatorParameters<Long> parameters) {
-			return (T) new SumAllInputOperator(parameters);
+			return (T) new SumAllInputOperator(parameters, numberOfInputs);
 		}
 
 		@Override


### PR DESCRIPTION
Previously number of input gates was assumed to be the same as number of logical inputs, which is not true in case of union inputs.

This PR depends on https://github.com/apache/flink/pull/13466. All commits except the last one are from that other PR.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
