### PR TITLE
[FLINK-19447][hbase] Run HBase 2.2 integration test only if hadoop version is between 2.8.0 - 3.0.3

### DIFF
--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestingClusterAutoStarter.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestingClusterAutoStarter.java
@@ -20,6 +20,7 @@
 
 package org.apache.flink.connector.hbase2.util;
 
+import org.apache.commons.lang3.Range;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -33,7 +34,9 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.ZooKeeperConnectionException;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.util.VersionUtil;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -50,6 +53,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class HBaseTestingClusterAutoStarter {
 	private static final Log LOG = LogFactory.getLog(HBaseTestingClusterAutoStarter.class);
+
+	private static final Range<String> HADOOP_VERSION_RANGE = Range.between("2.8.0", "3.0.3", VersionUtil::compareVersions);
 
 	private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
 	private static Admin admin = null;
@@ -119,6 +124,9 @@ public class HBaseTestingClusterAutoStarter {
 
 	@BeforeClass
 	public static void setUp() throws Exception {
+		// HBase 2.2.3 HBaseTestingUtility works with only a certain range of hadoop versions
+		String hadoopVersion = System.getProperty("hadoop.version");
+		Assume.assumeTrue(HADOOP_VERSION_RANGE.contains(hadoopVersion));
 		TEST_UTIL.startMiniCluster(1);
 		initialize(TEST_UTIL.getConfiguration());
 	}


### PR DESCRIPTION
## What is the purpose of the change

At HBase 2.2.3 the test mini cluster utility only works with hadoop 2.8.0 - 3.0.3, thus the integration tests should not run with other hadoop versions. It is causing issues in the nightly tests that run them with 2.4.1 and 3.1.3

## Brief change log

HBaseConnectorITCase now runs only if hadoop.version is within 2.8.0 - 3.0.3

## Verifying this change

HBaseConnectorITCase is skipped if it is executed with a hadoop.version ourside of the 2.8.0 - 3.0.3 range.
This change added tests and can be verified as follows: running the tests with different -Dhadoop.version=... settings

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
