### PR TITLE
[FLINK-19468][DataStream API] Metrics return empty when data stream / operator name contains "+"

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
@@ -217,6 +217,7 @@ public class MetricQueryService extends RpcEndpoint implements MetricQueryServic
 				case '.':
 				case ':':
 				case ',':
+			    case '+':
 					if (chars == null) {
 						chars = str.toCharArray();
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
@@ -217,7 +217,7 @@ public class MetricQueryService extends RpcEndpoint implements MetricQueryServic
 				case '.':
 				case ':':
 				case ',':
-			    case '+':
+				case '+':
 					if (chars == null) {
 						chars = str.toCharArray();
 					}


### PR DESCRIPTION
There is an issue in which the special character "+" is not removed from the data stream / operator name which causes metrics for the operator to not be properly returned. Code Reference:

https://github.com/apache/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java#L208

 

For example if the operator name is:

pulsar(url: pulsar+ssl://192.168.1.198:56014)

Metrics for an operator with the above name will always return empty.