### PR TITLE
[FLINK-19318] Deprecate timeWindow() operations in DataStream API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ val text = env.socketTextStream(host, port, '\n')
 val windowCounts = text.flatMap { w => w.split("\\s") }
   .map { w => WordWithCount(w, 1) }
   .keyBy("word")
-  .timeWindow(Time.seconds(5))
+  .window(TumblingEventTimeWindow.of(Time.seconds(5)))
   .sum("count")
 
 windowCounts.print()

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ val text = env.socketTextStream(host, port, '\n')
 val windowCounts = text.flatMap { w => w.split("\\s") }
   .map { w => WordWithCount(w, 1) }
   .keyBy("word")
-  .window(TumblingEventTimeWindow.of(Time.seconds(5)))
+  .window(TumblingProcessingTimeWindow.of(Time.seconds(5)))
   .sum("count")
 
 windowCounts.print()

--- a/docs/dev/connectors/cassandra.md
+++ b/docs/dev/connectors/cassandra.md
@@ -161,7 +161,7 @@ DataStream<Tuple2<String, Long>> result = text
             }
         })
         .keyBy(value -> value.f0)
-        .timeWindow(Time.seconds(5))
+        .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
         .sum(1);
 
 CassandraSink.addSink(result)
@@ -186,7 +186,7 @@ val result: DataStream[(String, Long)] = text
   .map((_, 1L))
   // group by the tuple field "0" and sum up tuple field "1"
   .keyBy(_._1)
-  .timeWindow(Time.seconds(5))
+  .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
   .sum(1)
 
 CassandraSink.addSink(result)
@@ -232,7 +232,7 @@ DataStream<WordCount> result = text
             }
         })
         .keyBy(WordCount::getWord)
-        .timeWindow(Time.seconds(5))
+        .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
 
         .reduce(new ReduceFunction<WordCount>() {
             @Override

--- a/docs/dev/connectors/cassandra.zh.md
+++ b/docs/dev/connectors/cassandra.zh.md
@@ -161,7 +161,7 @@ DataStream<Tuple2<String, Long>> result = text
             }
         })
         .keyBy(value -> value.f0)
-        .timeWindow(Time.seconds(5))
+        .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
         .sum(1);
 
 CassandraSink.addSink(result)
@@ -186,7 +186,7 @@ val result: DataStream[(String, Long)] = text
   .map((_, 1L))
   // group by the tuple field "0" and sum up tuple field "1"
   .keyBy(_._1)
-  .timeWindow(Time.seconds(5))
+  .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
   .sum(1)
 
 CassandraSink.addSink(result)
@@ -232,7 +232,7 @@ DataStream<WordCount> result = text
             }
         })
         .keyBy(WordCount::getWord)
