### PR TITLE
[FLINK-19445][hbase] Fix guava version conflict in Hbase 1.4 test

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-connector-hbase-1.4/pom.xml
@@ -193,6 +193,10 @@ under the License.
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-auth</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
## What is the purpose of the change

Fix guava version conflict for hbase 1.4 tests

## Brief change log

Exclude transitive guava dependency from hbase-server dep


## Verifying this change

```
mvn install -Dhadoop.version=3.1.3
mvn install -Dhadoop.version=2.4.1
```
