### PR TITLE
[FLINK-19181][python] Make python processes respect the calculated managed memory fraction

### DIFF
--- a/docs/_includes/generated/python_configuration.html
+++ b/docs/_includes/generated/python_configuration.html
@@ -39,12 +39,6 @@
             <td>The maximum number of elements to include in an arrow batch for Python user-defined function execution. The arrow batch size should not exceed the bundle size. Otherwise, the bundle size will be used as the arrow batch size.</td>
         </tr>
         <tr>
-            <td><h5>python.fn-execution.buffer.memory.size</h5></td>
-            <td style="word-wrap: break-word;">"15mb"</td>
-            <td>String</td>
-            <td>The amount of memory to be allocated by the input buffer and output buffer of a Python worker. The memory will be accounted as managed memory if the actual memory allocated to an operator is no less than the total memory of a Python worker. Otherwise, this configuration takes no effect.</td>
-        </tr>
-        <tr>
             <td><h5>python.fn-execution.bundle.size</h5></td>
             <td style="word-wrap: break-word;">100000</td>
             <td>Integer</td>
@@ -57,16 +51,10 @@
             <td>Sets the waiting timeout(in milliseconds) before processing a bundle for Python user-defined function execution. The timeout defines how long the elements of a bundle will be buffered before being processed. Lower timeouts lead to lower tail latencies, but may affect throughput.</td>
         </tr>
         <tr>
-            <td><h5>python.fn-execution.framework.memory.size</h5></td>
-            <td style="word-wrap: break-word;">"64mb"</td>
-            <td>String</td>
-            <td>The amount of memory to be allocated by the Python framework. The sum of the value of this configuration and "python.fn-execution.buffer.memory.size" represents the total memory of a Python worker. The memory will be accounted as managed memory if the actual memory allocated to an operator is no less than the total memory of a Python worker. Otherwise, this configuration takes no effect.</td>
-        </tr>
-        <tr>
             <td><h5>python.fn-execution.memory.managed</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>If set, the Python worker will configure itself to use the managed memory budget of the task slot. Otherwise, it will use the Off-Heap Memory of the task slot. In this case, users should set the Task Off-Heap Memory using the configuration key taskmanager.memory.task.off-heap.size. For each Python worker, the required Task Off-Heap Memory is the sum of the value of python.fn-execution.framework.memory.size and python.fn-execution.buffer.memory.size.</td>
+            <td>If set, the Python worker will configure itself to use the managed memory budget of the task slot. Otherwise, it will use the Off-Heap Memory of the task slot. In this case, users should set the Task Off-Heap Memory using the configuration key taskmanager.memory.task.off-heap.size.</td>
         </tr>
         <tr>
             <td><h5>python.metric.enabled</h5></td>

--- a/docs/dev/python/table-api-users-guide/udfs/python_udfs.md
+++ b/docs/dev/python/table-api-users-guide/udfs/python_udfs.md
@@ -51,9 +51,6 @@ class HashCode(ScalarFunction):
 
 table_env = BatchTableEnvironment.create(env)
 
-# configure the off-heap memory of current taskmanager to enable the python worker uses off-heap memory.
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 hash_code = udf(HashCode(), result_type=DataTypes.BIGINT())
 
 # use the Python function in Python Table API
@@ -63,10 +60,6 @@ my_table.select(my_table.string, my_table.bigint, hash_code(my_table.bigint), ca
 table_env.create_temporary_function("hash_code", udf(HashCode(), result_type=DataTypes.BIGINT()))
 table_env.sql_query("SELECT string, bigint, hash_code(bigint) FROM MyTable")
 {% endhighlight %}
-
-<span class="label label-info">Note</span> If not using RocksDB as state backend, you can also configure the python
-worker to use the managed memory of taskmanager by setting **python.fn-execution.memory.managed** to be **true**.
-Then there is no need to set the the configuration **taskmanager.memory.task.off-heap.size**.
 
 It also supports to use Java/Scala scalar functions in Python Table API programs.
 
@@ -87,9 +80,6 @@ from pyflink.table.expressions import call
 
 table_env = BatchTableEnvironment.create(env)
 
-# configure the off-heap memory of current taskmanager to enable the python worker uses off-heap memory.
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # register the Java function
 table_env.create_java_temporary_function("hash_code", "my.java.function.HashCode")
 
@@ -99,10 +89,6 @@ my_table.select(call('hash_code', my_table.string))
 # use the Java function in SQL API
 table_env.sql_query("SELECT string, bigint, hash_code(string) FROM MyTable")
 {% endhighlight %}
-
-<span class="label label-info">Note</span> If not using RocksDB as state backend, you can also configure the python
-worker to use the managed memory of taskmanager by setting **python.fn-execution.memory.managed** to be **true**.
-Then there is no need to set the the configuration **taskmanager.memory.task.off-heap.size**.
 
 There are many ways to define a Python scalar function besides extending the base class `ScalarFunction`.
 The following examples show the different ways to define a Python scalar function which takes two columns of
@@ -165,9 +151,6 @@ env = StreamExecutionEnvironment.get_execution_environment()
 table_env = StreamTableEnvironment.create(env)
 my_table = ...  # type: Table, table schema: [a: String]
 
-# configure the off-heap memory of current taskmanager to enable the python worker uses off-heap memory.
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # register the Python Table Function
 split = udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()])
 
