### PR TITLE
Single task subpartition reconnection 2

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
@@ -35,6 +35,8 @@ public final class FailoverStrategyFactoryLoader {
 	/** Config name for the {@link RestartPipelinedRegionFailoverStrategy}. */
 	public static final String PIPELINED_REGION_RESTART_STRATEGY_NAME = "region";
 
+	public static final String RESTART_INDIVIDUAL_STRATEGY_NAME = "individual";
+
 	private FailoverStrategyFactoryLoader() {
 	}
 
@@ -55,6 +57,9 @@ public final class FailoverStrategyFactoryLoader {
 
 			case PIPELINED_REGION_RESTART_STRATEGY_NAME:
 				return new RestartPipelinedRegionFailoverStrategy.Factory();
+
+			case RESTART_INDIVIDUAL_STRATEGY_NAME:
+				return new RestartIndividualFailoverStrategy.Factory();
 
 			default:
 				throw new IllegalConfigurationException("Unknown failover strategy: " + strategyParam);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartIndividualFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartIndividualFailoverStrategy.java
@@ -1,0 +1,41 @@
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+public class RestartIndividualFailoverStrategy implements FailoverStrategy {
+
+	/** The log object used for debugging. */
+	private static final Logger LOG = LoggerFactory.getLogger(RestartIndividualFailoverStrategy.class);
+
+	RestartIndividualFailoverStrategy(
+		SchedulingTopology topology,
+		ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+	}
+
+	@Override
+	public Set<ExecutionVertexID> getTasksNeedingRestart(ExecutionVertexID executionVertexId, Throwable cause) {
+		return ImmutableSet.of(executionVertexId);
+	}
+
+	/**
+	 * The factory to instantiate {@link RestartIndividualFailoverStrategy}.
+	 */
+	public static class Factory implements FailoverStrategy.Factory {
+
+		@Override
+		public FailoverStrategy create(
+			final SchedulingTopology topology,
+			final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+			return new RestartIndividualFailoverStrategy(topology, resultPartitionAvailabilityChecker);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.DATA_BUFFER;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilder.BUFFER_BUILDER_HEADER_SIZE;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilder.Header;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -138,6 +139,62 @@ public class BufferConsumer implements Closeable {
 		return slice.retainBuffer();
 	}
 
+	public PartialRecordCleanupResult skipPartialRecord() {
+		writerPosition.update();
+		int cachedWriterPosition = writerPosition.getCached();
+
+		Buffer slice;
+		boolean cleanedUp;
+
+		// partial record can happen only at the beginning of a buffer
+		// because buffer slicer can end with either a full record or full buffer (partial record)
+		if (startOfDataBuffer()) {
+			// either do not have any data, or at least have 4 bytes (header + data)
+			checkState(
+				(cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE)
+					|| (currentReaderPosition == cachedWriterPosition)
+			);
+
+			if (cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE) {
+				int head = buffer.getMemorySegment().getIntBigEndian(0);
+				boolean partial = Header.isPartial(head);
+				int length = Header.length(head);
+
+				if (partial) {
+					// case 1: long record spanning multiple buffers, haven't yet cleaned up, skip the whole buffer
+					if (length == buffer.getMaxCapacity() - BUFFER_BUILDER_HEADER_SIZE) {
+						slice = buffer.readOnlySlice(currentReaderPosition, 0);
+						cleanedUp = false;
+					} else {
+						// case 2: partial record ends within the buffer, cleaned up successfully, skip the partial record
+						slice = buffer.readOnlySlice(
+							currentReaderPosition + BUFFER_BUILDER_HEADER_SIZE + length,
+							cachedWriterPosition - currentReaderPosition - BUFFER_BUILDER_HEADER_SIZE - length);
+						cleanedUp = true;
+					}
+				} else {
+					// case 3: the record is not a partial record, cleaned up successfully, skip the head
+					slice = buffer.readOnlySlice(
+						currentReaderPosition + BUFFER_BUILDER_HEADER_SIZE ,
+						cachedWriterPosition - currentReaderPosition - BUFFER_BUILDER_HEADER_SIZE);
+					cleanedUp = true;
+				}
+			} else {
+				// case 4: written data is not visible yet, haven't yet cleaned up, return an empty slicer
+				slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+				cleanedUp = false;
+			}
+		} else {
+			// case 5: read from the middle of the buffer or event buffer; no clean up needed,
+			// because buffer slicer can end with either a full record or full buffer (partial record)
+			slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+			cleanedUp = true;
+		}
+
+		currentReaderPosition = cachedWriterPosition;
+		return new PartialRecordCleanupResult(slice.retainBuffer(), cleanedUp);
+	}
+
 	/**
 	 * Returns a retained copy with separate indexes. This allows to read from the same {@link MemorySegment} twice.
 	 *
@@ -225,6 +282,24 @@ public class BufferConsumer implements Closeable {
 
 		private void update() {
 			this.cachedPosition = positionMarker.get();
+		}
+	}
+
+	public static class PartialRecordCleanupResult {
+		private final Buffer buffer;
+		private final boolean cleaned;
+
+		PartialRecordCleanupResult(Buffer buffer, boolean cleaned) {
+			this.buffer = checkNotNull(buffer);
+			this.cleaned = cleaned;
+		}
+
+		public Buffer getBuffer() {
+			return buffer;
+		}
+
+		public boolean getCleaned() {
+			return cleaned;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -291,7 +291,7 @@ public class PipelinedSubpartition extends ResultSubpartition
 				if (isPartialBuffer) {
 					BufferConsumer.PartialRecordCleanupResult result = bufferConsumer.skipPartialRecord();
 					buffer = result.getBuffer();
-					isPartialBuffer = result.getCleaned();
+					isPartialBuffer = !result.getCleaned();
 				} else {
 					buffer = bufferConsumer.build();
 				}
@@ -371,6 +371,13 @@ public class PipelinedSubpartition extends ResultSubpartition
 		}
 
 		return readView;
+	}
+
+	public void releaseView() {
+		readView = null;
+		isPartialBuffer = true;
+		isBlockedByCheckpoint = false;
+		sequenceNumber = 0;
 	}
 
 	public boolean isAvailable(int numCreditsAvailable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -66,7 +66,7 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
 		if (isReleased.compareAndSet(false, true)) {
 			// The view doesn't hold any resources and the parent cannot be restarted. Therefore,
 			// it's OK to notify about consumption as well.
-			parent.onConsumedSubpartition();
+			parent.releaseView();
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
@@ -1,0 +1,262 @@
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.test.util.TestUtils.tryExecute;
+
+/** Use RemoteInputChannel. Only for Upstream Reconnection. **/
+
+/**
+ * 1. data size : 83
+ * 2. memory buffer size: 4096
+ * 3. full buffer: 49 record 4067 => 50 record 4150
+ */
+public class ApproximateLocalRecoveryUpstreamDiffTMITCase {
+	private static MiniClusterWithClientResource cluster;
+
+	@Before
+	public void setup() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "individual");
+		config.setString(JobManagerOptions.SCHEDULING_STRATEGY, "legacy");
+		config.setString(HighAvailabilityOptions.HA_MODE, RegionFailoverITCase.TestingHAFactory.class.getName());
+
+		config.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4096"));
+		config.setLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 1000000L);
+		config.setString(AkkaOptions.ASK_TIMEOUT, "1 h");
+		//configuration.setString("heartbeat.timeout", "1000000");
+
+		cluster = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+				.setConfiguration(config)
+				.setNumberTaskManagers(2)
+				.setNumberSlotsPerTaskManager(1).build());
+		cluster.before();
+	}
+
+	@AfterClass
+	public static void shutDownExistingCluster() {
+		if (cluster != null) {
+			cluster.after();
+			cluster = null;
+		}
+	}
+
+	@Test
+	public void localTaskFailureRecovery() throws Exception {
+		int numElementsPerTask = 1000000;
+		int producerParallelism = 1;
+		int failAfterElements = 20;
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+		env.setBufferTimeout(0);
+		env.disableOperatorChaining();
+		// env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
+
+		DataStream<Tuple4<Integer, Long, Integer, String>> source =
+			// env.addSource(new AppSourceFunction(numElementsPerTask))
+			env.addSource(new AppSourceFunction(numElementsPerTask, 4096))
+				.setParallelism(producerParallelism)
+				.slotSharingGroup("source");
+
+		source.map(new FailingMapper<>(failAfterElements))
+			.setParallelism(1)
+			.slotSharingGroup("map");
+
+		FailingMapper.failedBefore = false;
+		tryExecute(env, "test");
+	}
+
+	// Schema: (key, timestamp, source instance Id).
+	static class AppSourceFunction extends RichParallelSourceFunction<Tuple4<Integer, Long, Integer, String>>
+		implements ListCheckpointed<Integer> {
+		private static final Logger LOG = LoggerFactory.getLogger(AppSourceFunction.class);
+		private volatile boolean running = true;
+		private final int numElementsPerProducer;
+		private final StringBuilder veryLongString;
+
+		private int index = 0;
+
+		AppSourceFunction(int numElementsPerProducer) {
+			this.numElementsPerProducer = numElementsPerProducer;
+			this.veryLongString = null;
+		}
+
+		AppSourceFunction(int numElementsPerProducer, int bufferSize) {
+			this.numElementsPerProducer = numElementsPerProducer;
+			String longString = "I am a very long string to test partial records hohoho hahaha";
+			veryLongString = new StringBuilder(longString);
+
+			for (int i = 0; i <= bufferSize / longString.length(); i++) {
+				veryLongString.append(longString);
+			}
+		}
+
+		@Override
+		public void run(SourceContext<Tuple4<Integer, Long, Integer, String>> ctx) throws Exception{
+			long timestamp = 1593575900000L;
+			int sourceInstanceId = getRuntimeContext().getIndexOfThisSubtask();
+			for (; index < numElementsPerProducer && running; index++) {
+				synchronized (ctx.getCheckpointLock()) {
+					if (index % 100 == 0) {
+						Thread.sleep(500);
+					}
+					System.out.println("Source : [" + index + "," + timestamp + "," + sourceInstanceId + "]");
+					if (veryLongString == null) {
+						ctx.collect(new Tuple4<>(index, timestamp++, sourceInstanceId, "I am a very long string to test partial records hohoho hahaha"));
+					} else {
+						ctx.collect(new Tuple4<>(index, timestamp++, sourceInstanceId, veryLongString.toString()));
+					}
+				}
+			}
+			while (running) {
+				Thread.sleep(100);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			LOG.info("Snapshot of Source index " + index + " at checkpoint " + checkpointId);
+			return Collections.singletonList(index);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+
+			index = state.get(0);
+			LOG.info("restore Source index to " + index);
+		}
+	}
+
+	private static class FailingMapper<T> extends RichMapFunction<T, T> implements
+		ListCheckpointed<Integer>, CheckpointListener, Runnable {
+
+		private static final Logger LOG = LoggerFactory.getLogger(FailingMapper.class);
+
+		private static final long serialVersionUID = 6334389850158707313L;
+
+		public static volatile boolean failedBefore;
+
+		private final int failCount;
+		private int numElementsTotal;
+		private int numElementsThisTime;
+
+		private boolean failer;
+		private boolean hasBeenCheckpointed;
+
+		private Thread printer;
+		private volatile boolean printerRunning = true;
+
+		public FailingMapper(int failCount) {
+			this.failCount = failCount;
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			failer = getRuntimeContext().getIndexOfThisSubtask() == 0;
+			printer = new Thread(this, "FailingIdentityMapper Status Printer");
+			printer.start();
+		}
+
+		@Override
+		public T map(T value) throws Exception {
+			// System.out.println("Failing mapper: numElementsThisTime=" + numElementsThisTime + " totalCount=" + numElementsTotal);
+			System.out.println("Failing mapper: " + value.toString());
+			numElementsTotal++;
+			numElementsThisTime++;
+
+			if (!failedBefore) {
+				Thread.sleep(10);
+
+				if (failer && numElementsTotal >= failCount) {
+					failedBefore = true;
+					throw new Exception("Artificial Test Failure");
+				}
+			}
+			return value;
+		}
+
+		@Override
+		public void close() throws Exception {
+			printerRunning = false;
+			if (printer != null) {
+				printer.interrupt();
+				printer = null;
+			}
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			this.hasBeenCheckpointed = true;
+		}
+
+		@Override
+		public void notifyCheckpointAborted(long checkpointId) {
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			LOG.info("Snapshot of FailingMapper numElementsTotal " + numElementsTotal + " at checkpoint " + checkpointId);
+			return Collections.singletonList(numElementsTotal);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+
+			this.numElementsTotal = state.get(0);
+			LOG.info("restore FailingMapper numElementsTotal to " + numElementsTotal);
+		}
+
+		@Override
+		public void run() {
+			while (printerRunning) {
+				try {
+					Thread.sleep(5000);
+				} catch (InterruptedException e) {
+					// ignore
+				}
+				LOG.info("============================> Failing mapper  {}: count={}, totalCount={}",
+					getRuntimeContext().getIndexOfThisSubtask(),
+					numElementsThisTime, numElementsTotal);
+			}
+		}
+	}
+}

--- a/flink-tests/src/test/resources/log4j2-test.properties
+++ b/flink-tests/src/test/resources/log4j2-test.properties
@@ -18,7 +18,8 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = DEBUG
+#rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger


### PR DESCRIPTION
## What is the purpose of the change
- This PR includes a simple individual scheduler that can restart the sink for sink failure, so that we can test end-2-end for reconnection + partial partition clean-up;
- I've tested multiple cases including the case `a very long record spanning over more than one buffer`; `short record`; reading from the head of a buffer consumer; reading from the middle of a buffer consumer; and e.t.c. They all work perfectly.
- I've also rebased upon Kevin's change on RecordWriter's API, and Zhuzhu's change on pipelinedRegionSchedulingStrategy.

- #13476 handle partial flag when sub-partition is partial
- #13456 Single task add a partial flag in buffer

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
