### PR TITLE
[FLINK-18410][table-runtime-blink] correct PartitionCommitTrigger subclass name

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionCommitTrigger.java
@@ -29,8 +29,8 @@ import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION
 
 /**
  * Partition commit trigger.
- * See {@link PartitionTimeCommitTigger}.
- * See {@link ProcTimeCommitTigger}.
+ * See {@link PartitionTimeCommitTrigger}.
+ * See {@link ProcTimeCommitTrigger}.
  */
 public interface PartitionCommitTrigger {
 
@@ -67,10 +67,10 @@ public interface PartitionCommitTrigger {
 		String trigger = conf.get(SINK_PARTITION_COMMIT_TRIGGER);
 		switch (trigger) {
 			case PARTITION_TIME:
-				return new PartitionTimeCommitTigger(
+				return new PartitionTimeCommitTrigger(
 						isRestored, stateStore, conf, cl, partitionKeys);
 			case PROCESS_TIME:
-				return new ProcTimeCommitTigger(
+				return new ProcTimeCommitTrigger(
 						isRestored, stateStore, conf, procTimeService);
 			default:
 				throw new UnsupportedOperationException(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionTimeCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionTimeCommitTrigger.java
@@ -54,7 +54,7 @@ import static org.apache.flink.table.utils.PartitionPathUtils.extractPartitionVa
  * <p>Compares watermark, and watermark is related to records and checkpoint, so we need store
  * watermark information for checkpoint.
  */
-public class PartitionTimeCommitTigger implements PartitionCommitTrigger {
+public class PartitionTimeCommitTrigger implements PartitionCommitTrigger {
 
 	private static final ListStateDescriptor<List<String>> PENDING_PARTITIONS_STATE_DESC =
 			new ListStateDescriptor<>(
@@ -75,7 +75,7 @@ public class PartitionTimeCommitTigger implements PartitionCommitTrigger {
 	private final long commitDelay;
 	private final List<String> partitionKeys;
 
-	public PartitionTimeCommitTigger(
+	public PartitionTimeCommitTrigger(
 			boolean isRestored,
 			OperatorStateStore stateStore,
 			Configuration conf,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/ProcTimeCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/ProcTimeCommitTrigger.java
@@ -40,7 +40,7 @@ import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION
  * Partition commit trigger by creation time and processing time service,
  * if 'current processing time' > 'partition creation time' + 'delay', will commit the partition.
  */
-public class ProcTimeCommitTigger implements PartitionCommitTrigger {
+public class ProcTimeCommitTrigger implements PartitionCommitTrigger {
 
 	private static final ListStateDescriptor<Map<String, Long>> PENDING_PARTITIONS_STATE_DESC =
 			new ListStateDescriptor<>(
@@ -52,7 +52,7 @@ public class ProcTimeCommitTigger implements PartitionCommitTrigger {
 	private final long commitDelay;
 	private final ProcessingTimeService procTimeService;
 
-	public ProcTimeCommitTigger(
+	public ProcTimeCommitTrigger(
 			boolean isRestored,
 			OperatorStateStore stateStore,
 			Configuration conf,


### PR DESCRIPTION
correct PartitionCommitTrigger subclass name


## Brief change log
correct PartitionCommitTrigger subclass name



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
