### PR TITLE
[FLINK-19180][state backends] Make RocksDB respect managed memory fraction

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -303,6 +303,14 @@ public abstract class Transformation<T> {
 		managedMemorySlotScopeUseCases.add(managedMemoryUseCase);
 	}
 
+	protected void updateManagedMemoryStateBackendUseCase(boolean hasStateBackend) {
+		if (hasStateBackend) {
+			managedMemorySlotScopeUseCases.add(ManagedMemoryUseCase.STATE_BACKEND);
+		} else {
+			managedMemorySlotScopeUseCases.remove(ManagedMemoryUseCase.STATE_BACKEND);
+		}
+	}
+
 	/**
 	 * Get operator scope use cases that this transformation needs managed memory for, and the use-case-specific weights
 	 * for this transformation. The weights are used for sharing managed memory across transformations for the use cases.

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.core.memory;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
 /**
  * Use cases of managed memory.
  */
+@Internal
 public enum ManagedMemoryUseCase {
 	BATCH_OP(Scope.OPERATOR),
 	ROCKSDB(Scope.SLOT),

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
@@ -27,7 +27,7 @@ import org.apache.flink.util.Preconditions;
 @Internal
 public enum ManagedMemoryUseCase {
 	BATCH_OP(Scope.OPERATOR),
-	ROCKSDB(Scope.SLOT),
+	STATE_BACKEND(Scope.SLOT),
 	PYTHON(Scope.SLOT);
 
 	public final Scope scope;

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -47,9 +47,9 @@ public class TransformationTest extends TestLogger {
 	@Test
 	public void testDeclareManagedMemoryUseCase() {
 		transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 123);
-		transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.ROCKSDB);
+		transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.STATE_BACKEND);
 		assertThat(transformation.getManagedMemoryOperatorScopeUseCaseWeights().get(ManagedMemoryUseCase.BATCH_OP), is(123));
-		assertThat(transformation.getManagedMemorySlotScopeUseCases(), contains(ManagedMemoryUseCase.ROCKSDB));
+		assertThat(transformation.getManagedMemorySlotScopeUseCases(), contains(ManagedMemoryUseCase.STATE_BACKEND));
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.operators.MapPartitionOperator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.StateBackend;
@@ -194,6 +195,7 @@ public class BootstrapTransformation<T> {
 		config.setOperatorName(operatorID.toHexString());
 		config.setOperatorID(operatorID);
 		config.setStateBackend(stateBackend);
+		config.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.STATE_BACKEND, 1.0);
 		return config;
 	}
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -183,7 +183,8 @@ public class KeyedStateInputFormat<K, N, OUT> extends RichInputFormat<OUT, KeyGr
 				operator,
 				operator.getKeyType().createSerializer(environment.getExecutionConfig()),
 				registry,
-				getRuntimeContext().getMetricGroup());
+				getRuntimeContext().getMetricGroup(),
+				1.0);
 		} catch (Exception e) {
 			throw new IOException("Failed to restore state backend", e);
 		}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.python.env.PythonDependencyInfo;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.python.env.beam.ProcessPythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
+import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.memory.MemoryReservationException;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -280,10 +281,12 @@ public abstract class AbstractPythonFunctionOperator<OUT>
 			.getBytes();
 		MemoryManager memoryManager = getContainingTask().getEnvironment().getMemoryManager();
 		// TODO python operators should declare and use fraction of the PYTHON use case
