### PR TITLE
[FLINK-19477][docs-zh][python] Translate page "python_table_api_connectors" into Chinese

### DIFF
--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "Connectors"
+title: "连接器"
 nav-parent_id: python_tableapi
 nav-pos: 130
 ---
@@ -23,16 +23,16 @@ under the License.
 -->
 
 
-This page describes how to use connectors in PyFlink and highlights the details to be aware of when using Flink connectors in Python programs.
+这篇描述了如何在 PyFlink 中使用连接器，并强调了在 Python 程序中使用 Flink 连接器时需要注意的细节。
 
 * This will be replaced by the TOC
 {:toc}
 
-<span class="label label-info">Note</span> For general connector information and common configuration, please refer to the corresponding [Java/Scala documentation]({{ site.baseurl }}/zh/dev/table/connectors/index.html). 
+<span class="label label-info">Note</span> 想要了解常见的连接器信息和通用配置，请查阅相关的 [Java/Scala 文档]({{ site.baseurl }}/zh/dev/table/connectors/index.html)。
 
-## Download connector and format jars
+## 下载连接器和格式 jar 包
 
-Since Flink is a Java/Scala-based project, for both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html).
+由于 Flink 是一个基于 Java/Scala-based 的项目，对于连接器和格式的实现可以作为 jar 包使用，将其指定为作业的 [依赖]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html)。
 
 {% highlight python %}
 
@@ -40,9 +40,9 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 
 {% endhighlight %}
 
-## How to use connectors
+## 如何使用连接器
 
-In PyFink's Table API, DDL is the recommended way to define sources and sinks, executed via the `execute_sql()` method on the `TableEnvironment`. This makes the table available for use by the application.
+在 PyFink Table API 中，DDL 是定义 sources 和 sinks 推荐的方式，通过执行在 `TableEnvironment` 中的  `execute_sql()` 方法。这样使得在应用程序可以使用这张表。
 
 {% highlight python %}
 
@@ -78,7 +78,7 @@ t_env.sql_query("SELECT a FROM source_table") \
     .insert_into("sink_table")
 {% endhighlight %}
 
-Below is a complete example of how to use a Kafka source/sink and the JSON format in PyFlink.
+下面是如何在 PyFlink 中使用 Kafka source/sink 和 JSON 格式的完整例子。
 
 {% highlight python %}
 
@@ -133,45 +133,45 @@ if __name__ == '__main__':
 {% endhighlight %}
 
 
-## Predefined Sources and Sinks
+## 内置的 Sources 和 Sinks
 
-Some data sources and sinks are built into Flink and are available out-of-the-box. These predefined data sources include reading from Pandas DataFrame, or ingesting data from collections. The predefined data sinks support writing to Pandas DataFrame.
+有些 sources 和 sinks 被内置在 Flink 中，并且可以直接使用。这些内置的 sources 包括可以从 Pandas DataFrame 读数据，或者从 collections 消费数据。内置的 sinks 支持将数据写到 Pandas DataFrame 中。
 
-### from/to Pandas
+### 和 Pandas 之间转换
 
-PyFlink Tables support conversion to and from Pandas DataFrame.
+PyFlink 表支持和 Pandas DataFrame 之间转换数据。
 
 {% highlight python %}
 
 import pandas as pd
 import numpy as np
 
-# Create a PyFlink Table
+# 创建一个 PyFlink 表
 pdf = pd.DataFrame(np.random.rand(1000, 2))
 table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
 
-# Convert the PyFlink Table to a Pandas DataFrame
+# 将 PyFlink 表转换成 Pandas DataFrame
 pdf = table.to_pandas()
 {% endhighlight %}
 
 ### from_elements()
 
-`from_elements()` is used to create a table from a collection of elements. The element types must be acceptable atomic types or acceptable composite types.
+`from_elements()` 用于从一个元素集合中创建一张表。 元素类型必须是可支持的原子类型或者是可支持的复杂类型。
 
 {% highlight python %}
 
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
 
-# use the second parameter to specify custom field names
+# 使用第二个参数指定自定义字段名
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['a', 'b'])
 
-# use the second parameter to specify a custom table schema
+# 使用第二个参数指定自定义表模式
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
                         DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
                                        DataTypes.FIELD("b", DataTypes.STRING())]))
 {% endhighlight %}
 
-The above query returns a Table like:
+以上查询返回的表如下:
 
 {% highlight python %}
 +----+-------+
@@ -183,7 +183,7 @@ The above query returns a Table like:
 +----+-------+
 {% endhighlight %}
 
-## User-defined sources & sinks
+## 用户自定义的 sources 和 sinks
 
