### PR TITLE
[FLINK-19344] Fix DispatcherResourceCleanupTest race condition

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -350,6 +350,10 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 		final TestingJobManagerRunner testingJobManagerRunner = jobManagerRunnerFactory.takeCreatedJobManagerRunner();
 		testingJobManagerRunner.completeResultFutureExceptionally(new JobNotFinishedException(jobId));
 
+		// wait until termination JobManagerRunner closeAsync has been called.
+		// this is necessary to avoid race conditions with completion of the 1st job and the submission of the 2nd job (DuplicateJobSubmissionException).
+		testingJobManagerRunner.getCloseAsyncCalledFuture().get();
+
 		final CompletableFuture<Acknowledge> submissionFuture = dispatcherGateway.submitJob(jobGraph, timeout);
 
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -352,7 +352,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
 		// wait until termination JobManagerRunner closeAsync has been called.
 		// this is necessary to avoid race conditions with completion of the 1st job and the submission of the 2nd job (DuplicateJobSubmissionException).
-		testingJobManagerRunner.getCloseAsyncCalledFuture().get();
+		testingJobManagerRunner.getCloseAsyncCalledLatch().await();
 
 		final CompletableFuture<Acknowledge> submissionFuture = dispatcherGateway.submitJob(jobGraph, timeout);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -39,6 +39,8 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 
 	private final CompletableFuture<ArchivedExecutionGraph> resultFuture;
 
+	private final CompletableFuture<Void> closeAsyncCalledFuture = new CompletableFuture<>();
+
 	private TestingJobManagerRunner(JobID jobId,
 			boolean blockingTermination,
 			CompletableFuture<JobMasterGateway> jobMasterGatewayFuture,
@@ -76,7 +78,12 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 			terminationFuture.complete(null);
 		}
 
+		closeAsyncCalledFuture.complete(null);
 		return terminationFuture;
+	}
+
+	public CompletableFuture<Void> getCloseAsyncCalledFuture() {
+		return closeAsyncCalledFuture;
 	}
 
 	public void completeResultFuture(ArchivedExecutionGraph archivedExecutionGraph) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.util.Preconditions;
 
@@ -39,7 +40,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 
 	private final CompletableFuture<ArchivedExecutionGraph> resultFuture;
 
-	private final CompletableFuture<Void> closeAsyncCalledFuture = new CompletableFuture<>();
+	private final OneShotLatch closeAsyncCalledLatch = new OneShotLatch();
 
 	private TestingJobManagerRunner(JobID jobId,
 			boolean blockingTermination,
@@ -78,12 +79,12 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 			terminationFuture.complete(null);
 		}
 
-		closeAsyncCalledFuture.complete(null);
+		closeAsyncCalledLatch.trigger();
 		return terminationFuture;
 	}
 
-	public CompletableFuture<Void> getCloseAsyncCalledFuture() {
-		return closeAsyncCalledFuture;
+	public OneShotLatch getCloseAsyncCalledLatch() {
+		return closeAsyncCalledLatch;
 	}
 
 	public void completeResultFuture(ArchivedExecutionGraph archivedExecutionGraph) {


### PR DESCRIPTION

## What is the purpose of the change

This is removing a test-instability, where sometimes, the DispatcherResourceCleanupTest. testJobSubmissionUnderSameJobId() would report a `DuplicateJobSubmissionException`. 
The test is initialized with a dispatcher, recovering the testing job graph. Once the TestingJobManagerRunner for this job graph has been created, the result future is completed, and a new job gets submitted.
The problem is that the `DispatcherJob.isDuplicateJob()` method might still find the job in the `runningJobs` list, because the cleanup from that list happens asynchronously.

The test instability is resolved by waiting until TestingJobManagerRunner has been closed.



## Verifying this change

I have executed this patch 4000 times on CI, without a failure: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8421&view=results

## Does this pull request potentially affect one of the following parts:

The change only affects tests.
