### PR TITLE
[FLINK-19417][python] Fix the bug of the method from_data_stream in table_environement

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -34,6 +34,7 @@ from pyflink.serializers import BatchedSerializer, PickleSerializer
 from pyflink.table import Table, EnvironmentSettings, Module, Expression
 from pyflink.table.catalog import Catalog
 from pyflink.table.descriptors import StreamTableDescriptor, BatchTableDescriptor
+from pyflink.table.expression import _get_java_expression
 from pyflink.table.serializers import ArrowSerializer
 from pyflink.table.statement_set import StatementSet
 from pyflink.table.table_config import TableConfig
@@ -46,7 +47,7 @@ from pyflink.table.udf import UserDefinedFunctionWrapper, AggregateFunction, uda
 from pyflink.table.utils import to_expression_jarray
 from pyflink.util import utils
 from pyflink.util.utils import get_j_env_configuration, is_local_deployment, load_java_class, \
-    to_j_explain_detail_arr
+    to_j_explain_detail_arr, to_jarray
 
 __all__ = [
     'BatchTableEnvironment',
@@ -1747,7 +1748,7 @@ class StreamTableEnvironment(TableEnvironment):
                     stream_execution_environment._j_stream_execution_environment)
         return StreamTableEnvironment(j_tenv)
 
-    def from_data_stream(self, data_stream: DataStream, fields: List[str] = None) -> Table:
+    def from_data_stream(self, data_stream: DataStream, *fields: Union[str, Expression]) -> Table:
         """
         Converts the given DataStream into a Table with specified field names.
 
@@ -1770,11 +1771,19 @@ class StreamTableEnvironment(TableEnvironment):
                        of the Table
         :return: The converted Table.
         """
-        if fields is not None:
-            j_table = self._j_tenv.fromDataStream(data_stream._j_data_stream, fields)
-        else:
+        j_table = None
+        if len(fields) == 0:
             j_table = self._j_tenv.fromDataStream(data_stream._j_data_stream)
-        return Table(j_table=j_table, t_env=self._j_tenv)
+        elif len(fields) == 1 and isinstance(fields[0], str):
+            j_table = self._j_tenv.fromDataStream(data_stream._j_data_stream, fields[0])
+        elif len(fields) > 0 and \
+                [isinstance(f, Expression) for f in fields] == [True] * len(fields):
+            gateway = get_gateway()
+            j_table = self._j_tenv.fromDataStream(data_stream._j_data_stream,
+                                                  to_jarray(gateway.jvm.Expression,
+                                                            [_get_java_expression(f)
+                                                             for f in fields]))
+        return None if j_table is None else Table(j_table=j_table, t_env=self)
 
     def to_append_stream(self, table: Table, type_info: TypeInformation) -> DataStream:
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1782,7 +1782,7 @@ class StreamTableEnvironment(TableEnvironment):
                 DeprecationWarning)
             return Table(j_table=self._j_tenv.fromDataStream(j_data_stream, fields[0]), t_env=self)
         raise ValueError("invalid value for 'fields': %r" % fields)
-    
+
     def to_append_stream(self, table: Table, type_info: TypeInformation) -> DataStream:
         """
         Converts the given Table into a DataStream of a specified type. The Table must only have

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -32,6 +32,7 @@ from pyflink.table import DataTypes, CsvTableSink, StreamTableEnvironment, Envir
     Module, ResultKind
 from pyflink.table.descriptors import FileSystem, OldCsv, Schema
 from pyflink.table.explain_detail import ExplainDetail
+from pyflink.table.expressions import col
 from pyflink.table.table_config import TableConfig
 from pyflink.table.table_environment import BatchTableEnvironment
 from pyflink.table.types import RowType
@@ -409,6 +410,14 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
         t_env.execute("test_from_data_stream")
         result = source_sink_utils.results()
         expected = ['1,Hi,Hello', '2,Hello,Hi']
+        self.assert_equals(result, expected)
+
+        table = t_env.from_data_stream(ds, col('a'), col('b'), col('c'))
+        t_env.register_table_sink("ExprSink",
+                                  source_sink_utils.TestAppendSink(field_names, field_types))
+        t_env.insert_into("ExprSink", table)
+        t_env.execute("test_from_data_stream_with_expr")
+        result = source_sink_utils.results()
         self.assert_equals(result, expected)
 
     def test_to_append_stream(self):


### PR DESCRIPTION
## What is the purpose of the change

*The parameter of method `from_data_stream` in `StreamTableEnvironment` `fields` should be str or expression, not the current list [str]. And the `table_env` object passed to the Table object should be Python's TableEnvironment, not Java's TableEnvironment.*

## Brief change log

  - *Modify the parameter type of method `from_data_stream` in `StreamTableEnvironment` `fields` to str or expression .*

## Verifying this change

  - *Add the test case in `test_from_data_stream` in `TableEnvironmentTest` for the case that verifies the creation of data stream by `from_data_stream` with expression.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)