+		final Environment environment = getContainingTask().getEnvironment();
 		long availableManagedMemory = memoryManager.computeMemorySize(
 			getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.BATCH_OP,
-				getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
+				environment.getTaskManagerInfo().getConfiguration(),
+				environment.getUserCodeClassLoader().asClassLoader()));
 		if (requiredPythonWorkerMemory <= availableManagedMemory) {
 			memoryManager.reserveMemory(this, requiredPythonWorkerMemory);
 			LOG.info("Reserved memory {} for Python worker.", requiredPythonWorkerMemory);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -471,17 +471,6 @@ public class MemoryManager {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Acquires a shared memory resource, that uses all the memory of this memory manager.
-	 * This method behaves otherwise exactly as {@link #getSharedMemoryResourceForManagedMemory(String, LongFunctionWithException, double)}.
-	 */
-	public <T extends AutoCloseable> OpaqueMemoryResource<T> getSharedMemoryResourceForManagedMemory(
-			String type,
-			LongFunctionWithException<T, Exception> initializer) throws Exception {
-
-		return getSharedMemoryResourceForManagedMemory(type, initializer, 1.0);
-	}
-
-	/**
 	 * Acquires a shared memory resource, identified by a type string. If the resource already exists, this
 	 * returns a descriptor to the resource. If the resource does not yet exist, the given memory fraction
 	 * is reserved and the resource is initialized with that size.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractManagedMemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractManagedMemoryStateBackend.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+/**
+ * Abstract base class for state backends that use managed memory.
+ */
+public abstract class AbstractManagedMemoryStateBackend extends AbstractStateBackend {
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public abstract <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
+		Environment env,
+		JobID jobID,
+		String operatorIdentifier,
+		TypeSerializer<K> keySerializer,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		TaskKvStateRegistry kvStateRegistry,
+		TtlTimeProvider ttlTimeProvider,
+		MetricGroup metricGroup,
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry,
+		double managedMemoryFraction) throws Exception;
+
+	@Override
+	public boolean useManagedMemory() {
+		return true;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -155,6 +155,39 @@ public interface StateBackend extends java.io.Serializable {
 		MetricGroup metricGroup,
 		@Nonnull Collection<KeyedStateHandle> stateHandles,
 		CloseableRegistry cancelStreamRegistry) throws Exception;
+
+	/**
+	 * Creates a new {@link CheckpointableKeyedStateBackend} with the given managed memory fraction.
+	 * Backends that use managed memory are required to implement this interface.
+	 */
+	default <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+			Environment env,
+			JobID jobID,
+			String operatorIdentifier,
+			TypeSerializer<K> keySerializer,
+			int numberOfKeyGroups,
+			KeyGroupRange keyGroupRange,
+			TaskKvStateRegistry kvStateRegistry,
+			TtlTimeProvider ttlTimeProvider,
+			MetricGroup metricGroup,
+			@Nonnull Collection<KeyedStateHandle> stateHandles,
+			CloseableRegistry cancelStreamRegistry,
+			double managedMemoryFraction) throws Exception {
+
+		// ignore managed memory fraction by default
+		return createKeyedStateBackend(
+			env,
+			jobID,
+			operatorIdentifier,
+			keySerializer,
+			numberOfKeyGroups,
+			keyGroupRange,
+			kvStateRegistry,
+			ttlTimeProvider,
+			metricGroup,
+			stateHandles,
+			cancelStreamRegistry);
+	}
 	
 	/**
 	 * Creates a new {@link OperatorStateBackend} that can be used for storing operator state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -176,4 +176,11 @@ public interface StateBackend extends java.io.Serializable {
 		String operatorIdentifier,
 		@Nonnull Collection<OperatorStateHandle> stateHandles,
 		CloseableRegistry cancelStreamRegistry) throws Exception;
+
+	/**
+	 * Whether the state backend uses Flink's managed memory.
+	 */
+	default boolean useManagedMemory() {
+		return false;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
@@ -71,7 +71,7 @@ public enum ManagedMemoryUtils {
 					case TaskManagerOptions.ManagedMemoryConsumerNames.DATAPROC:
 						return Stream.of(
 							Tuple2.of(ManagedMemoryUseCase.BATCH_OP, weight),
-							Tuple2.of(ManagedMemoryUseCase.ROCKSDB, weight));
+							Tuple2.of(ManagedMemoryUseCase.STATE_BACKEND, weight));
 					case TaskManagerOptions.ManagedMemoryConsumerNames.PYTHON:
 						return Stream.of(Tuple2.of(ManagedMemoryUseCase.PYTHON, weight));
 					default:

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
@@ -59,7 +59,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
 	@Test
 	public void testGetWeightsFromConfig() {
 		final Map<ManagedMemoryUseCase, Integer> expectedWeights = new HashMap<ManagedMemoryUseCase, Integer>() {{
-			put(ManagedMemoryUseCase.ROCKSDB, DATA_PROC_WEIGHT);
+			put(ManagedMemoryUseCase.STATE_BACKEND, DATA_PROC_WEIGHT);
 			put(ManagedMemoryUseCase.BATCH_OP, DATA_PROC_WEIGHT);
 			put(ManagedMemoryUseCase.PYTHON, PYTHON_WEIGHT);
 		}};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -101,7 +103,9 @@ public class ManagedMemoryUtilsTest extends TestLogger {
 				add(ManagedMemoryUseCase.BATCH_OP);
 				add(ManagedMemoryUseCase.PYTHON);
 			}},
-			CONFIG_WITH_ALL_USE_CASES);
+			CONFIG_WITH_ALL_USE_CASES,
+			Optional.empty(),
+			ClassLoader.getSystemClassLoader());
 
 		assertEquals(fractionOfUseCase / 3, fractionOfSlot, DELTA);
 	}
@@ -122,8 +126,55 @@ public class ManagedMemoryUtilsTest extends TestLogger {
 				add(ManagedMemoryUseCase.BATCH_OP);
 				add(ManagedMemoryUseCase.PYTHON);
 			}},
