### PR TITLE
[FLINK-19472] Implement a one input sorting DataInput

### DIFF
--- a/docs/_includes/generated/algorithm_configuration.html
+++ b/docs/_includes/generated/algorithm_configuration.html
@@ -15,6 +15,12 @@
             <td>Flag to activate/deactivate bloom filters in the hybrid hash join implementation. In cases where the hash join needs to spill to disk (datasets larger than the reserved fraction of memory), these bloom filters can greatly reduce the number of spilled records, at the cost some CPU cycles.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.runtime.large-record-handler</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to use the LargeRecordHandler when spilling. If a record will not fit into the sorting buffer. The record will be spilled on disk and the sorting will continue with only the key. The record itself will be read afterwards when merging.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.runtime.max-fan</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/AlgorithmOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AlgorithmOptions.java
@@ -44,4 +44,12 @@ public class AlgorithmOptions {
 		key("taskmanager.runtime.sort-spilling-threshold")
 			.defaultValue(0.8f)
 			.withDescription("A sort operation starts spilling when this fraction of its memory budget is full.");
+
+	public static final ConfigOption<Boolean> USE_LARGE_RECORDS_HANDLER =
+		key("taskmanager.runtime.large-record-handler")
+			.defaultValue(false)
+			.withDescription(
+				"Whether to use the LargeRecordHandler when spilling. If a record will not fit into the sorting" +
+					" buffer. The record will be spilled on disk and the sorting will continue with only the key." +
+					" The record itself will be read afterwards when merging.");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -383,7 +383,9 @@ public final class ConfigConstants {
 
 	/**
 	 * Whether to use the LargeRecordHandler when spilling.
+	 * @deprecated use {@link AlgorithmOptions#USE_LARGE_RECORDS_HANDLER}
 	 */
+	@Deprecated
 	public static final String USE_LARGE_RECORD_HANDLER_KEY = "taskmanager.runtime.large-record-handler";
 
 
@@ -1517,7 +1519,10 @@ public final class ConfigConstants {
 
 	/**
 	 * Whether to use the LargeRecordHandler when spilling.
+	 *
+	 * @deprecated use {@link AlgorithmOptions#USE_LARGE_RECORDS_HANDLER} instead
 	 */
+	@Deprecated
 	public static final boolean DEFAULT_USE_LARGE_RECORD_HANDLER = false;
 
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -19,7 +19,6 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
@@ -56,14 +55,4 @@ public class ExecutionOptions {
 						"throughput")
 				)
 				.build());
-
-	@Documentation.ExcludeFromDocumentation("The option is considered internal and should rather not be used" +
-		" explicitly. It will be set automatically by the StreamGraphGenerator based on the RuntimeMode.")
-	public static final ConfigOption<Boolean> SORTED_INPUTS =
-		ConfigOptions.key("execution.sorted-inputs.enabled")
-			.booleanType()
-			.defaultValue(false)
-			.withDescription(
-				"A flag to enable/disable sorting inputs of keyed operators. This is an internal flag. " +
-					"Please use with care!");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
@@ -55,4 +56,14 @@ public class ExecutionOptions {
 						"throughput")
 				)
 				.build());
+
+	@Documentation.ExcludeFromDocumentation("The option is considered internal and should rather not be used" +
+		" explicitly. It will be set automatically by the StreamGraphGenerator based on the RuntimeMode.")
+	public static final ConfigOption<Boolean> SORTED_INPUTS =
+		ConfigOptions.key("execution.sorted-inputs.enabled")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription(
+				"A flag to enable/disable sorting inputs of keyed operators. This is an internal flag. " +
+					"Please use with care!");
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
@@ -18,14 +18,7 @@
 
 package org.apache.flink.api.common.typeutils;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
-import static org.junit.Assert.*;
-
+import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -34,6 +27,17 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Abstract test base for comparators.
@@ -45,8 +49,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	// Same as in the NormalizedKeySorter
 	private static final int DEFAULT_MAX_NORMALIZED_KEY_LEN = 8;
 
