### PR TITLE
[kafka connector]Fix cast question for properies() method  in  kafka ConnectorDescriptor

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/Kafka.java
@@ -98,7 +98,7 @@ public class Kafka extends ConnectorDescriptor {
 			this.kafkaProperties = new HashMap<>();
 		}
 		this.kafkaProperties.clear();
-		properties.forEach((k, v) -> this.kafkaProperties.put((String) k, (String) v));
+		properties.forEach((k, v) -> this.kafkaProperties.put(String.valueOf(k), String.valueOf(v)));
 		return this;
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

This pull resquest fixes Kafka connector. There is a cast  problem when use properties method.

 ```
   Properties props = new Properties();
    props.put( "enable.auto.commit", "false");
    props.put( "fetch.max.wait.ms", "3000");
    props.put("flink.poll-timeout", 5000);
    props.put( "flink.partition-discovery.interval-millis", false);

   kafka = new Kafka()
        .version("0.11")
        .topic(topic)
        .properties(props);
```

```
Exception in thread "main" java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String

Exception in thread "main" java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String
```

## Brief change log

  - *change  (String) v  ----> String.valueOf() in Kafka.java*




## Documentation

  - Does this pull request introduce a new feature? ( no)

