### PR TITLE
[FLINK-19509][Format-json] Fix ClassCastException of JsonRowDataDeserializationSchema and JsonRowDataSerializationSchema when type is multiset

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -152,8 +152,13 @@ public class JsonToRowDataConverters implements Serializable {
 			case ARRAY:
 				return createArrayConverter((ArrayType) type);
 			case MAP:
+				MapType mapType = (MapType) type;
+				return createMapConverter(
+					mapType.asSummaryString(), mapType.getKeyType(), mapType.getValueType());
 			case MULTISET:
-				return createMapConverter(type);
+				MultisetType multisetType = (MultisetType) type;
+				return createMapConverter(
+					multisetType.asSummaryString(), multisetType.getElementType(), new IntType());
 			case ROW:
 				return createRowConverter((RowType) type);
 			case RAW:
@@ -300,22 +305,12 @@ public class JsonToRowDataConverters implements Serializable {
 		};
 	}
 
-	private JsonToRowDataConverter createMapConverter(LogicalType type) {
-		LogicalType keyType;
-		LogicalType valueType;
-		if (type instanceof MapType) {
-			MapType mapType = (MapType) type;
-			keyType = mapType.getKeyType();
-			valueType = mapType.getValueType();
-		} else {
-			MultisetType multisetType = (MultisetType) type;
-			keyType = multisetType.getElementType();
-			valueType = new IntType();
-		}
+	private JsonToRowDataConverter createMapConverter(
+		String typeSummary, LogicalType keyType, LogicalType valueType) {
 		if (!LogicalTypeChecks.hasFamily(keyType, LogicalTypeFamily.CHARACTER_STRING)) {
 			throw new UnsupportedOperationException(
 				"JSON format doesn't support non-string as key type of map. " +
-					"The map type is: " + type.asSummaryString());
+					"The map type is: " + typeSummary);
 		}
 		final JsonToRowDataConverter keyConverter = createConverter(keyType);
 		final JsonToRowDataConverter valueConverter = createConverter(valueType);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -306,11 +306,11 @@ public class JsonToRowDataConverters implements Serializable {
 	}
 
 	private JsonToRowDataConverter createMapConverter(
-		String typeSummary, LogicalType keyType, LogicalType valueType) {
+			String typeSummary, LogicalType keyType, LogicalType valueType) {
 		if (!LogicalTypeChecks.hasFamily(keyType, LogicalTypeFamily.CHARACTER_STRING)) {
 			throw new UnsupportedOperationException(
 				"JSON format doesn't support non-string as key type of map. " +
-					"The map type is: " + typeSummary);
+					"The type is: " + typeSummary);
 		}
 		final JsonToRowDataConverter keyConverter = createConverter(keyType);
 		final JsonToRowDataConverter valueConverter = createConverter(valueType);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -226,11 +226,11 @@ public class RowDataToJsonConverters implements Serializable {
 	}
 
 	private RowDataToJsonConverter createMapConverter(
-		String typeSummary, LogicalType keyType, LogicalType valueType) {
+			String typeSummary, LogicalType keyType, LogicalType valueType) {
 		if (!LogicalTypeChecks.hasFamily(keyType, LogicalTypeFamily.CHARACTER_STRING)) {
 			throw new UnsupportedOperationException(
 				"JSON format doesn't support non-string as key type of map. " +
-					"The map type is: " + typeSummary);
+					"The type is: " + typeSummary);
 		}
 		final RowDataToJsonConverter valueConverter = createConverter(valueType);
 		return (mapper, reuse, object) -> {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -58,6 +58,7 @@ import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.MAP;
+import static org.apache.flink.table.api.DataTypes.MULTISET;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.SMALLINT;
 import static org.apache.flink.table.api.DataTypes.STRING;
@@ -97,6 +98,9 @@ public class JsonRowDataSerDeSchemaTest {
 		Map<String, Long> map = new HashMap<>();
 		map.put("flink", 123L);
 
+		Map<String, Integer> multiSet = new HashMap<>();
+		multiSet.put("blink", 2);
+
 		Map<String, Map<String, Integer>> nestedMap = new HashMap<>();
 		Map<String, Integer> innerMap = new HashMap<>();
 		innerMap.put("key", 234);
@@ -123,6 +127,7 @@ public class JsonRowDataSerDeSchemaTest {
 		root.put("timestamp9", "1990-10-14T12:12:43.123456789");
 		root.put("timestampWithLocalZone", "1990-10-14T12:12:43.123456789Z");
 		root.putObject("map").put("flink", 123);
+		root.putObject("multiSet").put("blink", 2);
 		root.putObject("map2map").putObject("inner_map").put("key", 234);
 
 		byte[] serializedJson = objectMapper.writeValueAsBytes(root);
@@ -144,6 +149,7 @@ public class JsonRowDataSerDeSchemaTest {
 			FIELD("timestamp9", TIMESTAMP(9)),
 			FIELD("timestampWithLocalZone", TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)),
 			FIELD("map", MAP(STRING(), BIGINT())),
+			FIELD("multiSet", MULTISET(STRING())),
 			FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))));
 		RowType schema = (RowType) dataType.getLogicalType();
 		TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
@@ -151,7 +157,7 @@ public class JsonRowDataSerDeSchemaTest {
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
 			schema, resultTypeInfo, false, false, TimestampFormat.ISO_8601);
 
-		Row expected = new Row(17);
+		Row expected = new Row(18);
 		expected.setField(0, true);
 		expected.setField(1, tinyint);
 		expected.setField(2, smallint);
@@ -168,7 +174,8 @@ public class JsonRowDataSerDeSchemaTest {
 		expected.setField(13, timestamp9.toLocalDateTime());
 		expected.setField(14, timestampWithLocalZone);
 		expected.setField(15, map);
-		expected.setField(16, nestedMap);
+		expected.setField(16, multiSet);
+		expected.setField(17, nestedMap);
 
 		RowData rowData = deserializationSchema.deserialize(serializedJson);
 		Row actual = convertToExternal(rowData, dataType);


### PR DESCRIPTION

## What is the purpose of the change

Fix ClassCastException of JsonRowDataDeserializationSchema and JsonRowDataSerializationSchema when type is multiset

## Brief change log
Add the determination of  multiset type for JsonToRowDataConverters#createMapConverter and RowDataToJsonConverters#createMapConverter


## Verifying this change

This change added tests and can be verified as follows:
JsonRowDataSerDeSchemaTest#testSerDe

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
