### PR TITLE
[FLINK-19422] Upgrade Kafka and schema registry versions in the avro registry e2e test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -26,7 +26,7 @@ KAFKA_VERSION="$1"
 CONFLUENT_VERSION="$2"
 CONFLUENT_MAJOR_VERSION="$3"
 
-KAFKA_DIR=$TEST_DATA_DIR/kafka_2.11-$KAFKA_VERSION
+KAFKA_DIR=$TEST_DATA_DIR/kafka_2.12-$KAFKA_VERSION
 CONFLUENT_DIR=$TEST_DATA_DIR/confluent-$CONFLUENT_VERSION
 SCHEMA_REGISTRY_PORT=8082
 SCHEMA_REGISTRY_URL=http://localhost:${SCHEMA_REGISTRY_PORT}
@@ -35,7 +35,7 @@ MAX_RETRY_SECONDS=120
 function setup_kafka_dist {
   # download Kafka
   mkdir -p $TEST_DATA_DIR
-  KAFKA_URL="https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
+  KAFKA_URL="https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.12-$KAFKA_VERSION.tgz"
   echo "Downloading Kafka from $KAFKA_URL"
   curl ${KAFKA_URL} --retry 10 --retry-max-time 120 --output ${TEST_DATA_DIR}/kafka.tgz
 
@@ -61,7 +61,7 @@ function setup_confluent_dist {
 
 function wait_for_zookeeper_running {
   start_time=$(date +%s)
-  while ! [[ $($KAFKA_DIR/bin/zookeeper-shell.sh localhost:2181 get /testnonexistent 2>&1 | grep "Node does not exist") ]] ; do
+  while ! [[ $($KAFKA_DIR/bin/zookeeper-shell.sh localhost:2181 get /testnonexistent 2>&1 | grep -e "Node does not exist" -e "NoNode for") ]] ; do
     current_time=$(date +%s)
     time_diff=$((current_time - start_time))
 

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -20,7 +20,7 @@
 set -Eeuo pipefail
 
 source "$(dirname "$0")"/common.sh
-source "$(dirname "$0")"/kafka-common.sh 0.10.2.0 3.2.0 3.2
+source "$(dirname "$0")"/kafka-common.sh 2.6.0 5.0.0 5.0
 
 function verify_output {
   local expected=$(printf $1)


### PR DESCRIPTION
## What is the purpose of the change

Upgrade Kafka & Schema registry versions to potentially decrease the probability of hitting problems in said systems.


## Brief change log

  - Upgrade Kafka to 2.6.0 (it required using the 2.12 binary as Kafka dropped support for 2.11 in 2.4)
  - Updated kafka-common to work with newer versions of Zookeeper
  - Upgrade Schema Registry version to 5.0.0


## Verifying this change

The e2e should still work.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**) - upgrades components versions used in e2e.
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
