### PR TITLE
[FLINK-15981][network] Implement FileRegion way to shuffle file-based blocking partition in network stack

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -126,7 +126,8 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			config.networkBufferSize(),
 			config.isBlockingShuffleCompressionEnabled(),
 			config.getCompressionCodec(),
-			config.getMaxBuffersPerChannel());
+			config.getMaxBuffersPerChannel(),
+			config.isSSLEnabled());
 
 		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
 			taskExecutorResourceId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferRecycler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferRecycler.java
@@ -32,4 +32,18 @@ public interface BufferRecycler {
 	 * @param memorySegment The memory segment to be recycled.
 	 */
 	void recycle(MemorySegment memorySegment);
+
+	/**
+	 * The buffer recycler does nothing for recycled segment.
+	 */
+	final class DummyBufferRecycler implements BufferRecycler {
+
+		public static final BufferRecycler INSTANCE = new DummyBufferRecycler();
+
+		private DummyBufferRecycler() {}
+
+		@Override
+		public void recycle(MemorySegment memorySegment) {
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/FileRegionBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/FileRegionBuffer.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
+import org.apache.flink.shaded.netty4.io.netty.channel.DefaultFileRegion;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class implements {@link Buffer} mainly for compatible with existing usages. We can also lazy read
+ * it into another buffer via {@link #readInto(MemorySegment)} for use. Since it behaves "read-only" style,
+ * then many methods implemented via throw {@link UnsupportedOperationException}.
+ *
+ * <p>This also extends from Netty's {@link DefaultFileRegion}, so we don't need to do any special handling.
+ * Netty will internally treat this differently than the Buffer that implements {@link ByteBuf}.
+ */
+public class FileRegionBuffer extends DefaultFileRegion implements Buffer {
+
+	/** The number of bytes to be read/transferred from this file region. */
+	private final int bufferSize;
+
+	private final FileChannel fileChannel;
+
+	/** The {@link DataType} this buffer represents. */
+	private final DataType dataType;
+
+	/** Whether the buffer is compressed or not. */
+	private final boolean isCompressed;
+
+	public FileRegionBuffer(
+			FileChannel fileChannel,
+			int bufferSize,
+			DataType dataType,
+			boolean isCompressed) throws IOException {
+
+		super(fileChannel, fileChannel.position(), bufferSize);
+
+		this.fileChannel = checkNotNull(fileChannel);
+		this.bufferSize = bufferSize;
+		this.dataType = checkNotNull(dataType);
+		this.isCompressed = isCompressed;
+	}
+
+	// ------------------------------------------------------------------------
+	// Buffer override methods
+	// ------------------------------------------------------------------------
+
+	@Override
+	public boolean isBuffer() {
+		return dataType.isBuffer();
+	}
+
+	@Override
+	public MemorySegment getMemorySegment() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public int getMemorySegmentOffset() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public ReadOnlySlicedNetworkBuffer readOnlySlice() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public ReadOnlySlicedNetworkBuffer readOnlySlice(int index, int length) {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public int getMaxCapacity() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public int getReaderIndex() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public void setReaderIndex(int readerIndex) throws IndexOutOfBoundsException {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	/**
+	 * This method is only implemented for tests at the moment.
+	 */
+	@Override
+	public ByteBuffer getNioBufferReadable() {
+		return BufferReaderWriterUtil.tryReadByteBuffer(fileChannel, bufferSize);
+	}
+
+	@Override
+	public ByteBuffer getNioBuffer(int index, int length) throws IndexOutOfBoundsException {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public ByteBuf asByteBuf() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public void setSize(int writerIndex) {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public int getSize() {
+		return bufferSize;
+	}
+
+	@Override
+	public int readableBytes() {
+		return bufferSize;
+	}
+
+	@Override
+	public void setAllocator(ByteBufAllocator allocator) {
+		// nothing to do
+	}
+
+	@Override
+	public BufferRecycler getRecycler() {
+		return null;
+	}
+
+	@Override
+	public void recycleBuffer() {
+		// nothing to do
+	}
+
+	@Override
+	public boolean isRecycled() {
+		return false;
+	}
+
+	@Override
+	public FileRegionBuffer retainBuffer() {
+		return (FileRegionBuffer) super.retain();
+	}
+
+	@Override
+	public boolean isCompressed() {
+		return isCompressed;
+	}
+
+	@Override
+	public void setCompressed(boolean isCompressed) {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public DataType getDataType() {
+		return dataType;
+	}
+
+	@Override
+	public void setDataType(DataType dataType) {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	// ------------------------------------------------------------------------
+	// File region override methods
+	// ------------------------------------------------------------------------
+
+	@Override
+	public void deallocate() {
+		// nothing to do
+	}
+
+	// ------------------------------------------------------------------------
+	// Utils
+	// ------------------------------------------------------------------------
+
+	public Buffer readInto(MemorySegment segment) throws IOException {
+		final ByteBuffer buffer = segment.wrap(0, bufferSize);
+		BufferReaderWriterUtil.readByteBufferFully(fileChannel, buffer);
+
+		return new NetworkBuffer(
+			segment,
+			BufferRecycler.DummyBufferRecycler.INSTANCE,
+			dataType,
+			isCompressed,
+			bufferSize);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
@@ -36,6 +37,7 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.CompositeByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOutboundHandlerAdapter;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOutboundInvoker;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
@@ -46,6 +48,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.ProtocolException;
 import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -67,7 +70,7 @@ public abstract class NettyMessage {
 
 	static final int MAGIC_NUMBER = 0xBADC0FFE;
 
-	abstract ByteBuf write(ByteBufAllocator allocator) throws Exception;
+	abstract void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException;
 
 	// ------------------------------------------------------------------------
 
@@ -165,22 +168,9 @@ public abstract class NettyMessage {
 	static class NettyMessageEncoder extends ChannelOutboundHandlerAdapter {
 
 		@Override
-		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws IOException {
 			if (msg instanceof NettyMessage) {
-
-				ByteBuf serialized = null;
-
-				try {
-					serialized = ((NettyMessage) msg).write(ctx.alloc());
-				}
-				catch (Throwable t) {
-					throw new IOException("Error while serializing message: " + msg, t);
-				}
-				finally {
-					if (serialized != null) {
-						ctx.write(serialized, promise);
-					}
-				}
+				((NettyMessage) msg).write(ctx, promise, ctx.alloc());
 			}
 			else {
 				ctx.write(msg, promise);
@@ -337,21 +327,29 @@ public abstract class NettyMessage {
 		// --------------------------------------------------------------------
 
 		@Override
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
+			ByteBuf headerBuf = null;
+			try {
+				// in order to forward the buffer to netty, it needs an allocator set
+				buffer.setAllocator(allocator);
+
+				headerBuf = fillHeader(allocator);
+				out.write(headerBuf);
+				out.write(buffer, promise);
+			}
+			catch (Throwable t) {
+				handleException(headerBuf, buffer, t);
+			}
+		}
+
+		@VisibleForTesting
 		ByteBuf write(ByteBufAllocator allocator) throws IOException {
 			ByteBuf headerBuf = null;
 			try {
 				// in order to forward the buffer to netty, it needs an allocator set
 				buffer.setAllocator(allocator);
 
-				// only allocate header buffer - we will combine it with the data buffer below
-				headerBuf = allocateBuffer(allocator, ID, MESSAGE_HEADER_LENGTH, bufferSize, false);
-
-				receiverId.writeTo(headerBuf);
-				headerBuf.writeInt(sequenceNumber);
-				headerBuf.writeInt(backlog);
-				headerBuf.writeByte(dataType.ordinal());
-				headerBuf.writeBoolean(isCompressed);
-				headerBuf.writeInt(buffer.readableBytes());
+				headerBuf = fillHeader(allocator);
 
 				CompositeByteBuf composityBuf = allocator.compositeDirectBuffer();
 				composityBuf.addComponent(headerBuf);
@@ -361,14 +359,22 @@ public abstract class NettyMessage {
 				return composityBuf;
 			}
 			catch (Throwable t) {
-				if (headerBuf != null) {
-					headerBuf.release();
-				}
-				buffer.recycleBuffer();
-
-				ExceptionUtils.rethrowIOException(t);
+				handleException(headerBuf, buffer, t);
 				return null; // silence the compiler
 			}
+		}
+
+		private ByteBuf fillHeader(ByteBufAllocator allocator) {
+			// only allocate header buffer - we will combine it with the data buffer below
+			ByteBuf headerBuf = allocateBuffer(allocator, ID, MESSAGE_HEADER_LENGTH, bufferSize, false);
+
+			receiverId.writeTo(headerBuf);
+			headerBuf.writeInt(sequenceNumber);
+			headerBuf.writeInt(backlog);
+			headerBuf.writeByte(dataType.ordinal());
+			headerBuf.writeBoolean(isCompressed);
+			headerBuf.writeInt(buffer.readableBytes());
+			return headerBuf;
 		}
 
 		/**
@@ -437,7 +443,7 @@ public abstract class NettyMessage {
 		}
 
 		@Override
-		ByteBuf write(ByteBufAllocator allocator) throws IOException {
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
 			final ByteBuf result = allocateBuffer(allocator, ID);
 
 			try (ObjectOutputStream oos = new ObjectOutputStream(new ByteBufOutputStream(result))) {
@@ -452,16 +458,10 @@ public abstract class NettyMessage {
 
 				// Update frame length...
 				result.setInt(0, result.readableBytes());
-				return result;
+				out.write(result, promise);
 			}
 			catch (Throwable t) {
-				result.release();
-
-				if (t instanceof IOException) {
-					throw (IOException) t;
-				} else {
-					throw new IOException(t);
-				}
+				handleException(result, null, t);
 			}
 		}
 
@@ -508,27 +508,16 @@ public abstract class NettyMessage {
 		}
 
 		@Override
-		ByteBuf write(ByteBufAllocator allocator) throws IOException {
-			ByteBuf result = null;
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
+			Consumer<ByteBuf> consumer = (bb) -> {
+				partitionId.getPartitionId().writeTo(bb);
+				partitionId.getProducerId().writeTo(bb);
+				bb.writeInt(queueIndex);
+				receiverId.writeTo(bb);
+				bb.writeInt(credit);
+			};
 
-			try {
-				result = allocateBuffer(allocator, ID, 20 + 40 + 4 + 16 + 4);
-
-				partitionId.getPartitionId().writeTo(result);
-				partitionId.getProducerId().writeTo(result);
-				result.writeInt(queueIndex);
-				receiverId.writeTo(result);
-				result.writeInt(credit);
-
-				return result;
-			}
-			catch (Throwable t) {
-				if (result != null) {
-					result.release();
-				}
-
-				throw new IOException(t);
-			}
+			writeToChannel(out, promise, allocator, consumer, ID, 20 + 40 + 4 + 16 + 4);
 		}
 
 		static PartitionRequest readFrom(ByteBuf buffer) {
@@ -566,32 +555,20 @@ public abstract class NettyMessage {
 		}
 
 		@Override
-		ByteBuf write(ByteBufAllocator allocator) throws IOException {
-			ByteBuf result = null;
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
+			// TODO Directly serialize to Netty's buffer
+			ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(event);
 
-			try {
-				// TODO Directly serialize to Netty's buffer
-				ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(event);
+			Consumer<ByteBuf> consumer = (bb) -> {
+				bb.writeInt(serializedEvent.remaining());
+				bb.writeBytes(serializedEvent);
 
-				result = allocateBuffer(allocator, ID, 4 + serializedEvent.remaining() + 20 + 40 + 16);
+				partitionId.getPartitionId().writeTo(bb);
+				partitionId.getProducerId().writeTo(bb);
+				receiverId.writeTo(bb);
+			};
 
-				result.writeInt(serializedEvent.remaining());
-				result.writeBytes(serializedEvent);
-
-				partitionId.getPartitionId().writeTo(result);
-				partitionId.getProducerId().writeTo(result);
-
-				receiverId.writeTo(result);
-
-				return result;
-			}
-			catch (Throwable t) {
-				if (result != null) {
-					result.release();
-				}
-
-				throw new IOException(t);
-			}
+			writeToChannel(out, promise, allocator, consumer, ID, 4 + serializedEvent.remaining() + 20 + 40 + 16);
 		}
 
 		static TaskEventRequest readFrom(ByteBuf buffer, ClassLoader classLoader) throws IOException {
@@ -633,22 +610,8 @@ public abstract class NettyMessage {
 		}
 
 		@Override
-		ByteBuf write(ByteBufAllocator allocator) throws Exception {
-			ByteBuf result = null;
-
-			try {
-				result = allocateBuffer(allocator, ID, 16);
-				receiverId.writeTo(result);
-			}
-			catch (Throwable t) {
-				if (result != null) {
-					result.release();
-				}
-
-				throw new IOException(t);
-			}
-
-			return result;
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
+			writeToChannel(out, promise, allocator, receiverId :: writeTo, ID, 16);
 		}
 
 		static CancelPartitionRequest readFrom(ByteBuf buffer) throws Exception {
@@ -664,8 +627,8 @@ public abstract class NettyMessage {
 		}
 
 		@Override
-		ByteBuf write(ByteBufAllocator allocator) throws Exception {
-			return allocateBuffer(allocator, ID, 0);
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
+			writeToChannel(out, promise, allocator, ignored -> {}, ID, 0);
 		}
 
 		static CloseRequest readFrom(@SuppressWarnings("unused") ByteBuf buffer) throws Exception {
@@ -691,7 +654,7 @@ public abstract class NettyMessage {
 		}
 
 		@Override
-		ByteBuf write(ByteBufAllocator allocator) throws IOException {
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
 			ByteBuf result = null;
 
 			try {
@@ -699,14 +662,10 @@ public abstract class NettyMessage {
 				result.writeInt(credit);
 				receiverId.writeTo(result);
 
-				return result;
+				out.write(result, promise);
 			}
 			catch (Throwable t) {
-				if (result != null) {
-					result.release();
-				}
-
-				throw new IOException(t);
+				handleException(result, null, t);
 			}
 		}
 
@@ -737,22 +696,8 @@ public abstract class NettyMessage {
 		}
 
 		@Override
-		ByteBuf write(ByteBufAllocator allocator) throws IOException {
-			ByteBuf result = null;
-
-			try {
-				result = allocateBuffer(allocator, ID, 16);
-				receiverId.writeTo(result);
-
-				return result;
-			}
-			catch (Throwable t) {
-				if (result != null) {
-					result.release();
-				}
-
-				throw new IOException(t);
-			}
+		void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator) throws IOException {
+			writeToChannel(out, promise, allocator, receiverId :: writeTo, ID, 16);
 		}
 
 		static ResumeConsumption readFrom(ByteBuf buffer) {
@@ -763,5 +708,36 @@ public abstract class NettyMessage {
 		public String toString() {
 			return String.format("ResumeConsumption(%s)", receiverId);
 		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	void writeToChannel(
+			ChannelOutboundInvoker out,
+			ChannelPromise promise,
+			ByteBufAllocator allocator,
+			Consumer<ByteBuf> consumer,
+			byte id,
+			int length) throws IOException {
+
+		ByteBuf byteBuf = null;
+		try {
+			byteBuf = allocateBuffer(allocator, id, length);
+			consumer.accept(byteBuf);
+			out.write(byteBuf, promise);
+		}
+		catch (Throwable t) {
+			handleException(byteBuf, null, t);
+		}
+	}
+
+	void handleException(@Nullable ByteBuf byteBuf, @Nullable Buffer buffer, Throwable t) throws IOException {
+		if (byteBuf != null) {
+			byteBuf.release();
+		}
+		if (buffer != null) {
+			buffer.recycleBuffer();
+		}
+		ExceptionUtils.rethrowIOException(t);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -74,7 +74,10 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 
 	/** All created and not yet released readers. */
 	@GuardedBy("lock")
-	private final Set<BoundedBlockingSubpartitionReader> readers;
+	private final Set<ResultSubpartitionView> readers;
+
+	/** Flag to transfer file via FileRegion way in network stack if partition type is file without SSL enabled. */
+	private final boolean useDirectFileTransfer;
 
 	/** Counter for the number of data buffers (not events!) written. */
 	private int numDataBuffersWritten;
@@ -91,11 +94,13 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 	public BoundedBlockingSubpartition(
 			int index,
 			ResultPartition parent,
-			BoundedData data) {
+			BoundedData data,
+			boolean useDirectFileTransfer) {
 
 		super(index, parent);
 
 		this.data = checkNotNull(data);
+		this.useDirectFileTransfer = useDirectFileTransfer;
 		this.readers = new HashSet<>();
 	}
 
@@ -204,14 +209,20 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 			checkState(!isReleased, "data partition already released");
 			checkState(isFinished, "writing of blocking partition not yet finished");
 
-			final BoundedBlockingSubpartitionReader reader = new BoundedBlockingSubpartitionReader(
+			final ResultSubpartitionView reader;
+			if (useDirectFileTransfer) {
+				reader = new BoundedBlockingSubpartitionDirectTransferReader(
+					this, data.getFilePath(), numDataBuffersWritten, numBuffersAndEventsWritten);
+			} else {
+				reader = new BoundedBlockingSubpartitionReader(
 					this, data, numDataBuffersWritten, availability);
+			}
 			readers.add(reader);
 			return reader;
 		}
 	}
 
-	void releaseReaderReference(BoundedBlockingSubpartitionReader reader) throws IOException {
+	void releaseReaderReference(ResultSubpartitionView reader) throws IOException {
 		onConsumedSubpartition();
 
 		synchronized (lock) {
@@ -262,10 +273,10 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 	 * Data is eagerly spilled (written to disk) and readers directly read from the file.
 	 */
 	public static BoundedBlockingSubpartition createWithFileChannel(
-			int index, ResultPartition parent, File tempFile, int readBufferSize) throws IOException {
+			int index, ResultPartition parent, File tempFile, int readBufferSize, boolean sslEnabled) throws IOException {
 
 		final FileChannelBoundedData bd = FileChannelBoundedData.create(tempFile.toPath(), readBufferSize);
-		return new BoundedBlockingSubpartition(index, parent, bd);
+		return new BoundedBlockingSubpartition(index, parent, bd, !sslEnabled);
 	}
 
 	/**
@@ -277,7 +288,7 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 			int index, ResultPartition parent, File tempFile) throws IOException {
 
 		final MemoryMappedBoundedData bd = MemoryMappedBoundedData.create(tempFile.toPath());
-		return new BoundedBlockingSubpartition(index, parent, bd);
+		return new BoundedBlockingSubpartition(index, parent, bd, false);
 
 	}
 
@@ -292,6 +303,6 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 			int index, ResultPartition parent, File tempFile) throws IOException {
 
 		final FileChannelMemoryMappedBoundedData bd = FileChannelMemoryMappedBoundedData.create(tempFile.toPath());
-		return new BoundedBlockingSubpartition(index, parent, bd);
+		return new BoundedBlockingSubpartition(index, parent, bd, false);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The reader (read view) of a BoundedBlockingSubpartition based on
+ * {@link org.apache.flink.shaded.netty4.io.netty.channel.FileRegion}.
+ */
+public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSubpartitionView {
+
+	/** The result subpartition that we read. */
+	private final BoundedBlockingSubpartition parent;
+
+	/** The reader/decoder to the file region with the data we currently read from. */
+	private final BoundedData.Reader dataReader;
+
+	/** The remaining number of data buffers (not events) in the result. */
+	private int numDataBuffers;
+
+	/** The remaining number of data buffers and events in the result. */
+	private int numDataAndEventBuffers;
+
+	/** Flag whether this reader is released. */
+	private boolean isReleased;
+
+	private int sequenceNumber;
+
+	BoundedBlockingSubpartitionDirectTransferReader(
+		BoundedBlockingSubpartition parent,
+		Path filePath,
+		int numDataBuffers,
+		int numDataAndEventBuffers) throws IOException {
+
+		this.parent = checkNotNull(parent);
+
+		checkNotNull(filePath);
+		this.dataReader = new FileRegionReader(filePath);
+
+		checkArgument(numDataBuffers >= 0);
+		this.numDataBuffers = numDataBuffers;
+
+		checkArgument(numDataAndEventBuffers >= 0);
+		this.numDataAndEventBuffers = numDataAndEventBuffers;
+	}
+
+	@Nullable
+	@Override
+	public BufferAndBacklog getNextBuffer() throws IOException {
+		if (isReleased) {
+			return null;
+		}
+
+		Buffer current = dataReader.nextBuffer();
+		if (current == null) {
+			// as per contract, we must return null when the reader is empty,
+			// but also in case the reader is disposed (rather than throwing an exception)
+			return null;
+		}
+
+		updateStatistics(current);
+
+		// We simply assume all the data are non-events for batch jobs to avoid pre-fetching the next header
+		Buffer.DataType nextDataType = numDataAndEventBuffers > 0 ? Buffer.DataType.DATA_BUFFER : Buffer.DataType.NONE;
+		return BufferAndBacklog.fromBufferAndLookahead(current, nextDataType, numDataBuffers, sequenceNumber++);
+	}
+
+	private void updateStatistics(Buffer buffer) {
+		if (buffer.isBuffer()) {
+			numDataBuffers--;
+		}
+		numDataAndEventBuffers--;
+	}
+
+	@Override
+	public boolean isAvailable(int numCreditsAvailable) {
+		// We simply assume there are no events except EndOfPartitionEvent for bath jobs,
+		// then it has no essential effect to ignore the judgement of next event buffer.
+		return numCreditsAvailable > 0 && numDataAndEventBuffers > 0;
+	}
+
+	@Override
+	public void releaseAllResources() throws IOException {
+		// it is not a problem if this method executes multiple times
+		isReleased = true;
+
+		IOUtils.closeQuietly(dataReader);
+
+		// Notify the parent that this one is released. This allows the parent to
+		// eventually release all resources (when all readers are done and the
+		// parent is disposed).
+		parent.releaseReaderReference(this);
+	}
+
+	@Override
+	public boolean isReleased() {
+		return isReleased;
+	}
+
+	@Override
+	public Throwable getFailureCause() {
+		// we can never throw an error after this was created
+		return null;
+	}
+
+	@Override
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		return parent.unsynchronizedGetNumberOfQueuedBuffers();
+	}
+
+	@Override
+	public void notifyDataAvailable() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public void resumeConsumption() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Blocking Subpartition Reader: ID=%s, index=%d",
+			parent.parent.getPartitionId(),
+			parent.getSubPartitionIndex());
+	}
+
+	/**
+	 * The reader to read from {@link BoundedBlockingSubpartition} and return the wrapped
+	 * {@link org.apache.flink.shaded.netty4.io.netty.channel.FileRegion} based buffer.
+	 */
+	static final class FileRegionReader implements BoundedData.Reader {
+
+		private final FileChannel fileChannel;
+
+		private final ByteBuffer headerBuffer;
+
+		private long lastPosition = -1L;
+
+		private int lastBufferSize;
+
+		FileRegionReader(Path filePath) throws IOException {
+			this.fileChannel = FileChannel.open(filePath, StandardOpenOption.READ);
+			this.headerBuffer = BufferReaderWriterUtil.allocatedHeaderBuffer();
+		}
+
+		@Nullable
+		@Override
+		public Buffer nextBuffer() throws IOException {
+			// As the file region transfer via network channel will not modify the underlining file position,
+			// then we need update the position with last buffer size before reading the next header.
+			if (fileChannel.position() == lastPosition) {
+				fileChannel.position(fileChannel.position() + lastBufferSize);
+			}
+
+			Buffer buffer = BufferReaderWriterUtil.readFromByteChannel(fileChannel, headerBuffer);
+			if (buffer != null) {
+				lastBufferSize = buffer.getSize();
+				lastPosition = fileChannel.position();
+			}
+			return buffer;
+		}
+
+		@Override
+		public void close() throws IOException {
+			fileChannel.close();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -94,8 +94,9 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
 
 		assert dataReader != null;
 		nextBuffer = dataReader.nextBuffer();
+		Buffer.DataType nextDataType = nextBuffer != null ? nextBuffer.getDataType() : Buffer.DataType.NONE;
 
-		return BufferAndBacklog.fromBufferAndLookahead(current, nextBuffer, dataBufferBacklog, sequenceNumber++);
+		return BufferAndBacklog.fromBufferAndLookahead(current, nextDataType, dataBufferBacklog, sequenceNumber++);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionType.java
@@ -33,8 +33,14 @@ public enum BoundedBlockingSubpartitionType {
 	FILE {
 
 		@Override
-		public BoundedBlockingSubpartition create(int index, BoundedBlockingResultPartition parent, File tempFile, int readBufferSize) throws IOException {
-			return BoundedBlockingSubpartition.createWithFileChannel(index, parent, tempFile, readBufferSize);
+		public BoundedBlockingSubpartition create(
+			int index,
+			ResultPartition parent,
+			File tempFile,
+			int readBufferSize,
+			boolean sslEnabled) throws IOException {
+
+			return BoundedBlockingSubpartition.createWithFileChannel(index, parent, tempFile, readBufferSize, sslEnabled);
 		}
 	},
 
@@ -46,7 +52,13 @@ public enum BoundedBlockingSubpartitionType {
 	MMAP {
 
 		@Override
-		public BoundedBlockingSubpartition create(int index, BoundedBlockingResultPartition parent, File tempFile, int readBufferSize) throws IOException {
+		public BoundedBlockingSubpartition create(
+			int index,
+			ResultPartition parent,
+			File tempFile,
+			int readBufferSize,
+			boolean sslEnabled) throws IOException {
+
 			return BoundedBlockingSubpartition.createWithMemoryMappedFile(index, parent, tempFile);
 		}
 	},
@@ -61,7 +73,13 @@ public enum BoundedBlockingSubpartitionType {
 	FILE_MMAP {
 
 		@Override
-		public BoundedBlockingSubpartition create(int index, BoundedBlockingResultPartition parent, File tempFile, int readBufferSize) throws IOException {
+		public BoundedBlockingSubpartition create(
+			int index,
+			ResultPartition parent,
+			File tempFile,
+			int readBufferSize,
+			boolean sslEnabled) throws IOException {
+
 			return BoundedBlockingSubpartition.createWithFileAndMemoryMappedReader(index, parent, tempFile);
 		}
 	},
@@ -74,8 +92,14 @@ public enum BoundedBlockingSubpartitionType {
 	AUTO {
 
 		@Override
-		public BoundedBlockingSubpartition create(int index, BoundedBlockingResultPartition parent, File tempFile, int readBufferSize) throws IOException {
-			return ResultPartitionFactory.getBoundedBlockingType().create(index, parent, tempFile, readBufferSize);
+		public BoundedBlockingSubpartition create(
+			int index,
+			ResultPartition parent,
+			File tempFile,
+			int readBufferSize,
+			boolean sslEnabled) throws IOException {
+
+			return ResultPartitionFactory.getBoundedBlockingType().create(index, parent, tempFile, readBufferSize, sslEnabled);
 		}
 	};
 
@@ -84,5 +108,10 @@ public enum BoundedBlockingSubpartitionType {
 	/**
 	 * Creates BoundedBlockingSubpartition of this type.
 	 */
-	public abstract BoundedBlockingSubpartition create(int index, BoundedBlockingResultPartition parent, File tempFile, int readBufferSize) throws IOException;
+	public abstract BoundedBlockingSubpartition create(
+		int index,
+		ResultPartition parent,
+		File tempFile,
+		int readBufferSize,
+		boolean sslEnabled) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedData.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * BoundedData is the data store in a single bounded blocking subpartition.
@@ -74,6 +75,11 @@ interface BoundedData extends Closeable {
 	 * Gets the number of bytes of all written data (including the metadata in the buffer headers).
 	 */
 	long getSize();
+
+	/**
+	 * The file path for the persisted {@link BoundedBlockingSubpartition}.
+	 */
+	Path getFilePath();
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedData.java
@@ -88,6 +88,11 @@ final class FileChannelBoundedData implements BoundedData {
 	}
 
 	@Override
+	public Path getFilePath() {
+		return filePath;
+	}
+
+	@Override
 	public void close() throws IOException {
 		IOUtils.closeQuietly(fileChannel);
 		Files.delete(filePath);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/FileChannelMemoryMappedBoundedData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/FileChannelMemoryMappedBoundedData.java
@@ -168,6 +168,11 @@ final class FileChannelMemoryMappedBoundedData implements BoundedData {
 		return pos;
 	}
 
+	@Override
+	public Path getFilePath() {
+		return filePath;
+	}
+
 	private void mapRegionAndStartNext() throws IOException {
 		final ByteBuffer region = fileChannel.map(MapMode.READ_ONLY, startOfCurrentRegion, pos - startOfCurrentRegion);
 		region.order(ByteOrder.nativeOrder());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/MemoryMappedBoundedData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/MemoryMappedBoundedData.java
@@ -177,6 +177,11 @@ final class MemoryMappedBoundedData implements BoundedData {
 		return size;
 	}
 
+	@Override
+	public Path getFilePath() {
+		return filePath;
+	}
+
 	private void rollOverToNextBuffer() throws IOException {
 		if (currentBuffer != null) {
 			// we need to remember the original buffers, not any slices.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -64,6 +64,8 @@ public class ResultPartitionFactory {
 
 	private final int maxBuffersPerChannel;
 
+	private final boolean sslEnabled;
+
 	public ResultPartitionFactory(
 		ResultPartitionManager partitionManager,
 		FileChannelManager channelManager,
@@ -74,7 +76,8 @@ public class ResultPartitionFactory {
 		int networkBufferSize,
 		boolean blockingShuffleCompressionEnabled,
 		String compressionCodec,
-		int maxBuffersPerChannel) {
+		int maxBuffersPerChannel,
+		boolean sslEnabled) {
 
 		this.partitionManager = partitionManager;
 		this.channelManager = channelManager;
@@ -86,6 +89,7 @@ public class ResultPartitionFactory {
 		this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;
 		this.compressionCodec = compressionCodec;
 		this.maxBuffersPerChannel = maxBuffersPerChannel;
+		this.sslEnabled = sslEnabled;
 	}
 
 	public ResultPartition create(
@@ -162,7 +166,8 @@ public class ResultPartitionFactory {
 				blockingPartition,
 				blockingSubpartitionType,
 				networkBufferSize,
-				channelManager);
+				channelManager,
+				sslEnabled);
 
 			partition = blockingPartition;
 		}
@@ -180,12 +185,13 @@ public class ResultPartitionFactory {
 			BoundedBlockingResultPartition parent,
 			BoundedBlockingSubpartitionType blockingSubpartitionType,
 			int networkBufferSize,
-			FileChannelManager channelManager) {
+			FileChannelManager channelManager,
+			boolean sslEnabled) {
 		int i = 0;
 		try {
 			for (i = 0; i < subpartitions.length; i++) {
 				final File spillFile = channelManager.createChannel().getPathFile();
-				subpartitions[i] = blockingSubpartitionType.create(i, parent, spillFile, networkBufferSize);
+				subpartitions[i] = blockingSubpartitionType.create(i, parent, spillFile, networkBufferSize, sslEnabled);
 			}
 		}
 		catch (IOException e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -23,8 +23,6 @@ import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -174,13 +172,13 @@ public abstract class ResultSubpartition {
 
 		public static BufferAndBacklog fromBufferAndLookahead(
 				Buffer current,
-				@Nullable Buffer lookahead,
+				Buffer.DataType nextDataType,
 				int backlog,
 				int sequenceNumber) {
 			return new BufferAndBacklog(
 				current,
 				backlog,
-				lookahead != null ? lookahead.getDataType() : Buffer.DataType.NONE,
+				nextDataType,
 				sequenceNumber);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
@@ -225,6 +226,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		}
 
 		Buffer buffer = next.buffer();
+
+		if (buffer instanceof FileRegionBuffer) {
+			buffer = ((FileRegionBuffer) buffer).readInto(inputGate.getUnpooledSegment());
+		}
 
 		numBytesIn.inc(buffer.getSize());
 		numBuffersIn.inc();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -134,7 +134,8 @@ public class SingleInputGateFactory {
 			partitionProducerStateProvider,
 			bufferPoolFactory,
 			bufferDecompressor,
-			networkBufferPool);
+			networkBufferPool,
+			networkBufferSize);
 
 		createInputChannels(owningTaskName, igdd, inputGate, metrics);
 		return inputGate;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -156,6 +156,10 @@ public class NettyShuffleEnvironmentConfiguration {
 		return blockingShuffleCompressionEnabled;
 	}
 
+	public boolean isSSLEnabled() {
+		return nettyConfig != null && nettyConfig.getSSLEnabled();
+	}
+
 	public String getCompressionCodec() {
 		return compressionCodec;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
@@ -48,13 +48,10 @@ import java.util.List;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
-import static org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.verifyBufferResponseHeader;
-import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.verifyErrorResponse;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 /**
  * Tests the client side message decoder.
@@ -163,7 +160,7 @@ public class NettyMessageClientDecoderDelegateTest extends TestLogger {
 		ByteBuf[] encodedMessages = null;
 		List<NettyMessage> decodedMessages = null;
 		try {
-			List<NettyMessage> messages = createMessageList(
+			List<BufferResponse> messages = createMessageList(
 				hasEmptyBuffer,
 				hasBufferForReleasedChannel,
 				hasBufferForRemovedChannel);
@@ -186,13 +183,13 @@ public class NettyMessageClientDecoderDelegateTest extends TestLogger {
 		}
 	}
 
-	private List<NettyMessage> createMessageList(
+	private List<BufferResponse> createMessageList(
 		boolean hasEmptyBuffer,
 		boolean hasBufferForRemovedChannel,
 		boolean hasBufferForReleasedChannel) {
 
 		int seqNumber = 1;
-		List<NettyMessage> messages = new ArrayList<>();
+		List<BufferResponse> messages = new ArrayList<>();
 
 		for (int i = 0; i < NUMBER_OF_BUFFER_RESPONSES - 1; i++) {
 			addBufferResponse(messages, inputChannelId, Buffer.DataType.DATA_BUFFER, BUFFER_SIZE, seqNumber++);
@@ -210,13 +207,12 @@ public class NettyMessageClientDecoderDelegateTest extends TestLogger {
 
 		addBufferResponse(messages, inputChannelId, Buffer.DataType.EVENT_BUFFER, 32, seqNumber++);
 		addBufferResponse(messages, inputChannelId, Buffer.DataType.DATA_BUFFER, BUFFER_SIZE, seqNumber);
-		messages.add(new NettyMessage.ErrorResponse(new RuntimeException("test"), inputChannelId));
 
 		return messages;
 	}
 
 	private void addBufferResponse(
-		List<NettyMessage> messages,
+		List<BufferResponse> messages,
 		InputChannelID inputChannelId,
 		Buffer.DataType dataType,
 		int bufferSize,
@@ -236,7 +232,7 @@ public class NettyMessageClientDecoderDelegateTest extends TestLogger {
 		return buffer;
 	}
 
-	private ByteBuf[] encodeMessages(List<NettyMessage> messages) throws Exception {
+	private ByteBuf[] encodeMessages(List<BufferResponse> messages) throws Exception {
 		ByteBuf[] encodedMessages = new ByteBuf[messages.size()];
 		for (int i = 0; i < messages.size(); ++i) {
 			encodedMessages[i] = messages.get(i).write(ALLOCATOR);
@@ -315,26 +311,18 @@ public class NettyMessageClientDecoderDelegateTest extends TestLogger {
 		return decodedMessages;
 	}
 
-	private void verifyDecodedMessages(List<NettyMessage> expectedMessages, List<NettyMessage> decodedMessages) {
+	private void verifyDecodedMessages(List<BufferResponse> expectedMessages, List<NettyMessage> decodedMessages) {
 		assertEquals(expectedMessages.size(), decodedMessages.size());
 		for (int i = 0; i < expectedMessages.size(); ++i) {
 			assertEquals(expectedMessages.get(i).getClass(), decodedMessages.get(i).getClass());
 
-			if (expectedMessages.get(i) instanceof NettyMessage.BufferResponse) {
-				BufferResponse expected = (BufferResponse) expectedMessages.get(i);
-				BufferResponse actual = (BufferResponse) decodedMessages.get(i);
-
-				verifyBufferResponseHeader(expected, actual);
-				if (expected.bufferSize == 0 || !expected.receiverId.equals(inputChannelId)) {
-					assertNull(actual.getBuffer());
-				} else {
-					assertEquals(expected.getBuffer(), actual.getBuffer());
-				}
-
-			} else if (expectedMessages.get(i) instanceof NettyMessage.ErrorResponse) {
-				verifyErrorResponse((ErrorResponse) expectedMessages.get(i), (ErrorResponse) decodedMessages.get(i));
+			BufferResponse expected = expectedMessages.get(i);
+			BufferResponse actual = (BufferResponse) decodedMessages.get(i);
+			verifyBufferResponseHeader(expected, actual);
+			if (expected.bufferSize == 0 || !expected.receiverId.equals(inputChannelId)) {
+				assertNull(actual.getBuffer());
 			} else {
-				fail("Unsupported message type");
+				assertEquals(expected.getBuffer(), actual.getBuffer());
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -175,9 +175,12 @@ public class NettyTestUtil {
 
 	static <T extends NettyMessage> T encodeAndDecode(T msg, EmbeddedChannel channel) {
 		channel.writeOutbound(msg);
-		ByteBuf encoded = channel.readOutbound();
-
-		assertTrue(channel.writeInbound(encoded));
+		ByteBuf encoded;
+		boolean msgNotEmpty = false;
+		while ((encoded = channel.readOutbound()) != null) {
+			msgNotEmpty = channel.writeInbound(encoded);
+		}
+		assertTrue(msgNotEmpty);
 
 		return channel.readInbound();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
@@ -125,6 +125,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
 		BoundedBlockingResultPartition parent = (BoundedBlockingResultPartition) new ResultPartitionBuilder()
 			.setResultPartitionType(ResultPartitionType.BLOCKING_PERSISTENT)
 			.setBoundedBlockingSubpartitionType(BoundedBlockingSubpartitionType.FILE)
+			.setSSLEnabled(true)
 			.setFileChannelManager(new FileChannelManagerImpl(new String[] { TMP_FOLDER.newFolder().toString() }, "data"))
 			.setNetworkBufferSize(BUFFER_SIZE)
 			.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import org.junit.AfterClass;
@@ -28,11 +29,17 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -46,11 +53,24 @@ import static org.junit.Assert.fail;
  * <p>Full read / write tests for the partition and the reader are in
  * {@link BoundedBlockingSubpartitionWriteReadTest}.
  */
+@RunWith(Parameterized.class)
 public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 
 	private static final String tempDir = EnvironmentInformation.getTemporaryFileDirectory();
 
 	private static FileChannelManager fileChannelManager;
+
+	private final BoundedBlockingSubpartitionType type;
+
+	private final boolean sslEnabled;
+
+	@Parameterized.Parameters(name = "type = {0}, sslEnabled = {1}")
+	public static Collection<Object[]> parameters() {
+		return Arrays.stream(BoundedBlockingSubpartitionType.values())
+			.map((type) -> new Object[][] { { type, true }, { type, false } })
+			.flatMap(Arrays::stream)
+			.collect(Collectors.toList());
+	}
 
 	@ClassRule
 	public static final TemporaryFolder TMP_DIR = new TemporaryFolder();
@@ -63,6 +83,11 @@ public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 	@AfterClass
 	public static void shutdown() throws Exception {
 		fileChannelManager.close();
+	}
+
+	public BoundedBlockingSubpartitionTest(BoundedBlockingSubpartitionType type, boolean sslEnabled) {
+		this.type = type;
+		this.sslEnabled = sslEnabled;
 	}
 
 	// ------------------------------------------------------------------------
@@ -97,8 +122,7 @@ public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 	@Override
 	ResultSubpartition createSubpartition() throws Exception {
 		final ResultPartition resultPartition = createPartition(ResultPartitionType.BLOCKING, fileChannelManager);
-		return BoundedBlockingSubpartition.createWithMemoryMappedFile(
-				0, resultPartition, new File(TMP_DIR.newFolder(), "subpartition"));
+		return type.create(0, resultPartition, new File(TMP_DIR.newFolder(), "subpartition"), BufferBuilderTestUtils.BUFFER_SIZE, sslEnabled);
 	}
 
 	@Override
@@ -108,7 +132,8 @@ public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 		return new BoundedBlockingSubpartition(
 				0,
 				resultPartition,
-				new FailingBoundedData());
+				new FailingBoundedData(),
+				!sslEnabled && type == BoundedBlockingSubpartitionType.FILE);
 	}
 
 	// ------------------------------------------------------------------------
@@ -132,6 +157,11 @@ public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 
 		@Override
 		public long getSize() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Path getFilePath() {
 			throw new UnsupportedOperationException();
 		}
 
@@ -162,6 +192,11 @@ public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 
 		@Override
 		public long getSize() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Path getFilePath() {
 			throw new UnsupportedOperationException();
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
@@ -75,6 +75,8 @@ public class BoundedBlockingSubpartitionWriteReadTest {
 
 	private final boolean compressionEnabled;
 
+	private final boolean sslEnabled;
+
 	@Parameters(name = "type = {0}, compressionEnabled = {1}")
 	public static Collection<Object[]> parameters() {
 		return Arrays.stream(BoundedBlockingSubpartitionType.values())
@@ -86,6 +88,8 @@ public class BoundedBlockingSubpartitionWriteReadTest {
 	public BoundedBlockingSubpartitionWriteReadTest(BoundedBlockingSubpartitionType type, boolean compressionEnabled) {
 		this.type = type;
 		this.compressionEnabled = compressionEnabled;
+		// we can also make use of the same flag since they are completely irrelevant
+		this.sslEnabled = compressionEnabled;
 	}
 
 	// ------------------------------------------------------------------------
@@ -235,7 +239,8 @@ public class BoundedBlockingSubpartitionWriteReadTest {
 					compressionEnabled,
 					BUFFER_SIZE),
 				new File(TMP_FOLDER.newFolder(), "partitiondata"),
-				BUFFER_SIZE);
+				BUFFER_SIZE,
+				sslEnabled);
 	}
 
 	private static LongReader[] createSubpartitionLongReaders(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
@@ -157,6 +157,7 @@ public class FileChannelBoundedDataTest extends BoundedDataTestBase {
 			.setResultPartitionType(ResultPartitionType.BLOCKING)
 			.setBoundedBlockingSubpartitionType(BoundedBlockingSubpartitionType.FILE)
 			.setFileChannelManager(fileChannelManager)
+			.setSSLEnabled(true)
 			.build();
 		return resultPartition.subpartitions[0];
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -327,6 +327,7 @@ public class InputGateFairnessTest {
 	// ------------------------------------------------------------------------
 
 	private static class FairnessVerifyingInputGate extends SingleInputGate {
+		private static final int BUFFER_SIZE = 32 * 1024;
 		private static final SupplierWithException<BufferPool, IOException> STUB_BUFFER_POOL_FACTORY =
 			NoOpBufferPool::new;
 
@@ -351,7 +352,8 @@ public class InputGateFairnessTest {
 				SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
 				STUB_BUFFER_POOL_FACTORY,
 				null,
-				new UnpooledMemorySegmentProvider(32 * 1024));
+				new UnpooledMemorySegmentProvider(BUFFER_SIZE),
+				BUFFER_SIZE);
 
 			channelsWithData = getInputChannelsWithData();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -64,6 +64,8 @@ public class ResultPartitionBuilder {
 
 	private boolean blockingShuffleCompressionEnabled = false;
 
+	private boolean sslEnabled = false;
+
 	private String compressionCodec = "LZ4";
 
 	public ResultPartitionBuilder setResultPartitionIndex(int partitionIndex) {
@@ -150,6 +152,11 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
+	public ResultPartitionBuilder setSSLEnabled(boolean sslEnabled) {
+		this.sslEnabled = sslEnabled;
+		return this;
+	}
+
 	public ResultPartition build() {
 		ResultPartitionFactory resultPartitionFactory = new ResultPartitionFactory(
 			partitionManager,
@@ -161,7 +168,8 @@ public class ResultPartitionBuilder {
 			networkBufferSize,
 			blockingShuffleCompressionEnabled,
 			compressionCodec,
-			maxBuffersPerChannel);
+			maxBuffersPerChannel,
+			sslEnabled);
 
 		SupplierWithException<BufferPool, IOException> factory = bufferPoolFactory.orElseGet(() ->
 			resultPartitionFactory.createBufferPoolFactory(numberOfSubpartitions, partitionType));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -102,7 +102,8 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			SEGMENT_SIZE,
 			false,
 			"LZ4",
-			Integer.MAX_VALUE);
+			Integer.MAX_VALUE,
+			false);
 
 		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(
 			PartitionDescriptorBuilder

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -45,6 +45,8 @@ public class SingleInputGateBuilder {
 
 	private final IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
 
+	private final int bufferSize = 4096;
+
 	private ResultPartitionType partitionType = ResultPartitionType.PIPELINED;
 
 	private int consumedSubpartitionIndex = 0;
@@ -147,7 +149,8 @@ public class SingleInputGateBuilder {
 			partitionProducerStateProvider,
 			bufferPoolFactory,
 			bufferDecompressor,
-			segmentProvider);
+			segmentProvider,
+			bufferSize);
 		if (channelFactory != null) {
 			gate.setInputChannels(IntStream.range(0, numberOfChannels)
 				.mapToObj(index -> channelFactory.apply(InputChannelBuilder.newBuilder().setChannelIndex(index), gate))

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/FileBufferReaderITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.RecordReader;
@@ -40,6 +41,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.net.SSLUtilsTest;
 import org.apache.flink.testutils.serialization.types.ByteArrayType;
 import org.apache.flink.util.TestLogger;
 
@@ -48,7 +50,11 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.Matchers.is;
@@ -65,6 +71,7 @@ import static org.junit.Assert.assertThat;
  * the first fetched buffer from {@link org.apache.flink.runtime.io.network.partition.FileChannelBoundedData} has not
  * been recycled while fetching the second buffer to trigger next read ahead, which breaks the above assumption.
  */
+@RunWith(Parameterized.class)
 public class FileBufferReaderITCase extends TestLogger {
 
 	private static final int parallelism = 8;
@@ -79,6 +86,14 @@ public class FileBufferReaderITCase extends TestLogger {
 
 	private static final byte[] dataSource = new byte[recordSize];
 
+	@Parameterized.Parameters(name = "SSL Enabled = {0}")
+	public static List<Boolean> paras() {
+		return Arrays.asList(true, false);
+	}
+
+	@Parameterized.Parameter
+	public boolean sslEnabled;
+
 	@BeforeClass
 	public static void setup() {
 		for (int i = 0; i < dataSource.length; i++) {
@@ -89,7 +104,12 @@ public class FileBufferReaderITCase extends TestLogger {
 	@Test
 	public void testSequentialReading() throws Exception {
 		// setup
-		final Configuration configuration = new Configuration();
+		final Configuration configuration;
+		if (sslEnabled) {
+			configuration = SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores("JDK");
+		} else {
+			configuration = new Configuration();
+		}
 		configuration.setString(RestOptions.BIND_PORT, "0");
 		configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");
 		configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));


### PR DESCRIPTION
## What is the purpose of the change

Implement the `FileRegion` based way in netty stack for transferring the bounded blocking partition data with file type, then we can avoid introducing any memory overhead in application layer to resolve OOM issue before.

Besides that, compared with existing mmap option, `FileRegion` has some advantages as below:

- Reduce the context switch

- Reduce the memory copy from kernel to socket based on DMA support 

- Somehow avoid killing by yarn cluster, since mmap has already side effect to be killed by yarn because of memory overuse.(`FileRegion` option needs to be further experimented in real scenario for this concern).

## Brief change log

- Refactor the `NettyMessage` as interface instead of abstract class.

- Introduce `FileRegionResponse` to implement `NettyMessage` for making use of file region way provided by netty stack.

- Introduce `PartitionData` and `BoundedPartitionData` abstract classes for unifying the code paths between pipelined and blocking partitions.

- Refactor series of interface methods from `getBuffer` to `getData` for fitting the above changes.

- Request one additional memory segment from global pool in `SingleInputGate` for reading bounded partition data in local channel.

## Verifying this change

The previous unit tests should cover almost all the changes, might supplement some new unit tests if necessary future.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