@@ -181,10 +164,6 @@ table_env.sql_query("SELECT a, word, length FROM MyTable, LATERAL TABLE(split(a)
 table_env.sql_query("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(split(a)) as T(word, length) ON TRUE")
 
 {% endhighlight %}
-
-<span class="label label-info">Note</span> If not using RocksDB as state backend, you can also configure the python
-worker to use the managed memory of taskmanager by setting **python.fn-execution.memory.managed** to be **true**.
-Then there is no need to set the the configuration **taskmanager.memory.task.off-heap.size**.
 
 It also supports to use Java/Scala table functions in Python Table API programs.
 {% highlight python %}
@@ -210,9 +189,6 @@ env = StreamExecutionEnvironment.get_execution_environment()
 table_env = StreamTableEnvironment.create(env)
 my_table = ...  # type: Table, table schema: [a: String]
 
-# configure the off-heap memory of current taskmanager to enable the python worker uses off-heap memory.
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # Register the java function.
 table_env.create_java_temporary_function("split", "my.java.function.Split")
 
@@ -228,10 +204,6 @@ table_env.sql_query("SELECT a, word, length FROM MyTable, LATERAL TABLE(split(a)
 # LEFT JOIN a table function (equivalent to "left_outer_join" in Table API).
 table_env.sql_query("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(split(a)) as T(word, length) ON TRUE")
 {% endhighlight %}
-
-<span class="label label-info">Note</span> If not using RocksDB as state backend, you can also configure the python
-worker to use the managed memory of taskmanager by setting **python.fn-execution.memory.managed** to be **true**.
-Then there is no need to set the the configuration **taskmanager.memory.task.off-heap.size**.
 
 Like Python scalar functions, you can use the above five ways to define Python TableFunctions.
 

--- a/docs/dev/python/table-api-users-guide/udfs/python_udfs.zh.md
+++ b/docs/dev/python/table-api-users-guide/udfs/python_udfs.zh.md
@@ -50,9 +50,6 @@ class HashCode(ScalarFunction):
 
 table_env = BatchTableEnvironment.create(env)
 
-# Python worker进程默认使用off-heap内存，配置当前taskmanager的off-heap内存大小
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 hash_code = udf(HashCode(), result_type=DataTypes.BIGINT())
 
 # 在Python Table API中使用Python自定义函数
@@ -62,10 +59,6 @@ my_table.select(my_table.string, my_table.bigint, hash_code(my_table.bigint), ca
 table_env.create_temporary_function("hash_code", udf(HashCode(), result_type=DataTypes.BIGINT()))
 table_env.sql_query("SELECT string, bigint, hash_code(bigint) FROM MyTable")
 {% endhighlight %}
-
-<span class="label label-info">注意</span>当前不支持Python worker进程与RocksDB state backend同时使用managed memory。
-如果作业中不使用RocksDB state backend的话, 您也可以将配置项**python.fn-execution.memory.managed**设置为**true**，
-配置Python worker进程使用managed memory。这样的话，就不需要配置**taskmanager.memory.task.off-heap.size**了。
 
 除此之外，还支持在Python Table API程序中使用Java / Scala标量函数。
 
@@ -86,9 +79,6 @@ from pyflink.table.expressions import call
 
 table_env = BatchTableEnvironment.create(env)
 
-# Python worker进程默认使用off-heap内存，配置当前taskmanager的off-heap内存大小
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # 注册Java函数
 table_env.create_java_temporary_function("hash_code", "my.java.function.HashCode")
 
@@ -98,10 +88,6 @@ my_table.select(call('hash_code', my_table.string))
 # 在SQL API中使用Java函数
 table_env.sql_query("SELECT string, bigint, hash_code(string) FROM MyTable")
 {% endhighlight %}
-
-<span class="label label-info">注意</span>当前不支持Python worker进程与RocksDB state backend同时使用managed memory。
-如果作业中不使用RocksDB state backend的话, 您也可以将配置项**python.fn-execution.memory.managed**设置为**true**，
-配置Python worker进程使用managed memory。这样的话，就不需要配置**taskmanager.memory.task.off-heap.size**了。
 
 除了扩展基类`ScalarFunction`之外，还支持多种方式来定义Python标量函数。
 以下示例显示了多种定义Python标量函数的方式。该函数需要两个类型为bigint的参数作为输入参数，并返回它们的总和作为结果。
@@ -160,9 +146,6 @@ env = StreamExecutionEnvironment.get_execution_environment()
 table_env = StreamTableEnvironment.create(env)
 my_table = ...  # type: Table, table schema: [a: String]
 
-# Python worker进程默认使用off-heap内存，配置当前taskmanager的off-heap内存大小
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # 注册Python表值函数
 split = udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()])
 
@@ -176,10 +159,6 @@ table_env.sql_query("SELECT a, word, length FROM MyTable, LATERAL TABLE(split(a)
 table_env.sql_query("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(split(a)) as T(word, length) ON TRUE")
 
 {% endhighlight %}
-
-<span class="label label-info">注意</span>当前不支持Python worker进程与RocksDB state backend同时使用managed memory。
-如果作业中不使用RocksDB state backend的话, 您也可以将配置项**python.fn-execution.memory.managed**设置为**true**，
-配置Python worker进程使用managed memory。这样的话，就不需要配置**taskmanager.memory.task.off-heap.size**了。
 
 除此之外，还支持在Python Table API程序中使用Java / Scala表值函数。
 {% highlight python %}
@@ -205,9 +184,6 @@ env = StreamExecutionEnvironment.get_execution_environment()
 table_env = StreamTableEnvironment.create(env)
 my_table = ...  # type: Table, table schema: [a: String]
 
-# Python worker进程默认使用off-heap内存，配置当前taskmanager的off-heap内存大小
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # 注册java自定义函数。
 table_env.create_java_temporary_function("split", "my.java.function.Split")
 
@@ -223,10 +199,6 @@ table_env.sql_query("SELECT a, word, length FROM MyTable, LATERAL TABLE(split(a)
 # LEFT JOIN一个表值函数（等同于Table API中的"left_outer_join"）。
 table_env.sql_query("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(split(a)) as T(word, length) ON TRUE")
 {% endhighlight %}
-
-<span class="label label-info">注意</span>当前不支持Python worker进程与RocksDB state backend同时使用managed memory。
-如果作业中不使用RocksDB state backend的话, 您也可以将配置项**python.fn-execution.memory.managed**设置为**true**，
-配置Python worker进程使用managed memory。这样的话，就不需要配置**taskmanager.memory.task.off-heap.size**了。
 
 像Python标量函数一样，您可以使用上述五种方式来定义Python表值函数。
 

--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
@@ -55,9 +55,6 @@ def add(i, j):
 
 table_env = BatchTableEnvironment.create(env)
 
-# configure the off-heap memory of current taskmanager to enable the python worker uses off-heap memory.
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # use the vectorized Python scalar function in Python Table API
 my_table.select(add(my_table.bigint, my_table.bigint))
 
@@ -65,7 +62,3 @@ my_table.select(add(my_table.bigint, my_table.bigint))
 table_env.create_temporary_function("add", add)
 table_env.sql_query("SELECT add(bigint, bigint) FROM MyTable")
 {% endhighlight %}
-
-<span class="label label-info">Note</span> If not using RocksDB as state backend, you can also configure the python
-worker to use the managed memory of taskmanager by setting **python.fn-execution.memory.managed** to be **true**.
-Then there is no need to set the the configuration **taskmanager.memory.task.off-heap.size**.

--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
@@ -53,9 +53,6 @@ def add(i, j):
 
 table_env = BatchTableEnvironment.create(env)
 
-# configure the off-heap memory of current taskmanager to enable the python worker uses off-heap memory.
-table_env.get_config().get_configuration().set_string("taskmanager.memory.task.off-heap.size", '80m')
-
 # use the vectorized Python scalar function in Python Table API
 my_table.select(add(my_table.bigint, my_table.bigint))
 
@@ -63,8 +60,3 @@ my_table.select(add(my_table.bigint, my_table.bigint))
 table_env.create_temporary_function("add", add)
 table_env.sql_query("SELECT add(bigint, bigint) FROM MyTable")
 {% endhighlight %}
-
-<span class="label label-info">注意</span>如果不使用RocksDB作为状态后端，则还可以通过
-将**python.fn-execution.memory.managed**设置为**true** ，来配置python worker以使用taskmanager的托管内存，
-则无需配置**taskmanager.memory.task.off-heap.size** 。
-

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.md
@@ -90,7 +90,6 @@ def log_processing():
     env = StreamExecutionEnvironment.get_execution_environment()
     env_settings = EnvironmentSettings.Builder().use_blink_planner().build()
     t_env = StreamTableEnvironment.create(stream_execution_environment=env, environment_settings=env_settings)
-    t_env.get_config().get_configuration().set_boolean("python.fn-execution.memory.managed", True)
     # specify connector and format jars
     t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
     

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -90,7 +90,6 @@ def log_processing():
     env = StreamExecutionEnvironment.get_execution_environment()
     env_settings = EnvironmentSettings.Builder().use_blink_planner().build()
     t_env = StreamTableEnvironment.create(stream_execution_environment=env, environment_settings=env_settings)
-    t_env.get_config().get_configuration().set_boolean("python.fn-execution.memory.managed", True)
     # specify connector and format jars
     t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
     

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -29,13 +29,16 @@ from pyflink.datastream.functions import CoMapFunction, CoFlatMapFunction
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.common import Row
-from pyflink.testing.test_case_utils import PyFlinkTestCase
+from pyflink.testing.test_case_utils import PyFlinkTestCase, invoke_java_object_method
 
 
 class DataStreamTests(PyFlinkTestCase):
 
     def setUp(self) -> None:
         self.env = StreamExecutionEnvironment.get_execution_environment()
+        getConfigurationMethod = invoke_java_object_method(
+            self.env._j_stream_execution_environment, "getConfiguration")
+        getConfigurationMethod.setString("akka.ask.timeout", "20 s")
         self.test_sink = DataStreamTestSinkFunction()
 
     def test_data_stream_name(self):

--- a/flink-python/pyflink/fn_execution/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/operation_utils.py
@@ -17,10 +17,9 @@
 ################################################################################
 import datetime
 
-import cloudpickle
 from typing import Any, Tuple, Dict, List
 
-from pyflink.fn_execution import flink_fn_execution_pb2
+from pyflink.fn_execution import flink_fn_execution_pb2, pickle
 from pyflink.serializers import PickleSerializer
 from pyflink.table.udf import DelegationTableFunction, DelegatingScalarFunction, \
     AggregateFunction, PandasAggregateFunctionWrapper
@@ -66,7 +65,7 @@ def extract_user_defined_function(user_defined_function_proto, pandas_udaf=False
     variable_dict = {}
     user_defined_funcs = []
 
-    user_defined_func = cloudpickle.loads(user_defined_function_proto.payload)
+    user_defined_func = pickle.loads(user_defined_function_proto.payload)
     if pandas_udaf:
         user_defined_func = PandasAggregateFunctionWrapper(user_defined_func)
     func_name = 'f%s' % _next_func_num()
@@ -111,12 +110,14 @@ def extract_data_stream_stateless_funcs(udf_proto):
     Extracts user-defined-function from the proto representation of a
     :class:`Function`.
 
-    :param udf: the proto representation of the Python :class:`Function`
+    :param udf_proto: the proto representation of the Python :class:`Function`
     """
     func_type = udf_proto.function_type
     UserDefinedDataStreamFunction = flink_fn_execution_pb2.UserDefinedDataStreamFunction
     func = None
-    user_defined_func = cloudpickle.loads(udf_proto.payload)
+    # import pyflink.datastream.tests.test_data_stream
+    # from pyflink.datastream.tests.test_data_stream import MyKeySelector
+    user_defined_func = pickle.loads(udf_proto.payload)
     if func_type == UserDefinedDataStreamFunction.MAP:
         func = user_defined_func.map
     elif func_type == UserDefinedDataStreamFunction.FLAT_MAP:
@@ -180,7 +181,7 @@ def _parse_constant_value(constant_value) -> Tuple[str, Any]:
 
 
 def extract_user_defined_aggregate_function(user_defined_function_proto):
-    user_defined_agg = cloudpickle.loads(user_defined_function_proto.payload)
+    user_defined_agg = pickle.loads(user_defined_function_proto.payload)
     assert isinstance(user_defined_agg, AggregateFunction)
     args_str = []
     local_variable_dict = {}

--- a/flink-python/pyflink/fn_execution/pickle.py
+++ b/flink-python/pyflink/fn_execution/pickle.py
@@ -1,0 +1,29 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from threading import RLock
+
+import cloudpickle
+
+_lock = RLock()
+
+
+def loads(payload):
+    with _lock:
+        # there is race condition for pickle.load() used in multi-thread environment,
+        # see https://bugs.python.org/issue36773 for more details.
+        return cloudpickle.loads(payload)

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -157,8 +157,6 @@ class PyFlinkStreamTableTestCase(PyFlinkTestCase):
             self.env,
             environment_settings=EnvironmentSettings.new_instance()
                 .in_streaming_mode().use_old_planner().build())
-        self.t_env.get_config().get_configuration().set_string(
-            "taskmanager.memory.task.off-heap.size", "80mb")
 
 
 class PyFlinkBatchTableTestCase(PyFlinkTestCase):
@@ -171,8 +169,6 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
         self.env = ExecutionEnvironment.get_execution_environment()
         self.env.set_parallelism(2)
         self.t_env = BatchTableEnvironment.create(self.env, TableConfig())
-        self.t_env.get_config().get_configuration().set_string(
-            "taskmanager.memory.task.off-heap.size", "80mb")
 
     def collect(self, table):
         j_table = table._j_table
@@ -195,8 +191,6 @@ class PyFlinkBlinkStreamTableTestCase(PyFlinkTestCase):
         self.t_env = StreamTableEnvironment.create(
             self.env, environment_settings=EnvironmentSettings.new_instance()
                 .in_streaming_mode().use_blink_planner().build())
-        self.t_env.get_config().get_configuration().set_string(
-            "taskmanager.memory.task.off-heap.size", "80mb")
 
 
 class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
@@ -209,8 +203,6 @@ class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
         self.t_env = BatchTableEnvironment.create(
             environment_settings=EnvironmentSettings.new_instance()
             .in_batch_mode().use_blink_planner().build())
-        self.t_env.get_config().get_configuration().set_string(
-            "taskmanager.memory.task.off-heap.size", "80mb")
         self.t_env._j_tenv.getPlanner().getExecEnv().setParallelism(2)
 
 

--- a/flink-python/src/main/java/org/apache/flink/python/PythonConfig.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonConfig.java
@@ -53,16 +53,6 @@ public class PythonConfig implements Serializable {
 	private final int maxArrowBatchSize;
 
 	/**
-	 * The amount of memory to be allocated by the Python framework.
-	 */
-	private final String pythonFrameworkMemorySize;
-
-	/**
-	 * The amount of memory to be allocated by the input/output buffer of a Python worker.
-	 */
-	private final String pythonDataBufferMemorySize;
-
-	/**
 	 * The python files uploaded by pyflink.table.TableEnvironment#add_python_file() or command line
 	 * option "-pyfs". The key is the file key in distribute cache and the value is the corresponding
 	 * origin file name.
@@ -117,8 +107,6 @@ public class PythonConfig implements Serializable {
 		maxBundleSize = config.get(PythonOptions.MAX_BUNDLE_SIZE);
 		maxBundleTimeMills = config.get(PythonOptions.MAX_BUNDLE_TIME_MILLS);
 		maxArrowBatchSize = config.get(PythonOptions.MAX_ARROW_BATCH_SIZE);
-		pythonFrameworkMemorySize = config.get(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE);
-		pythonDataBufferMemorySize = config.get(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE);
 		pythonFilesInfo = config.getOptional(PythonDependencyUtils.PYTHON_FILES).orElse(new HashMap<>());
 		pythonRequirementsFileInfo = config.getOptional(PythonDependencyUtils.PYTHON_REQUIREMENTS_FILE)
 			.orElse(new HashMap<>())
@@ -142,14 +130,6 @@ public class PythonConfig implements Serializable {
 
 	public int getMaxArrowBatchSize() {
 		return maxArrowBatchSize;
-	}
-
-	public String getPythonFrameworkMemorySize() {
-		return pythonFrameworkMemorySize;
-	}
-
-	public String getPythonDataBufferMemorySize() {
-		return pythonDataBufferMemorySize;
 	}
 
 	public Map<String, String> getPythonFilesInfo() {

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -62,29 +62,6 @@ public class PythonOptions {
 			"bundle size. Otherwise, the bundle size will be used as the arrow batch size.");
 
 	/**
-	 * The amount of memory to be allocated by the Python framework.
-	 */
-	public static final ConfigOption<String> PYTHON_FRAMEWORK_MEMORY_SIZE = ConfigOptions
-		.key("python.fn-execution.framework.memory.size")
-		.defaultValue("64mb")
-		.withDescription("The amount of memory to be allocated by the Python framework. The sum " +
-			"of the value of this configuration and \"python.fn-execution.buffer.memory.size\" " +
-			"represents the total memory of a Python worker. The memory will be accounted as " +
-			"managed memory if the actual memory allocated to an operator is no less than the " +
-			"total memory of a Python worker. Otherwise, this configuration takes no effect.");
-
-	/**
-	 * The amount of memory to be allocated by the input/output buffer of a Python worker.
-	 */
-	public static final ConfigOption<String> PYTHON_DATA_BUFFER_MEMORY_SIZE = ConfigOptions
-		.key("python.fn-execution.buffer.memory.size")
-		.defaultValue("15mb")
-		.withDescription("The amount of memory to be allocated by the input buffer and output " +
-			"buffer of a Python worker. The memory will be accounted as managed memory if the " +
-			"actual memory allocated to an operator is no less than the total memory of a Python " +
-			"worker. Otherwise, this configuration takes no effect.");
-
-	/**
 	 * The configuration to enable or disable metric for Python execution.
 	 */
 	public static final ConfigOption<Boolean> PYTHON_METRIC_ENABLED = ConfigOptions
@@ -156,13 +133,11 @@ public class PythonOptions {
 	 */
 	public static final ConfigOption<Boolean> USE_MANAGED_MEMORY = ConfigOptions
 		.key("python.fn-execution.memory.managed")
-		.defaultValue(false)
+		.defaultValue(true)
 		.withDescription(String.format("If set, the Python worker will configure itself to use the " +
 			"managed memory budget of the task slot. Otherwise, it will use the Off-Heap Memory " +
 			"of the task slot. In this case, users should set the Task Off-Heap Memory using the " +
-			"configuration key %s. For each Python worker, the required Task Off-Heap Memory " +
-			"is the sum of the value of %s and %s.", TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key(),
-			PYTHON_FRAMEWORK_MEMORY_SIZE.key(), PYTHON_DATA_BUFFER_MEMORY_SIZE.key()));
+			"configuration key %s.", TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key()));
 
 	/**
 	 * The maximum number of states cached in a Python UDF worker.

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonPartitionCustomOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonPartitionCustomOperator.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
@@ -68,7 +69,11 @@ public class PythonPartitionCustomOperator<IN, OUT> extends
 			getUserDefinedDataStreamFunctionProto(pythonFunctionInfo, getRuntimeContext(), internalParameters),
 			DATA_STREAM_MAP_FUNCTION_CODER_URN,
 			jobOptions,
-			getFlinkMetricContainer()
+			getFlinkMetricContainer(),
+			getContainingTask().getEnvironment().getMemoryManager(),
+			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.PYTHON,
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
 		);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonPartitionCustomOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonPartitionCustomOperator.java
@@ -73,7 +73,8 @@ public class PythonPartitionCustomOperator<IN, OUT> extends
 			getContainingTask().getEnvironment().getMemoryManager(),
 			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.PYTHON,
-				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getContainingTask().getEnvironment().getUserCodeClassLoader().asClassLoader())
 		);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonReduceOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonReduceOperator.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
 import org.apache.flink.streaming.api.runners.python.beam.BeamDataStreamStatelessPythonFunctionRunner;
@@ -123,7 +124,11 @@ public class PythonReduceOperator<OUT>
 			getUserDefinedDataStreamFunctionProto(pythonFunctionInfo, getRuntimeContext(), Collections.EMPTY_MAP),
 			DATA_STREAM_MAP_FUNCTION_CODER_URN,  // reuse map function coder
 			jobOptions,
-			getFlinkMetricContainer()
+			getFlinkMetricContainer(),
+			getContainingTask().getEnvironment().getMemoryManager(),
+			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.PYTHON,
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
 		);
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonReduceOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonReduceOperator.java
@@ -128,7 +128,8 @@ public class PythonReduceOperator<OUT>
 			getContainingTask().getEnvironment().getMemoryManager(),
 			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.PYTHON,
-				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getContainingTask().getEnvironment().getUserCodeClassLoader().asClassLoader())
 		);
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessOneInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessOneInputPythonFunctionOperator.java
@@ -132,7 +132,8 @@ public class StatelessOneInputPythonFunctionOperator<IN, OUT>
 			getContainingTask().getEnvironment().getMemoryManager(),
 			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.PYTHON,
-				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getContainingTask().getEnvironment().getUserCodeClassLoader().asClassLoader())
 		);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessOneInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessOneInputPythonFunctionOperator.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
@@ -127,7 +128,11 @@ public class StatelessOneInputPythonFunctionOperator<IN, OUT>
 			getUserDefinedDataStreamFunctionProto(pythonFunctionInfo, getRuntimeContext(), Collections.EMPTY_MAP),
 			coderUrn,
 			jobOptions,
-			getFlinkMetricContainer()
+			getFlinkMetricContainer(),
+			getContainingTask().getEnvironment().getMemoryManager(),
+			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.PYTHON,
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
 		);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessTwoInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessTwoInputPythonFunctionOperator.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
@@ -159,7 +160,11 @@ public class StatelessTwoInputPythonFunctionOperator<IN1, IN2, OUT>
 			getUserDefinedDataStreamFunctionProto(pythonFunctionInfo, getRuntimeContext(), Collections.EMPTY_MAP),
 			coderUrn,
 			jobOptions,
-			getFlinkMetricContainer()
+			getFlinkMetricContainer(),
+			getContainingTask().getEnvironment().getMemoryManager(),
+			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.PYTHON,
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
 		);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessTwoInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/StatelessTwoInputPythonFunctionOperator.java
@@ -164,7 +164,8 @@ public class StatelessTwoInputPythonFunctionOperator<IN1, IN2, OUT>
 			getContainingTask().getEnvironment().getMemoryManager(),
 			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.PYTHON,
-				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration())
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getContainingTask().getEnvironment().getUserCodeClassLoader().asClassLoader())
 		);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamStatelessPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamStatelessPythonFunctionRunner.java
@@ -24,7 +24,6 @@ import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.streaming.api.typeutils.PythonTypeUtils;
 import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 
 import org.apache.beam.model.pipeline.v1.RunnerApi;

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamStatelessPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamStatelessPythonFunctionRunner.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.api.typeutils.PythonTypeUtils;
 import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -52,8 +54,10 @@ public class BeamDataStreamStatelessPythonFunctionRunner extends BeamPythonFunct
 		FlinkFnApi.UserDefinedDataStreamFunction userDefinedDataStreamFunction,
 		String coderUrn,
 		Map<String, String> jobOptions,
-		@Nullable FlinkMetricContainer flinkMetricContainer) {
-		super(taskName, environmentManager, functionUrn, jobOptions, flinkMetricContainer, null, null);
+		@Nullable FlinkMetricContainer flinkMetricContainer,
+		MemoryManager memoryManager,
+		double managedMemoryFraction) {
+		super(taskName, environmentManager, functionUrn, jobOptions, flinkMetricContainer, null, null, memoryManager, managedMemoryFraction);
 		this.inputType = inputType;
 		this.outputTupe = outputType;
 		this.userDefinedDataStreamFunction = userDefinedDataStreamFunction;

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -35,12 +35,15 @@ import org.apache.flink.python.env.ProcessPythonEnvironment;
 import org.apache.flink.python.env.PythonEnvironment;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.LongFunctionWithException;
 
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -115,6 +118,9 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 
 	private static final String WINDOW_STRATEGY = "windowing_strategy";
 
+	private static final String MANAGED_MEMORY_RESOURCE_ID = "python-process-managed-memory";
+	private static final String PYTHON_WORKER_MEMORY_LIMIT = "_PYTHON_WORKER_MEMORY_LIMIT";
+
 	private transient boolean bundleStarted;
 
 	private final String taskName;
@@ -123,6 +129,8 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 	 * The Python execution environment manager.
 	 */
 	private final PythonEnvironmentManager environmentManager;
+
+	private final String functionUrn;
 
 	/**
 	 * The options used to configure the Python worker process.
@@ -179,7 +187,18 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 	@Nullable
 	private FlinkMetricContainer flinkMetricContainer;
 
-	private final String functionUrn;
+	@Nullable
+	private final MemoryManager memoryManager;
+
+	/**
+	 * The fraction of total managed memory in the slot that the Python worker could use.
+	 */
+	private final double managedMemoryFraction;
+
+	/**
+	 * The shared resource among Python operators of the same slot.
+	 */
+	private OpaqueMemoryResource<PythonSharedResources> sharedResources;
 
 	public BeamPythonFunctionRunner(
 			String taskName,
@@ -188,13 +207,17 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 			Map<String, String> jobOptions,
 			FlinkMetricContainer flinkMetricContainer,
 			@Nullable KeyedStateBackend keyedStateBackend,
-			@Nullable TypeSerializer keySerializer) {
+			@Nullable TypeSerializer keySerializer,
+			@Nullable MemoryManager memoryManager,
+			double managedMemoryFraction) {
 		this.taskName = Preconditions.checkNotNull(taskName);
 		this.environmentManager = Preconditions.checkNotNull(environmentManager);
-		this.functionUrn = functionUrn;
+		this.functionUrn = Preconditions.checkNotNull(functionUrn);
 		this.jobOptions = Preconditions.checkNotNull(jobOptions);
 		this.flinkMetricContainer = flinkMetricContainer;
 		this.stateRequestHandler = getStateRequestHandler(keyedStateBackend, keySerializer);
+		this.memoryManager = memoryManager;
+		this.managedMemoryFraction = managedMemoryFraction;
 		this.resultTuple = new Tuple2<>();
 	}
 
@@ -208,8 +231,6 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 
 		PortablePipelineOptions portableOptions =
 			PipelineOptionsFactory.as(PortablePipelineOptions.class);
-		// one operator has one Python SDK harness
-		portableOptions.setSdkWorkerParallelism(1);
 
 		if (jobOptions.containsKey(PythonOptions.STATE_CACHE_SIZE.key())) {
 			portableOptions.as(ExperimentalOptions.class).setExperiments(
@@ -220,8 +241,25 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 
 		Struct pipelineOptions = PipelineOptionsTranslation.toProto(portableOptions);
 
-		jobBundleFactory = createJobBundleFactory(pipelineOptions);
-		stageBundleFactory = createStageBundleFactory();
+		if (memoryManager != null && config.isUsingManagedMemory()) {
+			Preconditions.checkArgument(managedMemoryFraction > 0 && managedMemoryFraction <= 1.0);
+
+			final LongFunctionWithException<PythonSharedResources, Exception> initializer = (size) ->
+				new PythonSharedResources(createJobBundleFactory(pipelineOptions), createPythonExecutionEnvironment(size));
+
+			sharedResources =
+				memoryManager.getSharedMemoryResourceForManagedMemory(MANAGED_MEMORY_RESOURCE_ID, initializer, managedMemoryFraction);
+			LOG.info("Obtained shared Python process of size {} bytes", sharedResources.getSize());
+
+			JobBundleFactory jobBundleFactory = sharedResources.getResourceHandle().getJobBundleFactory();
+			RunnerApi.Environment environment = sharedResources.getResourceHandle().getEnvironment();
+			stageBundleFactory = createStageBundleFactory(jobBundleFactory, environment);
+		} else {
+			// there is no way to access the MemoryManager for the batch job of old planner,
+			// fallback to the way that spawning a Python process for each Python operator
+			jobBundleFactory = createJobBundleFactory(pipelineOptions);
+			stageBundleFactory = createStageBundleFactory(jobBundleFactory, createPythonExecutionEnvironment(-1));
+		}
 		progressHandler = getProgressHandler(flinkMetricContainer);
 	}
 
@@ -233,6 +271,14 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 			}
 		} finally {
 			jobBundleFactory = null;
+		}
+
+		try {
+			if (sharedResources != null) {
+				sharedResources.close();
+			}
+		} finally {
+			sharedResources = null;
 		}
 
 		environmentManager.close();
@@ -273,12 +319,13 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 	 * Creates a specification which specifies the portability Python execution environment.
 	 * It's used by Beam's portability framework to creates the actual Python execution environment.
 	 */
-	protected RunnerApi.Environment createPythonExecutionEnvironment() throws Exception {
+	private RunnerApi.Environment createPythonExecutionEnvironment(long memoryLimitBytes) throws Exception {
 		PythonEnvironment environment = environmentManager.createEnvironment();
 		if (environment instanceof ProcessPythonEnvironment) {
 			ProcessPythonEnvironment processEnvironment = (ProcessPythonEnvironment) environment;
 			Map<String, String> env = processEnvironment.getEnv();
 			env.putAll(jobOptions);
+			env.put(PYTHON_WORKER_MEMORY_LIMIT, String.valueOf(memoryLimitBytes));
 			return Environments.createProcessEnvironment(
 				"",
 				"",
@@ -347,9 +394,10 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 	/**
 	 * To make the error messages more user friendly, throws an exception with the boot logs.
 	 */
-	private StageBundleFactory createStageBundleFactory() throws Exception {
+	private StageBundleFactory createStageBundleFactory(
+			JobBundleFactory jobBundleFactory, RunnerApi.Environment environment) throws Exception {
 		try {
-			return jobBundleFactory.forStage(createExecutableStage());
+			return jobBundleFactory.forStage(createExecutableStage(environment));
 		} catch (Throwable e) {
 			throw new RuntimeException(environmentManager.getBootLog(), e);
 		}
@@ -371,7 +419,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 	 * and output coder, etc.
 	 */
 	@SuppressWarnings("unchecked")
-	private ExecutableStage createExecutableStage() throws Exception {
+	private ExecutableStage createExecutableStage(RunnerApi.Environment environment) throws Exception {
 		RunnerApi.Components components =
 			RunnerApi.Components.newBuilder()
 				.putPcollections(
@@ -427,7 +475,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 			Collections.singletonList(
 				PipelineNode.pCollection(OUTPUT_ID, components.getPcollectionsOrThrow(OUTPUT_ID)));
 		return ImmutableExecutableStage.of(
-			components, createPythonExecutionEnvironment(), input, sideInputs, userStates, timers, transforms, outputs, createValueOnlyWireCoderSetting());
+			components, environment, input, sideInputs, userStates, timers, transforms, outputs, createValueOnlyWireCoderSetting());
 	}
 
 	private Collection<RunnerApi.ExecutableStagePayload.WireCoderSetting> createValueOnlyWireCoderSetting() throws

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/PythonSharedResources.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/PythonSharedResources.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.runners.python.beam;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
+import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
+
+/**
+ * The set of resources that can be shared by all the Python operators in a slot.
+ */
+@Internal
+public final class PythonSharedResources implements AutoCloseable {
+
+	/**
+	 * The bundle factory which has all job-scoped information and can be used to create a {@link StageBundleFactory}.
+	 */
+	private final JobBundleFactory jobBundleFactory;
+
+	/**
+	 * An environment for executing Python UDFs.
+	 */
+	private final Environment environment;
+
+	PythonSharedResources(JobBundleFactory jobBundleFactory, Environment environment) {
+		this.jobBundleFactory = jobBundleFactory;
+		this.environment = environment;
+	}
+
+	JobBundleFactory getJobBundleFactory() {
+		return jobBundleFactory;
+	}
+
+	Environment getEnvironment() {
+		return environment;
+	}
+
+	@Override
+	public void close() throws Exception {
+		jobBundleFactory.close();
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonStatelessFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonStatelessFunctionFlatMap.java
@@ -318,7 +318,9 @@ public abstract class AbstractPythonStatelessFunctionFlatMap
 			getUserDefinedFunctionsProto(),
 			getInputOutputCoderUrn(),
 			jobOptions,
-			getFlinkMetricContainer());
+			getFlinkMetricContainer(),
+			null,
+			0.0);
 	}
 
 	private Map<String, String> buildJobOptions(Configuration config) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractStatelessFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractStatelessFunctionOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.api.operators.python.AbstractOneInputPythonFunctionOperator;
@@ -154,7 +155,11 @@ public abstract class AbstractStatelessFunctionOperator<IN, OUT, UDFIN>
 			getUserDefinedFunctionsProto(),
 			getInputOutputCoderUrn(),
 			jobOptions,
-			getFlinkMetricContainer());
+			getFlinkMetricContainer(),
+			getContainingTask().getEnvironment().getMemoryManager(),
+			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.PYTHON,
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
 	}
 
 	/**

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractStatelessFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractStatelessFunctionOperator.java
@@ -159,7 +159,8 @@ public abstract class AbstractStatelessFunctionOperator<IN, OUT, UDFIN>
 			getContainingTask().getEnvironment().getMemoryManager(),
 			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.PYTHON,
-				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getContainingTask().getEnvironment().getUserCodeClassLoader().asClassLoader()));
 	}
 
 	/**

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
@@ -277,7 +277,8 @@ public class PythonStreamGroupAggregateOperator
 			getContainingTask().getEnvironment().getMemoryManager(),
 			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.PYTHON,
-				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getContainingTask().getEnvironment().getUserCodeClassLoader().asClassLoader()));
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
@@ -272,7 +273,11 @@ public class PythonStreamGroupAggregateOperator
 			jobOptions,
 			getFlinkMetricContainer(),
 			getKeyedStateBackend(),
-			getKeySerializer());
+			getKeySerializer(),
+			getContainingTask().getEnvironment().getMemoryManager(),
+			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.PYTHON,
+				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/beam/BeamTableStatefulPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/beam/BeamTableStatefulPythonFunctionRunner.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.streaming.api.runners.python.beam.BeamPythonFunctionRunner;
 import org.apache.flink.table.types.logical.RowType;
@@ -54,7 +55,9 @@ public class BeamTableStatefulPythonFunctionRunner extends BeamPythonFunctionRun
 			Map<String, String> jobOptions,
 			FlinkMetricContainer flinkMetricContainer,
 			KeyedStateBackend keyedStateBackend,
-			TypeSerializer keySerializer) {
+			TypeSerializer keySerializer,
+			MemoryManager memoryManager,
+			double managedMemoryFraction) {
 		super(
 			taskName,
 			environmentManager,
@@ -62,7 +65,9 @@ public class BeamTableStatefulPythonFunctionRunner extends BeamPythonFunctionRun
 			jobOptions,
 			flinkMetricContainer,
 			keyedStateBackend,
-			keySerializer);
+			keySerializer,
+			memoryManager,
+			managedMemoryFraction);
 		this.coderUrn = Preconditions.checkNotNull(coderUrn);
 		this.inputType = Preconditions.checkNotNull(inputType);
 		this.outputType = Preconditions.checkNotNull(outputType);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/beam/BeamTableStatelessPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/beam/BeamTableStatelessPythonFunctionRunner.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.api.runners.python.beam.BeamPythonFunctionRunner;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
@@ -52,8 +53,10 @@ public class BeamTableStatelessPythonFunctionRunner extends BeamPythonFunctionRu
 		FlinkFnApi.UserDefinedFunctions userDefinedFunctions,
 		String coderUrn,
 		Map<String, String> jobOptions,
-		FlinkMetricContainer flinkMetricContainer) {
-		super(taskName, environmentManager, functionUrn, jobOptions, flinkMetricContainer, null, null);
+		FlinkMetricContainer flinkMetricContainer,
+		MemoryManager memoryManager,
+		double managedMemoryFraction) {
+		super(taskName, environmentManager, functionUrn, jobOptions, flinkMetricContainer, null, null, memoryManager, managedMemoryFraction);
 		this.coderUrn = Preconditions.checkNotNull(coderUrn);
 		this.inputType = Preconditions.checkNotNull(inputType);
 		this.outputType = Preconditions.checkNotNull(outputType);

--- a/flink-python/src/test/java/org/apache/flink/python/PythonConfigTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonConfigTest.java
@@ -42,10 +42,6 @@ public class PythonConfigTest {
 			is(equalTo(PythonOptions.MAX_BUNDLE_SIZE.defaultValue())));
 		assertThat(pythonConfig.getMaxBundleTimeMills(),
 			is(equalTo(PythonOptions.MAX_BUNDLE_TIME_MILLS.defaultValue())));
-		assertThat(pythonConfig.getPythonFrameworkMemorySize(),
-			is(equalTo(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE.defaultValue())));
-		assertThat(pythonConfig.getPythonDataBufferMemorySize(),
-			is(equalTo(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE.defaultValue())));
 		assertThat(pythonConfig.getMaxArrowBatchSize(),
 			is(equalTo(PythonOptions.MAX_ARROW_BATCH_SIZE.defaultValue())));
 		assertThat(pythonConfig.getPythonFilesInfo().isEmpty(), is(true));
@@ -71,22 +67,6 @@ public class PythonConfigTest {
 		config.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 10L);
 		PythonConfig pythonConfig = new PythonConfig(config);
 		assertThat(pythonConfig.getMaxBundleTimeMills(), is(equalTo(10L)));
-	}
-
-	@Test
-	public void testPythonFrameworkMemorySize() {
-		Configuration config = new Configuration();
-		config.set(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE, "100mb");
-		PythonConfig pythonConfig = new PythonConfig(config);
-		assertThat(pythonConfig.getPythonFrameworkMemorySize(), is(equalTo("100mb")));
-	}
-
-	@Test
-	public void testPythonDataBufferMemorySize() {
-		Configuration config = new Configuration();
-		config.set(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE, "100mb");
-		PythonConfig pythonConfig = new PythonConfig(config);
-		assertThat(pythonConfig.getPythonDataBufferMemorySize(), is(equalTo("100mb")));
 	}
 
 	@Test

--- a/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
@@ -60,32 +60,6 @@ public class PythonOptionsTest {
 	}
 
 	@Test
-	public void testPythonFrameworkMemorySize() {
-		final Configuration configuration = new Configuration();
-		final String defaultPythonFrameworkMemorySize = configuration.getString(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE);
-		assertThat(defaultPythonFrameworkMemorySize, is(equalTo(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE.defaultValue())));
-
-		final String expectedPythonFrameworkMemorySize = "100mb";
-		configuration.setString(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE, expectedPythonFrameworkMemorySize);
-
-		final String actualPythonFrameworkMemorySize = configuration.getString(PythonOptions.PYTHON_FRAMEWORK_MEMORY_SIZE);
-		assertThat(actualPythonFrameworkMemorySize, is(equalTo(expectedPythonFrameworkMemorySize)));
-	}
-
-	@Test
-	public void testPythonBufferMemorySize() {
-		final Configuration configuration = new Configuration();
-		final String defaultPythonBufferMemorySize = configuration.getString(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE);
-		assertThat(defaultPythonBufferMemorySize, is(equalTo(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE.defaultValue())));
-
-		final String expectedPythonBufferMemorySize = "100mb";
-		configuration.setString(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE, expectedPythonBufferMemorySize);
-
-		final String actualPythonBufferMemorySize = configuration.getString(PythonOptions.PYTHON_DATA_BUFFER_MEMORY_SIZE);
-		assertThat(actualPythonBufferMemorySize, is(equalTo(expectedPythonBufferMemorySize)));
-	}
-
-	@Test
 	public void testArrowBatchSize() {
 		final Configuration configuration = new Configuration();
 		final int defaultArrowBatchSize = configuration.getInteger(PythonOptions.MAX_ARROW_BATCH_SIZE);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
@@ -343,7 +343,7 @@ public class PythonStreamGroupAggregateOperatorTest {
 				1,
 				1,
 				0);
-		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.PYTHON, 0.5);
 		testHarness.setup(new RowDataSerializer(outputType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperatorTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractBatchArrowPythonAggregateFunctionOperatorTest
 
 		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.PYTHON, 0.5);
 		testHarness.setup(new RowDataSerializer(outputType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonAggregateFunctionOperatorTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractStreamArrowPythonAggregateFunctionOperatorTest
 			KeySelectorUtil.getRowDataSelector(grouping, InternalTypeInfo.of(getInputType()));
 		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, keySelector, keySelector.getProducedType());
-		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.PYTHON, 0.5);
 		testHarness.setup(new RowDataSerializer(outputType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -237,7 +237,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
 
 		OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.PYTHON, 0.5);
 		testHarness.setup(getOutputTypeSerializer(dataType));
 		return testHarness;
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
@@ -196,7 +196,7 @@ public abstract class PythonTableFunctionOperatorTestBase<IN, OUT, UDTFIN> {
 
 		OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
 			new OneInputStreamOperatorTestHarness<>(operator);
-		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.5);
+		testHarness.getStreamConfig().setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.PYTHON, 0.5);
 		return testHarness;
 	}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
@@ -83,7 +83,7 @@ public class PassThroughPythonAggregateFunctionRunner extends BeamTableStateless
 		FlinkMetricContainer flinkMetricContainer,
 		boolean isBatchOverWindow) {
 		super(taskName, environmentManager, inputType, outputType, functionUrn, userDefinedFunctions,
-			coderUrn, jobOptions, flinkMetricContainer);
+			coderUrn, jobOptions, flinkMetricContainer, null, 0.0);
 		this.buffer = new LinkedList<>();
 		this.isBatchOverWindow = isBatchOverWindow;
 		arrowSerializer = new RowDataArrowSerializer(inputType, outputType);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
@@ -48,7 +48,7 @@ public class PassThroughPythonScalarFunctionRunner extends BeamTableStatelessPyt
 		String coderUrn,
 		Map<String, String> jobOptions,
 		FlinkMetricContainer flinkMetricContainer) {
-		super(taskName, environmentManager, inputType, outputType, functionUrn, userDefinedFunctions, coderUrn, jobOptions, flinkMetricContainer);
+		super(taskName, environmentManager, inputType, outputType, functionUrn, userDefinedFunctions, coderUrn, jobOptions, flinkMetricContainer, null, 0.0);
 		this.buffer = new LinkedList<>();
 	}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonTableFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonTableFunctionRunner.java
@@ -50,7 +50,7 @@ public class PassThroughPythonTableFunctionRunner extends BeamTableStatelessPyth
 		FlinkFnApi.UserDefinedFunctions userDefinedFunctions,
 		String coderUrn, Map<String, String> jobOptions,
 		FlinkMetricContainer flinkMetricContainer) {
-		super(taskName, environmentManager, inputType, outputType, functionUrn, userDefinedFunctions, coderUrn, jobOptions, flinkMetricContainer);
+		super(taskName, environmentManager, inputType, outputType, functionUrn, userDefinedFunctions, coderUrn, jobOptions, flinkMetricContainer, null, 0.0);
 		this.buffer = new LinkedList<>();
 	}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamAggregatePythonFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamAggregatePythonFunctionRunner.java
@@ -58,7 +58,7 @@ public class PassThroughStreamAggregatePythonFunctionRunner extends BeamTableSta
 			TypeSerializer keySerializer,
 			Function<byte[], byte[]> processFunction) {
 		super(taskName, environmentManager, inputType, outputType, functionUrn, userDefinedFunctions,
-			coderUrn, jobOptions, flinkMetricContainer, keyedStateBackend, keySerializer);
+			coderUrn, jobOptions, flinkMetricContainer, keyedStateBackend, keySerializer, null, 0.0);
 		this.buffer = new LinkedList<>();
 		this.processFunction = processFunction;
 	}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.common
 
 import org.apache.calcite.rex.{RexCall, RexLiteral, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.flink.configuration.{ConfigOption, Configuration, MemorySize, TaskManagerOptions}
+import org.apache.flink.configuration.{ConfigOption, Configuration}
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.functions.FunctionDefinition
@@ -116,7 +116,6 @@ trait CommonPythonBase {
     method.setAccessible(true)
     val config = new Configuration(method.invoke(env).asInstanceOf[Configuration])
     config.addAll(tableConfig.getConfiguration)
-    checkPythonWorkerMemory(config, env)
     config
   }
 
@@ -134,58 +133,6 @@ trait CommonPythonBase {
     val clazz = loadClass("org.apache.flink.python.PythonOptions")
     config.getBoolean(clazz.getField("USE_MANAGED_MEMORY").get(null)
       .asInstanceOf[ConfigOption[java.lang.Boolean]])
-  }
-
-  protected def getPythonWorkerMemory(config: Configuration): MemorySize = {
-    val clazz = loadClass("org.apache.flink.python.PythonOptions")
-    val pythonFrameworkMemorySize = MemorySize.parse(
-      config.getString(
-        clazz.getField("PYTHON_FRAMEWORK_MEMORY_SIZE").get(null)
-          .asInstanceOf[ConfigOption[String]]))
-    val pythonBufferMemorySize = MemorySize.parse(
-      config.getString(
-        clazz.getField("PYTHON_DATA_BUFFER_MEMORY_SIZE").get(null)
-          .asInstanceOf[ConfigOption[String]]))
-    pythonFrameworkMemorySize.add(pythonBufferMemorySize)
-  }
-
-  private def checkPythonWorkerMemory(
-      config: Configuration, env: StreamExecutionEnvironment): Unit = {
-    if (!isPythonWorkerUsingManagedMemory(config)) {
-      val taskOffHeapMemory = config.get(TaskManagerOptions.TASK_OFF_HEAP_MEMORY)
-      val requiredPythonWorkerOffHeapMemory = getPythonWorkerMemory(config)
-      if (taskOffHeapMemory.compareTo(requiredPythonWorkerOffHeapMemory) < 0) {
-        throw new TableException(String.format("The configured Task Off-Heap Memory %s is less " +
-          "than the least required Python worker Memory %s. The Task Off-Heap Memory can be " +
-          "configured using the configuration key 'taskmanager.memory.task.off-heap.size'.",
-          taskOffHeapMemory, requiredPythonWorkerOffHeapMemory))
-      }
-    } else if (isRocksDbUsingManagedMemory(env)) {
-      throw new TableException("Currently it doesn't support to use Managed Memory for both " +
-        "RocksDB state backend and Python worker at the same time. You can either configure " +
-        "RocksDB state backend to use Task Off-Heap Memory via the configuration key " +
-        "'state.backend.rocksdb.memory.managed' or configure Python worker to use " +
-        "Task Off-Heap Memory via the configuration key " +
-        "'python.fn-execution.memory.managed'.")
-    }
-  }
-
-  private def isRocksDbUsingManagedMemory(env: StreamExecutionEnvironment): Boolean = {
-    val stateBackend = env.getStateBackend
-    if (stateBackend != null && env.getStateBackend.getClass.getCanonicalName.equals(
-      "org.apache.flink.contrib.streaming.state.RocksDBStateBackend")) {
-      val clazz = loadClass("org.apache.flink.contrib.streaming.state.RocksDBStateBackend")
-      val getMemoryConfigurationMethod = clazz.getDeclaredMethod("getMemoryConfiguration")
-      val rocksDbConfig = getMemoryConfigurationMethod.invoke(stateBackend)
-      val isUsingManagedMemoryMethod =
-        rocksDbConfig.getClass.getDeclaredMethod("isUsingManagedMemory")
-      val isUsingFixedMemoryPerSlotMethod =
-        rocksDbConfig.getClass.getDeclaredMethod("isUsingFixedMemoryPerSlot")
-      isUsingManagedMemoryMethod.invoke(rocksDbConfig).asInstanceOf[Boolean] &&
-        !isUsingFixedMemoryPerSlotMethod.invoke(rocksDbConfig).asInstanceOf[Boolean]
-    } else {
-      false
-    }
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
@@ -19,10 +19,10 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCalc
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
@@ -61,8 +61,7 @@ class BatchExecPythonCalc(
       getConfig(planner.getExecEnv, planner.getTableConfig))
 
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCorrelate
@@ -27,7 +28,6 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Correlate, JoinRelType}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexNode, RexProgram}
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 
 /**
   * Batch physical RelNode for [[Correlate]] (Python user defined table function).
@@ -80,8 +80,7 @@ class BatchExecPythonCorrelate(
       getConfig(planner.getExecEnv, planner.getTableConfig),
       joinType)
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.runtime.operators.DamBehavior
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
@@ -43,7 +44,6 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rel.{RelCollationTraitDef, RelCollations, RelNode, RelWriter}
 import org.apache.calcite.util.{ImmutableIntList, Util}
-
 import java.util
 
 import scala.collection.JavaConversions._
@@ -188,8 +188,7 @@ class BatchExecPythonGroupAggregate(
       outputType,
       getConfig(planner.getExecEnv, planner.getTableConfig))
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupWindowAggregate.scala
@@ -22,6 +22,7 @@ import java.util
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.runtime.operators.DamBehavior
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
@@ -155,8 +156,7 @@ class BatchExecPythonGroupWindowAggregate(
       getConfig(planner.getExecEnv, planner.getTableConfig))
 
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonOverAggregate.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.table.data.RowData
@@ -28,7 +29,6 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecPythonOverAggregate.ARROW_PYTHON_OVER_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME
 import org.apache.flink.table.planner.plan.utils.OverAggregateUtil.getLongBoundary
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
@@ -133,8 +133,7 @@ class BatchExecPythonOverAggregate(
       getConfig(planner.getExecEnv, planner.getTableConfig))
 
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCalc
@@ -27,7 +28,6 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Calc
 import org.apache.calcite.rex.RexProgram
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 
 /**
   * Stream physical RelNode for Python ScalarFunctions.
@@ -65,8 +65,7 @@ class StreamExecPythonCalc(
       ret.setMaxParallelism(1)
     }
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.delegation.StreamPlanner
@@ -28,7 +29,6 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinRelType
 import org.apache.calcite.rex.{RexNode, RexProgram}
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 
 /**
   * Flink RelNode which matches along with join a python user defined table function.
@@ -85,8 +85,7 @@ class StreamExecPythonCorrelate(
       getConfig(planner.getExecEnv, planner.getTableConfig),
       joinType)
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.table.api.TableException
@@ -31,7 +32,6 @@ import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.expressions.{PlannerRowtimeAttribute, PlannerWindowEnd, PlannerWindowStart}
 import org.apache.flink.table.planner.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecPythonGroupWindowAggregate.ARROW_STREAM_PYTHON_GROUP_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME
 import org.apache.flink.table.planner.plan.utils.AggregateUtil._
 import org.apache.flink.table.planner.plan.utils.{KeySelectorUtil, WindowEmitStrategy}
@@ -150,8 +150,7 @@ class StreamExecPythonGroupWindowAggregate(
     ret.setStateKeyType(selector.getProducedType)
 
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
-      ExecNode.setManagedMemoryWeight(
-        ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration).getBytes)
+      ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.plan.nodes
 import org.apache.calcite.rex.{RexCall, RexLiteral, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.flink.api.java.ExecutionEnvironment
-import org.apache.flink.configuration.{ConfigOption, Configuration, MemorySize, TaskManagerOptions}
+import org.apache.flink.configuration.{ConfigOption, Configuration}
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.functions.UserDefinedFunction
@@ -126,7 +126,6 @@ trait CommonPythonBase {
     method.setAccessible(true)
     val config = new Configuration(method.invoke(env).asInstanceOf[Configuration])
     config.addAll(tableConfig.getConfiguration)
-    checkPythonWorkerMemory(config, env)
     config
   }
 
@@ -139,7 +138,6 @@ trait CommonPythonBase {
     // ensure the user specified configuration has priority over others.
     val config = new Configuration(env.getConfiguration)
     config.addAll(tableConfig.getConfiguration)
-    checkPythonWorkerMemory(config)
     config
   }
 
@@ -153,62 +151,10 @@ trait CommonPythonBase {
     realEnv
   }
 
-  private def isPythonWorkerUsingManagedMemory(config: Configuration): Boolean = {
+  protected def isPythonWorkerUsingManagedMemory(config: Configuration): Boolean = {
     val clazz = loadClass("org.apache.flink.python.PythonOptions")
     config.getBoolean(clazz.getField("USE_MANAGED_MEMORY").get(null)
       .asInstanceOf[ConfigOption[java.lang.Boolean]])
-  }
-
-  private def getPythonWorkerMemory(config: Configuration): MemorySize = {
-    val clazz = loadClass("org.apache.flink.python.PythonOptions")
-    val pythonFrameworkMemorySize = MemorySize.parse(
-      config.getString(
-        clazz.getField("PYTHON_FRAMEWORK_MEMORY_SIZE").get(null)
-          .asInstanceOf[ConfigOption[String]]))
-    val pythonBufferMemorySize = MemorySize.parse(
-      config.getString(
-        clazz.getField("PYTHON_DATA_BUFFER_MEMORY_SIZE").get(null)
-          .asInstanceOf[ConfigOption[String]]))
-    pythonFrameworkMemorySize.add(pythonBufferMemorySize)
-  }
-
-  private def checkPythonWorkerMemory(
-      config: Configuration, env: StreamExecutionEnvironment = null): Unit = {
-    if (!isPythonWorkerUsingManagedMemory(config)) {
-      val taskOffHeapMemory = config.get(TaskManagerOptions.TASK_OFF_HEAP_MEMORY)
-      val requiredPythonWorkerOffHeapMemory = getPythonWorkerMemory(config)
-      if (taskOffHeapMemory.compareTo(requiredPythonWorkerOffHeapMemory) < 0) {
-        throw new TableException(String.format("The configured Task Off-Heap Memory %s is less " +
-          "than the least required Python worker Memory %s. The Task Off-Heap Memory can be " +
-          "configured using the configuration key 'taskmanager.memory.task.off-heap.size'.",
-          taskOffHeapMemory, requiredPythonWorkerOffHeapMemory))
-      }
-    } else if (env != null && isRocksDbUsingManagedMemory(env)) {
-      throw new TableException("Currently it doesn't support to use Managed Memory for both " +
-        "RocksDB state backend and Python worker at the same time. You can either configure " +
-        "RocksDB state backend to use Task Off-Heap Memory via the configuration key " +
-        "'state.backend.rocksdb.memory.managed' or configure Python worker to use " +
-        "Task Off-Heap Memory via the configuration key " +
-        "'python.fn-execution.memory.managed'.")
-    }
-  }
-
-  private def isRocksDbUsingManagedMemory(env: StreamExecutionEnvironment): Boolean = {
-    val stateBackend = env.getStateBackend
-    if (stateBackend != null && stateBackend.getClass.getCanonicalName.equals(
-      "org.apache.flink.contrib.streaming.state.RocksDBStateBackend")) {
-      val clazz = loadClass("org.apache.flink.contrib.streaming.state.RocksDBStateBackend")
-      val getMemoryConfigurationMethod = clazz.getDeclaredMethod("getMemoryConfiguration")
-      val rocksDbConfig = getMemoryConfigurationMethod.invoke(stateBackend)
-      val isUsingManagedMemoryMethod =
-        rocksDbConfig.getClass.getDeclaredMethod("isUsingManagedMemory")
-      val isUsingFixedMemoryPerSlotMethod =
-        rocksDbConfig.getClass.getDeclaredMethod("isUsingFixedMemoryPerSlot")
-      isUsingManagedMemoryMethod.invoke(rocksDbConfig).asInstanceOf[Boolean] &&
-        !isUsingFixedMemoryPerSlotMethod.invoke(rocksDbConfig).asInstanceOf[Boolean]
-    } else {
-      false
-    }
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.Calc
 import org.apache.calcite.rex.RexProgram
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.nodes.CommonPythonCalc
@@ -86,12 +87,17 @@ class DataStreamPythonCalc(
       pythonOperatorOutputRowType,
       calcProgram)
 
-    inputDataStream
+    val ret = inputDataStream
       .transform(
         calcOpName(calcProgram, getExpressionString),
         CRowTypeInfo(pythonOperatorResultTypeInfo),
         pythonOperator)
       // keep parallelism to ensure order of accumulate and retract messages
       .setParallelism(inputParallelism)
+
+    if (isPythonWorkerUsingManagedMemory(planner.getConfig.getConfiguration)) {
+      ret.getTransformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
+    }
+    ret
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

*This pull request make python processes to respect the calculated managed memory fraction.*

## Brief change log

  - *Make python processes to respect the calculated managed memory fraction.*
  - *Share the Python process between the Python operators in the same slot*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
