### PR TITLE
[FLINK-19409][Documentation] remove unrelated comment for getValue in ListView

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/dataview/ListView.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/dataview/ListView.java
@@ -64,7 +64,7 @@ import java.util.Objects;
  *    public long count = 0L;
  *  }
  *
- *  public class MyAggregateFunction extends AggregateFunction<Long, MyAccumulator> {
+ *  public class MyAggregateFunction extends AggregateFunction<String, MyAccumulator> {
  *
  *   {@literal @}Override
  *   public MyAccumulator createAccumulator() {
@@ -73,18 +73,13 @@ import java.util.Objects;
  *
  *   public void accumulate(MyAccumulator accumulator, String id) {
  *     accumulator.list.add(id);
- *     ... ...
- *     accumulator.list.get()
- *     ... ...
+ *     accumulator.count++;
  *   }
  *
  *   {@literal @}Override
- *   public Long getValue(MyAccumulator accumulator) {
- *     accumulator.list.add(id);
- *     ... ...
- *     accumulator.list.get()
- *     ... ...
- *     return accumulator.count;
+ *   public String getValue(MyAccumulator accumulator) {
+ *     // return the count and the joined elements
+ *     return count + ": " + String.join("|", acc.list.get());
  *   }
  * }
  *


### PR DESCRIPTION
## What is the purpose of the change

*In class ListView, the comment for method getValue has unrelated code 'accumulator.list.add(id);'. Users and developers may be confused with the comment. It should be removed.*


## Brief change log

  - *Remove the unrelated code comment and rewrite the example.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
