### PR TITLE
[FLINK-19258][docs] Fix the wrong example of "csv.line-delimiter" in CSV documentation

### DIFF
--- a/docs/dev/table/connectors/formats/csv.md
+++ b/docs/dev/table/connectors/formats/csv.md
@@ -102,8 +102,8 @@ Format Options
       <td>String</td>
       <td>Line delimiter, <code>\n</code> by default. Note the <code>\n</code> and <code>\r</code> are invisible special characters, you have to use unicode to specify them in plain SQL.
           <ul>
-           <li>e.g. <code>'csv.line-delimiter' = U&'\\000D'</code> specifies the to use carriage return <code>\r</code> as line delimiter.</li>
-           <li>e.g. <code>'csv.line-delimiter' = U&'\\000A'</code> specifies the to use line feed <code>\n</code> as line delimiter.</li>
+           <li>e.g. <code>'csv.line-delimiter' = U&'\000D'</code> specifies the to use carriage return <code>\r</code> as line delimiter.</li>
+           <li>e.g. <code>'csv.line-delimiter' = U&'\000A'</code> specifies the to use line feed <code>\n</code> as line delimiter.</li>
           </ul>
       </td>
     </tr>

--- a/docs/dev/table/connectors/formats/csv.zh.md
+++ b/docs/dev/table/connectors/formats/csv.zh.md
@@ -104,8 +104,8 @@ Format 参数
       <td>String</td>
       <td>行分隔符, 默认<code>\n</code>。注意 <code>\n</code> 和 <code>\r</code> 是不可见的特殊符号, 在显式的 SQL 语句中必须使用 unicode 编码。
           <ul>
-           <li>例如 <code>'csv.line-delimiter' = U&'\\000D'</code> 使用换行符号 <code>\r</code> 作为行分隔符。</li>
-           <li>例如 <code>'csv.line-delimiter' = U&'\\000A'</code> 使用换行符号 <code>\n</code> 作为行分隔符。</li>
+           <li>例如 <code>'csv.line-delimiter' = U&'\000D'</code> 使用回车符号 <code>\r</code> 作为行分隔符。</li>
+           <li>例如 <code>'csv.line-delimiter' = U&'\000A'</code> 使用换行符号 <code>\n</code> 作为行分隔符。</li>
           </ul>
       </td>
     </tr>


### PR DESCRIPTION

## What is the purpose of the change
Fix the wrong example of "csv.line-delimiter" in CSV documentation

## Brief change log
Fix the wrong example of "csv.line-delimiter" in CSV documentation


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
