### PR TITLE
[FLINK-19453][table-common] Deprecate old source and sink interfaces

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSinkFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.sinks.BatchTableSink;
 import org.apache.flink.table.sinks.TableSink;
 
@@ -29,7 +30,12 @@ import java.util.Map;
  * string-based properties. See also {@link TableSinkFactory} for more information.
  *
  * @param <T> type of records that the factory consumes
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSinkFactory}. The new interface
+ *             creates instances of {@link DynamicTableSink} and only works with the Blink planner.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface BatchTableSinkFactory<T> extends TableSinkFactory<T> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/BatchTableSourceFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.sources.BatchTableSource;
 import org.apache.flink.table.sources.TableSource;
 
@@ -29,7 +30,12 @@ import java.util.Map;
  * string-based properties. See also {@link TableSourceFactory} for more information.
  *
  * @param <T> type of records that the factory produces
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSourceFactory}. The new interface
+ *             creates instances of {@link DynamicTableSource} and only works with the Blink planner.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface BatchTableSourceFactory<T> extends TableSourceFactory<T> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.sinks.StreamTableSink;
 import org.apache.flink.table.sinks.TableSink;
 
@@ -30,7 +31,12 @@ import java.util.Map;
  * string-based properties. See also {@link TableSinkFactory} for more information.
  *
  * @param <T> type of records that the factory consumes
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSinkFactory}. The new interface
+ *             creates instances of {@link DynamicTableSink} and only works with the Blink planner.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface StreamTableSinkFactory<T> extends TableSinkFactory<T> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 
@@ -30,7 +31,12 @@ import java.util.Map;
  * string-based properties. See also {@link TableSourceFactory} for more information.
  *
  * @param <T> type of records that the factory produces
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSourceFactory}. The new interface
+ *             creates instances of {@link DynamicTableSource} and only works with the Blink planner.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface StreamTableSourceFactory<T> extends TableSourceFactory<T> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/AppendStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/AppendStreamTableSink.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 /**
  * Defines an external {@link TableSink} to emit streaming {@link Table} with only insert changes.
@@ -30,7 +31,12 @@ import org.apache.flink.table.api.TableException;
  * will be thrown.
  *
  * @param <T> Type of {@link DataStream} that this {@link TableSink} expects and supports.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface consumes
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 @PublicEvolving
 public interface AppendStreamTableSink<T> extends StreamTableSink<T> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
@@ -23,12 +23,18 @@ import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 /**
  * Defines an external {@link TableSink} to emit a bounded {@link Table}.
  *
  * @param <T> Type of the bounded {@link OutputFormat} that this {@link TableSink} expects and supports.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface consumes
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 @Experimental
 public abstract class OutputFormatTableSink<T> implements StreamTableSink<T> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/RetractStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/RetractStreamTableSink.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 /**
  * Defines an external {@link TableSink} to emit a streaming {@link Table} with insert, update,
@@ -38,7 +39,12 @@ import org.apache.flink.table.api.Table;
  * <p>A message with false flag is a retract message.
  *
  * @param <T> Type of records that this {@link TableSink} expects and supports.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface consumes
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 @PublicEvolving
 public interface RetractStreamTableSink<T> extends StreamTableSink<Tuple2<Boolean, T>> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/StreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/StreamTableSink.java
@@ -20,12 +20,18 @@ package org.apache.flink.table.sinks;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 /**
  * Defines an external stream table and provides write access to its data.
  *
  * @param <T> Type of the {@link DataStream} created by this {@link TableSink}.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface consumes
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 public interface StreamTableSink<T> extends TableSink<T> {
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/UpsertStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/UpsertStreamTableSink.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 /**
  * Defines an external {@link TableSink} to emit a streaming {@link Table} with insert, update,
@@ -49,7 +50,12 @@ import org.apache.flink.table.api.TableException;
  * as insertions.
  *
  * @param <T> Type of records that this {@link TableSink} expects and supports.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface consumes
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 @PublicEvolving
 public interface UpsertStreamTableSink<T> extends StreamTableSink<Tuple2<Boolean, T>> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/InputFormatTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/InputFormatTableSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 
 import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo;
 
@@ -30,7 +31,12 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToL
  * Defines an external bounded table and provides access to its data.
  *
  * @param <T> Type of the bounded {@link InputFormat} created by this {@link TableSource}.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSource}. The new interface produces
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 @Experimental
 public abstract class InputFormatTableSource<T> implements StreamTableSource<T> {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/StreamTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/StreamTableSource.java
@@ -20,11 +20,17 @@ package org.apache.flink.table.sources;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 
 /** Defines an external stream table and provides read access to its data.
  *
  * @param <T> Type of the {@link DataStream} created by this {@link TableSource}.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSource}. The new interface produces
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 public interface StreamTableSource<T> extends TableSource<T> {
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/OverwritableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/OverwritableTableSink.java
@@ -19,13 +19,20 @@
 package org.apache.flink.table.sinks;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 
 /**
  * A {@link TableSink} that supports INSERT OVERWRITE should implement this trait.
  * INSERT OVERWRITE will overwrite any existing data in the table or partition.
  *
  * @see PartitionableTableSink for the definition of partition.
+ *
+ * @deprecated This interface will not be supported in the new sink design around {@link DynamicTableSink}
+ *             which only works with the Blink planner. Use {@link SupportsOverwrite} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @Experimental
 public interface OverwritableTableSink {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.sinks;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 
 import java.util.Map;
 
@@ -55,7 +57,12 @@ import java.util.Map;
  * the static partition part is {@code dt='2019-06-20'} which will be told to the sink via
  * {@link #setStaticPartition(Map)}. And the {@code country} is the dynamic partition which will be
  * get from each record.
+ *
+ * @deprecated This interface will not be supported in the new sink design around {@link DynamicTableSink}
+ *             which only works with the Blink planner. Use {@link SupportsPartitioning} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @Experimental
 public interface PartitionableTableSink {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSink.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.types.DataType;
 
 import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
@@ -34,6 +35,10 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  * <p>The interface is generic such that it can support different storage locations and formats.
  *
  * @param <T> The return type of the {@link TableSink}.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface consumes
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
 @PublicEvolving
 public interface TableSink<T> {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedFieldMapping.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedFieldMapping.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.types.DataType;
 
 import javax.annotation.Nullable;
@@ -38,7 +39,11 @@ import java.util.Map;
  * provided by implementing this interface.
  *
  * <p>If a mapping is provided, all fields must be explicitly mapped.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface DefinedFieldMapping {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedProctimeAttribute.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedProctimeAttribute.java
@@ -21,12 +21,18 @@ package org.apache.flink.table.sources;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 
 import javax.annotation.Nullable;
 
 /**
  * Extends a {@link TableSource} to specify a processing time attribute.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use the concept of computed columns instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface DefinedProctimeAttribute {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedRowtimeAttributes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedRowtimeAttributes.java
@@ -21,13 +21,19 @@ package org.apache.flink.table.sources;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 
 import java.util.List;
 
 /**
  * Extends a {@link TableSource} to specify rowtime attributes via a
  * {@link RowtimeAttributeDescriptor}.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use the concept of computed columns instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface DefinedRowtimeAttributes {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FieldComputer.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FieldComputer.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedFieldReference;
 
@@ -28,7 +29,12 @@ import org.apache.flink.table.expressions.ResolvedFieldReference;
  * schema of a {@link TableSource} from one or more fields of the {@link TableSource}'s return type.
  *
  * @param <T> The result type of the provided expression.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use the concept of computed columns instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface FieldComputer<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FilterableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FilterableTableSource.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.sources;
 
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.expressions.Expression;
 
 import java.util.List;
@@ -25,7 +27,12 @@ import java.util.List;
 /**
  * Adds support for filtering push-down to a {@link TableSource}.
  * A {@link TableSource} extending this interface is able to filter records before returning.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use {@link SupportsFilterPushDown} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 public interface FilterableTableSource<T> {
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 
 /**
  * Adds support for limiting push-down to a {@link TableSource}.
@@ -26,7 +28,12 @@ import org.apache.flink.annotation.Experimental;
  *
  * <p>After pushing down, source only needs to try its best to limit the number of output records,
  * but does not need to guarantee that the number must be less than or equal to the limit.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use {@link SupportsLimitPushDown} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @Experimental
 public interface LimitableTableSource<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.functions.AsyncTableFunction;
 import org.apache.flink.table.functions.TableFunction;
 
@@ -28,7 +30,12 @@ import org.apache.flink.table.functions.TableFunction;
  * When temporal join this MySQL table, the runtime behavior could be in a lookup fashion.
  *
  * @param <T> type of the result
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use {@link LookupTableSource} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @Experimental
 public interface LookupableTableSource<T> extends TableSource<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/NestedFieldsProjectableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/NestedFieldsProjectableTableSource.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 
 /**
  * Adds support for projection push-down to a {@link TableSource} with nested fields.
@@ -28,7 +30,12 @@ import org.apache.flink.annotation.PublicEvolving;
  * {@code StreamTableSource}.
  *
  * @param <T> The return type of the {@link TableSource}.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use {@link SupportsProjectionPushDown} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface NestedFieldsProjectableTableSource<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionableTableSource.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 
 import java.util.List;
 import java.util.Map;
@@ -33,7 +35,12 @@ import java.util.Map;
  * <p>A partition is represented as a {@code Map<String, String>} which maps from partition
  * field name to partition value. Since the map is NOT ordered, the correct order of partition
  * fields should be obtained via partition keys of catalog table.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use {@link SupportsPartitionPushDown} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @Experimental
 public interface PartitionableTableSource {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/ProjectableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/ProjectableTableSource.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.sources;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 
 /**
  * Adds support for projection push-down to a {@link TableSource}.
@@ -28,7 +30,12 @@ import org.apache.flink.annotation.PublicEvolving;
  * {@code StreamTableSource}.
  *
  * @param <T> The return type of the {@link TableSource}.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use {@link SupportsProjectionPushDown} instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface ProjectableTableSource<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/RowtimeAttributeDescriptor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/RowtimeAttributeDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.sources;
 
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.sources.tsextractors.TimestampExtractor;
 import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy;
 
@@ -25,7 +26,12 @@ import java.util.Objects;
 
 /**
  * Describes a rowtime attribute of a {@link TableSource}.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use the concept of computed columns instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 public final class RowtimeAttributeDescriptor {
 
 	private final String attributeName;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableConnectorUtils;
 
@@ -40,7 +41,12 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  * {@link DefinedFieldMapping} interface.
  *
  * @param <T> The return type of the {@link TableSource}.
+ *
+ * @deprecated This interface has been replaced by {@link DynamicTableSource}. The new interface produces
+ *             internal data structures and only works with the Blink planner. See FLIP-95 for more
+ *             information.
  */
+@Deprecated
 @PublicEvolving
 public interface TableSource<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractor.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.sources.tsextractors;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.descriptors.Descriptor;
 import org.apache.flink.table.descriptors.Rowtime;
 import org.apache.flink.table.sources.FieldComputer;
@@ -32,7 +33,12 @@ import java.util.Map;
 
 /**
  * Provides an expression to extract the timestamp for a rowtime attribute.
+ *
+ * @deprecated This interface will not be supported in the new source design around {@link DynamicTableSource}
+ *             which only works with the Blink planner. Use the concept of computed columns instead.
+ *             See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public abstract class TimestampExtractor implements FieldComputer<Long>, Serializable, Descriptor {
 


### PR DESCRIPTION
## What is the purpose of the change

Deprecates all old source and sink interfaces and their helper interfaces that are not required in FLIP-95.

## Brief change log

Deprecation annotation and comment added.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
