### PR TITLE
[FLINK-18850][Table SQL / Runtime]Add late records dropped metric for row time over windows

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
@@ -27,8 +27,6 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Meter;
-import org.apache.flink.metrics.MeterView;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.data.JoinedRowData;
 import org.apache.flink.table.data.RowData;
@@ -76,9 +74,7 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 	// Metrics
 	// ------------------------------------------------------------------------
 	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
-	protected static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
 	private transient Counter numLateRecordsDropped;
-	private transient Meter lateRecordsDroppedRate;
 
 	@VisibleForTesting
 	public Counter getCounter() {
@@ -127,9 +123,6 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 
 		// metrics
 		this.numLateRecordsDropped = getRuntimeContext().getMetricGroup().counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
-		this.lateRecordsDroppedRate = getRuntimeContext().getMetricGroup().meter(
-			LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
-			new MeterView(numLateRecordsDropped));
 	}
 
 	/**
@@ -169,7 +162,7 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 			inputState.put(timestamp, rowList);
 		} else {
 			// discard late record
-			lateRecordsDroppedRate.markEvent();
+			numLateRecordsDropped.inc();
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
@@ -25,6 +26,9 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.data.JoinedRowData;
 import org.apache.flink.table.data.RowData;
@@ -68,6 +72,19 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 
 	protected transient AggsHandleFunction function;
 
+	// ------------------------------------------------------------------------
+	// Metrics
+	// ------------------------------------------------------------------------
+	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	protected static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
+	private transient Counter numLateRecordsDropped;
+	private transient Meter lateRecordsDroppedRate;
+
+	@VisibleForTesting
+	public Counter getCounter() {
+		return numLateRecordsDropped;
+	}
+
 	public AbstractRowTimeUnboundedPrecedingOver(
 			long minRetentionTime,
 			long maxRetentionTime,
@@ -107,6 +124,12 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 		inputState = getRuntimeContext().getMapState(inputStateDesc);
 
 		initCleanupTimeState("RowTimeUnboundedOverCleanupTime");
+
+		// metrics
+		this.numLateRecordsDropped = getRuntimeContext().getMetricGroup().counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
+		this.lateRecordsDroppedRate = getRuntimeContext().getMetricGroup().meter(
+			LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
+			new MeterView(numLateRecordsDropped));
 	}
 
 	/**
@@ -131,7 +154,6 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 		long timestamp = input.getLong(rowTimeIdx);
 		long curWatermark = ctx.timerService().currentWatermark();
 
-		// discard late record
 		if (timestamp > curWatermark) {
 			// ensure every key just registers one timer
 			// default watermark is Long.Min, avoid overflow we use zero when watermark < 0
@@ -145,6 +167,9 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 			}
 			rowList.add(input);
 			inputState.put(timestamp, rowList);
+		} else {
+			// discard late record
+			lateRecordsDroppedRate.markEvent();
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
@@ -73,11 +73,11 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 	// ------------------------------------------------------------------------
 	// Metrics
 	// ------------------------------------------------------------------------
-	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
 	private transient Counter numLateRecordsDropped;
 
 	@VisibleForTesting
-	public Counter getCounter() {
+	protected Counter getCounter() {
 		return numLateRecordsDropped;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
@@ -27,8 +27,6 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Meter;
-import org.apache.flink.metrics.MeterView;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.data.JoinedRowData;
 import org.apache.flink.table.data.RowData;
@@ -94,9 +92,7 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 	// Metrics
 	// ------------------------------------------------------------------------
 	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
-	protected static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
 	private transient Counter numLateRecordsDropped;
-	private transient Meter lateRecordsDroppedRate;
 
 	@VisibleForTesting
 	public Counter getCounter() {
@@ -150,9 +146,6 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 
 		// metrics
 		this.numLateRecordsDropped = getRuntimeContext().getMetricGroup().counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
-		this.lateRecordsDroppedRate = getRuntimeContext().getMetricGroup().meter(
-			LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
-			new MeterView(numLateRecordsDropped));
 	}
 
 	@Override
@@ -183,7 +176,7 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 			}
 			registerCleanupTimer(ctx, triggeringTs);
 		} else {
-			lateRecordsDroppedRate.markEvent();
+			numLateRecordsDropped.inc();
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
@@ -91,11 +91,11 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 	// ------------------------------------------------------------------------
 	// Metrics
 	// ------------------------------------------------------------------------
-	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
 	private transient Counter numLateRecordsDropped;
 
 	@VisibleForTesting
-	public Counter getCounter() {
+	protected Counter getCounter() {
 		return numLateRecordsDropped;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
@@ -157,9 +157,9 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 
 	@Override
 	public void processElement(
-		RowData input,
-		KeyedProcessFunction<K, RowData, RowData>.Context ctx,
-		Collector<RowData> out) throws Exception {
+			RowData input,
+			KeyedProcessFunction<K, RowData, RowData>.Context ctx,
+			Collector<RowData> out) throws Exception {
 		// triggering timestamp for trigger calculation
 		long triggeringTs = input.getLong(rowTimeIdx);
 
@@ -188,8 +188,8 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 	}
 
 	private void registerCleanupTimer(
-		KeyedProcessFunction<K, RowData, RowData>.Context ctx,
-		long timestamp) throws Exception {
+			KeyedProcessFunction<K, RowData, RowData>.Context ctx,
+			long timestamp) throws Exception {
 		// calculate safe timestamp to cleanup states
 		long minCleanupTimestamp = timestamp + precedingOffset + 1;
 		long maxCleanupTimestamp = timestamp + (long) (precedingOffset * 1.5) + 1;
@@ -205,9 +205,9 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 
 	@Override
 	public void onTimer(
-		long timestamp,
-		KeyedProcessFunction<K, RowData, RowData>.OnTimerContext ctx,
-		Collector<RowData> out) throws Exception {
+			long timestamp,
+			KeyedProcessFunction<K, RowData, RowData>.OnTimerContext ctx,
+			Collector<RowData> out) throws Exception {
 		Long cleanupTimestamp = cleanupTsState.value();
 		// if cleanupTsState has not been updated then it is safe to cleanup states
 		if (cleanupTimestamp != null && cleanupTimestamp <= timestamp) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
@@ -100,11 +100,11 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 	}
 
 	public RowTimeRangeBoundedPrecedingFunction(
-		GeneratedAggsHandleFunction genAggsHandler,
-		LogicalType[] accTypes,
-		LogicalType[] inputFieldTypes,
-		long precedingOffset,
-		int rowTimeIdx) {
+			GeneratedAggsHandleFunction genAggsHandler,
+			LogicalType[] accTypes,
+			LogicalType[] inputFieldTypes,
+			long precedingOffset,
+			int rowTimeIdx) {
 		Preconditions.checkNotNull(precedingOffset);
 		this.genAggsHandler = genAggsHandler;
 		this.accTypes = accTypes;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
@@ -27,8 +27,6 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Meter;
-import org.apache.flink.metrics.MeterView;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.data.JoinedRowData;
 import org.apache.flink.table.data.RowData;
@@ -95,9 +93,7 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 	// Metrics
 	// ------------------------------------------------------------------------
 	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
-	protected static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
 	private transient Counter numLateRecordsDropped;
-	private transient Meter lateRecordsDroppedRate;
 
 	@VisibleForTesting
 	public Counter getCounter() {
@@ -155,9 +151,6 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 
 		// metrics
 		this.numLateRecordsDropped = getRuntimeContext().getMetricGroup().counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
-		this.lateRecordsDroppedRate = getRuntimeContext().getMetricGroup().meter(
-			LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
-			new MeterView(numLateRecordsDropped));
 	}
 
 	@Override
@@ -190,7 +183,7 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 				ctx.timerService().registerEventTimeTimer(triggeringTs);
 			}
 		} else {
-			lateRecordsDroppedRate.markEvent();
+			numLateRecordsDropped.inc();
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
@@ -25,6 +26,9 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.data.JoinedRowData;
 import org.apache.flink.table.data.RowData;
@@ -87,6 +91,19 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 
 	private transient AggsHandleFunction function;
 
+	// ------------------------------------------------------------------------
+	// Metrics
+	// ------------------------------------------------------------------------
+	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	protected static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
+	private transient Counter numLateRecordsDropped;
+	private transient Meter lateRecordsDroppedRate;
+
+	@VisibleForTesting
+	public Counter getCounter() {
+		return numLateRecordsDropped;
+	}
+
 	public RowTimeRowsBoundedPrecedingFunction(
 			long minRetentionTime,
 			long maxRetentionTime,
@@ -135,6 +152,12 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 		inputState = getRuntimeContext().getMapState(inputStateDesc);
 
 		initCleanupTimeState("RowTimeBoundedRowsOverCleanupTime");
+
+		// metrics
+		this.numLateRecordsDropped = getRuntimeContext().getMetricGroup().counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
+		this.lateRecordsDroppedRate = getRuntimeContext().getMetricGroup().meter(
+			LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
+			new MeterView(numLateRecordsDropped));
 	}
 
 	@Override
@@ -166,6 +189,8 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 				// register event time timer
 				ctx.timerService().registerEventTimeTimer(triggeringTs);
 			}
+		} else {
+			lateRecordsDroppedRate.markEvent();
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
@@ -92,11 +92,11 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 	// ------------------------------------------------------------------------
 	// Metrics
 	// ------------------------------------------------------------------------
-	protected static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
 	private transient Counter numLateRecordsDropped;
 
 	@VisibleForTesting
-	public Counter getCounter() {
+	protected Counter getCounter() {
 		return numLateRecordsDropped;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeOverWindowTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeOverWindowTestBase.java
@@ -53,7 +53,7 @@ public class RowTimeOverWindowTestBase {
 	protected TypeInformation<RowData> keyType = keySelector.getProducedType();
 
 	protected OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
-		KeyedProcessOperator<RowData, RowData, RowData> operator) throws Exception {
+			KeyedProcessOperator<RowData, RowData, RowData> operator) throws Exception {
 		return new KeyedOneInputStreamOperatorTestHarness<>(operator, keySelector, keyType);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeOverWindowTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeOverWindowTestBase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.over;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.AggsHandleFunction;
+import org.apache.flink.table.runtime.generated.GeneratedAggsHandleFunction;
+import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+/**
+ * Base class for row-time over window test.
+ **/
+public class RowTimeOverWindowTestBase {
+	protected static GeneratedAggsHandleFunction aggsHandleFunction =
+		new GeneratedAggsHandleFunction("Function", "", new Object[0]) {
+			@Override
+			public AggsHandleFunction newInstance(ClassLoader classLoader) {
+				return new SumAggsHandleFunction(1);
+			}
+		};
+
+	protected LogicalType[] inputFieldTypes = new LogicalType[]{
+		new VarCharType(VarCharType.MAX_LENGTH),
+		new BigIntType(),
+		new BigIntType()
+	};
+	protected LogicalType[] accTypes = new LogicalType[]{new BigIntType()};
+
+	protected BinaryRowDataKeySelector keySelector = new BinaryRowDataKeySelector(new int[]{0}, inputFieldTypes);
+	protected TypeInformation<RowData> keyType = keySelector.getProducedType();
+
+	protected OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
+		KeyedProcessOperator<RowData, RowData, RowData> operator) throws Exception {
+		return new KeyedOneInputStreamOperatorTestHarness<>(operator, keySelector, keyType);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunctionTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test for {@link RowTimeRangeBoundedPrecedingFunction}.
  */
-public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase{
+public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
 	@Test
 	public void testStateCleanup() throws Exception {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test for {@link RowTimeRangeUnboundedPrecedingFunction}.
  */
-public class RowTimeRangeUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase{
+public class RowTimeRangeUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
 	@Test
 	public void testLateRecordMetrics() throws Exception {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.operators.over;
 
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -31,42 +30,14 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test for {@link RowTimeRangeBoundedPrecedingFunction}.
+ * Test for {@link RowTimeRangeUnboundedPrecedingFunction}.
  */
-public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase{
-
-	@Test
-	public void testStateCleanup() throws Exception {
-		RowTimeRangeBoundedPrecedingFunction<RowData> function = new RowTimeRangeBoundedPrecedingFunction<>(
-			aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
-		KeyedProcessOperator<RowData, RowData, RowData> operator = new KeyedProcessOperator<>(function);
-
-		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(operator);
-
-		testHarness.open();
-
-		AbstractKeyedStateBackend stateBackend = (AbstractKeyedStateBackend) operator.getKeyedStateBackend();
-
-		assertEquals("Initial state is not empty", 0, stateBackend.numKeyValueStateEntries());
-
-		// put some records
-		testHarness.processElement(insertRecord("key", 1L, 100L));
-		testHarness.processElement(insertRecord("key", 1L, 100L));
-		testHarness.processElement(insertRecord("key", 1L, 500L));
-
-		testHarness.processWatermark(new Watermark(1000L));
-		// at this moment we expect the function to have some records in state
-
-		testHarness.processWatermark(new Watermark(4000L));
-		// at this moment the function should have cleaned up states
-
-		assertEquals("State has not been cleaned up", 0, stateBackend.numKeyValueStateEntries());
-	}
+public class RowTimeRangeUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase{
 
 	@Test
 	public void testLateRecordMetrics() throws Exception {
-		RowTimeRangeBoundedPrecedingFunction<RowData> function = new RowTimeRangeBoundedPrecedingFunction<>(
-			aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
+		RowTimeRangeUnboundedPrecedingFunction<RowData> function = new RowTimeRangeUnboundedPrecedingFunction<>(1000, 2000,
+			aggsHandleFunction, accTypes, inputFieldTypes, 2);
 		KeyedProcessOperator<RowData, RowData, RowData> operator = new KeyedProcessOperator<>(function);
 
 		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(operator);
@@ -87,5 +58,4 @@ public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowT
 
 		assertEquals(1L, counter.getCount());
 	}
-
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunctionTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.operators.over;
 
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -31,41 +30,13 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test for {@link RowTimeRangeBoundedPrecedingFunction}.
+ * Test for {@link RowTimeRowsBoundedPrecedingFunction}.
  */
-public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase{
-
-	@Test
-	public void testStateCleanup() throws Exception {
-		RowTimeRangeBoundedPrecedingFunction<RowData> function = new RowTimeRangeBoundedPrecedingFunction<>(
-			aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
-		KeyedProcessOperator<RowData, RowData, RowData> operator = new KeyedProcessOperator<>(function);
-
-		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(operator);
-
-		testHarness.open();
-
-		AbstractKeyedStateBackend stateBackend = (AbstractKeyedStateBackend) operator.getKeyedStateBackend();
-
-		assertEquals("Initial state is not empty", 0, stateBackend.numKeyValueStateEntries());
-
-		// put some records
-		testHarness.processElement(insertRecord("key", 1L, 100L));
-		testHarness.processElement(insertRecord("key", 1L, 100L));
-		testHarness.processElement(insertRecord("key", 1L, 500L));
-
-		testHarness.processWatermark(new Watermark(1000L));
-		// at this moment we expect the function to have some records in state
-
-		testHarness.processWatermark(new Watermark(4000L));
-		// at this moment the function should have cleaned up states
-
-		assertEquals("State has not been cleaned up", 0, stateBackend.numKeyValueStateEntries());
-	}
+public class RowTimeRowsBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
 	@Test
 	public void testLateRecordMetrics() throws Exception {
-		RowTimeRangeBoundedPrecedingFunction<RowData> function = new RowTimeRangeBoundedPrecedingFunction<>(
+		RowTimeRowsBoundedPrecedingFunction<RowData> function = new RowTimeRowsBoundedPrecedingFunction<>(1000, 2000,
 			aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
 		KeyedProcessOperator<RowData, RowData, RowData> operator = new KeyedProcessOperator<>(function);
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunctionTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.operators.over;
 
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -31,42 +30,14 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test for {@link RowTimeRangeBoundedPrecedingFunction}.
+ * Test for {@link RowTimeRowsUnboundedPrecedingFunction}.
  */
-public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase{
-
-	@Test
-	public void testStateCleanup() throws Exception {
-		RowTimeRangeBoundedPrecedingFunction<RowData> function = new RowTimeRangeBoundedPrecedingFunction<>(
-			aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
-		KeyedProcessOperator<RowData, RowData, RowData> operator = new KeyedProcessOperator<>(function);
-
-		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(operator);
-
-		testHarness.open();
-
-		AbstractKeyedStateBackend stateBackend = (AbstractKeyedStateBackend) operator.getKeyedStateBackend();
-
-		assertEquals("Initial state is not empty", 0, stateBackend.numKeyValueStateEntries());
-
-		// put some records
-		testHarness.processElement(insertRecord("key", 1L, 100L));
-		testHarness.processElement(insertRecord("key", 1L, 100L));
-		testHarness.processElement(insertRecord("key", 1L, 500L));
-
-		testHarness.processWatermark(new Watermark(1000L));
-		// at this moment we expect the function to have some records in state
-
-		testHarness.processWatermark(new Watermark(4000L));
-		// at this moment the function should have cleaned up states
-
-		assertEquals("State has not been cleaned up", 0, stateBackend.numKeyValueStateEntries());
-	}
+public class RowTimeRowsUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
 	@Test
 	public void testLateRecordMetrics() throws Exception {
-		RowTimeRangeBoundedPrecedingFunction<RowData> function = new RowTimeRangeBoundedPrecedingFunction<>(
-			aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
+		RowTimeRowsUnboundedPrecedingFunction<RowData> function = new RowTimeRowsUnboundedPrecedingFunction<>(1000, 2000,
+			aggsHandleFunction, accTypes, inputFieldTypes, 2);
 		KeyedProcessOperator<RowData, RowData, RowData> operator = new KeyedProcessOperator<>(function);
 
 		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(operator);
@@ -87,5 +58,4 @@ public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowT
 
 		assertEquals(1L, counter.getCount());
 	}
-
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently all the row time over windows in blink planner runtime discards late records silently, it would be good to have a metric about the late records dropping.

## Brief change log

- add metrics of late records dropping to all row time over windows


## Verifying this change

This change added tests and can be verified as follows:
- RowTimeRangeBoundedPrecedingFunctionTest
- RowTimeRangeUnboundedPrecedingFunctionTest
- RowTimeRowsBoundedPrecedingFunctionTest
- RowTimeRowsUnboundedPrecedingFunctionTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
