### PR TITLE
[FLINK-19309][coordination] Add TaskExecutorManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
@@ -50,7 +50,14 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
- * SlotManager component for all task executor related things.
+ * SlotManager component for various task executor related responsibilities of the slot manager, including:
+ * <ul>
+ *     <li>tracking registered task executors</li>
+ *     <li>allocating new task executors (both on-demand, and for redundancy)</li>
+ *     <li>releasing idle task executors</li>
+ *     <li>tracking pending slots (expected slots from executors that are currently being allocated</li>
+ *     <li>tracking how many slots are used on each task executor</li>
+ * </ul>
  *
  * <p>Dev note: This component only exists to keep the code out of the slot manager.
  * It covers many aspects that aren't really the responsibility of the slot manager, and should be refactored to live

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * SlotManager component for all task executor related things.
+ *
+ * <p>Dev note: This component only exists to keep the code out of the slot manager.
+ * It covers many aspects that aren't really the responsibility of the slot manager, and should be refactored to live
+ * outside the slot manager and split into multiple parts.
+ */
+class TaskExecutorManager implements AutoCloseable {
+	private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorManager.class);
+
+	private final ResourceProfile defaultSlotResourceProfile;
+
+	/** The default resource spec of workers to request. */
+	private final WorkerResourceSpec defaultWorkerResourceSpec;
+
+	private final int numSlotsPerWorker;
+
+	/** Defines the max limitation of the total number of slots. */
+	private final int maxSlotNum;
+
+	/** Release task executor only when each produced result partition is either consumed or failed. */
+	private final boolean waitResultConsumedBeforeRelease;
+
+	/** Defines the number of redundant taskmanagers. */
+	private final int redundantTaskManagerNum;
+
+	/** Timeout after which an unused TaskManager is released. */
+	private final Time taskManagerTimeout;
+
+	/** Callbacks for resource (de-)allocations. */
+	private final ResourceActions resourceActions;
+
+	/** All currently registered task managers. */
+	private final Map<InstanceID, TaskManagerRegistration> taskManagerRegistrations = new HashMap<>();
+
+	private final Map<TaskManagerSlotId, PendingTaskManagerSlot> pendingSlots = new HashMap<>();
+
+	private final Executor mainThreadExecutor;
+
+	private final ScheduledFuture<?> taskManagerTimeoutsAndRedundancyCheck;
+
+	TaskExecutorManager(
+		WorkerResourceSpec defaultWorkerResourceSpec,
+		int numSlotsPerWorker,
+		int maxNumSlots,
+		boolean waitResultConsumedBeforeRelease,
+		int redundantTaskManagerNum,
+		Time taskManagerTimeout,
+		ScheduledExecutor scheduledExecutor,
+		Executor mainThreadExecutor,
+		ResourceActions resourceActions) {
+
+		this.defaultWorkerResourceSpec = defaultWorkerResourceSpec;
+		this.numSlotsPerWorker = numSlotsPerWorker;
+		this.maxSlotNum = maxNumSlots;
+		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
+		this.redundantTaskManagerNum = redundantTaskManagerNum;
+		this.taskManagerTimeout = taskManagerTimeout;
+		this.defaultSlotResourceProfile = generateDefaultSlotResourceProfile(defaultWorkerResourceSpec, numSlotsPerWorker);
+
+		this.resourceActions = Preconditions.checkNotNull(resourceActions);
+		this.mainThreadExecutor = mainThreadExecutor;
+		taskManagerTimeoutsAndRedundancyCheck = scheduledExecutor.scheduleWithFixedDelay(
+			() -> mainThreadExecutor.execute(
+				this::checkTaskManagerTimeoutsAndRedundancy),
+			0L,
+			taskManagerTimeout.toMilliseconds(),
+			TimeUnit.MILLISECONDS);
+	}
+
+	@VisibleForTesting
+	static ResourceProfile generateDefaultSlotResourceProfile(WorkerResourceSpec workerResourceSpec, int numSlotsPerWorker) {
+		return ResourceProfile.newBuilder()
+			.setCpuCores(workerResourceSpec.getCpuCores().divide(numSlotsPerWorker))
+			.setTaskHeapMemory(workerResourceSpec.getTaskHeapSize().divide(numSlotsPerWorker))
+			.setTaskOffHeapMemory(workerResourceSpec.getTaskOffHeapSize().divide(numSlotsPerWorker))
+			.setManagedMemory(workerResourceSpec.getManagedMemSize().divide(numSlotsPerWorker))
+			.setNetworkMemory(workerResourceSpec.getNetworkMemSize().divide(numSlotsPerWorker))
+			.build();
+	}
+
+	@Override
+	public void close() {
+		taskManagerTimeoutsAndRedundancyCheck.cancel(false);
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// TaskExecutor (un)registration
+	// ---------------------------------------------------------------------------------------------
+
+	public boolean isTaskManagerRegistered(InstanceID instanceId) {
+		return taskManagerRegistrations.containsKey(instanceId);
+	}
+
+	public boolean registerTaskManager(final TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport) {
+		if (isMaxSlotNumExceededAfterRegistration(initialSlotReport)) {
+			LOG.info("The total number of slots exceeds the max limitation {}, releasing the excess task executor.", maxSlotNum);
+			resourceActions.releaseResource(taskExecutorConnection.getInstanceID(), new FlinkException("The total number of slots exceeds the max limitation."));
+			return false;
+		}
+
+		TaskManagerRegistration taskManagerRegistration = new TaskManagerRegistration(
+			taskExecutorConnection,
+			StreamSupport.stream(initialSlotReport.spliterator(), false).map(SlotStatus::getSlotID).collect(Collectors.toList()));
+
+		taskManagerRegistrations.put(taskExecutorConnection.getInstanceID(), taskManagerRegistration);
+
+		// next register the new slots
+		for (SlotStatus slotStatus : initialSlotReport) {
+			if (slotStatus.getJobID() == null) {
+				findAndRemoveExactlyMatchingPendingTaskManagerSlot(slotStatus.getResourceProfile());
+			}
+		}
+
+		return true;
+	}
+
+	private boolean isMaxSlotNumExceededAfterRegistration(SlotReport initialSlotReport) {
+		// check if the total number exceed before matching pending slot.
+		if (!isMaxSlotNumExceededAfterAdding(initialSlotReport.getNumSlotStatus())) {
+			return false;
+		}
+
+		// check if the total number exceed slots after consuming pending slot.
+		return isMaxSlotNumExceededAfterAdding(getNumNonPendingReportedNewSlots(initialSlotReport));
+	}
+
+	private int getNumNonPendingReportedNewSlots(SlotReport slotReport) {
+		final Set<TaskManagerSlotId> matchingPendingSlots = new HashSet<>();
+
+		for (SlotStatus slotStatus : slotReport) {
+			for (PendingTaskManagerSlot pendingTaskManagerSlot : pendingSlots.values()) {
+				if (!matchingPendingSlots.contains(pendingTaskManagerSlot.getTaskManagerSlotId()) &&
+					isPendingSlotExactlyMatchingResourceProfile(pendingTaskManagerSlot, slotStatus.getResourceProfile())) {
+					matchingPendingSlots.add(pendingTaskManagerSlot.getTaskManagerSlotId());
+					break; // pendingTaskManagerSlot loop
+				}
+			}
+		}
+		return slotReport.getNumSlotStatus() - matchingPendingSlots.size();
+	}
+
+	private void findAndRemoveExactlyMatchingPendingTaskManagerSlot(ResourceProfile resourceProfile) {
+		for (PendingTaskManagerSlot pendingTaskManagerSlot : pendingSlots.values()) {
+			if (isPendingSlotExactlyMatchingResourceProfile(pendingTaskManagerSlot, resourceProfile)) {
+				pendingSlots.remove(pendingTaskManagerSlot.getTaskManagerSlotId());
+				return;
+			}
+		}
+	}
+
+	private boolean isPendingSlotExactlyMatchingResourceProfile(PendingTaskManagerSlot pendingTaskManagerSlot, ResourceProfile resourceProfile) {
+		return pendingTaskManagerSlot.getResourceProfile().equals(resourceProfile);
+	}
+
+	public void unregisterTaskExecutor(InstanceID instanceId) {
+		taskManagerRegistrations.remove(instanceId);
+	}
+
+	public Collection<InstanceID> getTaskExecutors() {
+		return new ArrayList<>(taskManagerRegistrations.keySet());
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// TaskExecutor allocation
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * Tries to allocate a worker that can provide a slot with the given resource profile.
+	 *
+	 * @param requestedSlotResourceProfile desired slot profile
+	 * @return an upper bound resource requirement that can be fulfilled by the new worker, if one was allocated
+	 */
+	public Optional<ResourceRequirement> allocateWorker(ResourceProfile requestedSlotResourceProfile) {
+		final int numRegisteredSlots = getNumberRegisteredSlots();
+		final int numPendingSlots = getNumberPendingTaskManagerSlots();
+		if (isMaxSlotNumExceededAfterAdding(numSlotsPerWorker)) {
+			LOG.warn("Could not allocate {} more slots. The number of registered and pending slots is {}, while the maximum is {}.",
+				numSlotsPerWorker, numPendingSlots + numRegisteredSlots, maxSlotNum);
+			return Optional.empty();
+		}
+
+		if (!defaultSlotResourceProfile.isMatching(requestedSlotResourceProfile)) {
+			// requested resource profile is unfulfillable
+			return Optional.empty();
+		}
+
+		if (!resourceActions.allocateResource(defaultWorkerResourceSpec)) {
+			// resource cannot be allocated
+			return Optional.empty();
+		}
+
+		for (int i = 0; i < numSlotsPerWorker; ++i) {
+			PendingTaskManagerSlot pendingTaskManagerSlot = new PendingTaskManagerSlot(defaultSlotResourceProfile);
+			pendingSlots.put(pendingTaskManagerSlot.getTaskManagerSlotId(), pendingTaskManagerSlot);
+		}
+
+		return Optional.of(ResourceRequirement.create(defaultSlotResourceProfile, numSlotsPerWorker));
+	}
+
+	private boolean isMaxSlotNumExceededAfterAdding(int numNewSlot) {
+		return getNumberRegisteredSlots() + getNumberPendingTaskManagerSlots() + numNewSlot > maxSlotNum;
+	}
+
+	public Map<WorkerResourceSpec, Integer> getRequiredWorkers() {
+		final int pendingWorkerNum = MathUtils.divideRoundUp(getNumberPendingTaskManagerSlots(), numSlotsPerWorker);
+		return pendingWorkerNum > 0 ?
+			Collections.singletonMap(defaultWorkerResourceSpec, pendingWorkerNum) :
+			Collections.emptyMap();
+	}
+
+	@VisibleForTesting
+	int getNumberPendingTaskManagerSlots() {
+		return pendingSlots.size();
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// TaskExecutor idleness / redundancy
+	// ---------------------------------------------------------------------------------------------
+
+	private void checkTaskManagerTimeoutsAndRedundancy() {
+		if (!taskManagerRegistrations.isEmpty()) {
+			long currentTime = System.currentTimeMillis();
+
+			ArrayList<TaskManagerRegistration> timedOutTaskManagers = new ArrayList<>(taskManagerRegistrations.size());
+
+			// first retrieve the timed out TaskManagers
+			for (TaskManagerRegistration taskManagerRegistration : taskManagerRegistrations.values()) {
+				if (currentTime - taskManagerRegistration.getIdleSince() >= taskManagerTimeout.toMilliseconds()) {
+					// we collect the instance ids first in order to avoid concurrent modifications by the
+					// ResourceActions.releaseResource call
+					timedOutTaskManagers.add(taskManagerRegistration);
+				}
+			}
+
+			int slotsDiff = redundantTaskManagerNum * numSlotsPerWorker - getNumberFreeSlots();
+			if (slotsDiff > 0) {
+				// Keep enough redundant taskManagers from time to time.
+				int requiredTaskManagers = MathUtils.divideRoundUp(slotsDiff, numSlotsPerWorker);
+				allocateRedundantTaskManagers(requiredTaskManagers);
+			} else {
+				// second we trigger the release resource callback which can decide upon the resource release
+				int maxReleaseNum = (-slotsDiff) / numSlotsPerWorker;
+				releaseIdleTaskExecutors(timedOutTaskManagers, Math.min(maxReleaseNum, timedOutTaskManagers.size()));
+			}
+		}
+	}
+
+	private void allocateRedundantTaskManagers(int number) {
+		LOG.debug("Allocating {} task executors for redundancy.", number);
+		int allocatedNumber = allocateWorkers(number);
+		if (number != allocatedNumber) {
+			LOG.warn("Expect to allocate {} taskManagers. Actually allocate {} taskManagers.", number, allocatedNumber);
+		}
+	}
+
+	/**
+	 * Allocate a number of workers based on the input param.
+	 *
+	 * @param workerNum the number of workers to allocate
+	 * @return the number of successfully allocated workers
+	 */
+	private int allocateWorkers(int workerNum) {
+		int allocatedWorkerNum = 0;
+		for (int i = 0; i < workerNum; ++i) {
+			if (allocateWorker(defaultSlotResourceProfile).isPresent()) {
+				++allocatedWorkerNum;
+			} else {
+				break;
+			}
+		}
+		return allocatedWorkerNum;
+	}
+
+	private void releaseIdleTaskExecutors(ArrayList<TaskManagerRegistration> timedOutTaskManagers, int releaseNum) {
+		for (int index = 0; index < releaseNum; ++index) {
+			if (waitResultConsumedBeforeRelease) {
+				releaseIdleTaskExecutorIfPossible(timedOutTaskManagers.get(index));
+			} else {
+				releaseIdleTaskExecutor(timedOutTaskManagers.get(index).getInstanceId());
+			}
+		}
+	}
+
+	private void releaseIdleTaskExecutorIfPossible(TaskManagerRegistration taskManagerRegistration) {
+		long idleSince = taskManagerRegistration.getIdleSince();
+		taskManagerRegistration
+			.getTaskManagerConnection()
+			.getTaskExecutorGateway()
+			.canBeReleased()
+			.thenAcceptAsync(
+				canBeReleased -> {
+					InstanceID timedOutTaskManagerId = taskManagerRegistration.getInstanceId();
+					boolean stillIdle = idleSince == taskManagerRegistration.getIdleSince();
+					if (stillIdle && canBeReleased) {
+						releaseIdleTaskExecutor(timedOutTaskManagerId);
+					}
+				},
+				mainThreadExecutor);
+	}
+
+	private void releaseIdleTaskExecutor(InstanceID timedOutTaskManagerId) {
+		final FlinkException cause = new FlinkException("TaskExecutor exceeded the idle timeout.");
+		LOG.debug("Release TaskExecutor {} because it exceeded the idle timeout.", timedOutTaskManagerId);
+		resourceActions.releaseResource(timedOutTaskManagerId, cause);
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// slot / resource counts
+	// ---------------------------------------------------------------------------------------------
+
+	public ResourceProfile getTotalRegisteredResources() {
+		return getResourceFromNumSlots(getNumberRegisteredSlots());
+	}
+
+	public ResourceProfile getTotalRegisteredResourcesOf(InstanceID instanceID) {
+		return getResourceFromNumSlots(getNumberRegisteredSlotsOf(instanceID));
+	}
+
+	public ResourceProfile getTotalFreeResources() {
+		return getResourceFromNumSlots(getNumberFreeSlots());
+	}
+
+	public ResourceProfile getTotalFreeResourcesOf(InstanceID instanceID) {
+		return getResourceFromNumSlots(getNumberFreeSlotsOf(instanceID));
+	}
+
+	private ResourceProfile getResourceFromNumSlots(int numSlots) {
+		if (numSlots < 0 || defaultSlotResourceProfile == null) {
+			return ResourceProfile.UNKNOWN;
+		} else {
+			return defaultSlotResourceProfile.multiply(numSlots);
+		}
+	}
+
+	public Iterable<SlotID> getSlotsOf(InstanceID instanceId) {
+		return taskManagerRegistrations.get(instanceId).getSlots();
+	}
+
+	public int getNumberRegisteredSlots() {
+		return taskManagerRegistrations.values().stream()
+			.map(TaskManagerRegistration::getNumberRegisteredSlots)
+			.reduce(0, Integer::sum);
+	}
+
+	public int getNumberRegisteredSlotsOf(InstanceID instanceId) {
+		TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(instanceId);
+
+		if (taskManagerRegistration != null) {
+			return taskManagerRegistration.getNumberRegisteredSlots();
+		} else {
+			return 0;
+		}
+	}
+
+	public int getNumberFreeSlots() {
+		return taskManagerRegistrations.values().stream().map(TaskManagerRegistration::getNumberFreeSlots).reduce(0, Integer::sum);
+	}
+
+	public int getNumberFreeSlotsOf(InstanceID instanceId) {
+		TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(instanceId);
+
+		if (taskManagerRegistration != null) {
+			return taskManagerRegistration.getNumberFreeSlots();
+		} else {
+			return 0;
+		}
+	}
+
+	public Collection<PendingTaskManagerSlot> getPendingTaskManagerSlots() {
+		return pendingSlots.values();
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// TaskExecutor slot book-keeping
+	// ---------------------------------------------------------------------------------------------
+
+	public void occupySlot(InstanceID instanceId) {
+		taskManagerRegistrations.get(instanceId).occupySlot();
+	}
+
+	public void freeSlot(InstanceID instanceId) {
+		taskManagerRegistrations.get(instanceId).freeSlot();
+	}
+
+	public void markUsed(InstanceID instanceID) {
+		taskManagerRegistrations.get(instanceID).markUsed();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Builder for {@link TaskExecutorManager}.
+ */
+public class TaskExecutorManagerBuilder {
+	private WorkerResourceSpec defaultWorkerResourceSpec = new WorkerResourceSpec.Builder().setCpuCores(4).build();
+	private int numSlotsPerWorker = 1;
+	private int maxSlotNum = 1;
+	private boolean waitResultConsumedBeforeRelease = true;
+	private int redundantTaskManagerNum = 0;
+	private Time taskManagerTimeout = Time.seconds(5);
+	private ScheduledExecutor scheduledExecutor = TestingUtils.defaultScheduledExecutor();
+	private Executor mainThreadExecutor = Executors.directExecutor();
+	private ResourceActions newResourceActions = new TestingResourceActionsBuilder().build();
+
+	public TaskExecutorManagerBuilder setDefaultWorkerResourceSpec(WorkerResourceSpec defaultWorkerResourceSpec) {
+		this.defaultWorkerResourceSpec = defaultWorkerResourceSpec;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setNumSlotsPerWorker(int numSlotsPerWorker) {
+		this.numSlotsPerWorker = numSlotsPerWorker;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setMaxNumSlots(int maxSlotNum) {
+		this.maxSlotNum = maxSlotNum;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setWaitResultConsumedBeforeRelease(boolean waitResultConsumedBeforeRelease) {
+		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setRedundantTaskManagerNum(int redundantTaskManagerNum) {
+		this.redundantTaskManagerNum = redundantTaskManagerNum;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setTaskManagerTimeout(Time taskManagerTimeout) {
+		this.taskManagerTimeout = taskManagerTimeout;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setScheduledExecutor(ScheduledExecutor scheduledExecutor) {
+		this.scheduledExecutor = scheduledExecutor;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setMainThreadExecutor(Executor mainThreadExecutor) {
+		this.mainThreadExecutor = mainThreadExecutor;
+		return this;
+	}
+
+	public TaskExecutorManagerBuilder setResourceActions(ResourceActions newResourceActions) {
+		this.newResourceActions = newResourceActions;
+		return this;
+	}
+
+	public TaskExecutorManager createTaskExecutorManager() {
+		return new TaskExecutorManager(defaultWorkerResourceSpec, numSlotsPerWorker, maxSlotNum, waitResultConsumedBeforeRelease, redundantTaskManagerNum, taskManagerTimeout, scheduledExecutor, mainThreadExecutor, newResourceActions);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
@@ -120,7 +120,7 @@ public class TaskExecutorManagerTest extends TestLogger {
 	 * <p>See FLINK-7793
 	 */
 	@Test
-	public void testTaskManagerTimeoutDoesNotRemoveSlots1() throws Exception {
+	public void testTaskManagerTimeoutDoesNotRemoveSlots() throws Exception {
 		final Time taskManagerTimeout = Time.milliseconds(10L);
 
 		final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link TaskExecutorManager}.
+ */
+public class TaskExecutorManagerTest extends TestLogger {
+
+	/**
+	 * Tests that a pending slot is only fulfilled by an exactly matching received slot.
+	 */
+	@Test
+	public void testPendingSlotNotFulfilledIfProfilesAreNotExactMatch() {
+		final int numWorkerCpuCores = 3;
+		final WorkerResourceSpec workerResourceSpec = new WorkerResourceSpec.Builder().setCpuCores(numWorkerCpuCores).build();
+		final ResourceProfile requestedSlotProfile = ResourceProfile.newBuilder().setCpuCores(numWorkerCpuCores).build();
+		final ResourceProfile offeredSlotProfile = ResourceProfile.newBuilder().setCpuCores(numWorkerCpuCores - 1).build();
+
+		try (final TaskExecutorManager taskExecutorManager = createTaskExecutorManagerBuilder()
+			.setDefaultWorkerResourceSpec(workerResourceSpec)
+			.setNumSlotsPerWorker(1) // set to one so that the slot profiles directly correspond to the worker spec
+			.setMaxNumSlots(2)
+			.createTaskExecutorManager()) {
+
+			// create pending slot
+			taskExecutorManager.allocateWorker(requestedSlotProfile);
+			assertThat(taskExecutorManager.getNumberPendingTaskManagerSlots(), is(1));
+
+			createAndRegisterTaskExecutor(taskExecutorManager, 1, offeredSlotProfile);
+
+			// the slot from the task executor should be accepted, but we should still be waiting for the originally requested slot
+			assertThat(taskExecutorManager.getNumberRegisteredSlots(), is(1));
+			assertThat(taskExecutorManager.getNumberPendingTaskManagerSlots(), is(1));
+		}
+	}
+
+	/**
+	 * Tests that a pending slot is not fulfilled by an already allocated slot.
+	 */
+	@Test
+	public void testPendingSlotNotFulfilledByAllocatedSlot() {
+		final int numWorkerCpuCores = 3;
+		final WorkerResourceSpec workerResourceSpec = new WorkerResourceSpec.Builder().setCpuCores(numWorkerCpuCores).build();
+		final ResourceProfile requestedSlotProfile = ResourceProfile.newBuilder().setCpuCores(numWorkerCpuCores).build();
+
+		try (final TaskExecutorManager taskExecutorManager = createTaskExecutorManagerBuilder()
+			.setDefaultWorkerResourceSpec(workerResourceSpec)
+			.setNumSlotsPerWorker(1) // set to one so that the slot profiles directly correspond to the worker spec
+			.setMaxNumSlots(2)
+			.createTaskExecutorManager()) {
+
+			// create pending slot
+			taskExecutorManager.allocateWorker(requestedSlotProfile);
+			assertThat(taskExecutorManager.getNumberPendingTaskManagerSlots(), is(1));
+
+			final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
+			final SlotReport slotReport = new SlotReport(
+				new SlotStatus(
+					new SlotID(taskExecutorConnection.getResourceID(), 0),
+					requestedSlotProfile,
+					JobID.generate(),
+					new AllocationID()));
+			taskExecutorManager.registerTaskManager(taskExecutorConnection, slotReport);
+
+			// the slot from the task executor should be accepted, but we should still be waiting for the originally requested slot
+			assertThat(taskExecutorManager.getNumberRegisteredSlots(), is(1));
+			assertThat(taskExecutorManager.getNumberPendingTaskManagerSlots(), is(1));
+		}
+	}
+
+	/**
+	 * Tests that a task manager timeout does not remove the slots from the SlotManager.
+	 * A timeout should only trigger the {@link ResourceActions#releaseResource(InstanceID, Exception)}
+	 * callback. The receiver of the callback can then decide what to do with the TaskManager.
+	 *
+	 * <p>See FLINK-7793
+	 */
+	@Test
+	public void testTaskManagerTimeoutDoesNotRemoveSlots1() throws Exception {
+		final Time taskManagerTimeout = Time.milliseconds(10L);
+
+		final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
+		final ResourceActions resourceActions = createResourceActionsBuilder()
+			.setReleaseResourceConsumer((instanceId, ignored) -> releaseResourceFuture.complete(instanceId))
+			.build();
+
+		final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
+
+		try (final TaskExecutorManager taskExecutorManager = createTaskExecutorManagerBuilder()
+			.setTaskManagerTimeout(taskManagerTimeout)
+			.setResourceActions(resourceActions)
+			.setMainThreadExecutor(mainThreadExecutor)
+			.createTaskExecutorManager()) {
+
+			CompletableFuture.supplyAsync(
+				() -> {
+					InstanceID newTaskExecutorId = createAndRegisterTaskExecutor(taskExecutorManager, 1, ResourceProfile.ANY);
+					assertEquals(1, taskExecutorManager.getNumberRegisteredSlots());
+					return newTaskExecutorId;
+				},
+				mainThreadExecutor)
+				// wait for the timeout to occur
+				.thenCombine(releaseResourceFuture, (registeredInstance, releasedInstance) -> {
+					assertThat(registeredInstance, is(releasedInstance));
+					assertEquals(1, taskExecutorManager.getNumberRegisteredSlots());
+					return registeredInstance;
+				})
+				.thenAccept(taskExecutorId -> {
+					taskExecutorManager.unregisterTaskExecutor(taskExecutorId);
+					assertEquals(0, taskExecutorManager.getNumberRegisteredSlots());
+				})
+				.get();
+		}
+	}
+
+	/**
+	 * Tests that formerly used task managers can timeout after all of their slots have been freed.
+	 */
+	@Test
+	public void testTimeoutForUnusedTaskManager() throws Exception {
+		WorkerResourceSpec workerResourceSpec = new WorkerResourceSpec.Builder().setCpuCores(1).build();
+		final ResourceProfile resourceProfile = ResourceProfile.newBuilder().setCpuCores(1).build();
+		final Time taskManagerTimeout = Time.milliseconds(50L);
+
+		final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
+			.setReleaseResourceConsumer((instanceID, e) -> releaseResourceFuture.complete(instanceID))
+			.build();
+
+		final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
+
+		try (final TaskExecutorManager taskExecutorManager = createTaskExecutorManagerBuilder()
+			.setTaskManagerTimeout(taskManagerTimeout)
+			.setDefaultWorkerResourceSpec(workerResourceSpec)
+			.setResourceActions(resourceManagerActions)
+			.setMainThreadExecutor(mainThreadExecutor)
+			.createTaskExecutorManager()) {
+
+			CompletableFuture.supplyAsync(() -> {
+					taskExecutorManager.allocateWorker(resourceProfile);
+					InstanceID taskExecutorId = createAndRegisterTaskExecutor(taskExecutorManager, 1, resourceProfile);
+
+					taskExecutorManager.occupySlot(taskExecutorId);
+					taskExecutorManager.freeSlot(taskExecutorId);
+
+					return taskExecutorId;
+				},
+				mainThreadExecutor)
+				// wait for the timeout to occur
+				.thenAcceptBoth(releaseResourceFuture, (registeredInstance, releasedInstance) -> assertThat(registeredInstance, is(releasedInstance)))
+				.get();
+		}
+	}
+
+	/**
+	 * Test that the task executor manager respects the max limitation of the number of slots when allocating new resources.
+	 */
+	@Test
+	public void testMaxSlotLimitAllocateResource() {
+		final int numberSlots = 1;
+		final int maxSlotNum = 1;
+
+		final AtomicInteger resourceRequests = new AtomicInteger(0);
+		ResourceActions resourceActions = createResourceActionsBuilder()
+			.setAllocateResourceFunction(
+				ignored -> {
+					resourceRequests.incrementAndGet();
+					return true;
+				})
+			.build();
+
+		try (final TaskExecutorManager taskExecutorManager = createTaskExecutorManagerBuilder()
+			.setNumSlotsPerWorker(numberSlots)
+			.setMaxNumSlots(maxSlotNum)
+			.setResourceActions(resourceActions)
+			.createTaskExecutorManager()) {
+
+			assertThat(resourceRequests.get(), is(0));
+
+			taskExecutorManager.allocateWorker(ResourceProfile.UNKNOWN);
+			assertThat(resourceRequests.get(), is(1));
+
+			taskExecutorManager.allocateWorker(ResourceProfile.UNKNOWN);
+			assertThat(resourceRequests.get(), is(1));
+		}
+	}
+
+	/**
+	 * Test that the slot manager release resource when the number of slots exceed max limit when new TaskExecutor registered.
+	 */
+	@Test
+	public void testMaxSlotLimitRegisterResource() throws Exception {
+		final int numberSlots = 1;
+		final int maxSlotNum = 1;
+
+		final CompletableFuture<InstanceID> releasedResourceFuture = new CompletableFuture<>();
+		ResourceActions resourceActions = createResourceActionsBuilder()
+			.setReleaseResourceConsumer((instanceID, e) -> releasedResourceFuture.complete(instanceID))
+			.build();
+
+		try (final TaskExecutorManager taskExecutorManager = createTaskExecutorManagerBuilder()
+			.setNumSlotsPerWorker(numberSlots)
+			.setMaxNumSlots(maxSlotNum)
+			.setResourceActions(resourceActions)
+			.createTaskExecutorManager()) {
+
+			createAndRegisterTaskExecutor(taskExecutorManager, 1, ResourceProfile.ANY);
+			InstanceID rejectedTaskExecutorId = createAndRegisterTaskExecutor(taskExecutorManager, 1, ResourceProfile.ANY);
+
+			assertThat(releasedResourceFuture.get(), is(rejectedTaskExecutorId));
+		}
+	}
+
+	@Test
+	public void testGenerateDefaultSlotProfile() {
+		final int numSlots = 5;
+		final ResourceProfile resourceProfile = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(1)
+			.setTaskOffHeapMemoryMB(2)
+			.setNetworkMemoryMB(3)
+			.setManagedMemoryMB(4)
+			.build();
+		final WorkerResourceSpec workerResourceSpec = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0 * numSlots)
+			.setTaskHeapMemoryMB(1 * numSlots)
+			.setTaskOffHeapMemoryMB(2 * numSlots)
+			.setNetworkMemoryMB(3 * numSlots)
+			.setManagedMemoryMB(4 * numSlots)
+			.build();
+
+		assertThat(
+			TaskExecutorManager.generateDefaultSlotResourceProfile(workerResourceSpec, numSlots),
+			is(resourceProfile));
+	}
+
+	private static TaskExecutorManagerBuilder createTaskExecutorManagerBuilder() {
+		return new TaskExecutorManagerBuilder()
+			.setResourceActions(createResourceActionsBuilder().build());
+	}
+
+	private static TestingResourceActionsBuilder createResourceActionsBuilder() {
+		return new TestingResourceActionsBuilder()
+			// ensures we do something when excess resource are requested
+			.setAllocateResourceFunction(ignored -> true);
+	}
+
+	private static InstanceID createAndRegisterTaskExecutor(TaskExecutorManager taskExecutorManager, int numSlots, ResourceProfile resourceProfile) {
+		final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
+
+		List<SlotStatus> slotStatuses = IntStream.range(0, numSlots)
+			.mapToObj(slotNumber -> new SlotStatus(
+				new SlotID(taskExecutorConnection.getResourceID(), slotNumber),
+				resourceProfile))
+			.collect(Collectors.toList());
+
+		final SlotReport slotReport = new SlotReport(slotStatuses);
+
+		taskExecutorManager.registerTaskManager(taskExecutorConnection, slotReport);
+
+		return taskExecutorConnection.getInstanceID();
+	}
+
+	private static TaskExecutorConnection createTaskExecutorConnection() {
+		return new TaskExecutorConnection(
+			ResourceID.generate(),
+			new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
+	}
+}


### PR DESCRIPTION
Adds the `TaskExecutorManager` (TEM), a component of the new declarative slot manager handling all task executor related things, including bookkeeping of active task executors, allocation of new workers, idleness checks, _and more_.

While this sounds sophisticated, it really isn't. The TEM was created by literally ripping out all the task executor stuff from the slot manager and dumping it into this class. Some log messages and method names were adjusted though.

The main purpose of this class is to keep all this stuff out of the slot manager; there are a fair number of things in there that the slot manager shouldn't deal with, but the current distribution of responsibilities (that we have to maintain to be compatible with the RM) does not allow us to change it. This component is a compromise of sorts. It _must_ be refactored in the future.

On the testing side things don't look any better; there were some tests for the slot manager that were only covering behaviors of the (now existing) TEM, and were moved to work directly against the TEM, which is essentially it.

Any person brave enough to glare at this PR is advised to take a peek at [this branch](https://github.com/tillrohrmann/flink/blob/declarative-resource-management/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java) to see how the new slot manager interacts with the TEM.