-			config);
+			config,
+			Optional.empty(),
+			ClassLoader.getSystemClassLoader());
 
 		assertEquals(0.0, fractionOfSlot, DELTA);
+	}
+
+	@Test
+	public void testConvertToFractionOfSlotStateBackendUseManagedMemory() {
+		testConvertToFractionOfSlotGivenWhetherStateBackendUsesManagedMemory(
+			true,
+			1.0 / 3,
+			1.0 * 2 / 3);
+	}
+
+	@Test
+	public void testConvertToFractionOfSlotStateBackendNotUserManagedMemory() {
+		testConvertToFractionOfSlotGivenWhetherStateBackendUsesManagedMemory(
+			false,
+			0.0,
+			1.0);
+	}
+
+	private void testConvertToFractionOfSlotGivenWhetherStateBackendUsesManagedMemory(
+			boolean stateBackendUsesManagedMemory,
+			double expectedStateFractionOfSlot,
+			double expectedPythonFractionOfSlot) {
+
+		final Set<ManagedMemoryUseCase> allUseCases = new HashSet<ManagedMemoryUseCase>() {{
+			add(ManagedMemoryUseCase.STATE_BACKEND);
+			add(ManagedMemoryUseCase.PYTHON);
+		}};
+
+		final double stateFractionOfSlot = ManagedMemoryUtils.convertToFractionOfSlot(
+			ManagedMemoryUseCase.STATE_BACKEND,
+			1.0,
+			allUseCases,
+			CONFIG_WITH_ALL_USE_CASES,
+			Optional.of(stateBackendUsesManagedMemory),
+			ClassLoader.getSystemClassLoader());
+		final double pythonFractionOfSlot = ManagedMemoryUtils.convertToFractionOfSlot(
+			ManagedMemoryUseCase.PYTHON,
+			1.0,
+			allUseCases,
+			CONFIG_WITH_ALL_USE_CASES,
+			Optional.of(stateBackendUsesManagedMemory),
+			ClassLoader.getSystemClassLoader());
+
+		assertEquals(expectedStateFractionOfSlot, stateFractionOfSlot, DELTA);
+		assertEquals(expectedPythonFractionOfSlot, pythonFractionOfSlot, DELTA);
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
@@ -190,6 +190,7 @@ public class RocksDBOperationUtils {
 	public static OpaqueMemoryResource<RocksDBSharedResources> allocateSharedCachesIfConfigured(
 			RocksDBMemoryConfiguration memoryConfig,
 			MemoryManager memoryManager,
+			double memoryFraction,
 			Logger logger) throws IOException {
 
 		if (!memoryConfig.isUsingFixedMemoryPerSlot() && !memoryConfig.isUsingManagedMemory()) {
@@ -212,7 +213,7 @@ public class RocksDBOperationUtils {
 			}
 			else {
 				logger.info("Getting managed memory shared cache for RocksDB.");
-				return memoryManager.getSharedMemoryResourceForManagedMemory(MANAGED_MEMORY_RESOURCE_ID, allocator);
+				return memoryManager.getSharedMemoryResourceForManagedMemory(MANAGED_MEMORY_RESOURCE_ID, allocator, memoryFraction);
 			}
 		}
 		catch (Exception e) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -451,6 +451,11 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		return initializedDbBasePaths[ni];
 	}
 
+	@Override
+	public boolean useManagedMemory() {
+		return true;
+	}
+
 	// ------------------------------------------------------------------------
 	//  Checkpoint initialization and persistent storage
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -523,6 +523,11 @@ public class StreamConfig implements Serializable {
 		}
 	}
 
+	@VisibleForTesting
+	public void setStateBackendUsesManagedMemory(boolean usesManagedMemory) {
+		this.config.setBoolean(STATE_BACKEND_USE_MANAGED_MEMORY, usesManagedMemory);
+	}
+
 	public StateBackend getStateBackend(ClassLoader cl) {
 		try {
 			return InstantiationUtil.readObjectFromConfig(this.config, STATE_BACKEND, cl);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
@@ -250,7 +251,11 @@ public abstract class AbstractStreamOperator<OUT>
 				this,
 				keySerializer,
 				streamTaskCloseableRegistry,
-				metrics);
+				metrics,
+				config.getManagedMemoryFractionOperatorUseCaseOfSlot(
+					ManagedMemoryUseCase.STATE_BACKEND,
+					runtimeContext.getTaskManagerRuntimeInfo().getConfiguration(),
+					runtimeContext.getUserCodeClassLoader()));
 
 		stateHandler = new StreamOperatorStateHandler(context, getExecutionConfig(), streamTaskCloseableRegistry);
 		timeServiceManager = context.internalTimerServiceManager();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
@@ -200,7 +201,11 @@ public abstract class AbstractStreamOperatorV2<OUT> implements StreamOperator<OU
 				this,
 				keySerializer,
 				cancelables,
-				metrics);
+				metrics,
+				config.getManagedMemoryFractionOperatorUseCaseOfSlot(
+					ManagedMemoryUseCase.STATE_BACKEND,
+					runtimeContext.getTaskManagerRuntimeInfo().getConfiguration(),
+					runtimeContext.getUserCodeClassLoader()));
 
 		stateHandler = new StreamOperatorStateHandler(context, getExecutionConfig(), cancelables);
 		timeServiceManager = context.internalTimerServiceManager();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
