### PR TITLE
[FLINK-19486] Make "Unexpected State Handle" Exception more helpful

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.util.LambdaUtil;
 
+import org.apache.flink.shaded.guava18.com.google.common.base.Joiner;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,5 +89,37 @@ public class StateUtil {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Creates an {@link RuntimeException} that signals that an operation did not get the type of
+	 * {@link StateObject} that was expected. This can mostly happen when a different {@link
+	 * StateBackend} from the one that was used for taking a checkpoint/savepoint is used when
+	 * restoring.
+	 */
+	@SuppressWarnings("unchecked")
+	public static RuntimeException unexpectedStateHandleException(
+			Class<? extends StateObject> expectedStateHandleClass,
+			Class<? extends StateObject> actualStateHandleClass) {
+		return unexpectedStateHandleException(
+				new Class[]{expectedStateHandleClass},
+				actualStateHandleClass);
+	}
+
+	/**
+	 * Creates a {@link RuntimeException} that signals that an operation did not get the type of
+	 * {@link StateObject} that was expected. This can mostly happen when a different {@link
+	 * StateBackend} from the one that was used for taking a checkpoint/savepoint is used when
+	 * restoring.
+	 */
+	public static RuntimeException unexpectedStateHandleException(
+			Class<? extends StateObject>[] expectedStateHandleClasses,
+			Class<? extends StateObject> actualStateHandleClass) {
+
+		return new IllegalStateException("Unexpected state handle type, expected one of: " +
+				Joiner.on(", ").join(expectedStateHandleClasses)
+				+ ", but found: " + actualStateHandleClass + ". "
+				+ "This can mostly happen when a different StateBackend from the one "
+				+ "that was used for taking a checkpoint/savepoint is used when restoring.");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -42,7 +42,7 @@ public class StateUtil {
 	}
 
 	/**
-	 * Returns the size of a state object
+	 * Returns the size of a state object.
 	 *
 	 * @param handle The handle to the retrieved state
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.state.heap;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
@@ -45,6 +44,8 @@ import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
+import org.apache.commons.io.IOUtils;
+
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
@@ -54,6 +55,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.flink.runtime.state.StateUtil.unexpectedStateHandleException;
 
 /**
  * Implementation of heap restore operation.
@@ -115,9 +118,7 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 			}
 
 			if (!(keyedStateHandle instanceof KeyGroupsStateHandle)) {
-				throw new IllegalStateException("Unexpected state handle type, " +
-					"expected: " + KeyGroupsStateHandle.class +
-					", but found: " + keyedStateHandle.getClass());
+				throw unexpectedStateHandleException(KeyGroupsStateHandle.class, keyedStateHandle.getClass());
 			}
 
 			KeyGroupsStateHandle keyGroupsStateHandle = (KeyGroupsStateHandle) keyedStateHandle;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link StateUtil}.
+ */
+public class StateUtilTest {
+
+	@Test
+	public void unexpectedStateExceptionForSingleExpectedType() {
+		Exception exception = StateUtil.unexpectedStateHandleException(
+				KeyGroupsStateHandle.class,
+				KeyGroupsStateHandle.class);
+
+		assertThat(
+				exception.getMessage(),
+				containsString(
+						"Unexpected state handle type, expected one of: class org.apache.flink.runtime.state.KeyGroupsStateHandle, but found: class org.apache.flink.runtime.state.KeyGroupsStateHandle. This can mostly happen when a different StateBackend from the one that was used for taking a checkpoint/savepoint is used when restoring."));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void unexpectedStateExceptionForMultipleExpectedTypes() {
+		Exception exception = StateUtil.unexpectedStateHandleException(
+				new Class[]{KeyGroupsStateHandle.class, KeyGroupsStateHandle.class},
+				KeyGroupsStateHandle.class);
+
+		assertThat(
+				exception.getMessage(),
+				containsString(
+						"Unexpected state handle type, expected one of: class org.apache.flink.runtime.state.KeyGroupsStateHandle, class org.apache.flink.runtime.state.KeyGroupsStateHandle, but found: class org.apache.flink.runtime.state.KeyGroupsStateHandle. This can mostly happen when a different StateBackend from the one that was used for taking a checkpoint/savepoint is used when restoring."));
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
@@ -62,6 +62,7 @@ import java.util.function.Function;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.END_OF_KEY_GROUP_MARK;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.clearMetaDataFollowsFlag;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.hasMetaDataFollowsFlag;
+import static org.apache.flink.runtime.state.StateUtil.unexpectedStateHandleException;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
@@ -143,9 +144,7 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
 			if (keyedStateHandle != null) {
 
 				if (!(keyedStateHandle instanceof KeyGroupsStateHandle)) {
-					throw new IllegalStateException("Unexpected state handle type, " +
-						"expected: " + KeyGroupsStateHandle.class +
-						", but found: " + keyedStateHandle.getClass());
+					throw unexpectedStateHandleException(KeyGroupsStateHandle.class, keyedStateHandle.getClass());
 				}
 				this.currentKeyGroupsStateHandle = (KeyGroupsStateHandle) keyedStateHandle;
 				restoreKeyGroupsInStateHandle();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -62,6 +62,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import static org.apache.flink.runtime.state.StateUtil.unexpectedStateHandleException;
+
 /**
  * This class is the main implementation of a {@link StreamTaskStateInitializer}. This class obtains the state to create
  * {@link StreamOperatorStateContext} objects for stream operators from the {@link TaskStateManager} of the task that
@@ -550,9 +552,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 			if (keyedStateHandle instanceof KeyGroupsStateHandle) {
 				keyGroupsStateHandles.add((KeyGroupsStateHandle) keyedStateHandle);
 			} else if (keyedStateHandle != null) {
-				throw new IllegalStateException("Unexpected state handle type, " +
-					"expected: " + KeyGroupsStateHandle.class +
-					", but found: " + keyedStateHandle.getClass() + ".");
+				throw unexpectedStateHandleException(KeyGroupsStateHandle.class, keyedStateHandle.getClass());
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

We now point out what might be the most likely cause for the exception.
In addition, we remove a lot of code duplication.

## Verifying this change

I added a new test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no