-	protected boolean[] getTestedOrder() {
-		return new boolean[] {true, false};
+	protected Order[] getTestedOrder() {
+		return new Order[] {Order.ASCENDING, Order.DESCENDING};
 	}
 
 	protected abstract TypeComparator<T> createComparator(boolean ascending);
@@ -67,7 +71,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	public void testDuplicate() {
 		try {
-			TypeComparator<T> comparator = getComparator(true);
+			boolean ascending = isAscending(getTestedOrder()[0]);
+			TypeComparator<T> comparator = getComparator(ascending);
 			TypeComparator<T> clone = comparator.duplicate();
 			
 			T[] data = getSortedData();
@@ -88,9 +93,9 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	
 	@Test
 	public void testEquality() {
-		for (boolean ascending : getTestedOrder()) {
-			testEquals(true);
-			testEquals(false);
+		for (Order order : getTestedOrder()) {
+			boolean ascending = isAscending(order);
+			testEquals(ascending);
 		}
 	}
 
@@ -128,8 +133,9 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	public void testEqualityWithReference() {
 		try {
 			TypeSerializer<T> serializer = createSerializer();
-			TypeComparator<T> comparator = getComparator(true);
-			TypeComparator<T> comparator2 = getComparator(true);
+			boolean ascending = isAscending(getTestedOrder()[0]);
+			TypeComparator<T> comparator = getComparator(ascending);
+			TypeComparator<T> comparator2 = getComparator(ascending);
 			T[] data = getSortedData();
 			for (T d : data) {
 				comparator.setReference(d);
@@ -151,7 +157,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	// --------------------------------- inequality tests ----------------------------------------
 	@Test
 	public void testInequality() {
-		for (boolean ascending : getTestedOrder()) {
+		for (Order order : getTestedOrder()) {
+			boolean ascending = isAscending(order);
 			testGreatSmallAscDesc(ascending, true);
 			testGreatSmallAscDesc(ascending, false);
 		}
@@ -202,7 +209,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 
 	@Test
 	public void testInequalityWithReference() {
-		for (boolean ascending : getTestedOrder()) {
+		for (Order order : getTestedOrder()) {
+			boolean ascending = isAscending(order);
 			testGreatSmallAscDescWithReference(ascending, true);
 			testGreatSmallAscDescWithReference(ascending, false);
 		}
@@ -276,7 +284,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	public void testNormalizedKeysEqualsFullLength() {
 		// Ascending or descending does not matter in this case
-		TypeComparator<T> comparator = getComparator(true);
+		boolean ascending = isAscending(getTestedOrder()[0]);
+		TypeComparator<T> comparator = getComparator(ascending);
 		if (!comparator.supportsNormalizedKey()) {
 			return;
 		}
@@ -285,7 +294,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 
 	@Test
 	public void testNormalizedKeysEqualsHalfLength() {
-		TypeComparator<T> comparator = getComparator(true);
+		boolean ascending = isAscending(getTestedOrder()[0]);
+		TypeComparator<T> comparator = getComparator(ascending);
 		if (!comparator.supportsNormalizedKey()) {
 			return;
 		}
@@ -294,7 +304,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	
 	public void testNormalizedKeysEquals(boolean halfLength) {
 		try {
-			TypeComparator<T> comparator = getComparator(true);
+			boolean ascending = isAscending(getTestedOrder()[0]);
+			TypeComparator<T> comparator = getComparator(ascending);
 			T[] data = getSortedData();
 			int normKeyLen = getNormKeyLen(halfLength, data, comparator);
 
@@ -315,7 +326,7 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	public void testNormalizedKeysGreatSmallFullLength() {
 		// ascending/descending in comparator doesn't matter for normalized keys
-		boolean ascending = getTestedOrder()[0];
+		boolean ascending = isAscending(getTestedOrder()[0]);
 		TypeComparator<T> comparator = getComparator(ascending);
 		if (!comparator.supportsNormalizedKey()) {
 			return;
@@ -327,7 +338,7 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	public void testNormalizedKeysGreatSmallAscDescHalfLength() {
 		// ascending/descending in comparator doesn't matter for normalized keys
-		boolean ascending = getTestedOrder()[0];
+		boolean ascending = isAscending(getTestedOrder()[0]);
 		TypeComparator<T> comparator = getComparator(ascending);
 		if (!comparator.supportsNormalizedKey()) {
 			return;
@@ -382,7 +393,7 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 			T[] data = getSortedData();
 			T reuse = getSortedData()[0];
 
-			boolean ascending = getTestedOrder()[0];
+			boolean ascending = isAscending(getTestedOrder()[0]);
 			TypeComparator<T> comp1 = getComparator(ascending);
 			if(!comp1.supportsSerializationWithKeyNormalization()){
 				return;
@@ -413,7 +424,7 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testKeyExtraction() {
-		boolean ascending = getTestedOrder()[0];
+		boolean ascending = isAscending(getTestedOrder()[0]);
 		TypeComparator<T> comparator = getComparator(ascending);
 		T[] data = getSortedData();
 
@@ -491,6 +502,11 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	}
 
 	// --------------------------------------------------------------------------------------------
+
+	private static boolean isAscending(Order order) {
+		return order == Order.ASCENDING;
+	}
+
 	public static final class TestOutputView extends DataOutputStream implements DataOutputView {
 
 		public TestOutputView() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
@@ -45,6 +45,10 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	// Same as in the NormalizedKeySorter
 	private static final int DEFAULT_MAX_NORMALIZED_KEY_LEN = 8;
 
+	protected boolean[] getTestedOrder() {
+		return new boolean[] {true, false};
+	}
+
 	protected abstract TypeComparator<T> createComparator(boolean ascending);
 
 	protected abstract TypeSerializer<T> createSerializer();
@@ -84,8 +88,10 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	
 	@Test
 	public void testEquality() {
-		testEquals(true);
-		testEquals(false);
+		for (boolean ascending : getTestedOrder()) {
+			testEquals(true);
+			testEquals(false);
+		}
 	}
 
 	protected void testEquals(boolean ascending) {
@@ -145,10 +151,10 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	// --------------------------------- inequality tests ----------------------------------------
 	@Test
 	public void testInequality() {
-		testGreatSmallAscDesc(true, true);
-		testGreatSmallAscDesc(false, true);
-		testGreatSmallAscDesc(true, false);
-		testGreatSmallAscDesc(false, false);
+		for (boolean ascending : getTestedOrder()) {
+			testGreatSmallAscDesc(ascending, true);
+			testGreatSmallAscDesc(ascending, false);
+		}
 	}
 
 	protected void testGreatSmallAscDesc(boolean ascending, boolean greater) {
@@ -196,10 +202,10 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 
 	@Test
 	public void testInequalityWithReference() {
-		testGreatSmallAscDescWithReference(true, true);
-		testGreatSmallAscDescWithReference(true, false);
-		testGreatSmallAscDescWithReference(false, true);
-		testGreatSmallAscDescWithReference(false, false);
+		for (boolean ascending : getTestedOrder()) {
+			testGreatSmallAscDescWithReference(ascending, true);
+			testGreatSmallAscDescWithReference(ascending, false);
+		}
 	}
 
 	protected void testGreatSmallAscDescWithReference(boolean ascending, boolean greater) {
@@ -309,7 +315,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	public void testNormalizedKeysGreatSmallFullLength() {
 		// ascending/descending in comparator doesn't matter for normalized keys
-		TypeComparator<T> comparator = getComparator(true);
+		boolean ascending = getTestedOrder()[0];
+		TypeComparator<T> comparator = getComparator(ascending);
 		if (!comparator.supportsNormalizedKey()) {
 			return;
 		}
@@ -320,7 +327,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	public void testNormalizedKeysGreatSmallAscDescHalfLength() {
 		// ascending/descending in comparator doesn't matter for normalized keys
-		TypeComparator<T> comparator = getComparator(true);
+		boolean ascending = getTestedOrder()[0];
+		TypeComparator<T> comparator = getComparator(ascending);
 		if (!comparator.supportsNormalizedKey()) {
 			return;
 		}
@@ -374,7 +382,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 			T[] data = getSortedData();
 			T reuse = getSortedData()[0];
 
-			TypeComparator<T> comp1 = getComparator(true);
+			boolean ascending = getTestedOrder()[0];
+			TypeComparator<T> comp1 = getComparator(ascending);
 			if(!comp1.supportsSerializationWithKeyNormalization()){
 				return;
 			}
@@ -404,7 +413,8 @@ public abstract class ComparatorTestBase<T> extends TestLogger {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testKeyExtraction() {
-		TypeComparator<T> comparator = getComparator(true);
+		boolean ascending = getTestedOrder()[0];
+		TypeComparator<T> comparator = getComparator(ascending);
 		T[] data = getSortedData();
 
 		for (T value : data) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/CircularQueues.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/CircularQueues.java
@@ -75,6 +75,9 @@ final class CircularQueues<E> implements StageRunner.StageMessageDispatcher<E> {
 
 	@Override
 	public void sendResult(MutableObjectIterator<E> result) {
+		if (iteratorFuture.isDone()) {
+			throw new IllegalStateException("Result already done");
+		}
 		iteratorFuture.complete(result);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/CircularQueues.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/CircularQueues.java
@@ -75,9 +75,6 @@ final class CircularQueues<E> implements StageRunner.StageMessageDispatcher<E> {
 
 	@Override
 	public void sendResult(MutableObjectIterator<E> result) {
-		if (iteratorFuture.isDone()) {
-			throw new IllegalStateException("Result already done");
-		}
 		iteratorFuture.complete(result);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeIterator.java
@@ -174,8 +174,7 @@ public class MergeIterator<E> implements MutableObjectIterator<E> {
 		
 		@Override
 		public int compare(HeadStream<E> o1, HeadStream<E> o2) {
-			int compareResult = o2.comparator.compareToReference(o1.comparator);
-			return compareResult;
+			return o2.comparator.compareToReference(o1.comparator);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeIterator.java
@@ -174,7 +174,8 @@ public class MergeIterator<E> implements MutableObjectIterator<E> {
 		
 		@Override
 		public int compare(HeadStream<E> o1, HeadStream<E> o2) {
-			return o2.comparator.compareToReference(o1.comparator);
+			int compareResult = o2.comparator.compareToReference(o1.comparator);
+			return compareResult;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java
@@ -531,7 +531,7 @@ public final class NormalizedKeySorter<T> implements InMemorySorter<T> {
 			}
 		}
 	}
-	
+
 	/**
 	 * Writes a subset of the records in this buffer in their logical order to the given output.
 	 * 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/SpillingThread.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/SpillingThread.java
@@ -310,9 +310,13 @@ final class SpillingThread<E> extends ThreadBase<E> {
 		disposeSortBuffers(true);
 
 		// set lazy iterator
-		this.dispatcher.sendResult(iterators.isEmpty() ? EmptyMutableObjectIterator.get() :
-			iterators.size() == 1 ? iterators.get(0) :
-				new MergeIterator<>(iterators, this.comparator));
+		if (iterators.isEmpty()) {
+			this.dispatcher.sendResult(EmptyMutableObjectIterator.get());
+		} else if (iterators.size() == 1) {
+			this.dispatcher.sendResult(iterators.get(0));
+		} else {
+			this.dispatcher.sendResult(new MergeIterator<>(iterators, this.comparator));
+		}
 	}
 
 	private List<ChannelWithBlockCount> startSpilling(Queue<CircularElement<E>> cache) throws IOException, InterruptedException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -523,7 +523,7 @@ public class StreamConfig implements Serializable {
 		}
 	}
 
-	public KeySelector<?, Serializable> getStatePartitioner(int input, ClassLoader cl) {
+	public <IN, K extends Serializable> KeySelector<IN, K> getStatePartitioner(int input, ClassLoader cl) {
 		try {
 			return InstantiationUtil.readObjectFromConfig(this.config, STATE_PARTITIONER + input, cl);
 		} catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -102,6 +102,13 @@ public class StreamConfig implements Serializable {
 
 	private static final String MANAGED_MEMORY_FRACTION_PREFIX = "managedMemFraction.";
 
+	private static final ConfigOption<Boolean> SORTED_INPUTS =
+		ConfigOptions.key("sorted-inputs")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription(
+				"A flag to enable/disable sorting inputs of keyed operators.");
+
 	// ------------------------------------------------------------------------
 	//  Default Values
 	// ------------------------------------------------------------------------
@@ -602,6 +609,14 @@ public class StreamConfig implements Serializable {
 		}
 
 		return builder.toString();
+	}
+
+	public void setShouldSortInputs(boolean sortInputs) {
+		config.set(SORTED_INPUTS, sortInputs);
+	}
+
+	public boolean shouldSortInputs() {
+		return config.get(SORTED_INPUTS);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -631,6 +631,10 @@ public class StreamGraph implements Pipeline {
 		getStreamNode(vertexID).setOutputFormat(outputFormat);
 	}
 
+	void setSortedInputs(int vertexId, boolean shouldSort) {
+		getStreamNode(vertexId).setSortedInputs(shouldSort);
+	}
+
 	void setTransformationUID(Integer nodeId, String transformationId) {
 		StreamNode node = streamNodes.get(nodeId);
 		if (node != null) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -87,6 +87,7 @@ public class StreamNode implements Serializable {
 
 	private String transformationUID;
 	private String userHash;
+	private boolean sortedInputs = false;
 
 	@VisibleForTesting
 	public StreamNode(
@@ -336,6 +337,15 @@ public class StreamNode implements Serializable {
 
 	public void setUserHash(String userHash) {
 		this.userHash = userHash;
+	}
+
+	@VisibleForTesting
+	public void setSortedInputs(boolean sortedInputs) {
+		this.sortedInputs = sortedInputs;
+	}
+
+	boolean getSortedInputs() {
+		return sortedInputs;
 	}
 
 	public Optional<OperatorCoordinator.Provider> getCoordinatorProvider(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.OperatorIDPair;
@@ -476,6 +477,7 @@ public class StreamingJobGraphGenerator {
 
 		config.setTypeSerializersIn(vertex.getTypeSerializersIn());
 		config.setTypeSerializerOut(vertex.getTypeSerializerOut());
+		config.getConfiguration().set(ExecutionOptions.SORTED_INPUTS, vertex.getSortedInputs());
 
 		// iterate edges, find sideOutput edges create and save serializers for each outputTag type
 		for (StreamEdge edge : chainableOutputs) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.OperatorIDPair;
@@ -477,7 +476,7 @@ public class StreamingJobGraphGenerator {
 
 		config.setTypeSerializersIn(vertex.getTypeSerializersIn());
 		config.setTypeSerializerOut(vertex.getTypeSerializerOut());
-		config.getConfiguration().set(ExecutionOptions.SORTED_INPUTS, vertex.getSortedInputs());
+		config.setShouldSortInputs(vertex.getSortedInputs());
 
 		// iterate edges, find sideOutput edges create and save serializers for each outputTag type
 		for (StreamEdge edge : chainableOutputs) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/BytesKeyNormalizationUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/BytesKeyNormalizationUtil.java
@@ -70,9 +70,10 @@ final class BytesKeyNormalizationUtil {
 
 	private static void putBytesArray(MemorySegment target, int offset, int numBytes, byte[] data) {
 		for (int i = 0; i < numBytes; i++) {
-			// default case, full normalized key. need to explicitly convert to int to
-			// avoid false results due to implicit type conversion to int when subtracting
-			// the min byte value
+			// We're converting the signed byte in data into an unsigned representation.
+			// A Java byte goes from -127 to 128, i.e. is signed. By subtracting -127 (MIN_VALUE)
+			// here we're shifting the number to be from 0 to 255. The normalized key sorter sorts
+			// bytes as "unsigned", so we need to convert here to maintain a correct ordering.
 			int highByte = data[i] & 0xff;
 			highByte -= Byte.MIN_VALUE;
 			target.put(offset + i, (byte) highByte);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/BytesKeyNormalizationUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/BytesKeyNormalizationUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import static org.apache.flink.streaming.api.operators.sort.FixedLengthByteKeyComparator.TIMESTAMP_BYTE_SIZE;
+
+/**
+ * Utility class for common key normalization used both in {@link VariableLengthByteKeyComparator}
+ * and {@link FixedLengthByteKeyComparator}.
+ */
+final class BytesKeyNormalizationUtil {
+	/**
+	 * Writes the normalized key of given record. The normalized key consists of the key serialized as bytes and
+	 * the timestamp of the record.
+	 *
+	 * <p>NOTE: The key does not represent a logical order. It can be used only for grouping keys!
+	 */
+	static <IN> void putNormalizedKey(
+			Tuple2<byte[], StreamRecord<IN>> record,
+			int dataLength,
+			MemorySegment target,
+			int offset,
+			int numBytes) {
+		byte[] data = record.f0;
+
+		if (dataLength >= numBytes) {
+			putBytesArray(target, offset, numBytes, data);
+		} else {
+			// whole key fits into the normalized key
+			putBytesArray(target, offset, dataLength, data);
+			int lastOffset = offset + numBytes;
+			offset += dataLength;
+			long valueOfTimestamp = record.f1.asRecord().getTimestamp() - Long.MIN_VALUE;
+			if (dataLength + TIMESTAMP_BYTE_SIZE <= numBytes) {
+				// whole timestamp fits into the normalized key
+				target.putLong(offset, valueOfTimestamp);
+				offset += TIMESTAMP_BYTE_SIZE;
+				// fill in the remaining space with zeros
+				while (offset < lastOffset) {
+					target.put(offset++, (byte) 0);
+				}
+			} else {
+				// only part of the timestamp fits into normalized key
+				for (int i = 0; offset < lastOffset; offset++, i++) {
+					target.put(offset, (byte) (valueOfTimestamp >>> ((7 - i) << 3)));
+				}
+			}
+		}
+	}
+
+	private static void putBytesArray(MemorySegment target, int offset, int numBytes, byte[] data) {
+		for (int i = 0; i < numBytes; i++) {
+			// default case, full normalized key. need to explicitly convert to int to
+			// avoid false results due to implicit type conversion to int when subtracting
+			// the min byte value
+			int highByte = data[i] & 0xff;
+			highByte -= Byte.MIN_VALUE;
+			target.put(offset + i, (byte) highByte);
+		}
+	}
+
+	private BytesKeyNormalizationUtil() {
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparator.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A comparator used in {@link SortingDataInput} which compares records keys and timestamps.
+ * It uses binary format produced by the {@link KeyAndValueSerializer}.
+ *
+ * <p>It assumes keys are always of a fixed length and thus the length of the record is not serialized.
+ */
+final class FixedLengthByteKeyComparator<IN> extends TypeComparator<Tuple2<byte[], StreamRecord<IN>>> {
+	static final int TIMESTAMP_BYTE_SIZE = 8;
+	private final int keyLength;
+	private byte[] keyReference;
+	private long timestampReference;
+
+	FixedLengthByteKeyComparator(int keyLength) {
+		this.keyLength = keyLength;
+	}
+
+	@Override
+	public int hash(Tuple2<byte[], StreamRecord<IN>> record) {
+		return record.hashCode();
+	}
+
+	@Override
+	public void setReference(Tuple2<byte[], StreamRecord<IN>> toCompare) {
+		this.keyReference = toCompare.f0;
+		this.timestampReference = toCompare.f1.asRecord().getTimestamp();
+	}
+
+	@Override
+	public boolean equalToReference(Tuple2<byte[], StreamRecord<IN>> candidate) {
+		return Arrays.equals(keyReference, candidate.f0) &&
+			timestampReference == candidate.f1.asRecord().getTimestamp();
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<Tuple2<byte[], StreamRecord<IN>>> referencedComparator) {
+		byte[] otherKey = ((FixedLengthByteKeyComparator<IN>) referencedComparator).keyReference;
+		long otherTimestamp = ((FixedLengthByteKeyComparator<IN>) referencedComparator).timestampReference;
+
+		int keyCmp = compare(otherKey, this.keyReference);
+		if (keyCmp != 0) {
+			return keyCmp;
+		}
+		return Long.compare(otherTimestamp, this.timestampReference);
+	}
+
+	@Override
+	public int compare(
+			Tuple2<byte[], StreamRecord<IN>> first,
+			Tuple2<byte[], StreamRecord<IN>> second) {
+		int keyCmp = compare(first.f0, second.f0);
+		if (keyCmp != 0) {
+			return keyCmp;
+		}
+		return Long.compare(first.f1.asRecord().getTimestamp(), second.f1.asRecord().getTimestamp());
+	}
+
+	private int compare(byte[] first, byte[] second) {
+		for (int i = 0; i < keyLength; i++) {
+			int cmp = Byte.compare(first[i], second[i]);
+
+			if (cmp != 0) {
+				return cmp < 0 ? -1 : 1;
+			}
+		}
+
+		return 0;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int minCount = keyLength;
+		while (minCount-- > 0) {
+			byte firstValue = firstSource.readByte();
+			byte secondValue = secondSource.readByte();
+
+			int cmp = Byte.compare(firstValue, secondValue);
+			if (cmp != 0) {
+				return cmp < 0 ? -1 : 1;
+			}
+		}
+
+		return Long.compare(firstSource.readLong(), secondSource.readLong());
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return true;
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return keyLength + TIMESTAMP_BYTE_SIZE;
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		return keyBytes < getNormalizeKeyLen();
+	}
+
+	@Override
+	public void putNormalizedKey(Tuple2<byte[], StreamRecord<IN>> record, MemorySegment target, int offset, int numBytes) {
+		BytesKeyNormalizationUtil.putNormalizedKey(record, keyLength, target, offset, numBytes);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return false;
+	}
+
+	@Override
+	public TypeComparator<Tuple2<byte[], StreamRecord<IN>>> duplicate() {
+		return new FixedLengthByteKeyComparator<>(this.keyLength);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator<?>[] getFlatComparators() {
+		return new TypeComparator[] {this};
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// unsupported normalization
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(
+		Tuple2<byte[], StreamRecord<IN>> record,
+		DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Tuple2<byte[], StreamRecord<IN>> readWithKeyDenormalization(
+		Tuple2<byte[], StreamRecord<IN>> reuse,
+		DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
@@ -42,6 +42,7 @@ import java.util.Objects;
  * </pre>
  */
 final class KeyAndValueSerializer<IN> extends TypeSerializer<Tuple2<byte[], StreamRecord<IN>>> {
+	private static final int TIMESTAMP_LENGTH = 8;
 	private final TypeSerializer<IN> valueSerializer;
 	private final int serializedKeyLength;
 
@@ -90,7 +91,10 @@ final class KeyAndValueSerializer<IN> extends TypeSerializer<Tuple2<byte[], Stre
 
 	@Override
 	public int getLength() {
-		return -1;
+		if (valueSerializer.getLength() < 0 || serializedKeyLength < 0) {
+			return -1;
+		}
+		return valueSerializer.getLength() + serializedKeyLength + TIMESTAMP_LENGTH;
 	}
 
 	@Override
@@ -176,6 +180,7 @@ final class KeyAndValueSerializer<IN> extends TypeSerializer<Tuple2<byte[], Stre
 
 	@Override
 	public TypeSerializerSnapshot<Tuple2<byte[], StreamRecord<IN>>> snapshotConfiguration() {
-		return null;
+		throw new UnsupportedOperationException(
+			"The KeyAndValueSerializer should not be used for persisting into State!");
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
@@ -44,6 +44,8 @@ import java.util.Objects;
 final class KeyAndValueSerializer<IN> extends TypeSerializer<Tuple2<byte[], StreamRecord<IN>>> {
 	private static final int TIMESTAMP_LENGTH = 8;
 	private final TypeSerializer<IN> valueSerializer;
+
+	// This represents either a variable length (-1) or a fixed one (>= 0).
 	private final int serializedKeyLength;
 
 	KeyAndValueSerializer(TypeSerializer<IN> valueSerializer, int serializedKeyLength) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A serializer used in {@link SortingDataInput} for serializing elements alongside their key and
+ * timestamp. It serializes the record in a format known by the {@link FixedLengthByteKeyComparator}
+ * and {@link VariableLengthByteKeyComparator}.
+ *
+ * <p>If the key is of known constant length, the length is not serialized with the data.
+ * Therefore the serialized data is as follows:
+ *
+ * <pre>
+ *      [key-length] | &lt;key&gt; | &lt;timestamp&gt; | &lt;record&gt;
+ * </pre>
+ */
+final class KeyAndValueSerializer<IN> extends TypeSerializer<Tuple2<byte[], StreamRecord<IN>>> {
+	private final TypeSerializer<IN> valueSerializer;
+	private final int serializedKeyLength;
+
+	KeyAndValueSerializer(TypeSerializer<IN> valueSerializer, int serializedKeyLength) {
+		this.valueSerializer = valueSerializer;
+		this.serializedKeyLength = serializedKeyLength;
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return false;
+	}
+
+	@Override
+	public TypeSerializer<Tuple2<byte[], StreamRecord<IN>>> duplicate() {
+		return new KeyAndValueSerializer<>(valueSerializer.duplicate(), this.serializedKeyLength);
+	}
+
+	@Override
+	public Tuple2<byte[], StreamRecord<IN>> copy(Tuple2<byte[], StreamRecord<IN>> from) {
+		StreamRecord<IN> fromRecord = from.f1;
+		return Tuple2.of(
+			Arrays.copyOf(from.f0, from.f0.length),
+			fromRecord.copy(valueSerializer.copy(fromRecord.getValue()))
+		);
+	}
+
+	@Override
+	public Tuple2<byte[], StreamRecord<IN>> createInstance() {
+		return Tuple2.of(new byte[0], new StreamRecord<>(valueSerializer.createInstance()));
+	}
+
+	@Override
+	public Tuple2<byte[], StreamRecord<IN>> copy(
+			Tuple2<byte[], StreamRecord<IN>> from,
+			Tuple2<byte[], StreamRecord<IN>> reuse) {
+		StreamRecord<IN> fromRecord = from.f1;
+		StreamRecord<IN> reuseRecord = reuse.f1;
+
+		IN valueCopy = valueSerializer.copy(fromRecord.getValue(), reuseRecord.getValue());
+		fromRecord.copyTo(valueCopy, reuseRecord);
+		reuse.f0 = Arrays.copyOf(from.f0, from.f0.length);
+		reuse.f1 = reuseRecord;
+		return reuse;
+	}
+
+	@Override
+	public int getLength() {
+		return -1;
+	}
+
+	@Override
+	public void serialize(Tuple2<byte[], StreamRecord<IN>> record, DataOutputView target) throws IOException {
+		if (serializedKeyLength < 0) {
+			target.writeInt(record.f0.length);
+		}
+		target.write(record.f0);
+		StreamRecord<IN> toSerialize = record.f1;
+		target.writeLong(toSerialize.getTimestamp());
+		valueSerializer.serialize(toSerialize.getValue(), target);
+	}
+
+	@Override
+	public Tuple2<byte[], StreamRecord<IN>> deserialize(DataInputView source) throws IOException {
+		final int length = getKeyLength(source);
+		byte[] bytes = new byte[length];
+		source.read(bytes);
+		long timestamp = source.readLong();
+		IN value = valueSerializer.deserialize(source);
+		return Tuple2.of(
+			bytes,
+			new StreamRecord<>(value, timestamp)
+		);
+	}
+
+	@Override
+	public Tuple2<byte[], StreamRecord<IN>> deserialize(Tuple2<byte[], StreamRecord<IN>> reuse, DataInputView source) throws IOException {
+		final int length = getKeyLength(source);
+		byte[] bytes = new byte[length];
+		source.read(bytes);
+		long timestamp = source.readLong();
+		IN value = valueSerializer.deserialize(source);
+		StreamRecord<IN> reuseRecord = reuse.f1;
+		reuseRecord.replace(value, timestamp);
+		reuse.f0 = bytes;
+		reuse.f1 = reuseRecord;
+		return reuse;
+	}
+
+	private int getKeyLength(DataInputView source) throws IOException {
+		final int length;
+		if (serializedKeyLength < 0) {
+			length = source.readInt();
+		} else {
+			length = serializedKeyLength;
+		}
+		return length;
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		final int length;
+		if (serializedKeyLength < 0) {
+			length = source.readInt();
+			target.writeInt(length);
+		} else {
+			length = serializedKeyLength;
+		}
+		for (int i = 0; i < length; i++) {
+			target.writeByte(source.readByte());
+		}
+		target.writeLong(source.readLong());
+		valueSerializer.copy(source, target);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		KeyAndValueSerializer<?> that = (KeyAndValueSerializer<?>) o;
+		return Objects.equals(valueSerializer, that.valueSerializer);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(valueSerializer);
+	}
+
+	@Override
+	public TypeSerializerSnapshot<Tuple2<byte[], StreamRecord<IN>>> snapshotConfiguration() {
+		return null;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
@@ -112,7 +112,7 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
 					jobConfiguration.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD))
 				.maxNumFileHandles(jobConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
 				.objectReuse(objectReuse)
-				.largeRecords(true)
+				.largeRecords(jobConfiguration.get(AlgorithmOptions.USE_LARGE_RECORDS_HANDLER))
 				.build();
 		} catch (MemoryAllocationException e) {
 			throw new RuntimeException(e);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.AlgorithmOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.sort.ExternalSorter;
+import org.apache.flink.runtime.operators.sort.PushSorter;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.MutableObjectIterator;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@link StreamTaskInput} which sorts in the incoming records from a chained input. It postpones
+ * emitting the records until it receives {@link InputStatus#END_OF_INPUT} from the chained input.
+ * After it is done it emits a single record at a time from the sorter.
+ *
+ * <p>The sorter uses binary comparison of keys, which are extracted and serialized when received
+ * from the chained input. Moreover the timestamps of incoming records are used for secondary ordering.
+ * For the comparison it uses either {@link FixedLengthByteKeyComparator} if the length of the
+ * serialized key is constant, or {@link VariableLengthByteKeyComparator} otherwise.
+ *
+ * <p>Watermarks, stream statuses, nor latency markers are not propagated downstream as they do not make
+ * sense with buffered records. The input emits a MAX_WATERMARK after all records.
+ *
+ * @param <T> The type of the value in incoming {@link StreamRecord StreamRecords}.
+ * @param <K> The type of the key.
+ */
+public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
+
+	private final StreamTaskInput<T> chained;
+	private final PushSorter<Tuple2<byte[], StreamRecord<T>>> sorter;
+	private final KeySelector<T, K> keySelector;
+	private final TypeSerializer<K> keySerializer;
+	private final DataOutputSerializer dataOutputSerializer;
+	private final ForwardingDataOutput forwardingDataOutput;
+	private MutableObjectIterator<Tuple2<byte[], StreamRecord<T>>> sortedInput = null;
+	private boolean emittedLast;
+
+	public SortingDataInput(
+			StreamTaskInput<T> chained,
+			TypeSerializer<T> typeSerializer,
+			TypeSerializer<K> keySerializer,
+			KeySelector<T, K> keySelector,
+			MemoryManager memoryManager,
+			IOManager ioManager,
+			boolean objectReuse,
+			double managedMemoryFraction,
+			Configuration jobConfiguration,
+			AbstractInvokable containingTask) {
+		try {
+			this.forwardingDataOutput = new ForwardingDataOutput();
+			this.keySelector = keySelector;
+			this.keySerializer = keySerializer;
+			int keyLength = keySerializer.getLength();
+			final TypeComparator<Tuple2<byte[], StreamRecord<T>>> comparator;
+			if (keyLength > 0) {
+				this.dataOutputSerializer = new DataOutputSerializer(keyLength);
+				comparator = new FixedLengthByteKeyComparator<>(keyLength);
+			} else {
+				this.dataOutputSerializer = new DataOutputSerializer(64);
+				comparator = new VariableLengthByteKeyComparator<>();
+			}
+			KeyAndValueSerializer<T> keyAndValueSerializer = new KeyAndValueSerializer<>(typeSerializer, keyLength);
+			this.chained = chained;
+			this.sorter = ExternalSorter.newBuilder(
+					memoryManager,
+					containingTask,
+					keyAndValueSerializer,
+					comparator)
+				.memoryFraction(managedMemoryFraction)
+				.enableSpilling(
+					ioManager,
+					jobConfiguration.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD))
+				.maxNumFileHandles(jobConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
+				.objectReuse(objectReuse)
+				.largeRecords(true)
+				.build();
+		} catch (MemoryAllocationException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public int getInputIndex() {
+		return chained.getInputIndex();
+	}
+
+	@Override
+	public CompletableFuture<Void> prepareSnapshot(
+			ChannelStateWriter channelStateWriter,
+			long checkpointId) throws IOException {
+		throw new UnsupportedOperationException("Checkpoints are not supported for sorting inputs");
+	}
+
+	@Override
+	public void close() throws IOException {
+		IOException ex = null;
+		try {
+			chained.close();
+		} catch (IOException e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		try {
+			sorter.close();
+		} catch (IOException e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		if (ex != null) {
+			throw ex;
+		}
+	}
+
+	private class ForwardingDataOutput implements DataOutput<T> {
+		@Override
+		public void emitRecord(StreamRecord<T> streamRecord) throws Exception {
+			K key = keySelector.getKey(streamRecord.getValue());
+
+			keySerializer.serialize(key, dataOutputSerializer);
+			byte[] serializedKey = dataOutputSerializer.getCopyOfBuffer();
+			dataOutputSerializer.clear();
+
+			sorter.writeRecord(Tuple2.of(serializedKey, streamRecord));
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) throws Exception {
+
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
+
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+
+		}
+	}
+
+	@Override
+	public InputStatus emitNext(DataOutput<T> output) throws Exception {
+		if (sortedInput != null) {
+			return emitNextSortedRecord(output);
+		}
+
+		InputStatus inputStatus = chained.emitNext(forwardingDataOutput);
+		if (inputStatus == InputStatus.END_OF_INPUT) {
+			endSorting();
+			return emitNextSortedRecord(output);
+		}
+
+		return inputStatus;
+	}
+
+	@Nonnull
+	private InputStatus emitNextSortedRecord(DataOutput<T> output) throws Exception {
+		if (emittedLast) {
+			return InputStatus.END_OF_INPUT;
+		}
+
+		Tuple2<byte[], StreamRecord<T>> next = sortedInput.next();
+		if (next != null) {
+			output.emitRecord(next.f1);
+			return InputStatus.MORE_AVAILABLE;
+		} else {
+			emittedLast = true;
+			output.emitWatermark(Watermark.MAX_WATERMARK);
+			return InputStatus.END_OF_INPUT;
+		}
+	}
+
+	private void endSorting() throws Exception {
+		this.sorter.finishReading();
+		this.sortedInput = sorter.getIterator();
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		if (sortedInput != null) {
+			return AvailabilityProvider.AVAILABLE;
+		} else {
+			return chained.getAvailableFuture();
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparator.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A comparator used in {@link SortingDataInput} which compares records keys and timestamps,.
+ * It uses binary format produced by the {@link KeyAndValueSerializer}.
+ *
+ * <p>It assumes keys are of a variable length and thus expects the length of the record to be serialized.
+ */
+final class VariableLengthByteKeyComparator<IN> extends TypeComparator<Tuple2<byte[], StreamRecord<IN>>> {
+	private byte[] keyReference;
+	private long timestampReference;
+
+	@Override
+	public int hash(Tuple2<byte[], StreamRecord<IN>> record) {
+		return record.hashCode();
+	}
+
+	@Override
+	public void setReference(Tuple2<byte[], StreamRecord<IN>> toCompare) {
+		this.keyReference = Arrays.copyOf(toCompare.f0, toCompare.f0.length);
+		this.timestampReference = toCompare.f1.asRecord().getTimestamp();
+	}
+
+	@Override
+	public boolean equalToReference(Tuple2<byte[], StreamRecord<IN>> candidate) {
+		return Arrays.equals(keyReference, candidate.f0) &&
+			timestampReference == candidate.f1.asRecord().getTimestamp();
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<Tuple2<byte[], StreamRecord<IN>>> referencedComparator) {
+		byte[] otherKey = ((VariableLengthByteKeyComparator<IN>) referencedComparator).keyReference;
+		long otherTimestamp = ((VariableLengthByteKeyComparator<IN>) referencedComparator).timestampReference;
+
+		int keyCmp = compare(otherKey, this.keyReference);
+		if (keyCmp != 0) {
+			return keyCmp;
+		}
+		return Long.compare(otherTimestamp, this.timestampReference);
+	}
+
+	@Override
+	public int compare(
+			Tuple2<byte[], StreamRecord<IN>> first,
+			Tuple2<byte[], StreamRecord<IN>> second) {
+		int keyCmp = compare(first.f0, second.f0);
+		if (keyCmp != 0) {
+			return keyCmp;
+		}
+		return Long.compare(first.f1.asRecord().getTimestamp(), second.f1.asRecord().getTimestamp());
+	}
+
+	private int compare(byte[] first, byte[] second) {
+		int firstLength = first.length;
+		int secondLength = second.length;
+		int minLength = Math.min(firstLength, secondLength);
+		for (int i = 0; i < minLength; i++) {
+			int cmp = Byte.compare(first[i], second[i]);
+
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+
+		return Integer.compare(firstLength, secondLength);
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int firstLength = firstSource.readInt();
+		int secondLength = secondSource.readInt();
+		int minLength = Math.min(firstLength, secondLength);
+		while (minLength-- > 0) {
+			byte firstValue = firstSource.readByte();
+			byte secondValue = secondSource.readByte();
+
+			int cmp = Byte.compare(firstValue, secondValue);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+
+		int lengthCompare = Integer.compare(firstLength, secondLength);
+		if (lengthCompare != 0) {
+			return lengthCompare;
+		} else {
+			return Long.compare(firstSource.readLong(), secondSource.readLong());
+		}
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return true;
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		return true;
+	}
+
+	@Override
+	public void putNormalizedKey(Tuple2<byte[], StreamRecord<IN>> record, MemorySegment target, int offset, int numBytes) {
+		BytesKeyNormalizationUtil.putNormalizedKey(record, record.f0.length, target, offset, numBytes);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return false;
+	}
+
+	@Override
+	public TypeComparator<Tuple2<byte[], StreamRecord<IN>>> duplicate() {
+		return new VariableLengthByteKeyComparator<>();
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator<?>[] getFlatComparators() {
+		return new TypeComparator[] {this};
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// unsupported normalization
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(
+		Tuple2<byte[], StreamRecord<IN>> record,
+		DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Tuple2<byte[], StreamRecord<IN>> readWithKeyDenormalization(
+		Tuple2<byte[], StreamRecord<IN>> reuse,
+		DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -123,7 +123,7 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 						checkpointedInputGates[networkInput.getInputGateIndex()],
 						networkInput.getTypeSerializer(),
 						ioManager,
-						new StatusWatermarkValve(checkpointedInputGates[networkInput.getInputGateIndex()].getNumberOfInputChannels(), dataOutput),
+						new StatusWatermarkValve(checkpointedInputGates[networkInput.getInputGateIndex()].getNumberOfInputChannels()),
 						i));
 			}
 			else if (configuredInput instanceof SourceInputConfig) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -178,11 +178,11 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 		if (recordOrMark.isRecord()){
 			output.emitRecord(recordOrMark.asRecord());
 		} else if (recordOrMark.isWatermark()) {
-			statusWatermarkValve.inputWatermark(recordOrMark.asWatermark(), lastChannel);
+			statusWatermarkValve.inputWatermark(recordOrMark.asWatermark(), lastChannel, output);
 		} else if (recordOrMark.isLatencyMarker()) {
 			output.emitLatencyMarker(recordOrMark.asLatencyMarker());
 		} else if (recordOrMark.isStreamStatus()) {
-			statusWatermarkValve.inputStreamStatus(recordOrMark.asStreamStatus(), lastChannel);
+			statusWatermarkValve.inputStreamStatus(recordOrMark.asStreamStatus(), lastChannel, output);
 		} else {
 			throw new UnsupportedOperationException("Unknown type of StreamElement");
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -118,13 +118,13 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 			checkpointedInputGates[0],
 			inputSerializer1,
 			ioManager,
-			new StatusWatermarkValve(checkpointedInputGates[0].getNumberOfInputChannels(), output1),
+			new StatusWatermarkValve(checkpointedInputGates[0].getNumberOfInputChannels()),
 			0);
 		this.input2 = new StreamTaskNetworkInput<>(
 			checkpointedInputGates[1],
 			inputSerializer2,
 			ioManager,
-			new StatusWatermarkValve(checkpointedInputGates[1].getNumberOfInputChannels(), output2),
+			new StatusWatermarkValve(checkpointedInputGates[1].getNumberOfInputChannels()),
 			1);
 
 		this.operatorChain = checkNotNull(operatorChain);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
@@ -59,6 +59,10 @@ public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT> extends StreamTa
 		StreamConfig configuration = getConfiguration();
 		ClassLoader userClassLoader = getUserCodeClassLoader();
 
+		if (configuration.shouldSortInputs()) {
+			throw new UnsupportedOperationException("Sorting inputs is not supported for a two input stream task yet.");
+		}
+
 		TypeSerializer<IN1> inputDeserializer1 = configuration.getTypeSerializerIn1(userClassLoader);
 		TypeSerializer<IN2> inputDeserializer2 = configuration.getTypeSerializerIn2(userClassLoader);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -73,6 +73,11 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 		StreamConfig configuration = getConfiguration();
 		ClassLoader userClassLoader = getUserCodeClassLoader();
 
+		if (configuration.shouldSortInputs()) {
+			throw new UnsupportedOperationException(
+				"Sorting inputs is not supported for a multiple input stream task yet.");
+		}
+
 		InputConfig[] inputs = configuration.getInputs(userClassLoader);
 
 		WatermarkGauge[] watermarkGauges = new WatermarkGauge[inputs.length];

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -88,7 +88,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			CheckpointedInputGate inputGate = createCheckpointedInputGate();
 			Counter numRecordsIn = setupNumRecordsInCounter(mainOperator);
 			DataOutput<IN> output = createDataOutput(numRecordsIn);
-			StreamTaskInput<IN> input = createTaskInput(inputGate, output);
+			StreamTaskInput<IN> input = createTaskInput(inputGate);
 			getEnvironment().getMetricGroup().getIOMetricGroup().reuseRecordsInputCounter(numRecordsIn);
 			inputProcessor = new StreamOneInputProcessor<>(
 				input,
@@ -121,9 +121,9 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			numRecordsIn);
 	}
 
-	private StreamTaskInput<IN> createTaskInput(CheckpointedInputGate inputGate, DataOutput<IN> output) {
+	private StreamTaskInput<IN> createTaskInput(CheckpointedInputGate inputGate) {
 		int numberOfInputChannels = inputGate.getNumberOfInputChannels();
-		StatusWatermarkValve statusWatermarkValve = new StatusWatermarkValve(numberOfInputChannels, output);
+		StatusWatermarkValve statusWatermarkValve = new StatusWatermarkValve(numberOfInputChannels);
 
 		TypeSerializer<IN> inSerializer = configuration.getTypeSerializerIn1(getUserCodeClassLoader());
 		return new StreamTaskNetworkInput<>(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
@@ -119,12 +120,10 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			getEnvironment().getMemoryManager(),
 			getEnvironment().getIOManager(),
 			getExecutionConfig().isObjectReuseEnabled(),
-			1.0,
-			// TODO we should get it from config somehow
-//			configuration.getManagedMemoryFractionOperatorUseCaseOfSlot(
-//				ManagedMemoryUseCase.BATCH_OP,
-//				getTaskConfiguration()
-//			),
+			configuration.getManagedMemoryFractionOperatorUseCaseOfSlot(
+				ManagedMemoryUseCase.BATCH_OP,
+				getTaskConfiguration()
+			),
 			getJobConfiguration(),
 			this
 		);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -21,12 +21,14 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.sort.SortingDataInput;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.AbstractDataOutput;
 import org.apache.flink.streaming.runtime.io.CheckpointedInputGate;
@@ -44,6 +46,7 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import javax.annotation.Nullable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link StreamTask} for executing a {@link OneInputStreamOperator}.
@@ -89,7 +92,15 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			Counter numRecordsIn = setupNumRecordsInCounter(mainOperator);
 			DataOutput<IN> output = createDataOutput(numRecordsIn);
 			StreamTaskInput<IN> input = createTaskInput(inputGate);
+
+			Boolean shouldSortInputs = configuration.getConfiguration().get(ExecutionOptions.SORTED_INPUTS);
+			if (shouldSortInputs) {
+				checkState(!configuration.isCheckpointingEnabled(), "Checkpointing is not allowed with sorted inputs.");
+				input = wrapWithSorted(input);
+			}
+
 			getEnvironment().getMetricGroup().getIOMetricGroup().reuseRecordsInputCounter(numRecordsIn);
+
 			inputProcessor = new StreamOneInputProcessor<>(
 				input,
 				output,
@@ -98,6 +109,27 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 		mainOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge);
 		// wrap watermark gauge since registered metrics must be unique
 		getEnvironment().getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge::getValue);
+	}
+
+	private StreamTaskInput<IN> wrapWithSorted(StreamTaskInput<IN> input) {
+		ClassLoader userCodeClassLoader = getUserCodeClassLoader();
+		return new SortingDataInput<>(
+			input,
+			configuration.getTypeSerializerIn(input.getInputIndex(), userCodeClassLoader),
+			configuration.getStateKeySerializer(userCodeClassLoader),
+			configuration.getStatePartitioner(input.getInputIndex(), userCodeClassLoader),
+			getEnvironment().getMemoryManager(),
+			getEnvironment().getIOManager(),
+			getExecutionConfig().isObjectReuseEnabled(),
+			1.0,
+			// TODO we should get it from config somehow
+//			configuration.getManagedMemoryFractionOperatorUseCaseOfSlot(
+//				ManagedMemoryUseCase.BATCH_OP,
+//				getTaskConfiguration()
+//			),
+			getJobConfiguration(),
+			this
+		);
 	}
 
 	private CheckpointedInputGate createCheckpointedInputGate() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
@@ -93,8 +92,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			DataOutput<IN> output = createDataOutput(numRecordsIn);
 			StreamTaskInput<IN> input = createTaskInput(inputGate);
 
-			Boolean shouldSortInputs = configuration.getConfiguration().get(ExecutionOptions.SORTED_INPUTS);
-			if (shouldSortInputs) {
+			if (configuration.shouldSortInputs()) {
 				checkState(!configuration.isCheckpointingEnabled(), "Checkpointing is not allowed with sorted inputs.");
 				input = wrapWithSorted(input);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.sort;
 
+import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -33,8 +34,8 @@ import static org.junit.Assert.assertThat;
  */
 public class FixedLengthByteKeyComparatorTest extends ComparatorTestBase<Tuple2<byte[], StreamRecord<Integer>>> {
 	@Override
-	protected boolean[] getTestedOrder() {
-		return new boolean[]{true};
+	protected Order[] getTestedOrder() {
+		return new Order[]{Order.ASCENDING};
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link FixedLengthByteKeyComparator}.
+ */
+public class FixedLengthByteKeyComparatorTest extends ComparatorTestBase<Tuple2<byte[], StreamRecord<Integer>>> {
+	@Override
+	protected boolean[] getTestedOrder() {
+		return new boolean[]{true};
+	}
+
+	@Override
+	protected TypeComparator<Tuple2<byte[], StreamRecord<Integer>>> createComparator(boolean ascending) {
+		return new FixedLengthByteKeyComparator<>(
+			new IntSerializer().getLength()
+		);
+	}
+
+	@Override
+	protected TypeSerializer<Tuple2<byte[], StreamRecord<Integer>>> createSerializer() {
+		IntSerializer intSerializer = new IntSerializer();
+		return new KeyAndValueSerializer<>(
+			intSerializer,
+			intSerializer.getLength()
+		);
+	}
+
+	@Override
+	protected void deepEquals(
+			String message,
+			Tuple2<byte[], StreamRecord<Integer>> should,
+			Tuple2<byte[], StreamRecord<Integer>> is) {
+		assertThat(message, should.f0, equalTo(is.f0));
+		assertThat(message, should.f1, equalTo(is.f1));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Tuple2<byte[], StreamRecord<Integer>>[] getSortedTestData() {
+		IntSerializer intSerializer = new IntSerializer();
+		DataOutputSerializer outputSerializer = new DataOutputSerializer(intSerializer.getLength());
+
+		return IntStream.range(-10, 10)
+			.mapToObj(
+				idx -> {
+					try {
+						intSerializer.serialize(idx, outputSerializer);
+						byte[] copyOfBuffer = outputSerializer.getCopyOfBuffer();
+						outputSerializer.clear();
+						return Tuple2.of(copyOfBuffer, new StreamRecord<>(idx, idx));
+					} catch (IOException e) {
+						throw new AssertionError(e);
+					}
+				}
+			).toArray(Tuple2[]::new);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthKeyAndValueSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthKeyAndValueSerializerTest.java
@@ -18,31 +18,21 @@
 
 package org.apache.flink.streaming.api.operators.sort;
 
-import org.apache.flink.api.common.typeutils.ComparatorTestBase;
-import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 /**
- * Tests for {@link FixedLengthByteKeyComparator}.
+ * Tests for {@link KeyAndValueSerializer}, which verify fixed length keys.
  */
-public class FixedLengthByteKeyComparatorTest extends ComparatorTestBase<Tuple2<byte[], StreamRecord<Integer>>> {
-	@Override
-	protected boolean[] getTestedOrder() {
-		return new boolean[]{true};
-	}
+public class FixedLengthKeyAndValueSerializerTest extends SerializerTestBase<Tuple2<byte[], StreamRecord<Integer>>> {
 
-	@Override
-	protected TypeComparator<Tuple2<byte[], StreamRecord<Integer>>> createComparator(boolean ascending) {
-		return new FixedLengthByteKeyComparator<>(
-			new IntSerializer().getLength()
-		);
-	}
+	private static final int INTEGER_SIZE = 4;
+	private static final int TIMESTAMP_SIZE = 8;
 
 	@Override
 	protected TypeSerializer<Tuple2<byte[], StreamRecord<Integer>>> createSerializer() {
@@ -54,16 +44,30 @@ public class FixedLengthByteKeyComparatorTest extends ComparatorTestBase<Tuple2<
 	}
 
 	@Override
-	protected void deepEquals(
-			String message,
-			Tuple2<byte[], StreamRecord<Integer>> should,
-			Tuple2<byte[], StreamRecord<Integer>> is) {
-		assertThat(message, should.f0, equalTo(is.f0));
-		assertThat(message, should.f1, equalTo(is.f1));
+	protected int getLength() {
+		return INTEGER_SIZE + TIMESTAMP_SIZE + INTEGER_SIZE;
 	}
 
 	@Override
-	protected Tuple2<byte[], StreamRecord<Integer>>[] getSortedTestData() {
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	protected Class<Tuple2<byte[], StreamRecord<Integer>>> getTypeClass() {
+		return (Class<Tuple2<byte[], StreamRecord<Integer>>>) (Class) Tuple2.class;
+	}
+
+	@Override
+	protected Tuple2<byte[], StreamRecord<Integer>>[] getTestData() {
 		return SerializerComparatorTestData.getOrderedIntTestData();
+	}
+
+	@Override
+	@Test(expected = UnsupportedOperationException.class)
+	public void testConfigSnapshotInstantiation() {
+		super.testConfigSnapshotInstantiation();
+	}
+
+	@Override
+	@Test(expected = UnsupportedOperationException.class)
+	public void testSnapshotConfigurationAndReconfigure() throws Exception {
+		super.testSnapshotConfigurationAndReconfigure();
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SerializerComparatorTestData.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SerializerComparatorTestData.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Test data for {@link VariableLengthByteKeyComparatorTest}, {@link FixedLengthByteKeyComparatorTest},
+ * {@link FixedLengthKeyAndValueSerializerTest}, and {@link VariableLengthKeyAndValueSerializerTest}.
+ */
+final class SerializerComparatorTestData {
+	@SuppressWarnings("unchecked")
+	static Tuple2<byte[], StreamRecord<Integer>>[] getOrderedIntTestData() {
+		IntSerializer intSerializer = new IntSerializer();
+		DataOutputSerializer outputSerializer = new DataOutputSerializer(intSerializer.getLength());
+
+		return IntStream.range(-10, 10)
+			.mapToObj(
+				idx -> {
+					try {
+						intSerializer.serialize(idx, outputSerializer);
+						byte[] copyOfBuffer = outputSerializer.getCopyOfBuffer();
+						outputSerializer.clear();
+						return Tuple2.of(copyOfBuffer, new StreamRecord<>(idx, idx));
+					} catch (IOException e) {
+						throw new AssertionError(e);
+					}
+				}
+			).toArray(Tuple2[]::new);
+	}
+
+	@SuppressWarnings("unchecked")
+	static Tuple2<byte[], StreamRecord<String>>[] getOrderedStringTestData() {
+		StringSerializer stringSerializer = new StringSerializer();
+		DataOutputSerializer outputSerializer = new DataOutputSerializer(64);
+		return Stream.of(
+			new String(new byte[] {-1, 0}),
+			new String(new byte[] {0, 1}),
+			"A",
+			"AB",
+			"ABC",
+			"ABCD",
+			"ABCDE",
+			"ABCDEF",
+			"ABCDEFG",
+			"ABCDEFGH")
+			.map(
+				str -> {
+					try {
+						stringSerializer.serialize(str, outputSerializer);
+						byte[] copyOfBuffer = outputSerializer.getCopyOfBuffer();
+						outputSerializer.clear();
+						return Tuple2.of(copyOfBuffer, new StreamRecord<>(str, 0));
+					} catch (IOException e) {
+						throw new AssertionError(e);
+					}
+				}
+			).sorted(
+				(o1, o2) -> {
+					byte[] key0 = o1.f0;
+					byte[] key1 = o2.f0;
+
+					int firstLength = key0.length;
+					int secondLength = key1.length;
+					int minLength = Math.min(firstLength, secondLength);
+					for (int i = 0; i < minLength; i++) {
+						int cmp = Byte.compare(key0[i], key1[i]);
+
+						if (cmp != 0) {
+							return cmp;
+						}
+					}
+
+					int lengthCmp = Integer.compare(firstLength, secondLength);
+					if (lengthCmp != 0) {
+						return lengthCmp;
+					}
+					return Long.compare(o1.f1.getTimestamp(), o2.f1.getTimestamp());
+				}
+			).toArray(Tuple2[]::new);
+	}
+
+	private SerializerComparatorTestData() {
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputITCase.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Longer running IT tests for {@link SortingDataInputTest}. For quicker smoke tests see {@link SortingDataInputTest}.
+ */
+public class SortingDataInputITCase {
+	@Test
+	public void intKeySorting() throws Exception {
+		int numberOfRecords = 1_000_000;
+		GeneratedRecordsDataInput input = new GeneratedRecordsDataInput(numberOfRecords);
+		KeySelector<Tuple3<Integer, String, byte[]>, Integer> keySelector = value -> value.f0;
+		try (
+			MockEnvironment environment = MockEnvironment.builder().build();
+			SortingDataInput<Tuple3<Integer, String, byte[]>, Integer> sortingDataInput = new SortingDataInput<>(
+			input,
+			GeneratedRecordsDataInput.SERIALIZER,
+			new IntSerializer(),
+			keySelector,
+			environment.getMemoryManager(),
+			environment.getIOManager(),
+			true,
+			1.0,
+			new Configuration(),
+			new DummyInvokable()
+		)) {
+			InputStatus inputStatus;
+			VerifyingOutput<Integer> output = new VerifyingOutput<>(keySelector);
+			do {
+				inputStatus = sortingDataInput.emitNext(output);
+			} while (inputStatus != InputStatus.END_OF_INPUT);
+
+			assertThat(output.getSeenRecords(), equalTo(numberOfRecords));
+		}
+	}
+
+	@Test
+	public void stringKeySorting() throws Exception {
+		int numberOfRecords = 1_000_000;
+		GeneratedRecordsDataInput input = new GeneratedRecordsDataInput(numberOfRecords);
+		KeySelector<Tuple3<Integer, String, byte[]>, String> keySelector = value -> value.f1;
+		try (
+			MockEnvironment environment = MockEnvironment.builder().build();
+			SortingDataInput<Tuple3<Integer, String, byte[]>, String> sortingDataInput = new SortingDataInput<>(
+			input,
+			GeneratedRecordsDataInput.SERIALIZER,
+			new StringSerializer(),
+			keySelector,
+			environment.getMemoryManager(),
+			environment.getIOManager(),
+			true,
+			1.0,
+			new Configuration(),
+			new DummyInvokable()
+		)) {
+			InputStatus inputStatus;
+			VerifyingOutput<String> output = new VerifyingOutput<>(keySelector);
+			do {
+				inputStatus = sortingDataInput.emitNext(output);
+			} while (inputStatus != InputStatus.END_OF_INPUT);
+
+			assertThat(output.getSeenRecords(), equalTo(numberOfRecords));
+		}
+	}
+
+	/**
+	 * The idea of the tests here is to check that the keys are grouped together. Therefore there should not be a
+	 * situation were we see a key different from the key of the previous record, but one that we've seen before.
+	 *
+	 * <p>This output verifies that invariant.
+	 */
+	private static final class VerifyingOutput<E> implements PushingAsyncDataInput.DataOutput<Tuple3<Integer, String, byte[]>> {
+
+		private final KeySelector<Tuple3<Integer, String, byte[]>, E> keySelector;
+		private final Set<E> seenKeys = new LinkedHashSet<>();
+		private E currentKey = null;
+		private int seenRecords = 0;
+
+		private VerifyingOutput(KeySelector<Tuple3<Integer, String, byte[]>, E> keySelector) {
+			this.keySelector = keySelector;
+		}
+
+		@Override
+		public void emitRecord(StreamRecord<Tuple3<Integer, String, byte[]>> streamRecord) throws Exception {
+			this.seenRecords++;
+			E incomingKey = keySelector.getKey(streamRecord.getValue());
+			if (!Objects.equals(incomingKey, currentKey)) {
+				if (!seenKeys.add(incomingKey)) {
+					Assert.fail("Received an out of order key: " + incomingKey);
+				}
+				this.currentKey = incomingKey;
+			}
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) throws Exception {
+
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
+
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+
+		}
+
+		public int getSeenRecords() {
+			return seenRecords;
+		}
+	}
+
+	private static final class GeneratedRecordsDataInput
+		implements StreamTaskInput<Tuple3<Integer, String, byte[]>> {
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		private static final TypeSerializer<Tuple3<Integer, String, byte[]>> SERIALIZER = new TupleSerializer<>(
+			(Class<Tuple3<Integer, String, byte[]>>) (Class) Tuple3.class,
+			new TypeSerializer[]{
+				new IntSerializer(),
+				new StringSerializer(),
+				new BytePrimitiveArraySerializer()
+			});
+
+		private static final String ALPHA_NUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+		private final long numberOfRecords;
+		private int recordsGenerated;
+		private final Random rnd = new Random();
+		private final byte[] buffer;
+
+		private GeneratedRecordsDataInput(int numberOfRecords) {
+			this.numberOfRecords = numberOfRecords;
+			this.recordsGenerated = 0;
+			this.buffer = new byte[500];
+			rnd.nextBytes(buffer);
+		}
+
+		@Override
+		public InputStatus emitNext(DataOutput<Tuple3<Integer, String, byte[]>> output) throws Exception {
+			if (recordsGenerated >= numberOfRecords) {
+				return InputStatus.END_OF_INPUT;
+			}
+
+			output.emitRecord(
+				new StreamRecord<>(
+					Tuple3.of(
+						rnd.nextInt(),
+						randomString(rnd.nextInt(256)),
+						buffer
+					),
+					1
+				)
+			);
+			if (recordsGenerated++ >= numberOfRecords) {
+				return InputStatus.END_OF_INPUT;
+			} else {
+				return InputStatus.MORE_AVAILABLE;
+			}
+		}
+
+		@Override
+		public CompletableFuture<?> getAvailableFuture() {
+			return AvailabilityProvider.AVAILABLE;
+		}
+
+		private String randomString(int len) {
+			StringBuilder sb = new StringBuilder(len);
+			for (int i = 0; i < len; i++) {
+				sb.append(ALPHA_NUM.charAt(rnd.nextInt(ALPHA_NUM.length())));
+			}
+			return sb.toString();
+		}
+
+		@Override
+		public int getInputIndex() {
+			return 0;
+		}
+
+		@Override
+		public CompletableFuture<Void> prepareSnapshot(
+				ChannelStateWriter channelStateWriter,
+				long checkpointId) throws IOException {
+			return CompletableFuture.completedFuture(null);
+		}
+
+		@Override
+		public void close() throws IOException {
+
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link SortingDataInput}.
+ *
+ * <p>These are rather simple unit tests. See also {@link SortingDataInputITCase} for more thorough tests.
+ */
+public class SortingDataInputTest {
+	@Test
+	public void simpleFixedLengthKeySorting() throws Exception {
+		CollectingDataOutput<Integer> collectingDataOutput = new CollectingDataOutput<>();
+		CollectionDataInput<Integer> input = new CollectionDataInput<>(
+			Arrays.asList(
+				new StreamRecord<>(1, 3),
+				new StreamRecord<>(1, 1),
+				new StreamRecord<>(2, 1),
+				new StreamRecord<>(2, 3),
+				new StreamRecord<>(1, 2),
+				new StreamRecord<>(2, 2)
+			)
+		);
+		MockEnvironment environment = MockEnvironment.builder().build();
+		SortingDataInput<Integer, Integer> sortingDataInput = new SortingDataInput<>(
+			input,
+			new IntSerializer(),
+			new IntSerializer(),
+			(KeySelector<Integer, Integer>) value -> value,
+			environment.getMemoryManager(),
+			environment.getIOManager(),
+			true,
+			1.0,
+			new Configuration(),
+			new DummyInvokable()
+		);
+
+		InputStatus inputStatus;
+		do {
+			inputStatus = sortingDataInput.emitNext(collectingDataOutput);
+		} while (inputStatus != InputStatus.END_OF_INPUT);
+
+		assertThat(collectingDataOutput.events, equalTo(
+			Arrays.asList(
+				new StreamRecord<>(1, 1),
+				new StreamRecord<>(1, 2),
+				new StreamRecord<>(1, 3),
+				new StreamRecord<>(2, 1),
+				new StreamRecord<>(2, 2),
+				new StreamRecord<>(2, 3),
+				Watermark.MAX_WATERMARK
+			)
+		));
+	}
+
+	@Test
+	public void watermarksAreNotPropagated() throws Exception {
+		CollectingDataOutput<Integer> collectingDataOutput = new CollectingDataOutput<>();
+		CollectionDataInput<Integer> input = new CollectionDataInput<>(
+			Arrays.asList(
+				new StreamRecord<>(1, 3),
+				new Watermark(1),
+				new StreamRecord<>(1, 1),
+				new Watermark(2),
+				new StreamRecord<>(2, 1),
+				new Watermark(3),
+				new StreamRecord<>(2, 3),
+				new Watermark(4),
+				new StreamRecord<>(1, 2),
+				new Watermark(5),
+				new StreamRecord<>(2, 2)
+			)
+		);
+		MockEnvironment environment = MockEnvironment.builder().build();
+		SortingDataInput<Integer, Integer> sortingDataInput = new SortingDataInput<>(
+			input,
+			new IntSerializer(),
+			new IntSerializer(),
+			(KeySelector<Integer, Integer>) value -> value,
+			environment.getMemoryManager(),
+			environment.getIOManager(),
+			true,
+			1.0,
+			new Configuration(),
+			new DummyInvokable()
+		);
+
+		InputStatus inputStatus;
+		do {
+			inputStatus = sortingDataInput.emitNext(collectingDataOutput);
+		} while (inputStatus != InputStatus.END_OF_INPUT);
+
+		assertThat(collectingDataOutput.events, equalTo(
+			Arrays.asList(
+				new StreamRecord<>(1, 1),
+				new StreamRecord<>(1, 2),
+				new StreamRecord<>(1, 3),
+				new StreamRecord<>(2, 1),
+				new StreamRecord<>(2, 2),
+				new StreamRecord<>(2, 3),
+				Watermark.MAX_WATERMARK
+			)
+		));
+	}
+
+	@Test
+	public void simpleVariableLengthKeySorting() throws Exception {
+		CollectingDataOutput<Integer> collectingDataOutput = new CollectingDataOutput<>();
+		CollectionDataInput<Integer> input = new CollectionDataInput<>(
+			Arrays.asList(
+				new StreamRecord<>(1, 3),
+				new StreamRecord<>(1, 1),
+				new StreamRecord<>(2, 1),
+				new StreamRecord<>(2, 3),
+				new StreamRecord<>(1, 2),
+				new StreamRecord<>(2, 2)
+			)
+		);
+		MockEnvironment environment = MockEnvironment.builder().build();
+		SortingDataInput<Integer, String> sortingDataInput = new SortingDataInput<>(
+			input,
+			new IntSerializer(),
+			new StringSerializer(),
+			(KeySelector<Integer, String>) value -> "" + value,
+			environment.getMemoryManager(),
+			environment.getIOManager(),
+			true,
+			1.0,
+			new Configuration(),
+			new DummyInvokable()
+		);
+
+		InputStatus inputStatus;
+		do {
+			inputStatus = sortingDataInput.emitNext(collectingDataOutput);
+		} while (inputStatus != InputStatus.END_OF_INPUT);
+
+		assertThat(collectingDataOutput.events, equalTo(
+			Arrays.asList(
+				new StreamRecord<>(1, 1),
+				new StreamRecord<>(1, 2),
+				new StreamRecord<>(1, 3),
+				new StreamRecord<>(2, 1),
+				new StreamRecord<>(2, 2),
+				new StreamRecord<>(2, 3),
+				Watermark.MAX_WATERMARK
+			)
+		));
+	}
+
+	private static final class CollectionDataInput<E> implements StreamTaskInput<E> {
+
+		private final Iterator<StreamElement> elementsIterator;
+
+		private CollectionDataInput(Collection<StreamElement> elements) {
+			this.elementsIterator = elements.iterator();
+		}
+
+		@Override
+		public InputStatus emitNext(DataOutput<E> output) throws Exception {
+			if (elementsIterator.hasNext()) {
+				StreamElement streamElement = elementsIterator.next();
+				if (streamElement instanceof StreamRecord) {
+					output.emitRecord(streamElement.asRecord());
+				} else if (streamElement instanceof Watermark) {
+					output.emitWatermark(streamElement.asWatermark());
+				} else {
+					throw new IllegalStateException("Unsupported element type: " + streamElement);
+				}
+			}
+			return elementsIterator.hasNext() ? InputStatus.MORE_AVAILABLE : InputStatus.END_OF_INPUT;
+		}
+
+		@Override
+		public CompletableFuture<?> getAvailableFuture() {
+			return CompletableFuture.completedFuture(null);
+		}
+
+		@Override
+		public int getInputIndex() {
+			return 0;
+		}
+
+		@Override
+		public CompletableFuture<Void> prepareSnapshot(
+				ChannelStateWriter channelStateWriter,
+				long checkpointId) throws IOException {
+			return null;
+		}
+
+		@Override
+		public void close() throws IOException {
+
+		}
+	}
+
+	/**
+	 * A test utility implementation of {@link PushingAsyncDataInput.DataOutput} that collects all events.
+	 */
+	private static final class CollectingDataOutput<E> implements PushingAsyncDataInput.DataOutput<E> {
+
+		final List<Object> events = new ArrayList<>();
+
+		@Override
+		public void emitWatermark(Watermark watermark) throws Exception {
+			events.add(watermark);
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
+			events.add(streamStatus);
+		}
+
+		@Override
+		public void emitRecord(StreamRecord<E> streamRecord) throws Exception {
+			events.add(streamRecord);
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+			events.add(latencyMarker);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputTest.java
@@ -92,14 +92,13 @@ public class SortingDataInputTest {
 				new StreamRecord<>(1, 3),
 				new StreamRecord<>(2, 1),
 				new StreamRecord<>(2, 2),
-				new StreamRecord<>(2, 3),
-				Watermark.MAX_WATERMARK
+				new StreamRecord<>(2, 3)
 			)
 		));
 	}
 
 	@Test
-	public void watermarksAreNotPropagated() throws Exception {
+	public void watermarkPropagation() throws Exception {
 		CollectingDataOutput<Integer> collectingDataOutput = new CollectingDataOutput<>();
 		CollectionDataInput<Integer> input = new CollectionDataInput<>(
 			Arrays.asList(
@@ -113,7 +112,8 @@ public class SortingDataInputTest {
 				new Watermark(4),
 				new StreamRecord<>(1, 2),
 				new Watermark(5),
-				new StreamRecord<>(2, 2)
+				new StreamRecord<>(2, 2),
+				new Watermark(6)
 			)
 		);
 		MockEnvironment environment = MockEnvironment.builder().build();
@@ -143,7 +143,7 @@ public class SortingDataInputTest {
 				new StreamRecord<>(2, 1),
 				new StreamRecord<>(2, 2),
 				new StreamRecord<>(2, 3),
-				Watermark.MAX_WATERMARK
+				new Watermark(6)
 			)
 		));
 	}
@@ -187,8 +187,7 @@ public class SortingDataInputTest {
 				new StreamRecord<>(1, 3),
 				new StreamRecord<>(2, 1),
 				new StreamRecord<>(2, 2),
-				new StreamRecord<>(2, 3),
-				Watermark.MAX_WATERMARK
+				new StreamRecord<>(2, 3)
 			)
 		));
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.sort;
 
+import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -33,8 +34,8 @@ import static org.junit.Assert.assertThat;
  */
 public class VariableLengthByteKeyComparatorTest extends ComparatorTestBase<Tuple2<byte[], StreamRecord<String>>> {
 	@Override
-	protected boolean[] getTestedOrder() {
-		return new boolean[]{true};
+	protected Order[] getTestedOrder() {
+		return new Order[]{Order.ASCENDING};
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparatorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link VariableLengthByteKeyComparator}.
+ */
+public class VariableLengthByteKeyComparatorTest extends ComparatorTestBase<Tuple2<byte[], StreamRecord<String>>> {
+	@Override
+	protected boolean[] getTestedOrder() {
+		return new boolean[]{true};
+	}
+
+	@Override
+	protected TypeComparator<Tuple2<byte[], StreamRecord<String>>> createComparator(boolean ascending) {
+		return new VariableLengthByteKeyComparator<>();
+	}
+
+	@Override
+	protected TypeSerializer<Tuple2<byte[], StreamRecord<String>>> createSerializer() {
+		StringSerializer stringSerializer = new StringSerializer();
+		return new KeyAndValueSerializer<>(
+			stringSerializer,
+			stringSerializer.getLength()
+		);
+	}
+
+	@Override
+	protected void deepEquals(
+			String message,
+			Tuple2<byte[], StreamRecord<String>> should,
+			Tuple2<byte[], StreamRecord<String>> is) {
+		assertThat(message, should.f0, equalTo(is.f0));
+		assertThat(message, should.f1, equalTo(is.f1));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Tuple2<byte[], StreamRecord<String>>[] getSortedTestData() {
+		StringSerializer stringSerializer = new StringSerializer();
+		DataOutputSerializer outputSerializer = new DataOutputSerializer(64);
+		return Stream.of(
+			new String(new byte[] {-1, 0}),
+			new String(new byte[] {0, 1}),
+			"A",
+			"AB",
+			"ABC",
+			"ABCD",
+			"ABCDE",
+			"ABCDEF",
+			"ABCDEFG",
+			"ABCDEFGH")
+			.map(
+				str -> {
+					try {
+						stringSerializer.serialize(str, outputSerializer);
+						byte[] copyOfBuffer = outputSerializer.getCopyOfBuffer();
+						outputSerializer.clear();
+						return Tuple2.of(copyOfBuffer, new StreamRecord<>(str, 0));
+					} catch (IOException e) {
+						throw new AssertionError(e);
+					}
+				}
+			).sorted(
+			(o1, o2) -> {
+				byte[] key0 = o1.f0;
+				byte[] key1 = o2.f0;
+
+				int firstLength = key0.length;
+				int secondLength = key1.length;
+				int minLength = Math.min(firstLength, secondLength);
+				for (int i = 0; i < minLength; i++) {
+					int cmp = Byte.compare(key0[i], key1[i]);
+
+					if (cmp != 0) {
+						return cmp;
+					}
+				}
+
+				int lengthCmp = Integer.compare(firstLength, secondLength);
+				if (lengthCmp != 0) {
+					return lengthCmp;
+				}
+				return Long.compare(o1.f1.getTimestamp(), o2.f1.getTimestamp());
+			}
+		).toArray(Tuple2[]::new);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthKeyAndValueSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthKeyAndValueSerializerTest.java
@@ -18,29 +18,18 @@
 
 package org.apache.flink.streaming.api.operators.sort;
 
-import org.apache.flink.api.common.typeutils.ComparatorTestBase;
-import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 /**
- * Tests for {@link VariableLengthByteKeyComparator}.
+ * Tests for {@link KeyAndValueSerializer}, which verify variable length keys.
  */
-public class VariableLengthByteKeyComparatorTest extends ComparatorTestBase<Tuple2<byte[], StreamRecord<String>>> {
-	@Override
-	protected boolean[] getTestedOrder() {
-		return new boolean[]{true};
-	}
-
-	@Override
-	protected TypeComparator<Tuple2<byte[], StreamRecord<String>>> createComparator(boolean ascending) {
-		return new VariableLengthByteKeyComparator<>();
-	}
+public class VariableLengthKeyAndValueSerializerTest extends SerializerTestBase<Tuple2<byte[], StreamRecord<String>>> {
 
 	@Override
 	protected TypeSerializer<Tuple2<byte[], StreamRecord<String>>> createSerializer() {
@@ -52,16 +41,30 @@ public class VariableLengthByteKeyComparatorTest extends ComparatorTestBase<Tupl
 	}
 
 	@Override
-	protected void deepEquals(
-			String message,
-			Tuple2<byte[], StreamRecord<String>> should,
-			Tuple2<byte[], StreamRecord<String>> is) {
-		assertThat(message, should.f0, equalTo(is.f0));
-		assertThat(message, should.f1, equalTo(is.f1));
+	protected int getLength() {
+		return -1;
 	}
 
 	@Override
-	protected Tuple2<byte[], StreamRecord<String>>[] getSortedTestData() {
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	protected Class<Tuple2<byte[], StreamRecord<String>>> getTypeClass() {
+		return (Class<Tuple2<byte[], StreamRecord<String>>>) (Class) Tuple2.class;
+	}
+
+	@Override
+	protected Tuple2<byte[], StreamRecord<String>>[] getTestData() {
 		return SerializerComparatorTestData.getOrderedStringTestData();
+	}
+
+	@Override
+	@Test(expected = UnsupportedOperationException.class)
+	public void testConfigSnapshotInstantiation() {
+		super.testConfigSnapshotInstantiation();
+	}
+
+	@Override
+	@Test(expected = UnsupportedOperationException.class)
+	public void testSnapshotConfigurationAndReconfigure() throws Exception {
+		super.testSnapshotConfigurationAndReconfigure();
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -88,7 +88,7 @@ public class StreamTaskNetworkInputTest {
 		List<BufferOrEvent> buffers = Collections.singletonList(createDataBuffer());
 
 		VerifyRecordsDataOutput output = new VerifyRecordsDataOutput<>();
-		StreamTaskNetworkInput input = createStreamTaskNetworkInput(buffers, output);
+		StreamTaskNetworkInput input = createStreamTaskNetworkInput(buffers);
 
 		assertHasNextElement(input, output);
 		assertHasNextElement(input, output);
@@ -108,7 +108,7 @@ public class StreamTaskNetworkInputTest {
 		buffers.add(createDataBuffer());
 
 		VerifyRecordsDataOutput output = new VerifyRecordsDataOutput<>();
-		StreamTaskNetworkInput input = createStreamTaskNetworkInput(buffers, output);
+		StreamTaskNetworkInput input = createStreamTaskNetworkInput(buffers);
 
 		assertHasNextElement(input, output);
 		assertEquals(0, output.getNumberOfEmittedRecords());
@@ -140,7 +140,7 @@ public class StreamTaskNetworkInputTest {
 					inputGate.getInputGate()),
 				new SyncMailboxExecutor()),
 			inSerializer,
-			new StatusWatermarkValve(numInputChannels, output),
+			new StatusWatermarkValve(numInputChannels),
 			0,
 			deserializers);
 
@@ -184,7 +184,7 @@ public class StreamTaskNetworkInputTest {
 				new CheckpointBarrierTracker(1, new DummyCheckpointInvokable()),
 				new SyncMailboxExecutor()),
 			inSerializer,
-			new StatusWatermarkValve(1, output),
+			new StatusWatermarkValve(1),
 			0,
 			deserializers);
 
@@ -206,7 +206,7 @@ public class StreamTaskNetworkInputTest {
 		return new BufferOrEvent(bufferConsumer.build(), new InputChannelInfo(0, 0));
 	}
 
-	private StreamTaskNetworkInput createStreamTaskNetworkInput(List<BufferOrEvent> buffers, DataOutput output) {
+	private StreamTaskNetworkInput createStreamTaskNetworkInput(List<BufferOrEvent> buffers) {
 		return new StreamTaskNetworkInput<>(
 			new CheckpointedInputGate(
 				new MockInputGate(1, buffers, false),
@@ -214,7 +214,7 @@ public class StreamTaskNetworkInputTest {
 				new SyncMailboxExecutor()),
 			LongSerializer.INSTANCE,
 			ioManager,
-			new StatusWatermarkValve(1, output),
+			new StatusWatermarkValve(1),
 			0);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValveTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamstatus/StatusWatermarkValveTest.java
@@ -53,13 +53,13 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testSingleInputIncreasingWatermarks() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
-		valve.inputWatermark(new Watermark(0), 0);
+		valve.inputWatermark(new Watermark(0), 0, valveOutput);
 		assertEquals(new Watermark(0), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(25), 0);
+		valve.inputWatermark(new Watermark(25), 0, valveOutput);
 		assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
@@ -70,15 +70,15 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testSingleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
-		valve.inputWatermark(new Watermark(25), 0);
+		valve.inputWatermark(new Watermark(25), 0, valveOutput);
 		assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(18), 0);
+		valve.inputWatermark(new Watermark(18), 0, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(42), 0);
+		valve.inputWatermark(new Watermark(42), 0, valveOutput);
 		assertEquals(new Watermark(42), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
@@ -90,19 +90,19 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testSingleInputStreamStatusToggling() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 0);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 0, valveOutput);
 		// this also implicitly verifies that input channels start as ACTIVE
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 0);
+		valve.inputStreamStatus(StreamStatus.IDLE, 0, valveOutput);
 		assertEquals(StreamStatus.IDLE, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 0);
+		valve.inputStreamStatus(StreamStatus.IDLE, 0, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 0);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 0, valveOutput);
 		assertEquals(StreamStatus.ACTIVE, valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
@@ -113,24 +113,24 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testSingleInputWatermarksIntactDuringIdleness() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(1, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
-		valve.inputWatermark(new Watermark(25), 0);
+		valve.inputWatermark(new Watermark(25), 0, valveOutput);
 		assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 0);
+		valve.inputStreamStatus(StreamStatus.IDLE, 0, valveOutput);
 		assertEquals(StreamStatus.IDLE, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(50), 0);
+		valve.inputWatermark(new Watermark(50), 0, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 		assertEquals(25, valve.getInputChannelStatus(0).watermark);
 
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 0);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 0, valveOutput);
 		assertEquals(StreamStatus.ACTIVE, valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(50), 0);
+		valve.inputWatermark(new Watermark(50), 0, valveOutput);
 		assertEquals(new Watermark(50), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
@@ -141,14 +141,14 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputYieldsWatermarkOnlyWhenAllChannelsReceivesWatermarks() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
-		valve.inputWatermark(new Watermark(0), 0);
-		valve.inputWatermark(new Watermark(0), 1);
+		valve.inputWatermark(new Watermark(0), 0, valveOutput);
+		valve.inputWatermark(new Watermark(0), 1, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// now, all channels have watermarks
-		valve.inputWatermark(new Watermark(0), 2);
+		valve.inputWatermark(new Watermark(0), 2, valveOutput);
 		assertEquals(new Watermark(0), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
@@ -160,29 +160,29 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputIncreasingWatermarks() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
-		valve.inputWatermark(new Watermark(0), 0);
-		valve.inputWatermark(new Watermark(0), 1);
-		valve.inputWatermark(new Watermark(0), 2);
+		valve.inputWatermark(new Watermark(0), 0, valveOutput);
+		valve.inputWatermark(new Watermark(0), 1, valveOutput);
+		valve.inputWatermark(new Watermark(0), 2, valveOutput);
 		assertEquals(new Watermark(0), valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(12), 0);
-		valve.inputWatermark(new Watermark(8), 2);
-		valve.inputWatermark(new Watermark(10), 2);
+		valve.inputWatermark(new Watermark(12), 0, valveOutput);
+		valve.inputWatermark(new Watermark(8), 2, valveOutput);
+		valve.inputWatermark(new Watermark(10), 2, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(15), 1);
+		valve.inputWatermark(new Watermark(15), 1, valveOutput);
 		// lowest watermark across all channels is now channel 2, with watermark @ 10
 		assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(17), 2);
+		valve.inputWatermark(new Watermark(17), 2, valveOutput);
 		// lowest watermark across all channels is now channel 0, with watermark @ 12
 		assertEquals(new Watermark(12), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(20), 0);
+		valve.inputWatermark(new Watermark(20), 0, valveOutput);
 		// lowest watermark across all channels is now channel 1, with watermark @ 15
 		assertEquals(new Watermark(15), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
@@ -194,16 +194,16 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
-		valve.inputWatermark(new Watermark(25), 0);
-		valve.inputWatermark(new Watermark(10), 1);
-		valve.inputWatermark(new Watermark(17), 2);
+		valve.inputWatermark(new Watermark(25), 0, valveOutput);
+		valve.inputWatermark(new Watermark(10), 1, valveOutput);
+		valve.inputWatermark(new Watermark(17), 2, valveOutput);
 		assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(12), 0);
-		valve.inputWatermark(new Watermark(8), 1);
-		valve.inputWatermark(new Watermark(15), 2);
+		valve.inputWatermark(new Watermark(12), 0, valveOutput);
+		valve.inputWatermark(new Watermark(8), 1, valveOutput);
+		valve.inputWatermark(new Watermark(15), 2, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
 
@@ -214,29 +214,29 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputStreamStatusToggling() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(2, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(2);
 
 		// this also implicitly verifies that all input channels start as active
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 0);
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 1);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 0, valveOutput);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 1, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 1);
+		valve.inputStreamStatus(StreamStatus.IDLE, 1, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// now, all channels are IDLE
-		valve.inputStreamStatus(StreamStatus.IDLE, 0);
+		valve.inputStreamStatus(StreamStatus.IDLE, 0, valveOutput);
 		assertEquals(StreamStatus.IDLE, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 0);
-		valve.inputStreamStatus(StreamStatus.IDLE, 1);
+		valve.inputStreamStatus(StreamStatus.IDLE, 0, valveOutput);
+		valve.inputStreamStatus(StreamStatus.IDLE, 1, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// as soon as at least one input becomes active again, the ACTIVE marker should be forwarded
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 1);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 1, valveOutput);
 		assertEquals(StreamStatus.ACTIVE, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 0);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 0, valveOutput);
 		// already back to ACTIVE, should yield no output
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
@@ -248,23 +248,23 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputWatermarkAdvancingWithPartiallyIdleChannels() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
-		valve.inputWatermark(new Watermark(15), 0);
-		valve.inputWatermark(new Watermark(10), 1);
+		valve.inputWatermark(new Watermark(15), 0, valveOutput);
+		valve.inputWatermark(new Watermark(10), 1, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 2);
+		valve.inputStreamStatus(StreamStatus.IDLE, 2, valveOutput);
 		// min watermark should be computed from remaining ACTIVE channels
 		assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(18), 1);
+		valve.inputWatermark(new Watermark(18), 1, valveOutput);
 		// now, min watermark should be 15 from channel #0
 		assertEquals(new Watermark(15), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputWatermark(new Watermark(20), 0);
+		valve.inputWatermark(new Watermark(20), 0, valveOutput);
 		// now, min watermark should be 18 from channel #1
 		assertEquals(new Watermark(18), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
@@ -277,18 +277,18 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputWatermarkAdvancingAsChannelsIndividuallyBecomeIdle() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
-		valve.inputWatermark(new Watermark(25), 0);
-		valve.inputWatermark(new Watermark(10), 1);
-		valve.inputWatermark(new Watermark(17), 2);
+		valve.inputWatermark(new Watermark(25), 0, valveOutput);
+		valve.inputWatermark(new Watermark(10), 1, valveOutput);
+		valve.inputWatermark(new Watermark(17), 2, valveOutput);
 		assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 1);
+		valve.inputStreamStatus(StreamStatus.IDLE, 1, valveOutput);
 		// only channel 0 & 2 is ACTIVE; 17 is the overall min watermark now
 		assertEquals(new Watermark(17), valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 2);
+		valve.inputStreamStatus(StreamStatus.IDLE, 2, valveOutput);
 		// only channel 0 is ACTIVE; 25 is the overall min watermark now
 		assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
@@ -305,7 +305,7 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputFlushMaxWatermarkAndStreamStatusOnceAllInputsBecomeIdle() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
 		// -------------------------------------------------------------------------------------------
 		// Setup valve for test case:
@@ -315,9 +315,9 @@ public class StatusWatermarkValveTest {
 		//  Min Watermark across channels = 3 (from channel #3)
 		// -------------------------------------------------------------------------------------------
 
-		valve.inputWatermark(new Watermark(10), 0);
-		valve.inputWatermark(new Watermark(5), 1);
-		valve.inputWatermark(new Watermark(3), 2);
+		valve.inputWatermark(new Watermark(10), 0, valveOutput);
+		valve.inputWatermark(new Watermark(5), 1, valveOutput);
+		valve.inputWatermark(new Watermark(3), 2, valveOutput);
 		assertEquals(new Watermark(3), valveOutput.popLastSeenOutput());
 
 		// -------------------------------------------------------------------------------------------
@@ -326,11 +326,11 @@ public class StatusWatermarkValveTest {
 		//   |-> (nothing emitted)        |-> (nothing emitted)        |-> Emit Watermark(10) & IDLE
 		// -------------------------------------------------------------------------------------------
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 0);
-		valve.inputStreamStatus(StreamStatus.IDLE, 1);
+		valve.inputStreamStatus(StreamStatus.IDLE, 0, valveOutput);
+		valve.inputStreamStatus(StreamStatus.IDLE, 1, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 2);
+		valve.inputStreamStatus(StreamStatus.IDLE, 2, valveOutput);
 		assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
 		assertEquals(StreamStatus.IDLE, valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
@@ -343,35 +343,35 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testMultipleInputWatermarkRealignmentAfterResumeActive() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
-		valve.inputWatermark(new Watermark(10), 0);
-		valve.inputWatermark(new Watermark(7), 1);
-		valve.inputWatermark(new Watermark(3), 2);
+		valve.inputWatermark(new Watermark(10), 0, valveOutput);
+		valve.inputWatermark(new Watermark(7), 1, valveOutput);
+		valve.inputWatermark(new Watermark(3), 2, valveOutput);
 		assertEquals(new Watermark(3), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
-		valve.inputStreamStatus(StreamStatus.IDLE, 2);
+		valve.inputStreamStatus(StreamStatus.IDLE, 2, valveOutput);
 		assertEquals(new Watermark(7), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// let channel 2 become active again; since the min watermark has now advanced to 7,
 		// channel 2 should have been marked as non-aligned.
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 2);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 2, valveOutput);
 		assertFalse(valve.getInputChannelStatus(2).isWatermarkAligned);
 
 		// during the realignment process, watermarks should still be accepted by channel 2 (but shouldn't yield new watermarks)
-		valve.inputWatermark(new Watermark(5), 2);
+		valve.inputWatermark(new Watermark(5), 2, valveOutput);
 		assertEquals(5, valve.getInputChannelStatus(2).watermark);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// let channel 2 catch up with the min watermark; now should be realigned
-		valve.inputWatermark(new Watermark(9), 2);
+		valve.inputWatermark(new Watermark(9), 2, valveOutput);
 		assertTrue(valve.getInputChannelStatus(2).isWatermarkAligned);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// check that realigned inputs is now taken into account for watermark advancement
-		valve.inputWatermark(new Watermark(12), 1);
+		valve.inputWatermark(new Watermark(12), 1, valveOutput);
 		assertEquals(new Watermark(9), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 	}
@@ -384,23 +384,23 @@ public class StatusWatermarkValveTest {
 	@Test
 	public void testNoOutputWhenAllActiveChannelsAreUnaligned() throws Exception {
 		StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-		StatusWatermarkValve valve = new StatusWatermarkValve(3, valveOutput);
+		StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
-		valve.inputWatermark(new Watermark(10), 0);
-		valve.inputWatermark(new Watermark(7), 1);
+		valve.inputWatermark(new Watermark(10), 0, valveOutput);
+		valve.inputWatermark(new Watermark(7), 1, valveOutput);
 
 		// make channel 2 ACTIVE, it is now in "catch up" mode (unaligned watermark)
-		valve.inputStreamStatus(StreamStatus.IDLE, 2);
+		valve.inputStreamStatus(StreamStatus.IDLE, 2, valveOutput);
 		assertEquals(new Watermark(7), valveOutput.popLastSeenOutput());
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// make channel 2 ACTIVE again, it is still unaligned
-		valve.inputStreamStatus(StreamStatus.ACTIVE, 2);
+		valve.inputStreamStatus(StreamStatus.ACTIVE, 2, valveOutput);
 		assertEquals(null, valveOutput.popLastSeenOutput());
 
 		// make channel 0 and 1 IDLE, now channel 2 is the only ACTIVE channel but it's unaligned
-		valve.inputStreamStatus(StreamStatus.IDLE, 0);
-		valve.inputStreamStatus(StreamStatus.IDLE, 1);
+		valve.inputStreamStatus(StreamStatus.IDLE, 0, valveOutput);
+		valve.inputStreamStatus(StreamStatus.IDLE, 1, valveOutput);
 
 		// we should not see any output
 		assertEquals(null, valveOutput.popLastSeenOutput());

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.collect.CollectResultIterator;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory;
+import org.apache.flink.streaming.api.operators.collect.CollectStreamSink;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.SplittableIterator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * An end to end test for sorted inputs for a keyed operator with bounded inputs.
+ */
+public class SortingBoundedInputITCase {
+	@Test
+	public void testOneInputOperator() throws Exception {
+		long numberOfRecords = 1_000_000;
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Tuple2<Integer, byte[]>> elements = env.fromParallelCollection(
+			new InputGenerator(numberOfRecords),
+			new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO)
+		);
+
+		SingleOutputStreamOperator<Long> counts = elements
+			.keyBy(element -> element.f0)
+			.transform(
+				"Asserting operator",
+				BasicTypeInfo.LONG_TYPE_INFO,
+				new AssertingOperator()
+			);
+
+		// TODO we should replace this block with DataStreamUtils#collect once
+		// we have the automatic runtime mode determination in place.
+		CollectResultIterator<Long> collectedCounts = applyCollect(env, counts);
+		StreamGraph streamGraph = env.getStreamGraph();
+		streamGraph.getStreamNode(counts.getId()).setSortedInputs(true);
+		JobClient jobClient = env.executeAsync(streamGraph);
+		collectedCounts.setJobClient(jobClient);
+
+		long sum = CollectionUtil.iteratorToList(collectedCounts)
+			.stream()
+			.mapToLong(l -> l)
+			.sum();
+
+		assertThat(numberOfRecords, equalTo(sum));
+	}
+
+	private CollectResultIterator<Long> applyCollect(StreamExecutionEnvironment env, SingleOutputStreamOperator<Long> counts) {
+		String accumulatorName = "dataStreamCollect_" + UUID.randomUUID().toString();
+
+		CollectSinkOperatorFactory<Long> factory = new CollectSinkOperatorFactory<>(
+			new LongSerializer(),
+			accumulatorName);
+		CollectSinkOperator<Long> operator = (CollectSinkOperator<Long>) factory.getOperator();
+		CollectStreamSink<Long> sink = new CollectStreamSink<>(counts, factory);
+		sink.name("Data stream collect sink");
+		env.addOperator(sink.getTransformation());
+
+		return new CollectResultIterator<>(
+			operator.getOperatorIdFuture(),
+			new LongSerializer(),
+			accumulatorName,
+			env.getCheckpointConfig());
+	}
+
+	private static class AssertingOperator extends AbstractStreamOperator<Long>
+			implements OneInputStreamOperator<Tuple2<Integer, byte[]>, Long>, BoundedOneInput {
+		private final Set<Integer> seenKeys = new HashSet<>();
+		private long seenRecords = 0;
+		private Integer currentKey = null;
+
+		@Override
+		public void processElement(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+			this.seenRecords++;
+			Integer incomingKey = element.getValue().f0;
+			if (!Objects.equals(incomingKey, currentKey)) {
+				if (!seenKeys.add(incomingKey)) {
+					Assert.fail("Received an out of order key: " + incomingKey);
+				}
+				this.currentKey = incomingKey;
+			}
+		}
+
+		@Override
+		public void endInput() throws Exception {
+			output.collect(new StreamRecord<>(seenRecords));
+		}
+	}
+
+	private static class InputGenerator extends SplittableIterator<Tuple2<Integer, byte[]>> {
+
+		private final long numberOfRecords;
+		private long generatedRecords;
+		private final Random rnd = new Random();
+		private final byte[] bytes = new byte[500];
+
+		private InputGenerator(long numberOfRecords) {
+			this.numberOfRecords = numberOfRecords;
+			rnd.nextBytes(bytes);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public Iterator<Tuple2<Integer, byte[]>>[] split(int numPartitions) {
+			long numberOfRecordsPerPartition = numberOfRecords / numPartitions;
+			long remainder = numberOfRecords % numPartitions;
+			Iterator<Tuple2<Integer, byte[]>>[] iterators = new Iterator[numPartitions];
+
+			for (int i = 0; i < numPartitions - 1; i++) {
+				iterators[i] = new InputGenerator(numberOfRecordsPerPartition);
+			}
+
+			iterators[numPartitions - 1] = new InputGenerator(numberOfRecordsPerPartition + remainder);
+
+			return iterators;
+		}
+
+		@Override
+		public int getMaximumNumberOfSplits() {
+			return (int) Math.min(numberOfRecords, Integer.MAX_VALUE);
+		}
+
+		@Override
+		public boolean hasNext() {
+			return generatedRecords < numberOfRecords;
+		}
+
+		@Override
+		public Tuple2<Integer, byte[]> next() {
+			if (hasNext()) {
+				generatedRecords++;
+				return Tuple2.of(
+					rnd.nextInt(10),
+					bytes
+				);
+			}
+
+			return null;
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -42,6 +43,8 @@ import org.apache.flink.util.SplittableIterator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
@@ -78,6 +81,12 @@ public class SortingBoundedInputITCase {
 		CollectResultIterator<Long> collectedCounts = applyCollect(env, counts);
 		StreamGraph streamGraph = env.getStreamGraph();
 		streamGraph.getStreamNode(counts.getId()).setSortedInputs(true);
+		HashMap<ManagedMemoryUseCase, Integer> operatorMemory = new HashMap<>();
+		operatorMemory.put(ManagedMemoryUseCase.BATCH_OP, 1);
+		streamGraph.getStreamNode(counts.getId()).setManagedMemoryUseCaseWeights(
+			operatorMemory,
+			Collections.emptySet()
+		);
 		JobClient jobClient = env.executeAsync(streamGraph);
 		collectedCounts.setJobClient(jobClient);
 


### PR DESCRIPTION
## What is the purpose of the change
This is part of https://cwiki.apache.org/confluence/display/FLINK/FLIP-140%3A+Introduce+batch-style+execution+for+bounded+keyed+streams

## Brief change log

Please look at each commit message which describes in detail what is happening.

1. Implements the sorting DataInput
2. Makes the `StatusWatermarkValve` use the `DataOutput` passed in `DataInput#emitNext`.
3. Optionally injects the sorted input in the OneInputStreamTask


## Verifying this change

This change added tests and can be verified as follows:
* Added unit tests in `SortingDataInputTest`
* Added an IT tests with a higher number of incoming records to sort in `SortingDataInputITCase`
* Added end to end test `SortingBoundedInputITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
