### PR TITLE
[FLINK-14406][runtime] Exposes managed memory usage through the REST API

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -861,7 +861,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>                                                         
   <tbody>                                                          
     <tr>                                                           
-      <th rowspan="15"><strong>Job-/TaskManager</strong></th>
+      <th rowspan="17"><strong>Job-/TaskManager</strong></th>
       <td rowspan="15">Status.JVM.Memory</td>
       <td>Heap.Used</td>
       <td>The amount of heap memory currently used (in bytes).</td>
@@ -936,7 +936,18 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Mapped.TotalCapacity</td>
       <td>The number of buffers in the mapped buffer pool (in bytes).</td>
       <td>Gauge</td>
-    </tr>                                                         
+    </tr>
+    <tr>
+      <td rowspan="2">Status.Flink.Memory</td>
+      <td>Managed.Used</td>
+      <td>The amount of managed memory currently used.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Managed.Total</td>
+      <td>The total amount of managed memory.</td>
+      <td>Gauge</td>
+    </tr>
   </tbody>                                                         
 </table>
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -860,7 +860,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-      <th rowspan="15"><strong>Job-/TaskManager</strong></th>
+      <th rowspan="17"><strong>Job-/TaskManager</strong></th>
       <td rowspan="15">Status.JVM.Memory</td>
       <td>Heap.Used</td>
       <td>The amount of heap memory currently used (in bytes).</td>
