### PR TITLE
[FLINK-19403][python] Support Pandas Stream Group Window Aggregation

### DIFF
--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -17,11 +17,13 @@
 ################################################################################
 import unittest
 
+from pyflink.datastream import TimeCharacteristic
 from pyflink.table import expressions as expr
 from pyflink.table.types import DataTypes
 from pyflink.table.udf import udaf, udf, AggregateFunction
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
+    PyFlinkBlinkStreamTableTestCase
 
 
 class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
@@ -257,6 +259,129 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
                             "2,2.0,9,2.0,4.0,4.0,2.0,2.0,4.0,4.0",
                             "2,2.0,3,2.0,2.0,4.0,1.0,2.0,4.0,2.0",
                             "3,2.0,3,2.0,1.0,1.0,2.0,2.0,1.0,1.0"])
+
+
+class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
+    def test_group_window_aggregate_function_over_time(self):
+        # create source file path
+        import tempfile
+        import os
+        tmp_dir = tempfile.gettempdir()
+        data = [
+            '1,2,2018-03-11 03:10:00',
+            '3,2,2018-03-11 03:10:00',
+            '2,1,2018-03-11 03:10:00',
+            '1,3,2018-03-11 03:40:00',
+            '1,8,2018-03-11 04:20:00',
+            '2,3,2018-03-11 03:30:00'
+        ]
+        source_path = tmp_dir + '/test_group_window_aggregate_function_over_time.csv'
+        with open(source_path, 'w') as fd:
+            for ele in data:
+                fd.write(ele + '\n')
+
+        from pyflink.table.window import Slide
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+        self.t_env.register_function("mean_udaf", mean_udaf)
+
+        source_table = """
+            create table source_table(
+                a TINYINT,
+                b SMALLINT,
+                rowtime TIMESTAMP(3),
+                WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
+            ) with(
+                'connector.type' = 'filesystem',
+                'format.type' = 'csv',
+                'connector.path' = '%s',
+                'format.ignore-first-line' = 'false',
+                'format.field-delimiter' = ','
+            )
+        """ % source_path
+        self.t_env.execute_sql(source_table)
+        t = self.t_env.from_path("source_table")
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c', 'd'],
+            [
+                DataTypes.TINYINT(),
+                DataTypes.TIMESTAMP(3),
+                DataTypes.TIMESTAMP(3),
+                DataTypes.FLOAT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t.window(Slide.over("1.hours").every("30.minutes").on("rowtime").alias("w")) \
+            .group_by("a, w") \
+            .select("a, w.start, w.end, mean_udaf(b) as b") \
+            .execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual,
+                           ["1,2018-03-11 02:30:00.0,2018-03-11 03:30:00.0,2.0",
+                            "1,2018-03-11 03:00:00.0,2018-03-11 04:00:00.0,2.5",
+                            "1,2018-03-11 03:30:00.0,2018-03-11 04:30:00.0,5.5",
+                            "1,2018-03-11 04:00:00.0,2018-03-11 05:00:00.0,8.0",
+                            "2,2018-03-11 02:30:00.0,2018-03-11 03:30:00.0,1.0",
+                            "2,2018-03-11 03:00:00.0,2018-03-11 04:00:00.0,2.0",
+                            "2,2018-03-11 03:30:00.0,2018-03-11 04:30:00.0,3.0",
+                            "3,2018-03-11 03:00:00.0,2018-03-11 04:00:00.0,2.0",
+                            "3,2018-03-11 02:30:00.0,2018-03-11 03:30:00.0,2.0"])
+        os.remove(source_path)
+
+    def test_group_window_aggregate_function_over_count(self):
+        self.env.set_parallelism(1)
+        # create source file path
+        import tempfile
+        import os
+        tmp_dir = tempfile.gettempdir()
+        data = [
+            '1,2,2018-03-11 03:10:00',
+            '3,2,2018-03-11 03:10:00',
+            '2,1,2018-03-11 03:10:00',
+            '1,3,2018-03-11 03:40:00',
+            '1,8,2018-03-11 04:20:00',
+            '2,3,2018-03-11 03:30:00',
+            '3,3,2018-03-11 03:30:00'
+        ]
+        source_path = tmp_dir + '/test_group_window_aggregate_function_over_count.csv'
+        with open(source_path, 'w') as fd:
+            for ele in data:
+                fd.write(ele + '\n')
+
+        from pyflink.table.window import Slide
+        from pyflink.datastream import TimeCharacteristic
+        self.env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
+        self.t_env.register_function("mean_udaf", mean_udaf)
+
+        source_table = """
+            create table source_table(
+                a TINYINT,
+                b SMALLINT,
+                protime as PROCTIME()
+            ) with(
+                'connector.type' = 'filesystem',
+                'format.type' = 'csv',
+                'connector.path' = '%s',
+                'format.ignore-first-line' = 'false',
+                'format.field-delimiter' = ','
+            )
+        """ % source_path
+        self.t_env.execute_sql(source_table)
+        t = self.t_env.from_path("source_table")
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'd'],
+            [
+                DataTypes.TINYINT(),
+                DataTypes.FLOAT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t.window(Slide.over("2.rows").every("1.rows").on("protime").alias("w")) \
+            .group_by("a, w") \
+            .select("a, mean_udaf(b) as b") \
+            .execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,2.5", "1,5.5", "2,2.0", "3,2.5"])
+        os.remove(source_path)
 
 
 @udaf(result_type=DataTypes.FLOAT(), func_type="pandas")

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -268,12 +268,12 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
         import os
         tmp_dir = tempfile.gettempdir()
         data = [
-            '1,2,2018-03-11 03:10:00',
-            '3,2,2018-03-11 03:10:00',
-            '2,1,2018-03-11 03:10:00',
-            '1,3,2018-03-11 03:40:00',
-            '1,8,2018-03-11 04:20:00',
-            '2,3,2018-03-11 03:30:00'
+            '1,1,2,2018-03-11 03:10:00',
+            '3,3,2,2018-03-11 03:10:00',
+            '2,2,1,2018-03-11 03:10:00',
+            '1,1,3,2018-03-11 03:40:00',
+            '1,1,8,2018-03-11 04:20:00',
+            '2,2,3,2018-03-11 03:30:00'
         ]
         source_path = tmp_dir + '/test_sliding_group_window_over_time.csv'
         with open(source_path, 'w') as fd:
@@ -288,6 +288,7 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
             create table source_table(
                 a TINYINT,
                 b SMALLINT,
+                c SMALLINT,
                 rowtime TIMESTAMP(3),
                 WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
             ) with(
@@ -310,8 +311,8 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
                 DataTypes.FLOAT()])
         self.t_env.register_table_sink("Results", table_sink)
         t.window(Slide.over("1.hours").every("30.minutes").on("rowtime").alias("w")) \
-            .group_by("a, w") \
-            .select("a, w.start, w.end, mean_udaf(b) as b") \
+            .group_by("a, b, w") \
+            .select("a, w.start, w.end, mean_udaf(c) as b") \
             .execute_insert("Results") \
             .wait()
         actual = source_sink_utils.results()