@@ -45,6 +45,7 @@ public interface StreamTaskStateInitializer {
 	 * @param keySerializer the key-serializer for the operator. Can be null.
 	 * @param streamTaskCloseableRegistry the closeable registry to which created closeable objects will be registered.
 	 * @param metricGroup the parent metric group for all statebackend metrics
+	 * @param managedMemoryFraction the managed memory fraction of the operator for state backend
 	 * @return a context from which the given operator can initialize everything related to state.
 	 * @throws Exception when something went wrong while creating the context.
 	 */
@@ -55,5 +56,6 @@ public interface StreamTaskStateInitializer {
 		@Nonnull KeyContext keyContext,
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,
-		@Nonnull MetricGroup metricGroup) throws Exception;
+		@Nonnull MetricGroup metricGroup,
+		double managedMemoryFraction) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -123,7 +123,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		@Nonnull KeyContext keyContext,
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,
-		@Nonnull MetricGroup metricGroup) throws Exception {
+		@Nonnull MetricGroup metricGroup,
+		double managedMemoryFraction) throws Exception {
 
 		TaskInfo taskInfo = environment.getTaskInfo();
 		OperatorSubtaskDescriptionText operatorSubtaskDescription =
@@ -152,7 +153,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 				operatorIdentifierText,
 				prioritizedOperatorSubtaskStates,
 				streamTaskCloseableRegistry,
-				metricGroup);
+				metricGroup,
+				managedMemoryFraction);
 
 			// -------------- Operator State Backend --------------
 			operatorStateBackend = operatorStateBackend(
@@ -253,7 +255,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		String operatorIdentifierText,
 		PrioritizedOperatorSubtaskState prioritizedOperatorSubtaskStates,
 		CloseableRegistry backendCloseableRegistry,
-		MetricGroup metricGroup) throws Exception {
+		MetricGroup metricGroup,
+		double managedMemoryFraction) throws Exception {
 
 		if (keySerializer == null) {
 			return null;
@@ -286,7 +289,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 					ttlTimeProvider,
 					metricGroup,
 					stateHandles,
-					cancelStreamRegistryForRestore),
+					cancelStreamRegistryForRestore,
+					managedMemoryFraction),
 				backendCloseableRegistry,
 				logDescription);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedMultipleInputTransformation.java