@@ -934,6 +934,17 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
     <tr>
       <td>Mapped.TotalCapacity</td>
       <td>The number of buffers in the mapped buffer pool (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Status.Flink.Memory</td>
+      <td>Managed.Used</td>
+      <td>The amount of managed memory currently used.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Managed.Total</td>
+      <td>The total amount of managed memory.</td>
       <td>Gauge</td>
     </tr>
   </tbody>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -579,7 +579,7 @@ public class MemoryManager {
 	}
 
 	/**
-	 * Returns the available amount of the certain type of memory handled by this memory manager.
+	 * Returns the available amount of memory handled by this memory manager.
 	 *
 	 * @return The available amount of memory.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -26,7 +26,9 @@ import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
@@ -35,6 +37,8 @@ import org.apache.flink.runtime.metrics.groups.ProcessMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
+import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -57,10 +61,12 @@ import java.lang.management.ThreadMXBean;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.metrics.util.SystemResourcesMetricsInitializer.instantiateSystemMetrics;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Utility class to register pre-defined metric sets.
@@ -73,6 +79,15 @@ public class MetricUtils {
 	static final String METRIC_GROUP_HEAP_NAME = "Heap";
 	static final String METRIC_GROUP_NONHEAP_NAME = "NonHeap";
 	static final String METRIC_GROUP_METASPACE_NAME = "Metaspace";
+
+	@VisibleForTesting
+	static final String METRIC_GROUP_FLINK = "Flink";
+
+	@VisibleForTesting
+	static final String METRIC_GROUP_MEMORY = "Memory";
+
+	@VisibleForTesting
+	static final String METRIC_GROUP_MANAGED_MEMORY = "Managed";
 
 	private MetricUtils() {
 	}
@@ -131,9 +146,48 @@ public class MetricUtils {
 
 		instantiateClassLoaderMetrics(jvm.addGroup("ClassLoader"));
 		instantiateGarbageCollectorMetrics(jvm.addGroup("GarbageCollector"));
-		instantiateMemoryMetrics(jvm.addGroup("Memory"));
+		instantiateMemoryMetrics(jvm.addGroup(METRIC_GROUP_MEMORY));
 		instantiateThreadMetrics(jvm.addGroup("Threads"));
 		instantiateCPUMetrics(jvm.addGroup("CPU"));
+	}
+
+	public static void instantiateFlinkMemoryMetricGroup(
+			MetricGroup parentMetricGroup,
+			TaskSlotTable<?> taskSlotTable,
+			Supplier<Long> managedMemoryTotalSupplier) {
+		checkNotNull(parentMetricGroup);
+		checkNotNull(taskSlotTable);
+		checkNotNull(managedMemoryTotalSupplier);
+
+		MetricGroup flinkMemoryMetricGroup = parentMetricGroup.addGroup(METRIC_GROUP_FLINK).addGroup(METRIC_GROUP_MEMORY);
+
+		instantiateManagedMemoryMetrics(flinkMemoryMetricGroup, taskSlotTable, managedMemoryTotalSupplier);
+	}
+
+	private static void instantiateManagedMemoryMetrics(
+			MetricGroup metricGroup,
+			TaskSlotTable<?> taskSlotTable,
+			Supplier<Long> managedMemoryTotalSupplier) {
+		MetricGroup managedMemoryMetricGroup = metricGroup.addGroup(METRIC_GROUP_MANAGED_MEMORY);
+
+		managedMemoryMetricGroup.gauge("Used", () -> getUsedManagedMemory(taskSlotTable));
+		managedMemoryMetricGroup.gauge("Total", managedMemoryTotalSupplier::get);
+	}
+
+	private static long getUsedManagedMemory(TaskSlotTable<?> taskSlotTable) {
+		Set<AllocationID> activeTaskAllocationIds = taskSlotTable.getActiveTaskSlotAllocationIds();
+
+		long usedMemory = 0L;
+		for (AllocationID allocationID : activeTaskAllocationIds) {
+			try {
+				MemoryManager taskSlotMemoryManager = taskSlotTable.getTaskMemoryManager(allocationID);
+				usedMemory += taskSlotMemoryManager.getMemorySize() - taskSlotMemoryManager.availableMemory();
+			} catch (SlotNotFoundException e) {
+				LOG.debug("The task slot {} is not present anymore and will be ignored in calculating the amount of used memory.", allocationID);
+			}
+		}
+
+		return usedMemory;
 	}
 
 	public static RpcService startRemoteMetricsRpcService(Configuration configuration, String hostname) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1427,7 +1427,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		// 2. Move the active slots to state allocated (possible to time out again)
-		Set<AllocationID> activeSlotAllocationIDs = taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId);
+		Set<AllocationID> activeSlotAllocationIDs = taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId);
 
 		final FlinkException freeingCause = new FlinkException("Slot could not be marked inactive.");
 
@@ -1696,7 +1696,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	}
 
 	private void freeNoLongerUsedSlots(AllocatedSlotReport allocatedSlotReport) {
-		final Set<AllocationID> activeSlots = taskSlotTable.getActiveTaskAllocationIdsPerJob(allocatedSlotReport.getJobId());
+		final Set<AllocationID> activeSlots = taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(allocatedSlotReport.getJobId());
 		final Set<AllocationID> reportedSlots = allocatedSlotReport.getAllocatedSlotInfos().stream()
 				.map(AllocatedSlotInfo::getAllocationId).collect(Collectors.toSet());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -398,6 +398,11 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			ioExecutor,
 			fatalErrorHandler);
 
+		MetricUtils.instantiateFlinkMemoryMetricGroup(
+			taskManagerMetricGroup.f1,
+			taskManagerServices.getTaskSlotTable(),
+			taskManagerServices::getManagedMemorySize);
+
 		TaskManagerConfiguration taskManagerConfiguration =
 			TaskManagerConfiguration.fromConfiguration(configuration, taskExecutorResourceSpec, externalAddress);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -113,7 +113,7 @@ public class TaskManagerServices {
 	//  Getter/Setter
 	// --------------------------------------------------------------------------------------------
 
-	long getManagedMemorySize() {
+	public long getManagedMemorySize() {
 		return managedMemorySize;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -63,6 +63,12 @@ public interface TaskSlotTable<T extends TaskSlotPayload> extends TimeoutListene
 	Set<AllocationID> getAllocationIdsPerJob(JobID jobId);
 
 	/**
+	 * Returns the {@link AllocationID} of any active task listed in this {@code TaskSlotTable}.
+	 * @return The {@code AllocationID} of any active task.
+	 */
+	Set<AllocationID> getActiveTaskSlotAllocationIds();
+
+	/**
 	 * Returns the {@link AllocationID} of active {@link TaskSlot}s attached to the job with the given {@link JobID}.
 	 *
 	 * @param jobId The {@code JobID} of the job for which the {@code AllocationID}s of the attached active

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -75,7 +75,7 @@ public interface TaskSlotTable<T extends TaskSlotPayload> extends TimeoutListene
 	 * {@link TaskSlot}s shall be returned.
 	 * @return A set of {@code AllocationID}s that belong to active {@code TaskSlot}s having the passed {@code JobID}.
 	 */
-	Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId);
+	Set<AllocationID> getActiveTaskSlotAllocationIdsPerJob(JobID jobId);
 
 	SlotReport createSlotReport(ResourceID resourceId);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
