### PR TITLE
 [FLINK-13095][state-processor-api] Introduce window bootstrap writer for writing window operator state

### DIFF
--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -350,8 +350,8 @@ Along with reading registered state values, each key has access to a `Context` w
 The state processor api supports reading state from a [window operator]({{ site.baseurl }}/dev/stream/operators/windows.html).
 When reading a window state, users specify the operator id, window assigner, and aggregation type.
 
-Additionally, a `WindowReaderFunction` can be specified to enrich each read with additional information similiar to 
-a `WindowFunction` or `ProcessWindowFunction`.
+Additionally, a `WindowReaderFunction` can be specified to enrich each read with additional information similar
+to a `WindowFunction` or `ProcessWindowFunction`.
 
 Suppose a DataStream application that counts the number of clicks per user per minute.
 
@@ -508,6 +508,9 @@ savepoint
 {% endhighlight %}
 </div>
 </div>
+
+Additionally, trigger state - from `CountTrigger`s or custom triggers - can be read using the method
+`Context#triggerState` inside the `WindowReaderFunction`.
 
 ## Writing New Savepoints
 
@@ -739,6 +742,56 @@ The timers will not fire inside the bootstrap function and only become active on
 If a processing time timer is set but the state is not restored until after that time has passed, the timer will fire immediately upon start.
 
 <span class="label label-danger">Attention</span> If your bootstrap function creates timers, the state can only be restored using one of the [process]({{ site.baseurl }}/dev/stream/operators/process_function.html) type functions.
+
+### Window State
+
+The state processor api supports writing state for the [window operator]({{ site.baseurl }}/dev/stream/operators/windows.html).
+When writing window state, users specify the operator id, window assigner, evictor, optional trigger, and aggregation type.
+It is important the configurations on the bootstrap transformation match the configurations on the DataStream window.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+public class Account {
+    public int id;
+
+    public double amount;	
+
+    public long timestamp;
+}
+ 
+ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+
+DataSet<Account> accountDataSet = bEnv.fromCollection(accounts);
+
+BootstrapTransformation<Account> transformation = OperatorTransformation
+    .bootstrapWith(accountDataSet)
+    // When using event time windows, it is important
+    // to assign timestamps to each record.
+    .assignTimestamps(account -> account.timestamp)
+    .keyBy(acc -> acc.id)
+    .window(TumblingEventTimeWindows.of(Time.minutes(5)))
+    .reduce((left, right) -> left + right);
+{% endhighlight %}
+</div>
+<div data-lang="java" markdown="1">
+{% highlight scala %}
+case class Account(id: Int, amount: Double, timestamp: Long)
+ 
+val bEnv = ExecutionEnvironment.getExecutionEnvironment();
+val accountDataSet = bEnv.fromCollection(accounts);
+
+val transformation = OperatorTransformation
+    .bootstrapWith(accountDataSet)
+    // When using event time windows, its important
+    // to assign timestamps to each record.
+    .assignTimestamps(account => account.timestamp)
+    .keyBy(acc => acc.id)
+    .window(TumblingEventTimeWindows.of(Time.minutes(5)))
+    .reduce((left, right) => left + right)
+{% endhighlight %}
+</div>
+</div>
 
 ## Modifying Savepoints
 

--- a/docs/dev/libs/state_processor_api.md
+++ b/docs/dev/libs/state_processor_api.md
@@ -509,8 +509,6 @@ savepoint
 </div>
 </div>
 
-{% panel **Note:** Reading state written by a Trigger is not currently supported. %}
-
 ## Writing New Savepoints
 
 `Savepoint`'s may also be written, which allows such use cases as bootstrapping state based on historical data.

