### PR TITLE
[Test]Fix case demo is more obvious to understand for ReinterpretAsKeyedStream

### DIFF
--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/ReinterpretDataStreamAsKeyedStreamITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/ReinterpretDataStreamAsKeyedStreamITCase.scala
@@ -17,8 +17,7 @@
  */
 package org.apache.flink.streaming.api.scala
 
-import org.apache.flink.streaming.api.functions.sink.DiscardingSink
-import org.apache.flink.streaming.api.windowing.time.Time
+import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction
 import org.junit.Test
 
 /**
@@ -30,11 +29,11 @@ class ReinterpretDataStreamAsKeyedStreamITCase {
   def testReinterpretAsKeyedStream(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val source = env.fromElements(1, 2, 3)
+    val source = env.fromElements(1, 2, 3, 1, 2, 3, 4, 4, 1, 1, 3)
     new DataStreamUtils(source).reinterpretAsKeyedStream((in) => in)
-      .timeWindow(Time.seconds(1))
+      .countWindow(2)
       .reduce((a, b) => a + b)
-      .addSink(new DiscardingSink[Int])
+      .addSink(new PrintSinkFunction[Int])
     env.execute()
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

To make case demo more obvious.
Change

![image](https://user-images.githubusercontent.com/18002496/94387913-2567d180-017e-11eb-9adb-44e3167cca38.png)

To

![image](https://user-images.githubusercontent.com/18002496/94387868-00735e80-017e-11eb-8529-f6af47bf2c79.png)

