### PR TITLE
[FLINK-18818][filesystem][tests] Ignores exceptions after files written successfully in HadoopRenameCommitter test

### DIFF
--- a/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/AbstractFileCommitterTest.java
+++ b/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/AbstractFileCommitterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.hadoop.bulk;
 
 import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.IOUtils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -218,12 +219,19 @@ public abstract class AbstractFileCommitterTest extends AbstractTestBase {
 
 	private void writeFile(Path path, Configuration configuration) throws IOException {
 		FileSystem fileSystem = FileSystem.get(path.toUri(), configuration);
-		try (FSDataOutputStream fsDataOutputStream = fileSystem.create(path, override);
-			PrintWriter printWriter = new PrintWriter(fsDataOutputStream)) {
+
+		FSDataOutputStream fsDataOutputStream = null;
+		PrintWriter printWriter = null;
+
+		try {
+			fsDataOutputStream = fileSystem.create(path, override);
+			printWriter = new PrintWriter(fsDataOutputStream);
 
 			for (String line : CONTENTS) {
 				printWriter.println(line);
 			}
+		} finally {
+			IOUtils.closeAllQuietly(printWriter, fsDataOutputStream);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the issue occurred in `HadoopRenameCommitterHDFSTest`. With Hadoop 2.x some exception might thrown after files are written successfully, these exception should be ignored. 

## Brief change log

- fb621d653a6765dca63ad6c057fbcd7a2b549a90 ignores the exceptions on closing `FSDataOutputStream`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature?**no**
  - If yes, how is the feature documented? **not applicable**