@@ -334,13 +335,13 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
         import os
         tmp_dir = tempfile.gettempdir()
         data = [
-            '1,2,2018-03-11 03:10:00',
-            '3,2,2018-03-11 03:10:00',
-            '2,1,2018-03-11 03:10:00',
-            '1,3,2018-03-11 03:40:00',
-            '1,8,2018-03-11 04:20:00',
-            '2,3,2018-03-11 03:30:00',
-            '3,3,2018-03-11 03:30:00'
+            '1,1,2,2018-03-11 03:10:00',
+            '3,3,2,2018-03-11 03:10:00',
+            '2,2,1,2018-03-11 03:10:00',
+            '1,1,3,2018-03-11 03:40:00',
+            '1,1,8,2018-03-11 04:20:00',
+            '2,2,3,2018-03-11 03:30:00',
+            '3,3,3,2018-03-11 03:30:00'
         ]
         source_path = tmp_dir + '/test_sliding_group_window_over_count.csv'
         with open(source_path, 'w') as fd:
@@ -356,6 +357,7 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
             create table source_table(
                 a TINYINT,
                 b SMALLINT,
+                c SMALLINT,
                 protime as PROCTIME()
             ) with(
                 'connector.type' = 'filesystem',
@@ -375,8 +377,8 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
                 DataTypes.FLOAT()])
         self.t_env.register_table_sink("Results", table_sink)
         t.window(Slide.over("2.rows").every("1.rows").on("protime").alias("w")) \
-            .group_by("a, w") \
-            .select("a, mean_udaf(b) as b") \
+            .group_by("a, b, w") \
+            .select("a, mean_udaf(c) as b") \
             .execute_insert("Results") \
             .wait()
         actual = source_sink_utils.results()
@@ -389,12 +391,12 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
         import os
         tmp_dir = tempfile.gettempdir()
         data = [
-            '1,2,2018-03-11 03:10:00',
-            '3,2,2018-03-11 03:10:00',
-            '2,1,2018-03-11 03:10:00',
-            '1,3,2018-03-11 03:40:00',
-            '1,8,2018-03-11 04:20:00',
-            '2,3,2018-03-11 03:30:00'
+            '1,1,2,2018-03-11 03:10:00',
+            '3,3,2,2018-03-11 03:10:00',
+            '2,2,1,2018-03-11 03:10:00',
+            '1,1,3,2018-03-11 03:40:00',
+            '1,1,8,2018-03-11 04:20:00',
+            '2,2,3,2018-03-11 03:30:00'
         ]
         source_path = tmp_dir + '/test_tumbling_group_window_over_time.csv'
         with open(source_path, 'w') as fd:
@@ -409,6 +411,7 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
             create table source_table(
                 a TINYINT,
                 b SMALLINT,
+                c SMALLINT,
                 rowtime TIMESTAMP(3),
                 WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
             ) with(
@@ -431,8 +434,8 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
                 DataTypes.FLOAT()])
         self.t_env.register_table_sink("Results", table_sink)
         t.window(Tumble.over("1.hours").on("rowtime").alias("w")) \
-            .group_by("a, w") \
-            .select("a, w.start, w.end, mean_udaf(b) as b") \
+            .group_by("a, b, w") \
+            .select("a, w.start, w.end, mean_udaf(c) as b") \
             .execute_insert("Results") \
             .wait()
         actual = source_sink_utils.results()
@@ -450,14 +453,14 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
         import os
         tmp_dir = tempfile.gettempdir()
         data = [
-            '1,2,2018-03-11 03:10:00',
-            '3,2,2018-03-11 03:10:00',
-            '2,1,2018-03-11 03:10:00',
-            '1,3,2018-03-11 03:40:00',
-            '1,8,2018-03-11 04:20:00',
-            '2,3,2018-03-11 03:30:00',
-            '3,3,2018-03-11 03:30:00',
-            '1,4,2018-03-11 04:20:00',
+            '1,1,2,2018-03-11 03:10:00',
+            '3,3,2,2018-03-11 03:10:00',
+            '2,2,1,2018-03-11 03:10:00',
+            '1,1,3,2018-03-11 03:40:00',
+            '1,1,8,2018-03-11 04:20:00',
+            '2,2,3,2018-03-11 03:30:00',
+            '3,3,3,2018-03-11 03:30:00',
+            '1,1,4,2018-03-11 04:20:00',
         ]
         source_path = tmp_dir + '/test_group_window_aggregate_function_over_count.csv'
         with open(source_path, 'w') as fd:
@@ -473,6 +476,7 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
             create table source_table(
                 a TINYINT,
                 b SMALLINT,
+                c SMALLINT,
                 protime as PROCTIME()
             ) with(
                 'connector.type' = 'filesystem',
@@ -492,8 +496,8 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
                 DataTypes.FLOAT()])
         self.t_env.register_table_sink("Results", table_sink)
         t.window(Tumble.over("2.rows").on("protime").alias("w")) \
-            .group_by("a, w") \
-            .select("a, mean_udaf(b) as b") \
+            .group_by("a, b, w") \
+            .select("a, mean_udaf(c) as b") \
             .execute_insert("Results") \
             .wait()
         actual = source_sink_utils.results()

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -262,7 +262,7 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
 
 
 class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
-    def test_group_window_aggregate_function_over_time(self):
+    def test_sliding_group_window_over_time(self):
         # create source file path
         import tempfile
         import os
@@ -275,7 +275,7 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
             '1,8,2018-03-11 04:20:00',
             '2,3,2018-03-11 03:30:00'
         ]
-        source_path = tmp_dir + '/test_group_window_aggregate_function_over_time.csv'
+        source_path = tmp_dir + '/test_sliding_group_window_over_time.csv'
         with open(source_path, 'w') as fd:
             for ele in data:
                 fd.write(ele + '\n')
@@ -327,7 +327,7 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
                             "3,2018-03-11 02:30:00.0,2018-03-11 03:30:00.0,2.0"])
         os.remove(source_path)
 
-    def test_group_window_aggregate_function_over_count(self):
+    def test_sliding_group_window_over_count(self):
         self.env.set_parallelism(1)
         # create source file path
         import tempfile
@@ -342,7 +342,7 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
             '2,3,2018-03-11 03:30:00',
             '3,3,2018-03-11 03:30:00'
         ]
-        source_path = tmp_dir + '/test_group_window_aggregate_function_over_count.csv'
+        source_path = tmp_dir + '/test_sliding_group_window_over_count.csv'
         with open(source_path, 'w') as fd:
             for ele in data:
                 fd.write(ele + '\n')