-In some cases, you may want to define custom sources and sinks. Currently, sources and sinks must be implemented in Java/Scala, but you can define a `TableFactory` to support their use via DDL. More details can be found in the [Java/Scala documentation]({{ site.baseurl }}/zh/dev/table/sourceSinks.html).
+在某些情况下，你可能想要自定义 sources 和 sinks。目前，sources 和 sinks 必须使用 Java/Scala 实现，但是你可以通过DDL定义一个 `TableFactory` 来使用它们。更多详情，可查阅 [Java/Scala 文档]({{ site.baseurl }}/zh/dev/table/sourceSinks.html)。
 

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -23,16 +23,16 @@ under the License.
 -->
 
 
-这篇描述了如何在 PyFlink 中使用连接器，并强调了在 Python 程序中使用 Flink 连接器时需要注意的细节。
+本篇描述了如何在 PyFlink 中使用连接器，并着重介绍了在 Python 程序中使用 Flink 连接器时需要注意的细节。
 
 * This will be replaced by the TOC
 {:toc}
 
 <span class="label label-info">Note</span> 想要了解常见的连接器信息和通用配置，请查阅相关的 [Java/Scala 文档]({{ site.baseurl }}/zh/dev/table/connectors/index.html)。
 
-## 下载连接器和格式 jar 包
+## 下载连接器（connector）和格式（format）jar 包
 
-由于 Flink 是一个基于 Java/Scala-based 的项目，对于连接器和格式的实现可以作为 jar 包使用，将其指定为作业的 [依赖]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html)。
+由于 Flink 是一个基于 Java/Scala-based 的项目，连接器和格式的实现是作为 jar 包存在的，需要将其指定为作业的 [依赖]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html)。
 
 {% highlight python %}
 
@@ -42,7 +42,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 
 ## 如何使用连接器
 
-在 PyFink Table API 中，DDL 是定义 sources 和 sinks 推荐的方式，通过执行在 `TableEnvironment` 中的  `execute_sql()` 方法。这样使得在应用程序可以使用这张表。
+在 PyFink Table API 中，DDL 是定义 sources 和 sinks 比较推荐的方式，这可以通过 `TableEnvironment` 中的 `execute_sql()` 方法来完成。然后就可以在作业中使用这张表了。
 
 {% highlight python %}
 
@@ -135,11 +135,11 @@ if __name__ == '__main__':
 
 ## 内置的 Sources 和 Sinks
 
-有些 sources 和 sinks 被内置在 Flink 中，并且可以直接使用。这些内置的 sources 包括可以从 Pandas DataFrame 读数据，或者从 collections 消费数据。内置的 sinks 支持将数据写到 Pandas DataFrame 中。
+有些 sources 和 sinks 被内置在 Flink 中，可以直接使用。这些内置的 sources 包括可以从 Pandas DataFrame 读取数据，或者从 collections 中消费数据。内置的 sinks 包括将数据写到 Pandas DataFrame 中。
 
 ### 和 Pandas 之间转换
 
-PyFlink 表支持和 Pandas DataFrame 之间转换数据。
+PyFlink 表支持与 Pandas DataFrame 之间互相转换。
 
 {% highlight python %}
 
@@ -165,7 +165,7 @@ table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
 # 使用第二个参数指定自定义字段名
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['a', 'b'])
 
-# 使用第二个参数指定自定义表模式
+# 使用第二个参数指定自定义表结构
 table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
                         DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
                                        DataTypes.FIELD("b", DataTypes.STRING())]))
@@ -185,5 +185,5 @@ table_env.from_elements([(1, 'Hi'), (2, 'Hello')],
 
 ## 用户自定义的 sources 和 sinks
 
-在某些情况下，你可能想要自定义 sources 和 sinks。目前，sources 和 sinks 必须使用 Java/Scala 实现，但是你可以通过DDL定义一个 `TableFactory` 来使用它们。更多详情，可查阅 [Java/Scala 文档]({{ site.baseurl }}/zh/dev/table/sourceSinks.html)。
+在某些情况下，你可能想要自定义 sources 和 sinks。目前，sources 和 sinks 必须使用 Java/Scala 实现，但是你可以定义一个 `TableFactory` ，然后通过 DDL 来使用它们。更多详情，可查阅 [Java/Scala 文档]({{ site.baseurl }}/zh/dev/table/sourceSinks.html)。
 


### PR DESCRIPTION

## What is the purpose of the change

Translate page "python_table_api_connectors" into Chinese

## Brief change log

Translate page "python_table_api_connectors" into Chinese

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