-        .timeWindow(Time.seconds(5))
+        .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
 
         .reduce(new ReduceFunction<WordCount>() {
             @Override

--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -275,7 +275,7 @@ public class WindowWordCount {
                 .socketTextStream("localhost", 9999)
                 .flatMap(new Splitter())
                 .keyBy(value -> value.f0)
-                .timeWindow(Time.seconds(5))
+                .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
                 .sum(1);
 
         dataStream.print();
@@ -312,7 +312,7 @@ object WindowWordCount {
     val counts = text.flatMap { _.toLowerCase.split("\\W+") filter { _.nonEmpty } }
       .map { (_, 1) }
       .keyBy(_._1)
-      .timeWindow(Time.seconds(5))
+      .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
       .sum(1)
 
     counts.print()

--- a/docs/dev/datastream_api.zh.md
+++ b/docs/dev/datastream_api.zh.md
@@ -275,7 +275,7 @@ public class WindowWordCount {
                 .socketTextStream("localhost", 9999)
                 .flatMap(new Splitter())
                 .keyBy(value -> value.f0)
-                .timeWindow(Time.seconds(5))
+                .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
                 .sum(1);
 
         dataStream.print();
@@ -312,7 +312,7 @@ object WindowWordCount {
     val counts = text.flatMap { _.toLowerCase.split("\\W+") filter { _.nonEmpty } }
       .map { (_, 1) }
       .keyBy(_._1)
-      .timeWindow(Time.seconds(5))
+      .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
       .sum(1)
 
     counts.print()

--- a/docs/dev/event_time.zh.md
+++ b/docs/dev/event_time.zh.md
@@ -28,7 +28,7 @@ under the License.
 
 有关如何在 Flink 程序中使用时间特性，请参阅[窗口]({% link dev/stream/operators/windows.zh.md %})和 [ProcessFunction]({% link dev/stream/operators/process_function.zh.md %}) 小节。
 
-使用*事件时间*处理数据之前需要在程序中设置正确的*时间语义*。此项设置会定义源数据的处理方式（例如：程序是否会对数据分配时间戳），以及程序应使用什么时间语义执行 `KeyedStream.timeWindow(Time.seconds(30))` 之类的窗口操作。
+使用*事件时间*处理数据之前需要在程序中设置正确的*时间语义*。此项设置会定义源数据的处理方式（例如：程序是否会对数据分配时间戳），以及程序应使用什么时间语义执行 `KeyedStream.window(TumblingEventTimeWindows.of(Time.seconds(30)))` 之类的窗口操作。
 
 可以通过 `StreamExecutionEnvironment.setStreamTimeCharacteristic()` 设置程序的时间语义，示例如下：
 
@@ -43,7 +43,7 @@ DataStream<MyEvent> stream = env.addSource(new FlinkKafkaConsumer<MyEvent>(topic
 
 stream
     .keyBy( (event) -> event.getUser() )
-    .timeWindow(Time.hours(1))
+    .window(TumblingEventTimeWindows.of(Time.hours(1)))
     .reduce( (a, b) -> a.add(b) )
     .addSink(...);
 {% endhighlight %}
@@ -58,7 +58,7 @@ val stream: DataStream[MyEvent] = env.addSource(new FlinkKafkaConsumer[MyEvent](
 
 stream
     .keyBy( _.getUser )
-    .timeWindow(Time.hours(1))
+    .window(TumblingEventTimeWindows.of(Time.hours(1)))
     .reduce( (a, b) => a.add(b) )
     .addSink(...)
 {% endhighlight %}

--- a/docs/dev/event_timestamps_watermarks.md
+++ b/docs/dev/event_timestamps_watermarks.md
@@ -138,7 +138,7 @@ DataStream<MyEvent> withTimestampsAndWatermarks = stream
 
 withTimestampsAndWatermarks
         .keyBy( (event) -> event.getGroup() )
-        .timeWindow(Time.seconds(10))
+        .window(TumblingEventTimeWindows.of(Time.seconds(10)))
         .reduce( (a, b) -> a.add(b) )
         .addSink(...);
 {% endhighlight %}
@@ -157,7 +157,7 @@ val withTimestampsAndWatermarks: DataStream[MyEvent] = stream
 
 withTimestampsAndWatermarks
         .keyBy( _.getGroup )
-        .timeWindow(Time.seconds(10))
+        .window(TumblingEventTimeWindows.of(Time.seconds(10)))
         .reduce( (a, b) => a.add(b) )
         .addSink(...)
 {% endhighlight %}

--- a/docs/dev/event_timestamps_watermarks.zh.md
+++ b/docs/dev/event_timestamps_watermarks.zh.md
@@ -110,7 +110,7 @@ DataStream<MyEvent> withTimestampsAndWatermarks = stream
 
 withTimestampsAndWatermarks
         .keyBy( (event) -> event.getGroup() )
-        .timeWindow(Time.seconds(10))
+        .window(TumblingEventTimeWindows.of(Time.seconds(10)))
         .reduce( (a, b) -> a.add(b) )
         .addSink(...);
 {% endhighlight %}
@@ -129,7 +129,7 @@ val withTimestampsAndWatermarks: DataStream[MyEvent] = stream
 
 withTimestampsAndWatermarks
         .keyBy( _.getGroup )
-        .timeWindow(Time.seconds(10))
+        .window(TumblingEventTimeWindows.of(Time.seconds(10)))
         .reduce( (a, b) => a.add(b) )
         .addSink(...)
 {% endhighlight %}

--- a/docs/dev/parallel.md
+++ b/docs/dev/parallel.md
@@ -55,7 +55,7 @@ DataStream<String> text = [...]
 DataStream<Tuple2<String, Integer>> wordCounts = text
     .flatMap(new LineSplitter())
     .keyBy(value -> value.f0)
-    .timeWindow(Time.seconds(5))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1).setParallelism(5);
 
 wordCounts.print();
@@ -71,7 +71,7 @@ val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
     .keyBy(_._1)
-    .timeWindow(Time.seconds(5))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1).setParallelism(5)
 wordCounts.print()
 
@@ -114,7 +114,7 @@ val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
     .keyBy(_._1)
-    .timeWindow(Time.seconds(5))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1)
 wordCounts.print()
 

--- a/docs/dev/parallel.zh.md
+++ b/docs/dev/parallel.zh.md
@@ -46,7 +46,7 @@ DataStream<String> text = [...]
 DataStream<Tuple2<String, Integer>> wordCounts = text
     .flatMap(new LineSplitter())
     .keyBy(value -> value.f0)
-    .timeWindow(Time.seconds(5))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1).setParallelism(5);
 
 wordCounts.print();
@@ -62,7 +62,7 @@ val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
     .keyBy(_._1)
-    .timeWindow(Time.seconds(5))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1).setParallelism(5)
 wordCounts.print()
 
@@ -99,7 +99,7 @@ val text = [...]
 val wordCounts = text
     .flatMap{ _.split(" ") map { (_, 1) } }
     .keyBy(_._1)
-    .timeWindow(Time.seconds(5))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1)
 wordCounts.print()
 

--- a/docs/dev/stream/experimental.md
+++ b/docs/dev/stream/experimental.md
@@ -60,7 +60,7 @@ Code example:
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 DataStreamSource<Integer> source = ...
 DataStreamUtils.reinterpretAsKeyedStream(source, (in) -> in, TypeInformation.of(Integer.class))
-    .timeWindow(Time.seconds(1))
+    .window(TumblingEventTimeWindows.of(Time.seconds(1)))
     .reduce((a, b) -> a + b)
     .addSink(new DiscardingSink<>());
 env.execute();
@@ -72,7 +72,7 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment
 env.setParallelism(1)
 val source = ...
 new DataStreamUtils(source).reinterpretAsKeyedStream((in) => in)
-  .timeWindow(Time.seconds(1))
+  .window(TumblingEventTimeWindows.of(Time.seconds(1)))
   .reduce((a, b) => a + b)
   .addSink(new DiscardingSink[Int])
 env.execute()

--- a/docs/dev/stream/experimental.zh.md
+++ b/docs/dev/stream/experimental.zh.md
@@ -60,7 +60,7 @@ Code example:
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 DataStreamSource<Integer> source = ...
 DataStreamUtils.reinterpretAsKeyedStream(source, (in) -> in, TypeInformation.of(Integer.class))
-    .timeWindow(Time.seconds(1))
+    .window(TumblingEventTimeWindows.of(Time.seconds(1)))
     .reduce((a, b) -> a + b)
     .addSink(new DiscardingSink<>());
 env.execute();
@@ -72,7 +72,7 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment
 env.setParallelism(1)
 val source = ...
 new DataStreamUtils(source).reinterpretAsKeyedStream((in) => in)
-  .timeWindow(Time.seconds(1))
+  .window(TumblingEventTimeWindows.of(Time.seconds(1)))
   .reduce((a, b) => a + b)
   .addSink(new DiscardingSink[Int])
 env.execute()

--- a/docs/dev/stream/operators/windows.md
+++ b/docs/dev/stream/operators/windows.md
@@ -684,7 +684,7 @@ DataStream<Tuple2<String, Long>> input = ...;
 
 input
   .keyBy(t -> t.f0)
-  .timeWindow(Time.minutes(5))
+  .window(TumblingEventTimeWindows.of(Time.minutes(5)))
   .process(new MyProcessWindowFunction());
 
 /* ... */
@@ -711,7 +711,7 @@ val input: DataStream[(String, Long)] = ...
 
 input
   .keyBy(_._1)
-  .timeWindow(Time.minutes(5))
+  .window(TumblingEventTimeWindows.of(Time.minutes(5)))
   .process(new MyProcessWindowFunction())
 
 /* ... */
@@ -758,7 +758,7 @@ DataStream<SensorReading> input = ...;
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .reduce(new MyReduceFunction(), new MyProcessWindowFunction());
 
 // Function definitions
@@ -791,7 +791,7 @@ val input: DataStream[SensorReading] = ...
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .reduce(
     (r1: SensorReading, r2: SensorReading) => { if (r1.value > r2.value) r2 else r1 },
     ( key: String,
@@ -821,7 +821,7 @@ DataStream<Tuple2<String, Long>> input = ...;
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .aggregate(new AverageAggregate(), new MyProcessWindowFunction());
 
 // Function definitions
@@ -874,7 +874,7 @@ val input: DataStream[(String, Long)] = ...
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .aggregate(new AverageAggregate(), new MyProcessWindowFunction())
 
 // Function definitions

--- a/docs/dev/stream/operators/windows.zh.md
+++ b/docs/dev/stream/operators/windows.zh.md
@@ -684,7 +684,7 @@ DataStream<Tuple2<String, Long>> input = ...;
 
 input
   .keyBy(t -> t.f0)
-  .timeWindow(Time.minutes(5))
+  .window(TumblingEventTimeWindows.of(Time.minutes(5)))
   .process(new MyProcessWindowFunction());
 
 /* ... */
@@ -711,7 +711,7 @@ val input: DataStream[(String, Long)] = ...
 
 input
   .keyBy(_._1)
-  .timeWindow(Time.minutes(5))
+  .window(TumblingEventTimeWindows.of(Time.minutes(5)))
   .process(new MyProcessWindowFunction())
 
 /* ... */
@@ -758,7 +758,7 @@ DataStream<SensorReading> input = ...;
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .reduce(new MyReduceFunction(), new MyProcessWindowFunction());
 
 // Function definitions
@@ -791,7 +791,7 @@ val input: DataStream[SensorReading] = ...
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .reduce(
     (r1: SensorReading, r2: SensorReading) => { if (r1.value > r2.value) r2 else r1 },
     ( key: String,
@@ -821,7 +821,7 @@ DataStream<Tuple2<String, Long>> input = ...;
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .aggregate(new AverageAggregate(), new MyProcessWindowFunction());
 
 // Function definitions
@@ -874,7 +874,7 @@ val input: DataStream[(String, Long)] = ...
 
 input
   .keyBy(<key selector>)
-  .timeWindow(<duration>)
+  .window(<window assigner>)
   .aggregate(new AverageAggregate(), new MyProcessWindowFunction())
 
 // Function definitions

--- a/docs/learn-flink/streaming_analytics.md
+++ b/docs/learn-flink/streaming_analytics.md
@@ -411,9 +411,9 @@ For example, it works to do this:
 {% highlight java %}
 stream
     .keyBy(t -> t.key)
-    .timeWindow(<time specification>)
+    .window(<window assigner>)
     .reduce(<reduce function>)
-    .timeWindowAll(<same time specification>)
+    .windowAll(<same window assigner>)
     .reduce(<same reduce function>)
 {% endhighlight %}
 

--- a/docs/learn-flink/streaming_analytics.zh.md
+++ b/docs/learn-flink/streaming_analytics.zh.md
@@ -352,9 +352,9 @@ Flink 的窗口 API 某些方面有一些奇怪的行为，可能和我们预期
 {% highlight java %}
 stream
     .keyBy(t -> t.key)
-    .timeWindow(<time specification>)
+    .window(<window assigner>)
     .reduce(<reduce function>)
-    .timeWindowAll(<same time specification>)
+    .windowAll(<same window assigner>)
     .reduce(<same reduce function>)
 {% endhighlight %}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -775,7 +775,12 @@ public class DataStream<T> {
 	 * {@link org.apache.flink.streaming.api.environment.StreamExecutionEnvironment#setStreamTimeCharacteristic(org.apache.flink.streaming.api.TimeCharacteristic)}
 	 *
 	 * @param size The size of the window.
+	 *
+	 * @deprecated Please use {@link #windowAll(WindowAssigner)} with either {@link
+	 *        TumblingEventTimeWindows} or {@link TumblingProcessingTimeWindows}. For more information,
+	 * 		see the deprecation notice on {@link TimeCharacteristic}
 	 */
+	@Deprecated
 	public AllWindowedStream<T, TimeWindow> timeWindowAll(Time size) {
 		if (environment.getStreamTimeCharacteristic() == TimeCharacteristic.ProcessingTime) {
 			return windowAll(TumblingProcessingTimeWindows.of(size));
@@ -796,7 +801,12 @@ public class DataStream<T> {
 	 * the same operator instance.
 	 *
 	 * @param size The size of the window.
+	 *
+	 * @deprecated Please use {@link #windowAll(WindowAssigner)} with either {@link
+	 *        SlidingEventTimeWindows} or {@link SlidingProcessingTimeWindows}. For more information,
+	 * 		see the deprecation notice on {@link TimeCharacteristic}
 	 */
+	@Deprecated
 	public AllWindowedStream<T, TimeWindow> timeWindowAll(Time size, Time slide) {
 		if (environment.getStreamTimeCharacteristic() == TimeCharacteristic.ProcessingTime) {
 			return windowAll(SlidingProcessingTimeWindows.of(size, slide));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -616,7 +616,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	 *
 	 * @param size The size of the window.
 	 *
-	 * @deprecated Please use {@link #windowAll(WindowAssigner)} with either {@link
+	 * @deprecated Please use {@link #window(WindowAssigner)} with either {@link
 	 *        TumblingEventTimeWindows} or {@link TumblingProcessingTimeWindows}. For more information,
 	 * 		see the deprecation notice on {@link TimeCharacteristic}
 	 */
@@ -639,7 +639,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	 *
 	 * @param size The size of the window.
 	 *
-	 * @deprecated Please use {@link #windowAll(WindowAssigner)} with either {@link
+	 * @deprecated Please use {@link #window(WindowAssigner)} with either {@link
 	 *        SlidingEventTimeWindows} or {@link SlidingProcessingTimeWindows}. For more information,
 	 * 		see the deprecation notice on {@link TimeCharacteristic}
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -615,7 +615,12 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	 * {@link org.apache.flink.streaming.api.environment.StreamExecutionEnvironment#setStreamTimeCharacteristic(org.apache.flink.streaming.api.TimeCharacteristic)}
 	 *
 	 * @param size The size of the window.
+	 *
+	 * @deprecated Please use {@link #windowAll(WindowAssigner)} with either {@link
+	 *        TumblingEventTimeWindows} or {@link TumblingProcessingTimeWindows}. For more information,
+	 * 		see the deprecation notice on {@link TimeCharacteristic}
 	 */
+	@Deprecated
 	public WindowedStream<T, KEY, TimeWindow> timeWindow(Time size) {
 		if (environment.getStreamTimeCharacteristic() == TimeCharacteristic.ProcessingTime) {
 			return window(TumblingProcessingTimeWindows.of(size));
@@ -633,7 +638,12 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	 * {@link org.apache.flink.streaming.api.environment.StreamExecutionEnvironment#setStreamTimeCharacteristic(org.apache.flink.streaming.api.TimeCharacteristic)}
 	 *
 	 * @param size The size of the window.
+	 *
+	 * @deprecated Please use {@link #windowAll(WindowAssigner)} with either {@link
+	 *        SlidingEventTimeWindows} or {@link SlidingProcessingTimeWindows}. For more information,
+	 * 		see the deprecation notice on {@link TimeCharacteristic}
 	 */
+	@Deprecated
 	public WindowedStream<T, KEY, TimeWindow> timeWindow(Time size, Time slide) {
 		if (environment.getStreamTimeCharacteristic() == TimeCharacteristic.ProcessingTime) {
 			return window(SlidingProcessingTimeWindows.of(size, slide));

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -741,7 +741,12 @@ class DataStream[T](stream: JavaStream[T]) {
    * it possible to perform this operation in parallel).
    *
    * @param size The size of the window.
+   *
+   * @deprecated Please use [[windowAll()]] with either [[TumblingEventTimeWindows]] or
+   *             [[TumblingProcessingTimeWindows]]. For more information, see the deprecation
+   *             notice on [[org.apache.flink.streaming.api.TimeCharacteristic]].
    */
+  @deprecated
   def timeWindowAll(size: Time): AllWindowedStream[T, TimeWindow] = {
     new AllWindowedStream(javaStream.timeWindowAll(size))
   }
@@ -759,7 +764,12 @@ class DataStream[T](stream: JavaStream[T]) {
    * it possible to perform this operation in parallel).
    *
    * @param size The size of the window.
+   *
+   * @deprecated Please use [[windowAll()]] with either [[SlidingEventTimeWindows]] or
+   *             [[SlidingProcessingTimeWindows]]. For more information, see the deprecation
+   *             notice on [[org.apache.flink.streaming.api.TimeCharacteristic]].
    */
+  @deprecated
   def timeWindowAll(size: Time, slide: Time): AllWindowedStream[T, TimeWindow] = {
     new AllWindowedStream(javaStream.timeWindowAll(size, slide))
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -232,7 +232,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
    *
    * @param size The size of the window.
    *
-   * @deprecated Please use [[windowAll()]] with either [[TumblingEventTimeWindows]] or
+   * @deprecated Please use [[window()]] with either [[TumblingEventTimeWindows]] or
    *             [[TumblingProcessingTimeWindows]]. For more information, see the deprecation
    *             notice on [[org.apache.flink.streaming.api.TimeCharacteristic]].
    */
@@ -251,7 +251,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
    *
    * @param size The size of the window.
    *
-   * @deprecated Please use [[windowAll()]] with either [[SlidingEventTimeWindows]] or
+   * @deprecated Please use [[window()]] with either [[SlidingEventTimeWindows]] or
    *             [[SlidingProcessingTimeWindows]]. For more information, see the deprecation
    *             notice on [[org.apache.flink.streaming.api.TimeCharacteristic]].
    */

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -231,10 +231,35 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
    * [[StreamExecutionEnvironment.setStreamTimeCharacteristic()]]
    *
    * @param size The size of the window.
+   *
+   * @deprecated Please use [[windowAll()]] with either [[TumblingEventTimeWindows]] or
+   *             [[TumblingProcessingTimeWindows]]. For more information, see the deprecation
+   *             notice on [[org.apache.flink.streaming.api.TimeCharacteristic]].
    */
+  @deprecated
   def timeWindow(size: Time): WindowedStream[T, K, TimeWindow] = {
     new WindowedStream(javaStream.timeWindow(size))
   }
+
+  /**
+   * Windows this [[KeyedStream]] into sliding time windows.
+   *
+   * This is a shortcut for either `.window(SlidingEventTimeWindows.of(size))` or
+   * `.window(SlidingProcessingTimeWindows.of(size))` depending on the time characteristic
+   * set using
+   * [[StreamExecutionEnvironment.setStreamTimeCharacteristic()]]
+   *
+   * @param size The size of the window.
+   *
+   * @deprecated Please use [[windowAll()]] with either [[SlidingEventTimeWindows]] or
+   *             [[SlidingProcessingTimeWindows]]. For more information, see the deprecation
+   *             notice on [[org.apache.flink.streaming.api.TimeCharacteristic]].
+   */
+  @deprecated
+  def timeWindow(size: Time, slide: Time): WindowedStream[T, K, TimeWindow] = {
+    new WindowedStream(javaStream.timeWindow(size, slide))
+  }
+
 
   /**
    * Windows this [[KeyedStream]] into sliding count windows.
@@ -253,20 +278,6 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
    */
   def countWindow(size: Long): WindowedStream[T, K, GlobalWindow] = {
     new WindowedStream(javaStream.countWindow(size))
-  }
-
-  /**
-   * Windows this [[KeyedStream]] into sliding time windows.
-   *
-   * This is a shortcut for either `.window(SlidingEventTimeWindows.of(size))` or
-   * `.window(SlidingProcessingTimeWindows.of(size))` depending on the time characteristic
-   * set using
-   * [[StreamExecutionEnvironment.setStreamTimeCharacteristic()]]
-   *
-   * @param size The size of the window.
-   */
-  def timeWindow(size: Time, slide: Time): WindowedStream[T, K, TimeWindow] = {
-    new WindowedStream(javaStream.timeWindow(size, slide))
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

This is part of FLIP-134 (https://cwiki.apache.org/confluence/x/4i94CQ).

## Verifying this change

This is not adding anything, only deprecating methods. You can verify the deprecation message.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
