### PR TITLE
[FLINK-19497] [metrics] implement mutator methods for FlinkCounterWrapper

### DIFF
--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/FlinkCounterWrapperTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/FlinkCounterWrapperTest.java
@@ -19,39 +19,29 @@
 package org.apache.flink.dropwizard.metrics;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.util.TestCounter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
- * A wrapper that allows a Flink counter to be used as a DropWizard counter.
+ * Tests for the FlinkCounterWrapper.
  */
-public class FlinkCounterWrapper extends com.codahale.metrics.Counter {
-	private final Counter counter;
+public class FlinkCounterWrapperTest {
 
-	public FlinkCounterWrapper(Counter counter) {
-		this.counter = counter;
-	}
+	@Test
+	public void testWrapperIncDec() {
+		Counter counter = new TestCounter();
+		counter.inc();
 
-	@Override
-	public long getCount() {
-		return this.counter.getCount();
-	}
-
-	@Override
-	public void inc() {
-		this.counter.inc();
-	}
-
-	@Override
-	public void inc(long n) {
-		this.counter.inc(n);
-	}
-
-	@Override
-	public void dec() {
-		this.counter.dec();
-	}
-
-	@Override
-	public void dec(long n) {
-		this.counter.dec(n);
+		FlinkCounterWrapper wrapper = new FlinkCounterWrapper(counter);
+		assertEquals(1L, wrapper.getCount());
+		wrapper.dec();
+		assertEquals(0L, wrapper.getCount());
+		wrapper.inc(2);
+		assertEquals(2L, wrapper.getCount());
+		wrapper.dec(2);
+		assertEquals(0L, wrapper.getCount());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

[FlinkCounterWrapper](https://github.com/apache/flink/blob/master/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/metrics/FlinkCounterWrapper.java) does not implement mutator methods as the other dropwizard wrappers do ([example](https://github.com/apache/flink/blob/master/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/metrics/FlinkMeterWrapper.java#L45)).


## Brief change log

Implemented `inc` and `dec` methods for FlinkCounterWrapper.


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit tests for FlinkCounterWrapper*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
