### PR TITLE
[FLINK-19027][network] Assign exclusive buffers to LocalRecoveredInputChannel.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
@@ -42,8 +42,17 @@ public class LocalRecoveredInputChannel extends RecoveredInputChannel {
 			TaskEventPublisher taskEventPublisher,
 			int initialBackOff,
 			int maxBackoff,
+			int networkBuffersPerChannel,
 			InputChannelMetrics metrics) {
-		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, metrics.getNumBytesInLocalCounter(), metrics.getNumBuffersInLocalCounter());
+		super(
+			inputGate,
+			channelIndex,
+			partitionId,
+			initialBackOff,
+			maxBackoff,
+			metrics.getNumBytesInLocalCounter(),
+			metrics.getNumBuffersInLocalCounter(),
+			networkBuffersPerChannel);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventPublisher = checkNotNull(taskEventPublisher);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * An input channel reads recovered state from previous unaligned checkpoint snapshots
@@ -36,9 +35,6 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 	private final ConnectionID connectionId;
 	private final ConnectionManager connectionManager;
-	private final int networkBuffersPerChannel;
-
-	private boolean exclusiveBuffersAssigned;
 
 	RemoteRecoveredInputChannel(
 			SingleInputGate inputGate,
@@ -50,11 +46,18 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 			int maxBackoff,
 			int networkBuffersPerChannel,
 			InputChannelMetrics metrics) {
-		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, metrics.getNumBytesInRemoteCounter(), metrics.getNumBuffersInRemoteCounter());
+		super(
+			inputGate,
+			channelIndex,
+			partitionId,
+			initialBackOff,
+			maxBackoff,
+			metrics.getNumBytesInRemoteCounter(),
+			metrics.getNumBuffersInRemoteCounter(),
+			networkBuffersPerChannel);
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
-		this.networkBuffersPerChannel = networkBuffersPerChannel;
 	}
 
 	@Override
@@ -77,10 +80,4 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 		return remoteInputChannel;
 	}
 