@@ -381,6 +381,123 @@ class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
             .wait()
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["1,2.5", "1,5.5", "2,2.0", "3,2.5"])
+        os.remove(source_path)
+
+    def test_tumbling_group_window_over_time(self):
+        # create source file path
+        import tempfile
+        import os
+        tmp_dir = tempfile.gettempdir()
+        data = [
+            '1,2,2018-03-11 03:10:00',
+            '3,2,2018-03-11 03:10:00',
+            '2,1,2018-03-11 03:10:00',
+            '1,3,2018-03-11 03:40:00',
+            '1,8,2018-03-11 04:20:00',
+            '2,3,2018-03-11 03:30:00'
+        ]
+        source_path = tmp_dir + '/test_tumbling_group_window_over_time.csv'
+        with open(source_path, 'w') as fd:
+            for ele in data:
+                fd.write(ele + '\n')
+
+        from pyflink.table.window import Tumble
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+        self.t_env.register_function("mean_udaf", mean_udaf)
+
+        source_table = """
+            create table source_table(
+                a TINYINT,
+                b SMALLINT,
+                rowtime TIMESTAMP(3),
+                WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
+            ) with(
+                'connector.type' = 'filesystem',
+                'format.type' = 'csv',
+                'connector.path' = '%s',
+                'format.ignore-first-line' = 'false',
+                'format.field-delimiter' = ','
+            )
+        """ % source_path
+        self.t_env.execute_sql(source_table)
+        t = self.t_env.from_path("source_table")
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c', 'd'],
+            [
+                DataTypes.TINYINT(),
+                DataTypes.TIMESTAMP(3),
+                DataTypes.TIMESTAMP(3),
+                DataTypes.FLOAT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t.window(Tumble.over("1.hours").on("rowtime").alias("w")) \
+            .group_by("a, w") \
+            .select("a, w.start, w.end, mean_udaf(b) as b") \
+            .execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual,
+                           ["1,2018-03-11 03:00:00.0,2018-03-11 04:00:00.0,2.5",
+                            "1,2018-03-11 04:00:00.0,2018-03-11 05:00:00.0,8.0",
+                            "2,2018-03-11 03:00:00.0,2018-03-11 04:00:00.0,2.0",
+                            "3,2018-03-11 03:00:00.0,2018-03-11 04:00:00.0,2.0"])
+        os.remove(source_path)
+
+    def test_tumbling_group_window_over_count(self):
+        self.env.set_parallelism(1)
+        # create source file path
+        import tempfile
+        import os
+        tmp_dir = tempfile.gettempdir()
+        data = [
+            '1,2,2018-03-11 03:10:00',
+            '3,2,2018-03-11 03:10:00',
+            '2,1,2018-03-11 03:10:00',
+            '1,3,2018-03-11 03:40:00',
+            '1,8,2018-03-11 04:20:00',
+            '2,3,2018-03-11 03:30:00',
+            '3,3,2018-03-11 03:30:00',
+            '1,4,2018-03-11 04:20:00',
+        ]
+        source_path = tmp_dir + '/test_group_window_aggregate_function_over_count.csv'
+        with open(source_path, 'w') as fd:
+            for ele in data:
+                fd.write(ele + '\n')
+
+        from pyflink.table.window import Tumble
+        from pyflink.datastream import TimeCharacteristic
+        self.env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime)
+        self.t_env.register_function("mean_udaf", mean_udaf)
+
+        source_table = """
+            create table source_table(
+                a TINYINT,
+                b SMALLINT,
+                protime as PROCTIME()
+            ) with(
+                'connector.type' = 'filesystem',
+                'format.type' = 'csv',
+                'connector.path' = '%s',
+                'format.ignore-first-line' = 'false',
+                'format.field-delimiter' = ','
+            )
+        """ % source_path
+        self.t_env.execute_sql(source_table)
+        t = self.t_env.from_path("source_table")
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'd'],
+            [
+                DataTypes.TINYINT(),
+                DataTypes.FLOAT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        t.window(Tumble.over("2.rows").on("protime").alias("w")) \
+            .group_by("a, w") \
+            .select("a, mean_udaf(b) as b") \
+            .execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,2.5", "1,6.0", "2,2.0", "3,2.5"])
         os.remove(source_path)
 
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -1,0 +1,547 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.python.aggregate.arrow.stream;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.JoinedRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.BinaryRowDataUtil;
+import org.apache.flink.table.data.util.RowDataUtil;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.operators.python.aggregate.arrow.AbstractArrowPythonAggregateFunctionOperator;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.internal.InternalWindowProcessFunction;
+import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * The Stream Arrow Python {@link AggregateFunction} Operator for Group Window Aggregation.
+ */
+@Internal
+public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends Window>
+	extends AbstractArrowPythonAggregateFunctionOperator implements Triggerable<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The Infos of the Window.
+	 * 0 -> start of the Window.
+	 * 1 -> end of the Window.
+	 * 2 -> row time of the Window.
+	 */
+	private final int[] namedProperties;
+
+	/**
+	 * The row time index of the input data.
+	 */
+	private final int inputTimeFieldIndex;
+
+	/**
+	 * A {@link WindowAssigner} assigns zero or more {@link Window Windows} to an element.
+	 */
+	private final WindowAssigner<W> windowAssigner;
+
+	/**
+	 * A {@link Trigger} determines when a pane of a window should be evaluated to emit the
+	 * results for that part of the window.
+	 */
+	private final Trigger<W> trigger;
+
+	/**
+	 * The allowed lateness for elements. This is used for:
+	 * <ul>
+	 * 		<li>Deciding if an element should be dropped from a window due to lateness.
+	 * 		<li>Clearing the state of a window if the system time passes the
+	 * 		{@code window.maxTimestamp + allowedLateness} landmark.
+	 * </ul>
+	 */
+	private final long allowedLateness;
+
+	/**
+	 * Interface for working with time and timers.
+	 */
+	private transient InternalTimerService<W> internalTimerService;
+
+	/**
+	 * Stores accumulate message data(INSERT/UPDATE_AFTER) in window.
+	 */
+	private transient InternalListState<K, W, RowData> windowAccumulateData;
+
+	/**
+	 * Stores retract message data(DELETE/UPDATE_BEFORE) in window.
+	 */
+	private transient InternalListState<K, W, RowData> windowRetractData;
+
+	private transient TriggerContext triggerContext;
+
+	/**
+	 * For serializing the window in checkpoints.
+	 */
+	private TypeSerializer<W> windowSerializer;
+
+	/**
+	 * The queue holding the input groupSet with the Window for which the execution results
+	 * have not been received.
+	 */
+	private transient LinkedList<Tuple2<RowData, W>> inputKeyAndWindow;
+
+	/**
+	 * The GenericRowData reused holding the property of the window, such as window start, window
+	 * end and window time.
+	 */
+	private transient GenericRowData windowProperty;
+
+	/**
+	 * The JoinedRowData reused holding the window agg execution result.
+	 */
+	private transient JoinedRowData windowAggResult;
+
+	private transient long timestamp;
+
+	private transient Collection<W> elementWindows;
+
+	public StreamArrowPythonGroupWindowAggregateFunctionOperator(
+		Configuration config,
+		PythonFunctionInfo[] pandasAggFunctions,
+		RowType inputType,
+		RowType outputType,
+		int inputTimeFieldIndex,
+		WindowAssigner<W> windowAssigner,
+		Trigger<W> trigger,
+		long allowedLateness,
+		int[] namedProperties,
+		int[] groupingSet,
+		int[] udafInputOffsets) {
+		super(config, pandasAggFunctions, inputType, outputType, groupingSet, udafInputOffsets);
+		this.namedProperties = namedProperties;
+		this.inputTimeFieldIndex = inputTimeFieldIndex;
+		this.windowAssigner = windowAssigner;
+		this.trigger = trigger;
+		this.allowedLateness = allowedLateness;
+	}
+
+	@Override
+	public void open() throws Exception {
+		userDefinedFunctionOutputType = new RowType(
+			outputType.getFields().subList(groupingSet.length, outputType.getFieldCount() - namedProperties.length));
+		windowSerializer = windowAssigner.getWindowSerializer(new ExecutionConfig());
+
+		internalTimerService = getInternalTimerService("window-timers", windowSerializer, this);
+
+		triggerContext = new TriggerContext();
+		triggerContext.open();
+
+		StateDescriptor<ListState<RowData>, List<RowData>> windowStateDescriptor = new ListStateDescriptor<>(
+			"window-input",
+			new RowDataSerializer(inputType));
+		StateDescriptor<ListState<RowData>, List<RowData>> dataRetractStateDescriptor = new ListStateDescriptor<>(
+			"data-retract",
+			new RowDataSerializer(inputType));
+		this.windowAccumulateData = (InternalListState<K, W, RowData>) getOrCreateKeyedState(windowSerializer, windowStateDescriptor);
+		this.windowRetractData = (InternalListState<K, W, RowData>) getOrCreateKeyedState(windowSerializer, dataRetractStateDescriptor);
+		inputKeyAndWindow = new LinkedList<>();
+		windowProperty = new GenericRowData(namedProperties.length);
+		windowAggResult = new JoinedRowData();
+
+		WindowContext windowContext = new WindowContext();
+		windowAssigner.open(windowContext);
+		super.open();
+	}
+
+	@Override
+	public void bufferInput(RowData input) throws Exception {
+		if (windowAssigner.isEventTime()) {
+			timestamp = input.getLong(inputTimeFieldIndex);
+		} else {
+			timestamp = internalTimerService.currentProcessingTime();
+		}
+		// Given the timestamp and element, returns the set of windows into which it
+		// should be placed.
+		elementWindows = windowAssigner.assignWindows(input, timestamp);
+		for (W window : elementWindows) {
+			if (RowDataUtil.isAccumulateMsg(input)) {
+				windowAccumulateData.setCurrentNamespace(window);
+				windowAccumulateData.add(input);
+			} else {
+				windowRetractData.setCurrentNamespace(window);
+				windowRetractData.add(input);
+			}
+		}
+	}
+
+	@Override
+	public void processElementInternal(RowData value) throws Exception {
+		List<W> actualWindows = new ArrayList<>(elementWindows.size());
+		for (W window : elementWindows) {
+			if (!isWindowLate(window)) {
+				actualWindows.add(window);
+			}
+		}
+		for (W window : actualWindows) {
+			triggerContext.window = window;
+			boolean triggerResult = triggerContext.onElement(value, timestamp);
+			if (triggerResult) {
+				emitWindowResult(window);
+			}
+			// register a clean up timer for the window
+			registerCleanupTimer(window);
+		}
+	}
+
+	@Override
+	@SuppressWarnings("ConstantConditions")
+	public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
+		byte[] udafResult = resultTuple.f0;
+		int length = resultTuple.f1;
+		bais.setBuffer(udafResult, 0, length);
+		int rowCount = arrowSerializer.load();
+		for (int i = 0; i < rowCount; i++) {
+			Tuple2<RowData, W> input = inputKeyAndWindow.poll();
+			RowData key = input.f0;
+			W window = input.f1;
+			setWindowProperty(window);
+			windowAggResult.replace(key, arrowSerializer.read(i));
+			rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
+		}
+	}
+
+	@Override
+	public void onEventTime(InternalTimer<K, W> timer) throws Exception {
+		setCurrentKey(timer.getKey());
+
+		triggerContext.window = timer.getNamespace();
+		if (triggerContext.onEventTime(timer.getTimestamp())) {
+			// fire
+			emitWindowResult(triggerContext.window);
+		}
+
+		if (windowAssigner.isEventTime()) {
+			cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+		}
+	}
+
+	@Override
+	public void onProcessingTime(InternalTimer<K, W> timer) throws Exception {
+		setCurrentKey(timer.getKey());
+
+		triggerContext.window = timer.getNamespace();
+		if (triggerContext.onProcessingTime(timer.getTimestamp())) {
+			// fire
+			emitWindowResult(triggerContext.window);
+		}
+
+		if (!windowAssigner.isEventTime()) {
+			cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+		}
+	}
+
+	/**
+	 * Returns {@code true} if the watermark is after the end timestamp plus the allowed lateness
+	 * of the given window.
+	 */
+	private boolean isWindowLate(W window) {
+		return windowAssigner.isEventTime() &&
+			(cleanupTime(window) <= internalTimerService.currentWatermark());
+	}
+
+	/**
+	 * Returns the cleanup time for a window, which is
+	 * {@code window.maxTimestamp + allowedLateness}. In
+	 * case this leads to a value greated than {@link Long#MAX_VALUE}
+	 * then a cleanup time of {@link Long#MAX_VALUE} is
+	 * returned.
+	 *
+	 * @param window the window whose cleanup time we are computing.
+	 */
+	private long cleanupTime(W window) {
+		if (windowAssigner.isEventTime()) {
+			long cleanupTime = window.maxTimestamp() + allowedLateness;
+			return cleanupTime >= window.maxTimestamp() ? cleanupTime : Long.MAX_VALUE;
+		} else {
+			return window.maxTimestamp();
+		}
+	}
+
+	private void emitWindowResult(W window) throws Exception {
+		windowAccumulateData.setCurrentNamespace(window);
+		windowRetractData.setCurrentNamespace(window);
+		Iterable<RowData> currentWindowAccumulateDatas = windowAccumulateData.get();
+		if (currentWindowAccumulateDatas != null) {
+			currentBatchCount = 0;
+			for (RowData accumulateData : currentWindowAccumulateDatas) {
+				if (!hasRetractData(accumulateData)) {
+					arrowSerializer.write(getFunctionInput(accumulateData));
+					currentBatchCount++;
+				}
+			}
+			if (currentBatchCount > 0) {
+				inputKeyAndWindow.add(Tuple2.of((RowData) getCurrentKey(), window));
+				arrowSerializer.finishCurrentBatch();
+				pythonFunctionRunner.process(baos.toByteArray());
+				elementCount += currentBatchCount;
+				checkInvokeFinishBundleByCount();
+				currentBatchCount = 0;
+				baos.reset();
+			}
+		}
+	}
+
+	private boolean hasRetractData(RowData accumulateData) throws Exception {
+		BinaryRowData binaryAccumulateRowData = (BinaryRowData) accumulateData;
+		Iterable<RowData> currentWindowRetractDatas = windowRetractData.get();
+		if (currentWindowRetractDatas != null) {
+			for (RowData retractData : currentWindowRetractDatas) {
+				if (retractData.getRowKind() == RowKind.UPDATE_BEFORE) {
+					retractData.setRowKind(RowKind.UPDATE_AFTER);
+				} else {
+					retractData.setRowKind(RowKind.INSERT);
+				}
+				BinaryRowData binaryRetractData = (BinaryRowData) retractData;
+				if (binaryAccumulateRowData.getSizeInBytes() == binaryRetractData.getSizeInBytes() &&
+					BinaryRowDataUtil.byteArrayEquals(
+						binaryAccumulateRowData.getSegments()[0].getHeapMemory(),
+						binaryRetractData.getSegments()[0].getHeapMemory(),
+						binaryAccumulateRowData.getSizeInBytes())) {
+					return true;
+				}
+
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Registers a timer to cleanup the content of the window.
+	 *
+	 * @param window the window whose state to discard
+	 */
+	private void registerCleanupTimer(W window) {
+		long cleanupTime = cleanupTime(window);
+		if (cleanupTime == Long.MAX_VALUE) {
+			// don't set a GC timer for "end of time"
+			return;
+		}
+
+		if (windowAssigner.isEventTime()) {
+			triggerContext.registerEventTimeTimer(cleanupTime);
+		} else {
+			triggerContext.registerProcessingTimeTimer(cleanupTime);
+		}
+	}
+
+	private void setWindowProperty(W currentWindow) {
+		for (int i = 0; i < namedProperties.length; i++) {
+			switch (namedProperties[i]) {
+				case 0:
+					windowProperty.setField(i, TimestampData.fromEpochMillis(((TimeWindow) currentWindow).getStart()));
+					break;
+				case 1:
+					windowProperty.setField(i, TimestampData.fromEpochMillis(((TimeWindow) currentWindow).getEnd()));
+					break;
+				case 2:
+					windowProperty.setField(i, TimestampData.fromEpochMillis(currentWindow.maxTimestamp()));
+					break;
+			}
+		}
+	}
+
+	private void cleanWindowIfNeeded(W window, long currentTime) throws Exception {
+		if (currentTime == cleanupTime(window)) {
+			windowAccumulateData.setCurrentNamespace(window);
+			windowAccumulateData.clear();
+			windowRetractData.setCurrentNamespace(window);
+			windowRetractData.clear();
+			triggerContext.window = window;
+			triggerContext.clear();
+		}
+	}
+
+	/**
+	 * {@code TriggerContext} is a utility for handling {@code Trigger} invocations. It can be
+	 * reused by setting the {@code key} and {@code window} fields. No internal state must be kept
+	 * in the {@code TriggerContext}.
+	 */
+	private class TriggerContext implements Trigger.TriggerContext {
+
+		private W window;
+
+		public void open() throws Exception {
+			trigger.open(this);
+		}
+
+		boolean onElement(RowData row, long timestamp) throws Exception {
+			return trigger.onElement(row, timestamp, window);
+		}
+
+		boolean onProcessingTime(long time) throws Exception {
+			return trigger.onProcessingTime(time, window);
+		}
+
+		boolean onEventTime(long time) throws Exception {
+			return trigger.onEventTime(time, window);
+		}
+
+		@Override
+		public long getCurrentProcessingTime() {
+			return internalTimerService.currentProcessingTime();
+		}
+
+		@Override
+		public long getCurrentWatermark() {
+			return internalTimerService.currentWatermark();
+		}
+
+		@Override
+		public MetricGroup getMetricGroup() {
+			return StreamArrowPythonGroupWindowAggregateFunctionOperator.this.getMetricGroup();
+		}
+
+		@Override
+		public void registerProcessingTimeTimer(long time) {
+			internalTimerService.registerProcessingTimeTimer(window, time);
+		}
+
+		@Override
+		public void registerEventTimeTimer(long time) {
+			internalTimerService.registerEventTimeTimer(window, time);
+		}
+
+		@Override
+		public void deleteProcessingTimeTimer(long time) {
+			internalTimerService.deleteProcessingTimeTimer(window, time);
+		}
+
+		@Override
+		public void deleteEventTimeTimer(long time) {
+			internalTimerService.deleteEventTimeTimer(window, time);
+		}
+
+		public void clear() throws Exception {
+			trigger.clear(window);
+		}
+
+		@Override
+		public <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+			try {
+				return StreamArrowPythonGroupWindowAggregateFunctionOperator.this.
+					getPartitionedState(window, windowSerializer, stateDescriptor);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not retrieve state", e);
+			}
+		}
+	}
+
+	private class WindowContext implements InternalWindowProcessFunction.Context<K, W> {
+		@Override
+		public <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			return StreamArrowPythonGroupWindowAggregateFunctionOperator.this.
+				getPartitionedState(stateDescriptor);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public K currentKey() {
+			return (K) StreamArrowPythonGroupWindowAggregateFunctionOperator.this.getCurrentKey();
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return internalTimerService.currentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return internalTimerService.currentWatermark();
+		}
+
+		@Override
+		public RowData getWindowAccumulators(W window) {
+			throw new RuntimeException("The method getWindowAccumulators should not be called.");
+		}
+
+		@Override
+		public void setWindowAccumulators(W window, RowData acc) {
+			throw new RuntimeException("The method setWindowAccumulators should not be called.");
+		}
+
+		@Override
+		public void clearWindowState(W window) {
+			windowAccumulateData.setCurrentNamespace(window);
+			windowAccumulateData.clear();
+			windowRetractData.setCurrentNamespace(window);
+			windowRetractData.clear();
+		}
+
+		@Override
+		public void clearPreviousState(W window) {
+			throw new RuntimeException("The method clearPreviousState should not be called.");
+		}
+
+		@Override
+		public void clearTrigger(W window) throws Exception {
+			triggerContext.window = window;
+			triggerContext.clear();
+		}
+
+		@Override
+		public void onMerge(W newWindow, Collection<W> mergedWindows) {
+			throw new RuntimeException("The method onMerge should not be called.");
+		}
+
+		@Override
+		public void deleteCleanupTimer(W window) throws Exception {
+			long cleanupTime = cleanupTime(window);
+			if (cleanupTime == Long.MAX_VALUE) {
+				// no need to clean up because we didn't set one
+				return;
+			}
+			if (windowAssigner.isEventTime()) {
+				triggerContext.deleteEventTimeTimer(cleanupTime);
+			} else {
+				triggerContext.deleteProcessingTimeTimer(cleanupTime);
+			}
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -422,6 +422,10 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
 			return trigger.onEventTime(time, window);
 		}
 
+		void clear() throws Exception {
+			trigger.clear(window);
+		}
+
 		@Override
 		public long getCurrentProcessingTime() {
 			return internalTimerService.currentProcessingTime();
@@ -455,10 +459,6 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
 		@Override
 		public void deleteEventTimeTimer(long time) {
 			internalTimerService.deleteEventTimeTimer(window, time);
-		}
-
-		public void clear() throws Exception {
-			trigger.clear(window);
 		}
 
 		@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/ArrowPythonAggregateFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/ArrowPythonAggregateFunctionOperatorTestBase.java
@@ -19,12 +19,9 @@
 package org.apache.flink.table.runtime.operators.python.aggregate.arrow;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
-import org.apache.flink.table.runtime.operators.python.scalar.PythonScalarFunctionOperatorTestBase;
-import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -41,28 +38,6 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
 public abstract class ArrowPythonAggregateFunctionOperatorTestBase {
 
 	private RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(getOutputLogicalType());
-
-	protected OneInputStreamOperatorTestHarness<RowData, RowData> getTestHarness(
-		Configuration config) throws Exception {
-		RowType inputType = getInputType();
-		RowType outputType = getOutputType();
-		AbstractArrowPythonAggregateFunctionOperator operator = getTestOperator(
-			config,
-			new PythonFunctionInfo[]{
-				new PythonFunctionInfo(
-					PythonScalarFunctionOperatorTestBase.DummyPythonFunction.INSTANCE,
-					new Integer[]{0})},
-			inputType,
-			outputType,
-			new int[]{0},
-			new int[]{2});
-
-		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
-			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
-		testHarness.setup(new RowDataSerializer(outputType));
-		return testHarness;
-	}
 
 	protected RowData newRow(boolean accumulateMsg, Object... fields) {
 		if (accumulateMsg) {
@@ -87,6 +62,8 @@ public abstract class ArrowPythonAggregateFunctionOperatorTestBase {
 	protected void assertOutputEquals(String message, Collection<Object> expected, Collection<Object> actual) {
 		assertor.assertOutputEquals(message, expected, actual);
 	}
+
+	public abstract OneInputStreamOperatorTestHarness<RowData, RowData> getTestHarness(Configuration config) throws Exception;
 
 	public abstract LogicalType[] getOutputLogicalType();
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.operators.python.aggregate.arrow.AbstractArrowPythonAggregateFunctionOperator;
+import org.apache.flink.table.runtime.operators.python.aggregate.arrow.ArrowPythonAggregateFunctionOperatorTestBase;
+import org.apache.flink.table.runtime.operators.python.scalar.PythonScalarFunctionOperatorTestBase;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Base class for Batch Arrow Python aggregate function operator tests.
+ */
+public abstract class AbstractBatchArrowPythonAggregateFunctionOperatorTest
+	extends ArrowPythonAggregateFunctionOperatorTestBase {
+
+	public OneInputStreamOperatorTestHarness<RowData, RowData> getTestHarness(
+		Configuration config) throws Exception {
+		RowType inputType = getInputType();
+		RowType outputType = getOutputType();
+		AbstractArrowPythonAggregateFunctionOperator operator = getTestOperator(
+			config,
+			new PythonFunctionInfo[]{
+				new PythonFunctionInfo(
+					PythonScalarFunctionOperatorTestBase.DummyPythonFunction.INSTANCE,
+					new Integer[]{0})},
+			inputType,
+			outputType,
+			new int[]{0},
+			new int[]{2});
+
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+			new OneInputStreamOperatorTestHarness<>(operator);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
+		testHarness.setup(new RowDataSerializer(outputType));
+		return testHarness;
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.operators.python.aggregate.arrow.AbstractArrowPythonAggregateFunctionOperator;
-import org.apache.flink.table.runtime.operators.python.aggregate.arrow.ArrowPythonAggregateFunctionOperatorTestBase;
 import org.apache.flink.table.runtime.utils.PassThroughPythonAggregateFunctionRunner;
 import org.apache.flink.table.runtime.utils.PythonTestUtils;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -50,7 +49,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * </ul>
  */
 public class BatchArrowPythonGroupAggregateFunctionOperatorTest
-	extends ArrowPythonAggregateFunctionOperatorTestBase {
+	extends AbstractBatchArrowPythonAggregateFunctionOperatorTest {
 
 	@Test
 	public void testGroupAggregateFunction() throws Exception {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperatorTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.operators.python.aggregate.arrow.AbstractArrowPythonAggregateFunctionOperator;
-import org.apache.flink.table.runtime.operators.python.aggregate.arrow.ArrowPythonAggregateFunctionOperatorTestBase;
 import org.apache.flink.table.runtime.utils.PassThroughPythonAggregateFunctionRunner;
 import org.apache.flink.table.runtime.utils.PythonTestUtils;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -53,7 +52,8 @@ import static org.junit.Assert.assertEquals;
  * 		<li>FinishBundle is called when bundled time reach to max bundle time</li>
  * </ul>
  */
-public class BatchArrowPythonOverWindowAggregateFunctionOperatorTest extends ArrowPythonAggregateFunctionOperatorTestBase {
+public class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
+	extends AbstractBatchArrowPythonAggregateFunctionOperatorTest {
 
 	@Test
 	public void testOverWindowAggregateFunction() throws Exception {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonAggregateFunctionOperatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.python.aggregate.arrow.stream;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.python.aggregate.arrow.AbstractArrowPythonAggregateFunctionOperator;
+import org.apache.flink.table.runtime.operators.python.aggregate.arrow.ArrowPythonAggregateFunctionOperatorTestBase;
+import org.apache.flink.table.runtime.operators.python.scalar.PythonScalarFunctionOperatorTestBase;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Base class for Stream Arrow Python aggregate function operator tests.
+ */
+public abstract class AbstractStreamArrowPythonAggregateFunctionOperatorTest
+	extends ArrowPythonAggregateFunctionOperatorTestBase {
+
+	public OneInputStreamOperatorTestHarness<RowData, RowData> getTestHarness(
+		Configuration config) throws Exception {
+		RowType inputType = getInputType();
+		RowType outputType = getOutputType();
+		AbstractArrowPythonAggregateFunctionOperator operator = getTestOperator(
+			config,
+			new PythonFunctionInfo[]{
+				new PythonFunctionInfo(
+					PythonScalarFunctionOperatorTestBase.DummyPythonFunction.INSTANCE,
+					new Integer[]{0})},
+			inputType,
+			outputType,
+			new int[]{0},
+			new int[]{2});
+
+		int[] grouping = new int[] {0};
+		RowDataKeySelector keySelector =
+			KeySelectorUtil.getRowDataSelector(grouping, InternalTypeInfo.of(getInputType()));
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+			new KeyedOneInputStreamOperatorTestHarness<>(operator, keySelector, keySelector.getProducedType());
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
+		testHarness.setup(new RowDataSerializer(outputType));
+		return testHarness;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupWindowAggregateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupWindowAggregateRule.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.functions.python.PythonFunctionKind;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.plan.logical.LogicalWindow;
+import org.apache.flink.table.planner.plan.logical.SessionGroupWindow;
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWindowAggregate;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecPythonGroupWindowAggregate;
+import org.apache.flink.table.planner.plan.trait.FlinkRelDistribution;
+import org.apache.flink.table.planner.plan.utils.AggregateUtil;
+import org.apache.flink.table.planner.plan.utils.PythonUtil;
+import org.apache.flink.table.planner.plan.utils.WindowEmitStrategy;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+
+import java.util.List;
+
+import scala.collection.JavaConverters;
+
+/**
+ * The physical rule is responsible for converting {@link FlinkLogicalWindowAggregate} to
+ * {@link StreamExecPythonGroupWindowAggregate}.
+ */
+public class StreamExecPythonGroupWindowAggregateRule extends ConverterRule {
+
+	public static final StreamExecPythonGroupWindowAggregateRule INSTANCE = new StreamExecPythonGroupWindowAggregateRule();
+
+	private StreamExecPythonGroupWindowAggregateRule() {
+		super(FlinkLogicalWindowAggregate.class,
+			FlinkConventions.LOGICAL(),
+			FlinkConventions.STREAM_PHYSICAL(),
+			"StreamExecPythonGroupWindowAggregateRule");
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		FlinkLogicalWindowAggregate agg = call.rel(0);
+		List<AggregateCall> aggCalls = agg.getAggCallList();
+
+		// check if we have grouping sets
+		if (agg.getGroupType() != Aggregate.Group.SIMPLE || agg.indicator) {
+			throw new TableException("GROUPING SETS are currently not supported.");
+		}
+
+		boolean existGeneralPythonFunction =
+			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.GENERAL));
+		boolean existPandasFunction =
+			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.PANDAS));
+		boolean existJavaFunction =
+			aggCalls.stream().anyMatch(x -> !PythonUtil.isPythonAggregate(x, null));
+		if (existPandasFunction || existGeneralPythonFunction) {
+			if (existGeneralPythonFunction) {
+				throw new TableException("non-Pandas UDAFs are not supported in stream mode currently.");
+			}
+			if (existJavaFunction) {
+				throw new TableException("Python UDAF and Java/Scala UDAF cannot be used together.");
+			}
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public RelNode convert(RelNode rel) {
+		FlinkLogicalWindowAggregate agg = (FlinkLogicalWindowAggregate) rel;
+		LogicalWindow window = agg.getWindow();
+
+		if (window instanceof SessionGroupWindow) {
+			throw new TableException("Session Group Window is currently not supported.");
+		}
+		RelNode input = agg.getInput();
+		RelDataType inputRowType = input.getRowType();
+		RelOptCluster cluster = rel.getCluster();
+		FlinkRelDistribution requiredDistribution;
+		if (agg.getGroupCount() != 0) {
+			requiredDistribution = FlinkRelDistribution.hash(agg.getGroupSet().asList(), true);
+		} else {
+			requiredDistribution = FlinkRelDistribution.SINGLETON();
+		}
+		RelTraitSet requiredTraitSet = input.getTraitSet()
+			.replace(FlinkConventions.STREAM_PHYSICAL())
+			.replace(requiredDistribution);
+
+		RelTraitSet providedTraitSet = rel.getTraitSet().replace(FlinkConventions.STREAM_PHYSICAL());
+		RelNode newInput = RelOptRule.convert(input, requiredTraitSet);
+		TableConfig config = cluster.getPlanner().getContext().unwrap(FlinkContext.class).getTableConfig();
+		WindowEmitStrategy emitStrategy = WindowEmitStrategy.apply(config, agg.getWindow());
+
+		FieldReferenceExpression timeField = agg.getWindow().timeAttribute();
+
+		int inputTimestampIndex;
+		if (AggregateUtil.isRowtimeAttribute(timeField)) {
+			inputTimestampIndex = AggregateUtil.timeFieldIndex(
+				inputRowType, relBuilderFactory.create(cluster, null), timeField);
+		} else {
+			inputTimestampIndex = -1;
+		}
+
+		return new StreamExecPythonGroupWindowAggregate(
+			cluster,
+			providedTraitSet,
+			newInput,
+			rel.getRowType(),
+			inputRowType,
+			agg.getGroupSet().toArray(),
+			JavaConverters.asScalaIteratorConverter(
+				agg.getAggCallList().iterator()).asScala().toSeq(),
+			agg.getWindow(),
+			agg.getNamedProperties(),
+			inputTimestampIndex,
+			emitStrategy);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.functions.python.PythonFunctionInfo
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.expressions.{PlannerRowtimeAttribute, PlannerWindowEnd, PlannerWindowStart}
+import org.apache.flink.table.planner.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
+import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecPythonGroupWindowAggregate.ARROW_STREAM_PYTHON_GROUP_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME
+import org.apache.flink.table.planner.plan.utils.AggregateUtil._
+import org.apache.flink.table.planner.plan.utils.{KeySelectorUtil, WindowEmitStrategy}
+import org.apache.flink.table.runtime.operators.window.assigners._
+import org.apache.flink.table.runtime.operators.window.triggers.{ElementTriggers, EventTimeTriggers, ProcessingTimeTriggers, Trigger}
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.flink.table.types.logical.RowType
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+
+/**
+  * Stream physical RelNode for group widow aggregate (Python user defined aggregate function).
+  */
+class StreamExecPythonGroupWindowAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
+    window: LogicalWindow,
+    namedProperties: Seq[PlannerNamedWindowProperty],
+    inputTimeFieldIndex: Int,
+    emitStrategy: WindowEmitStrategy)
+  extends StreamExecGroupWindowAggregateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    outputRowType,
+    inputRowType,
+    grouping,
+    aggCalls,
+    window,
+    namedProperties,
+    inputTimeFieldIndex,
+    emitStrategy,
+    "PythonAggregate")
+  with CommonPythonAggregate {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new StreamExecPythonGroupWindowAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      outputRowType,
+      inputRowType,
+      grouping,
+      aggCalls,
+      window,
+      namedProperties,
+      inputTimeFieldIndex,
+      emitStrategy)
+  }
+
+  override def translateToPlanInternal(planner: StreamPlanner): Transformation[RowData] = {
+    val config = planner.getTableConfig
+
+    val inputTransform = getInputNodes.get(0).translateToPlan(planner)
+      .asInstanceOf[Transformation[RowData]]
+
+    val inputRowTypeInfo = inputTransform.getOutputType.asInstanceOf[InternalTypeInfo[RowData]]
+
+    val outputType = FlinkTypeFactory.toLogicalRowType(getRowType)
+    val inputType = FlinkTypeFactory.toLogicalRowType(inputRowType)
+
+    val isCountWindow = window match {
+      case TumblingGroupWindow(_, _, size) if hasRowIntervalType(size) => true
+      case SlidingGroupWindow(_, _, size, _) if hasRowIntervalType(size) => true
+      case _ => false
+    }
+
+    if (isCountWindow && grouping.length > 0 && config.getMinIdleStateRetentionTime < 0) {
+      LOG.warn(
+        "No state retention interval configured for a query which accumulates state. " +
+          "Please provide a query configuration with valid retention interval to prevent " +
+          "excessive state size. You may specify a retention time of 0 to not clean up the state.")
+    }
+
+    val timeIdx = if (isRowtimeAttribute(window.timeAttribute)) {
+      if (inputTimeFieldIndex < 0) {
+        throw new TableException(
+          s"Group window PythonAggregate must defined on a time attribute, " +
+            "but the time attribute can't be found.\n" +
+            "This should never happen. Please file an issue."
+          )
+      }
+      inputTimeFieldIndex
+    } else {
+      -1
+    }
+
+    val (windowAssigner, trigger) = generateWindowAssignerAndTrigger()
+    val ret = createPythonStreamWindowGroupOneInputTransformation(
+      inputTransform,
+      inputType,
+      outputType,
+      timeIdx,
+      windowAssigner,
+      trigger,
+      emitStrategy.getAllowLateness,
+      getConfig(planner.getExecEnv, planner.getTableConfig))
+
+    if (inputsContainSingleton()) {
+      ret.setParallelism(1)
+      ret.setMaxParallelism(1)
+    }
+
+    val selector = KeySelectorUtil.getRowDataSelector(grouping, inputRowTypeInfo)
+
+    // set KeyType and Selector for state
+    ret.setStateKeySelector(selector)
+    ret.setStateKeyType(selector.getProducedType)
+
+    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+      ExecNode.setManagedMemoryWeight(
+        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+    }
+    ret
+  }
+
+  private[this] def generateWindowAssignerAndTrigger(): (WindowAssigner[_], Trigger[_]) = {
+    window match {
+      case TumblingGroupWindow(_, timeField, size)
+        if isProctimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        (TumblingWindowAssigner.of(toDuration(size)).withProcessingTime(),
+          ProcessingTimeTriggers.afterEndOfWindow())
+
+      case TumblingGroupWindow(_, timeField, size)
+        if isRowtimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        (TumblingWindowAssigner.of(toDuration(size)).withEventTime(),
+          EventTimeTriggers.afterEndOfWindow())
+
+      case TumblingGroupWindow(_, timeField, size)
+        if isProctimeAttribute(timeField) && hasRowIntervalType(size) =>
+        (CountTumblingWindowAssigner.of(toLong(size)),
+          ElementTriggers.count(toLong(size)))
+
+      case TumblingGroupWindow(_, _, _) =>
+        // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+        // before applying the  windowing logic. Otherwise, this would be the same as a
+        // ProcessingTimeTumblingGroupWindow
+        throw new UnsupportedOperationException(
+          "Event-time grouping windows on row intervals are currently not supported.")
+
+      case SlidingGroupWindow(_, timeField, size, slide)
+        if isProctimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        (SlidingWindowAssigner.of(toDuration(size), toDuration(slide)),
+          ProcessingTimeTriggers.afterEndOfWindow())
+
+      case SlidingGroupWindow(_, timeField, size, slide)
+        if isRowtimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        (SlidingWindowAssigner.of(toDuration(size), toDuration(slide)),
+          EventTimeTriggers.afterEndOfWindow())
+
+      case SlidingGroupWindow(_, timeField, size, slide)
+        if isProctimeAttribute(timeField) && hasRowIntervalType(size) =>
+        (CountSlidingWindowAssigner.of(toLong(size), toLong(slide)),
+          ElementTriggers.count(toLong(size)))
+
+      case SlidingGroupWindow(_, _, _, _) =>
+        // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+        // before applying the  windowing logic. Otherwise, this would be the same as a
+        // ProcessingTimeTumblingGroupWindow
+        throw new UnsupportedOperationException(
+          "Event-time grouping windows on row intervals are currently not supported.")
+    }
+  }
+
+  private[this] def createPythonStreamWindowGroupOneInputTransformation(
+      inputTransform: Transformation[RowData],
+      inputRowType: RowType,
+      outputRowType: RowType,
+      inputTimeFieldIndex: Int,
+      windowAssigner: WindowAssigner[_],
+      trigger: Trigger[_],
+      allowance: Long,
+      config: Configuration): OneInputTransformation[RowData, RowData] = {
+
+    val namePropertyTypeArray = namedProperties
+      .map {
+        case PlannerNamedWindowProperty(_, p) => p match {
+          case PlannerWindowStart(_) => 0
+          case PlannerWindowEnd(_) => 1
+          case PlannerRowtimeAttribute(_) => 2
+        }
+      }.toArray
+
+    val (pythonUdafInputOffsets, pythonFunctionInfos) =
+      extractPythonAggregateFunctionInfosFromAggregateCall(aggCalls)
+    val pythonOperator = getPythonStreamGroupWindowAggregateFunctionOperator(
+      config,
+      inputRowType,
+      outputRowType,
+      windowAssigner,
+      trigger,
+      allowance,
+      inputTimeFieldIndex,
+      namePropertyTypeArray,
+      pythonUdafInputOffsets,
+      pythonFunctionInfos)
+
+    new OneInputTransformation(
+      inputTransform,
+      "StreamExecPythonGroupWindowAggregate",
+      pythonOperator,
+      InternalTypeInfo.of(outputRowType),
+      inputTransform.getParallelism)
+  }
+
+  private[this] def getPythonStreamGroupWindowAggregateFunctionOperator(
+      config: Configuration,
+      inputRowType: RowType,
+      outputRowType: RowType,
+      windowAssigner: WindowAssigner[_],
+      trigger: Trigger[_],
+      allowance: Long,
+      inputTimeFieldIndex: Int,
+      namedProperties: Array[Int],
+      udafInputOffsets: Array[Int],
+      pythonFunctionInfos: Array[PythonFunctionInfo]): OneInputStreamOperator[RowData, RowData] = {
+    val clazz = loadClass(ARROW_STREAM_PYTHON_GROUP_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME)
+
+    val ctor = clazz.getConstructor(
+      classOf[Configuration],
+      classOf[Array[PythonFunctionInfo]],
+      classOf[RowType],
+      classOf[RowType],
+      classOf[Int],
+      classOf[WindowAssigner[_]],
+      classOf[Trigger[_]],
+      classOf[Long],
+      classOf[Array[Int]],
+      classOf[Array[Int]],
+      classOf[Array[Int]])
+
+    ctor.newInstance(
+      config,
+      pythonFunctionInfos,
+      inputRowType,
+      outputRowType,
+      Integer.valueOf(inputTimeFieldIndex),
+      windowAssigner,
+      trigger,
+      java.lang.Long.valueOf(allowance),
+      namedProperties,
+      grouping,
+      udafInputOffsets)
+      .asInstanceOf[OneInputStreamOperator[RowData, RowData]]
+  }
+}
+
+object StreamExecPythonGroupWindowAggregate {
+  val ARROW_STREAM_PYTHON_GROUP_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME: String =
+    "org.apache.flink.table.runtime.operators.python.aggregate.arrow.stream." +
+      "StreamArrowPythonGroupWindowAggregateFunctionOperator"
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -458,7 +458,8 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
       case _: StreamExecGroupWindowAggregate | _: StreamExecGroupWindowTableAggregate |
            _: StreamExecDeduplicate | _: StreamExecTemporalSort | _: StreamExecMatch |
-           _: StreamExecOverAggregate | _: StreamExecIntervalJoin =>
+           _: StreamExecOverAggregate | _: StreamExecIntervalJoin |
+           _: StreamExecPythonGroupWindowAggregate =>
         // WindowAggregate, WindowTableAggregate, Deduplicate, TemporalSort, CEP, OverAggregate
         // and IntervalJoin require nothing about UpdateKind.
         val children = visitChildren(rel, UpdateKindTrait.NONE)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -404,6 +404,7 @@ object FlinkStreamRuleSets {
     // window agg
     StreamExecGroupWindowAggregateRule.INSTANCE,
     StreamExecGroupWindowTableAggregateRule.INSTANCE,
+    StreamExecPythonGroupWindowAggregateRule.INSTANCE,
     // join
     StreamExecJoinRule.INSTANCE,
     StreamExecIntervalJoinRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecGroupWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecGroupWindowAggregateRule.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWindowAggregate
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecGroupWindowAggregate
 import org.apache.flink.table.planner.plan.utils.AggregateUtil.{isRowtimeAttribute, timeFieldIndex}
+import org.apache.flink.table.planner.plan.utils.PythonUtil.isPythonAggregate
 import org.apache.flink.table.planner.plan.utils.WindowEmitStrategy
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -53,7 +54,7 @@ class StreamExecGroupWindowAggregateRule
       throw new TableException("GROUPING SETS are currently not supported.")
     }
 
-    true
+    !agg.getAggCallList.exists(isPythonAggregate(_))
   }
 
   override def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testPandasEventTimeSlidingGroupWindowOverCount">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[PandasAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, proctime, 5, 2)], properties=[])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, proctime, 5, 2)], select=[b, PandasAggregateFunction(a, c) AS EXPR$0])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasEventTimeTumblingGroupWindowOverTime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[PandasAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, PandasAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasEventTimeSlidingGroupWindowOverTime">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[PandasAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, PandasAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasEventTimeTumblingGroupWindowOverCount">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[PandasAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, proctime, 2)], properties=[])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, proctime, 2)], select=[b, PandasAggregateFunction(a, c) AS EXPR$0])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api._
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.PandasAggregateFunction
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.junit.Test
+
+class PythonGroupWindowAggregateTest extends TableTestBase {
+
+  @Test
+  def testPandasEventTimeTumblingGroupWindowOverTime(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new PandasAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Tumble over 5.millis on 'rowtime as 'w)
+      .groupBy('w, 'b)
+      .select('b, 'w.start,'w.end, func('a, 'c))
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test
+  def testPandasEventTimeTumblingGroupWindowOverCount(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int)](
+      "MyTable", 'a, 'b, 'c, 'proctime.proctime)
+    val func = new PandasAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Tumble over 2.rows on 'proctime as 'w)
+      .groupBy('w, 'b)
+      .select('b, func('a, 'c))
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test
+  def testPandasEventTimeSlidingGroupWindowOverTime(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new PandasAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Slide over 5.millis every 2.millis on 'rowtime as 'w)
+      .groupBy('w, 'b)
+      .select('b, 'w.start,'w.end, func('a, 'c))
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test
+  def testPandasEventTimeSlidingGroupWindowOverCount(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int)](
+      "MyTable", 'a, 'b, 'c, 'proctime.proctime)
+    val func = new PandasAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Slide over 5.rows every 2.rows on 'proctime as 'w)
+      .groupBy('w, 'b)
+      .select('b, func('a, 'c))
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testPandasEventTimeSessionGroupWindowOverTime(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new PandasAggregateFunction
+
+    val windowedTable = sourceTable
+      .window(Session withGap 7.millis on 'rowtime as 'w)
+      .groupBy('w, 'b)
+      .select('b, 'w.start, 'w.end, func('a, 'c))
+    util.verifyPlan(windowedTable)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support Pandas Stream Group Window Aggregation*


## Brief change log

  - *Add StreamArrowPythonGroupWindowAggregateFunctionOperator*
  - *Add Physical Rule and RelNode*

## Verifying this change

This change added tests and can be verified as follows:

  - *Add UT PythonGroupWindowAggregateTest*
  - *Add IT StreamPandasUDAFITTests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