@@ -43,6 +43,7 @@ public class KeyedMultipleInputTransformation<OUT> extends AbstractMultipleInput
 			TypeInformation<?> stateKeyType) {
 		super(name, operatorFactory, outputType, parallelism);
 		this.stateKeyType = stateKeyType;
+		updateManagedMemoryStateBackendUseCase(true);
 	}
 
 	public KeyedMultipleInputTransformation<OUT> addInput(Transformation<?> input, KeySelector<?, ?> keySelector) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -114,6 +114,7 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
 	 */
 	public void setStateKeySelector(KeySelector<IN, ?> stateKeySelector) {
 		this.stateKeySelector = stateKeySelector;
+		updateManagedMemoryStateBackendUseCase(stateKeySelector != null);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
@@ -103,6 +103,7 @@ public class SinkTransformation<T> extends PhysicalTransformation<Object> {
 	 */
 	public void setStateKeySelector(KeySelector<T, ?> stateKeySelector) {
 		this.stateKeySelector = stateKeySelector;
+		updateManagedMemoryStateBackendUseCase(stateKeySelector != null);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -139,6 +139,7 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends PhysicalTransformatio
 	public void setStateKeySelectors(KeySelector<IN1, ?> stateKeySelector1, KeySelector<IN2, ?> stateKeySelector2) {
 		this.stateKeySelector1 = stateKeySelector1;
 		this.stateKeySelector2 = stateKeySelector2;
+		updateManagedMemoryStateBackendUseCase(stateKeySelector1 != null || stateKeySelector2 != null);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -122,8 +122,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			getExecutionConfig().isObjectReuseEnabled(),
 			configuration.getManagedMemoryFractionOperatorUseCaseOfSlot(
 				ManagedMemoryUseCase.BATCH_OP,
-				getTaskConfiguration()
-			),
+				getTaskConfiguration(),
+				getEnvironment().getUserCodeClassLoader().asClassLoader()),
 			getJobConfiguration(),
 			this
 		);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -900,12 +900,12 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 			StreamConfig streamConfig,
 			double expectedBatchFrac,
 			double expectedPythonFrac,
-			double expectedRocksdbFrac,
+			double expectedStateBackendFrac,
 			Configuration tmConfig) {
 		final double delta = 0.000001;
 		assertEquals(
-			expectedRocksdbFrac,
-			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.ROCKSDB, tmConfig),
+			expectedStateBackendFrac,
+			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.STATE_BACKEND, tmConfig),
 			delta);
 		assertEquals(
 			expectedPythonFrac,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -905,15 +905,15 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final double delta = 0.000001;
 		assertEquals(
 			expectedStateBackendFrac,
-			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.STATE_BACKEND, tmConfig),
+			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.STATE_BACKEND, tmConfig, ClassLoader.getSystemClassLoader()),
 			delta);
 		assertEquals(
 			expectedPythonFrac,
-			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.PYTHON, tmConfig),
+			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.PYTHON, tmConfig, ClassLoader.getSystemClassLoader()),
 			delta);
 		assertEquals(
 			expectedBatchFrac,
-			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.BATCH_OP, tmConfig),
+			streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(ManagedMemoryUseCase.BATCH_OP, tmConfig, ClassLoader.getSystemClassLoader()),
 			delta);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -201,7 +201,8 @@ public class StateInitializationContextImplTest {
 			// consumed by the timer service.
 			IntSerializer.INSTANCE,
 			closableRegistry,
-			new UnregisteredMetricsGroup());
+			new UnregisteredMetricsGroup(),
+			1.0);
 
 		this.initializationContext =
 				new StateInitializationContextImpl(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
@@ -104,7 +104,8 @@ public class StreamOperatorStateHandlerTest {
 				new UnUsedKeyContext(),
 				IntSerializer.INSTANCE,
 				closeableRegistry,
-				new InterceptingOperatorMetricGroup());
+				new InterceptingOperatorMetricGroup(),
+				1.0);
 			StreamOperatorStateHandler stateHandler = new StreamOperatorStateHandler(stateContext, new ExecutionConfig(), closeableRegistry);
 
 			final String keyedStateField = "keyedStateField";

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -101,7 +101,8 @@ public class StreamTaskStateInitializerImplTest {
 			streamOperator,
 			typeSerializer,
 			closeableRegistry,
-			new UnregisteredMetricsGroup());
+			new UnregisteredMetricsGroup(),
+			1.0);
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
 		CheckpointableKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