-	void assignExclusiveSegments() throws IOException {
-		checkState(!exclusiveBuffersAssigned, "Exclusive buffers should be assigned only once.");
-
-		bufferManager.requestExclusiveBuffers(networkBuffersPerChannel);
-		exclusiveBuffersAssigned = true;
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -254,8 +254,8 @@ public class SingleInputGate extends IndexedInputGate {
 				return FutureUtils.completedVoidFuture();
 			}
 			for (InputChannel inputChannel : inputChannels.values()) {
-				if (inputChannel instanceof RemoteRecoveredInputChannel) {
-					((RemoteRecoveredInputChannel) inputChannel).assignExclusiveSegments();
+				if (inputChannel instanceof RecoveredInputChannel) {
+					((RecoveredInputChannel) inputChannel).assignExclusiveSegments();
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -219,6 +219,7 @@ public class SingleInputGateFactory {
 				taskEventPublisher,
 				partitionRequestInitialBackoff,
 				partitionRequestMaxBackoff,
+				networkBuffersPerChannel,
 				metrics);
 		} else {
 			// Different instances => remote

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -160,6 +160,7 @@ public class InputChannelBuilder {
 			taskEventPublisher,
 			initialBackoff,
 			maxBackoff,
+			networkBuffersPerChannel,
 			metrics);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -151,11 +151,11 @@ public class SingleInputGateTest extends InputGateTestBase {
 	 */
 	@Test
 	public void testReadRecoveredState() throws Exception {
-		final int totalStates = 5;
-		final int[] states = {1, 2, 3, 4};
+		final int totalStates = 7;
+		final int[] states = {1, 2, 3, 4, 5, 6};
 		final ChannelStateReader stateReader = new ResultPartitionTest.FiniteChannelStateReader(totalStates, states);
 
-		final int totalBuffers = 3; // the total buffers are less than the requirement from total states
+		final int totalBuffers = 5; // the total buffers are less than the requirement from total states
 		final NettyShuffleEnvironment environment = new NettyShuffleEnvironmentBuilder()
 			.setBufferSize(states.length * Integer.BYTES)
 			.setNumNetworkBuffers(totalBuffers)
@@ -193,11 +193,11 @@ public class SingleInputGateTest extends InputGateTestBase {
 	 */
 	@Test
 	public void testConcurrentReadStateAndProcessAndClose() throws Exception {
-		final int totalStates = 5;
-		final int[] states = {1, 2, 3, 4};
+		final int totalStates = 7;
+		final int[] states = {1, 2, 3, 4, 5, 6};
 		final ChannelStateReader stateReader = new ResultPartitionTest.FiniteChannelStateReader(totalStates, states);
 
-		final int totalBuffers = 3;
+		final int totalBuffers = 5;
 		final NettyShuffleEnvironment environment = new NettyShuffleEnvironmentBuilder()
 			.setBufferSize(states.length * Integer.BYTES)
 			.setNumNetworkBuffers(totalBuffers)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -125,9 +125,21 @@ public class SingleInputGateTest extends InputGateTestBase {
 			assertEquals(1, inputGate.getBufferPool().getNumberOfRequiredMemorySegments());
 			for (InputChannel inputChannel : inputGate.getInputChannels().values()) {
 				if (inputChannel instanceof RemoteRecoveredInputChannel) {
-					assertEquals(2, ((RemoteRecoveredInputChannel) inputChannel).bufferManager.getNumberOfAvailableBuffers());
+					assertEquals(0,
+						((RemoteRecoveredInputChannel) inputChannel).bufferManager.getNumberOfAvailableBuffers());
 				} else if (inputChannel instanceof LocalRecoveredInputChannel) {
-					assertEquals(0, ((LocalRecoveredInputChannel) inputChannel).bufferManager.getNumberOfAvailableBuffers());
+					assertEquals(0,
+						((LocalRecoveredInputChannel) inputChannel).bufferManager.getNumberOfAvailableBuffers());
+				}
+			}
+
+			inputGate.convertRecoveredInputChannels();
+			assertNotNull(inputGate.getBufferPool());
+			assertEquals(1, inputGate.getBufferPool().getNumberOfRequiredMemorySegments());
+			for (InputChannel inputChannel : inputGate.getInputChannels().values()) {
+				if (inputChannel instanceof RemoteInputChannel) {
+					assertEquals(2,
+						((RemoteInputChannel) inputChannel).getNumberOfAvailableBuffers());
 				}
 			}
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -214,7 +214,6 @@ public class UnalignedCheckpointITCase extends TestLogger {
 		env.setParallelism(parallelism);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(EXPECTED_FAILURES, Time.milliseconds(100)));
 		env.getCheckpointConfig().enableUnalignedCheckpoints(true);
-		env.getCheckpointConfig().setCheckpointTimeout(TimeUnit.SECONDS.toMillis(30));
 		return env;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -45,6 +45,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -204,6 +205,9 @@ public class UnalignedCheckpointITCase extends TestLogger {
 
 		conf.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
 		conf.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, temp.newFolder().toURI().toString());
+
+		conf.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, 1);
+		conf.set(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE, slotsPerTaskManager);
 
 		final LocalStreamEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(parallelism, conf);
 		env.enableCheckpointing(100);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

If a local channel does not receive a buffer during recovery, a live lock may occur where the local channel cannot recover because it is waiting for a buffer but upstream operators are fully backpressured and cannot release a buffer.
It's important to treat LocalRecoveredInputChannel like RemoteInputChannels and assign exclusive buffers for recovery to avoid this situation.

## Brief change log

- Assign exclusive buffers to LocalRecoveredInputChannel.
- Ensure SingleInputGateTest does not swallow exceptions during cleanup.
- Revert https://github.com/apache/flink/pull/13532 as the test failure actually revealed the live lock.


## Verifying this change

Adjusted a few unit tests.
Already covered and reveleaed by UnalignedCheckpointITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
