### PR TITLE
[FLINK-19470][orc][parquet] Parquet and ORC reader reachEnd returns f…

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReader.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReader.java
@@ -128,12 +128,12 @@ public abstract class OrcSplitReader<T, BATCH> implements Closeable {
 	private boolean ensureBatch() throws IOException {
 
 		if (nextRow >= rowsInBatch) {
-			// No more rows available in the Rows array.
-			nextRow = 0;
 			// Try to read the next batch if rows from the ORC file.
 			boolean moreRows = shim.nextBatch(orcRowsReader, rowBatchWrapper.getBatch());
 
 			if (moreRows) {
+				// No more rows available in the Rows array.
+				nextRow = 0;
 				// Load the data into the Rows array.
 				rowsInBatch = fillRows();
 			}

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
@@ -58,6 +58,7 @@ import static org.apache.flink.table.runtime.functions.SqlDateTimeUtils.internal
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for {@link OrcColumnarRowSplitReader}.
@@ -386,6 +387,21 @@ public class OrcColumnarRowSplitReaderTest {
 		}
 		// check that all rows have been read
 		assertEquals(rowSize, cnt);
+	}
+
+	@Test
+	public void testReachEnd() throws Exception {
+		FileInputSplit[] splits = createSplits(testFileFlat, 1);
+		try (OrcColumnarRowSplitReader reader = createReader(
+				new int[]{0, 1},
+				testSchemaFlat,
+				new HashMap<>(),
+				splits[0])) {
+			while (!reader.reachedEnd()) {
+				reader.nextRecord(null);
+			}
+			assertTrue(reader.reachedEnd());
+		}
 	}
 
 	protected static Timestamp toTimestamp(int i) {

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
@@ -266,10 +266,13 @@ public class ParquetColumnarRowSplitReader implements Closeable {
 	 */
 	private boolean ensureBatch() throws IOException {
 		if (nextRow >= rowsInBatch) {
-			// No more rows available in the Rows array.
-			nextRow = 0;
 			// Try to read the next batch if rows from the file.
-			return nextBatch();
+			if (nextBatch()) {
+				// No more rows available in the Rows array.
+				nextRow = 0;
+				return true;
+			}
+			return false;
 		}
 		// there is at least one Row left in the Rows array.
 		return true;


### PR DESCRIPTION
…alse after it has reached end

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the issue that ORC and parquet reader `reachEnd` methods return false after it has reached end.


## Brief change log

  - Fix the readers
  - Add test cases


## Verifying this change

Added test cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