@@ -212,7 +213,8 @@ public class StreamTaskStateInitializerImplTest {
 			streamOperator,
 			typeSerializer,
 			closeableRegistry,
-			new UnregisteredMetricsGroup());
+			new UnregisteredMetricsGroup(),
+			1.0);
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
 		CheckpointableKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
@@ -139,6 +140,8 @@ public class StreamConfigChainer<OWNER> {
 		if (createKeyedStateBackend) {
 			// used to test multiple stateful operators chained in a single task.
 			tailConfig.setStateKeySerializer(inputSerializer);
+			tailConfig.setStateBackendUsesManagedMemory(true);
+			tailConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.STATE_BACKEND, 1.0);
 		}
 		tailConfig.setChainIndex(chainIndex);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1528,7 +1528,7 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public StreamTaskStateInitializer createStreamTaskStateInitializer() {
 			final StreamTaskStateInitializer streamTaskStateManager = super.createStreamTaskStateInitializer();
-			return (operatorID, operatorClassName, processingTimeService, keyContext, keySerializer, closeableRegistry, metricGroup) -> {
+			return (operatorID, operatorClassName, processingTimeService, keyContext, keySerializer, closeableRegistry, metricGroup, fraction) -> {
 
 				final StreamOperatorStateContext controller = streamTaskStateManager.streamOperatorStateContext(
 					operatorID,
@@ -1537,7 +1537,8 @@ public class StreamTaskTest extends TestLogger {
 					keyContext,
 					keySerializer,
 					closeableRegistry,
-					metricGroup);
+					metricGroup,
+					fraction);
 
 				return new StreamOperatorStateContext() {
 					@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -149,6 +150,8 @@ public class StreamTaskTestHarness<OUT> {
 		this.executionConfig = new ExecutionConfig();
 
 		streamConfig = new StreamConfig(taskConfig);
+		streamConfig.setStateBackendUsesManagedMemory(true);
+		streamConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.STATE_BACKEND, 1.0);
 
 		outputSerializer = outputType.createSerializer(executionConfig);
 		outputStreamRecordSerializer = new StreamElementSerializer<>(outputSerializer);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.OperatorStateRepartitioner;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -242,6 +243,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		this.config = new StreamConfig(underlyingConfig);
 		this.config.setCheckpointingEnabled(true);
 		this.config.setOperatorID(operatorID);
+		this.config.setStateBackendUsesManagedMemory(true);
+		this.config.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.STATE_BACKEND, 1.0);
 		this.executionConfig = env.getExecutionConfig();
 		this.checkpointLock = new Object();
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators;
 
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
@@ -51,9 +52,11 @@ public class TableStreamOperator<OUT> extends AbstractStreamOperator<OUT> {
 	 * Compute memory size from memory faction.
 	 */
 	public long computeMemorySize() {
-		return getContainingTask().getEnvironment().getMemoryManager().computeMemorySize(
+		final Environment environment = getContainingTask().getEnvironment();
+		return environment.getMemoryManager().computeMemorySize(
 				getOperatorConfig().getManagedMemoryFractionOperatorUseCaseOfSlot(
 					ManagedMemoryUseCase.BATCH_OP,
-					getContainingTask().getEnvironment().getTaskManagerInfo().getConfiguration()));
+					environment.getTaskManagerInfo().getConfiguration(),
+					environment.getUserCodeClassLoader().asClassLoader()));
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -210,7 +210,7 @@ public class BufferDataOverWindowOperatorTest {
 				StreamConfig conf = mock(StreamConfig.class);
 				when(conf.<RowData>getTypeSerializerIn1(getUserCodeClassloader()))
 						.thenReturn(inputSer);
-				when(conf.getManagedMemoryFractionOperatorUseCaseOfSlot(eq(ManagedMemoryUseCase.BATCH_OP), any(Configuration.class)))
+				when(conf.getManagedMemoryFractionOperatorUseCaseOfSlot(eq(ManagedMemoryUseCase.BATCH_OP), any(Configuration.class), any(ClassLoader.class)))
 						.thenReturn(0.99);
 				return conf;
 			}


### PR DESCRIPTION
## What is the purpose of the change

This PR makes `RocksDBStateBackend` respect the calculated managed memory fraction in `StreamConfig`, instead of always assuming the fraction to be `1.0`.