--- a/docs/dev/libs/state_processor_api.zh.md
+++ b/docs/dev/libs/state_processor_api.zh.md
@@ -246,26 +246,24 @@ public class StatefulFunctionWithTime extends KeyedProcessFunction<Integer, Inte
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-class StatefulFunctionWithTime extends KeyedProcessFunction[Integer, Integer, Void] {
- 
-   var state: ValueState[Integer] = _
- 
-   var updateTimes: ListState[Long] = _ 
+class StatefulFunctionWithTime extends KeyedProcessFunction[Int, Int, Void] {
+  var state: ValueState[Int] = _
+  var updateTimes: ListState[Long] = _
 
-   @throws[Exception]
-   override def open(parameters: Configuration): Unit = {
-      val stateDescriptor = new ValueStateDescriptor("state", Types.INT)
-      state = getRuntimeContext().getState(stateDescriptor)
+  @throws[Exception]
+  override def open(parameters: Configuration): Unit = {
+    val stateDescriptor = new ValueStateDescriptor("state", createTypeInformation[Int])
+    state = getRuntimeContext().getState(stateDescriptor)
 
-      val updateDescriptor = new ListStateDescriptor("times", Types.LONG)
-      updateTimes = getRuntimeContext().getListState(updateDescriptor)
-   }
- 
-   @throws[Exception]
-   override def processElement(value: Integer, ctx: KeyedProcessFunction[ Integer, Integer, Void ]#Context, out: Collector[Void]): Unit = {
-      state.update(value + 1)
-      updateTimes.add(System.currentTimeMillis)
-   }
+    val updateDescriptor = new ListStateDescriptor("times", createTypeInformation[Long])
+    updateTimes = getRuntimeContext().getListState(updateDescriptor)
+  }
+
+  @throws[Exception]
+  override def processElement(value: Int, ctx: KeyedProcessFunction[Int, Int, Void]#Context, out: Collector[Void]): Unit = {
+    state.update(value + 1)
+    updateTimes.add(System.currentTimeMillis)
+  }
 }
 {% endhighlight %}
 </div>
@@ -321,34 +319,22 @@ public class ReaderFunction extends KeyedStateReaderFunction<Integer, KeyedState
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-val keyedState = savepoint.readKeyedState("my-uid", new ReaderFunction)
-
-case class KeyedState(key: Int, value: Int, times: List[Long])
- 
-class ReaderFunction extends KeyedStateReaderFunction[Integer, KeyedState] {
- 
-  var state: ValueState[Integer] = _
-
+class ReaderFunction extends KeyedStateReaderFunction[Int, KeyedState] {
+  var state: ValueState[Int] = _
   var updateTimes: ListState[Long] = _
- 
+
   @throws[Exception]
   override def open(parameters: Configuration): Unit = {
-     val stateDescriptor = new ValueStateDescriptor("state", Types.INT)
-     state = getRuntimeContext().getState(stateDescriptor)
+    val stateDescriptor = new ValueStateDescriptor("state", createTypeInformation[Int])
+    state = getRuntimeContext().getState(stateDescriptor)
 
-      val updateDescriptor = new ListStateDescriptor("times", Types.LONG)
-      updateTimes = getRuntimeContext().getListState(updateDescriptor)
-    }
- 
+    val updateDescriptor = new ListStateDescriptor("times", createTypeInformation[Long])
+    updateTimes = getRuntimeContext().getListState(updateDescriptor)
+  }
 
-  @throws[Exception]
-  override def processKey(
-    key: Int,
-    ctx: Context,
-    out: Collector[Keyedstate]): Unit = {
- 
-     val data = KeyedState(key, state.value(), updateTimes.get.asScala.toList)
-     out.collect(data)
+  override def readKey(key: Int, ctx: KeyedStateReaderFunction.Context, out: Collector[KeyedState]): Unit = {
+    val data = KeyedState(key, state.value, updateTimes.get.asScala.toList)
+    out.collect(data)
   }
 }
 {% endhighlight %}
@@ -364,8 +350,8 @@ Along with reading registered state values, each key has access to a `Context` w
 The state processor api supports reading state from a [window operator]({{ site.baseurl }}/dev/stream/operators/windows.html).
 When reading a window state, users specify the operator id, window assigner, and aggregation type.
 
-Additionally, a `WindowReaderFunction` can be specified to enrich each read with additional information similiar to 
-a `WindowFunction` or `ProcessWindowFunction`.
+Additionally, a `WindowReaderFunction` can be specified to enrich each read with additional information similar
+to a `WindowFunction` or `ProcessWindowFunction`.
 
 Suppose a DataStream application that counts the number of clicks per user per minute.
 
@@ -522,6 +508,9 @@ savepoint
 {% endhighlight %}
 </div>
 </div>
+
+Additionally, trigger state - from `CountTrigger`s or custom triggers - can be read using the method
+`Context#triggerState` inside the `WindowReaderFunction`.
 
 ## Writing New Savepoints
 
@@ -753,6 +742,56 @@ The timers will not fire inside the bootstrap function and only become active on
 If a processing time timer is set but the state is not restored until after that time has passed, the timer will fire immediately upon start.
 
 <span class="label label-danger">Attention</span> If your bootstrap function creates timers, the state can only be restored using one of the [process]({{ site.baseurl }}/dev/stream/operators/process_function.html) type functions.
+
+### Window State
+
+The state processor api supports writing state for the [window operator]({{ site.baseurl }}/dev/stream/operators/windows.html).
+When writing window state, users specify the operator id, window assigner, evictor, optional trigger, and aggregation type.
+It is important the configurations on the bootstrap transformation match the configurations on the DataStream window.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+public class Account {
+    public int id;
+
+    public double amount;	
+
+    public long timestamp;
+}
+ 
+ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+
+DataSet<Account> accountDataSet = bEnv.fromCollection(accounts);
+
+BootstrapTransformation<Account> transformation = OperatorTransformation
+    .bootstrapWith(accountDataSet)
+    // When using event time windows, it is important
+    // to assign timestamps to each record.
+    .assignTimestamps(account -> account.timestamp)
+    .keyBy(acc -> acc.id)
+    .window(TumblingEventTimeWindows.of(Time.minutes(5)))
+    .reduce((left, right) -> left + right);
+{% endhighlight %}
+</div>
+<div data-lang="java" markdown="1">
+{% highlight scala %}
+case class Account(id: Int, amount: Double, timestamp: Long)
+ 
+val bEnv = ExecutionEnvironment.getExecutionEnvironment();
+val accountDataSet = bEnv.fromCollection(accounts);
+
+val transformation = OperatorTransformation
+    .bootstrapWith(accountDataSet)
+    // When using event time windows, its important
+    // to assign timestamps to each record.
+    .assignTimestamps(account => account.timestamp)
+    .keyBy(acc => acc.id)
+    .window(TumblingEventTimeWindows.of(Time.minutes(5)))
+    .reduce((left, right) => left + right)
+{% endhighlight %}
+</div>
+</div>
 
 ## Modifying Savepoints
 

--- a/docs/dev/libs/state_processor_api.zh.md
+++ b/docs/dev/libs/state_processor_api.zh.md
@@ -523,8 +523,6 @@ savepoint
 </div>
 </div>
 
-{% panel **Note:** Reading state written by a Trigger is not currently supported. %}
-
 ## Writing New Savepoints
 
 `Savepoint`'s may also be written, which allows such use cases as bootstrapping state based on historical data.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
@@ -32,6 +32,7 @@ import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.state.api.functions.Timestamper;
 import org.apache.flink.state.api.output.BoundedOneInputStreamTaskRunner;
 import org.apache.flink.state.api.output.OperatorSubtaskStateReducer;
 import org.apache.flink.state.api.output.TaggedOperatorSubtaskState;
@@ -83,13 +84,18 @@ public class BootstrapTransformation<T> {
 	/** Local max parallelism for the bootstrapped operator. */
 	private final OptionalInt operatorMaxParallelism;
 
+	@Nullable
+	private final Timestamper<T> timestamper;
+
 	BootstrapTransformation(
 		DataSet<T> dataSet,
 		OptionalInt operatorMaxParallelism,
+		@Nullable Timestamper<T> timestamper,
 		SavepointWriterOperatorFactory factory) {
 		this.dataSet = dataSet;
 		this.operatorMaxParallelism = operatorMaxParallelism;
 		this.factory = factory;
+		this.timestamper = timestamper;
 		this.originalKeySelector = null;
 		this.hashKeySelector = null;
 		this.keyType = null;
@@ -98,12 +104,14 @@ public class BootstrapTransformation<T> {
 	<K> BootstrapTransformation(
 		DataSet<T> dataSet,
 		OptionalInt operatorMaxParallelism,
+		@Nullable Timestamper<T> timestamper,
 		SavepointWriterOperatorFactory factory,
 		@Nonnull KeySelector<T, K> keySelector,
 		@Nonnull TypeInformation<K> keyType) {
 		this.dataSet = dataSet;
 		this.operatorMaxParallelism = operatorMaxParallelism;
 		this.factory = factory;
+		this.timestamper = timestamper;
 		this.originalKeySelector = keySelector;
 		this.hashKeySelector = new HashSelector<>(keySelector);
 		this.keyType = keyType;
@@ -157,7 +165,8 @@ public class BootstrapTransformation<T> {
 
 		BoundedOneInputStreamTaskRunner<T> operatorRunner = new BoundedOneInputStreamTaskRunner<>(
 			config,
-			localMaxParallelism);
+			localMaxParallelism,
+			timestamper);
 
 		MapPartitionOperator<T, TaggedOperatorSubtaskState> subtaskStates = input
 			.mapPartition(operatorRunner)

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/KeyedOperatorTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/KeyedOperatorTransformation.java
@@ -23,7 +23,12 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction;
+import org.apache.flink.state.api.functions.Timestamper;
 import org.apache.flink.state.api.output.operators.KeyedStateBootstrapOperator;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+
+import javax.annotation.Nullable;
 
 import java.util.OptionalInt;
 
@@ -44,6 +49,9 @@ public class KeyedOperatorTransformation<K, T> {
 	/** Local max parallelism for the bootstrapped operator. */
 	private final OptionalInt operatorMaxParallelism;
 
+	@Nullable
+	private final Timestamper<T> timestamper;
+
 	/** Partitioner for the bootstrapping data set. */
 	private final KeySelector<T, K> keySelector;
 
@@ -53,10 +61,12 @@ public class KeyedOperatorTransformation<K, T> {
 	KeyedOperatorTransformation(
 		DataSet<T> dataSet,
 		OptionalInt operatorMaxParallelism,
+		@Nullable Timestamper<T> timestamper,
 		KeySelector<T, K> keySelector,
 		TypeInformation<K> keyType) {
 		this.dataSet = dataSet;
 		this.operatorMaxParallelism = operatorMaxParallelism;
+		this.timestamper = timestamper;
 		this.keySelector = keySelector;
 		this.keyType = keyType;
 	}
@@ -85,7 +95,21 @@ public class KeyedOperatorTransformation<K, T> {
 	 * @return An {@link BootstrapTransformation} that can be added to a {@link Savepoint}.
 	 */
 	public BootstrapTransformation<T> transform(SavepointWriterOperatorFactory factory) {
-		return new BootstrapTransformation<>(dataSet, operatorMaxParallelism, factory, keySelector, keyType);
+		return new BootstrapTransformation<>(dataSet, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	/**
+	 * Windows this transformation into a {@code WindowedOperatorTransformation}, which bootstraps state
+	 * that can be restored by a {@code WindowOperator}. Elements are put into windows by a {@link WindowAssigner}.
+	 * The grouping of elements is done both by key and by window.
+	 *
+	 * <p>A {@link org.apache.flink.streaming.api.windowing.triggers.Trigger} can be defined to
+	 * specify when windows are evaluated. However, {@code WindowAssigners} have a default
+	 * {@code Trigger} that is used if a {@code Trigger} is not specified.
+	 *
+	 * @param assigner The {@code WindowAssigner} that assigns elements to windows.
+	 */
+	public <W extends Window> WindowedOperatorTransformation<T, K, W> window(WindowAssigner<? super T, W> assigner) {
+		return new WindowedOperatorTransformation<>(dataSet, operatorMaxParallelism, timestamper, keySelector, keyType, assigner);
 	}
 }
-

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedOperatorTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedOperatorTransformation.java
@@ -1,0 +1,464 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.state.api.functions.Timestamper;
+import org.apache.flink.state.api.output.operators.StateBootstrapWrapperOperator;
+import org.apache.flink.streaming.api.functions.windowing.PassThroughWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator;
+import org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorBuilder;
+
+import javax.annotation.Nullable;
+
+import java.util.OptionalInt;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link WindowedOperatorTransformation} represents a {@link OneInputOperatorTransformation} for bootstrapping
+ * window state.
+ *
+ * @param <K> The type of the key in the window.
+ * @param <T> The type of the elements in the window.
+ * @param <W> The type of the window.
+ */
+@PublicEvolving
+public class WindowedOperatorTransformation<T, K, W extends Window> {
+
+	private final DataSet<T> input;
+
+	private final WindowOperatorBuilder<T, K, W> builder;
+
+	private final OptionalInt operatorMaxParallelism;
+
+	@Nullable
+	private final Timestamper<T> timestamper;
+
+	private final KeySelector<T, K> keySelector;
+
+	private final TypeInformation<K> keyType;
+
+	WindowedOperatorTransformation(
+		DataSet<T> input,
+		OptionalInt operatorMaxParallelism,
+		@Nullable Timestamper<T> timestamper,
+		KeySelector<T, K> keySelector,
+		TypeInformation<K> keyType,
+		WindowAssigner<? super T, W> windowAssigner) {
+		this.input = input;
+		this.operatorMaxParallelism = operatorMaxParallelism;
+		this.timestamper = timestamper;
+		this.keySelector = keySelector;
+		this.keyType = keyType;
+
+		this.builder = new WindowOperatorBuilder<>(
+			windowAssigner,
+			windowAssigner.getDefaultTrigger(null),
+			input.getExecutionEnvironment().getConfig(),
+			input.getType(),
+			keySelector,
+			keyType);
+	}
+
+	/**
+	 * Sets the {@code Trigger} that should be used to trigger window emission.
+	 */
+	@PublicEvolving
+	public WindowedOperatorTransformation<T, K, W> trigger(Trigger<? super T, ? super W> trigger) {
+		builder.trigger(trigger);
+		return this;
+	}
+
+	/**
+	 * Sets the {@code Evictor} that should be used to evict elements from a window before emission.
+	 *
+	 * <p>Note: When using an evictor window performance will degrade significantly, since
+	 * incremental aggregation of window results cannot be used.
+	 */
+	@PublicEvolving
+	public WindowedOperatorTransformation<T, K, W> evictor(Evictor<? super T, ? super W> evictor) {
+		builder.evictor(evictor);
+		return this;
+	}
+
+
+	// ------------------------------------------------------------------------
+	//  Operations on the keyed windows
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies a reduce function to the window. The window function is called for each evaluation
+	 * of the window for each key individually. The output of the reduce function is interpreted
+	 * as a regular non-windowed stream.
+	 *
+	 * <p>This window will try and incrementally aggregate data as much as the window policies
+	 * permit. For example, tumbling time windows can aggregate the data, meaning that only one
+	 * element per key is stored. Sliding time windows will aggregate on the granularity of the
+	 * slide interval, so a few elements are stored per key (one per slide interval).
+	 * Custom windows may not be able to incrementally aggregate, or may need to store extra values
+	 * in an aggregation tree.
+	 *
+	 * @param function The reduce function.
+	 * @return The data stream that is the result of applying the reduce function to the window.
+	 */
+	@SuppressWarnings("unchecked")
+	public BootstrapTransformation<T> reduce(ReduceFunction<T> function) {
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of reduce can not be a RichFunction. " +
+				"Please use reduce(ReduceFunction, WindowFunction) instead.");
+		}
+
+		//clean the closure
+		function = input.clean(function);
+		return reduce(function, new PassThroughWindowFunction<>());
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given reducer.
+	 *
+	 * @param reduceFunction The reduce function that is used for incremental aggregation.
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	public <R> BootstrapTransformation<T> reduce(
+		ReduceFunction<T> reduceFunction,
+		WindowFunction<T, R, K, W> function) {
+
+		//clean the closures
+		function = input.clean(function);
+		reduceFunction = input.clean(reduceFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given reducer.
+	 *
+	 * @param reduceFunction The reduce function that is used for incremental aggregation.
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	@Internal
+	public <R> BootstrapTransformation<T> reduce(ReduceFunction<T> reduceFunction, ProcessWindowFunction<T, R, K, W> function) {
+		//clean the closures
+		function = input.clean(function);
+		reduceFunction = input.clean(reduceFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Aggregation Function
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies the given aggregation function to each window. The aggregation function is called for
+	 * each element, aggregating values incrementally and keeping the state to one accumulator
+	 * per key and window.
+	 *
+	 * @param function The aggregation function.
+	 * @return The data stream that is the result of applying the fold function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            AggregateFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, R> BootstrapTransformation<T> aggregate(AggregateFunction<T, ACC, R> function) {
+		checkNotNull(function, "function");
+
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
+		}
+
+		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
+			function, input.getType(), null, false);
+
+		return aggregate(function, accumulatorType);
+	}
+
+	/**
+	 * Applies the given aggregation function to each window. The aggregation function is called for
+	 * each element, aggregating values incrementally and keeping the state to one accumulator
+	 * per key and window.
+	 *
+	 * @param function The aggregation function.
+	 * @return The data stream that is the result of applying the aggregation function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            AggregateFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, R> function,
+		TypeInformation<ACC> accumulatorType) {
+
+		checkNotNull(function, "function");
+		checkNotNull(accumulatorType, "accumulatorType");
+
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
+		}
+
+		return aggregate(function, new PassThroughWindowFunction<>(), accumulatorType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggFunction The aggregate function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggFunction,
+		WindowFunction<V, R, K, W> windowFunction) {
+
+		checkNotNull(aggFunction, "aggFunction");
+		checkNotNull(windowFunction, "windowFunction");
+
+		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
+			aggFunction, input.getType(), null, false);
+
+		return aggregate(aggFunction, windowFunction, accumulatorType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggregateFunction The aggregation function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 * @param accumulatorType Type information for the internal accumulator type of the aggregation function
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		WindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		checkNotNull(aggregateFunction, "aggregateFunction");
+		checkNotNull(windowFunction, "windowFunction");
+		checkNotNull(accumulatorType, "accumulatorType");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		//clean the closures
+		windowFunction = input.clean(windowFunction);
+		aggregateFunction = input.clean(aggregateFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggFunction The aggregate function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction) {
+
+		checkNotNull(aggFunction, "aggFunction");
+		checkNotNull(windowFunction, "windowFunction");
+
+		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
+			aggFunction, input.getType(), null, false);
+
+		return aggregate(aggFunction, windowFunction, accumulatorType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggregateFunction The aggregation function that is used for incremental aggregation.
+	 * @param windowFunction The window function.
+	 * @param accumulatorType Type information for the internal accumulator type of the aggregation function
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 * @param <V> The type of AggregateFunction's result, and the WindowFunction's input
+	 * @param <R> The type of the elements in the resulting stream, equal to the
+	 *            WindowFunction's result type
+	 */
+	@PublicEvolving
+	public <ACC, V, R> BootstrapTransformation<T> aggregate(
+		AggregateFunction<T, ACC, V> aggregateFunction,
+		ProcessWindowFunction<V, R, K, W> windowFunction,
+		TypeInformation<ACC> accumulatorType) {
+
+		checkNotNull(aggregateFunction, "aggregateFunction");
+		checkNotNull(windowFunction, "windowFunction");
+		checkNotNull(accumulatorType, "accumulatorType");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		//clean the closures
+		windowFunction = input.clean(windowFunction);
+		aggregateFunction = input.clean(aggregateFunction);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Window Function (apply)
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
+	 * is evaluated, as the function provides no means of incremental aggregation.
+	 *
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	public <R> BootstrapTransformation<T> apply(WindowFunction<T, R, K, W> function) {
+		WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
+	 * is evaluated, as the function provides no means of incremental aggregation.
+	 *
+	 * @param function The window function.
+	 * @param resultType Type information for the result type of the window function
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	public <R> BootstrapTransformation<T> apply(WindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
+		function = input.clean(function);
+
+		WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function is
+	 * interpreted as a regular non-windowed stream.
+	 *
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
+	 * is evaluated, as the function provides no means of incremental aggregation.
+	 *
+	 * @param function The window function.
+	 * @return The data stream that is the result of applying the window function to the window.
+	 */
+	@PublicEvolving
+	public <R> BootstrapTransformation<T> process(ProcessWindowFunction<T, R, K, W> function) {
+		WindowOperator<K, T, ?, R, W> operator = builder.process(function);
+
+		SavepointWriterOperatorFactory factory = (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+		return new BootstrapTransformation<>(input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/Timestamper.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/Timestamper.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.Function;
+
+/**
+ * Assigns an event time timestamp to the given record. This class
+ * does not create watermarks.
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface Timestamper<T> extends Function {
+	long timestamp(T element);
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/WindowReaderFunction.java
@@ -21,6 +21,8 @@ package org.apache.flink.state.api.functions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Collector;
 
@@ -60,6 +62,18 @@ public abstract class WindowReaderFunction<IN, OUT, KEY, W extends Window> exten
 		 * Returns the window that is being evaluated.
 		 */
 		W window();
+
+		/**
+		 * Retrieves a {@link State} object that can be used to interact with
+		 * fault-tolerant state that is scoped to the trigger which corresponds
+		 * to the current window.
+		 *
+		 * @param descriptor The StateDescriptor that contains the name and type of the
+		 *                        state that is being accessed.
+		 * @param <S>             The type of the state.
+		 * @return The partitioned state object.
+		 */
+		<S extends State> S triggerState(StateDescriptor<S, ?> descriptor);
 
 		/**
 		 * State accessor for per-key and per-window state.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/WindowReaderOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/WindowReaderOperator.java
@@ -211,6 +211,15 @@ public class WindowReaderOperator<S extends State, KEY, IN, W extends Window, OU
 		}
 
 		@Override
+		public <TS extends State> TS triggerState(StateDescriptor<TS, ?> descriptor) {
+			try {
+				return getKeyedStateBackend().getPartitionedState(window, namespaceSerializer, descriptor);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not retrieve trigger state", e);
+			}
+		}
+
+		@Override
 		public KeyedStateStore windowState() {
 			perWindowKeyedStateStore.window = window;
 			return perWindowKeyedStateStore;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedOneInputStreamTaskRunner.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedOneInputStreamTaskRunner.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.state.api.functions.Timestamper;
 import org.apache.flink.state.api.runtime.SavepointEnvironment;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.util.Collector;
@@ -45,6 +46,8 @@ public class BoundedOneInputStreamTaskRunner<IN> extends RichMapPartitionFunctio
 
 	private final int maxParallelism;
 
+	private final Timestamper<IN> timestamper;
+
 	private transient SavepointEnvironment env;
 
 	/**
@@ -55,10 +58,12 @@ public class BoundedOneInputStreamTaskRunner<IN> extends RichMapPartitionFunctio
 	 */
 	public BoundedOneInputStreamTaskRunner(
 		StreamConfig streamConfig,
-		int maxParallelism) {
+		int maxParallelism,
+		Timestamper<IN> timestamper) {
 
 		this.streamConfig = streamConfig;
 		this.maxParallelism = maxParallelism;
+		this.timestamper = timestamper;
 	}
 
 	@Override
@@ -73,7 +78,6 @@ public class BoundedOneInputStreamTaskRunner<IN> extends RichMapPartitionFunctio
 
 	@Override
 	public void mapPartition(Iterable<IN> values, Collector<TaggedOperatorSubtaskState> out) throws Exception {
-		new BoundedStreamTask<>(env, values, out).invoke();
+		new BoundedStreamTask<>(env, values, timestamper, out).invoke();
 	}
 }
-

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
@@ -20,6 +20,7 @@ package org.apache.flink.state.api.output;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.state.api.functions.Timestamper;
 import org.apache.flink.state.api.runtime.NeverFireProcessingTimeService;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -55,16 +56,17 @@ class BoundedStreamTask<IN, OUT, OP extends OneInputStreamOperator<IN, OUT> & Bo
 
 	private final Collector<OUT> collector;
 
-	private final StreamRecord<IN> reuse;
+	private final Timestamper<IN> timestamper;
 
 	BoundedStreamTask(
 		Environment environment,
 		Iterable<IN> input,
+		Timestamper<IN> timestamper,
 		Collector<OUT> collector) throws Exception {
 		super(environment, new NeverFireProcessingTimeService());
 		this.input = input.iterator();
 		this.collector = collector;
-		this.reuse = new StreamRecord<>(null);
+		this.timestamper = timestamper;
 	}
 
 	@Override
@@ -89,9 +91,15 @@ class BoundedStreamTask<IN, OUT, OP extends OneInputStreamOperator<IN, OUT> & Bo
 	@Override
 	protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
 		if (input.hasNext()) {
-			reuse.replace(input.next());
-			mainOperator.setKeyContextElement1(reuse);
-			mainOperator.processElement(reuse);
+			StreamRecord<IN> streamRecord = new StreamRecord<>(input.next());
+
+			if (timestamper != null) {
+				long timestamp = timestamper.timestamp(streamRecord.getValue());
+				streamRecord.setTimestamp(timestamp);
+			}
+
+			mainOperator.setKeyContextElement1(streamRecord);
+			mainOperator.processElement(streamRecord);
 		} else {
 			mainOperator.endInput();
 			controller.allActionsCompleted();

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/TimestampAssignerWrapper.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/TimestampAssignerWrapper.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.output;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.state.api.functions.Timestamper;
+import org.apache.flink.streaming.api.functions.TimestampAssigner;
+
+/**
+ * Wraps an existing {@link TimestampAssigner} into a {@link Timestamper}.
+ */
+@Internal
+public class TimestampAssignerWrapper<T> implements Timestamper<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final TimestampAssigner<T> assigner;
+
+	public TimestampAssignerWrapper(TimestampAssigner<T> assigner) {
+		this.assigner = assigner;
+	}
+
+	@Override
+	public long timestamp(T element) {
+		return assigner.extractTimestamp(element, Long.MIN_VALUE);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.output.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.state.api.output.SnapshotUtils;
+import org.apache.flink.state.api.output.TaggedOperatorSubtaskState;
+import org.apache.flink.state.api.runtime.NeverFireProcessingTimeService;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.SetupableStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Wraps an existing operator so it can be bootstrapped.
+ */
+@Internal
+@SuppressWarnings({"unchecked", "deprecation", "rawtypes"})
+public final class StateBootstrapWrapperOperator<IN, OUT, OP extends AbstractStreamOperator<OUT> & OneInputStreamOperator<IN, OUT>>
+	implements OneInputStreamOperator<IN, TaggedOperatorSubtaskState>,
+	SetupableStreamOperator<TaggedOperatorSubtaskState>,
+	BoundedOneInput {
+
+	private static final long serialVersionUID = 1L;
+
+	private final long timestamp;
+
+	private final Path savepointPath;
+
+	private Output<StreamRecord<TaggedOperatorSubtaskState>> output;
+
+	private final OP operator;
+
+	public StateBootstrapWrapperOperator(
+		long timestamp,
+		Path savepointPath,
+		OP operator) {
+
+		this.timestamp = timestamp;
+		this.savepointPath = savepointPath;
+		this.operator = operator;
+	}
+
+	@Override
+	public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<TaggedOperatorSubtaskState>> output) {
+		((SetupableStreamOperator) operator).setup(containingTask, config, new VoidOutput<>());
+		operator.setProcessingTimeService(new NeverFireProcessingTimeService());
+		this.output = output;
+	}
+
+	@Override
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		operator.processElement(element);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		operator.processWatermark(mark);
+	}
+
+	@Override
+	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		operator.processLatencyMarker(latencyMarker);
+	}
+
+	@Override
+	public void open() throws Exception {
+		operator.open();
+	}
+
+	@Override
+	public void close() throws Exception {
+		operator.close();
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		operator.dispose();
+	}
+
+	@Override
+	public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+		operator.prepareSnapshotPreBarrier(checkpointId);
+	}
+
+	@Override
+	public OperatorSnapshotFutures snapshotState(long checkpointId, long timestamp, CheckpointOptions checkpointOptions, CheckpointStreamFactory storageLocation) throws Exception {
+		return operator.snapshotState(checkpointId, timestamp, checkpointOptions, storageLocation);
+	}
+
+	@Override
+	public void initializeState(StreamTaskStateInitializer streamTaskStateManager) throws Exception {
+		operator.initializeState(streamTaskStateManager);
+	}
+
+	@Override
+	public void setKeyContextElement1(StreamRecord<?> record) throws Exception {
+		operator.setKeyContextElement1(record);
+	}
+
+	@Override
+	public void setKeyContextElement2(StreamRecord<?> record) throws Exception {
+		operator.setKeyContextElement2(record);
+	}
+
+	@Override
+	public ChainingStrategy getChainingStrategy() {
+		return operator.getChainingStrategy();
+	}
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		operator.setChainingStrategy(strategy);
+	}
+
+	@Override
+	public MetricGroup getMetricGroup() {
+		return operator.getMetricGroup();
+	}
+
+	@Override
+	public OperatorID getOperatorID() {
+		return operator.getOperatorID();
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		operator.notifyCheckpointComplete(checkpointId);
+	}
+
+	@Override
+	public void setCurrentKey(Object key) {
+		operator.setCurrentKey(key);
+	}
+
+	@Override
+	public Object getCurrentKey() {
+		return operator.getCurrentKey();
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		TaggedOperatorSubtaskState state = SnapshotUtils.snapshot(
+			this,
+			operator.getContainingTask().getEnvironment().getTaskInfo().getIndexOfThisSubtask(),
+			timestamp,
+			operator.getContainingTask().getConfiguration().isExactlyOnceCheckpointMode(),
+			operator.getContainingTask().getConfiguration().isUnalignedCheckpointsEnabled(),
+			operator.getContainingTask().getCheckpointStorage(),
+			savepointPath);
+
+		output.collect(new StreamRecord<>(state));
+	}
+
+	private static class VoidOutput<T> implements Output<T> {
+
+		@Override
+		public void emitWatermark(Watermark mark) {
+		}
+
+		@Override
+		public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		}
+
+		@Override
+		public void collect(T record) {
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWindowReaderITCase.java
@@ -335,7 +335,6 @@ public abstract class SavepointWindowReaderITCase<B extends StateBackend> extend
 	public void testWindowTriggerStateReader() throws Exception {
 		String savepointPath = takeSavepoint(numbers, source -> {
 			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.setStateBackend(getStateBackend());
 			env.setParallelism(4);
 

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
@@ -197,7 +197,6 @@ public class SavepointWriterITCase extends AbstractTestBase {
 		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		sEnv.setStateBackend(backend);
 
-
 		DataStream<Account> stream = sEnv.fromCollection(accounts)
 			.keyBy(acc -> acc.id)
 			.flatMap(new UpdateAndGetAccount())

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.state.api.utils.MaxWatermarkSource;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.datastream.WindowedStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.evictors.CountEvictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.util.StreamCollector;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.SerializedThrowable;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * IT Test for writing savepoints to the {@code WindowOperator}.
+ */
+@SuppressWarnings("unchecked")
+@RunWith(Parameterized.class)
+public class SavepointWriterWindowITCase extends AbstractTestBase {
+
+	private static final String UID = "uid";
+
+	private static final Collection<String> WORDS = Arrays.asList("hello", "world", "hello", "everyone");
+
+	private static final Matcher<Iterable<? extends Tuple2<String, Integer>>> STANDARD_MATCHER = Matchers.containsInAnyOrder(
+		Tuple2.of("hello", 2),
+		Tuple2.of("world", 1),
+		Tuple2.of("everyone", 1));
+
+	private static final Matcher<Iterable<? extends Tuple2<String, Integer>>> EVICTOR_MATCHER = Matchers.containsInAnyOrder(
+		Tuple2.of("hello", 1),
+		Tuple2.of("world", 1),
+		Tuple2.of("everyone", 1));
+
+	private static final TypeInformation<Tuple2<String, Integer>> TUPLE_TYPE_INFO = new TypeHint<Tuple2<String, Integer>>() {}.getTypeInfo();
+
+	private static final List<Tuple3<String, WindowBootstrap, WindowStream>> SETUP_FUNCTIONS = Arrays.asList(
+		Tuple3.of(
+			"reduce",
+			transformation -> transformation.reduce(new Reducer()),
+			stream -> stream.reduce(new Reducer())),
+		Tuple3.of(
+			"aggregate",
+			transformation -> transformation.aggregate(new Aggregator()),
+			stream -> stream.aggregate(new Aggregator())),
+		Tuple3.of(
+			"apply",
+			transformation -> transformation.apply(new CustomWindowFunction()),
+			stream -> stream.apply(new CustomWindowFunction())),
+		Tuple3.of(
+			"process",
+			transformation -> transformation.process(new CustomProcessWindowFunction()),
+			stream -> stream.process(new CustomProcessWindowFunction())));
+
+	private static final List<Tuple2<String, StateBackend>> STATE_BACKENDS = Arrays.asList(
+		Tuple2.of(
+			"MemoryStateBackend",
+			new MemoryStateBackend()),
+		Tuple2.of(
+			"RocksDB",
+			new RocksDBStateBackend((StateBackend) new MemoryStateBackend())));
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> data() {
+		List<Object[]> parameterList = new ArrayList<>();
+		for (Tuple2<String, StateBackend> stateBackend : STATE_BACKENDS) {
+			for (Tuple3<String, WindowBootstrap, WindowStream> setup : SETUP_FUNCTIONS) {
+				Object[] parameters = new Object[] {
+					stateBackend.f0 + ": " + setup.f0,
+					setup.f1,
+					setup.f2,
+					stateBackend.f1
+				};
+				parameterList.add(parameters);
+			}
+		}
+
+		return parameterList;
+	}
+
+	@Rule
+	public StreamCollector collector = new StreamCollector();
+
+	private final WindowBootstrap windowBootstrap;
+
+	private final WindowStream windowStream;
+
+	private final StateBackend stateBackend;
+
+	@SuppressWarnings("unused")
+	public SavepointWriterWindowITCase(String ignore, WindowBootstrap windowBootstrap, WindowStream windowStream, StateBackend stateBackend) {
+		this.windowBootstrap = windowBootstrap;
+		this.windowStream = windowStream;
+		this.stateBackend = stateBackend;
+	}
+
+	@Test
+	public void testTumbleWindow() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(5)));
+
+		Savepoint
+			.create(stateBackend, 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		sEnv.setStateBackend(stateBackend);
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<Tuple2<String, Integer>>())
+			.returns(TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(5)));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertThat("Incorrect results from bootstrapped windows", results, STANDARD_MATCHER);
+	}
+
+	@Test
+	public void testTumbleWindowWithEvictor() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(5)))
+			.evictor(CountEvictor.of(1));
+
+		Savepoint
+			.create(new MemoryStateBackend(), 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<>(), TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.window(TumblingEventTimeWindows.of(Time.milliseconds(5)))
+			.evictor(CountEvictor.of(1));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertThat("Incorrect results from bootstrapped windows", results, EVICTOR_MATCHER);
+	}
+
+	@Test
+	public void testSlideWindow() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.window(SlidingEventTimeWindows.of(Time.milliseconds(5), Time.milliseconds(1)));
+
+		Savepoint
+			.create(new MemoryStateBackend(), 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<Tuple2<String, Integer>>())
+			.returns(TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.window(SlidingEventTimeWindows.of(Time.milliseconds(5), Time.milliseconds(1)));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertEquals("Incorrect number of results", 15, results.size());
+		Assert.assertThat("Incorrect bootstrap state", new HashSet<>(results), STANDARD_MATCHER);
+	}
+
+	@Test
+	public void testSlideWindowWithEvictor() throws Exception {
+		final String savepointPath = getTempDirPath(new AbstractID().toHexString());
+
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<String, Integer>> bootstrapData = bEnv
+			.fromCollection(WORDS)
+			.map(word -> Tuple2.of(word, 1))
+			.returns(TUPLE_TYPE_INFO);
+
+		WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation = OperatorTransformation
+			.bootstrapWith(bootstrapData)
+			.assignTimestamps(record -> 2L)
+			.keyBy(tuple -> tuple.f0, Types.STRING)
+			.window(SlidingEventTimeWindows.of(Time.milliseconds(5), Time.milliseconds(1)))
+			.evictor(CountEvictor.of(1));
+
+		Savepoint
+			.create(new MemoryStateBackend(), 128)
+			.withOperator(UID, windowBootstrap.bootstrap(transformation))
+			.write(savepointPath);
+
+		bEnv.execute("write state");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream = sEnv
+			.addSource(new MaxWatermarkSource<Tuple2<String, Integer>>())
+			.returns(TUPLE_TYPE_INFO)
+			.keyBy(tuple -> tuple.f0)
+			.window(SlidingEventTimeWindows.of(Time.milliseconds(5), Time.milliseconds(1)))
+			.evictor(CountEvictor.of(1));
+
+		DataStream<Tuple2<String, Integer>> windowed = windowStream.window(stream).uid(UID);
+		CompletableFuture<Collection<Tuple2<String, Integer>>> future = collector.collect(windowed);
+
+		submitJob(savepointPath, sEnv);
+
+		Collection<Tuple2<String, Integer>> results = future.get();
+		Assert.assertEquals("Incorrect number of results", 15, results.size());
+		Assert.assertThat("Incorrect bootstrap state", new HashSet<>(results), EVICTOR_MATCHER);
+	}
+
+	private void submitJob(String savepointPath, StreamExecutionEnvironment sEnv) {
+		JobGraph jobGraph = sEnv.getStreamGraph().getJobGraph();
+		jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath, true));
+
+		ClusterClient<?> client = miniClusterResource.getClusterClient();
+		try {
+			Optional<SerializedThrowable> serializedThrowable = client
+				.submitJob(jobGraph)
+				.thenCompose(client::requestJobResult)
+				.get()
+				.getSerializedThrowable();
+			Assert.assertFalse(serializedThrowable.isPresent());
+		} catch (Throwable t) {
+			Assert.fail("Failed to submit job");
+		}
+	}
+
+	private static class Reducer implements ReduceFunction<Tuple2<String, Integer>> {
+
+		@Override
+		public Tuple2<String, Integer> reduce(Tuple2<String, Integer> value1, Tuple2<String, Integer> value2) {
+			return Tuple2.of(value1.f0, value1.f1 + value2.f1);
+		}
+	}
+
+	private static class Aggregator implements AggregateFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, Tuple2<String, Integer>> {
+
+		@Override
+		public Tuple2<String, Integer> createAccumulator() {
+			return null;
+		}
+
+		@Override
+		public Tuple2<String, Integer> add(Tuple2<String, Integer> value, Tuple2<String, Integer> accumulator) {
+			if (accumulator == null) {
+				return Tuple2.of(value.f0, value.f1);
+			}
+
+			accumulator.f1 += value.f1;
+			return accumulator;
+		}
+
+		@Override
+		public Tuple2<String, Integer> getResult(Tuple2<String, Integer> accumulator) {
+			return accumulator;
+		}
+
+		@Override
+		public Tuple2<String, Integer> merge(Tuple2<String, Integer> a, Tuple2<String, Integer> b) {
+			a.f1 += b.f1;
+			return a;
+		}
+	}
+
+	private static class CustomWindowFunction implements WindowFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String, TimeWindow> {
+
+		@Override
+		public void apply(String s, TimeWindow window, Iterable<Tuple2<String, Integer>> input, Collector<Tuple2<String, Integer>> out) {
+			Iterator<Tuple2<String, Integer>> iterator = input.iterator();
+			Tuple2<String, Integer> acc = iterator.next();
+
+			while (iterator.hasNext()) {
+				Tuple2<String, Integer> next = iterator.next();
+				acc.f1 += next.f1;
+			}
+
+			out.collect(acc);
+		}
+	}
+
+	private static class CustomProcessWindowFunction extends ProcessWindowFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String, TimeWindow> {
+
+		@Override
+		public void process(String s, Context context, Iterable<Tuple2<String, Integer>> elements, Collector<Tuple2<String, Integer>> out) {
+			Iterator<Tuple2<String, Integer>> iterator = elements.iterator();
+			Tuple2<String, Integer> acc = iterator.next();
+
+			while (iterator.hasNext()) {
+				Tuple2<String, Integer> next = iterator.next();
+				acc.f1 += next.f1;
+			}
+
+			out.collect(acc);
+		}
+	}
+
+	@FunctionalInterface
+	private interface WindowBootstrap {
+		BootstrapTransformation<Tuple2<String, Integer>> bootstrap(WindowedOperatorTransformation<Tuple2<String, Integer>, String, TimeWindow> transformation);
+	}
+
+	@FunctionalInterface
+	private interface WindowStream {
+		SingleOutputStreamOperator<Tuple2<String, Integer>> window(WindowedStream<Tuple2<String, Integer>, String, TimeWindow> stream);
+	}
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/MaxWatermarkSource.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/MaxWatermarkSource.java
@@ -1,0 +1,42 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.utils;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+
+/**
+ * A simple source that emits a max watermark and then immediately returns.
+ * This provides an easy way to trigger all event time timers for a restored savepoint.
+ */
+public class MaxWatermarkSource<T> implements SourceFunction<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public void run(SourceContext<T> ctx) {
+		ctx.emitWatermark(Watermark.MAX_WATERMARK);
+	}
+
+	@Override
+	public void cancel() {
+
+	}
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/StreamCollector.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/StreamCollector.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A simple utility for collecting all the elements in a {@link DataStream}.
+ * <pre>{@code
+ * public class DataStreamTest {
+ *
+ * 		{@literal @}Rule
+ * 		public StreamCollector collector = new StreamCollector();
+ *
+ * 		public void test() throws Exception {
+ * 		 	StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+ * 		 	DataStream<Integer> stream = env.fromElements(1, 2, 3);
+ *
+ * 		 	CompletableFuture<Collection<Integer>> results = collector.collect(stream);
+ * 		 	Assert.assertThat(results.get(), hasItems(1, 2, 3));
+ * 		}
+ * }
+ * }
+ * </pre>
+ *
+ * <p><b>Note:</b> The stream collector assumes:
+ * 1) The stream is bounded.
+ * 2) All elements will fit in memory.
+ * 3) All tasks run within the same JVM.
+ */
+@SuppressWarnings("rawtypes")
+public class StreamCollector extends ExternalResource {
+
+	private static final AtomicLong counter = new AtomicLong();
+
+	private static final Map<Long, CountDownLatch> latches = new ConcurrentHashMap<>();
+
+	private static final Map<Long, Queue> resultQueues = new ConcurrentHashMap<>();
+
+	private List<Long> ids;
+
+	@Override
+	protected void before() {
+		ids = new ArrayList<>();
+	}
+
+	/**
+	 * @return A future that contains all the elements of the DataStream
+	 * which completes when all elements have been processed.
+	 */
+	public <IN> CompletableFuture<Collection<IN>> collect(DataStream<IN> stream) {
+		final long id = counter.getAndIncrement();
+		ids.add(id);
+
+		int parallelism = stream.getParallelism();
+		if (parallelism == ExecutionConfig.PARALLELISM_DEFAULT) {
+			parallelism = stream.getExecutionEnvironment().getParallelism();
+		}
+
+		CountDownLatch latch = new CountDownLatch(parallelism);
+		latches.put(id, latch);
+
+		Queue<IN> results = new ConcurrentLinkedDeque<>();
+		resultQueues.put(id, results);
+
+		stream.addSink(new CollectingSink<>(id));
+
+		return CompletableFuture.runAsync(() -> {
+			try {
+				latch.await();
+			} catch (InterruptedException e) {
+				throw new RuntimeException("Failed to collect results");
+			}
+		}).thenApply(ignore -> results);
+	}
+
+	@Override
+	protected void after() {
+		for (Long id : ids) {
+			latches.remove(id);
+			resultQueues.remove(id);
+		}
+	}
+
+	private static class CollectingSink<IN> extends RichSinkFunction<IN> {
+
+		private final long id;
+
+		private transient CountDownLatch latch;
+
+		private transient Queue<IN> results;
+
+		private CollectingSink(long id) {
+			this.id = id;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public void open(Configuration parameters) throws Exception {
+			latch   = StreamCollector.latches.get(id);
+			results = (Queue<IN>) StreamCollector.resultQueues.get(id);
+		}
+
+		@Override
+		public void invoke(IN value, Context context) throws Exception {
+			results.add(value);
+		}
+
+		@Override
+		public void close() throws Exception {
+			latch.countDown();
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Adds support to bootstrap window operators using the state processor api. This PR is a lot of boilerplate because of all the ways to configure window operator but all the runtime changes have already been merged in. 

I also realized we already support reading trigger state, it was just missing a public method so I added that in a hotfix. 

## Verifying this change

UT / IT tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
