### PR TITLE
 [FLINK-19473] Implement multi inputs sorting DataInput 

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -107,7 +107,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 				// in theory, the subclasses of StreamSource may implement the BoundedOneInput interface,
 				// so we still need the following call to end the input
 				synchronized (lockingObject) {
-					operatorChain.endMainOperatorInput(1);
+					operatorChain.endInput(1);
 				}
 			}
 		} finally {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.AlgorithmOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.sort.ExternalSorter;
+import org.apache.flink.runtime.operators.sort.PushSorter;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.MutableObjectIterator;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.PriorityQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+/**
+ * An input that wraps an underlying input and sorts the incoming records. It starts emitting records
+ * downstream only when all the other inputs coupled with this {@link MultiInputSortingDataInput} have
+ * finished sorting as well.
+ *
+ * <p>Moreover it will report it is {@link #isAvailable() available} or
+ * {@link #isApproximatelyAvailable() approximately available} if it has some records pending only if the head
+ * of the {@link CommonContext#getQueueOfHeads()} belongs to the input. That way there is only ever one input
+ * that reports it is available.
+ *
+ * <p>The sorter uses binary comparison of keys, which are extracted and serialized when received
+ * from the chained input. Moreover the timestamps of incoming records are used for secondary ordering.
+ * For the comparison it uses either {@link FixedLengthByteKeyComparator} if the length of the
+ * serialized key is constant, or {@link VariableLengthByteKeyComparator} otherwise.
+ *
+ * <p>Watermarks, stream statuses, nor latency markers are propagated downstream as they do not make
+ * sense with buffered records. The input emits the largest watermark seen after all records.
+ */
+public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<IN> {
+	private final int idx;
+	private final StreamTaskInput<IN> wrappedInput;
+	private final PushSorter<Tuple2<byte[], StreamRecord<IN>>> sorter;
+	private final CommonContext commonContext;
+	private final SortingPhaseDataOutput sortingPhaseDataOutput = new SortingPhaseDataOutput();
+
+	private final KeySelector<IN, K> keySelector;
+	private final TypeSerializer<K> keySerializer;
+	private final DataOutputSerializer dataOutputSerializer;
+
+	private MutableObjectIterator<Tuple2<byte[], StreamRecord<IN>>> sortedInput;
+	private long seenWatermark = Long.MIN_VALUE;
+
+	private MultiInputSortingDataInput(
+			CommonContext commonContext,
+			StreamTaskInput<IN> wrappedInput,
+			int inputIdx,
+			PushSorter<Tuple2<byte[], StreamRecord<IN>>> sorter,
+			KeySelector<IN, K> keySelector,
+			TypeSerializer<K> keySerializer,
+			DataOutputSerializer dataOutputSerializer) {
+		this.wrappedInput = wrappedInput;
+		this.idx = inputIdx;
+		this.commonContext = commonContext;
+		this.sorter = sorter;
+		this.keySelector = keySelector;
+		this.keySerializer = keySerializer;
+		this.dataOutputSerializer = dataOutputSerializer;
+	}
+
+	public static <K> StreamTaskInput<?>[] wrapInputs(
+			AbstractInvokable containingTask,
+			StreamTaskInput<Object>[] inputs,
+			KeySelector<Object, K>[] keySelectors,
+			TypeSerializer<Object>[] inputSerializers,
+			TypeSerializer<K> keySerializer,
+			MemoryManager memoryManager,
+			IOManager ioManager,
+			boolean objectReuse,
+			double managedMemoryFraction,
+			Configuration jobConfiguration) {
+		int keyLength = keySerializer.getLength();
+		final TypeComparator<Tuple2<byte[], StreamRecord<Object>>> comparator;
+		DataOutputSerializer dataOutputSerializer;
+		if (keyLength > 0) {
+			dataOutputSerializer = new DataOutputSerializer(keyLength);
+			comparator = new FixedLengthByteKeyComparator<>(keyLength);
+		} else {
+			dataOutputSerializer = new DataOutputSerializer(64);
+			comparator = new VariableLengthByteKeyComparator<>();
+		}
+
+		int numberOfInputs = inputs.length;
+		CommonContext commonContext = new CommonContext(numberOfInputs);
+		return IntStream.range(0, numberOfInputs)
+			.mapToObj(
+				idx -> {
+					try {
+						KeyAndValueSerializer<Object> keyAndValueSerializer = new KeyAndValueSerializer<>(
+							inputSerializers[idx],
+							keyLength);
+						return new MultiInputSortingDataInput<>(
+							commonContext,
+							inputs[idx],
+							idx,
+							ExternalSorter.newBuilder(
+								memoryManager,
+								containingTask,
+								keyAndValueSerializer,
+								comparator)
+								.memoryFraction(managedMemoryFraction / numberOfInputs)
+								.enableSpilling(
+									ioManager,
+									jobConfiguration.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD))
+								.maxNumFileHandles(
+									jobConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN) / numberOfInputs)
+								.objectReuse(objectReuse)
+								.largeRecords(true)
+								.build(),
+							keySelectors[idx],
+							keySerializer,
+							dataOutputSerializer
+						);
+					} catch (MemoryAllocationException e) {
+						throw new RuntimeException();
+					}
+				}
+			).toArray(StreamTaskInput[]::new);
+	}
+
+	@Override
+	public int getInputIndex() {
+		return idx;
+	}
+
+	@Override
+	public CompletableFuture<Void> prepareSnapshot(
+			ChannelStateWriter channelStateWriter,
+			long checkpointId) {
+		throw new UnsupportedOperationException("Checkpoints are not supported with sorted inputs" +
+			" in the BATCH runtime.");
+	}
+
+	@Override
+	public void close() throws IOException {
+		IOException ex = null;
+		try {
+			wrappedInput.close();
+		} catch (IOException e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		try {
+			sorter.close();
+		} catch (IOException e) {
+			ex = ExceptionUtils.firstOrSuppressed(e, ex);
+		}
+
+		if (ex != null) {
+			throw ex;
+		}
+	}
+
+	@Override
+	public InputStatus emitNext(DataOutput<IN> output) throws Exception {
+		if (sortedInput != null) {
+			return emitNextAfterSorting(output);
+		}
+
+		InputStatus inputStatus = wrappedInput.emitNext(sortingPhaseDataOutput);
+		if (inputStatus == InputStatus.END_OF_INPUT) {
+			endSorting();
+			return addNextToQueue(new HeadElement(idx), output);
+		}
+
+		return inputStatus;
+	}
+
+	@Nonnull
+	@SuppressWarnings({"unchecked"})
+	private InputStatus emitNextAfterSorting(DataOutput<IN> output) throws Exception {
+		if (commonContext.isFinishedEmitting(idx)) {
+			return InputStatus.END_OF_INPUT;
+		} else if (commonContext.allSorted()) {
+			HeadElement head = commonContext.getQueueOfHeads().peek();
+			if (head != null && head.inputIndex == idx) {
+				HeadElement headElement = commonContext.getQueueOfHeads().poll();
+				output.emitRecord((StreamRecord<IN>) headElement.streamElement.f1);
+				return addNextToQueue(headElement, output);
+			} else {
+				return InputStatus.NOTHING_AVAILABLE;
+			}
+		} else {
+			return InputStatus.NOTHING_AVAILABLE;
+		}
+	}
+
+	private void endSorting() throws Exception {
+		sorter.finishReading();
+		commonContext.setFinishedSorting(idx);
+		sortedInput = sorter.getIterator();
+		if (commonContext.allSorted()) {
+			commonContext.getAllFinished().getUnavailableToResetAvailable().complete(null);
+		}
+	}
+
+	@Nonnull
+	private InputStatus addNextToQueue(HeadElement reuse, DataOutput<IN> output) throws Exception {
+		Tuple2<byte[], StreamRecord<IN>> next = sortedInput.next();
+		if (next != null) {
+			reuse.streamElement = getAsObject(next);
+			commonContext.getQueueOfHeads().add(reuse);
+		} else {
+			commonContext.setFinishedEmitting(idx);
+			if (seenWatermark > Long.MIN_VALUE) {
+				output.emitWatermark(new Watermark(seenWatermark));
+			}
+			return InputStatus.END_OF_INPUT;
+		}
+
+		if (commonContext.allSorted()) {
+			HeadElement headElement = commonContext.getQueueOfHeads().peek();
+			if (headElement != null) {
+				if (headElement.inputIndex == idx) {
+					return InputStatus.MORE_AVAILABLE;
+				}
+			}
+		}
+
+		return InputStatus.NOTHING_AVAILABLE;
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private Tuple2<byte[], StreamRecord<Object>> getAsObject(Tuple2<byte[], StreamRecord<IN>> next) {
+		return (Tuple2<byte[], StreamRecord<Object>>) (Tuple2) next;
+	}
+
+	@Override
+	public boolean isApproximatelyAvailable() {
+		if (sortedInput != null) {
+			return isHeadAvailable();
+		} else {
+			return StreamTaskInput.super.isApproximatelyAvailable();
+		}
+	}
+
+	@Override
+	public boolean isAvailable() {
+		if (sortedInput != null) {
+			return isHeadAvailable();
+		} else {
+			return StreamTaskInput.super.isAvailable();
+		}
+	}
+
+	private boolean isHeadAvailable() {
+		if (!commonContext.allSorted()) {
+			return false;
+		}
+		HeadElement headElement = commonContext.getQueueOfHeads().peek();
+		return headElement != null && headElement.inputIndex == idx;
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		if (sortedInput != null) {
+			return commonContext.getAllFinished().getAvailableFuture();
+		} else {
+			return wrappedInput.getAvailableFuture();
+		}
+	}
+
+	// ---------------------------------------------------------------------------------
+	//  Utility classes
+	// ---------------------------------------------------------------------------------
+
+	/**
+	 * A simple {@link PushingAsyncDataInput.DataOutput} used in the sorting phase when we have not seen all the
+	 * records from the underlying input yet. It forwards the records to a corresponding sorter.
+	 */
+	private class SortingPhaseDataOutput implements PushingAsyncDataInput.DataOutput<IN> {
+
+		@Override
+		public void emitRecord(StreamRecord<IN> streamRecord) throws Exception {
+			K key = keySelector.getKey(streamRecord.getValue());
+
+			keySerializer.serialize(key, dataOutputSerializer);
+			byte[] serializedKey = dataOutputSerializer.getCopyOfBuffer();
+			dataOutputSerializer.clear();
+
+			sorter.writeRecord(Tuple2.of(serializedKey, streamRecord));
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) {
+			seenWatermark = Math.max(seenWatermark, watermark.getTimestamp());
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) {
+
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) {
+
+		}
+	}
+
+	/**
+	 * A thin wrapper that represents a head of a sorted input. Additionally it keeps the id of
+	 * the input it belongs to.
+	 *
+	 * <p>The class is mutable and we only ever have a single instance per input.
+	 */
+	private static final class HeadElement implements Comparable<HeadElement> {
+		final int inputIndex;
+		Tuple2<byte[], StreamRecord<Object>> streamElement;
+
+		private HeadElement(int inputIndex) {
+			this.inputIndex = inputIndex;
+		}
+
+		@Override
+		public int compareTo(HeadElement o) {
+			int keyCmp = compare(streamElement.f0, o.streamElement.f0);
+			if (keyCmp != 0) {
+				return keyCmp;
+			}
+			return Long.compare(
+				streamElement.f1.asRecord().getTimestamp(),
+				o.streamElement.f1.asRecord().getTimestamp());
+		}
+
+		private int compare(byte[] first, byte[] second) {
+			int firstLength = first.length;
+			int secondLength = second.length;
+			int minLength = Math.min(firstLength, secondLength);
+			for (int i = 0; i < minLength; i++) {
+				int cmp = Byte.compare(first[i], second[i]);
+
+				if (cmp != 0) {
+					return cmp;
+				}
+			}
+
+			return Integer.compare(firstLength, secondLength);
+		}
+	}
+
+	private static final class CommonContext {
+		private final PriorityQueue<HeadElement> queueOfHeads = new PriorityQueue<>();
+		private final AvailabilityProvider.AvailabilityHelper allFinished = new AvailabilityProvider.AvailabilityHelper();
+		private long notFinishedSortingMask = 0;
+		private long finishedEmitting = 0;
+
+		public CommonContext(int numberOfInputs) {
+			for (int i = 0; i < numberOfInputs; i++) {
+				notFinishedSortingMask = setBitMask(notFinishedSortingMask, i);
+			}
+		}
+
+		public boolean allSorted() {
+			return notFinishedSortingMask == 0;
+		}
+
+		public void setFinishedSorting(int inputIndex) {
+			this.notFinishedSortingMask = unsetBitMask(this.notFinishedSortingMask, inputIndex);
+		}
+
+		public void setFinishedEmitting(int inputIndex) {
+			this.finishedEmitting = setBitMask(this.finishedEmitting, inputIndex);
+		}
+
+		public boolean isFinishedEmitting(int inputIndex) {
+			return checkBitMask(this.finishedEmitting, inputIndex);
+		}
+
+		public PriorityQueue<HeadElement> getQueueOfHeads() {
+			return queueOfHeads;
+		}
+
+		public AvailabilityHelper getAllFinished() {
+			return allFinished;
+		}
+
+		private static long setBitMask(long mask, int inputIndex) {
+			return mask | 1L << inputIndex;
+		}
+
+		private static long unsetBitMask(long mask, int inputIndex) {
+			return mask & ~(1L << inputIndex);
+		}
+
+		private static boolean checkBitMask(long mask, int inputIndex) {
+			return (mask & (1L << inputIndex)) != 0;
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
@@ -58,7 +58,7 @@ import java.util.concurrent.CompletableFuture;
  * serialized key is constant, or {@link VariableLengthByteKeyComparator} otherwise.
  *
  * <p>Watermarks, stream statuses, nor latency markers are not propagated downstream as they do not make
- * sense with buffered records. The input emits a MAX_WATERMARK after all records.
+ * sense with buffered records. The input emits the largest watermark seen after all records.
  *
  * @param <T> The type of the value in incoming {@link StreamRecord StreamRecords}.
  * @param <K> The type of the key.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
@@ -57,7 +57,7 @@ import java.util.concurrent.CompletableFuture;
  * For the comparison it uses either {@link FixedLengthByteKeyComparator} if the length of the
  * serialized key is constant, or {@link VariableLengthByteKeyComparator} otherwise.
  *
- * <p>Watermarks, stream statuses, nor latency markers are not propagated downstream as they do not make
+ * <p>Watermarks, stream statuses, nor latency markers are propagated downstream as they do not make
  * sense with buffered records. The input emits the largest watermark seen after all records.
  *
  * @param <T> The type of the value in incoming {@link StreamRecord StreamRecords}.
@@ -128,7 +128,8 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
 	public CompletableFuture<Void> prepareSnapshot(
 			ChannelStateWriter channelStateWriter,
 			long checkpointId) {
-		throw new UnsupportedOperationException("Checkpoints are not supported for sorting inputs");
+		throw new UnsupportedOperationException("Checkpoints are not supported with sorted inputs" +
+			" in the BATCH runtime.");
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.streaming.api.operators.InputSelectable;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -33,6 +34,9 @@ import java.util.concurrent.CompletableFuture;
 @Internal
 public interface StreamInputProcessor extends AvailabilityProvider, Closeable {
 	/**
+	 * In case of two and more input processors this method must call {@link InputSelectable#nextSelection()}
+	 * to choose which input to consume from next.
+	 *
 	 * @return input status to estimate whether more records can be processed immediately or not.
 	 * If there are no more records available at the moment and the caller should check finished
 	 * state and/or {@link #getAvailableFuture()}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -79,7 +79,7 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 
 		lastReadInputIndex = readingInputIndex;
 		InputStatus inputStatus = inputProcessors[readingInputIndex].processInput();
-		checkFinished(inputStatus);
+		inputSelectionHandler.nextSelection();
 		return inputSelectionHandler.updateStatus(inputStatus, readingInputIndex);
 	}
 
@@ -92,12 +92,6 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 		isPrepared = true;
 
 		return selectNextReadingInputIndex();
-	}
-
-	private void checkFinished(InputStatus status) throws Exception {
-		if (status == InputStatus.END_OF_INPUT) {
-			inputSelectionHandler.nextSelection();
-		}
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -130,15 +130,14 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 				Output<StreamRecord<?>> chainedSourceOutput = operatorChain.getChainedSourceOutput(sourceInput);
 				StreamTaskSourceInput<?> sourceTaskInput = operatorChain.getSourceTaskInput(sourceInput);
 
-				inputProcessors[i] = new SourceInputProcessor(
-					new StreamTaskSourceOutput(chainedSourceOutput, streamStatusMaintainer, inputWatermarkGauges[i], i),
+				inputProcessors[i] = new StreamOneInputProcessor(
 					sourceTaskInput,
+					new StreamTaskSourceOutput(chainedSourceOutput, streamStatusMaintainer, inputWatermarkGauges[i], i),
 					operatorChain);
 			}
 			else {
 				throw new UnsupportedOperationException("Unknown input type: " + configuredInput);
 			}
-
 		}
 	}
 
@@ -258,20 +257,6 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 			}
 		}
 		return true;
-	}
-
-	private static class SourceInputProcessor<T> extends StreamOneInputProcessor<T> {
-		public SourceInputProcessor(
-				PushingAsyncDataInput.DataOutput<T> dataOutput,
-				StreamTaskInput<T> taskInput,
-				OperatorChain<?, ?> operatorChain) {
-			super(taskInput, dataOutput, operatorChain);
-		}
-
-		@Override
-		public void close() throws IOException {
-			// SourceOperator is closed via OperatorChain
-		}
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -20,125 +20,33 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.streaming.api.graph.StreamConfig.InputConfig;
-import org.apache.flink.streaming.api.graph.StreamConfig.NetworkInputConfig;
-import org.apache.flink.streaming.api.graph.StreamConfig.SourceInputConfig;
-import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
-import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
-import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
-import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
-import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
-import org.apache.flink.streaming.runtime.tasks.OperatorChain;
-import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask.AsyncDataOutputToOutput;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Input processor for {@link MultipleInputStreamOperator}.
  */
 @Internal
-@SuppressWarnings({"unchecked", "rawtypes"})
 public final class StreamMultipleInputProcessor implements StreamInputProcessor {
 
 	private final MultipleInputSelectionHandler inputSelectionHandler;
 
 	private final StreamOneInputProcessor<?>[] inputProcessors;
-
-	/**
-	 * Stream status for the two inputs. We need to keep track for determining when
-	 * to forward stream status changes downstream.
-	 */
-	private final StreamStatus[] streamStatuses;
-
-	private final Counter networkRecordsIn = new SimpleCounter();
-
-	private final Counter mainOperatorRecordsIn;
-
 	/** Always try to read from the first input. */
 	private int lastReadInputIndex = 1;
 
 	private boolean isPrepared;
 
 	public StreamMultipleInputProcessor(
-			CheckpointedInputGate[] checkpointedInputGates,
-			InputConfig[] configuredInputs,
-			IOManager ioManager,
-			TaskIOMetricGroup ioMetricGroup,
-			Counter mainOperatorRecordsIn,
-			StreamStatusMaintainer streamStatusMaintainer,
-			MultipleInputStreamOperator<?> mainOperator,
 			MultipleInputSelectionHandler inputSelectionHandler,
-			WatermarkGauge[] inputWatermarkGauges,
-			OperatorChain<?, ?> operatorChain) {
-		checkNotNull(operatorChain);
-
-		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
-
-		List<Input> operatorInputs = mainOperator.getInputs();
-		int inputsCount = operatorInputs.size();
-
-		this.inputProcessors = new StreamOneInputProcessor[inputsCount];
-		this.streamStatuses = new StreamStatus[inputsCount];
-		this.mainOperatorRecordsIn = mainOperatorRecordsIn;
-		ioMetricGroup.reuseRecordsInputCounter(networkRecordsIn);
-
-		checkState(
-			configuredInputs.length == inputsCount,
-			"Number of configured inputs in StreamConfig [%s] doesn't match the main operator's number of inputs [%s]",
-			configuredInputs.length,
-			inputsCount);
-		for (int i = 0; i < inputsCount; i++) {
-			InputConfig configuredInput = configuredInputs[i];
-			streamStatuses[i] = StreamStatus.ACTIVE;
-			if (configuredInput instanceof NetworkInputConfig) {
-				NetworkInputConfig networkInput = (NetworkInputConfig) configuredInput;
-				StreamTaskNetworkOutput dataOutput = new StreamTaskNetworkOutput<>(
-					operatorInputs.get(i),
-					streamStatusMaintainer,
-					inputWatermarkGauges[i],
-					i);
-
-				inputProcessors[i] = new StreamOneInputProcessor(
-					new StreamTaskNetworkInput<>(
-						checkpointedInputGates[networkInput.getInputGateIndex()],
-						networkInput.getTypeSerializer(),
-						ioManager,
-						new StatusWatermarkValve(checkpointedInputGates[networkInput.getInputGateIndex()].getNumberOfInputChannels()),
-						i),
-					dataOutput,
-					operatorChain);
-			}
-			else if (configuredInput instanceof SourceInputConfig) {
-				SourceInputConfig sourceInput = (SourceInputConfig) configuredInput;
-				Output<StreamRecord<?>> chainedSourceOutput = operatorChain.getChainedSourceOutput(sourceInput);
-				StreamTaskSourceInput<?> sourceTaskInput = operatorChain.getSourceTaskInput(sourceInput);
-
-				inputProcessors[i] = new StreamOneInputProcessor(
-					sourceTaskInput,
-					new StreamTaskSourceOutput(chainedSourceOutput, streamStatusMaintainer, inputWatermarkGauges[i], i),
-					operatorChain);
-			}
-			else {
-				throw new UnsupportedOperationException("Unknown input type: " + configuredInput);
-			}
-		}
+			StreamOneInputProcessor<?>[] inputProcessors) {
+		this.inputSelectionHandler = inputSelectionHandler;
+		this.inputProcessors = inputProcessors;
 	}
 
 	@Override
@@ -246,103 +154,6 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 			// once per every record. This might be optimized to only check once per processed NetworkBuffer
 			if (inputProcessor.isApproximatelyAvailable() || inputProcessor.isAvailable()) {
 				inputSelectionHandler.setAvailableInput(i);
-			}
-		}
-	}
-
-	private boolean allStreamStatusesAreIdle() {
-		for (StreamStatus streamStatus : streamStatuses) {
-			if (streamStatus.isActive()) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * The network data output implementation used for processing stream elements
-	 * from {@link StreamTaskNetworkInput} in two input selective processor.
-	 */
-	private class StreamTaskNetworkOutput<T> extends AbstractDataOutput<T> {
-		private final Input<T> input;
-
-		private final WatermarkGauge inputWatermarkGauge;
-
-		/** The input index to indicate how to process elements by two input operator. */
-		private final int inputIndex;
-
-		private StreamTaskNetworkOutput(
-				Input<T> input,
-				StreamStatusMaintainer streamStatusMaintainer,
-				WatermarkGauge inputWatermarkGauge,
-				int inputIndex) {
-			super(streamStatusMaintainer);
-
-			this.input = checkNotNull(input);
-			this.inputWatermarkGauge = checkNotNull(inputWatermarkGauge);
-			this.inputIndex = inputIndex;
-		}
-
-		@Override
-		public void emitRecord(StreamRecord<T> record) throws Exception {
-			input.setKeyContextElement(record);
-			input.processElement(record);
-			mainOperatorRecordsIn.inc();
-			networkRecordsIn.inc();
-			inputSelectionHandler.nextSelection();
-		}
-
-		@Override
-		public void emitWatermark(Watermark watermark) throws Exception {
-			inputWatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
-			input.processWatermark(watermark);
-		}
-
-		@Override
-		public void emitStreamStatus(StreamStatus streamStatus) {
-			streamStatuses[inputIndex] = streamStatus;
-
-			// check if we need to toggle the task's stream status
-			if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
-				if (streamStatus.isActive()) {
-					// we're no longer idle if at least one input has become active
-					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
-				} else if (allStreamStatusesAreIdle()) {
-					streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
-				}
-			}
-		}
-
-		@Override
-		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
-			input.processLatencyMarker(latencyMarker);
-		}
-	}
-
-	private class StreamTaskSourceOutput extends AsyncDataOutputToOutput {
-		private final int inputIndex;
-
-		public StreamTaskSourceOutput(
-				Output<StreamRecord<?>> chainedSourceOutput,
-				StreamStatusMaintainer streamStatusMaintainer,
-				WatermarkGauge inputWatermarkGauge,
-				int inputIndex) {
-			super(chainedSourceOutput, streamStatusMaintainer, inputWatermarkGauge);
-			this.inputIndex = inputIndex;
-		}
-
-		@Override
-		public void emitStreamStatus(StreamStatus streamStatus) {
-			streamStatuses[inputIndex] = streamStatus;
-
-			// check if we need to toggle the task's stream status
-			if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
-				if (streamStatus.isActive()) {
-					// we're no longer idle if at least one input has become active
-					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
-				} else if (allStreamStatusesAreIdle()) {
-					streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
-				}
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -85,7 +85,7 @@ public class StreamMultipleInputProcessorFactory {
 					operatorInputs.get(i),
 					streamStatusMaintainer,
 					inputWatermarkGauges[i],
-					inputSelectionHandler, streamStatusTracker,
+					streamStatusTracker,
 					i,
 					mainOperatorRecordsIn,
 					networkRecordsIn);
@@ -168,8 +168,6 @@ public class StreamMultipleInputProcessorFactory {
 
 		private final MultiStreamStreamStatusTracker streamStatusTracker;
 
-		private final MultipleInputSelectionHandler inputSelectionHandler;
-
 		private final Counter mainOperatorRecordsIn;
 
 		private final Counter networkRecordsIn;
@@ -178,7 +176,6 @@ public class StreamMultipleInputProcessorFactory {
 				Input<T> input,
 				StreamStatusMaintainer streamStatusMaintainer,
 				WatermarkGauge inputWatermarkGauge,
-				MultipleInputSelectionHandler inputSelectionHandler,
 				MultiStreamStreamStatusTracker streamStatusTracker,
 				int inputIndex,
 				Counter mainOperatorRecordsIn,
@@ -187,7 +184,6 @@ public class StreamMultipleInputProcessorFactory {
 
 			this.input = checkNotNull(input);
 			this.inputWatermarkGauge = checkNotNull(inputWatermarkGauge);
-			this.inputSelectionHandler = inputSelectionHandler;
 			this.streamStatusTracker = streamStatusTracker;
 			this.inputIndex = inputIndex;
 			this.mainOperatorRecordsIn = mainOperatorRecordsIn;
@@ -200,7 +196,6 @@ public class StreamMultipleInputProcessorFactory {
 			input.processElement(record);
 			mainOperatorRecordsIn.inc();
 			networkRecordsIn.inc();
-			inputSelectionHandler.nextSelection();
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A factory for {@link StreamMultipleInputProcessor}.
+ */
+@Internal
+public class StreamMultipleInputProcessorFactory {
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static StreamMultipleInputProcessor create(
+			CheckpointedInputGate[] checkpointedInputGates,
+			StreamConfig.InputConfig[] configuredInputs,
+			IOManager ioManager,
+			TaskIOMetricGroup ioMetricGroup,
+			Counter mainOperatorRecordsIn,
+			StreamStatusMaintainer streamStatusMaintainer,
+			MultipleInputStreamOperator<?> mainOperator,
+			MultipleInputSelectionHandler inputSelectionHandler,
+			WatermarkGauge[] inputWatermarkGauges,
+			OperatorChain<?, ?> operatorChain) {
+		checkNotNull(operatorChain);
+		checkNotNull(inputSelectionHandler);
+
+		List<Input> operatorInputs = mainOperator.getInputs();
+		int inputsCount = operatorInputs.size();
+
+		StreamOneInputProcessor<?>[] inputProcessors = new StreamOneInputProcessor[inputsCount];
+		Counter networkRecordsIn = new SimpleCounter();
+		ioMetricGroup.reuseRecordsInputCounter(networkRecordsIn);
+
+		MultiStreamStreamStatusTracker streamStatusTracker = new MultiStreamStreamStatusTracker(inputsCount);
+		checkState(
+			configuredInputs.length == inputsCount,
+			"Number of configured inputs in StreamConfig [%s] doesn't match the main operator's number of inputs [%s]",
+			configuredInputs.length,
+			inputsCount);
+		for (int i = 0; i < inputsCount; i++) {
+			StreamConfig.InputConfig configuredInput = configuredInputs[i];
+			if (configuredInput instanceof StreamConfig.NetworkInputConfig) {
+				StreamConfig.NetworkInputConfig networkInput = (StreamConfig.NetworkInputConfig) configuredInput;
+				StreamTaskNetworkOutput dataOutput = new StreamTaskNetworkOutput<>(
+					operatorInputs.get(i),
+					streamStatusMaintainer,
+					inputWatermarkGauges[i],
+					inputSelectionHandler, streamStatusTracker,
+					i,
+					mainOperatorRecordsIn,
+					networkRecordsIn);
+
+				inputProcessors[i] = new StreamOneInputProcessor(
+					new StreamTaskNetworkInput<>(
+						checkpointedInputGates[networkInput.getInputGateIndex()],
+						networkInput.getTypeSerializer(),
+						ioManager,
+						new StatusWatermarkValve(checkpointedInputGates[networkInput.getInputGateIndex()].getNumberOfInputChannels()),
+						i),
+					dataOutput,
+					operatorChain);
+			}
+			else if (configuredInput instanceof StreamConfig.SourceInputConfig) {
+				StreamConfig.SourceInputConfig sourceInput = (StreamConfig.SourceInputConfig) configuredInput;
+				Output<StreamRecord<?>> chainedSourceOutput = operatorChain.getChainedSourceOutput(sourceInput);
+				StreamTaskSourceInput<?> sourceTaskInput = operatorChain.getSourceTaskInput(sourceInput);
+
+				inputProcessors[i] = new StreamOneInputProcessor(
+					sourceTaskInput,
+					new StreamTaskSourceOutput(chainedSourceOutput, streamStatusMaintainer, inputWatermarkGauges[i],
+						streamStatusTracker,
+						i),
+					operatorChain);
+			}
+			else {
+				throw new UnsupportedOperationException("Unknown input type: " + configuredInput);
+			}
+		}
+
+		return new StreamMultipleInputProcessor(
+			inputSelectionHandler,
+			inputProcessors
+		);
+	}
+
+
+	/**
+	 * Stream status tracker for the inputs. We need to keep track for determining when
+	 * to forward stream status changes downstream.
+	 */
+	private static class MultiStreamStreamStatusTracker {
+		private final StreamStatus[] streamStatuses;
+
+		private MultiStreamStreamStatusTracker(int numberOfInputs) {
+			this.streamStatuses = new StreamStatus[numberOfInputs];
+			Arrays.fill(streamStatuses, StreamStatus.ACTIVE);
+		}
+
+		public void setStreamStatus(int index, StreamStatus streamStatus) {
+			streamStatuses[index] = streamStatus;
+		}
+
+		public StreamStatus getStreamStatus(int index) {
+			return streamStatuses[index];
+		}
+
+		public boolean allStreamStatusesAreIdle() {
+			for (StreamStatus streamStatus : streamStatuses) {
+				if (streamStatus.isActive()) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+
+	/**
+	 * The network data output implementation used for processing stream elements
+	 * from {@link StreamTaskNetworkInput} in two input selective processor.
+	 */
+	private static class StreamTaskNetworkOutput<T> extends AbstractDataOutput<T> {
+		private final Input<T> input;
+
+		private final WatermarkGauge inputWatermarkGauge;
+
+		/** The input index to indicate how to process elements by two input operator. */
+		private final int inputIndex;
+
+		private final MultiStreamStreamStatusTracker streamStatusTracker;
+
+		private final MultipleInputSelectionHandler inputSelectionHandler;
+
+		private final Counter mainOperatorRecordsIn;
+
+		private final Counter networkRecordsIn;
+
+		private StreamTaskNetworkOutput(
+				Input<T> input,
+				StreamStatusMaintainer streamStatusMaintainer,
+				WatermarkGauge inputWatermarkGauge,
+				MultipleInputSelectionHandler inputSelectionHandler,
+				MultiStreamStreamStatusTracker streamStatusTracker,
+				int inputIndex,
+				Counter mainOperatorRecordsIn,
+				Counter networkRecordsIn) {
+			super(streamStatusMaintainer);
+
+			this.input = checkNotNull(input);
+			this.inputWatermarkGauge = checkNotNull(inputWatermarkGauge);
+			this.inputSelectionHandler = inputSelectionHandler;
+			this.streamStatusTracker = streamStatusTracker;
+			this.inputIndex = inputIndex;
+			this.mainOperatorRecordsIn = mainOperatorRecordsIn;
+			this.networkRecordsIn = networkRecordsIn;
+		}
+
+		@Override
+		public void emitRecord(StreamRecord<T> record) throws Exception {
+			input.setKeyContextElement(record);
+			input.processElement(record);
+			mainOperatorRecordsIn.inc();
+			networkRecordsIn.inc();
+			inputSelectionHandler.nextSelection();
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) throws Exception {
+			inputWatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+			input.processWatermark(watermark);
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) {
+			streamStatusTracker.setStreamStatus(inputIndex, streamStatus);
+
+			// check if we need to toggle the task's stream status
+			if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
+				if (streamStatus.isActive()) {
+					// we're no longer idle if at least one input has become active
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
+				} else if (streamStatusTracker.allStreamStatusesAreIdle()) {
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
+				}
+			}
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+			input.processLatencyMarker(latencyMarker);
+		}
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private static class StreamTaskSourceOutput extends SourceOperatorStreamTask.AsyncDataOutputToOutput {
+		private final int inputIndex;
+		private final MultiStreamStreamStatusTracker streamStatusTracker;
+
+		public StreamTaskSourceOutput(
+				Output<StreamRecord<?>> chainedSourceOutput,
+				StreamStatusMaintainer streamStatusMaintainer,
+				WatermarkGauge inputWatermarkGauge,
+				MultiStreamStreamStatusTracker streamStatusTracker,
+				int inputIndex) {
+			super(chainedSourceOutput, streamStatusMaintainer, inputWatermarkGauge);
+			this.streamStatusTracker = streamStatusTracker;
+			this.inputIndex = inputIndex;
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) {
+			streamStatusTracker.setStreamStatus(inputIndex, streamStatus);
+
+			// check if we need to toggle the task's stream status
+			if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
+				if (streamStatus.isActive()) {
+					// we're no longer idle if at least one input has become active
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
+				} else if (streamStatusTracker.allStreamStatusesAreIdle()) {
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
+				}
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -21,8 +21,8 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
-import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,16 +45,16 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 	private final StreamTaskInput<IN> input;
 	private final DataOutput<IN> output;
 
-	private final OperatorChain<?, ?> operatorChain;
+	private final BoundedMultiInput endOfInputAware;
 
 	public StreamOneInputProcessor(
 			StreamTaskInput<IN> input,
 			DataOutput<IN> output,
-			OperatorChain<?, ?> operatorChain) {
+			BoundedMultiInput endOfInputAware) {
 
 		this.input = checkNotNull(input);
 		this.output = checkNotNull(output);
-		this.operatorChain = checkNotNull(operatorChain);
+		this.endOfInputAware = checkNotNull(endOfInputAware);
 	}
 
 	@Override
@@ -67,7 +67,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 		InputStatus status = input.emitNext(output);
 
 		if (status == InputStatus.END_OF_INPUT) {
-			operatorChain.endMainOperatorInput(input.getInputIndex() + 1);
+			endOfInputAware.endInput(input.getInputIndex() + 1);
 		}
 
 		return status;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -38,7 +38,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <IN> The type of the record that can be read with this record reader.
  */
 @Internal
-public class StreamOneInputProcessor<IN> implements StreamInputProcessor {
+public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamOneInputProcessor.class);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -38,7 +38,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <IN> The type of the record that can be read with this record reader.
  */
 @Internal
-public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
+public class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamOneInputProcessor.class);
 
@@ -67,7 +67,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
 		InputStatus status = input.emitNext(output);
 
 		if (status == InputStatus.END_OF_INPUT) {
-			operatorChain.endMainOperatorInput(1);
+			operatorChain.endMainOperatorInput(input.getInputIndex() + 1);
 		}
 
 		return status;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -46,12 +46,14 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Check
 	private final int inputGateIndex;
 	private final AvailabilityHelper isBlockedAvailability = new AvailabilityHelper();
 	private final List<InputChannelInfo> inputChannelInfos;
+	private final int inputIndex;
 
-	public StreamTaskSourceInput(SourceOperator<T, ?> operator, int inputGateIndex) {
+	public StreamTaskSourceInput(SourceOperator<T, ?> operator, int inputGateIndex, int inputIndex) {
 		this.operator = checkNotNull(operator);
 		this.inputGateIndex = inputGateIndex;
 		inputChannelInfos = Collections.singletonList(new InputChannelInfo(inputGateIndex, 0));
 		isBlockedAvailability.resetAvailable();
+		this.inputIndex = inputIndex;
 	}
 
 	@Override
@@ -126,12 +128,9 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Check
 		return inputGateIndex;
 	}
 
-	/**
-	 * This method is invalid and never called by the one/source input processor.
-	 */
 	@Override
 	public int getInputIndex() {
-		throw new UnsupportedOperationException();
+		return inputIndex;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.SourceOperator;
-import org.apache.flink.util.IOUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -135,7 +134,7 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Check
 
 	@Override
 	public void close() {
-		IOUtils.closeQuietly(operator::close);
+		// SourceOperator is closed via OperatorChain
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -35,7 +36,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
-import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -86,7 +86,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 			TwoInputSelectionHandler inputSelectionHandler,
 			WatermarkGauge input1WatermarkGauge,
 			WatermarkGauge input2WatermarkGauge,
-			OperatorChain<?, ?> operatorChain,
+			BoundedMultiInput endOfInputAware,
 			Counter numRecordsIn) {
 
 		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
@@ -107,7 +107,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 				new StatusWatermarkValve(checkpointedInputGates[0].getNumberOfInputChannels()),
 				0),
 			output1,
-			operatorChain
+			endOfInputAware
 		);
 
 		StreamTaskNetworkOutput<IN2> output2 = new StreamTaskNetworkOutput<>(
@@ -125,7 +125,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 				new StatusWatermarkValve(checkpointedInputGates[1].getNumberOfInputChannels()),
 				1),
 			output2,
-			operatorChain
+			endOfInputAware
 		);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -135,7 +135,6 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 
 		streamOperator.setKeyContextElement1(record);
 		streamOperator.processElement1(record);
-		postProcessRecord();
 	}
 
 	private void processRecord2(
@@ -144,11 +143,6 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 
 		streamOperator.setKeyContextElement2(record);
 		streamOperator.processElement2(record);
-		postProcessRecord();
-	}
-
-	private void postProcessRecord() {
-		inputSelectionHandler.nextSelection();
 	}
 
 	@Override
@@ -180,10 +174,10 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 
 		if (readingInputIndex == 0) {
 			firstInputStatus = processor1.processInput();
-			checkFinished(firstInputStatus);
+			inputSelectionHandler.nextSelection();
 		} else {
 			secondInputStatus = processor2.processInput();
-			checkFinished(secondInputStatus);
+			inputSelectionHandler.nextSelection();
 		}
 
 		return getInputStatus();
@@ -207,12 +201,6 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		isPrepared = true;
 
 		return selectNextReadingInputIndex();
-	}
-
-	private void checkFinished(InputStatus status) throws Exception {
-		if (status == InputStatus.END_OF_INPUT) {
-			inputSelectionHandler.nextSelection();
-		}
 	}
 
 	private InputStatus getInputStatus() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -19,31 +19,15 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.InputSelection;
-import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
-import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
-import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
-import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.function.ThrowingConsumer;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Input reader for {@link TwoInputStreamTask}.
@@ -63,86 +47,18 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 	private InputStatus firstInputStatus = InputStatus.MORE_AVAILABLE;
 	private InputStatus secondInputStatus = InputStatus.MORE_AVAILABLE;
 
-	/**
-	 * Stream status for the two inputs. We need to keep track for determining when
-	 * to forward stream status changes downstream.
-	 */
-	private StreamStatus firstStatus = StreamStatus.ACTIVE;
-	private StreamStatus secondStatus = StreamStatus.ACTIVE;
-
 	/** Always try to read from the first input. */
 	private int lastReadInputIndex = 1;
 
 	private boolean isPrepared;
 
 	public StreamTwoInputProcessor(
-			CheckpointedInputGate[] checkpointedInputGates,
-			TypeSerializer<IN1> inputSerializer1,
-			TypeSerializer<IN2> inputSerializer2,
-			IOManager ioManager,
-			TaskIOMetricGroup taskIOMetricGroup,
-			StreamStatusMaintainer streamStatusMaintainer,
-			TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
 			TwoInputSelectionHandler inputSelectionHandler,
-			WatermarkGauge input1WatermarkGauge,
-			WatermarkGauge input2WatermarkGauge,
-			BoundedMultiInput endOfInputAware,
-			Counter numRecordsIn) {
-
-		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
-
-		taskIOMetricGroup.reuseRecordsInputCounter(numRecordsIn);
-		StreamTaskNetworkOutput<IN1> output1 = new StreamTaskNetworkOutput<>(
-			streamOperator,
-			record -> processRecord1(record, streamOperator),
-			streamStatusMaintainer,
-			input1WatermarkGauge,
-			0,
-			numRecordsIn);
-		this.processor1 = new StreamOneInputProcessor<>(
-			new StreamTaskNetworkInput<>(
-				checkpointedInputGates[0],
-				inputSerializer1,
-				ioManager,
-				new StatusWatermarkValve(checkpointedInputGates[0].getNumberOfInputChannels()),
-				0),
-			output1,
-			endOfInputAware
-		);
-
-		StreamTaskNetworkOutput<IN2> output2 = new StreamTaskNetworkOutput<>(
-			streamOperator,
-			record -> processRecord2(record, streamOperator),
-			streamStatusMaintainer,
-			input2WatermarkGauge,
-			1,
-			numRecordsIn);
-		this.processor2 = new StreamOneInputProcessor<>(
-			new StreamTaskNetworkInput<>(
-				checkpointedInputGates[1],
-				inputSerializer2,
-				ioManager,
-				new StatusWatermarkValve(checkpointedInputGates[1].getNumberOfInputChannels()),
-				1),
-			output2,
-			endOfInputAware
-		);
-	}
-
-	private void processRecord1(
-			StreamRecord<IN1> record,
-			TwoInputStreamOperator<IN1, IN2, ?> streamOperator) throws Exception {
-
-		streamOperator.setKeyContextElement1(record);
-		streamOperator.processElement1(record);
-	}
-
-	private void processRecord2(
-			StreamRecord<IN2> record,
-			TwoInputStreamOperator<IN1, IN2, ?> streamOperator) throws Exception {
-
-		streamOperator.setKeyContextElement2(record);
-		streamOperator.processElement2(record);
+			StreamOneInputProcessor<IN1> processor1,
+			StreamOneInputProcessor<IN2> processor2) {
+		this.inputSelectionHandler = inputSelectionHandler;
+		this.processor1 = processor1;
+		this.processor2 = processor2;
 	}
 
 	@Override
@@ -314,86 +230,4 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		return inputIndex == 0 ? processor1 : processor2;
 	}
 
-	/**
-	 * The network data output implementation used for processing stream elements
-	 * from {@link StreamTaskNetworkInput} in two input selective processor.
-	 */
-	private class StreamTaskNetworkOutput<T> extends AbstractDataOutput<T> {
-
-		private final TwoInputStreamOperator<IN1, IN2, ?> operator;
-
-		/** The function way is only used for frequent record processing as for JIT optimization. */
-		private final ThrowingConsumer<StreamRecord<T>, Exception> recordConsumer;
-
-		private final WatermarkGauge inputWatermarkGauge;
-
-		/** The input index to indicate how to process elements by two input operator. */
-		private final int inputIndex;
-
-		private final Counter numRecordsIn;
-
-		private StreamTaskNetworkOutput(
-				TwoInputStreamOperator<IN1, IN2, ?> operator,
-				ThrowingConsumer<StreamRecord<T>, Exception> recordConsumer,
-				StreamStatusMaintainer streamStatusMaintainer,
-				WatermarkGauge inputWatermarkGauge,
-				int inputIndex,
-				Counter numRecordsIn) {
-			super(streamStatusMaintainer);
-
-			this.operator = checkNotNull(operator);
-			this.recordConsumer = checkNotNull(recordConsumer);
-			this.inputWatermarkGauge = checkNotNull(inputWatermarkGauge);
-			this.inputIndex = inputIndex;
-			this.numRecordsIn = numRecordsIn;
-		}
-
-		@Override
-		public void emitRecord(StreamRecord<T> record) throws Exception {
-			numRecordsIn.inc();
-			recordConsumer.accept(record);
-		}
-
-		@Override
-		public void emitWatermark(Watermark watermark) throws Exception {
-			inputWatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
-			if (inputIndex == 0) {
-				operator.processWatermark1(watermark);
-			} else {
-				operator.processWatermark2(watermark);
-			}
-		}
-
-		@Override
-		public void emitStreamStatus(StreamStatus streamStatus) {
-			final StreamStatus anotherStreamStatus;
-			if (inputIndex == 0) {
-				firstStatus = streamStatus;
-				anotherStreamStatus = secondStatus;
-			} else {
-				secondStatus = streamStatus;
-				anotherStreamStatus = firstStatus;
-			}
-
-			// check if we need to toggle the task's stream status
-			if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
-				if (streamStatus.isActive()) {
-					// we're no longer idle if at least one input has become active
-					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
-				} else if (anotherStreamStatus.isIdle()) {
-					// we're idle once both inputs are idle
-					streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
-				}
-			}
-		}
-
-		@Override
-		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
-			if (inputIndex == 0) {
-				operator.processLatencyMarker1(latencyMarker);
-			} else {
-				operator.processLatencyMarker2(latencyMarker);
-			}
-		}
-	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A factory for {@link StreamTwoInputProcessor}.
+ */
+public class StreamTwoInputProcessorFactory {
+	public static <IN1, IN2> StreamTwoInputProcessor<IN1, IN2> create(
+			CheckpointedInputGate[] checkpointedInputGates,
+			TypeSerializer<IN1> inputSerializer1,
+			TypeSerializer<IN2> inputSerializer2,
+			IOManager ioManager,
+			TaskIOMetricGroup taskIOMetricGroup,
+			StreamStatusMaintainer streamStatusMaintainer,
+			TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
+			TwoInputSelectionHandler inputSelectionHandler,
+			WatermarkGauge input1WatermarkGauge,
+			WatermarkGauge input2WatermarkGauge,
+			BoundedMultiInput endOfInputAware,
+			Counter numRecordsIn) {
+
+		checkNotNull(endOfInputAware);
+		checkNotNull(inputSelectionHandler);
+		StreamStatusTracker statusTracker = new StreamStatusTracker();
+		taskIOMetricGroup.reuseRecordsInputCounter(numRecordsIn);
+		StreamTaskNetworkOutput<IN1> output1 = new StreamTaskNetworkOutput<>(
+			streamOperator,
+			record -> processRecord1(record, streamOperator),
+			streamStatusMaintainer,
+			input1WatermarkGauge,
+			statusTracker,
+			0,
+			numRecordsIn);
+		StreamOneInputProcessor<IN1> processor1 = new StreamOneInputProcessor<>(
+			new StreamTaskNetworkInput<>(
+				checkpointedInputGates[0],
+				inputSerializer1,
+				ioManager,
+				new StatusWatermarkValve(checkpointedInputGates[0].getNumberOfInputChannels()),
+				0),
+			output1,
+			endOfInputAware
+		);
+
+		StreamTaskNetworkOutput<IN2> output2 = new StreamTaskNetworkOutput<>(
+			streamOperator,
+			record -> processRecord2(record, streamOperator),
+			streamStatusMaintainer,
+			input2WatermarkGauge,
+			statusTracker,
+			1,
+			numRecordsIn);
+		StreamOneInputProcessor<IN2> processor2 = new StreamOneInputProcessor<>(
+			new StreamTaskNetworkInput<>(
+				checkpointedInputGates[1],
+				inputSerializer2,
+				ioManager,
+				new StatusWatermarkValve(checkpointedInputGates[1].getNumberOfInputChannels()),
+				1),
+			output2,
+			endOfInputAware
+		);
+
+		return new StreamTwoInputProcessor<>(
+			inputSelectionHandler,
+			processor1,
+			processor2
+		);
+	}
+
+	private static <T> void processRecord1(
+		StreamRecord<T> record,
+		TwoInputStreamOperator<T, ?, ?> streamOperator) throws Exception {
+
+		streamOperator.setKeyContextElement1(record);
+		streamOperator.processElement1(record);
+	}
+
+	private static <T> void processRecord2(
+		StreamRecord<T> record,
+		TwoInputStreamOperator<?, T, ?> streamOperator) throws Exception {
+
+		streamOperator.setKeyContextElement2(record);
+		streamOperator.processElement2(record);
+	}
+
+	private static class StreamStatusTracker {
+		/**
+		 * Stream status for the two inputs. We need to keep track for determining when
+		 * to forward stream status changes downstream.
+		 */
+		private StreamStatus firstStatus = StreamStatus.ACTIVE;
+		private StreamStatus secondStatus = StreamStatus.ACTIVE;
+
+		public StreamStatus getFirstStatus() {
+			return firstStatus;
+		}
+
+		public void setFirstStatus(StreamStatus firstStatus) {
+			this.firstStatus = firstStatus;
+		}
+
+		public StreamStatus getSecondStatus() {
+			return secondStatus;
+		}
+
+		public void setSecondStatus(StreamStatus secondStatus) {
+			this.secondStatus = secondStatus;
+		}
+	}
+
+	/**
+	 * The network data output implementation used for processing stream elements
+	 * from {@link StreamTaskNetworkInput} in two input selective processor.
+	 */
+	private static class StreamTaskNetworkOutput<T> extends AbstractDataOutput<T> {
+
+		private final TwoInputStreamOperator<?, ?, ?> operator;
+
+		/** The function way is only used for frequent record processing as for JIT optimization. */
+		private final ThrowingConsumer<StreamRecord<T>, Exception> recordConsumer;
+
+		private final WatermarkGauge inputWatermarkGauge;
+
+		/** The input index to indicate how to process elements by two input operator. */
+		private final int inputIndex;
+
+		private final Counter numRecordsIn;
+
+		private final StreamStatusTracker statusTracker;
+
+		private StreamTaskNetworkOutput(
+				TwoInputStreamOperator<?, ?, ?> operator,
+				ThrowingConsumer<StreamRecord<T>, Exception> recordConsumer,
+				StreamStatusMaintainer streamStatusMaintainer,
+				WatermarkGauge inputWatermarkGauge,
+				StreamStatusTracker statusTracker,
+				int inputIndex,
+				Counter numRecordsIn) {
+			super(streamStatusMaintainer);
+
+			this.operator = checkNotNull(operator);
+			this.recordConsumer = checkNotNull(recordConsumer);
+			this.inputWatermarkGauge = checkNotNull(inputWatermarkGauge);
+			this.statusTracker = statusTracker;
+			this.inputIndex = inputIndex;
+			this.numRecordsIn = numRecordsIn;
+		}
+
+		@Override
+		public void emitRecord(StreamRecord<T> record) throws Exception {
+			numRecordsIn.inc();
+			recordConsumer.accept(record);
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) throws Exception {
+			inputWatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+			if (inputIndex == 0) {
+				operator.processWatermark1(watermark);
+			} else {
+				operator.processWatermark2(watermark);
+			}
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) {
+			final StreamStatus anotherStreamStatus;
+			if (inputIndex == 0) {
+				statusTracker.setFirstStatus(streamStatus);
+				anotherStreamStatus = statusTracker.getSecondStatus();
+			} else {
+				statusTracker.setSecondStatus(streamStatus);
+				anotherStreamStatus = statusTracker.getFirstStatus();
+			}
+
+			// check if we need to toggle the task's stream status
+			if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
+				if (streamStatus.isActive()) {
+					// we're no longer idle if at least one input has become active
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
+				} else if (anotherStreamStatus.isIdle()) {
+					// we're idle once both inputs are idle
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
+				}
+			}
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+			if (inputIndex == 0) {
+				operator.processLatencyMarker1(latencyMarker);
+			} else {
+				operator.processLatencyMarker2(latencyMarker);
+			}
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.metrics.MetricNames;
@@ -59,13 +58,6 @@ public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT> extends StreamTa
 		StreamConfig configuration = getConfiguration();
 		ClassLoader userClassLoader = getUserCodeClassLoader();
 
-		if (configuration.shouldSortInputs()) {
-			throw new UnsupportedOperationException("Sorting inputs is not supported for a two input stream task yet.");
-		}
-
-		TypeSerializer<IN1> inputDeserializer1 = configuration.getTypeSerializerIn1(userClassLoader);
-		TypeSerializer<IN2> inputDeserializer2 = configuration.getTypeSerializerIn2(userClassLoader);
-
 		int numberOfInputs = configuration.getNumberOfNetworkInputs();
 
 		ArrayList<IndexedInputGate> inputList1 = new ArrayList<>();
@@ -88,7 +80,7 @@ public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT> extends StreamTa
 			}
 		}
 
-		createInputProcessor(inputList1, inputList2, inputDeserializer1, inputDeserializer2);
+		createInputProcessor(inputList1, inputList2);
 
 		mainOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge);
 		mainOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_1_WATERMARK, input1WatermarkGauge);
@@ -99,7 +91,5 @@ public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT> extends StreamTa
 
 	protected abstract void createInputProcessor(
 		List<IndexedInputGate> inputGates1,
-		List<IndexedInputGate> inputGates2,
-		TypeSerializer<IN1> inputDeserializer1,
-		TypeSerializer<IN2> inputDeserializer2) throws Exception;
+		List<IndexedInputGate> inputGates2) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -35,7 +35,7 @@ import org.apache.flink.streaming.runtime.io.CheckpointBarrierHandler;
 import org.apache.flink.streaming.runtime.io.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
 import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
-import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessorFactory;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.metrics.MinWatermarkGauge;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
@@ -144,7 +144,7 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
 			checkpointBarrierHandler);
 
-		inputProcessor = new StreamMultipleInputProcessor(
+		inputProcessor = StreamMultipleInputProcessorFactory.create(
 			checkpointedInputGates,
 			inputs,
 			getEnvironment().getIOManager(),
@@ -167,7 +167,7 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 		mainMailboxExecutor.execute(
 			() -> {
 				try {
-					/**
+					/*
 					 * Contrary to {@link SourceStreamTask}, we are not using here
 					 * {@link StreamTask#latestAsyncCheckpointStartDelayNanos} to measure the start delay
 					 * metric, but we will be using {@link CheckpointBarrierHandler#getCheckpointStartDelayNanos()}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -73,11 +73,6 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 		StreamConfig configuration = getConfiguration();
 		ClassLoader userClassLoader = getUserCodeClassLoader();
 
-		if (configuration.shouldSortInputs()) {
-			throw new UnsupportedOperationException(
-				"Sorting inputs is not supported for a multiple input stream task yet.");
-		}
-
 		InputConfig[] inputs = configuration.getInputs(userClassLoader);
 
 		WatermarkGauge[] watermarkGauges = new WatermarkGauge[inputs.length];
@@ -145,15 +140,22 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			checkpointBarrierHandler);
 
 		inputProcessor = StreamMultipleInputProcessorFactory.create(
+			this,
 			checkpointedInputGates,
 			inputs,
 			getEnvironment().getIOManager(),
+			getEnvironment().getMemoryManager(),
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
 			setupNumRecordsInCounter(mainOperator),
 			getStreamStatusMaintainer(),
 			mainOperator,
 			selectionHandler,
 			inputWatermarkGauges,
+			getConfiguration(),
+			getTaskConfiguration(),
+			getJobConfiguration(),
+			getExecutionConfig(),
+			getUserCodeClassLoader(),
 			operatorChain);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -29,12 +29,10 @@ import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamConfig.InputConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
-import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.runtime.io.CheckpointBarrierHandler;
 import org.apache.flink.streaming.runtime.io.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
-import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
 import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessorFactory;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.metrics.MinWatermarkGauge;
@@ -121,10 +119,6 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			List<IndexedInputGate>[] inputGates,
 			InputConfig[] inputs,
 			WatermarkGauge[] inputWatermarkGauges) {
-		MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(
-			mainOperator instanceof InputSelectable ? (InputSelectable) mainOperator : null,
-			inputs.length);
-
 		checkpointBarrierHandler = InputProcessorUtil.createCheckpointBarrierHandler(
 			this,
 			getConfiguration(),
@@ -149,7 +143,6 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			setupNumRecordsInCounter(mainOperator),
 			getStreamStatusMaintainer(),
 			mainOperator,
-			selectionHandler,
 			inputWatermarkGauges,
 			getConfiguration(),
 			getTaskConfiguration(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamConfig.InputConfig;
 import org.apache.flink.streaming.api.graph.StreamConfig.SourceInputConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -86,7 +87,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *              main operator.
  */
 @Internal
-public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements StreamStatusMaintainer {
+public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements StreamStatusMaintainer, BoundedMultiInput {
 
 	private static final Logger LOG = LoggerFactory.getLogger(OperatorChain.class);
 
@@ -381,7 +382,8 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 	 *
 	 * @param inputId the input ID starts from 1 which indicates the first input.
 	 */
-	public void endMainOperatorInput(int inputId) throws Exception {
+	@Override
+	public void endInput(int inputId) throws Exception {
 		if (mainOperatorWrapper != null) {
 			mainOperatorWrapper.endOperatorInput(inputId);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -305,7 +305,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 				sourceInput,
 				new ChainedSource(
 					chainedSourceOutput,
-					new StreamTaskSourceInput<>(sourceOperator, sourceInputGateIndex++)));
+					new StreamTaskSourceInput<>(sourceOperator, sourceInputGateIndex++, inputId)));
 		}
 		return chainedSourceInputs;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -49,7 +49,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 
 	@Override
 	public void init() {
-		StreamTaskInput<T> input = new StreamTaskSourceInput<>(mainOperator, 0);
+		StreamTaskInput<T> input = new StreamTaskSourceInput<>(mainOperator, 0, 0);
 		/**
 		 * {@link SourceOperatorStreamTask} doesn't have any inputs, so there is no need for
 		 * {@link WatermarkGauge} on the input.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.io.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
-import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessorFactory;
 import org.apache.flink.streaming.runtime.io.TwoInputSelectionHandler;
 
 import java.util.Collections;
@@ -66,7 +66,7 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			Collections.emptyList());
 		checkState(checkpointedInputGates.length == 2);
 
-		inputProcessor = new StreamTwoInputProcessor<>(
+		inputProcessor = StreamTwoInputProcessorFactory.create(
 			checkpointedInputGates,
 			inputDeserializer1,
 			inputDeserializer2,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -20,12 +20,10 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
-import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.io.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessorFactory;
-import org.apache.flink.streaming.runtime.io.TwoInputSelectionHandler;
 
 import java.util.Collections;
 import java.util.List;
@@ -48,9 +46,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 		List<IndexedInputGate> inputGates1,
 		List<IndexedInputGate> inputGates2) {
 
-		TwoInputSelectionHandler twoInputSelectionHandler = new TwoInputSelectionHandler(
-			mainOperator instanceof InputSelectable ? (InputSelectable) mainOperator : null);
-
 		// create an input instance for each input
 		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedMultipleInputGate(
 			this,
@@ -71,7 +66,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
 			getStreamStatusMaintainer(),
 			mainOperator,
-			twoInputSelectionHandler,
 			input1WatermarkGauge,
 			input2WatermarkGauge,
 			operatorChain,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.streaming.api.operators.InputSelectable;
@@ -47,9 +46,7 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 	@Override
 	protected void createInputProcessor(
 		List<IndexedInputGate> inputGates1,
-		List<IndexedInputGate> inputGates2,
-		TypeSerializer<IN1> inputDeserializer1,
-		TypeSerializer<IN2> inputDeserializer2) {
+		List<IndexedInputGate> inputGates2) {
 
 		TwoInputSelectionHandler twoInputSelectionHandler = new TwoInputSelectionHandler(
 			mainOperator instanceof InputSelectable ? (InputSelectable) mainOperator : null);
@@ -67,10 +64,10 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 		checkState(checkpointedInputGates.length == 2);
 
 		inputProcessor = StreamTwoInputProcessorFactory.create(
+			this,
 			checkpointedInputGates,
-			inputDeserializer1,
-			inputDeserializer2,
 			getEnvironment().getIOManager(),
+			getEnvironment().getMemoryManager(),
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
 			getStreamStatusMaintainer(),
 			mainOperator,
@@ -78,6 +75,11 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			input1WatermarkGauge,
 			input2WatermarkGauge,
 			operatorChain,
+			getConfiguration(),
+			getTaskConfiguration(),
+			getJobConfiguration(),
+			getExecutionConfig(),
+			getUserCodeClassLoader(),
 			setupNumRecordsInCounter(mainOperator));
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectingDataOutput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectingDataOutput.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A test utility implementation of {@link PushingAsyncDataInput.DataOutput} that collects all events.
+ */
+final class CollectingDataOutput<E> implements PushingAsyncDataInput.DataOutput<E> {
+	final List<Object> events = new ArrayList<>();
+
+	@Override
+	public void emitWatermark(Watermark watermark) throws Exception {
+		events.add(watermark);
+	}
+
+	@Override
+	public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
+		events.add(streamStatus);
+	}
+
+	@Override
+	public void emitRecord(StreamRecord<E> streamRecord) throws Exception {
+		events.add(streamRecord);
+	}
+
+	@Override
+	public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		events.add(latencyMarker);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectionDataInput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectionDataInput.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+
+final class CollectionDataInput<E> implements StreamTaskInput<E> {
+	private final Iterator<StreamElement> elementsIterator;
+	private final int inputIdx;
+
+	CollectionDataInput(Collection<StreamElement> elements) {
+		this(elements, 0);
+	}
+
+	CollectionDataInput(Collection<StreamElement> elements, int inputIdx) {
+		this.elementsIterator = elements.iterator();
+		this.inputIdx = inputIdx;
+	}
+
+	@Override
+	public InputStatus emitNext(DataOutput<E> output) throws Exception {
+		if (elementsIterator.hasNext()) {
+			StreamElement streamElement = elementsIterator.next();
+			if (streamElement instanceof StreamRecord) {
+				output.emitRecord(streamElement.asRecord());
+			} else if (streamElement instanceof Watermark) {
+				output.emitWatermark(streamElement.asWatermark());
+			} else {
+				throw new IllegalStateException("Unsupported element type: " + streamElement);
+			}
+		}
+		return elementsIterator.hasNext() ? InputStatus.MORE_AVAILABLE : InputStatus.END_OF_INPUT;
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public int getInputIndex() {
+		return inputIdx;
+	}
+
+	@Override
+	public CompletableFuture<Void> prepareSnapshot(
+		ChannelStateWriter channelStateWriter,
+		long checkpointId) throws IOException {
+		return null;
+	}
+
+	@Override
+	public void close() throws IOException {
+
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
@@ -31,8 +31,12 @@ import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -52,13 +56,16 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
- * Longer running IT tests for {@link SortingDataInputTest}. For quicker smoke tests see {@link SortingDataInputTest}.
+ * Longer running IT tests for {@link SortingDataInput} and {@link MultiInputSortingDataInput}.
+ *
+ * @see SortingDataInputTest
+ * @see MultiInputSortingDataInputsTest
  */
-public class SortingDataInputITCase {
+public class LargeSortingDataInputITCase {
 	@Test
 	public void intKeySorting() throws Exception {
-		int numberOfRecords = 1_000_000;
-		GeneratedRecordsDataInput input = new GeneratedRecordsDataInput(numberOfRecords);
+		int numberOfRecords = 500_000;
+		GeneratedRecordsDataInput input = new GeneratedRecordsDataInput(numberOfRecords, 0);
 		KeySelector<Tuple3<Integer, String, byte[]>, Integer> keySelector = value -> value.f0;
 		try (
 			MockEnvironment environment = MockEnvironment.builder().build();
@@ -86,8 +93,8 @@ public class SortingDataInputITCase {
 
 	@Test
 	public void stringKeySorting() throws Exception {
-		int numberOfRecords = 1_000_000;
-		GeneratedRecordsDataInput input = new GeneratedRecordsDataInput(numberOfRecords);
+		int numberOfRecords = 500_000;
+		GeneratedRecordsDataInput input = new GeneratedRecordsDataInput(numberOfRecords, 0);
 		KeySelector<Tuple3<Integer, String, byte[]>, String> keySelector = value -> value.f1;
 		try (
 			MockEnvironment environment = MockEnvironment.builder().build();
@@ -110,6 +117,57 @@ public class SortingDataInputITCase {
 			} while (inputStatus != InputStatus.END_OF_INPUT);
 
 			assertThat(output.getSeenRecords(), equalTo(numberOfRecords));
+		}
+	}
+
+	@Test
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public void multiInputKeySorting() throws Exception {
+		int numberOfRecords = 500_000;
+		GeneratedRecordsDataInput input1 = new GeneratedRecordsDataInput(numberOfRecords, 0);
+		GeneratedRecordsDataInput input2 = new GeneratedRecordsDataInput(numberOfRecords, 1);
+		KeySelector<Tuple3<Integer, String, byte[]>, String> keySelector = value -> value.f1;
+		try (MockEnvironment environment = MockEnvironment.builder().build()) {
+			StreamTaskInput<?>[] sortedInputs = MultiInputSortingDataInput.wrapInputs(
+				new DummyInvokable(),
+				new StreamTaskInput[]{input1, input2},
+				new KeySelector[]{keySelector, keySelector},
+				new TypeSerializer[]{GeneratedRecordsDataInput.SERIALIZER, GeneratedRecordsDataInput.SERIALIZER},
+				new StringSerializer(),
+				environment.getMemoryManager(),
+				environment.getIOManager(),
+				true,
+				1.0,
+				new Configuration()
+			);
+
+			try (
+				StreamTaskInput<Tuple3<Integer, String, byte[]>> sortedInput1 = (StreamTaskInput<Tuple3<Integer, String, byte[]>>) sortedInputs[0];
+				StreamTaskInput<Tuple3<Integer, String, byte[]>> sortedInput2 = (StreamTaskInput<Tuple3<Integer, String, byte[]>>) sortedInputs[1]) {
+
+				VerifyingOutput<String> output = new VerifyingOutput<>(keySelector);
+				StreamMultipleInputProcessor multiSortedProcessor = new StreamMultipleInputProcessor(
+					new MultipleInputSelectionHandler(null, 2),
+					new StreamOneInputProcessor[]{
+						new StreamOneInputProcessor(
+							sortedInput1,
+							output,
+							new DummyOperatorChain()
+						),
+						new StreamOneInputProcessor(
+							sortedInput2,
+							output,
+							new DummyOperatorChain()
+						)
+					}
+				);
+				InputStatus inputStatus;
+				do {
+					inputStatus = multiSortedProcessor.processInput();
+				} while (inputStatus != InputStatus.END_OF_INPUT);
+
+				assertThat(output.getSeenRecords(), equalTo(numberOfRecords * 2));
+			}
 		}
 	}
 
@@ -176,15 +234,17 @@ public class SortingDataInputITCase {
 
 		private static final String ALPHA_NUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 		private final long numberOfRecords;
+		private final int inputIdx;
 		private int recordsGenerated;
 		private final Random rnd = new Random();
 		private final byte[] buffer;
 
-		private GeneratedRecordsDataInput(int numberOfRecords) {
+		private GeneratedRecordsDataInput(int numberOfRecords, int inputIdx) {
 			this.numberOfRecords = numberOfRecords;
 			this.recordsGenerated = 0;
 			this.buffer = new byte[500];
 			rnd.nextBytes(buffer);
+			this.inputIdx = inputIdx;
 		}
 
 		@Override
@@ -225,7 +285,7 @@ public class SortingDataInputITCase {
 
 		@Override
 		public int getInputIndex() {
-			return 0;
+			return inputIdx;
 		}
 
 		@Override
@@ -237,6 +297,13 @@ public class SortingDataInputITCase {
 
 		@Override
 		public void close() throws IOException {
+
+		}
+	}
+
+	private static class DummyOperatorChain implements BoundedMultiInput {
+		@Override
+		public void endInput(int inputId) throws Exception {
 
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
+import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link MultiInputSortingDataInput}.
+ */
+public class MultiInputSortingDataInputsTest  {
+	@Test
+	@SuppressWarnings("unchecked")
+	public void simpleFixedLengthKeySorting() throws Exception {
+		CollectingDataOutput<Object> collectingDataOutput = new CollectingDataOutput<>();
+		List<StreamElement> elements = Arrays.asList(
+			new StreamRecord<>(1, 3),
+			new StreamRecord<>(1, 1),
+			new StreamRecord<>(2, 1),
+			new StreamRecord<>(2, 3),
+			new StreamRecord<>(1, 2),
+			new StreamRecord<>(2, 2),
+			Watermark.MAX_WATERMARK
+		);
+		CollectionDataInput<Integer> dataInput1 = new CollectionDataInput<>(elements, 0);
+		CollectionDataInput<Integer> dataInput2 = new CollectionDataInput<>(elements, 1);
+		KeySelector<Integer, Integer> keySelector = value -> value;
+		try (MockEnvironment environment = MockEnvironment.builder().build()) {
+			StreamTaskInput<?>[] sortingDataInput = MultiInputSortingDataInput.wrapInputs(
+				new DummyInvokable(),
+				new StreamTaskInput[]{dataInput1, dataInput2},
+				new KeySelector[]{keySelector, keySelector},
+				new TypeSerializer[]{new IntSerializer(), new IntSerializer()},
+				new IntSerializer(),
+				environment.getMemoryManager(),
+				environment.getIOManager(),
+				true,
+				1.0,
+				new Configuration()
+			);
+
+			try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInput[0];
+					StreamTaskInput<Object> input2 = (StreamTaskInput<Object>) sortingDataInput[1]) {
+
+				MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(null, 2);
+				StreamMultipleInputProcessor processor = new StreamMultipleInputProcessor(
+					selectionHandler,
+					new StreamOneInputProcessor[]{
+						new StreamOneInputProcessor<>(
+							input1,
+							collectingDataOutput,
+							new DummyOperatorChain()
+						),
+						new StreamOneInputProcessor<>(
+							input2,
+							collectingDataOutput,
+							new DummyOperatorChain()
+						)
+					}
+				);
+
+				InputStatus inputStatus;
+				do {
+					inputStatus = processor.processInput();
+				} while (inputStatus != InputStatus.END_OF_INPUT);
+			}
+		}
+
+		assertThat(collectingDataOutput.events, equalTo(
+			Arrays.asList(
+				new StreamRecord<>(1, 1),
+				new StreamRecord<>(1, 1),
+				new StreamRecord<>(1, 2),
+				new StreamRecord<>(1, 2),
+				new StreamRecord<>(1, 3),
+				new StreamRecord<>(1, 3),
+				new StreamRecord<>(2, 1),
+				new StreamRecord<>(2, 1),
+				new StreamRecord<>(2, 2),
+				new StreamRecord<>(2, 2),
+				new StreamRecord<>(2, 3),
+				Watermark.MAX_WATERMARK, // max watermark from one of the inputs
+				new StreamRecord<>(2, 3),
+				Watermark.MAX_WATERMARK // max watermark from the other input
+			)
+		));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void watermarkPropagation() throws Exception {
+		CollectingDataOutput<Object> collectingDataOutput = new CollectingDataOutput<>();
+		List<StreamElement> elements1 = Arrays.asList(
+			new StreamRecord<>(2, 3),
+			new Watermark(3),
+			new StreamRecord<>(3, 3),
+			new Watermark(7)
+		);
+		List<StreamElement> elements2 = Arrays.asList(
+			new StreamRecord<>(0, 3),
+			new Watermark(1),
+			new StreamRecord<>(1, 3),
+			new Watermark(3)
+		);
+		CollectionDataInput<Integer> dataInput1 = new CollectionDataInput<>(elements1, 0);
+		CollectionDataInput<Integer> dataInput2 = new CollectionDataInput<>(elements2, 1);
+		KeySelector<Integer, Integer> keySelector = value -> value;
+		try (MockEnvironment environment = MockEnvironment.builder().build()) {
+			StreamTaskInput<?>[] sortingDataInput = MultiInputSortingDataInput.wrapInputs(
+				new DummyInvokable(),
+				new StreamTaskInput[]{dataInput1, dataInput2},
+				new KeySelector[]{keySelector, keySelector},
+				new TypeSerializer[]{new IntSerializer(), new IntSerializer()},
+				new IntSerializer(),
+				environment.getMemoryManager(),
+				environment.getIOManager(),
+				true,
+				1.0,
+				new Configuration()
+			);
+
+			try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInput[0];
+					StreamTaskInput<Object> input2 = (StreamTaskInput<Object>) sortingDataInput[1]) {
+
+				MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(null, 2);
+				StreamMultipleInputProcessor processor = new StreamMultipleInputProcessor(
+					selectionHandler,
+					new StreamOneInputProcessor[]{
+						new StreamOneInputProcessor<>(
+							input1,
+							collectingDataOutput,
+							new DummyOperatorChain()
+						),
+						new StreamOneInputProcessor<>(
+							input2,
+							collectingDataOutput,
+							new DummyOperatorChain()
+						)
+					}
+				);
+
+				InputStatus inputStatus;
+				do {
+					inputStatus = processor.processInput();
+				} while (inputStatus != InputStatus.END_OF_INPUT);
+			}
+		}
+
+		assertThat(collectingDataOutput.events, equalTo(
+			Arrays.asList(
+				new StreamRecord<>(0, 3),
+				new StreamRecord<>(1, 3),
+				new Watermark(3), // watermark from the second input
+				new StreamRecord<>(2, 3),
+				new StreamRecord<>(3, 3),
+				new Watermark(7) // watermark from the first input
+			)
+		));
+	}
+
+	private static class DummyOperatorChain implements BoundedMultiInput {
+		@Override
+		public void endInput(int inputId) {
+
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.sort.MultiInputSortingDataInput.SelectableSortingInputs;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
 import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
@@ -63,7 +64,7 @@ public class MultiInputSortingDataInputsTest  {
 		CollectionDataInput<Integer> dataInput2 = new CollectionDataInput<>(elements, 1);
 		KeySelector<Integer, Integer> keySelector = value -> value;
 		try (MockEnvironment environment = MockEnvironment.builder().build()) {
-			StreamTaskInput<?>[] sortingDataInput = MultiInputSortingDataInput.wrapInputs(
+			SelectableSortingInputs selectableSortingInputs = MultiInputSortingDataInput.wrapInputs(
 				new DummyInvokable(),
 				new StreamTaskInput[]{dataInput1, dataInput2},
 				new KeySelector[]{keySelector, keySelector},
@@ -76,10 +77,13 @@ public class MultiInputSortingDataInputsTest  {
 				new Configuration()
 			);
 
-			try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInput[0];
-					StreamTaskInput<Object> input2 = (StreamTaskInput<Object>) sortingDataInput[1]) {
+			StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortingInputs();
+			try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInputs[0];
+					StreamTaskInput<Object> input2 = (StreamTaskInput<Object>) sortingDataInputs[1]) {
 
-				MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(null, 2);
+				MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(
+					selectableSortingInputs.getInputSelectable(),
+					2);
 				StreamMultipleInputProcessor processor = new StreamMultipleInputProcessor(
 					selectionHandler,
 					new StreamOneInputProcessor[]{
@@ -143,7 +147,7 @@ public class MultiInputSortingDataInputsTest  {
 		CollectionDataInput<Integer> dataInput2 = new CollectionDataInput<>(elements2, 1);
 		KeySelector<Integer, Integer> keySelector = value -> value;
 		try (MockEnvironment environment = MockEnvironment.builder().build()) {
-			StreamTaskInput<?>[] sortingDataInput = MultiInputSortingDataInput.wrapInputs(
+			SelectableSortingInputs selectableSortingInputs = MultiInputSortingDataInput.wrapInputs(
 				new DummyInvokable(),
 				new StreamTaskInput[]{dataInput1, dataInput2},
 				new KeySelector[]{keySelector, keySelector},
@@ -156,10 +160,13 @@ public class MultiInputSortingDataInputsTest  {
 				new Configuration()
 			);
 
-			try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInput[0];
-					StreamTaskInput<Object> input2 = (StreamTaskInput<Object>) sortingDataInput[1]) {
+			StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortingInputs();
+			try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInputs[0];
+					StreamTaskInput<Object> input2 = (StreamTaskInput<Object>) sortingDataInputs[1]) {
 
-				MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(null, 2);
+				MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(
+					selectableSortingInputs.getInputSelectable(),
+					2);
 				StreamMultipleInputProcessor processor = new StreamMultipleInputProcessor(
 					selectionHandler,
 					new StreamOneInputProcessor[]{

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
@@ -25,19 +25,31 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.operators.collect.CollectResultIterator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory;
 import org.apache.flink.streaming.api.operators.collect.CollectStreamSink;
+import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.CollectionUtil;
@@ -46,15 +58,18 @@ import org.apache.flink.util.SplittableIterator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -148,7 +163,62 @@ public class SortingBoundedInputITCase extends AbstractTestBase {
 		assertThat(sum, equalTo(numberOfRecords * 2));
 	}
 
-	private CollectResultIterator<Long> applyCollect(StreamExecutionEnvironment env, SingleOutputStreamOperator<Long> counts) {
+	@Test
+	public void testThreeInputOperator() throws Exception {
+		long numberOfRecords = 500_000;
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		KeyedStream<Tuple2<Integer, byte[]>, Object> elements1 = env.fromParallelCollection(
+			new InputGenerator(numberOfRecords),
+			new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO)
+		).keyBy(el -> el.f0);
+
+		KeyedStream<Tuple2<Integer, byte[]>, Object> elements2 = env.fromParallelCollection(
+			new InputGenerator(numberOfRecords),
+			new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO)
+		).keyBy(el -> el.f0);
+
+		KeyedStream<Tuple2<Integer, byte[]>, Object> elements3 = env.fromParallelCollection(
+			new InputGenerator(numberOfRecords),
+			new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO)
+		).keyBy(el -> el.f0);
+
+		KeyedMultipleInputTransformation<Long> assertingTransformation = new KeyedMultipleInputTransformation<>(
+			"Asserting operator",
+			new AssertingThreeInputOperatorFactory(),
+			BasicTypeInfo.LONG_TYPE_INFO,
+			-1,
+			BasicTypeInfo.INT_TYPE_INFO
+		);
+		assertingTransformation.addInput(elements1.getTransformation(), elements1.getKeySelector());
+		assertingTransformation.addInput(elements2.getTransformation(), elements2.getKeySelector());
+		assertingTransformation.addInput(elements3.getTransformation(), elements3.getKeySelector());
+
+		env.addOperator(assertingTransformation);
+		DataStream<Long> counts = new DataStream<>(env, assertingTransformation);
+
+		// TODO we should replace this block with DataStreamUtils#collect once
+		// we have the automatic runtime mode determination in place.
+		CollectResultIterator<Long> collectedCounts = applyCollect(env, counts);
+		StreamGraph streamGraph = env.getStreamGraph();
+		streamGraph.getStreamNode(assertingTransformation.getId()).setSortedInputs(true);
+		Map<ManagedMemoryUseCase, Integer> operatorMemory = new HashMap<>();
+		operatorMemory.put(ManagedMemoryUseCase.BATCH_OP, 1);
+		streamGraph.getStreamNode(counts.getId()).setManagedMemoryUseCaseWeights(
+			operatorMemory,
+			Collections.emptySet()
+		);
+		JobClient jobClient = env.executeAsync(streamGraph);
+		collectedCounts.setJobClient(jobClient);
+
+		long sum = CollectionUtil.iteratorToList(collectedCounts)
+			.stream()
+			.mapToLong(l -> l)
+			.sum();
+
+		assertThat(sum, equalTo(numberOfRecords * 3));
+	}
+
+	private CollectResultIterator<Long> applyCollect(StreamExecutionEnvironment env, DataStream<Long> counts) {
 		String accumulatorName = "dataStreamCollect_" + UUID.randomUUID().toString();
 
 		CollectSinkOperatorFactory<Long> factory = new CollectSinkOperatorFactory<>(
@@ -232,6 +302,114 @@ public class SortingBoundedInputITCase extends AbstractTestBase {
 			if (input1Finished && input2Finished) {
 				output.collect(new StreamRecord<>(seenRecords));
 			}
+		}
+	}
+
+	private static class AssertingThreeInputOperator extends AbstractStreamOperatorV2<Long>
+			implements MultipleInputStreamOperator<Long>, BoundedMultiInput {
+		private final Set<Integer> seenKeys = new HashSet<>();
+		private long seenRecords = 0;
+		private Integer currentKey = null;
+		private boolean input1Finished = false;
+		private boolean input2Finished = false;
+		private boolean input3Finished = false;
+
+		public AssertingThreeInputOperator(
+				StreamOperatorParameters<Long> parameters,
+				int numberOfInputs) {
+			super(parameters, 3);
+			assert numberOfInputs == 3;
+		}
+
+		private void processElement(Tuple2<Integer, byte[]> element) {
+			this.seenRecords++;
+			Integer incomingKey = element.f0;
+			if (!Objects.equals(incomingKey, currentKey)) {
+				if (!seenKeys.add(incomingKey)) {
+					Assert.fail("Received an out of order key: " + incomingKey);
+				}
+				this.currentKey = incomingKey;
+			}
+		}
+
+		@Override
+		public void endInput(int inputId) throws Exception {
+			if (inputId == 1) {
+				input1Finished = true;
+			}
+
+			if (inputId == 2) {
+				input2Finished = true;
+			}
+
+			if (inputId == 3) {
+				input3Finished = true;
+			}
+
+			if (input1Finished && input2Finished && input3Finished) {
+				output.collect(new StreamRecord<>(seenRecords));
+			}
+		}
+
+		@Override
+		public List<Input> getInputs() {
+			return Arrays.asList(
+				new SingleInput(this::processElement),
+				new SingleInput(this::processElement),
+				new SingleInput(this::processElement)
+			);
+		}
+	}
+
+	private static class AssertingThreeInputOperatorFactory implements StreamOperatorFactory<Long> {
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T extends StreamOperator<Long>> T createStreamOperator(StreamOperatorParameters<Long> parameters) {
+			return (T) new AssertingThreeInputOperator(parameters, 3);
+		}
+
+		@Override
+		public void setChainingStrategy(ChainingStrategy strategy) {
+
+		}
+
+		@Override
+		public ChainingStrategy getChainingStrategy() {
+			return ChainingStrategy.NEVER;
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return AssertingThreeInputOperator.class;
+		}
+	}
+
+	private static class SingleInput implements Input<Tuple2<Integer, byte[]>> {
+
+		private final Consumer<Tuple2<Integer, byte[]>> recordConsumer;
+
+		private SingleInput(Consumer<Tuple2<Integer, byte[]>> recordConsumer) {
+			this.recordConsumer = recordConsumer;
+		}
+
+		@Override
+		public void processElement(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+			recordConsumer.accept(element.getValue());
+		}
+
+		@Override
+		public void processWatermark(Watermark mark) throws Exception {
+
+		}
+
+		@Override
+		public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+
+		}
+
+		@Override
+		public void setKeyContextElement(StreamRecord<Tuple2<Integer, byte[]>> record) throws Exception {
+
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
@@ -30,13 +30,16 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.operators.collect.CollectResultIterator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory;
 import org.apache.flink.streaming.api.operators.collect.CollectStreamSink;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.SplittableIterator;
 
@@ -47,6 +50,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
@@ -58,7 +62,7 @@ import static org.junit.Assert.assertThat;
 /**
  * An end to end test for sorted inputs for a keyed operator with bounded inputs.
  */
-public class SortingBoundedInputITCase {
+public class SortingBoundedInputITCase extends AbstractTestBase {
 	@Test
 	public void testOneInputOperator() throws Exception {
 		long numberOfRecords = 1_000_000;
@@ -81,7 +85,7 @@ public class SortingBoundedInputITCase {
 		CollectResultIterator<Long> collectedCounts = applyCollect(env, counts);
 		StreamGraph streamGraph = env.getStreamGraph();
 		streamGraph.getStreamNode(counts.getId()).setSortedInputs(true);
-		HashMap<ManagedMemoryUseCase, Integer> operatorMemory = new HashMap<>();
+		Map<ManagedMemoryUseCase, Integer> operatorMemory = new HashMap<>();
 		operatorMemory.put(ManagedMemoryUseCase.BATCH_OP, 1);
 		streamGraph.getStreamNode(counts.getId()).setManagedMemoryUseCaseWeights(
 			operatorMemory,
@@ -95,7 +99,53 @@ public class SortingBoundedInputITCase {
 			.mapToLong(l -> l)
 			.sum();
 
-		assertThat(numberOfRecords, equalTo(sum));
+		assertThat(sum, equalTo(numberOfRecords));
+	}
+
+	@Test
+	public void testTwoInputOperator() throws Exception {
+		long numberOfRecords = 500_000;
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Tuple2<Integer, byte[]>> elements1 = env.fromParallelCollection(
+			new InputGenerator(numberOfRecords),
+			new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO)
+		);
+
+		DataStreamSource<Tuple2<Integer, byte[]>> elements2 = env.fromParallelCollection(
+			new InputGenerator(numberOfRecords),
+			new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO)
+		);
+		SingleOutputStreamOperator<Long> counts = elements1.connect(elements2)
+			.keyBy(
+				element -> element.f0,
+				element -> element.f0
+			)
+			.transform(
+				"Asserting operator",
+				BasicTypeInfo.LONG_TYPE_INFO,
+				new AssertingTwoInputOperator()
+			);
+
+		// TODO we should replace this block with DataStreamUtils#collect once
+		// we have the automatic runtime mode determination in place.
+		CollectResultIterator<Long> collectedCounts = applyCollect(env, counts);
+		StreamGraph streamGraph = env.getStreamGraph();
+		streamGraph.getStreamNode(counts.getId()).setSortedInputs(true);
+		Map<ManagedMemoryUseCase, Integer> operatorMemory = new HashMap<>();
+		operatorMemory.put(ManagedMemoryUseCase.BATCH_OP, 1);
+		streamGraph.getStreamNode(counts.getId()).setManagedMemoryUseCaseWeights(
+			operatorMemory,
+			Collections.emptySet()
+		);
+		JobClient jobClient = env.executeAsync(streamGraph);
+		collectedCounts.setJobClient(jobClient);
+
+		long sum = CollectionUtil.iteratorToList(collectedCounts)
+			.stream()
+			.mapToLong(l -> l)
+			.sum();
+
+		assertThat(sum, equalTo(numberOfRecords * 2));
 	}
 
 	private CollectResultIterator<Long> applyCollect(StreamExecutionEnvironment env, SingleOutputStreamOperator<Long> counts) {
@@ -137,6 +187,51 @@ public class SortingBoundedInputITCase {
 		@Override
 		public void endInput() throws Exception {
 			output.collect(new StreamRecord<>(seenRecords));
+		}
+	}
+
+	private static class AssertingTwoInputOperator extends AbstractStreamOperator<Long>
+		implements TwoInputStreamOperator<Tuple2<Integer, byte[]>, Tuple2<Integer, byte[]>, Long>, BoundedMultiInput {
+		private final Set<Integer> seenKeys = new HashSet<>();
+		private long seenRecords = 0;
+		private Integer currentKey = null;
+		private boolean input1Finished = false;
+		private boolean input2Finished = false;
+
+		@Override
+		public void processElement1(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+			processElement(element);
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+			processElement(element);
+		}
+
+		private void processElement(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+			this.seenRecords++;
+			Integer incomingKey = element.getValue().f0;
+			if (!Objects.equals(incomingKey, currentKey)) {
+				if (!seenKeys.add(incomingKey)) {
+					Assert.fail("Received an out of order key: " + incomingKey);
+				}
+				this.currentKey = incomingKey;
+			}
+		}
+
+		@Override
+		public void endInput(int inputId) {
+			if (inputId == 1) {
+				input1Finished = true;
+			}
+
+			if (inputId == 2) {
+				input2Finished = true;
+			}
+
+			if (input1Finished && input2Finished) {
+				output.collect(new StreamRecord<>(seenRecords));
+			}
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
@@ -185,7 +185,7 @@ public class SortingBoundedInputITCase extends AbstractTestBase {
 		}
 
 		@Override
-		public void endInput() throws Exception {
+		public void endInput() {
 			output.collect(new StreamRecord<>(seenRecords));
 		}
 	}
@@ -199,16 +199,16 @@ public class SortingBoundedInputITCase extends AbstractTestBase {
 		private boolean input2Finished = false;
 
 		@Override
-		public void processElement1(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+		public void processElement1(StreamRecord<Tuple2<Integer, byte[]>> element) {
 			processElement(element);
 		}
 
 		@Override
-		public void processElement2(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+		public void processElement2(StreamRecord<Tuple2<Integer, byte[]>> element) {
 			processElement(element);
 		}
 
-		private void processElement(StreamRecord<Tuple2<Integer, byte[]>> element) throws Exception {
+		private void processElement(StreamRecord<Tuple2<Integer, byte[]>> element) {
 			this.seenRecords++;
 			Integer incomingKey = element.getValue().f0;
 			if (!Objects.equals(incomingKey, currentKey)) {


### PR DESCRIPTION
## What is the purpose of the change

This PR implements sorting inputs for multi input operators/tasks. It is based on the work in #13521
First I sort all inputs individually and after that I do a sorting merge of all the inputs to make sure that operator sees all incoming records with the same key from all inputs.


## Brief change log
For a more thorough explanation see the commits messages. Some highlights:
* Some of the commits refactor the TwoInputStreamProcessor/MultiInputStreamProcessor etc. to reduce code duplication
* Some of the commits extract the instantiation logic out of the processor and moves it to the Task. It makes it a) easier to instantiate in tests b) we need to pass less arguments to the ctor from the Task
* One of the commits implements proper `AvailabilityProvider` handling logic, which did not work before.


## Verifying this change

Added tests in:
* MultiInputSortingDataInputsTest
* SortedDataInputITCase
* SortingBoundedInputITCase.java 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
