### PR TITLE
Single task result partition type --- the most original one

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
@@ -35,6 +35,8 @@ public final class FailoverStrategyFactoryLoader {
 	/** Config name for the {@link RestartPipelinedRegionFailoverStrategy}. */
 	public static final String PIPELINED_REGION_RESTART_STRATEGY_NAME = "region";
 
+	public static final String RESTART_INDIVIDUAL_STRATEGY_NAME = "individual";
+
 	private FailoverStrategyFactoryLoader() {
 	}
 
@@ -55,6 +57,9 @@ public final class FailoverStrategyFactoryLoader {
 
 			case PIPELINED_REGION_RESTART_STRATEGY_NAME:
 				return new RestartPipelinedRegionFailoverStrategy.Factory();
+
+			case RESTART_INDIVIDUAL_STRATEGY_NAME:
+				return new RestartIndividualFailoverStrategy.Factory();
 
 			default:
 				throw new IllegalConfigurationException("Unknown failover strategy: " + strategyParam);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartIndividualFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartIndividualFailoverStrategy.java
@@ -1,0 +1,41 @@
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+public class RestartIndividualFailoverStrategy implements FailoverStrategy {
+
+	/** The log object used for debugging. */
+	private static final Logger LOG = LoggerFactory.getLogger(RestartIndividualFailoverStrategy.class);
+
+	RestartIndividualFailoverStrategy(
+		SchedulingTopology topology,
+		ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+	}
+
+	@Override
+	public Set<ExecutionVertexID> getTasksNeedingRestart(ExecutionVertexID executionVertexId, Throwable cause) {
+		return ImmutableSet.of(executionVertexId);
+	}
+
+	/**
+	 * The factory to instantiate {@link RestartIndividualFailoverStrategy}.
+	 */
+	public static class Factory implements FailoverStrategy.Factory {
+
+		@Override
+		public FailoverStrategy create(
+			final SchedulingTopology topology,
+			final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+			return new RestartIndividualFailoverStrategy(topology, resultPartitionAvailabilityChecker);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.DATA_BUFFER;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilder.BUFFER_BUILDER_HEADER_SIZE;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilder.Header;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -138,6 +139,62 @@ public class BufferConsumer implements Closeable {
 		return slice.retainBuffer();
 	}
 
+	public PartialRecordCleanupResult skipPartialRecord() {
+		writerPosition.update();
+		int cachedWriterPosition = writerPosition.getCached();
+
+		Buffer slice;
+		boolean cleanedUp;
+
+		// partial record can happen only at the beginning of a buffer
+		// because buffer slicer can end with either a full record or full buffer (partial record)
+		if (startOfDataBuffer()) {
+			// either do not have any data, or at least have 4 bytes (header + data)
+			checkState(
+				(cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE)
+					|| (currentReaderPosition == cachedWriterPosition)
+			);
+
+			if (cachedWriterPosition - currentReaderPosition > BUFFER_BUILDER_HEADER_SIZE) {
+				int head = buffer.getMemorySegment().getIntBigEndian(0);
+				boolean partial = Header.isPartial(head);
+				int length = Header.length(head);
+
+				if (partial) {
+					// case 1: long record spanning multiple buffers, haven't yet cleaned up, skip the whole buffer
+					if (length == buffer.getMaxCapacity() - BUFFER_BUILDER_HEADER_SIZE) {
+						slice = buffer.readOnlySlice(currentReaderPosition, 0);
+						cleanedUp = false;
+					} else {
+						// case 2: partial record ends within the buffer, cleaned up successfully, skip the partial record
+						slice = buffer.readOnlySlice(
+							currentReaderPosition + BUFFER_BUILDER_HEADER_SIZE + length,
+							cachedWriterPosition - currentReaderPosition - BUFFER_BUILDER_HEADER_SIZE - length);
+						cleanedUp = true;
+					}
+				} else {
+					// case 3: the record is not a partial record, cleaned up successfully, skip the head
+					slice = buffer.readOnlySlice(
+						currentReaderPosition + BUFFER_BUILDER_HEADER_SIZE ,
+						cachedWriterPosition - currentReaderPosition - BUFFER_BUILDER_HEADER_SIZE);
+					cleanedUp = true;
+				}
+			} else {
+				// case 4: written data is not visible yet, haven't yet cleaned up, return an empty slicer
+				slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+				cleanedUp = false;
+			}
+		} else {
+			// case 5: read from the middle of the buffer or event buffer; no clean up needed,
+			// because buffer slicer can end with either a full record or full buffer (partial record)
+			slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
+			cleanedUp = true;
+		}
+
+		currentReaderPosition = cachedWriterPosition;
+		return new PartialRecordCleanupResult(slice.retainBuffer(), cleanedUp);
+	}
+
 	/**
 	 * Returns a retained copy with separate indexes. This allows to read from the same {@link MemorySegment} twice.
 	 *
@@ -225,6 +282,24 @@ public class BufferConsumer implements Closeable {
 
 		private void update() {
 			this.cachedPosition = positionMarker.get();
+		}
+	}
+
+	public static class PartialRecordCleanupResult {
+		private final Buffer buffer;
+		private final boolean cleaned;
+
+		PartialRecordCleanupResult(Buffer buffer, boolean cleaned) {
+			this.buffer = checkNotNull(buffer);
+			this.cleaned = cleaned;
+		}
+
+		public Buffer getBuffer() {
+			return buffer;
+		}
+
+		public boolean getCleaned() {
+			return cleaned;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -223,6 +223,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 		ensureUnicastMode();
 
 		final BufferBuilder bufferBuilder = requestNewBufferBuilderFromPool(targetSubpartition);
+		LOG.debug("bufferPool status after requesting a new builder: " + bufferPool.toString());
 		subpartitions[targetSubpartition].add(bufferBuilder.createBufferConsumer());
 		subpartitionBufferBuilders[targetSubpartition] = bufferBuilder;
 		return bufferBuilder;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -1,0 +1,138 @@
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PipelinedApproximateSubpartition.class);
+
+	private boolean isPartialBuffer = false;
+
+	PipelinedApproximateSubpartition(int index, ResultPartition parent) {
+		super(index, parent);
+	}
+
+	public void releaseView() {
+		readView = null;
+		isPartialBuffer = true;
+		isBlockedByCheckpoint = false;
+		sequenceNumber = 0;
+	}
+
+	@Override
+	public PipelinedSubpartitionView createReadView(BufferAvailabilityListener availabilityListener) {
+		synchronized (buffers) {
+			checkState(!isReleased);
+
+			// if the view is not released yet
+			if (readView != null) {
+				releaseView();
+			}
+
+			LOG.debug("{}: Creating read view for subpartition {} of partition {}.",
+				parent.getOwningTaskName(), getSubPartitionIndex(), parent.getPartitionId());
+
+			readView = new PipelinedApproximateSubpartitionView(this, availabilityListener);
+		}
+
+		return readView;
+	}
+
+	@Nullable
+	@Override
+	BufferAndBacklog pollBuffer() {
+		synchronized (buffers) {
+			if (isBlockedByCheckpoint) {
+				return null;
+			}
+
+			Buffer buffer = null;
+
+			if (buffers.isEmpty()) {
+				flushRequested = false;
+			}
+
+			while (!buffers.isEmpty()) {
+				BufferConsumer bufferConsumer = buffers.peek();
+
+				// `isPartialBuffer` is set to true in the same Netty thread when ResultPartitionView is released
+				if (isPartialBuffer) {
+					BufferConsumer.PartialRecordCleanupResult result = bufferConsumer.skipPartialRecord();
+					buffer = result.getBuffer();
+					isPartialBuffer = !result.getCleaned();
+				} else {
+					buffer = bufferConsumer.build();
+				}
+
+				checkState(bufferConsumer.isFinished() || buffers.size() == 1,
+					"When there are multiple buffers, an unfinished bufferConsumer can not be at the head of the buffers queue.");
+
+				if (buffers.size() == 1) {
+					// turn off flushRequested flag if we drained all of the available data
+					flushRequested = false;
+				}
+
+				if (bufferConsumer.isFinished()) {
+					buffers.poll().close();
+					decreaseBuffersInBacklogUnsafe(bufferConsumer.isBuffer());
+				}
+
+				if (buffer.readableBytes() > 0) {
+					break;
+				}
+
+				buffer.recycleBuffer();
+				buffer = null;
+
+				if (!bufferConsumer.isFinished()) {
+					break;
+				}
+			}
+
+			if (buffer == null) {
+				return null;
+			}
+
+			if (buffer.getDataType().isBlockingUpstream()) {
+				isBlockedByCheckpoint = true;
+			}
+
+			updateStatistics(buffer);
+			// Do not report last remaining buffer on buffers as available to read (assuming it's unfinished).
+			// It will be reported for reading either on flush or when the number of buffers in the queue
+			// will be 2 or more.
+			return new BufferAndBacklog(
+				buffer,
+				getBuffersInBacklog(),
+				isDataAvailableUnsafe() ? getNextBufferTypeUnsafe() : Buffer.DataType.NONE,
+				sequenceNumber++);
+		}
+	}
+
+	@Override
+	public String toString() {
+		final long numBuffers;
+		final long numBytes;
+		final boolean finished;
+		final boolean hasReadView;
+
+		synchronized (buffers) {
+			numBuffers = getTotalNumberOfBuffers();
+			numBytes = getTotalNumberOfBytes();
+			finished = isFinished;
+			hasReadView = readView != null;
+		}
+
+		return String.format(
+			"PipelinedApproximateSubpartition#%d [number of buffers: %d (%d bytes), number of buffers in backlog: %d, finished? %s, read view? %s]",
+			getSubPartitionIndex(), numBuffers, numBytes, getBuffersInBacklog(), finished, hasReadView);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionView.java
@@ -1,0 +1,27 @@
+package org.apache.flink.runtime.io.network.partition;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+public class PipelinedApproximateSubpartitionView extends PipelinedSubpartitionView {
+
+	PipelinedApproximateSubpartitionView(PipelinedApproximateSubpartition parent, BufferAvailabilityListener listener) {
+		super(parent, listener);
+	}
+
+	@Override
+	public void releaseAllResources() {
+		if (isReleased.compareAndSet(false, true)) {
+			// The view doesn't hold any resources and the parent cannot be restarted. Therefore,
+			// it's OK to notify about consumption as well.
+			checkState(parent instanceof PipelinedApproximateSubpartition);
+			((PipelinedApproximateSubpartition) parent).releaseView();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format("PipelinedApproximateSubpartition(index: %d) of ResultPartition %s",
+			parent.getSubPartitionIndex(),
+			parent.parent.getPartitionId());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
@@ -169,7 +169,7 @@ public class PipelinedResultPartition extends BufferWritingResultPartition
 	// ------------------------------------------------------------------------
 
 	private static ResultPartitionType checkResultPartitionType(ResultPartitionType type) {
-		checkArgument(type == ResultPartitionType.PIPELINED || type == ResultPartitionType.PIPELINED_BOUNDED);
+		checkArgument(type == ResultPartitionType.PIPELINED || type == ResultPartitionType.PIPELINED_BOUNDED || type == ResultPartitionType.PIPELINED_APPROXIMATE);
 		return type;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -291,7 +291,7 @@ public class PipelinedSubpartition extends ResultSubpartition
 				if (isPartialBuffer) {
 					BufferConsumer.PartialRecordCleanupResult result = bufferConsumer.skipPartialRecord();
 					buffer = result.getBuffer();
-					isPartialBuffer = result.getCleaned();
+					isPartialBuffer = !result.getCleaned();
 				} else {
 					buffer = bufferConsumer.build();
 				}
@@ -371,6 +371,13 @@ public class PipelinedSubpartition extends ResultSubpartition
 		}
 
 		return readView;
+	}
+
+	public void releaseView() {
+		readView = null;
+		isPartialBuffer = true;
+		isBlockedByCheckpoint = false;
+		sequenceNumber = 0;
 	}
 
 	public boolean isAvailable(int numCreditsAvailable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -32,12 +32,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class PipelinedSubpartitionView implements ResultSubpartitionView {
 
 	/** The subpartition this view belongs to. */
-	private final PipelinedSubpartition parent;
+	final PipelinedSubpartition parent;
 
-	private final BufferAvailabilityListener availabilityListener;
+	final BufferAvailabilityListener availabilityListener;
 
 	/** Flag indicating whether this view has been released. */
-	private final AtomicBoolean isReleased;
+	final AtomicBoolean isReleased;
 
 	public PipelinedSubpartitionView(PipelinedSubpartition parent, BufferAvailabilityListener listener) {
 		this.parent = checkNotNull(parent);
@@ -66,7 +66,7 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
 		if (isReleased.compareAndSet(false, true)) {
 			// The view doesn't hold any resources and the parent cannot be restarted. Therefore,
 			// it's OK to notify about consumption as well.
-			parent.releaseView();
+			parent.onConsumedSubpartition();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -66,7 +66,7 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
 		if (isReleased.compareAndSet(false, true)) {
 			// The view doesn't hold any resources and the parent cannot be restarted. Therefore,
 			// it's OK to notify about consumption as well.
-			parent.onConsumedSubpartition();
+			parent.releaseView();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -119,7 +119,8 @@ public class ResultPartitionFactory {
 		ResultSubpartition[] subpartitions = new ResultSubpartition[numberOfSubpartitions];
 
 		final ResultPartition partition;
-		if (type == ResultPartitionType.PIPELINED || type == ResultPartitionType.PIPELINED_BOUNDED) {
+		if (type == ResultPartitionType.PIPELINED || type == ResultPartitionType.PIPELINED_BOUNDED ||
+			type == ResultPartitionType.PIPELINED_APPROXIMATE) {
 			final PipelinedResultPartition pipelinedPartition = new PipelinedResultPartition(
 				taskNameWithSubtaskAndId,
 				partitionIndex,
@@ -131,8 +132,15 @@ public class ResultPartitionFactory {
 				bufferCompressor,
 				bufferPoolFactory);
 
-			for (int i = 0; i < subpartitions.length; i++) {
-				subpartitions[i] = new PipelinedSubpartition(i, pipelinedPartition);
+			if (type == ResultPartitionType.PIPELINED_APPROXIMATE) {
+				for (int i = 0; i < subpartitions.length; i++) {
+					subpartitions[i] = new PipelinedApproximateSubpartition(i, pipelinedPartition);
+					// subpartitions[i] = new PipelinedSubpartition(i, pipelinedPartition);
+				}
+			} else {
+				for (int i = 0; i < subpartitions.length; i++) {
+					subpartitions[i] = new PipelinedSubpartition(i, pipelinedPartition);
+				}
 			}
 
 			partition = pipelinedPartition;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -71,7 +71,17 @@ public enum ResultPartitionType {
 	 * <p>For batch jobs, it will be best to keep this unlimited ({@link #PIPELINED}) since there are
 	 * no checkpoint barriers.
 	 */
-	PIPELINED_BOUNDED(true, true, true, false);
+	PIPELINED_BOUNDED(true, true, true, false),
+
+	/**
+	 * Pipelined partitions with a bounded (local) buffer pool to support downstream task to
+	 * continue consuming data after reconnection in Approximate Local-Recovery.
+	 *
+	 * <p> Pipelined results can be consumed only once by a single consumer at one time.
+	 * {@link #PIPELINED_APPROXIMATE} is different from {@link #PIPELINED_BOUNDED} in that
+	 * {@link #PIPELINED_APPROXIMATE} is not decomposed automatically after consumption.
+	 */
+	PIPELINED_APPROXIMATE(true, true, true, true);
 
 	/** Can the partition be consumed while being produced? */
 	private final boolean isPipelined;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -81,6 +81,7 @@ import org.apache.flink.streaming.api.functions.source.SocketTextStreamFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
@@ -151,6 +152,8 @@ public class StreamExecutionEnvironment {
 	protected final List<Transformation<?>> transformations = new ArrayList<>();
 
 	private long bufferTimeout = StreamingJobGraphGenerator.UNDEFINED_NETWORK_BUFFER_TIMEOUT;
+
+	private GlobalDataExchangeMode globalDataExchangeMode = GlobalDataExchangeMode.ALL_EDGES_PIPELINED;
 
 	protected boolean isChainingEnabled = true;
 
@@ -356,6 +359,12 @@ public class StreamExecutionEnvironment {
 	 */
 	public long getBufferTimeout() {
 		return this.bufferTimeout;
+	}
+
+
+	public StreamExecutionEnvironment setGlobalDataExchangeMode(GlobalDataExchangeMode globalDataExchangeMode) {
+		this.globalDataExchangeMode = globalDataExchangeMode;
+		return this;
 	}
 
 	/**
@@ -1888,7 +1897,8 @@ public class StreamExecutionEnvironment {
 			.setChaining(isChainingEnabled)
 			.setUserArtifacts(cacheFile)
 			.setTimeCharacteristic(timeCharacteristic)
-			.setDefaultBufferTimeout(bufferTimeout);
+			.setDefaultBufferTimeout(bufferTimeout)
+			.setGlobalDataExchangeMode(globalDataExchangeMode);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalDataExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalDataExchangeMode.java
@@ -44,5 +44,8 @@ public enum GlobalDataExchangeMode {
 	POINTWISE_EDGES_PIPELINED,
 
 	/** Set all job edges {@link ResultPartitionType#PIPELINED_BOUNDED}. */
-	ALL_EDGES_PIPELINED
+	ALL_EDGES_PIPELINED,
+
+	/** Set all job edges {@link ResultPartitionType#PIPELINED_APPROXIMATE}. */
+	ALL_EDGES_PIPELINED_APPROXIMATE
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -630,6 +630,8 @@ public class StreamingJobGraphGenerator {
 				}
 			case ALL_EDGES_PIPELINED:
 				return ResultPartitionType.PIPELINED_BOUNDED;
+			case ALL_EDGES_PIPELINED_APPROXIMATE:
+				return ResultPartitionType.PIPELINED_APPROXIMATE;
 			default:
 				throw new RuntimeException("Unrecognized global data exchange mode " + streamGraph.getGlobalDataExchangeMode());
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
@@ -1,5 +1,6 @@
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple4;
@@ -17,6 +18,7 @@ import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.junit.AfterClass;
@@ -78,6 +80,7 @@ public class ApproximateLocalRecoveryUpstreamDiffTMITCase {
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
 		env.setBufferTimeout(0);
 		env.disableOperatorChaining();
+		env.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_PIPELINED_APPROXIMATE);
 		// env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
 
 		DataStream<Tuple4<Integer, Long, Integer, String>> source =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryUpstreamDiffTMITCase.java
@@ -1,0 +1,262 @@
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.test.util.TestUtils.tryExecute;
+
+/** Use RemoteInputChannel. Only for Upstream Reconnection. **/
+
+/**
+ * 1. data size : 83
+ * 2. memory buffer size: 4096
+ * 3. full buffer: 49 record 4067 => 50 record 4150
+ */
+public class ApproximateLocalRecoveryUpstreamDiffTMITCase {
+	private static MiniClusterWithClientResource cluster;
+
+	@Before
+	public void setup() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "individual");
+		config.setString(JobManagerOptions.SCHEDULING_STRATEGY, "legacy");
+		config.setString(HighAvailabilityOptions.HA_MODE, RegionFailoverITCase.TestingHAFactory.class.getName());
+
+		config.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4096"));
+		config.setLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 1000000L);
+		config.setString(AkkaOptions.ASK_TIMEOUT, "1 h");
+		//configuration.setString("heartbeat.timeout", "1000000");
+
+		cluster = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+				.setConfiguration(config)
+				.setNumberTaskManagers(2)
+				.setNumberSlotsPerTaskManager(1).build());
+		cluster.before();
+	}
+
+	@AfterClass
+	public static void shutDownExistingCluster() {
+		if (cluster != null) {
+			cluster.after();
+			cluster = null;
+		}
+	}
+
+	@Test
+	public void localTaskFailureRecovery() throws Exception {
+		int numElementsPerTask = 1000000;
+		int producerParallelism = 1;
+		int failAfterElements = 123;
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+		env.setBufferTimeout(0);
+		env.disableOperatorChaining();
+		// env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
+
+		DataStream<Tuple4<Integer, Long, Integer, String>> source =
+			// env.addSource(new AppSourceFunction(numElementsPerTask))
+			env.addSource(new AppSourceFunction(numElementsPerTask, 4096))
+				.setParallelism(producerParallelism)
+				.slotSharingGroup("source");
+
+		source.map(new FailingMapper<>(failAfterElements))
+			.setParallelism(1)
+			.slotSharingGroup("map");
+
+		FailingMapper.failedBefore = false;
+		tryExecute(env, "test");
+	}
+
+	// Schema: (key, timestamp, source instance Id).
+	static class AppSourceFunction extends RichParallelSourceFunction<Tuple4<Integer, Long, Integer, String>>
+		implements ListCheckpointed<Integer> {
+		private static final Logger LOG = LoggerFactory.getLogger(AppSourceFunction.class);
+		private volatile boolean running = true;
+		private final int numElementsPerProducer;
+		private final StringBuilder veryLongString;
+
+		private int index = 0;
+
+		AppSourceFunction(int numElementsPerProducer) {
+			this.numElementsPerProducer = numElementsPerProducer;
+			this.veryLongString = null;
+		}
+
+		AppSourceFunction(int numElementsPerProducer, int bufferSize) {
+			this.numElementsPerProducer = numElementsPerProducer;
+			String longString = "I am a very long string to test partial records hohoho hahaha";
+			veryLongString = new StringBuilder(longString);
+
+			for (int i = 0; i <= 2 * bufferSize / longString.length() + 1; i++) {
+				veryLongString.append(longString);
+			}
+		}
+
+		@Override
+		public void run(SourceContext<Tuple4<Integer, Long, Integer, String>> ctx) throws Exception{
+			long timestamp = 1593575900000L;
+			int sourceInstanceId = getRuntimeContext().getIndexOfThisSubtask();
+			for (; index < numElementsPerProducer && running; index++) {
+				synchronized (ctx.getCheckpointLock()) {
+					if (index % 100 == 0) {
+						Thread.sleep(500);
+					}
+					System.out.println("Source : [" + index + "," + timestamp + "," + sourceInstanceId + "]");
+					if (veryLongString == null) {
+						ctx.collect(new Tuple4<>(index, timestamp++, sourceInstanceId, "I am a very long string to test partial records hohoho hahaha"));
+					} else {
+						ctx.collect(new Tuple4<>(index, timestamp++, sourceInstanceId, veryLongString.toString()));
+					}
+				}
+			}
+			while (running) {
+				Thread.sleep(100);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			LOG.info("Snapshot of Source index " + index + " at checkpoint " + checkpointId);
+			return Collections.singletonList(index);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+
+			index = state.get(0);
+			LOG.info("restore Source index to " + index);
+		}
+	}
+
+	private static class FailingMapper<T> extends RichMapFunction<T, T> implements
+		ListCheckpointed<Integer>, CheckpointListener, Runnable {
+
+		private static final Logger LOG = LoggerFactory.getLogger(FailingMapper.class);
+
+		private static final long serialVersionUID = 6334389850158707313L;
+
+		public static volatile boolean failedBefore;
+
+		private final int failCount;
+		private int numElementsTotal;
+		private int numElementsThisTime;
+
+		private boolean failer;
+		private boolean hasBeenCheckpointed;
+
+		private Thread printer;
+		private volatile boolean printerRunning = true;
+
+		public FailingMapper(int failCount) {
+			this.failCount = failCount;
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			failer = getRuntimeContext().getIndexOfThisSubtask() == 0;
+			printer = new Thread(this, "FailingIdentityMapper Status Printer");
+			printer.start();
+		}
+
+		@Override
+		public T map(T value) throws Exception {
+			// System.out.println("Failing mapper: numElementsThisTime=" + numElementsThisTime + " totalCount=" + numElementsTotal);
+			System.out.println("Failing mapper: " + value.toString());
+			numElementsTotal++;
+			numElementsThisTime++;
+
+			if (!failedBefore) {
+				Thread.sleep(10);
+
+				if (failer && numElementsTotal >= failCount) {
+					failedBefore = true;
+					throw new Exception("Artificial Test Failure");
+				}
+			}
+			return value;
+		}
+
+		@Override
+		public void close() throws Exception {
+			printerRunning = false;
+			if (printer != null) {
+				printer.interrupt();
+				printer = null;
+			}
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			this.hasBeenCheckpointed = true;
+		}
+
+		@Override
+		public void notifyCheckpointAborted(long checkpointId) {
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			LOG.info("Snapshot of FailingMapper numElementsTotal " + numElementsTotal + " at checkpoint " + checkpointId);
+			return Collections.singletonList(numElementsTotal);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+
+			this.numElementsTotal = state.get(0);
+			LOG.info("restore FailingMapper numElementsTotal to " + numElementsTotal);
+		}
+
+		@Override
+		public void run() {
+			while (printerRunning) {
+				try {
+					Thread.sleep(5000);
+				} catch (InterruptedException e) {
+					// ignore
+				}
+				LOG.info("============================> Failing mapper  {}: count={}, totalCount={}",
+					getRuntimeContext().getIndexOfThisSubtask(),
+					numElementsThisTime, numElementsTotal);
+			}
+		}
+	}
+}

--- a/flink-tests/src/test/resources/log4j2-test.properties
+++ b/flink-tests/src/test/resources/log4j2-test.properties
@@ -18,7 +18,8 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = DEBUG
+#rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger


### PR DESCRIPTION
## What is the purpose of the change

Commit 1
- Attach header to memory segment: commit 1
This PR adds a header to each BufferBuilder to indicate whether the first record in the buffer is partial or not.
For each buffer builder, a header with a 4-byte integer is attached.
Since the length of bytes written can only be 0 or positive, the first bit of the integer is used to identify whether the first record is partial (1) or not (0). The remaining 31 bits stand for the length of the first record remaining. When reading from the buffer through BufferConsumer, `BufferConsumer.build()` makes sure the header is removed off when returning a sliced buffer.
No header info is transmitted through the network.

Commit 2
- The partial subpartition clean-up logic: commit 2
The clean-up logic for partial-record sub-partition is handled in `skipPartialRecord()`; Notice that partial record can happen only at the beginning of a buffer because the buffer builder can end with either a full record or full buffer after each `bufferbuilder.commit()` and consequently each `bufferconsumer.build()`; (or full record + full buffer, but that’s fine). Partial records occur only when a bufferBuilder ends with a full buffer but not a full record;

Totally five cases:
**CASE** Read position starts from the beginning of a data buffer:
case 1: written data is not visible yet => cleaned up is not successful => return an empty slicer
case 2: the record is not a partial record => cleaned up successfully => skip the head
case 3: long record spanning over multiple buffers => clean up is not successful => we need to skip the whole buffer
case 4: partial record ends within the buffer => cleaned up successfully => skip the partial record

**CASE** Read position starts from the middle of a data buffer
// bufferbuilder can end with either a full record or full buffer (partial record) after each commit, so in this case, we are guaranteed to start with a complete record
case 5: no clean up needed 

Commit 3
- Introduce a simple restart sink strategy: commit 3
This commit includes a simple individual task restart strategy that can restart the sink for sink failure so that we can test end-2-end for reconnection + partial partition clean-up;
I’ve tested multiple cases including the case a very long record spanning over more than one buffer; short record; reading from the head of a buffer consumer; reading from the middle of a buffer consumer, and e.t.c. They all work perfectly.

Commit 4
- Introduce a new ResultPartitionType: commit 4
This commit introduces
1). a new ResultPartitionType (`ResultPartitionType.PIPELINED_APPROXIMATE`) and
2). `PipelinedApproximateSubpartition`/`PipelinedApproximateSubpartitionView`
The ResultPartitionType is decided in StreamGraph generator based on `GlobalDataExchangeMode`. Then `PipelinedApproximateSubpartition`  for sub-partition creation.
`PipelinedApproximateSubpartition` and `PipelinedApproximateSubpartitionView` extend `PipelinedSubpartition` and `PipelinedSubpartitionView` respectively. The differences are very little, limited within view creation/view release and `pollBuffer()`

Overall the change is very small and safe. Also, by introducing a new ResultPartitionType, I think I probably do not need extra work for life cycle management for partitions. I will double-check this during the rest of the day.

