### PR TITLE
[FLINK-19498][Connector Files] Port LocatableInputSplitAssigner to new File Source API

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
@@ -28,7 +28,7 @@ import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
-import org.apache.flink.connector.file.src.assigners.SimpleSplitAssigner;
+import org.apache.flink.connector.file.src.assigners.LocalityAwareSplitAssigner;
 import org.apache.flink.connector.file.src.enumerate.BlockSplittingRecursiveEnumerator;
 import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
 import org.apache.flink.connector.file.src.impl.ContinuousFileSplitEnumerator;
@@ -112,9 +112,9 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 	private static final long serialVersionUID = 1L;
 
 	/**
-	 * The default split assigner, a lazy non-locality-aware assigner.
+	 * The default split assigner, a lazy locality-aware assigner.
 	 */
-	public static final FileSplitAssigner.Provider DEFAULT_SPLIT_ASSIGNER = SimpleSplitAssigner::new;
+	public static final FileSplitAssigner.Provider DEFAULT_SPLIT_ASSIGNER = LocalityAwareSplitAssigner::new;
 
 	/**
 	 * The default file enumerator used for splittable formats.

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.assigners;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link FileSplitAssigner} that assigns to each host preferably splits that are local,
+ * before assigning splits that are not local.
+ *
+ * <p>Implementation Note: This class is an adjusted copy of the previous API's class
+ * {@link org.apache.flink.api.common.io.LocatableInputSplitAssigner} and reproduces the same assignment
+ * logic, for compatibility. The logic has not been changed or optimized.
+ */
+@PublicEvolving
+public class LocalityAwareSplitAssigner implements FileSplitAssigner {
+
+	private static final Logger LOG = LoggerFactory.getLogger(LocalityAwareSplitAssigner.class);
+
+	/**
+	 * All unassigned input splits.
+	 */
+	private final HashSet<SplitWithCount> unassigned = new HashSet<>();
+
+	/**
+	 * Input splits indexed by host for local assignment.
+	 */
+	private final HashMap<String, LocatableSplitChooser> localPerHost = new HashMap<>();
+
+	/**
+	 * Unassigned splits for remote assignment.
+	 */
+	private final LocatableSplitChooser remoteSplitChooser;
+
+	private final SimpleCounter localAssignments;
+	private final SimpleCounter remoteAssignments;
+
+	// --------------------------------------------------------------------------------------------
+
+	public LocalityAwareSplitAssigner(Collection<FileSourceSplit> splits) {
+		for (FileSourceSplit split : splits) {
+			this.unassigned.add(new SplitWithCount(split));
+		}
+		this.remoteSplitChooser = new LocatableSplitChooser(unassigned);
+
+		// this will be replaced with metrics registration once we can expose the metric group
+		// properly to the assigners
+		this.localAssignments = new SimpleCounter();
+		this.remoteAssignments = new SimpleCounter();
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public Optional<FileSourceSplit> getNext(@Nullable String host) {
+		// for a null host, we always return a remote split
+		if (StringUtils.isNullOrWhitespaceOnly(host)) {
+			final Optional<FileSourceSplit> split = getRemoteSplit();
+			if (split.isPresent()) {
+				LOG.info("Assigning split to non-localized request: {}", split);
+			}
+			return split;
+		}
+
+		host = normalize(host);
+
+		// for any non-null host, we take the list of non-null splits
+		final LocatableSplitChooser localSplits = localPerHost.computeIfAbsent(
+			host,
+			(theHost) -> buildChooserForHost(theHost, unassigned));
+
+		final SplitWithCount localSplit = localSplits.getNextUnassignedMinLocalCountSplit(unassigned);
+		if (localSplit != null) {
+			checkState(unassigned.remove(localSplit), "Selected split has already been assigned. This should not happen!");
+			LOG.info("Assigning local split to requesting host '{}': {}", host, localSplit.getSplit());
+			localAssignments.inc();
+			return Optional.of(localSplit.getSplit());
+		}
+
+		// we did not find a local split, return a remote split
+		final Optional<FileSourceSplit> remoteSplit = getRemoteSplit();
+		if (remoteSplit.isPresent()) {
+			LOG.info("Assigning remote split to requesting host '{}': {}", host, remoteSplit);
+		}
+		return remoteSplit;
+	}
+
+	@Override
+	public void addSplits(Collection<FileSourceSplit> splits) {
+		for (FileSourceSplit split : splits) {
+			SplitWithCount sc = new SplitWithCount(split);
+			remoteSplitChooser.addInputSplit(sc);
+			unassigned.add(sc);
+		}
+	}
+
+	@Override
+	public Collection<FileSourceSplit> remainingSplits() {
+		return unassigned.stream().map(SplitWithCount::getSplit)
+			.collect(Collectors.toList());
+	}
+
+	private Optional<FileSourceSplit> getRemoteSplit() {
+		final SplitWithCount split = remoteSplitChooser.getNextUnassignedMinLocalCountSplit(unassigned);
+		if (split == null) {
+			return Optional.empty();
+		}
+
+		checkState(unassigned.remove(split), "Selected split has already been assigned. This should not happen!");
+		remoteAssignments.inc();
+		return Optional.of(split.getSplit());
+	}
+
+	@VisibleForTesting
+	int getNumberOfLocalAssignments() {
+		return MathUtils.checkedDownCast(localAssignments.getCount());
+	}
+
+	@VisibleForTesting
+	int getNumberOfRemoteAssignments() {
+		return MathUtils.checkedDownCast(remoteAssignments.getCount());
+	}
+
+	private static String normalize(String str) {
+		return str.toLowerCase(Locale.US);
+	}
+
+	private static boolean isLocal(String flinkHost, String[] hosts) {
+		if (flinkHost == null || hosts == null) {
+			return false;
+		}
+		for (String h : hosts) {
+			if (h != null && NetUtils.getHostnameFromFQDN(h.toLowerCase()).equals(flinkHost)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static LocatableSplitChooser buildChooserForHost(String host, Set<SplitWithCount> splits) {
+		final LocatableSplitChooser newChooser = new LocatableSplitChooser();
+		for (SplitWithCount splitWithCount : splits) {
+			if (isLocal(host, splitWithCount.getSplit().hostnames())) {
+				splitWithCount.incrementLocalCount();
+				newChooser.addInputSplit(splitWithCount);
+			}
+		}
+		return newChooser;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Wraps a LocatableInputSplit and adds a count for the number of observed hosts
+	 * that can access the split locally.
+	 */
+	private static class SplitWithCount {
+
+		private final FileSourceSplit split;
+		private int localCount;
+
+		public SplitWithCount(FileSourceSplit split) {
+			this.split = split;
+			this.localCount = 0;
+		}
+
+		public void incrementLocalCount() {
+			this.localCount++;
+		}
+
+		public int getLocalCount() {
+			return localCount;
+		}
+
+		public FileSourceSplit getSplit() {
+			return split;
+		}
+
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Holds a list of LocatableInputSplits and returns the split with the lowest local count.
+	 * The rational is that splits which are local on few hosts should be preferred over others which
+	 * have more degrees of freedom for local assignment.
+	 *
+	 * <p>Internally, the splits are stored in a linked list. Sorting the list is not a good solution,
+	 * as local counts are updated whenever a previously unseen host requests a split.
+	 * Instead, we track the minimum local count and iteratively look for splits with that minimum count.
+	 */
+	private static class LocatableSplitChooser {
+
+		/**
+		 * list of all input splits.
+		 */
+		private final LinkedList<SplitWithCount> splits = new LinkedList<>();
+
+		/**
+		 * The current minimum local count. We look for splits with this local count.
+		 */
+		private int minLocalCount = -1;
+
+		/**
+		 * The second smallest count observed so far.
+		 */
+		private int nextMinLocalCount = -1;
+
+		/**
+		 * number of elements we need to inspect for the minimum local count.
+		 */
+		private int elementCycleCount = 0;
+
+		LocatableSplitChooser() {
+		}
+
+		LocatableSplitChooser(Collection<SplitWithCount> splits) {
+			for (SplitWithCount split : splits) {
+				addInputSplit(split);
+			}
+		}
+
+		/**
+		 * Adds a single input split.
+		 */
+		void addInputSplit(SplitWithCount split) {
+			int localCount = split.getLocalCount();
+
+			if (minLocalCount == -1) {
+				// first split to add
+				this.minLocalCount = localCount;
+				this.elementCycleCount = 1;
+				this.splits.offerFirst(split);
+			} else if (localCount < minLocalCount) {
+				// split with new min local count
+				this.nextMinLocalCount = this.minLocalCount;
+				this.minLocalCount = localCount;
+				// all other splits have more local host than this one
+				this.elementCycleCount = 1;
+				splits.offerFirst(split);
+			} else if (localCount == minLocalCount) {
+				this.elementCycleCount++;
+				this.splits.offerFirst(split);
+			} else {
+				if (localCount < nextMinLocalCount) {
+					nextMinLocalCount = localCount;
+				}
+				splits.offerLast(split);
+			}
+		}
+
+		/**
+		 * Retrieves a LocatableInputSplit with minimum local count.
+		 * InputSplits which have already been assigned (i.e., which are not contained in the provided set) are filtered out.
+		 * The returned input split is NOT removed from the provided set.
+		 *
+		 * @param unassignedSplits Set of unassigned input splits.
+		 * @return An input split with minimum local count or null if all splits have been assigned.
+		 */
+		@Nullable
+		SplitWithCount getNextUnassignedMinLocalCountSplit(Set<SplitWithCount> unassignedSplits) {
+			if (splits.size() == 0) {
+				return null;
+			}
+
+			do {
+				elementCycleCount--;
+				// take first split of the list
+				SplitWithCount split = splits.pollFirst();
+				if (unassignedSplits.contains(split)) {
+					int localCount = split.getLocalCount();
+					// still unassigned, check local count
+					if (localCount > minLocalCount) {
+						// re-insert at end of the list and continue to look for split with smaller local count
+						splits.offerLast(split);
+						// check and update second smallest local count
+						if (nextMinLocalCount == -1 || split.getLocalCount() < nextMinLocalCount) {
+							nextMinLocalCount = split.getLocalCount();
+						}
+						split = null;
+					}
+				} else {
+					// split was already assigned
+					split = null;
+				}
+				if (elementCycleCount == 0) {
+					// one full cycle, but no split with min local count found
+					// update minLocalCnt and element cycle count for next pass over the splits
+					minLocalCount = nextMinLocalCount;
+					nextMinLocalCount = -1;
+					elementCycleCount = splits.size();
+				}
+				if (split != null) {
+					// found a split to assign
+					return split;
+				}
+			} while (elementCycleCount > 0);
+
+			// no split left
+			return null;
+		}
+
+	}
+}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssignerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssignerTest.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.assigners;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the {@link LocalityAwareSplitAssigner}.
+ */
+public class LocalityAwareSplitAssignerTest {
+
+	private static final Path TEST_PATH = Path.fromLocalFile(new File(System.getProperty("java.io.tmpdir")));
+
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void testAssignmentWithNullHost() {
+		final int numSplits = 50;
+		final String[][] hosts = new String[][] {
+			new String[] { "localhost" },
+			new String[0]
+		};
+
+		// load some splits
+		final Set<FileSourceSplit> splits = new HashSet<>();
+		for (int i = 0; i < numSplits; i++) {
+			splits.add(createSplit(i, hosts[i % hosts.length]));
+		}
+
+		// get all available splits
+		final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
+		Optional<FileSourceSplit> is;
+		while ((is = ia.getNext(null)).isPresent()) {
+			assertTrue(splits.remove(is.get()));
+		}
+
+		// check we had all
+		assertTrue(splits.isEmpty());
+		assertFalse(ia.getNext("").isPresent());
+		assertEquals(numSplits, ia.getNumberOfRemoteAssignments());
+		assertEquals(0, ia.getNumberOfLocalAssignments());
+	}
+
+	@Test
+	public void testAssignmentAllForSameHost() {
+		final int numSplits = 50;
+
+		// load some splits
+		final Set<FileSourceSplit> splits = new HashSet<>();
+		for (int i = 0; i < numSplits; i++) {
+			splits.add(createSplit(i, "testhost"));
+		}
+
+		// get all available splits
+		LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
+		Optional<FileSourceSplit> is;
+		while ((is = ia.getNext("testhost")).isPresent()) {
+			assertTrue(splits.remove(is.get()));
+		}
+
+		// check we had all
+		assertTrue(splits.isEmpty());
+		assertFalse(ia.getNext("").isPresent());
+
+		assertEquals(0, ia.getNumberOfRemoteAssignments());
+		assertEquals(numSplits, ia.getNumberOfLocalAssignments());
+	}
+
+	@Test
+	public void testAssignmentAllForRemoteHost() {
+		final String[] hosts = { "host1", "host1", "host1", "host2", "host2", "host3" };
+		final int numSplits = 10 * hosts.length;
+
+		// load some splits
+		final Set<FileSourceSplit> splits = new HashSet<>();
+		for (int i = 0; i < numSplits; i++) {
+			splits.add(createSplit(i, hosts[i % hosts.length]));
+		}
+
+		// get all available splits
+		final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
+		Optional<FileSourceSplit> is;
+		while ((is = ia.getNext("testhost")).isPresent()) {
+			assertTrue(splits.remove(is.get()));
+		}
+
+		// check we had all
+		assertTrue(splits.isEmpty());
+		assertFalse(ia.getNext("anotherHost").isPresent());
+
+		assertEquals(numSplits, ia.getNumberOfRemoteAssignments());
+		assertEquals(0, ia.getNumberOfLocalAssignments());
+	}
+
+	@Test
+	public void testAssignmentSomeForRemoteHost() {
+		// host1 reads all local
+		// host2 reads 10 local and 10 remote
+		// host3 reads all remote
+		final String[] hosts = { "host1", "host2", "host3" };
+		final int numLocalHost1Splits = 20;
+		final int numLocalHost2Splits = 10;
+		final int numRemoteSplits = 30;
+		final int numLocalSplits = numLocalHost1Splits + numLocalHost2Splits;
+
+		// load local splits
+		int splitCnt = 0;
+		final Set<FileSourceSplit> splits = new HashSet<>();
+		// host1 splits
+		for (int i = 0; i < numLocalHost1Splits; i++) {
+			splits.add(createSplit(splitCnt++, "host1"));
+		}
+		// host2 splits
+		for (int i = 0; i < numLocalHost2Splits; i++) {
+			splits.add(createSplit(splitCnt++, "host2"));
+		}
+		// load remote splits
+		for (int i = 0; i < numRemoteSplits; i++) {
+			splits.add(createSplit(splitCnt++, "remoteHost"));
+		}
+
+		// get all available splits
+		final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
+		Optional<FileSourceSplit> is;
+		int i = 0;
+		while ((is = ia.getNext(hosts[i++ % hosts.length])).isPresent()) {
+			assertTrue(splits.remove(is.get()));
+		}
+
+		// check we had all
+		assertTrue(splits.isEmpty());
+		assertFalse(ia.getNext("anotherHost").isPresent());
+
+		assertEquals(numRemoteSplits, ia.getNumberOfRemoteAssignments());
+		assertEquals(numLocalSplits, ia.getNumberOfLocalAssignments());
+	}
+
+	@SuppressWarnings("UnnecessaryLocalVariable")
+	@Test
+	public void testAssignmentMultiLocalHost() {
+		final String[] localHosts = { "local1", "local2", "local3" };
+		final String[] remoteHosts = { "remote1", "remote2", "remote3" };
+		final String[] requestingHosts = { "local3", "local2", "local1", "other" };
+
+		final int numThreeLocalSplits = 10;
+		final int numTwoLocalSplits = 10;
+		final int numOneLocalSplits = 10;
+		final int numLocalSplits = 30;
+		final int numRemoteSplits = 10;
+		final int numSplits = 40;
+
+		final String[] threeLocalHosts = localHosts;
+		final String[] twoLocalHosts = {localHosts[0], localHosts[1], remoteHosts[0]};
+		final String[] oneLocalHost = {localHosts[0], remoteHosts[0], remoteHosts[1]};
+		final String[] noLocalHost = remoteHosts;
+
+		int splitCnt = 0;
+		final Set<FileSourceSplit> splits = new HashSet<>();
+		// add splits with three local hosts
+		for (int i = 0; i < numThreeLocalSplits; i++) {
+			splits.add(createSplit(splitCnt++, threeLocalHosts));
+		}
+		// add splits with two local hosts
+		for (int i = 0; i < numTwoLocalSplits; i++) {
+			splits.add(createSplit(splitCnt++, twoLocalHosts));
+		}
+		// add splits with two local hosts
+		for (int i = 0; i < numOneLocalSplits; i++) {
+			splits.add(createSplit(splitCnt++, oneLocalHost));
+		}
+		// add splits with two local hosts
+		for (int i = 0; i < numRemoteSplits; i++) {
+			splits.add(createSplit(splitCnt++, noLocalHost));
+		}
+
+		// get all available splits
+		final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
+		for (int i = 0; i < numSplits; i++) {
+			final String host = requestingHosts[i % requestingHosts.length];
+
+			final Optional<FileSourceSplit> ois = ia.getNext(host);
+			assertTrue(ois.isPresent());
+
+			final FileSourceSplit is = ois.get();
+			assertTrue(splits.remove(is));
+			// check priority of split
+			if (host.equals(localHosts[0])) {
+				assertArrayEquals(is.hostnames(), oneLocalHost);
+			} else if (host.equals(localHosts[1])) {
+				assertArrayEquals(is.hostnames(), twoLocalHosts);
+			} else if (host.equals(localHosts[2])) {
+				assertArrayEquals(is.hostnames(), threeLocalHosts);
+			} else {
+				assertArrayEquals(is.hostnames(), noLocalHost);
+			}
+		}
+		// check we had all
+		assertTrue(splits.isEmpty());
+		assertFalse(ia.getNext("anotherHost").isPresent());
+
+		assertEquals(numRemoteSplits, ia.getNumberOfRemoteAssignments());
+		assertEquals(numLocalSplits, ia.getNumberOfLocalAssignments());
+	}
+
+	@Test
+	public void testAssignmentMixedLocalHost() {
+		final String[] hosts = { "host1", "host1", "host1", "host2", "host2", "host3" };
+		final int numSplits = 10 * hosts.length;
+
+		// load some splits
+		Set<FileSourceSplit> splits = new HashSet<>();
+		for (int i = 0; i < numSplits; i++) {
+			splits.add(createSplit(i, hosts[i % hosts.length]));
+		}
+
+		// get all available splits
+		LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
+		Optional<FileSourceSplit> is;
+		int i = 0;
+		while ((is = ia.getNext(hosts[i++ % hosts.length])).isPresent()) {
+			assertTrue(splits.remove(is.get()));
+		}
+
+		// check we had all
+		assertTrue(splits.isEmpty());
+		assertFalse(ia.getNext("anotherHost").isPresent());
+
+		assertEquals(0, ia.getNumberOfRemoteAssignments());
+		assertEquals(numSplits, ia.getNumberOfLocalAssignments());
+	}
+
+	@Test
+	public void testAssignmentOfManySplitsRandomly() {
+		final long seed = Calendar.getInstance().getTimeInMillis();
+
+		final int numSplits = 1000;
+		final String[] splitHosts = new String[256];
+		final String[] requestingHosts = new String[256];
+		final Random rand = new Random(seed);
+
+		for (int i = 0; i < splitHosts.length; i++) {
+			splitHosts[i] = "localHost" + i;
+		}
+		for (int i = 0; i < requestingHosts.length; i++) {
+			if (i % 2 == 0) {
+				requestingHosts[i] = "localHost" + i;
+			} else {
+				requestingHosts[i] = "remoteHost" + i;
+			}
+		}
+
+		String[] stringArray = {};
+		Set<String> hosts = new HashSet<>();
+		Set<FileSourceSplit> splits = new HashSet<>();
+		for (int i = 0; i < numSplits; i++) {
+			while (hosts.size() < 3) {
+				hosts.add(splitHosts[rand.nextInt(splitHosts.length)]);
+			}
+			splits.add(createSplit(i, hosts.toArray(stringArray)));
+			hosts.clear();
+		}
+
+		final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
+
+		for (int i = 0; i < numSplits; i++) {
+			final Optional<FileSourceSplit> split = ia.getNext(requestingHosts[rand.nextInt(requestingHosts.length)]);
+			assertTrue(split.isPresent());
+			assertTrue(splits.remove(split.get()));
+		}
+
+		assertTrue(splits.isEmpty());
+		assertFalse(ia.getNext("testHost").isPresent());
+	}
+
+	// ------------------------------------------------------------------------
+	//  utilities
+	// ------------------------------------------------------------------------
+
+	private static FileSourceSplit createSplit(int id, String... hosts) {
+		return new FileSourceSplit(String.valueOf(id), TEST_PATH, 0, 1024, hosts);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This adds the `LocalityAwareSplitAssigner` for the new File Source API. The new assigner works the exact same way as the `LocatableInputSplitAssigner` from the *InputFormat API*.

This new split assigner is also the default now for the `FileSource`.

The code of the `LocalityAwareSplitAssigner` is largely a copy of the code from the `LocatableInputSplitAssigner`, adjusted for the different interface methods and cleaned up (code style / checkstyle).

## Verifying this change

This copies and adjusts the tests from the `LocatableInputSplitAssigner`, except for the concurrency-related tests. Those are dropped, because the new FileSplitAssigners are not concurrent.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes, but only unreleased classes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
