### PR TITLE
[FLINK-19392] Add the execution.runtime-mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/RuntimeExecutionMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/RuntimeExecutionMode.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Runtime execution mode of DataStream programs. Among other things, this controls task scheduling,
+ * network shuffle behavior, and time semantics. Some operations will also change their record emission behaviour
+ * based on the configured execution mode.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-134%3A+Batch+execution+for+the+DataStream+API">
+ *     https://cwiki.apache.org/confluence/display/FLINK/FLIP-134%3A+Batch+execution+for+the+DataStream+API</a>
+ */
+@Internal
+public enum RuntimeExecutionMode {
+
+	/**
+	 * The Pipeline will be executed with Streaming Semantics. All tasks will be deployed before execution starts,
+	 * checkpoints will be enabled, and both processing and event time will be fully supported.
+	 */
+	STREAMING,
+
+	/**
+	 * The Pipeline will be executed with Batch Semantics. Tasks will be scheduled gradually based
+	 * on the scheduling region they belong, shuffles between regions will be blocking, watermarks are
+	 * assumed to be "perfect" i.e. no late data, and processing time is assumed to not advance during execution.
+	 */
+	BATCH,
+
+	/**
+	 * Flink will set the execution mode to {@link RuntimeExecutionMode#BATCH} if all sources are bounded,
+	 * or {@link RuntimeExecutionMode#STREAMING} if there is at least one source which is unbounded.
+	 */
+	AUTOMATIC
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1065,8 +1065,8 @@ public class StreamExecutionEnvironment {
 
 	// private helper for passing different names
 	private <OUT> DataStreamSource<OUT> fromParallelCollection(
-			SplittableIterator<OUT> iterator, TypeInformation<OUT>
-			typeInfo,
+			SplittableIterator<OUT> iterator,
+			TypeInformation<OUT> typeInfo,
 			String operatorName) {
 		return addSource(new FromSplittableIteratorFunction<>(iterator), operatorName, typeInfo, Boundedness.BOUNDED);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -140,7 +140,10 @@ public class StreamGraphGenerator {
 	// we have loops, i.e. feedback edges.
 	private Map<Transformation<?>, Collection<Integer>> alreadyTransformed;
 
-	public StreamGraphGenerator(List<Transformation<?>> transformations, ExecutionConfig executionConfig, CheckpointConfig checkpointConfig) {
+	public StreamGraphGenerator(
+			final List<Transformation<?>> transformations,
+			final ExecutionConfig executionConfig,
+			final CheckpointConfig checkpointConfig) {
 		this.transformations = checkNotNull(transformations);
 		this.executionConfig = checkNotNull(executionConfig);
 		this.checkpointConfig = checkNotNull(checkpointConfig);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
@@ -64,6 +65,10 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
 		this.source = checkNotNull(source);
 		this.watermarkStrategy = checkNotNull(watermarkStrategy);
 		this.numCoordinatorWorkerThread = numCoordinatorWorkerThread;
+	}
+
+	public Boundedness getBoundedness() {
+		return source.getBoundedness();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.transformations;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
@@ -29,6 +30,8 @@ import org.apache.flink.streaming.api.operators.StreamSource;
 
 import java.util.Collection;
 import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * This represents a Source. This does not actually transform anything since it has no inputs but
@@ -40,6 +43,8 @@ import java.util.Collections;
 public class LegacySourceTransformation<T> extends PhysicalTransformation<T> {
 
 	private final StreamOperatorFactory<T> operatorFactory;
+
+	private final Boundedness boundedness;
 
 	/**
 	 * Creates a new {@code LegacySourceTransformation} from the given operator.
@@ -53,17 +58,24 @@ public class LegacySourceTransformation<T> extends PhysicalTransformation<T> {
 			String name,
 			StreamSource<T, ?> operator,
 			TypeInformation<T> outputType,
-			int parallelism) {
-		this(name, SimpleOperatorFactory.of(operator), outputType, parallelism);
+			int parallelism,
+			Boundedness boundedness) {
+		this(name, SimpleOperatorFactory.of(operator), outputType, parallelism, boundedness);
 	}
 
 	public LegacySourceTransformation(
 			String name,
 			StreamOperatorFactory<T> operatorFactory,
 			TypeInformation<T> outputType,
-			int parallelism) {
+			int parallelism,
+			Boundedness boundedness) {
 		super(name, outputType, parallelism);
-		this.operatorFactory = operatorFactory;
+		this.operatorFactory = checkNotNull(operatorFactory);
+		this.boundedness = checkNotNull(boundedness);
+	}
+
+	public Boundedness getBoundedness() {
+		return boundedness;
 	}
 
 	@VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
@@ -40,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of the elements that this source produces
  */
 @Internal
-public class LegacySourceTransformation<T> extends PhysicalTransformation<T> {
+public class LegacySourceTransformation<T> extends PhysicalTransformation<T> implements WithBoundedness {
 
 	private final StreamOperatorFactory<T> operatorFactory;
 
@@ -74,6 +74,7 @@ public class LegacySourceTransformation<T> extends PhysicalTransformation<T> {
 		this.boundedness = checkNotNull(boundedness);
 	}
 
+	@Override
 	public Boundedness getBoundedness() {
 		return boundedness;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.transformations;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -33,7 +34,7 @@ import java.util.Collections;
  * A {@link PhysicalTransformation} for {@link Source}.
  */
 @Internal
-public class SourceTransformation<OUT> extends PhysicalTransformation<OUT> {
+public class SourceTransformation<OUT> extends PhysicalTransformation<OUT> implements WithBoundedness {
 	private final SourceOperatorFactory<OUT> sourceFactory;
 	/**
 	 * Creates a new {@code Transformation} with the given name, output type and parallelism.
@@ -50,6 +51,11 @@ public class SourceTransformation<OUT> extends PhysicalTransformation<OUT> {
 			int parallelism) {
 		super(name, outputType, parallelism);
 		this.sourceFactory = sourceFactory;
+	}
+
+	@Override
+	public Boundedness getBoundedness() {
+		return sourceFactory.getBoundedness();
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/WithBoundedness.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/WithBoundedness.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.Boundedness;
+
+/**
+ * An interface to be implemented by transformations that have explicitly set {@link Boundedness}.
+ */
+@Internal
+public interface WithBoundedness {
+
+	/**
+	 * Returns the {@link Boundedness} of this {@link org.apache.flink.api.dag.Transformation Transformation}.
+	 */
+	Boundedness getBoundedness();
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
@@ -46,7 +46,7 @@ public class DataStreamSourceTest {
 			"TestingSource");
 		stream.setParallelism(expectParallelism);
 
-		assertEquals(expectIsParallel, stream.isParallel);
+		assertEquals(expectIsParallel, stream.isParallel());
 
 		assertEquals(expectParallelism, stream.getParallelism());
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.mocks.MockSource;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.streaming.api.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the detection of the {@link RuntimeExecutionMode runtime execution mode} during
+ * stream graph translation.
+ */
+public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
+
+	@Test
+	public void testDetectionThroughTransitivePredecessors() {
+		final SourceTransformation<Integer> bounded =
+				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
+		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
+
+		final SourceTransformation<Integer> unbounded = getSourceTransformation(
+				"Unbounded Source", Boundedness.CONTINUOUS_UNBOUNDED);
+		assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, unbounded.getBoundedness());
+
+		final TwoInputTransformation<Integer, Integer, Integer> resultTransform = new TwoInputTransformation<>(
+				bounded,
+				unbounded,
+				"Test Two Input Transformation",
+				SimpleOperatorFactory.of(new StreamGraphGeneratorTest.OutputTypeConfigurableOperationWithTwoInputs()),
+				BasicTypeInfo.INT_TYPE_INFO,
+				1);
+
+		final StreamGraph graph = generateStreamGraph(RuntimeExecutionMode.AUTOMATIC, resultTransform);
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, graph.getGlobalDataExchangeMode());
+		assertEquals(ScheduleMode.EAGER, graph.getScheduleMode());
+		assertTrue(graph.isAllVerticesInSameSlotSharingGroupByDefault());
+	}
+
+	@Test
+	public void testBoundedDetection() {
+		final SourceTransformation<Integer> bounded =
+				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
+		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
+
+		final StreamGraph graph = generateStreamGraph(RuntimeExecutionMode.AUTOMATIC, bounded);
+		assertEquals(GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED, graph.getGlobalDataExchangeMode());
+		assertEquals(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST, graph.getScheduleMode());
+		assertFalse(graph.isAllVerticesInSameSlotSharingGroupByDefault());
+	}
+
+	@Test
+	public void testUnboundedDetection() {
+		final SourceTransformation<Integer> unbounded =
+				getSourceTransformation("Unbounded Source", Boundedness.CONTINUOUS_UNBOUNDED);
+		assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, unbounded.getBoundedness());
+
+		final StreamGraph graph = generateStreamGraph(RuntimeExecutionMode.AUTOMATIC, unbounded);
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, graph.getGlobalDataExchangeMode());
+		assertEquals(ScheduleMode.EAGER, graph.getScheduleMode());
+		assertTrue(graph.isAllVerticesInSameSlotSharingGroupByDefault());
+	}
+
+	@Test
+	public void testMixedDetection() {
+		final SourceTransformation<Integer> unbounded =
+				getSourceTransformation("Unbounded Source", Boundedness.CONTINUOUS_UNBOUNDED);
+		assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, unbounded.getBoundedness());
+
+		final SourceTransformation<Integer> bounded =
+				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
+		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
+
+		final StreamGraph graph = generateStreamGraph(RuntimeExecutionMode.AUTOMATIC, unbounded);
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, graph.getGlobalDataExchangeMode());
+		assertEquals(ScheduleMode.EAGER, graph.getScheduleMode());
+		assertTrue(graph.isAllVerticesInSameSlotSharingGroupByDefault());
+	}
+
+	@Test
+	public void testExplicitOverridesDetectedMode() {
+		final SourceTransformation<Integer> bounded =
+				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
+		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
+
+		final StreamGraph graph = generateStreamGraph(RuntimeExecutionMode.AUTOMATIC, bounded);
+		assertEquals(GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED, graph.getGlobalDataExchangeMode());
+		assertEquals(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST, graph.getScheduleMode());
+		assertFalse(graph.isAllVerticesInSameSlotSharingGroupByDefault());
+
+		final StreamGraph streamingGraph = generateStreamGraph(RuntimeExecutionMode.STREAMING, bounded);
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, streamingGraph.getGlobalDataExchangeMode());
+		assertEquals(ScheduleMode.EAGER, streamingGraph.getScheduleMode());
+		assertTrue(streamingGraph.isAllVerticesInSameSlotSharingGroupByDefault());
+	}
+
+	private StreamGraph generateStreamGraph(
+			final RuntimeExecutionMode initMode,
+			final Transformation<?>... transformations) {
+
+		final List<Transformation<?>> registeredTransformations = new ArrayList<>();
+		Collections.addAll(registeredTransformations, transformations);
+
+		StreamGraphGenerator streamGraphGenerator =
+				new StreamGraphGenerator(
+						registeredTransformations,
+						new ExecutionConfig(),
+						new CheckpointConfig());
+		streamGraphGenerator.setRuntimeExecutionMode(initMode);
+		return streamGraphGenerator.generate();
+	}
+
+	private SourceTransformation<Integer> getSourceTransformation(
+			final String name,
+			final Boundedness boundedness) {
+		return new SourceTransformation<>(
+				name,
+				new SourceOperatorFactory<>(new MockSource(boundedness, 100), WatermarkStrategy.noWatermarks()),
+				IntegerTypeInfo.of(Integer.class),
+				1);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -85,9 +85,10 @@ public class StreamGraphGeneratorTest extends TestLogger {
 	@Test
 	public void generatorForwardsSavepointRestoreSettings() {
 		StreamGraphGenerator streamGraphGenerator =
-				new StreamGraphGenerator(Collections.emptyList(),
-				new ExecutionConfig(),
-				new CheckpointConfig());
+				new StreamGraphGenerator(
+					Collections.emptyList(),
+					new ExecutionConfig(),
+					new CheckpointConfig());
 
 		streamGraphGenerator.setSavepointRestoreSettings(SavepointRestoreSettings.forPath("hello"));
 
@@ -468,7 +469,9 @@ public class StreamGraphGeneratorTest extends TestLogger {
 
 		// all stream nodes share default group by default
 		StreamGraph streamGraph = new StreamGraphGenerator(
-				transformations, env.getConfig(), env.getCheckpointConfig())
+				transformations,
+				env.getConfig(),
+				env.getCheckpointConfig())
 			.generate();
 
 		Collection<StreamNode> streamNodes = streamGraph.getStreamNodes();
@@ -495,7 +498,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
 		}
 	}
 
-	private static class OutputTypeConfigurableOperationWithTwoInputs
+	static class OutputTypeConfigurableOperationWithTwoInputs
 			extends AbstractStreamOperator<Integer>
 			implements TwoInputStreamOperator<Integer, Integer, Integer>, OutputTypeConfigurable<Integer> {
 		private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -686,26 +686,13 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		// use eager schedule mode by default
-		StreamGraph streamGraph = new StreamGraphGenerator(Collections.emptyList(),
-			env.getConfig(), env.getCheckpointConfig())
+		StreamGraph streamGraph = new StreamGraphGenerator(
+				Collections.emptyList(),
+				env.getConfig(),
+				env.getCheckpointConfig())
 			.generate();
 		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 		assertEquals(ScheduleMode.EAGER, jobGraph.getScheduleMode());
-	}
-
-	/**
-	 * Test schedule mode is configurable or not.
-	 */
-	@Test
-	public void testSetScheduleMode() {
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-
-		StreamGraph streamGraph = new StreamGraphGenerator(Collections.emptyList(),
-			env.getConfig(), env.getCheckpointConfig())
-			.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES)
-			.generate();
-		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
-		assertEquals(ScheduleMode.LAZY_FROM_SOURCES, jobGraph.getScheduleMode());
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/BatchExecutorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.delegation;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
@@ -59,7 +60,8 @@ public class BatchExecutorTest extends TestLogger {
 				}
 			}),
 			BasicTypeInfo.STRING_TYPE_INFO,
-			1);
+			1,
+			Boundedness.BOUNDED);
 		Pipeline pipeline = batchExecutor.createPipeline(
 			Collections.singletonList(testTransform), new TableConfig(), "Test Job");
 		streamGraph = (StreamGraph) pipeline;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/executor/StreamExecutor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/executor/StreamExecutor.java
@@ -51,7 +51,9 @@ public class StreamExecutor implements Executor {
 			throw new IllegalStateException("No operators defined in streaming topology. Cannot generate StreamGraph.");
 		}
 		return new StreamGraphGenerator(
-			transformations, executionEnvironment.getConfig(), executionEnvironment.getCheckpointConfig())
+				transformations,
+				executionEnvironment.getConfig(),
+				executionEnvironment.getCheckpointConfig())
 			.setStateBackend(executionEnvironment.getStateBackend())
 			.setChaining(executionEnvironment.isChainingEnabled())
 			.setUserArtifacts(executionEnvironment.getCachedFiles())


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the `execution.runtime-mode`, as described in FLIP-134, without exposing it yet to the user. 

For now, we set the mode globally at the `StreamGraphGenerator`. An alternative would be to set it at each `Transformation` individually based on its predecessors. We went with the global option because, at least for now, we will schedule the whole graph either in STREAMING or in BATCH mode so the setting has to be global. In the future, if we consider mixed graphs where subgraphs are scheduled in BATCH mode and others in STREAMING, then we could consider setting the mode on each transformation individually.

In addition, this PR sets the `Boundedness` of some Legacy sources to BOUNDED (e.g. `env.fromCollection()`). If this were to be combined with runtime.execution-mode set to AUTOMATIC, it would change the already exposed semantics. Given that we do not want that, we have set the default runtime.execution-mode to STREAMING so that the Boundedness is ignored and the exposed semantics are the same as before.

## Brief change log

The main additions are:

1. the logic in the `StreamGraphGenerator.determineExecutionMode()`, which determines the `execution.runtime-mode` based on either an explicit setting, or by looking at the `Boundedness` of the sources of the pipeline and

2. the setting of Boundedness for some of the source in the `StreamExecutionEnvironment`.

## Verifying this change

Add the `StreamGraphGeneratorRuntimeExecutionModeDetection` class with the relevant tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
