### PR TITLE
[FLINK-19341][table] Update all API related methods to FLIP-107

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
@@ -116,7 +116,7 @@ public abstract class ElasticsearchUpsertTableSinkBase implements UpsertStreamTa
 			RequestFactory requestFactory) {
 
 		this.isAppendOnly = isAppendOnly;
-		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
+		this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 		this.hosts = Preconditions.checkNotNull(hosts);
 		this.index = Preconditions.checkNotNull(index);
 		this.keyDelimiter = Preconditions.checkNotNull(keyDelimiter);

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
@@ -116,7 +116,7 @@ public abstract class ElasticsearchUpsertTableSinkBase implements UpsertStreamTa
 			RequestFactory requestFactory) {
 
 		this.isAppendOnly = isAppendOnly;
-		this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
 		this.hosts = Preconditions.checkNotNull(hosts);
 		this.index = Preconditions.checkNotNull(index);
 		this.keyDelimiter = Preconditions.checkNotNull(keyDelimiter);

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcUpsertTableSink.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcUpsertTableSink.java
@@ -65,7 +65,7 @@ public class JdbcUpsertTableSink implements UpsertStreamTableSink<Row> {
 			int flushMaxSize,
 			long flushIntervalMills,
 			int maxRetryTime) {
-		this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
 		this.options = options;
 		this.flushMaxSize = flushMaxSize;
 		this.flushIntervalMills = flushIntervalMills;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcUpsertTableSink.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcUpsertTableSink.java
@@ -65,7 +65,7 @@ public class JdbcUpsertTableSink implements UpsertStreamTableSink<Row> {
 			int flushMaxSize,
 			long flushIntervalMills,
 			int maxRetryTime) {
-		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
+		this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 		this.options = options;
 		this.flushMaxSize = flushMaxSize;
 		this.flushIntervalMills = flushIntervalMills;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/utils/JdbcTypeUtil.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/utils/JdbcTypeUtil.java
@@ -123,7 +123,7 @@ public class JdbcTypeUtil {
 		TableSchema.Builder physicalSchemaBuilder = TableSchema.builder();
 		schema.getTableColumns()
 			.forEach(c -> {
-				if (!c.isGenerated()) {
+				if (c.isPhysical()) {
 					final DataType type = DataTypeUtils.transform(c.getType(), TypeTransformations.timeToSqlTypes());
 					physicalSchemaBuilder.field(c.getName(), type);
 				}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
@@ -68,7 +68,7 @@ public abstract class KafkaTableSinkBase implements AppendStreamTableSink<Row> {
 			Properties properties,
 			Optional<FlinkKafkaPartitioner<Row>> partitioner,
 			SerializationSchema<Row> serializationSchema) {
-		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
+		this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 		this.topic = Preconditions.checkNotNull(topic, "Topic must not be null.");
 		this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
 		this.partitioner = Preconditions.checkNotNull(partitioner, "Partitioner must not be null.");

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
@@ -68,7 +68,7 @@ public abstract class KafkaTableSinkBase implements AppendStreamTableSink<Row> {
 			Properties properties,
 			Optional<FlinkKafkaPartitioner<Row>> partitioner,
 			SerializationSchema<Row> serializationSchema) {
-		this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
 		this.topic = Preconditions.checkNotNull(topic, "Topic must not be null.");
 		this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
 		this.partitioner = Preconditions.checkNotNull(partitioner, "Partitioner must not be null.");

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
@@ -124,7 +124,7 @@ public abstract class KafkaTableSourceBase implements
 			StartupMode startupMode,
 			Map<KafkaTopicPartition, Long> specificStartupOffsets,
 			long startupTimestampMillis) {
-		this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
 		this.proctimeAttribute = validateProctimeAttribute(proctimeAttribute);
 		this.rowtimeAttributeDescriptors = validateRowtimeAttributeDescriptors(rowtimeAttributeDescriptors);
 		this.fieldMapping = fieldMapping;

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceBase.java
@@ -124,7 +124,7 @@ public abstract class KafkaTableSourceBase implements
 			StartupMode startupMode,
 			Map<KafkaTopicPartition, Long> specificStartupOffsets,
 			long startupTimestampMillis) {
-		this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
+		this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 		this.proctimeAttribute = validateProctimeAttribute(proctimeAttribute);
 		this.rowtimeAttributeDescriptors = validateRowtimeAttributeDescriptors(rowtimeAttributeDescriptors);
 		this.fieldMapping = fieldMapping;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
@@ -43,7 +43,7 @@ public class CollectBatchTableSink extends OutputFormatTableSink<Row> implements
 	public CollectBatchTableSink(String accumulatorName, TypeSerializer<Row> serializer, TableSchema tableSchema) {
 		this.accumulatorName = accumulatorName;
 		this.serializer = serializer;
-		this.tableSchema = TableSchemaUtils.checkNoGeneratedColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkPhysicalColumns(tableSchema);
 	}
 
 	/**

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
@@ -43,7 +43,7 @@ public class CollectBatchTableSink extends OutputFormatTableSink<Row> implements
 	public CollectBatchTableSink(String accumulatorName, TypeSerializer<Row> serializer, TableSchema tableSchema) {
 		this.accumulatorName = accumulatorName;
 		this.serializer = serializer;
-		this.tableSchema = TableSchemaUtils.checkPhysicalColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkOnlyPhysicalColumns(tableSchema);
 	}
 
 	/**

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
@@ -51,7 +51,7 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 		this.targetAddress = targetAddress;
 		this.targetPort = targetPort;
 		this.serializer = serializer;
-		this.tableSchema = TableSchemaUtils.checkNoGeneratedColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkPhysicalColumns(tableSchema);
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
@@ -51,7 +51,7 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 		this.targetAddress = targetAddress;
 		this.targetPort = targetPort;
 		this.serializer = serializer;
-		this.tableSchema = TableSchemaUtils.checkPhysicalColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkOnlyPhysicalColumns(tableSchema);
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -96,7 +96,7 @@ public class DependencyTest {
 			assertEquals(
 					tableResult.getTableSchema(),
 					TableSchema.builder().fields(
-							new String[] { "name", "type", "null", "key", "computed column", "watermark" },
+							new String[] { "name", "type", "null", "key", "extras", "watermark" },
 							new DataType[] { DataTypes.STRING(), DataTypes.STRING(), DataTypes.BOOLEAN(),
 									DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING() }
 					).build()

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -428,12 +428,14 @@ public class LocalExecutorITCase extends TestLogger {
 
 		TableResult tableResult = executor.executeSql(sessionId, "DESCRIBE TableNumber2");
 		assertEquals(
-				tableResult.getTableSchema(),
-				TableSchema.builder().fields(
-						new String[] { "name", "type", "null", "key", "computed column", "watermark" },
+			TableSchema.builder()
+					.fields(
+						new String[] { "name", "type", "null", "key", "extras", "watermark" },
 						new DataType[] { DataTypes.STRING(), DataTypes.STRING(), DataTypes.BOOLEAN(),
 								DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING() }
-				).build()
+					)
+					.build(),
+			tableResult.getTableSchema()
 		);
 		List<Row> schemaData = Arrays.asList(
 				Row.of("IntegerField2", "INT", true, null, null, null),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -114,7 +114,7 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 		private final String property;
 
 		public TestTableSink(TableSchema schema, String property) {
-			this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+			this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
 			this.property = property;
 		}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -114,7 +114,7 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 		private final String property;
 
 		public TestTableSink(TableSchema schema, String property) {
-			this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
+			this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 			this.property = property;
 		}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
@@ -127,7 +127,7 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
 		private final List<RowtimeAttributeDescriptor> rowtime;
 
 		public TestTableSource(TableSchema schema, String property, String proctime, List<RowtimeAttributeDescriptor> rowtime) {
-			this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
+			this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 			this.property = property;
 			this.proctime = proctime;
 			this.rowtime = rowtime;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
@@ -127,7 +127,7 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
 		private final List<RowtimeAttributeDescriptor> rowtime;
 
 		public TestTableSource(TableSchema schema, String property, String proctime, List<RowtimeAttributeDescriptor> rowtime) {
-			this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+			this.schema = TableSchemaUtils.checkPhysicalColumns(schema);
 			this.property = property;
 			this.proctime = proctime;
 			this.rowtime = rowtime;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
@@ -24,12 +24,14 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.NlsString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -161,8 +163,13 @@ public abstract class SqlTableColumn extends SqlCall {
 			this.isVirtual = isVirtual;
 		}
 
-		public Optional<SqlNode> getMetadataAlias() {
-			return Optional.ofNullable(metadataAlias);
+		public SqlDataTypeSpec getType() {
+			return type;
+		}
+
+		public Optional<String> getMetadataAlias() {
+			return Optional.ofNullable(metadataAlias)
+				.map(alias -> ((NlsString) SqlLiteral.value(alias)).getValue());
 		}
 
 		public boolean isVirtual() {

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/SchemaValidator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/descriptors/SchemaValidator.java
@@ -222,9 +222,8 @@ public class SchemaValidator implements DescriptorValidator {
 			final TableColumn tableColumn = tableSchema.getTableColumns().get(i);
 			final String fieldName = tableColumn.getName();
 			final DataType dataType = tableColumn.getType();
-			boolean isGeneratedColumn = tableColumn.isGenerated();
-			if (isGeneratedColumn) {
-				// skip generated column
+			if (!tableColumn.isPhysical()) {
+				// skip non-physical column
 				continue;
 			}
 			boolean isProctime = properties

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -136,8 +136,6 @@ import org.apache.flink.table.utils.PrintUtils;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.types.Row;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1111,18 +1109,19 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			schema.getTableColumns()
 				.stream()
 				.map((c) -> {
-					LogicalType logicalType = c.getType().getLogicalType();
+					final LogicalType logicalType = c.getType().getLogicalType();
 					return new Object[]{
 						c.getName(),
-						StringUtils.removeEnd(logicalType.toString(), " NOT NULL"),
+						logicalType.copy(true).asSummaryString(),
 						logicalType.isNullable(),
 						fieldToPrimaryKey.getOrDefault(c.getName(), null),
-						c.getExpr().orElse(null),
-						fieldToWatermark.getOrDefault(c.getName(), null)};
+						c.explainExtras().orElse(null),
+						fieldToWatermark.getOrDefault(c.getName(), null)
+					};
 				}).toArray(Object[][]::new);
 
 		return buildResult(
-			new String[]{"name", "type", "null", "key", "computed column", "watermark"},
+			new String[]{"name", "type", "null", "key", "extras", "watermark"},
 			new DataType[]{DataTypes.STRING(), DataTypes.STRING(), DataTypes.BOOLEAN(), DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING()},
 			rows);
 	}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceMock.java
@@ -33,7 +33,7 @@ public class TableSourceMock implements TableSource<Row> {
 	private final TableSchema tableSchema;
 
 	public TableSourceMock(TableSchema tableSchema) {
-		this.tableSchema = TableSchemaUtils.checkPhysicalColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkOnlyPhysicalColumns(tableSchema);
 		this.producedDataType = tableSchema.toRowDataType();
 	}
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceMock.java
@@ -33,7 +33,7 @@ public class TableSourceMock implements TableSource<Row> {
 	private final TableSchema tableSchema;
 
 	public TableSourceMock(TableSchema tableSchema) {
-		this.tableSchema = TableSchemaUtils.checkNoGeneratedColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkPhysicalColumns(tableSchema);
 		this.producedDataType = tableSchema.toRowDataType();
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableColumn.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableColumn.java
@@ -28,60 +28,121 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A table column represents a table column's structure with
- * column name, column data type and computation expression(if it is a computed column).
+ * Representation of a table column in the API.
+ *
+ * <p>A table column is fully resolved with a name and {@link DataType}. It describes either a
+ * {@link PhysicalColumn}, {@link ComputedColumn}, or {@link MetadataColumn}.
  */
 @PublicEvolving
-public class TableColumn {
-
-	//~ Instance fields --------------------------------------------------------
+public abstract class TableColumn {
 
 	private final String name;
+
 	private final DataType type;
-	@Nullable
-	private final String expr;
 
-	//~ Constructors -----------------------------------------------------------
-
-	/**
-	 * Creates a {@link TableColumn} instance.
-	 *
-	 * @param name Column name
-	 * @param type Column data type
-	 * @param expr Column computation expression if it is a computed column
-	 */
-	private TableColumn(
-			String name,
-			DataType type,
-			@Nullable String expr) {
+	private TableColumn(String name, DataType type) {
 		this.name = name;
 		this.type = type;
-		this.expr = expr;
 	}
 
-	//~ Methods ----------------------------------------------------------------
-
 	/**
-	 * Creates a table column from given name and data type.
+	 * Creates a regular table column that represents physical data.
 	 */
-	public static TableColumn of(String name, DataType type) {
-		Preconditions.checkNotNull(name, "Column name can not be null!");
-		Preconditions.checkNotNull(type, "Column type can not be null!");
-		return new TableColumn(name, type, null);
+	public static PhysicalColumn physical(String name, DataType type) {
+		Preconditions.checkNotNull(name, "Column name can not be null.");
+		Preconditions.checkNotNull(type, "Column type can not be null.");
+		return new PhysicalColumn(name, type);
 	}
 
 	/**
-	 * Creates a table column from given name and computation expression.
+	 * Creates a computed column that is computed from the given SQL expression.
+	 */
+	public static ComputedColumn computed(String name, DataType type, String expression) {
+		Preconditions.checkNotNull(name, "Column name can not be null.");
+		Preconditions.checkNotNull(type, "Column type can not be null.");
+		Preconditions.checkNotNull(expression, "Column expression can not be null.");
+		return new ComputedColumn(name, type, expression);
+	}
+
+	/**
+	 * Creates a metadata column from metadata of the given column name.
 	 *
-	 * @param name Name of the column
-	 * @param expression SQL-style expression
+	 * <p>The column is not virtual by default.
 	 */
-	public static TableColumn of(String name, DataType type, String expression) {
-		Preconditions.checkNotNull(name, "Column name can not be null!");
-		Preconditions.checkNotNull(type, "Column type can not be null!");
-		Preconditions.checkNotNull(expression, "Column expression can not be null!");
-		return new TableColumn(name, type, expression);
+	public static MetadataColumn metadata(String name, DataType type) {
+		return metadata(name, type, null, false);
 	}
+
+	/**
+	 * Creates a metadata column from metadata of the given column name.
+	 *
+	 * <p>Allows to specify whether the column is virtual or not.
+	 */
+	public static MetadataColumn metadata(String name, DataType type, boolean isVirtual) {
+		return metadata(name, type, null, isVirtual);
+	}
+
+	/**
+	 * Creates a metadata column from metadata of the given alias.
+	 *
+	 * <p>The column is not virtual by default.
+	 */
+	public static MetadataColumn metadata(String name, DataType type, String metadataAlias) {
+		Preconditions.checkNotNull(metadataAlias, "Metadata alias can not be null.");
+		return metadata(name, type, metadataAlias, false);
+	}
+
+	/**
+	 * Creates a metadata column from metadata of the given column name or from metadata of the given
+	 * alias (if not null).
+	 *
+	 * <p>Allows to specify whether the column is virtual or not.
+	 */
+	public static MetadataColumn metadata(
+			String name,
+			DataType type,
+			@Nullable String metadataAlias,
+			boolean isVirtual) {
+		Preconditions.checkNotNull(name, "Column name can not be null.");
+		Preconditions.checkNotNull(type, "Column type can not be null.");
+		return new MetadataColumn(name, type, metadataAlias, isVirtual);
+	}
+
+	/**
+	 * Returns whether the given column is a physical column of a table; neither computed
+	 * nor metadata.
+	 */
+	public abstract boolean isPhysical();
+
+	/** Returns the data type of this column. */
+	public DataType getType() {
+		return this.type;
+	}
+
+	/** Returns the name of this column. */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Returns a string that summarizes this column for printing to a console.
+	 */
+	public String asSummaryString() {
+		final StringBuilder sb = new StringBuilder();
+		sb.append(name);
+		sb.append(": ");
+		sb.append(type);
+		explainExtras().ifPresent(e -> {
+			sb.append(" ");
+			sb.append(e);
+		});
+		return sb.toString();
+	}
+
+	/**
+	 * Returns an explanation of specific column extras next to name and type.
+	 */
+	public abstract Optional<String> explainExtras();
 
 	@Override
 	public boolean equals(Object o) {
@@ -93,40 +154,155 @@ public class TableColumn {
 		}
 		TableColumn that = (TableColumn) o;
 		return Objects.equals(this.name, that.name)
-			&& Objects.equals(this.type, that.type)
-			&& Objects.equals(this.expr, that.expr);
+			&& Objects.equals(this.type, that.type);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.name, this.type, this.expr);
+		return Objects.hash(this.name, this.type);
 	}
 
-	//~ Getter/Setter ----------------------------------------------------------
-
-	/** Returns data type of this column. */
-	public DataType getType() {
-		return this.type;
+	@Override
+	public String toString() {
+		return asSummaryString();
 	}
 
-	/** Returns name of this column. */
-	public String getName() {
-		return name;
-	}
+	// --------------------------------------------------------------------------------------------
+	// Specific kinds of columns
+	// --------------------------------------------------------------------------------------------
 
-	/** Returns computation expression of this column. Or empty if this column
-	 * is not a computed column. */
-	public Optional<String> getExpr() {
-		return Optional.ofNullable(this.expr);
+	/**
+	 * Representation of a physical column.
+	 */
+	public static class PhysicalColumn extends TableColumn {
+
+		private PhysicalColumn(String name, DataType type) {
+			super(name, type);
+		}
+
+		@Override
+		public boolean isPhysical() {
+			return true;
+		}
+
+		@Override
+		public Optional<String> explainExtras() {
+			return Optional.empty();
+		}
 	}
 
 	/**
-	 * Returns if this column is a computed column that is generated from an expression.
-	 *
-	 * @return true if this column is generated
+	 * Representation of a computed column.
 	 */
-	public boolean isGenerated() {
-		return this.expr != null;
+	public static class ComputedColumn extends TableColumn {
+
+		private final String expression;
+
+		private ComputedColumn(String name, DataType type, String expression) {
+			super(name, type);
+			this.expression = expression;
+		}
+
+		@Override
+		public boolean isPhysical() {
+			return false;
+		}
+
+		public String getExpression() {
+			return expression;
+		}
+
+		@Override
+		public Optional<String> explainExtras() {
+			return Optional.of("AS " + expression);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			ComputedColumn that = (ComputedColumn) o;
+			return expression.equals(that.expression);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), expression);
+		}
 	}
 
+	/**
+	 * Representation of a metadata column.
+	 */
+	public static class MetadataColumn extends TableColumn {
+
+		private final @Nullable String metadataAlias;
+
+		private final boolean isVirtual;
+
+		private MetadataColumn(
+				String name,
+				DataType type,
+				@Nullable String metadataAlias,
+				boolean isVirtual) {
+			super(name, type);
+			this.metadataAlias = metadataAlias;
+			this.isVirtual = isVirtual;
+		}
+
+		public boolean isVirtual() {
+			return isVirtual;
+		}
+
+		public Optional<String> getMetadataAlias() {
+			return Optional.ofNullable(metadataAlias);
+		}
+
+		@Override
+		public boolean isPhysical() {
+			return false;
+		}
+
+		@Override
+		public Optional<String> explainExtras() {
+			final StringBuilder sb = new StringBuilder();
+			sb.append("METADATA");
+			if (metadataAlias != null) {
+				sb.append(" FROM ");
+				sb.append(metadataAlias);
+			}
+			if (isVirtual) {
+				sb.append(" VIRTUAL");
+			}
+			return Optional.of(sb.toString());
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			MetadataColumn that = (MetadataColumn) o;
+			return isVirtual == that.isVirtual &&
+				Objects.equals(metadataAlias, that.metadataAlias);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), metadataAlias, isVirtual);
+		}
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
@@ -71,6 +71,11 @@ public class WatermarkSpec {
 		return watermarkExprOutputType;
 	}
 
+	public String asSummaryString() {
+		return "WATERMARK FOR " + rowtimeAttribute + ": " + watermarkExprOutputType +
+			" AS " + watermarkExpressionString;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -92,9 +97,6 @@ public class WatermarkSpec {
 
 	@Override
 	public String toString() {
-		return "WatermarkSpec{rowtime: '" + rowtimeAttribute + '\'' +
-			", watermark: '" + watermarkExpressionString + '\'' +
-			", outputType: '" + watermarkExprOutputType + '\'' +
-			"}";
+		return asSummaryString();
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
@@ -162,9 +162,8 @@ public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T>
 			final TableColumn tableColumn = tableSchema.getTableColumns().get(i);
 			final String fieldName = tableColumn.getName();
 			final DataType dataType = tableColumn.getType();
-			final boolean isGeneratedColumn = tableColumn.isGenerated();
-			if (isGeneratedColumn) {
-				//skip generated column
+			if (!tableColumn.isPhysical()) {
+				// skip non-physical columns
 				continue;
 			}
 			final boolean isProctime = descriptorProperties

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSourceValidation.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSourceValidation.java
@@ -179,9 +179,9 @@ public class TableSourceValidation {
 	}
 
 	private static void validateNoGeneratedColumns(TableSchema tableSchema) {
-		if (TableSchemaUtils.containsGeneratedColumns(tableSchema)) {
+		if (!TableSchemaUtils.containsPhysicalColumnsOnly(tableSchema)) {
 			throw new ValidationException(
-				"TableSource#getTableSchema shouldn't contain generated columns, schema: \n" + tableSchema);
+				"TableSource#getTableSchema should only contain physical columns, schema: \n" + tableSchema);
 		}
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaUtils.java
@@ -42,18 +42,18 @@ public class TableSchemaUtils {
 
 	/**
 	 * Return {@link TableSchema} which consists of all physical columns. That means, the computed
-	 * columns are filtered out.
+	 * columns and metadata columns are filtered out.
 	 *
 	 * <p>Readers(or writers) such as {@link TableSource} and {@link TableSink} should use this physical
 	 * schema to generate {@link TableSource#getProducedDataType()} and {@link TableSource#getTableSchema()}
-	 * rather than using the raw TableSchema which may contains computed columns.
+	 * rather than using the raw TableSchema which may contains additional columns.
 	 */
 	public static TableSchema getPhysicalSchema(TableSchema tableSchema) {
 		Preconditions.checkNotNull(tableSchema);
 		TableSchema.Builder builder = new TableSchema.Builder();
 		tableSchema.getTableColumns().forEach(
 			tableColumn -> {
-				if (!tableColumn.isGenerated()) {
+				if (tableColumn.isPhysical()) {
 					builder.field(tableColumn.getName(), tableColumn.getType());
 				}
 			});
@@ -72,7 +72,7 @@ public class TableSchemaUtils {
 	 * @see org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown
 	 */
 	public static TableSchema projectSchema(TableSchema tableSchema, int[][] projectedFields) {
-		checkArgument(!containsGeneratedColumns(tableSchema), "It's illegal to project on a schema contains computed columns.");
+		checkArgument(containsPhysicalColumnsOnly(tableSchema), "Projection is only supported for physical columns.");
 		TableSchema.Builder schemaBuilder = TableSchema.builder();
 		List<TableColumn> tableColumns = tableSchema.getTableColumns();
 		for (int[] fieldPath : projectedFields) {
@@ -84,21 +84,21 @@ public class TableSchemaUtils {
 	}
 
 	/**
-	 * Returns true if there are any generated columns in the given {@link TableColumn}.
+	 * Returns true if there are only physical columns in the given {@link TableSchema}.
 	 */
-	public static boolean containsGeneratedColumns(TableSchema schema) {
+	public static boolean containsPhysicalColumnsOnly(TableSchema schema) {
 		Preconditions.checkNotNull(schema);
-		return schema.getTableColumns().stream().anyMatch(TableColumn::isGenerated);
+		return schema.getTableColumns().stream().allMatch(TableColumn::isPhysical);
 	}
 
 	/**
-	 * Throws exception if the given {@link TableSchema} contains any generated columns.
+	 * Throws an exception if the given {@link TableSchema} contains any non-physical columns.
 	 */
-	public static TableSchema checkNoGeneratedColumns(TableSchema schema) {
+	public static TableSchema checkPhysicalColumns(TableSchema schema) {
 		Preconditions.checkNotNull(schema);
-		if (containsGeneratedColumns(schema)) {
+		if (!containsPhysicalColumnsOnly(schema)) {
 			throw new ValidationException(
-				"The given schema contains generated columns, schema: " + schema.toString());
+				"The given schema contains non-physical columns, schema: \n" + schema.toString());
 		}
 		return schema;
 	}
@@ -164,14 +164,10 @@ public class TableSchemaUtils {
 	}
 
 	/** Returns the builder with copied columns info from the given table schema. */
-	private static TableSchema.Builder builderWithGivenColumns(List<TableColumn> oriColumns) {
-		TableSchema.Builder builder = TableSchema.builder();
-		for (TableColumn column : oriColumns) {
-			if (column.isGenerated()) {
-				builder.field(column.getName(), column.getType(), column.getExpr().get());
-			} else {
-				builder.field(column.getName(), column.getType());
-			}
+	private static TableSchema.Builder builderWithGivenColumns(List<TableColumn> originalColumns) {
+		final TableSchema.Builder builder = TableSchema.builder();
+		for (TableColumn column : originalColumns) {
+			builder.add(column);
 		}
 		return builder;
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaUtils.java
@@ -94,7 +94,7 @@ public class TableSchemaUtils {
 	/**
 	 * Throws an exception if the given {@link TableSchema} contains any non-physical columns.
 	 */
-	public static TableSchema checkPhysicalColumns(TableSchema schema) {
+	public static TableSchema checkOnlyPhysicalColumns(TableSchema schema) {
 		Preconditions.checkNotNull(schema);
 		if (!containsPhysicalColumnsOnly(schema)) {
 			throw new ValidationException(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
@@ -85,7 +85,7 @@ public class TableSchemaUtilsTest {
 				.watermark("t", "t", DataTypes.TIMESTAMP(3))
 				.build();
 			exceptionRule.expect(IllegalArgumentException.class);
-			exceptionRule.expectMessage("It's illegal to project on a schema contains computed columns.");
+			exceptionRule.expectMessage("Projection is only supported for physical columns.");
 			int[][] projectedFields = {{1}};
 			TableSchemaUtils.projectSchema(schema, projectedFields);
 		}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
@@ -49,7 +49,7 @@ public class TableSchemaUtilsTest {
 
 	@Test
 	public void testDropConstraint() {
-		TableSchema oriSchema = TableSchema.builder()
+		TableSchema originalSchema = TableSchema.builder()
 				.field("a", DataTypes.INT().notNull())
 				.field("b", DataTypes.STRING())
 				.field("c", DataTypes.INT(), "a + 1")
@@ -57,18 +57,20 @@ public class TableSchemaUtilsTest {
 				.primaryKey("ct1", new String[] {"a"})
 				.watermark("t", "t", DataTypes.TIMESTAMP(3))
 				.build();
-		TableSchema newSchema = TableSchemaUtils.dropConstraint(oriSchema, "ct1");
-		final String expected = "root\n" +
-				" |-- a: INT NOT NULL\n" +
-				" |-- b: STRING\n" +
-				" |-- c: INT AS a + 1\n" +
-				" |-- t: TIMESTAMP(3)\n" +
-				" |-- WATERMARK FOR t AS t\n";
-		assertEquals(expected, newSchema.toString());
+		TableSchema newSchema = TableSchemaUtils.dropConstraint(originalSchema, "ct1");
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("a", DataTypes.INT().notNull())
+				.field("b", DataTypes.STRING())
+				.field("c", DataTypes.INT(), "a + 1")
+				.field("t", DataTypes.TIMESTAMP(3))
+				.watermark("t", "t", DataTypes.TIMESTAMP(3))
+				.build();
+		assertEquals(expectedSchema, newSchema);
+
 		// Drop non-exist constraint.
 		exceptionRule.expect(ValidationException.class);
 		exceptionRule.expectMessage("Constraint ct2 to drop does not exist");
-		TableSchemaUtils.dropConstraint(oriSchema, "ct2");
+		TableSchemaUtils.dropConstraint(originalSchema, "ct2");
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -153,7 +153,7 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 		// It should be removed after we remove DefinedProctimeAttribute/DefinedRowtimeAttributes.
 		Optional<TableSource<?>> sourceOpt = findAndCreateTableSource();
 		if (isStreamingMode
-			&& tableSchema.getTableColumns().stream().noneMatch(TableColumn::isGenerated)
+			&& tableSchema.getTableColumns().stream().allMatch(TableColumn::isPhysical)
 			&& tableSchema.getWatermarkSpecs().isEmpty()
 			&& sourceOpt.isPresent()) {
 			TableSource<?> source = sourceOpt.get();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
@@ -19,7 +19,9 @@
 package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlComputedColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlMetadataColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableLike;
 import org.apache.flink.sql.parser.ddl.SqlTableLike.FeatureOption;
@@ -27,6 +29,9 @@ import org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy;
 import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableColumn.ComputedColumn;
+import org.apache.flink.table.api.TableColumn.MetadataColumn;
+import org.apache.flink.table.api.TableColumn.PhysicalColumn;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.WatermarkSpec;
@@ -69,6 +74,7 @@ class MergeTableLikeUtil {
 		defaultMergingStrategies.put(FeatureOption.OPTIONS, MergingStrategy.OVERWRITING);
 		defaultMergingStrategies.put(FeatureOption.WATERMARKS, MergingStrategy.INCLUDING);
 		defaultMergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.INCLUDING);
+		defaultMergingStrategies.put(FeatureOption.METADATA, MergingStrategy.INCLUDING);
 		defaultMergingStrategies.put(FeatureOption.CONSTRAINTS, MergingStrategy.INCLUDING);
 		defaultMergingStrategies.put(FeatureOption.PARTITIONS, MergingStrategy.INCLUDING);
 	}
@@ -206,7 +212,7 @@ class MergeTableLikeUtil {
 
 			// Intermediate state
 			Map<String, RelDataType> physicalFieldNamesToTypes = new LinkedHashMap<>();
-			Map<String, RelDataType> computedFieldNamesToTypes = new LinkedHashMap<>();
+			Map<String, RelDataType> nonPhysicalFieldNamesToTypes = new LinkedHashMap<>();
 
 			Function<SqlNode, String> escapeExpressions;
 			FlinkTypeFactory typeFactory;
@@ -230,15 +236,19 @@ class MergeTableLikeUtil {
 				Map<FeatureOption, MergingStrategy> mergingStrategies,
 				TableSchema sourceSchema) {
 			for (TableColumn sourceColumn : sourceSchema.getTableColumns()) {
-				if (sourceColumn.getExpr().isPresent()) {
-					if (mergingStrategies.get(FeatureOption.GENERATED) != MergingStrategy.EXCLUDING) {
-						columns.put(sourceColumn.getName(), sourceColumn);
-					}
-				} else {
+				if (sourceColumn instanceof PhysicalColumn) {
 					physicalFieldNamesToTypes.put(
 						sourceColumn.getName(),
 						typeFactory.createFieldTypeFromLogicalType(sourceColumn.getType().getLogicalType()));
 					columns.put(sourceColumn.getName(), sourceColumn);
+				} else if (sourceColumn instanceof ComputedColumn) {
+					if (mergingStrategies.get(FeatureOption.GENERATED) != MergingStrategy.EXCLUDING) {
+						columns.put(sourceColumn.getName(), sourceColumn);
+					}
+				} else if (sourceColumn instanceof MetadataColumn) {
+					if (mergingStrategies.get(FeatureOption.METADATA) != MergingStrategy.EXCLUDING) {
+						columns.put(sourceColumn.getName(), sourceColumn);
+					}
 				}
 			}
 		}
@@ -272,15 +282,15 @@ class MergeTableLikeUtil {
 					String primaryKey = ((SqlIdentifier) primaryKeyNode).getSimple();
 					if (!columns.containsKey(primaryKey)) {
 						throw new ValidationException(
-							String.format("Primary key column '%s' is not defined in the schema, at %s",
+							String.format("Primary key column '%s' is not defined in the schema at %s",
 								primaryKey,
 								primaryKeyNode.getParserPosition()));
 					}
-					if (columns.get(primaryKey).isGenerated()) {
+					if (!columns.get(primaryKey).isPhysical()) {
 						throw new ValidationException(
 							String.format(
-								"Could not create a PRIMARY KEY with a generated column '%s', at %s.\n" +
-									"PRIMARY KEY constraint is not allowed on computed columns.",
+								"Could not create a PRIMARY KEY with column '%s' at %s.\n" +
+									"A PRIMARY KEY constraint must be declared on physical columns.",
 								primaryKey,
 								primaryKeyNode.getParserPosition()));
 					}
@@ -300,7 +310,7 @@ class MergeTableLikeUtil {
 				SqlIdentifier eventTimeColumnName = derivedWatermarkSpec.getEventTimeColumnName();
 
 				HashMap<String, RelDataType> nameToTypeMap = new LinkedHashMap<>(physicalFieldNamesToTypes);
-				nameToTypeMap.putAll(computedFieldNamesToTypes);
+				nameToTypeMap.putAll(nonPhysicalFieldNamesToTypes);
 				verifyRowtimeAttribute(mergingStrategies, eventTimeColumnName, nameToTypeMap);
 				String rowtimeAttribute = eventTimeColumnName.toString();
 
@@ -372,42 +382,66 @@ class MergeTableLikeUtil {
 			collectPhysicalFieldsTypes(derivedColumns);
 
 			for (SqlNode derivedColumn : derivedColumns) {
+				final String name = ((SqlTableColumn) derivedColumn).getName().getSimple();
 				final TableColumn column;
 				if (derivedColumn instanceof SqlRegularColumn) {
-					SqlRegularColumn regularColumn = (SqlRegularColumn) derivedColumn;
-					String name = regularColumn.getName().getSimple();
-					LogicalType logicalType = FlinkTypeFactory.toLogicalType(physicalFieldNamesToTypes.get(name));
-					column = TableColumn.of(name, TypeConversions.fromLogicalToDataType(logicalType));
+					final LogicalType logicalType = FlinkTypeFactory.toLogicalType(physicalFieldNamesToTypes.get(name));
+					column = TableColumn.physical(name, TypeConversions.fromLogicalToDataType(logicalType));
 				} else if (derivedColumn instanceof SqlComputedColumn) {
-					SqlComputedColumn computedColumn = (SqlComputedColumn) derivedColumn;
-					String fieldName = computedColumn.getName().toString();
-					if (columns.containsKey(fieldName)) {
-						if (!columns.get(fieldName).isGenerated()) {
+					final SqlComputedColumn computedColumn = (SqlComputedColumn) derivedColumn;
+					if (columns.containsKey(name)) {
+						if (!(columns.get(name) instanceof ComputedColumn)) {
 							throw new ValidationException(String.format(
-								"A physical column named '%s' already exists in the base table. Computed columns can" +
-									"not overwrite physical fields.",
-								fieldName));
+								"A column named '%s' already exists in the base table. " +
+									"Computed columns can only overwrite other computed columns.",
+								name));
 						}
 
 						if (mergingStrategies.get(FeatureOption.GENERATED) != MergingStrategy.OVERWRITING) {
 							throw new ValidationException(String.format(
 								"A generated column named '%s' already exists in the base table. You " +
 									"might want to specify EXCLUDING GENERATED or OVERWRITING GENERATED.",
-								fieldName));
+								name));
 						}
 					}
 
-					SqlNode validatedExpr = sqlValidator.validateParameterizedExpression(
+					final SqlNode validatedExpr = sqlValidator.validateParameterizedExpression(
 						computedColumn.getExpr(),
 						physicalFieldNamesToTypes);
 					final RelDataType validatedType = sqlValidator.getValidatedNodeType(validatedExpr);
-					column = TableColumn.of(
-						fieldName,
+					column = TableColumn.computed(
+						name,
 						fromLogicalToDataType(toLogicalType(validatedType)),
 						escapeExpressions.apply(validatedExpr));
-					computedFieldNamesToTypes.put(fieldName, validatedType);
+					nonPhysicalFieldNamesToTypes.put(name, validatedType);
+				} else if (derivedColumn instanceof SqlMetadataColumn) {
+					final SqlMetadataColumn metadataColumn = (SqlMetadataColumn) derivedColumn;
+					if (columns.containsKey(name)) {
+						if (!(columns.get(name) instanceof MetadataColumn)) {
+							throw new ValidationException(String.format(
+								"A column named '%s' already exists in the base table. " +
+									"Metadata columns can only overwrite other metadata columns.",
+								name));
+						}
+
+						if (mergingStrategies.get(FeatureOption.METADATA) != MergingStrategy.OVERWRITING) {
+							throw new ValidationException(String.format(
+								"A metadata column named '%s' already exists in the base table. You " +
+									"might want to specify EXCLUDING METADATA or OVERWRITING METADATA.",
+								name));
+						}
+					}
+
+					final RelDataType relType = metadataColumn.getType()
+						.deriveType(sqlValidator, metadataColumn.getType().getNullable());
+					column = TableColumn.metadata(
+						name,
+						fromLogicalToDataType(toLogicalType(relType)),
+						metadataColumn.getMetadataAlias().orElse(null),
+						metadataColumn.isVirtual());
+					nonPhysicalFieldNamesToTypes.put(name, relType);
 				} else {
-					throw new ValidationException("Unsupported column type."); // TODO
+					throw new ValidationException("Unsupported column type: " + derivedColumn);
 				}
 				columns.put(column.getName(), column);
 			}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -97,7 +97,7 @@ class SqlCreateTableConverter {
 			sourceTableSchema = table.getSchema();
 			sourcePartitionKeys = table.getPartitionKeys();
 			likeOptions = sqlTableLike.getOptions();
-			sourceProperties = table.getProperties();
+			sourceProperties = table.getOptions();
 		} else {
 			sourceTableSchema = TableSchema.builder().build();
 			sourcePartitionKeys = Collections.emptyList();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
@@ -176,7 +176,7 @@ public class OperationConverterUtils {
 		LogicalType logicalType = FlinkTypeFactory.toLogicalType(
 				typeSpec.deriveType(sqlValidator, typeSpec.getNullable()));
 		DataType dataType = TypeConversions.fromLogicalToDataType(logicalType);
-		return TableColumn.of(name, dataType);
+		return TableColumn.physical(name, dataType);
 	}
 
 	private static void setWatermarkAndPK(TableSchema.Builder builder, TableSchema schema) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.schema
 
 import org.apache.flink.configuration.ReadableConfig
+import org.apache.flink.table.api.TableColumn.ComputedColumn
 import org.apache.flink.table.api.config.TableConfigOptions
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.catalog.CatalogTable
@@ -63,8 +64,12 @@ class LegacyCatalogSourceTable[T](
   lazy val columnExprs: Map[String, String] = {
     catalogTable.getSchema
       .getTableColumns
-      .filter(column => column.isGenerated)
-      .map(column => (column.getName, column.getExpr.get()))
+      .flatMap {
+        case computedColumn: ComputedColumn =>
+          Some((computedColumn.getName, computedColumn.getExpression))
+        case _ =>
+          None
+      }
       .toMap
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableColumn.ComputedColumn;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -384,8 +385,8 @@ public class SqlToOperationConverterTest {
 	public void testPrimaryKeyOnGeneratedColumn() {
 		thrown.expect(ValidationException.class);
 		thrown.expectMessage(
-			"Could not create a PRIMARY KEY with a generated column 'c', at line 5, column 34.\n" +
-				"PRIMARY KEY constraint is not allowed on computed columns.");
+			"Could not create a PRIMARY KEY with column 'c' at line 5, column 34.\n" +
+				"A PRIMARY KEY constraint must be declared on physical columns.");
 		final String sql2 = "CREATE TABLE tbl1 (\n" +
 			"  a bigint not null,\n" +
 			"  b varchar not null,\n" +
@@ -401,7 +402,7 @@ public class SqlToOperationConverterTest {
 	@Test
 	public void testPrimaryKeyNonExistentColumn() {
 		thrown.expect(ValidationException.class);
-		thrown.expectMessage("Primary key column 'd' is not defined in the schema, at line 5, column 34");
+		thrown.expectMessage("Primary key column 'd' is not defined in the schema at line 5, column 34");
 		final String sql2 = "CREATE TABLE tbl1 (\n" +
 			"  a bigint not null,\n" +
 			"  b varchar not null,\n" +
@@ -934,8 +935,9 @@ public class SqlToOperationConverterTest {
 			catalogTable.getSchema().getFieldDataTypes());
 		String[] columnExpressions =
 			catalogTable.getSchema().getTableColumns().stream()
-				.filter(TableColumn::isGenerated)
-				.map(c -> c.getExpr().orElse(null))
+				.filter(ComputedColumn.class::isInstance)
+				.map(ComputedColumn.class::cast)
+				.map(ComputedColumn::getExpression)
 				.toArray(String[]::new);
 		String[] expected = new String[] {
 			"`a` - 1",
@@ -947,6 +949,37 @@ public class SqlToOperationConverterTest {
 		assertArrayEquals(
 			expected,
 			columnExpressions);
+	}
+
+	@Test
+	public void testCreateTableWithMetadataColumn() {
+		final String sql = "CREATE TABLE tbl1 (\n" +
+			"  a INT,\n" +
+			"  b STRING,\n" +
+			"  c INT METADATA,\n" +
+			"  d INT METADATA FROM 'other.key',\n" +
+			"  e INT METADATA VIRTUAL\n" +
+			")\n" +
+			"  WITH (\n" +
+			"    'connector' = 'kafka',\n" +
+			"    'kafka.topic' = 'log.test'\n" +
+			")\n";
+
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		final Operation operation = parse(sql, planner, getParserBySqlDialect(SqlDialect.DEFAULT));
+		assert operation instanceof CreateTableOperation;
+		final CreateTableOperation op = (CreateTableOperation) operation;
+		final TableSchema actualSchema = op.getCatalogTable().getSchema();
+
+		final TableSchema expectedSchema = TableSchema.builder()
+			.add(TableColumn.physical("a", DataTypes.INT()))
+			.add(TableColumn.physical("b", DataTypes.STRING()))
+			.add(TableColumn.metadata("c", DataTypes.INT()))
+			.add(TableColumn.metadata("d", DataTypes.INT(), "other.key"))
+			.add(TableColumn.metadata("e", DataTypes.INT(), true))
+			.build();
+
+		assertEquals(expectedSchema, actualSchema);
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -1124,7 +1124,7 @@ class TableEnvironmentTest {
         Row.of("f25", "STRING", Boolean.box(false), null, null, null),
         Row.of("f26", "ROW<`f0` INT NOT NULL, `f1` INT>", Boolean.box(false),
           "PRI(f24, f26)", null, null),
-        Row.of("ts", "TIMESTAMP(3) *ROWTIME*", Boolean.box(true), null, "TO_TIMESTAMP(`f25`)",
+        Row.of("ts", "TIMESTAMP(3) *ROWTIME*", Boolean.box(true), null, "AS TO_TIMESTAMP(`f25`)",
           "`ts` - INTERVAL '1' SECOND")
       ).iterator(),
       tableResult1.collect())

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
@@ -33,17 +33,16 @@ import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR
 import org.apache.flink.table.factories.{TableSinkFactory, TableSourceFactory}
 import org.apache.flink.table.functions.{AsyncTableFunction, TableFunction}
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory.{getCollectionSink, getCollectionSource}
-import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.table.sinks.{AppendStreamTableSink, BatchTableSink, StreamTableSink, TableSink}
 import org.apache.flink.table.sources.{BatchTableSource, LookupableTableSource, StreamTableSource}
 import org.apache.flink.table.types.DataType
 import org.apache.flink.types.Row
+
 import java.io.IOException
 import java.util
 import java.util.{ArrayList => JArrayList, LinkedList => JLinkedList, List => JList, Map => JMap}
-
-import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
+import org.apache.flink.table.utils.TableSchemaUtils.getPhysicalSchema
 
 import scala.collection.JavaConversions._
 
@@ -104,19 +103,12 @@ object TestCollectionTableFactory {
   def getCollectionSource(context: TableSourceFactory.Context): CollectionTableSource = {
     val schema = context.getTable.getSchema
     val isBounded = context.getTable.getProperties.getOrDefault(IS_BOUNDED, "true").toBoolean
-    new CollectionTableSource(emitIntervalMS, physicalSchema(schema), isBounded)
+    new CollectionTableSource(emitIntervalMS, getPhysicalSchema(schema), isBounded)
   }
 
   def getCollectionSink(context: TableSinkFactory.Context): CollectionTableSink = {
     val schema = context.getTable.getSchema
-    new CollectionTableSink(physicalSchema(schema))
-  }
-
-  def physicalSchema(schema: TableSchema): TableSchema = {
-    val builder = TableSchema.builder()
-    schema.getTableColumns.filter(c => !c.isGenerated)
-      .foreach(c => builder.field(c.getName, c.getType))
-    builder.build()
+    new CollectionTableSink(getPhysicalSchema(schema))
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
@@ -48,7 +48,8 @@ import org.apache.flink.table.sources._
 import org.apache.flink.table.sources.tsextractors.ExistingField
 import org.apache.flink.table.sources.wmstrategies.{AscendingTimestamps, PreserveWatermarks}
 import org.apache.flink.table.types.DataType
-import org.apache.flink.table.utils.{EncodingUtils, TableSchemaUtils}
+import org.apache.flink.table.utils.TableSchemaUtils.getPhysicalSchema
+import org.apache.flink.table.utils.{EncodingUtils}
 import org.apache.flink.types.Row
 
 import _root_.java.io.{File, FileOutputStream, OutputStreamWriter}
@@ -457,13 +458,7 @@ class TestLegacyProjectableTableSourceFactory extends StreamTableSourceFactory[R
     descriptorProps.putProperties(properties)
     val isBounded = descriptorProps.getBoolean("is-bounded")
     val tableSchema = descriptorProps.getTableSchema(Schema.SCHEMA)
-    // Build physical row type.
-    val schemaBuilder = TableSchema.builder()
-    tableSchema
-      .getTableColumns
-      .filter(c => !c.isGenerated)
-      .foreach(c => schemaBuilder.field(c.getName, c.getType))
-    val rowTypeInfo = schemaBuilder.build().toRowType
+    val rowTypeInfo = getPhysicalSchema(tableSchema).toRowType
     new TestLegacyProjectableTableSource(isBounded, tableSchema, rowTypeInfo, Seq())
   }
 
@@ -798,7 +793,7 @@ class TestDataTypeTableSourceFactory extends TableSourceFactory[Row] {
   override def createTableSource(properties: JMap[String, String]): TableSource[Row] = {
     val descriptorProperties = new DescriptorProperties
     descriptorProperties.putProperties(properties)
-    val tableSchema = TableSchemaUtils.getPhysicalSchema(
+    val tableSchema = getPhysicalSchema(
       descriptorProperties.getTableSchema(Schema.SCHEMA))
     val serializedRows = descriptorProperties.getOptionalString("data").orElse(null)
     val data = if (serializedRows != null) {
@@ -877,7 +872,7 @@ class TestDataTypeTableSourceWithTimeFactory extends TableSourceFactory[Row] {
   override def createTableSource(properties: JMap[String, String]): TableSource[Row] = {
     val descriptorProperties = new DescriptorProperties
     descriptorProperties.putProperties(properties)
-    val tableSchema = TableSchemaUtils.getPhysicalSchema(
+    val tableSchema = getPhysicalSchema(
       descriptorProperties.getTableSchema(Schema.SCHEMA))
 
     val serializedRows = descriptorProperties.getOptionalString("data").orElse(null)
@@ -1314,7 +1309,7 @@ class OptionsTableSource(
   override def explainSource(): String = s"${classOf[OptionsTableSource].getSimpleName}" +
     s"(props=$props)"
 
-  override def getTableSchema: TableSchema = TableSchemaUtils.getPhysicalSchema(tableSchema)
+  override def getTableSchema: TableSchema = getPhysicalSchema(tableSchema)
 
   override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] =
     None.asInstanceOf[DataStream[Row]]
@@ -1341,7 +1336,7 @@ class OptionsTableSink(
   override def getTableSchema: TableSchema = tableSchema
 
   override def getConsumedDataType: DataType = {
-    TableSchemaUtils.getPhysicalSchema(tableSchema).toRowDataType
+    getPhysicalSchema(tableSchema).toRowDataType
   }
 
   override def consumeDataSet(dataSet: DataSet[Row]): DataSink[_] = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -25,7 +25,7 @@ import org.apache.flink.api.java.operators.DataSink
 import org.apache.flink.core.execution.JobClient
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.internal.TableResultImpl.PrintStyle
-import org.apache.flink.table.calcite.{CalciteParser, FlinkPlannerImpl, FlinkRelBuilder}
+import org.apache.flink.table.calcite.{CalciteParser, FlinkPlannerImpl}
 import org.apache.flink.table.catalog._
 import org.apache.flink.table.catalog.exceptions.{TableNotExistException => _, _}
 import org.apache.flink.table.delegation.Parser
@@ -48,7 +48,6 @@ import org.apache.flink.types.Row
 import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools.FrameworkConfig
-import org.apache.commons.lang3.StringUtils
 
 import _root_.java.lang.{Iterable => JIterable, Long => JLong}
 import _root_.java.util.function.{Function => JFunction, Supplier => JSupplier}
@@ -828,15 +827,15 @@ abstract class TableEnvImpl(
       case (c, i) => {
         val logicalType = c.getType.getLogicalType
         data(i)(0) = c.getName
-        data(i)(1) = StringUtils.removeEnd(logicalType.toString, " NOT NULL")
+        data(i)(1) = logicalType.copy(true).asSummaryString()
         data(i)(2) = Boolean.box(logicalType.isNullable)
         data(i)(3) = fieldToPrimaryKey.getOrDefault(c.getName, null)
-        data(i)(4) = c.getExpr.orElse(null)
+        data(i)(4) = c.explainExtras().orElse(null)
         data(i)(5) = fieldToWatermark.getOrDefault(c.getName, null)
       }
     }
     buildResult(
-      Array("name", "type", "null", "key", "computed column", "watermark"),
+      Array("name", "type", "null", "key", "extras", "watermark"),
       Array(DataTypes.STRING, DataTypes.STRING, DataTypes.BOOLEAN, DataTypes.STRING,
         DataTypes.STRING, DataTypes.STRING),
       data)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -64,9 +64,7 @@ import org.apache.flink.table.utils.ParserMock;
 import org.apache.calcite.sql.SqlNode;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nullable;
 
@@ -78,8 +76,13 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 /** Test cases for {@link SqlToOperationConverter}. **/
 public class SqlToOperationConverterTest {
@@ -99,9 +102,6 @@ public class SqlToOperationConverterTest {
 			functionCatalog,
 			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, tableConfig, false)),
 			new ExpressionBridge<>(PlannerExpressionConverter.INSTANCE()));
-
-	@Rule
-	public ExpectedException expectedEx = ExpectedException.none();
 
 	@Before
 	public void before() throws TableAlreadyExistException, DatabaseNotExistException {
@@ -499,7 +499,7 @@ public class SqlToOperationConverterTest {
 	}
 
 	@Test
-	public void testCreateTableWithUnSupportedDataTypes() {
+	public void testCreateTableWithUnsupportedFeatures() {
 		final List<TestItem> testItems = Arrays.asList(
 			createTestItem("ARRAY<TIMESTAMP(3) WITH LOCAL TIME ZONE>",
 				"Type is not supported: TIMESTAMP_WITH_LOCAL_TIME_ZONE"),
@@ -511,18 +511,22 @@ public class SqlToOperationConverterTest {
 			createTestItem("VARBINARY(33)", "Type is not supported: VARBINARY"),
 			createTestItem("VARBINARY", "Type is not supported: VARBINARY"),
 			createTestItem("BINARY(33)", "Type is not supported: BINARY"),
-			createTestItem("BINARY", "Type is not supported: BINARY")
+			createTestItem("BINARY", "Type is not supported: BINARY"),
+			createTestItem("AS 1 + 1", "Only regular columns are supported in the DDL of the old planner."),
+			createTestItem("INT METADATA", "Only regular columns are supported in the DDL of the old planner.")
 		);
-		final String sqlTemplate = "create table t1(\n" +
-			"  f0 %s)";
+		final String sqlTemplate = "CREATE TABLE T1 (f0 %s)";
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
 		for (TestItem item : testItems) {
 			String sql = String.format(sqlTemplate, item.testExpr);
 			SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
 			assert node instanceof SqlCreateTable;
-			expectedEx.expect(TableException.class);
-			expectedEx.expectMessage(item.expectedError);
-			SqlToOperationConverter.convert(planner, catalogManager, node);
+			try {
+				SqlToOperationConverter.convert(planner, catalogManager, node);
+			} catch (Exception e) {
+				assertThat(e, is(instanceOf(TableException.class)));
+				assertThat(e, hasMessage(equalTo(item.expectedError)));
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This updates all API related classes to support the concept of a
metadata column. It considers all location until planner level.

## Brief change log

- Update `TableColumn` to a hierarchy of 3 column types
- Update TableSchemaUtils and all related locations that rely on computed column but have to deal with metadata column now as well.

## Verifying this change

This change is already covered by existing tests. Plus `DescriptorPropertiesTest`, `MergeLikeUtilTest`, and others.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
