### PR TITLE
[FLINK-19434][DataStream API] Add source input chaining to StreamingJobGraphGenerator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -35,7 +35,6 @@ import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,9 +50,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * Class representing the operators in the streaming programs, with all their properties.
  */
 @Internal
-public class StreamNode implements Serializable {
-
-	private static final long serialVersionUID = 1L;
+public class StreamNode {
 
 	private final int id;
 	private int parallelism;
@@ -73,7 +70,7 @@ public class StreamNode implements Serializable {
 	private KeySelector<?, ?>[] statePartitioners = new KeySelector[0];
 	private TypeSerializer<?> stateKeySerializer;
 
-	private transient StreamOperatorFactory<?> operatorFactory;
+	private StreamOperatorFactory<?> operatorFactory;
 	private TypeSerializer<?>[] typeSerializersIn = new TypeSerializer[0];
 	private TypeSerializer<?> typeSerializerOut;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -66,7 +67,6 @@ import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationHead;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationTail;
 import org.apache.flink.util.FlinkRuntimeException;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
 import org.apache.commons.lang3.StringUtils;
@@ -139,8 +139,6 @@ public class StreamingJobGraphGenerator {
 	private final StreamGraphHasher defaultStreamGraphHasher;
 	private final List<StreamGraphHasher> legacyStreamGraphHashers;
 
-	private final Map<Integer, OperatorChainInfo> chainInfos;
-
 	private StreamingJobGraphGenerator(StreamGraph streamGraph, @Nullable JobID jobID) {
 		this.streamGraph = streamGraph;
 		this.defaultStreamGraphHasher = new StreamGraphHasherV2();
@@ -155,7 +153,6 @@ public class StreamingJobGraphGenerator {
 		this.chainedPreferredResources = new HashMap<>();
 		this.chainedInputOutputFormats = new HashMap<>();
 		this.physicalEdgesInOrder = new ArrayList<>();
-		this.chainInfos = new HashMap<>();
 
 		jobGraph = new JobGraph(jobID, streamGraph.getJobName());
 	}
@@ -260,7 +257,7 @@ public class StreamingJobGraphGenerator {
 		}
 	}
 
-	private Collection<OperatorChainInfo> buildChainedInputsAndGetHeadInputs(
+	private  Map<Integer, OperatorChainInfo> buildChainedInputsAndGetHeadInputs(
 			final Map<Integer, byte[]> hashes,
 			final List<Map<Integer, byte[]>> legacyHashes) {
 
@@ -274,8 +271,9 @@ public class StreamingJobGraphGenerator {
 				// as long as only NAry ops support this chaining, we need to skip the other parts
 				final StreamEdge sourceOutEdge = sourceNode.getOutEdges().get(0);
 				final StreamNode target = streamGraph.getStreamNode(sourceOutEdge.getTargetId());
+				final ChainingStrategy targetChainingStrategy = target.getOperatorFactory().getChainingStrategy();
 
-				if (isMultipleInput(target) && isChainableIgnoringInEdgesSize(sourceOutEdge, streamGraph)) {
+				if (targetChainingStrategy == ChainingStrategy.HEAD_WITH_SOURCES && isChainableInput(sourceOutEdge, streamGraph)) {
 					final OperatorID opId = new OperatorID(hashes.get(sourceNodeId));
 					final StreamConfig.SourceInputConfig inputConfig = new StreamConfig.SourceInputConfig(sourceOutEdge);
 					final StreamConfig operatorConfig = new StreamConfig(new Configuration());
@@ -296,15 +294,12 @@ public class StreamingJobGraphGenerator {
 				}
 			}
 
-			chainEntryPoints.computeIfAbsent(
+			chainEntryPoints.put(
 				sourceNodeId,
-				(k) -> new OperatorChainInfo(sourceNodeId, hashes, legacyHashes, chainedSources, streamGraph));
+				new OperatorChainInfo(sourceNodeId, hashes, legacyHashes, chainedSources, streamGraph));
 		}
 
-		for (Map.Entry<Integer, OperatorChainInfo> entry : chainEntryPoints.entrySet()) {
-			chainInfos.put(entry.getKey(), entry.getValue());
-		}
-		return chainEntryPoints.values();
+		return chainEntryPoints;
 	}
 
 	/**
@@ -315,17 +310,25 @@ public class StreamingJobGraphGenerator {
 	private void setChaining(Map<Integer, byte[]> hashes, List<Map<Integer, byte[]>> legacyHashes) {
 		// we separate out the sources that run as inputs to another operator (chained inputs)
 		// from the sources that needs to run as the main (head) operator.
-		final Collection<OperatorChainInfo> entryPoints = buildChainedInputsAndGetHeadInputs(hashes, legacyHashes);
+		final Map<Integer, OperatorChainInfo> chainEntryPoints = buildChainedInputsAndGetHeadInputs(hashes, legacyHashes);
+		final Collection<OperatorChainInfo> initialEntryPoints = new ArrayList<>(chainEntryPoints.values());
 
-		for (OperatorChainInfo info : entryPoints) {
+		// iterate over a copy of the values, because this map get
+		for (OperatorChainInfo info : initialEntryPoints) {
 			createChain(
 					info.getStartNodeId(),
 					1,  // operators start at position 1 because 0 is for chained source inputs
-					info);
+					info,
+					chainEntryPoints);
 		}
 	}
 
-	private List<StreamEdge> createChain(Integer currentNodeId, int chainIndex, OperatorChainInfo chainInfo) {
+	private List<StreamEdge> createChain(
+			final Integer currentNodeId,
+			final int chainIndex,
+			final OperatorChainInfo chainInfo,
+			final Map<Integer, OperatorChainInfo> chainEntryPoints) {
+
 		Integer startNodeId = chainInfo.getStartNodeId();
 		if (!builtVertices.contains(startNodeId)) {
 
@@ -346,7 +349,7 @@ public class StreamingJobGraphGenerator {
 
 			for (StreamEdge chainable : chainableOutputs) {
 				transitiveOutEdges.addAll(
-						createChain(chainable.getTargetId(), chainIndex + 1, chainInfo));
+						createChain(chainable.getTargetId(), chainIndex + 1, chainInfo, chainEntryPoints));
 			}
 
 			for (StreamEdge nonChainable : nonChainableOutputs) {
@@ -354,9 +357,10 @@ public class StreamingJobGraphGenerator {
 				createChain(
 						nonChainable.getTargetId(),
 						1, // operators start at position 1 because 0 is for chained source inputs
-						chainInfos.computeIfAbsent(
+						chainEntryPoints.computeIfAbsent(
 							nonChainable.getTargetId(),
-							(k) -> chainInfo.newChain(nonChainable.getTargetId())));
+							(k) -> chainInfo.newChain(nonChainable.getTargetId())),
+						chainEntryPoints);
 			}
 
 			chainedNames.put(currentNodeId, createChainedName(currentNodeId, chainableOutputs));
@@ -540,20 +544,34 @@ public class StreamingJobGraphGenerator {
 
 		// build the inputs as a combination of source and network inputs
 		final List<StreamEdge> inEdges = vertex.getInEdges();
-		final StreamConfig.InputConfig[] inputConfigs = new StreamConfig.InputConfig[inEdges.size()];
+		final TypeSerializer<?>[] inputSerializers = vertex.getTypeSerializersIn();
+
+		final StreamConfig.InputConfig[] inputConfigs = new StreamConfig.InputConfig[inputSerializers.length];
 
 		int inputGateCount = 0;
-		for (int i = 0; i < inEdges.size(); i++) {
-			final StreamEdge inEdge = inEdges.get(i);
+		for (final StreamEdge inEdge : inEdges) {
 			final ChainedSourceInfo chainedSource = chainedSources.get(inEdge.getSourceId());
+
+			final int inputIndex = inEdge.getTypeNumber() == 0
+				? 0 // single input operator
+				: inEdge.getTypeNumber() - 1; // in case of 2 or more inputs
+
 			if (chainedSource != null) {
-				inputConfigs[i] = chainedSource.getInputConfig();
+				// chained source is the input
+				if (inputConfigs[inputIndex] != null) {
+					throw new IllegalStateException("Trying to union a chained source with another input.");
+				}
+				inputConfigs[inputIndex] = chainedSource.getInputConfig();
 				chainedConfigs
-						.computeIfAbsent(vertexID, (key) -> new HashMap<>())
-						.put(inEdge.getSourceId(), chainedSource.getOperatorConfig());
+					.computeIfAbsent(vertexID, (key) -> new HashMap<>())
+					.put(inEdge.getSourceId(), chainedSource.getOperatorConfig());
 			} else {
-				inputConfigs[i] = new StreamConfig.NetworkInputConfig(
-					vertex.getTypeSerializerIn(Math.max(0, inEdge.getTypeNumber() - 1)), inputGateCount++);
+				// network input. null if we move to a new input, non-null if this is a further edge
+				// that is union-ed into the same input
+				if (inputConfigs[inputIndex] == null) {
+					inputConfigs[inputIndex] = new StreamConfig.NetworkInputConfig(
+						inputSerializers[inputIndex], inputGateCount++);
+				}
 			}
 		}
 		config.setInputs(inputConfigs);
@@ -722,10 +740,10 @@ public class StreamingJobGraphGenerator {
 		StreamNode downStreamVertex = streamGraph.getTargetVertex(edge);
 
 		return downStreamVertex.getInEdges().size() == 1
-				&& isChainableIgnoringInEdgesSize(edge, streamGraph);
+				&& isChainableInput(edge, streamGraph);
 	}
 
-	private static boolean isChainableIgnoringInEdgesSize(StreamEdge edge, StreamGraph streamGraph) {
+	private static boolean isChainableInput(StreamEdge edge, StreamGraph streamGraph) {
 		StreamNode upStreamVertex = streamGraph.getSourceVertex(edge);
 		StreamNode downStreamVertex = streamGraph.getTargetVertex(edge);
 
@@ -748,17 +766,47 @@ public class StreamingJobGraphGenerator {
 			return false;
 		}
 
-		if (upStreamOperator.getChainingStrategy() == ChainingStrategy.NEVER ||
-			downStreamOperator.getChainingStrategy() != ChainingStrategy.ALWAYS) {
+		// yielding operators cannot be chained to legacy sources
+		// unfortunately the information that vertices have been chained is not preserved at this point
+		if (downStreamOperator instanceof YieldingOperatorFactory &&
+				getHeadOperator(upStreamVertex, streamGraph).isStreamSource()) {
 			return false;
 		}
 
-		// yielding operators cannot be chained to legacy sources
-		if (downStreamOperator instanceof YieldingOperatorFactory) {
-			// unfortunately the information that vertices have been chained is not preserved at this point
-			return !getHeadOperator(upStreamVertex, streamGraph).isStreamSource();
+		// we use switch/case here to make sure this is exhaustive if ever values are added to the
+		// ChainingStrategy enum
+		boolean isChainable;
+
+		switch (upStreamOperator.getChainingStrategy()) {
+			case NEVER:
+				isChainable = false;
+				break;
+			case ALWAYS:
+			case HEAD:
+			case HEAD_WITH_SOURCES:
+				isChainable = true;
+				break;
+			default:
+				throw new RuntimeException("Unknown chaining strategy: " + upStreamOperator.getChainingStrategy());
 		}
-		return true;
+
+		switch (downStreamOperator.getChainingStrategy()) {
+			case NEVER:
+			case HEAD:
+				isChainable = false;
+				break;
+			case ALWAYS:
+				// keep the value from upstream
+				break;
+			case HEAD_WITH_SOURCES:
+				// only if upstream is a source
+				isChainable &= (upStreamOperator instanceof SourceOperatorFactory);
+				break;
+			default:
+				throw new RuntimeException("Unknown chaining strategy: " + upStreamOperator.getChainingStrategy());
+		}
+
+		return isChainable;
 	}
 
 	/**
@@ -1093,18 +1141,9 @@ public class StreamingJobGraphGenerator {
 		jobGraph.setSnapshotSettings(settings);
 	}
 
-	private static boolean isMultipleInput(StreamNode vertex) {
-		StreamOperatorFactory<?> factory = vertex.getOperatorFactory();
-		// FIXME super hack!
-		return factory.getClass().getName().equals(
-			"org.apache.flink.table.runtime.operators.multipleinput.BatchMultipleInputStreamOperatorFactory") ||
-			factory.getClass().getName().equals(
-				"org.apache.flink.table.runtime.operators.multipleinput.StreamMultipleInputStreamOperatorFactory");
-	}
-
 	/**
 	 * A private class to help maintain the information of an operator chain during the recursive call in
-	 * {@link #createChain(Integer, int, OperatorChainInfo)}.
+	 * {@link #createChain(Integer, int, OperatorChainInfo, Map)}.
 	 */
 	private static class OperatorChainInfo {
 		private final Integer startNodeId;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ChainingStrategy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ChainingStrategy.java
@@ -49,5 +49,12 @@ public enum ChainingStrategy {
 	 * The operator will not be chained to the predecessor, but successors may chain to this
 	 * operator.
 	 */
-	HEAD
+	HEAD,
+
+	/**
+	 * This operator will run at the head of a chain (similar as in {@link #HEAD}, but it will additionally
+	 * try to chain source inputs if possible. This allows multi-input operators to be chained with multiple
+	 * sources into one task.
+	 */
+	HEAD_WITH_SOURCES;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -94,7 +94,7 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			.filter(input -> (input instanceof StreamConfig.NetworkInputConfig))
 			.count();
 
-		ArrayList[] inputLists = new ArrayList[numberOfLogicalNetworkInputs];
+		ArrayList[] inputLists = new ArrayList[inputs.length];
 		for (int i = 0; i < inputLists.length; i++) {
 			inputLists[i] = new ArrayList<>();
 		}
@@ -105,7 +105,13 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			inputLists[inputType - 1].add(reader);
 		}
 
-		createInputProcessor(inputLists, inputs, watermarkGauges);
+		ArrayList<ArrayList<?>> networkInputLists = new ArrayList<>();
+		for (ArrayList<?> inputList : inputLists) {
+			if (!inputList.isEmpty()) {
+				networkInputLists.add(inputList);
+			}
+		}
+		createInputProcessor(networkInputLists.toArray(new ArrayList[0]), inputs, watermarkGauges);
 
 		// wrap watermark gauge since registered metrics must be unique
 		getEnvironment().getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge::getValue);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SourceChainingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SourceChainingITCase.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.MultipleConnectedStreams;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+import org.apache.flink.streaming.api.operators.AbstractInput;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for chaining the source operators / inputs.
+ */
+@SuppressWarnings("serial")
+public class SourceChainingITCase extends TestLogger {
+
+	private static final int PARALLELISM = 4;
+
+	@ClassRule
+	public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+	@ClassRule
+	public static final MiniClusterWithClientResource MINI_CLUSTER = new MiniClusterWithClientResource(
+		new MiniClusterResourceConfiguration.Builder()
+			.setNumberTaskManagers(1)
+			.setNumberSlotsPerTaskManager(PARALLELISM)
+			.build());
+
+	// ------------------------------------------------------------------------
+
+	// We currently only have tests for chaining sources in N-ary Input Operators,
+	// because those are the only ones where the runtime supports chaining at the moment.
+
+	@Test
+	public void testNAryInputOperatorChainCreation() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+
+		final DataStream<Long> stream = createNAryInputProgram(env);
+		final JobGraph jobGraph = sinkAndCompileJobGraph(stream);
+
+		assertEquals(1, jobGraph.getNumberOfVertices());
+	}
+
+	@Test
+	public void testNAryInputOperatorExecution() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(PARALLELISM);
+
+		final DataStream<Long> stream = createNAryInputProgram(env);
+		final List<Long> result = DataStreamUtils.collectBoundedStream(stream, "N-Ary Source Chaining Test Program");
+
+		verifySequence(result, 1L, 30L);
+	}
+
+	@Test
+	public void testNAryInputOperatorMixedInputChainCreation() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+
+		final DataStream<Long> stream = createNAryInputProgramWithMixedInputs(env);
+		final JobGraph jobGraph = sinkAndCompileJobGraph(stream);
+
+		assertEquals(3, jobGraph.getNumberOfVertices());
+	}
+
+	@Test
+	public void testNAryInputOperatorMixedInputExecution() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(PARALLELISM);
+
+		final DataStream<Long> stream = createNAryInputProgramWithMixedInputs(env);
+		final List<Long> result = DataStreamUtils.collectBoundedStream(stream, "N-Ary Source Chaining Test Program");
+
+		verifySequence(result, 1L, 30L);
+	}
+
+	/**
+	 * Creates a DataStream program as shown below.
+	 * <pre>
+	 *               +--------------+
+	 *   (src 1) --> |              |
+	 *               |     N-Ary    |
+	 *   (src 2) --> |              |
+	 *               |   Operator   |
+	 *   (src 3) --> |              |
+	 *               +--------------+
+	 * </pre>
+	 */
+	private DataStream<Long> createNAryInputProgram(final StreamExecutionEnvironment env) {
+		env.getConfig().enableObjectReuse();
+
+		final DataStream<Long> source1 = env.fromSource(
+				new NumberSequenceSource(1L, 10L),
+				WatermarkStrategy.noWatermarks(),
+				"source-1");
+
+		final DataStream<Long> source2 = env.fromSource(
+				new NumberSequenceSource(11L, 20L),
+				WatermarkStrategy.noWatermarks(),
+				"source-2");
+
+		final DataStream<Long> source3 = env.fromSource(
+				new NumberSequenceSource(21L, 30L),
+				WatermarkStrategy.noWatermarks(),
+				"source-3");
+
+		return nAryInputStreamOperation(source1, source2, source3);
+	}
+
+	/**
+	 * Creates a DataStream program as shown below.
+	 * <pre>
+	 *                         +--------------+
+	 *   (src 1) --> (map) --> |              |
+	 *                         |     N-Ary    |
+	 *             (src 2) --> |              |
+	 *                         |   Operator   |
+	 *   (src 3) --> (map) --> |              |
+	 *                         +--------------+
+	 * </pre>
+	 */
+	private DataStream<Long> createNAryInputProgramWithMixedInputs(final StreamExecutionEnvironment env) {
+		env.getConfig().enableObjectReuse();
+
+		final DataStream<Long> source1 = env.fromSource(
+			new NumberSequenceSource(1L, 10L),
+			WatermarkStrategy.noWatermarks(),
+			"source-1");
+
+		final DataStream<Long> source2 = env.fromSource(
+			new NumberSequenceSource(11L, 20L),
+			WatermarkStrategy.noWatermarks(),
+			"source-2");
+
+		final DataStream<Long> source3 = env.fromSource(
+			new NumberSequenceSource(21L, 30L),
+			WatermarkStrategy.noWatermarks(),
+			"source-3");
+
+		final DataStream<Long> stream1 = source1.map(v -> v);
+		final DataStream<Long> stream3 = source3.map(v -> v);
+
+		return nAryInputStreamOperation(stream1, source2, stream3);
+	}
+
+	private static DataStream<Long> nAryInputStreamOperation(
+			final DataStream<Long> input1,
+			final DataStream<Long> input2,
+			final DataStream<Long> input3) {
+
+		final StreamExecutionEnvironment env = input1.getExecutionEnvironment();
+
+		// this is still clumsy due to the raw API
+
+		final MultipleInputTransformation<Long> transform = new MultipleInputTransformation<>(
+			"MultipleInputOperator", new NAryUnionOpFactory(), Types.LONG, env.getParallelism());
+		transform.addInput(input1.getTransformation());
+		transform.addInput(input2.getTransformation());
+		transform.addInput(input3.getTransformation());
+		transform.setChainingStrategy(ChainingStrategy.HEAD_WITH_SOURCES);
+		env.addOperator(transform);
+
+		return new MultipleConnectedStreams(env).transform(transform);
+	}
+
+	private static JobGraph sinkAndCompileJobGraph(DataStream<?> stream) {
+		stream.addSink(new DiscardingSink<>());
+
+		final StreamGraph streamGraph = stream.getExecutionEnvironment().getStreamGraph();
+		return  StreamingJobGraphGenerator.createJobGraph(streamGraph);
+	}
+
+	private static void verifySequence(final List<Long> sequence, final long from, final long to) {
+		final ArrayList<Long> list = new ArrayList<>(sequence); // copy to be safe against immutable lists, etc.
+		list.sort(Long::compareTo);
+
+		int pos = 0;
+		for (long value = from; value <= to; value++, pos++) {
+			if (value != list.get(pos)) {
+				fail(String.format("Expected: Sequence [%d, %d]. Found: %s", from, to, list));
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Tests mocks for N-ary input operator
+	// ------------------------------------------------------------------------
+
+	private static final class NAryUnionOp<T> extends AbstractStreamOperatorV2<T> implements MultipleInputStreamOperator<T> {
+
+		public NAryUnionOp(StreamOperatorParameters<T> parameters) {
+			super(parameters, 3);
+		}
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		public List<Input> getInputs() {
+			return Arrays.asList(
+				new PassThoughInput<>(this, 1),
+				new PassThoughInput<>(this, 2),
+				new PassThoughInput<>(this, 3));
+		}
+	}
+
+	/**
+	 * Factory for {@link MultipleInputITCase.SumAllInputOperator}.
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static class NAryUnionOpFactory extends AbstractStreamOperatorFactory<Long> {
+		@Override
+		public <T extends StreamOperator<Long>> T createStreamOperator(StreamOperatorParameters<Long> parameters) {
+			final StreamOperator<Long> operator = new NAryUnionOp<>(parameters);
+			return (T) operator;
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return NAryUnionOp.class;
+		}
+	}
+
+	private static final class PassThoughInput<T> extends AbstractInput<T, T> {
+
+		PassThoughInput(AbstractStreamOperatorV2<T> owner, int inputId) {
+			super(owner, inputId);
+		}
+
+		@Override
+		public void processElement(StreamRecord<T> element) throws Exception {
+			output.collect(element);
+		}
+	}
+}


### PR DESCRIPTION
## Prerequisites

**This PR is based on #13512 , on which it relies as a testing util.**

## What is the purpose of the change

This adds the `StreamingJobGraphGenerator` logic for chaining sources to N-Ary-Input Operators.
Joint work with @TsReaper.

## Verifying this change

This change adds the `SourceChainingITCase` to verify correctness.
The fact that the changes do not interfere with other stream graph setup logic is covered by the existing `StreamingJobGraphGeneratorTest` and the sum of all end-to-end integration tests that execute *DataStream* and *Table* programs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