@@ -207,7 +207,7 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
 	}
 
 	@Override
-	public Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId) {
+	public Set<AllocationID> getActiveTaskSlotAllocationIdsPerJob(JobID jobId) {
 		return createAllocationIdSet(new TaskSlotIterator(jobId, TaskSlotState.ACTIVE));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/UnsafeMemoryBudgetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/UnsafeMemoryBudgetTest.java
@@ -37,6 +37,18 @@ public class UnsafeMemoryBudgetTest extends TestLogger {
 	}
 
 	@Test
+	public void testAvailableMemory() throws MemoryReservationException {
+		UnsafeMemoryBudget budget = createUnsafeMemoryBudget();
+		assertThat(budget.getAvailableMemorySize(), is(100L));
+
+		budget.reserveMemory(10L);
+		assertThat(budget.getAvailableMemorySize(), is(90L));
+
+		budget.releaseMemory(10L);
+		assertThat(budget.getAvailableMemorySize(), is(100L));
+	}
+
+	@Test
 	public void testReserveMemory() throws MemoryReservationException {
 		UnsafeMemoryBudget budget = createUnsafeMemoryBudget();
 		budget.reserveMemory(50L);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -152,30 +151,6 @@ public class MetricUtilsTest extends TestLogger {
 			Thread.sleep(50);
 		}
 		Assert.fail("Heap usage metric never changed it's value.");
-	}
-
-	@Test
-	public void testNonHeapMetricUsageNotStatic() throws InterruptedException {
-		final InterceptingOperatorMetricGroup nonHeapMetrics = new InterceptingOperatorMetricGroup();
-
-		MetricUtils.instantiateNonHeapMemoryMetrics(nonHeapMetrics);
-
-		@SuppressWarnings("unchecked")
-		final Gauge<Long> used = (Gauge<Long>) nonHeapMetrics.get(MetricNames.MEMORY_USED);
-
-		final long usedNonHeapInitially = used.getValue();
-
-		// check memory usage difference multiple times since other tests may affect memory usage as well
-		for (int x = 0; x < 10; x++) {
-			final ByteBuffer tmpByteBuffer = ByteBuffer.allocateDirect(1024 * 1024 * 8);
-			final long usedNonHeapAfterAllocation = used.getValue();
-
-			if (usedNonHeapInitially != usedNonHeapAfterAllocation) {
-				return;
-			}
-			Thread.sleep(50);
-		}
-		Assert.fail("Non-Heap usage metric never changed it's value.");
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestingMetricRegistry.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestingMetricRegistry.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.util;
+
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+import org.apache.flink.runtime.metrics.scope.ScopeFormats;
+import org.apache.flink.util.function.TriConsumer;
+
+/**
+ * <code>TestingMetricRegistry</code> is the test implementation for {@link MetricRegistry}.
+ */
+public class TestingMetricRegistry implements MetricRegistry {
+
+	private final char delimiter;
+	private final int numberReporters;
+	private final TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer;
+	private final TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer;
+	private final ScopeFormats scopeFormats;
+
+	private TestingMetricRegistry(
+			char delimiter,
+			int numberReporters,
+			TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer,
+			TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer,
+			ScopeFormats scopeFormats) {
+		this.delimiter = delimiter;
+		this.numberReporters = numberReporters;
+		this.registerConsumer = registerConsumer;
+		this.unregisterConsumer = unregisterConsumer;
+		this.scopeFormats = scopeFormats;
+	}
+
+	@Override
+	public char getDelimiter() {
+		return delimiter;
+	}
+
+	@Override
+	public int getNumberReporters() {
+		return numberReporters;
+	}
+
+	@Override
+	public void register(Metric metric, String metricName, AbstractMetricGroup group) {
+		registerConsumer.accept(metric, metricName, group);
+	}
+
+	@Override
+	public void unregister(Metric metric, String metricName, AbstractMetricGroup group) {
+		unregisterConsumer.accept(metric, metricName, group);
+	}
+
+	@Override
+	public ScopeFormats getScopeFormats() {
+		return scopeFormats;
+	}
+
+	public static TestingMetricRegistryBuilder builder() {
+		return new TestingMetricRegistryBuilder();
+	}
+
+	/**
+	 * <code>TestingMetricRegistryBuilder</code> builds TestingMetricRegistry instances.
+	 */
+	public static class TestingMetricRegistryBuilder {
+
+		private char delimiter = '.';
+		private int numberReporters = 0;
+		private TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer = (ignoreMetric, ignoreMetricName, ignoreGroup) -> {};
+		private TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer = (ignoreMetric, ignoreMetricName, ignoreGroup) -> {};
+		private ScopeFormats scopeFormats = null;
+
+		private TestingMetricRegistryBuilder() { }
+
+		public TestingMetricRegistryBuilder setDelimiter(char delimiter) {
+			this.delimiter = delimiter;
+			return this;
+		}
+
+		public TestingMetricRegistryBuilder setNumberReporters(int numberReporters) {
+			this.numberReporters = numberReporters;
+			return this;
+		}
+
+		public TestingMetricRegistryBuilder setRegisterConsumer(TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer) {
+			this.registerConsumer = registerConsumer;
+			return this;
+		}
+
+		public TestingMetricRegistryBuilder setUnregisterConsumer(TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer) {
+			this.unregisterConsumer = unregisterConsumer;
+			return this;
+		}
+
+		public TestingMetricRegistryBuilder setScopeFormats(ScopeFormats scopeFormats) {
+			this.scopeFormats = scopeFormats;
+			return this;
+		}
+
+		public TestingMetricRegistry build() {
+			return new TestingMetricRegistry(
+				delimiter,
+				numberReporters,
+				registerConsumer,
+				unregisterConsumer,
+				scopeFormats
+			);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -31,11 +31,17 @@ import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ScopeFormats;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -50,7 +56,16 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static org.hamcrest.collection.IsIn.isIn;
+import static org.hamcrest.core.Every.everyItem;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -73,6 +88,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 	@Before
 	public void setupTest() {
 		highAvailabilityServices = new TestingHighAvailabilityServices();
+		highAvailabilityServices.setResourceManagerLeaderRetriever(new SettableLeaderRetrievalService());
 	}
 
 	@After
@@ -159,6 +175,63 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Checks that all expected metrics are initialized.
+	 */
+	@Test
+	public void testMetricInitialization() throws Exception {
+		Configuration cfg = createFlinkConfiguration();
+
+		List<String> registeredMetrics = new ArrayList<>();
+		startTaskManager(
+			cfg,
+			rpcService,
+			highAvailabilityServices,
+			TestingMetricRegistry.builder()
+				.setRegisterConsumer((metric, metricName, group) -> registeredMetrics.add(group.getMetricIdentifier(metricName)))
+				.setScopeFormats(ScopeFormats.fromConfig(cfg))
+				.build());
+
+		// GC-related metrics are not checked since their existence depends on the JVM used
+		Set<String> expectedTaskManagerMetricsWithoutTaskManagerId = Sets.newHashSet(
+			".taskmanager..Status.JVM.ClassLoader.ClassesLoaded",
+			".taskmanager..Status.JVM.ClassLoader.ClassesUnloaded",
+			".taskmanager..Status.JVM.Memory.Heap.Used",
+			".taskmanager..Status.JVM.Memory.Heap.Committed",
+			".taskmanager..Status.JVM.Memory.Heap.Max",
+			".taskmanager..Status.JVM.Memory.NonHeap.Used",
+			".taskmanager..Status.JVM.Memory.NonHeap.Committed",
+			".taskmanager..Status.JVM.Memory.NonHeap.Max",
+			".taskmanager..Status.JVM.Memory.Direct.Count",
+			".taskmanager..Status.JVM.Memory.Direct.MemoryUsed",
+			".taskmanager..Status.JVM.Memory.Direct.TotalCapacity",
+			".taskmanager..Status.JVM.Memory.Mapped.Count",
+			".taskmanager..Status.JVM.Memory.Mapped.MemoryUsed",
+			".taskmanager..Status.JVM.Memory.Mapped.TotalCapacity",
+			".taskmanager..Status.Flink.Memory.Managed.Used",
+			".taskmanager..Status.Flink.Memory.Managed.Total",
+			".taskmanager..Status.JVM.Threads.Count",
+			".taskmanager..Status.JVM.CPU.Load",
+			".taskmanager..Status.JVM.CPU.Time",
+			".taskmanager..Status.Network.TotalMemorySegments",
+			".taskmanager..Status.Network.AvailableMemorySegments",
+			".taskmanager..Status.Shuffle.Netty.TotalMemorySegments",
+			".taskmanager..Status.Shuffle.Netty.TotalMemory",
+			".taskmanager..Status.Shuffle.Netty.AvailableMemorySegments",
+			".taskmanager..Status.Shuffle.Netty.AvailableMemory",
+			".taskmanager..Status.Shuffle.Netty.UsedMemorySegments",
+			".taskmanager..Status.Shuffle.Netty.UsedMemory"
+		);
+
+		Pattern pattern = Pattern.compile("\\.taskmanager\\.([^.]+)\\..*");
+		Set<String> registeredMetricsWithoutTaskManagerId = registeredMetrics.stream()
+			.map(pattern::matcher)
+			.flatMap(matcher -> matcher.find() ? Stream.of(matcher.group(0).replaceAll(matcher.group(1), "")) : Stream.empty())
+			.collect(Collectors.toSet());
+
+		assertThat(expectedTaskManagerMetricsWithoutTaskManagerId, everyItem(isIn(registeredMetricsWithoutTaskManagerId)));
+	}
+
 	//-----------------------------------------------------------------------------------------------
 
 	private static Configuration createFlinkConfiguration() {
@@ -170,6 +243,20 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices
 	) throws Exception {
+		startTaskManager(
+			configuration,
+			rpcService,
+			highAvailabilityServices,
+			NoOpMetricRegistry.INSTANCE
+		);
+	}
+
+	private static void startTaskManager(
+		Configuration configuration,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		MetricRegistry metricRegistry
+	) throws Exception {
 
 		TaskManagerRunner.startTaskManager(
 			configuration,
@@ -177,7 +264,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 			rpcService,
 			highAvailabilityServices,
 			new TestingHeartbeatServices(),
-			NoOpMetricRegistry.INSTANCE,
+			metricRegistry,
 			new BlobCacheService(
 				configuration,
 				new VoidBlobStore(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -58,6 +58,7 @@ public class TaskManagerServicesBuilder {
 	private TaskEventDispatcher taskEventDispatcher;
 	private ExecutorService ioExecutor;
 	private LibraryCacheManager libraryCacheManager;
+	private long managedMemorySize;
 
 	public TaskManagerServicesBuilder() {
 		unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
@@ -72,6 +73,7 @@ public class TaskManagerServicesBuilder {
 		taskStateManager = mock(TaskExecutorLocalStateStoresManager.class);
 		ioExecutor = TestingUtils.defaultExecutor();
 		libraryCacheManager = TestingLibraryCacheManager.newBuilder().build();
+		managedMemorySize = MemoryManager.MIN_PAGE_SIZE;
 	}
 
 	public TaskManagerServicesBuilder setUnresolvedTaskManagerLocation(UnresolvedTaskManagerLocation unresolvedTaskManagerLocation) {
@@ -129,10 +131,15 @@ public class TaskManagerServicesBuilder {
 		return this;
 	}
 
+	public TaskManagerServicesBuilder setManagedMemorySize(long managedMemorySize) {
+		this.managedMemorySize = managedMemorySize;
+		return this;
+	}
+
 	public TaskManagerServices build() {
 		return new TaskManagerServices(
 			unresolvedTaskManagerLocation,
-			MemoryManager.MIN_PAGE_SIZE,
+			managedMemorySize,
 			ioManager,
 			shuffleEnvironment,
 			kvStateService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -79,13 +79,13 @@ public class TaskSlotTableImplTest extends TestLogger {
 			assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId2), is(true));
 			assertThat(taskSlotTable.isAllocated(2, jobId2, allocationId3), is(true));
 
-			assertThat(taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId1), is(equalTo(Sets.newHashSet(allocationId1))));
+			assertThat(taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId1), is(equalTo(Sets.newHashSet(allocationId1))));
 
 			assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId1), is(true));
 			assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId2), is(true));
 			assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId3), is(false));
 
-			assertThat(taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId1), is(equalTo(new HashSet<>(Arrays.asList(allocationId2, allocationId1)))));
+			assertThat(taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId1), is(equalTo(new HashSet<>(Arrays.asList(allocationId2, allocationId1)))));
 		} finally {
 			taskSlotTable.close();
 			assertThat(taskSlotTable.isClosed(), is(true));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -93,6 +93,28 @@ public class TaskSlotTableImplTest extends TestLogger {
 	}
 
 	/**
+	 * Tests {@link TaskSlotTableImpl#getActiveTaskSlotAllocationIds()}.
+	 */
+	@Test
+	public void testRetrievingAllActiveSlots() throws Exception {
+		try (final TaskSlotTableImpl<?> taskSlotTable = createTaskSlotTableAndStart(3)) {
+			final JobID jobId1 = new JobID();
+			final AllocationID allocationId1 = new AllocationID();
+			taskSlotTable.allocateSlot(0, jobId1, allocationId1, SLOT_TIMEOUT);
+			final AllocationID allocationId2 = new AllocationID();
+			taskSlotTable.allocateSlot(1, jobId1, allocationId2, SLOT_TIMEOUT);
+			final AllocationID allocationId3 = new AllocationID();
+			final JobID jobId2 = new JobID();
+			taskSlotTable.allocateSlot(2, jobId2, allocationId3, SLOT_TIMEOUT);
+
+			taskSlotTable.markSlotActive(allocationId1);
+			taskSlotTable.markSlotActive(allocationId3);
+
+			assertThat(taskSlotTable.getActiveTaskSlotAllocationIds(), is(Sets.newHashSet(allocationId1, allocationId3)));
+		}
+	}
+
+	/**
 	 * Tests that redundant slot allocation with the same AllocationID to a different slot is rejected.
 	 */
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTaskSlotTable.java
@@ -51,6 +51,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 	private final Function<AllocationID, MemoryManager> memoryManagerGetter;
 	private final Supplier<CompletableFuture<Void>> closeAsyncSupplier;
 	private final Function<JobID, Iterator<T>> tasksForJobFunction;
+	private final Supplier<Set<AllocationID>> allActiveSlotAllocationIdsSupplier;
 	private final Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction;
 
 	private TestingTaskSlotTable(
@@ -61,6 +62,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 			Function<AllocationID, MemoryManager> memoryManagerGetter,
 			Supplier<CompletableFuture<Void>> closeAsyncSupplier,
 			Function<JobID, Iterator<T>> tasksForJobFunction,
+			Supplier<Set<AllocationID>> allActiveSlotAllocationIdsSupplier,
 			Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction) {
 		this.createSlotReportSupplier = createSlotReportSupplier;
 		this.allocateSlotSupplier = allocateSlotSupplier;
@@ -69,6 +71,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 		this.memoryManagerGetter = memoryManagerGetter;
 		this.closeAsyncSupplier = closeAsyncSupplier;
 		this.tasksForJobFunction = tasksForJobFunction;
+		this.allActiveSlotAllocationIdsSupplier = allActiveSlotAllocationIdsSupplier;
 		this.activeSlotAllocationIdsForJobFunction = activeSlotAllocationIdsForJobFunction;
 	}
 
@@ -80,6 +83,11 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 	@Override
 	public Set<AllocationID> getAllocationIdsPerJob(JobID jobId) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Set<AllocationID> getActiveTaskSlotAllocationIds() {
+		return allActiveSlotAllocationIdsSupplier.get();
 	}
 
 	@Override
@@ -210,6 +218,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 		};
 		private Supplier<CompletableFuture<Void>> closeAsyncSupplier = FutureUtils::completedVoidFuture;
 		private Function<JobID, Iterator<T>> tasksForJobFunction = ignored -> Collections.emptyIterator();
+		private Supplier<Set<AllocationID>> allActiveSlotAllocationIdsSupplier = Collections::emptySet;
 		private Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction = ignored -> Collections.emptySet();
 
 		public TestingTaskSlotTableBuilder<T> createSlotReportSupplier(Supplier<SlotReport> createSlotReportSupplier) {
@@ -247,7 +256,12 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 			return this;
 		}
 
-		public TestingTaskSlotTableBuilder<T> activeSlotsForJobReturns(Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction) {
+		public TestingTaskSlotTableBuilder<T> allActiveSlotAllocationIds(Supplier<Set<AllocationID>> allActiveSlotAllocationIdsSupplier) {
+			this.allActiveSlotAllocationIdsSupplier = allActiveSlotAllocationIdsSupplier;
+			return this;
+		}
+
+		public TestingTaskSlotTableBuilder<T> activeSlotAllocationIdsForJobReturns(Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction) {
 			this.activeSlotAllocationIdsForJobFunction = activeSlotAllocationIdsForJobFunction;
 			return this;
 		}
@@ -261,6 +275,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 				memoryManagerGetter,
 				closeAsyncSupplier,
 				tasksForJobFunction,
+				allActiveSlotAllocationIdsSupplier,
 				activeSlotAllocationIdsForJobFunction);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTaskSlotTable.java
@@ -91,7 +91,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 	}
 
 	@Override
-	public Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId) {
+	public Set<AllocationID> getActiveTaskSlotAllocationIdsPerJob(JobID jobId) {
 		return activeSlotAllocationIdsForJobFunction.apply(jobId);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
@@ -86,8 +86,8 @@ public class ThreadSafeTaskSlotTable<T extends TaskSlotPayload> implements TaskS
 	}
 
 	@Override
-	public Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId) {
-		return callAsync(() -> taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId));
+	public Set<AllocationID> getActiveTaskSlotAllocationIdsPerJob(JobID jobId) {
+		return callAsync(() -> taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId));
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
@@ -81,6 +81,11 @@ public class ThreadSafeTaskSlotTable<T extends TaskSlotPayload> implements TaskS
 	}
 
 	@Override
+	public Set<AllocationID> getActiveTaskSlotAllocationIds() {
+		return callAsync(taskSlotTable::getActiveTaskSlotAllocationIds);
+	}
+
+	@Override
 	public Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId) {
 		return callAsync(() -> taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId));
 	}


### PR DESCRIPTION
## What is the purpose of the change

This change is meant to expose the managed memory usage through the REST API to make it available in the web UI.


## Brief change log

- Added new metrics for used and total managed memory
- The used managed memory is determined by accessing the MemoryManagers of all active slots of the TaskSlotTable
- Added new metrics to TaskManagerDetailsHandler

## Verifying this change

This change added tests and can be verified as follows:
- the TaskManagerDetailsHandlerTest was extended accordingly
- A test was added for retrieving all active slots in TaskSlotTableImplTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
