### PR TITLE
[FLINK-19474] Implement a state backend that holds a single key at a time

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtilsTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -43,6 +44,8 @@ import static org.apache.flink.contrib.streaming.state.benchmark.StateBackendBen
 import static org.apache.flink.contrib.streaming.state.benchmark.StateBackendBenchmarkUtils.getListState;
 import static org.apache.flink.contrib.streaming.state.benchmark.StateBackendBenchmarkUtils.getMapState;
 import static org.apache.flink.contrib.streaming.state.benchmark.StateBackendBenchmarkUtils.getValueState;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 
 /**
  * Test for {@link StateBackendBenchmarkUtils}.
@@ -96,6 +99,7 @@ public class StateBackendBenchmarkUtilsTest {
 
 	@Test
 	public void testApplyToAllKeys() throws Exception {
+		Assume.assumeThat(backendType, not(equalTo(StateBackendBenchmarkUtils.StateBackendType.BATCH_EXECUTION)));
 		KeyedStateBackend<Long> backend = createKeyedStateBackend(backendType);
 		ListState<Long> listState = getListState(backend, listStateDescriptor);
 		for (long i = 0; i < 10; i++) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/AbstractBatchExecutionKeyState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/AbstractBatchExecutionKeyState.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A common class for all internal states in a single key state backend.
+ */
+abstract class AbstractBatchExecutionKeyState<K, N, V> implements InternalKvState<K, N, V> {
+
+	private final V defaultValue;
+	private final TypeSerializer<V> stateTypeSerializer;
+	private final TypeSerializer<K> keySerializer;
+	private final TypeSerializer<N> namespaceSerializer;
+
+	private final Map<N, V> valuesForNamespaces = new HashMap<>();
+	private N currentNamespace;
+	private V currentNamespaceValue;
+
+	protected AbstractBatchExecutionKeyState(
+			V defaultValue,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<V> stateTypeSerializer) {
+		this.defaultValue = defaultValue;
+		this.stateTypeSerializer = stateTypeSerializer;
+		this.keySerializer = keySerializer;
+		this.namespaceSerializer = namespaceSerializer;
+	}
+
+	V getOrDefault() {
+		if (currentNamespaceValue == null && defaultValue != null) {
+			return stateTypeSerializer.copy(defaultValue);
+		}
+		return currentNamespaceValue;
+	}
+
+	public V getCurrentNamespaceValue() {
+		return currentNamespaceValue;
+	}
+
+	public void setCurrentNamespaceValue(V currentNamespaceValue) {
+		this.currentNamespaceValue = currentNamespaceValue;
+	}
+
+	@Override
+	public TypeSerializer<V> getValueSerializer() {
+		return stateTypeSerializer;
+	}
+
+	@Override
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializer;
+	}
+
+	@Override
+	public TypeSerializer<N> getNamespaceSerializer() {
+		return namespaceSerializer;
+	}
+
+	@Override
+	public void setCurrentNamespace(N namespace) {
+		if (Objects.equals(currentNamespace, namespace)) {
+			return;
+		}
+
+		if (currentNamespace != null) {
+			if (currentNamespaceValue == null) {
+				valuesForNamespaces.remove(currentNamespace);
+			} else {
+				valuesForNamespaces.put(currentNamespace, currentNamespaceValue);
+			}
+		}
+		currentNamespaceValue = valuesForNamespaces.get(namespace);
+		currentNamespace = namespace;
+	}
+
+	@Override
+	public byte[] getSerializedValue(
+			byte[] serializedKeyAndNamespace,
+			TypeSerializer<K> safeKeySerializer,
+			TypeSerializer<N> safeNamespaceSerializer,
+			TypeSerializer<V> safeValueSerializer) {
+		throw new UnsupportedOperationException("Queryable state is not supported in BATCH runtime.");
+	}
+
+	@Override
+	public StateIncrementalVisitor<K, N, V> getStateIncrementalVisitor(int recommendedMaxNumberOfReturnedRecords) {
+		return null;
+	}
+
+	@Override
+	public void clear() {
+		this.currentNamespaceValue = null;
+		this.valuesForNamespaces.remove(currentNamespace);
+	}
+
+	void clearAllNamespaces() {
+		currentNamespaceValue = null;
+		currentNamespace = null;
+		valuesForNamespaces.clear();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalPriorityQueueSet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalPriorityQueueSet.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueue;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Very similar implementation to {@link org.apache.flink.runtime.state.heap.HeapPriorityQueueSet}. The only difference
+ * is it keeps track of elements for a single key at a time.
+ */
+class BatchExecutionInternalPriorityQueueSet<T extends HeapPriorityQueueElement>
+		extends HeapPriorityQueue<T>
+		implements KeyGroupedInternalPriorityQueue<T> {
+
+	private final Map<T, T> dedupMap = new HashMap<>();
+
+	BatchExecutionInternalPriorityQueueSet(
+			@Nonnull PriorityComparator<T> elementPriorityComparator,
+			int minimumCapacity) {
+		super(elementPriorityComparator, minimumCapacity);
+	}
+
+	@Nonnull
+	@Override
+	public Set<T> getSubsetForKeyGroup(int keyGroupId) {
+		throw new UnsupportedOperationException("Getting subset for key group is not supported in BATCH runtime mode.");
+	}
+
+	@Override
+	@Nullable
+	public T poll() {
+		final T toRemove = super.poll();
+		return toRemove != null ? dedupMap.remove(toRemove) : null;
+	}
+
+	@Override
+	public boolean add(@Nonnull T element) {
+		return dedupMap.putIfAbsent(element, element) == null && super.add(element);
+	}
+
+	@Override
+	public boolean remove(@Nonnull T toRemove) {
+		T storedElement = dedupMap.remove(toRemove);
+		return storedElement != null && super.remove(storedElement);
+	}
+
+	@Override
+	public void clear() {
+		super.clear();
+		dedupMap.clear();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyAggregatingState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyAggregatingState.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+
+import java.io.IOException;
+
+/**
+ * An {@link AggregatingState} which keeps value for a single key at a time.
+ */
+class BatchExecutionKeyAggregatingState<K, N, IN, ACC, OUT>
+		extends MergingAbstractBatchExecutionKeyState<K, N, ACC, IN, OUT>
+		implements InternalAggregatingState<K, N, IN, ACC, OUT> {
+
+	private final AggregateFunction<IN, ACC, OUT> aggFunction;
+
+	public BatchExecutionKeyAggregatingState(
+			ACC defaultValue,
+			AggregateFunction<IN, ACC, OUT> aggregateFunction,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<ACC> stateSerializer) {
+		super(defaultValue, keySerializer, namespaceSerializer, stateSerializer);
+		this.aggFunction = aggregateFunction;
+	}
+
+	@Override
+	public OUT get() {
+		ACC acc = getOrDefault();
+		return acc != null ? aggFunction.getResult(acc) : null;
+	}
+
+	@Override
+	public void add(IN value) throws IOException {
+		if (value == null) {
+			clear();
+			return;
+		}
+
+		try {
+			if (getCurrentNamespaceValue() == null) {
+				setCurrentNamespaceValue(aggFunction.createAccumulator());
+			}
+			setCurrentNamespaceValue(aggFunction.add(value, getCurrentNamespaceValue()));
+		} catch (Exception e) {
+			throw new IOException("Exception while applying AggregateFunction in aggregating state", e);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T, K, N, SV, S extends State, IS extends S> IS create(
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, SV> stateDesc) {
+		return (IS) new BatchExecutionKeyAggregatingState<>(
+			stateDesc.getDefaultValue(),
+			((AggregatingStateDescriptor<T, SV, ?>) stateDesc).getAggregateFunction(),
+			keySerializer,
+			namespaceSerializer,
+			stateDesc.getSerializer());
+	}
+
+	@Override
+	protected ACC merge(ACC target, ACC source) {
+		return aggFunction.merge(target, source);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyListState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyListState.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link ListState} which keeps value for a single key at a time.
+ */
+class BatchExecutionKeyListState<K, N, T>
+		extends MergingAbstractBatchExecutionKeyState<K, N, List<T>, T, Iterable<T>>
+		implements InternalListState<K, N, T> {
+
+	protected BatchExecutionKeyListState(
+			List<T> defaultValue,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<List<T>> stateTypeSerializer) {
+		super(defaultValue, keySerializer, namespaceSerializer, stateTypeSerializer);
+	}
+
+	@Override
+	public void update(List<T> values) {
+		checkNotNull(values);
+		clear();
+		for (T value : values) {
+			add(value);
+		}
+	}
+
+	@Override
+	public void addAll(List<T> values) {
+		if (checkNotNull(values).isEmpty()) {
+			return;
+		}
+		for (T value : values) {
+			add(value);
+		}
+	}
+
+	@Override
+	public void add(T value) {
+		checkNotNull(value);
+		initIfNull();
+		getCurrentNamespaceValue().add(value);
+	}
+
+	private void initIfNull() {
+		if (getCurrentNamespaceValue() == null) {
+			setCurrentNamespaceValue(new ArrayList<>());
+		}
+	}
+
+	@Override
+	public Iterable<T> get() throws Exception {
+		return getCurrentNamespaceValue();
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T, K, N, SV, S extends State, IS extends S> IS create(
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, SV> stateDesc) {
+		return (IS) new BatchExecutionKeyListState<>(
+			(List<T>) stateDesc.getDefaultValue(),
+			keySerializer,
+			namespaceSerializer,
+			(TypeSerializer<List<T>>) stateDesc.getSerializer());
+	}
+
+	@Override
+	protected List<T> merge(List<T> target, List<T> source) {
+		target.addAll(source);
+		return target;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyMapState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyMapState.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * A {@link MapState} which keeps value for a single key at a time.
+ */
+class BatchExecutionKeyMapState<K, N, UK, UV>
+		extends AbstractBatchExecutionKeyState<K, N, Map<UK, UV>>
+		implements InternalMapState<K, N, UK, UV> {
+
+	protected BatchExecutionKeyMapState(
+			Map<UK, UV> defaultValue,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<Map<UK, UV>> stateTypeSerializer) {
+		super(defaultValue, keySerializer, namespaceSerializer, stateTypeSerializer);
+	}
+
+	@Override
+	public UV get(UK key) throws Exception {
+		if (getCurrentNamespaceValue() == null) {
+			return null;
+		}
+		return getCurrentNamespaceValue().get(key);
+	}
+
+	@Override
+	public void put(UK key, UV value) {
+		initIfNull();
+		getCurrentNamespaceValue().put(key, value);
+	}
+
+	@Override
+	public void putAll(Map<UK, UV> map) {
+		initIfNull();
+		this.getCurrentNamespaceValue().putAll(map);
+	}
+
+	private void initIfNull() {
+		if (getCurrentNamespaceValue() == null) {
+			setCurrentNamespaceValue(new HashMap<>());
+		}
+	}
+
+	@Override
+	public void remove(UK key) throws Exception {
+		if (getCurrentNamespaceValue() == null) {
+			return;
+		}
+		getCurrentNamespaceValue().remove(key);
+		if (getCurrentNamespaceValue().isEmpty()) {
+			clear();
+		}
+	}
+
+	@Override
+	public boolean contains(UK key) throws Exception {
+		return getCurrentNamespaceValue() != null && getCurrentNamespaceValue().containsKey(key);
+	}
+
+	@Override
+	public Iterable<Map.Entry<UK, UV>> entries() {
+		return getCurrentNamespaceValue() == null ? Collections.emptySet() : getCurrentNamespaceValue().entrySet();
+	}
+
+	@Override
+	public Iterable<UK> keys() {
+		return getCurrentNamespaceValue() == null ? Collections.emptySet() : getCurrentNamespaceValue().keySet();
+	}
+
+	@Override
+	public Iterable<UV> values() {
+		return getCurrentNamespaceValue() == null ? Collections.emptySet() : getCurrentNamespaceValue().values();
+	}
+
+	@Override
+	public Iterator<Map.Entry<UK, UV>> iterator() {
+		return getCurrentNamespaceValue() == null ? Collections.emptyIterator() : getCurrentNamespaceValue().entrySet()
+			.iterator();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return getCurrentNamespaceValue() == null || getCurrentNamespaceValue().isEmpty();
+	}
+
+	@SuppressWarnings("unchecked")
+	static <UK, UV, K, N, SV, S extends State, IS extends S> IS create(
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, SV> stateDesc) {
+		return (IS) new BatchExecutionKeyMapState<>(
+			(Map<UK, UV>) stateDesc.getDefaultValue(),
+			keySerializer,
+			namespaceSerializer,
+			(TypeSerializer<Map<UK, UV>>) stateDesc.getSerializer());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyReducingState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyReducingState.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+
+import java.io.IOException;
+
+/**
+ * A {@link ReducingState} which keeps value for a single key at a time.
+ */
+class BatchExecutionKeyReducingState<K, N, T>
+		extends MergingAbstractBatchExecutionKeyState<K, N, T, T, T>
+		implements InternalReducingState<K, N, T> {
+	private final ReduceFunction<T> reduceFunction;
+
+	public BatchExecutionKeyReducingState(
+			T defaultValue,
+			ReduceFunction<T> reduceFunction,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<T> stateSerializer) {
+		super(defaultValue, keySerializer, namespaceSerializer, stateSerializer);
+		this.reduceFunction = reduceFunction;
+	}
+
+	@Override
+	public T get() {
+		return getOrDefault();
+	}
+
+	@Override
+	public void add(T value) throws IOException {
+		if (value == null) {
+			clear();
+			return;
+		}
+
+		try {
+			T currentNamespaceValue = getCurrentNamespaceValue();
+			if (currentNamespaceValue != null) {
+				setCurrentNamespaceValue(reduceFunction.reduce(currentNamespaceValue, value));
+			} else {
+				setCurrentNamespaceValue(value);
+			}
+		} catch (Exception e) {
+			throw new IOException("Exception while applying ReduceFunction in reducing state", e);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T, K, N, SV, S extends State, IS extends S> IS create(
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, SV> stateDesc) {
+		return (IS) new BatchExecutionKeyReducingState<>(
+			stateDesc.getDefaultValue(),
+			((ReducingStateDescriptor<SV>) stateDesc).getReduceFunction(),
+			keySerializer,
+			namespaceSerializer,
+			stateDesc.getSerializer());
+	}
+
+	@Override
+	protected T merge(T target, T source) throws Exception {
+		return reduceFunction.reduce(target, source);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyValueState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyValueState.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+/**
+ * A {@link ValueState} which keeps value for a single key at a time.
+ */
+class BatchExecutionKeyValueState<K, N, T>
+		extends AbstractBatchExecutionKeyState<K, N, T>
+		implements InternalValueState<K, N, T> {
+
+	BatchExecutionKeyValueState(
+			T defaultValue,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<T> stateTypeSerializer) {
+		super(defaultValue, keySerializer, namespaceSerializer, stateTypeSerializer);
+	}
+
+	@Override
+	public T value() {
+		return getOrDefault();
+	}
+
+	@Override
+	public void update(T value) {
+		setCurrentNamespaceValue(value);
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T, K, N, SV, S extends State, IS extends S> IS create(
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, SV> stateDesc) {
+		return (IS) new BatchExecutionKeyValueState<>(
+			stateDesc.getDefaultValue(),
+			keySerializer,
+			namespaceSerializer,
+			stateDesc.getSerializer());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedStateFunction;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.RunnableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link CheckpointableKeyedStateBackend} which keeps values for a single key at a time.
+ *
+ * <p><b>IMPORTANT:</b> Requires the incoming records to be sorted/grouped by the key. Used in a BATCH style execution.
+ */
+class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedStateBackend<K> {
+	@SuppressWarnings("rawtypes")
+	private static final Map<Class<? extends StateDescriptor>, StateFactory> STATE_FACTORIES =
+		Stream.of(
+			Tuple2.of(ValueStateDescriptor.class, (StateFactory) BatchExecutionKeyValueState::create),
+			Tuple2.of(ListStateDescriptor.class, (StateFactory) BatchExecutionKeyListState::create),
+			Tuple2.of(MapStateDescriptor.class, (StateFactory) BatchExecutionKeyMapState::create),
+			Tuple2.of(AggregatingStateDescriptor.class, (StateFactory) BatchExecutionKeyAggregatingState::create),
+			Tuple2.of(ReducingStateDescriptor.class, (StateFactory) BatchExecutionKeyReducingState::create)
+		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+	private K currentKey = null;
+	private final TypeSerializer<K> keySerializer;
+	private final List<KeySelectionListener<K>> keySelectionListeners = new ArrayList<>();
+	private final Map<String, State> states = new HashMap<>();
+	private final Map<String, KeyGroupedInternalPriorityQueue<?>> priorityQueues = new HashMap<>();
+	private final KeyGroupRange keyGroupRange;
+
+	public BatchExecutionKeyedStateBackend(
+			TypeSerializer<K> keySerializer,
+			KeyGroupRange keyGroupRange) {
+		this.keySerializer = keySerializer;
+		this.keyGroupRange = keyGroupRange;
+	}
+
+	@Override
+	public void setCurrentKey(K newKey) {
+		if (!Objects.equals(newKey, currentKey)) {
+			notifyKeySelected(newKey);
+			for (State value : states.values()) {
+				((AbstractBatchExecutionKeyState<?, ?, ?>) value).clearAllNamespaces();
+			}
+			for (KeyGroupedInternalPriorityQueue<?> value : priorityQueues.values()) {
+				while (value.poll() != null) {
+					// remove everything for the key
+				}
+			}
+			this.currentKey = newKey;
+		}
+	}
+
+	@Override
+	public K getCurrentKey() {
+		return currentKey;
+	}
+
+	@Override
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializer;
+	}
+
+	@Override
+	public <N, S extends State, T> void applyToAllKeys(
+			N namespace,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, T> stateDescriptor,
+			KeyedStateFunction<K, S> function) {
+		throw new UnsupportedOperationException("applyToAllKeys() is not supported in BATCH execution mode.");
+	}
+
+	@Override
+	public <N> Stream<K> getKeys(String state, N namespace) {
+		throw new UnsupportedOperationException("getKeys() is not supported in BATCH execution mode.");
+	}
+
+	@Override
+	public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
+		throw new UnsupportedOperationException("getKeysAndNamespaces() is not supported in BATCH execution mode.");
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <N, S extends State, T> S getOrCreateKeyedState(
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, T> stateDescriptor) throws Exception {
+		checkNotNull(namespaceSerializer, "Namespace serializer");
+		checkNotNull(keySerializer, "State key serializer has not been configured in the config. " +
+			"This operation cannot use partitioned state.");
+
+		if (!stateDescriptor.isSerializerInitialized()) {
+			stateDescriptor.initializeSerializerUnlessSet(new ExecutionConfig());
+		}
+
+		State state = states.get(stateDescriptor.getName());
+		if (state == null) {
+			state = createState(namespaceSerializer, stateDescriptor);
+			states.put(stateDescriptor.getName(), state);
+		}
+		return (S) state;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <N, S extends State> S getPartitionedState(
+			N namespace,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, ?> stateDescriptor) throws Exception {
+		S state = getOrCreateKeyedState(
+			namespaceSerializer,
+			stateDescriptor
+		);
+		((InternalKvState<K, N, ?>) state).setCurrentNamespace(namespace);
+		return state;
+	}
+
+	@Override
+	public void dispose() {
+
+	}
+
+	private void notifyKeySelected(K newKey) {
+		// we prefer a for-loop over other iteration schemes for performance reasons here.
+		for (KeySelectionListener<K> keySelectionListener : keySelectionListeners) {
+			keySelectionListener.keySelected(newKey);
+		}
+	}
+
+	@Override
+	public void registerKeySelectionListener(KeySelectionListener<K> listener) {
+		keySelectionListeners.add(listener);
+	}
+
+	@Override
+	public boolean deregisterKeySelectionListener(KeySelectionListener<K> listener) {
+		return keySelectionListeners.remove(listener);
+	}
+
+	@Nonnull
+	@Override
+	public <N, SV, SEV, S extends State, IS extends S> IS createInternalState(
+				@Nonnull TypeSerializer<N> namespaceSerializer,
+				@Nonnull StateDescriptor<S, SV> stateDesc,
+				@Nonnull StateSnapshotTransformer.StateSnapshotTransformFactory<SEV> snapshotTransformFactory)
+			throws Exception {
+		return createState(namespaceSerializer, stateDesc);
+	}
+
+	private <N, SV, S extends State, IS extends S> IS createState(
+				@Nonnull TypeSerializer<N> namespaceSerializer,
+				@Nonnull StateDescriptor<S, SV> stateDesc)
+			throws Exception {
+		StateFactory stateFactory = STATE_FACTORIES.get(stateDesc.getClass());
+		if (stateFactory == null) {
+			String message = String.format("State %s is not supported by %s",
+				stateDesc.getClass(), this.getClass());
+			throw new FlinkRuntimeException(message);
+		}
+		return stateFactory.createState(keySerializer, namespaceSerializer, stateDesc);
+	}
+
+	@Nonnull
+	@Override
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T> create(
+			@Nonnull String stateName,
+			@Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+		KeyGroupedInternalPriorityQueue<?> priorityQueue = priorityQueues.get(stateName);
+		if (priorityQueue == null) {
+			priorityQueue = new BatchExecutionInternalPriorityQueueSet<>(
+				PriorityComparator.forPriorityComparableObjects(),
+				128
+			);
+			priorityQueues.put(stateName, priorityQueue);
+		}
+		return (KeyGroupedInternalPriorityQueue<T>) priorityQueue;
+	}
+
+	@Override
+	public KeyGroupRange getKeyGroupRange() {
+		return keyGroupRange;
+	}
+
+	@Override
+	public void close() throws IOException {
+
+	}
+
+	@Nonnull
+	@Override
+	public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+			long checkpointId,
+			long timestamp,
+			@Nonnull CheckpointStreamFactory streamFactory,
+			@Nonnull CheckpointOptions checkpointOptions) {
+		throw new UnsupportedOperationException("Snapshotting is not supported in BATCH runtime mode.");
+	}
+
+	@FunctionalInterface
+	private interface StateFactory {
+		<T, K, N, SV, S extends State, IS extends S> IS createState(
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, SV> stateDesc) throws Exception;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+
+/**
+ * A simple {@link StateBackend} which is used in a BATCH style execution.
+ */
+public class BatchExecutionStateBackend implements StateBackend {
+	@Override
+	public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
+		throw new UnsupportedOperationException("Checkpoints are not supported in a single key state backend");
+	}
+
+	@Override
+	public CheckpointStorage createCheckpointStorage(JobID jobId) {
+		return new NonCheckpointingStorage();
+	}
+
+	@Override
+	public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+			Environment env,
+			JobID jobID,
+			String operatorIdentifier,
+			TypeSerializer<K> keySerializer,
+			int numberOfKeyGroups,
+			KeyGroupRange keyGroupRange,
+			TaskKvStateRegistry kvStateRegistry,
+			TtlTimeProvider ttlTimeProvider,
+			MetricGroup metricGroup,
+			@Nonnull Collection<KeyedStateHandle> stateHandles,
+			CloseableRegistry cancelStreamRegistry) {
+		return new BatchExecutionKeyedStateBackend<>(keySerializer, keyGroupRange);
+	}
+
+	@Override
+	public OperatorStateBackend createOperatorStateBackend(
+			Environment env,
+			String operatorIdentifier,
+			@Nonnull Collection<OperatorStateHandle> stateHandles,
+			CloseableRegistry cancelStreamRegistry) throws Exception {
+		return new DefaultOperatorStateBackendBuilder(
+			env.getUserCodeClassLoader().asClassLoader(),
+			env.getExecutionConfig(),
+			false,
+			stateHandles,
+			cancelStreamRegistry
+		).build();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/MergingAbstractBatchExecutionKeyState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/MergingAbstractBatchExecutionKeyState.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalMergingState;
+
+import java.util.Collection;
+
+/**
+ * An abstract class with a common implementation of {@link InternalMergingState#mergeNamespaces(Object, Collection)}.
+ */
+abstract class MergingAbstractBatchExecutionKeyState<K, N, V, IN, OUT>
+		extends AbstractBatchExecutionKeyState<K, N, V>
+		implements InternalMergingState<K, N, IN, V, OUT> {
+	protected MergingAbstractBatchExecutionKeyState(
+			V defaultValue,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<V> stateTypeSerializer) {
+		super(defaultValue, keySerializer, namespaceSerializer, stateTypeSerializer);
+	}
+
+	protected abstract V merge(V target, V source) throws Exception;
+
+	@Override
+	public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+		if (sources == null || sources.isEmpty()) {
+			return;
+		}
+
+		setCurrentNamespace(target);
+		V targetValue = getCurrentNamespaceValue();
+		for (N source : sources) {
+			setCurrentNamespace(source);
+			V sourceValue = getCurrentNamespaceValue();
+			if (targetValue == null) {
+				targetValue = sourceValue;
+			} else if (sourceValue != null) {
+				targetValue = merge(targetValue, sourceValue);
+				clear();
+			}
+		}
+		setCurrentNamespace(target);
+		setCurrentNamespaceValue(targetValue);
+	}
+
+	@Override
+	public V getInternal() {
+		return getCurrentNamespaceValue();
+	}
+
+	@Override
+	public void updateInternal(V valueToStore) {
+		setCurrentNamespaceValue(valueToStore);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/NonCheckpointingStorage.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/NonCheckpointingStorage.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageLocation;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+
+import javax.annotation.Nullable;
+
+/**
+ * A dummy {@link CheckpointStorage} which does not perform checkpoints.
+ */
+class NonCheckpointingStorage implements CheckpointStorage {
+	@Override
+	public boolean supportsHighlyAvailableStorage() {
+		return false;
+	}
+
+	@Override
+	public boolean hasDefaultSavepointLocation() {
+		return false;
+	}
+
+	@Override
+	public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
+		throw new UnsupportedOperationException("Checkpoints are not supported in a single key state backend");
+	}
+
+	@Override
+	public void initializeBaseLocations() {
+
+	}
+
+	@Override
+	public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {
+		throw new UnsupportedOperationException("Checkpoints are not supported in a single key state backend");
+	}
+
+	@Override
+	public CheckpointStorageLocation initializeLocationForSavepoint(
+			long checkpointId,
+			@Nullable String externalLocationPointer) {
+		throw new UnsupportedOperationException("Checkpoints are not supported in a single key state backend");
+	}
+
+	@Override
+	public CheckpointStreamFactory resolveCheckpointStorageLocation(
+			long checkpointId,
+			CheckpointStorageLocationReference reference) {
+		throw new UnsupportedOperationException("Checkpoints are not supported in a single key state backend");
+	}
+
+	@Override
+	public CheckpointStreamFactory.CheckpointStateOutputStream createTaskOwnedStateStream() {
+		throw new UnsupportedOperationException("Checkpoints are not supported in a single key state backend");
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalPriorityQueueSetTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalPriorityQueueSetTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.runtime.state.InternalPriorityQueue;
+import org.apache.flink.runtime.state.InternalPriorityQueueTestBase;
+
+/**
+ * Tests for {@link BatchExecutionInternalPriorityQueueSet}.
+ */
+public class BatchExecutionInternalPriorityQueueSetTest extends InternalPriorityQueueTestBase {
+	@Override
+	protected InternalPriorityQueue<TestElement> newPriorityQueue(int initialCapacity) {
+		return new BatchExecutionInternalPriorityQueueSet<>(TEST_ELEMENT_PRIORITY_COMPARATOR, initialCapacity);
+	}
+
+	@Override
+	protected boolean testSetSemanticsAgainstDuplicateElements() {
+		return true;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendTest.java
@@ -1,0 +1,1431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StateBackendTestBase;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests copied over from {@link StateBackendTestBase} and adjusted to make sense for a single key state backend.
+ *
+ * <p>Some of the tests in {@link StateBackendTestBase} do not make sense for {@link BatchExecutionKeyedStateBackend}, e.g.
+ * checkpointing tests, tests verifying methods used by the queryable state etc. Moreover the tests had to be adjusted
+ * as the state backend assumes keys are grouped.
+ */
+public class BatchExecutionStateBackendTest extends TestLogger {
+
+	@Rule
+	public final ExpectedException expectedException = ExpectedException.none();
+
+	private  <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer) {
+		return new BatchExecutionKeyedStateBackend<>(
+			keySerializer,
+			new KeyGroupRange(0, 9)
+		);
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * adding {@code null}.
+	 */
+	@Test
+	public void testListStateAddNull() throws Exception {
+		CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+			state.add(null);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * {@link ListState#addAll(List)} to be called with {@code null} entries in the list of entries
+	 * to add.
+	 */
+	@Test
+	public void testListStateAddAllNullEntries() throws Exception {
+		CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+
+			List<Long> adding = new ArrayList<>();
+			adding.add(3L);
+			adding.add(null);
+			adding.add(5L);
+			state.addAll(adding);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * {@link ListState#addAll(List)} to be called with {@code null}.
+	 */
+	@Test
+	public void testListStateAddAllNull() throws Exception {
+		CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+			state.addAll(null);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * {@link ListState#update(List)} to be called with {@code null} entries in the list of entries
+	 * to add.
+	 */
+	@Test
+	public void testListStateUpdateNullEntries() throws Exception {
+		CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+
+			List<Long> adding = new ArrayList<>();
+			adding.add(3L);
+			adding.add(null);
+			adding.add(5L);
+			state.update(adding);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * {@link ListState#update(List)} to be called with {@code null}.
+	 */
+	@Test
+	public void testListStateUpdateNull() throws Exception {
+		CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+			state.update(null);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	@Test
+	public void testListStateAPIs() throws Exception {
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescr);
+
+			keyedBackend.setCurrentKey("g");
+			assertNull(state.get());
+			assertNull(state.get());
+			state.addAll(Collections.emptyList());
+			assertNull(state.get());
+			state.addAll(Arrays.asList(3L, 4L));
+			assertThat(state.get(), containsInAnyOrder(3L, 4L));
+			assertThat(state.get(), containsInAnyOrder(3L, 4L));
+			state.addAll(new ArrayList<>());
+			assertThat(state.get(), containsInAnyOrder(3L, 4L));
+			state.addAll(Arrays.asList(5L, 6L));
+			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
+			state.addAll(new ArrayList<>());
+			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
+
+			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
+			state.update(Arrays.asList(1L, 2L));
+			assertThat(state.get(), containsInAnyOrder(1L, 2L));
+		}
+	}
+
+	@Test
+	public void testListStateMergingOverThreeNamespaces() throws Exception {
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalListState<String, Integer, Long> state =
+				(InternalListState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - abc spreads the values over three namespaces
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.add(33L);
+			state.add(55L);
+
+			state.setCurrentNamespace(namespace2);
+			state.add(22L);
+			state.add(11L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(44L);
+
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertThat(state.get(), containsInAnyOrder(11L, 22L, 33L, 44L, 55L));
+
+			// make sure all lists / maps are cleared
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testListStateMergingWithEmptyNamespace() throws Exception {
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalListState<String, Integer, Long> state =
+				(InternalListState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - def spreads the values over two namespaces (one empty)
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(44L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(22L);
+			state.add(55L);
+			state.add(33L);
+
+			keyedBackend.setCurrentKey("def");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertThat(state.get(), containsInAnyOrder(11L, 22L, 33L, 44L, 55L));
+
+			// make sure all lists / maps are cleared
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testListStateMergingEmpty() throws Exception {
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalListState<String, Integer, Long> state =
+				(InternalListState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - ghi is empty
+
+			keyedBackend.setCurrentKey("ghi");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertNull(state.get());
+
+			// make sure all lists / maps are cleared
+
+			keyedBackend.setCurrentKey("ghi");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testListStateMergingAllInTargetNamespace() throws Exception {
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalListState<String, Integer, Long> state =
+				(InternalListState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - jkl has all elements already in the target namespace
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("jkl");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertThat(state.get(), containsInAnyOrder(11L, 22L, 33L, 44L, 55L));
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testListStateMergingInASingleNamespace() throws Exception {
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalListState<String, Integer, Long> state =
+				(InternalListState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - mno has all elements already in one source namespace
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace3);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("mno");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertThat(state.get(), containsInAnyOrder(11L, 22L, 33L, 44L, 55L));
+
+			// make sure all lists / maps are cleared
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testReducingStateAddAndGet() throws Exception {
+
+		final ReducingStateDescriptor<Long> stateDescr =
+			new ReducingStateDescriptor<>("my-state", Long::sum, Long.class);
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			ReducingState<Long> state =
+				keyedBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescr);
+
+			keyedBackend.setCurrentKey("def");
+			assertNull(state.get());
+			state.add(17L);
+			state.add(11L);
+			assertEquals(28L, state.get().longValue());
+
+			keyedBackend.setCurrentKey("def");
+			assertEquals(28L, state.get().longValue());
+			state.clear();
+			assertNull(state.get());
+
+			keyedBackend.setCurrentKey("g");
+			assertNull(state.get());
+			state.add(1L);
+			state.add(2L);
+
+			keyedBackend.setCurrentKey("g");
+			state.add(3L);
+			state.add(2L);
+			state.add(1L);
+
+			keyedBackend.setCurrentKey("g");
+			assertEquals(9L, state.get().longValue());
+		}
+	}
+
+	@Test
+	public void testReducingStateMergingOverThreeNamespaces() throws Exception {
+
+		final ReducingStateDescriptor<Long> stateDescr =
+			new ReducingStateDescriptor<>("my-state", Long::sum, Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			final InternalReducingState<String, Integer, Long> state =
+				(InternalReducingState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - abc spreads the values over three namespaces
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.add(33L);
+			state.add(55L);
+
+			state.setCurrentNamespace(namespace2);
+			state.add(22L);
+			state.add(11L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(44L);
+
+			keyedBackend.setCurrentKey("abc");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testReducingStateMergingWithEmpty() throws Exception {
+
+		final ReducingStateDescriptor<Long> stateDescr =
+			new ReducingStateDescriptor<>("my-state", Long::sum, Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			final InternalReducingState<String, Integer, Long> state =
+				(InternalReducingState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - def spreads the values over two namespaces (one empty)
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(44L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(22L);
+			state.add(55L);
+			state.add(33L);
+
+			keyedBackend.setCurrentKey("def");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testReducingStateMergingEmpty() throws Exception {
+
+		final ReducingStateDescriptor<Long> stateDescr =
+			new ReducingStateDescriptor<>("my-state", Long::sum, Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			final InternalReducingState<String, Integer, Long> state =
+				(InternalReducingState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - ghi is empty
+
+			keyedBackend.setCurrentKey("ghi");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testReducingStateMergingInTargetNamespace() throws Exception {
+
+		final ReducingStateDescriptor<Long> stateDescr =
+			new ReducingStateDescriptor<>("my-state", Long::sum, Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			final InternalReducingState<String, Integer, Long> state =
+				(InternalReducingState<String, Integer, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - jkl has all elements already in the target namespace
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("jkl");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testReducingStateMergingInASingleNamespace() throws Exception {
+
+		final ReducingStateDescriptor<Long> stateDescr =
+			new ReducingStateDescriptor<>("my-state", Long::sum, Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			final InternalReducingState<String, Integer, Long> state =
+				(InternalReducingState<String, Integer, Long>) keyedBackend.getPartitionedState(0, IntSerializer.INSTANCE, stateDescr);
+
+			// populate the different namespaces
+			//  - mno has all elements already in one source namespace
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace3);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("mno");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateAddAndGetWithMutableAccumulator() throws Exception {
+
+		final AggregatingStateDescriptor<Long, MutableLong, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			AggregatingState<Long, Long> state =
+				keyedBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescr);
+
+			keyedBackend.setCurrentKey("def");
+			assertNull(state.get());
+			state.add(17L);
+			state.add(11L);
+			assertEquals(28L, state.get().longValue());
+
+			keyedBackend.setCurrentKey("def");
+			assertEquals(28L, state.get().longValue());
+			state.clear();
+			assertNull(state.get());
+
+			keyedBackend.setCurrentKey("def");
+			assertNull(state.get());
+
+			keyedBackend.setCurrentKey("g");
+			assertNull(state.get());
+			state.add(1L);
+			state.add(2L);
+
+			keyedBackend.setCurrentKey("g");
+			state.add(3L);
+			state.add(2L);
+			state.add(1L);
+
+			keyedBackend.setCurrentKey("g");
+			assertEquals(9L, state.get().longValue());
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithMutableAccumulatorOverThreeNamespaces() throws Exception {
+		final AggregatingStateDescriptor<Long, MutableLong, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - abc spreads the values over three namespaces
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.add(33L);
+			state.add(55L);
+
+			state.setCurrentNamespace(namespace2);
+			state.add(22L);
+			state.add(11L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(44L);
+
+			keyedBackend.setCurrentKey("abc");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithMutableAccumulatorWithEmpty() throws Exception {
+		final AggregatingStateDescriptor<Long, MutableLong, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - def spreads the values over two namespaces (one empty)
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(44L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(22L);
+			state.add(55L);
+			state.add(33L);
+
+			keyedBackend.setCurrentKey("def");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithMutableAccumulatorEmpty() throws Exception {
+		final AggregatingStateDescriptor<Long, MutableLong, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - ghi is empty
+
+			keyedBackend.setCurrentKey("ghi");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithMutableAccumulatorInTargetNamespace() throws Exception {
+		final AggregatingStateDescriptor<Long, MutableLong, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - jkl has all elements already in the target namespace
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("jkl");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithMutableAccumulatorInASingleNamespace() throws Exception {
+		final AggregatingStateDescriptor<Long, MutableLong, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(0, IntSerializer.INSTANCE, stateDescr);
+
+			// populate the different namespaces
+			//  - mno has all elements already in one source namespace
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace3);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("mno");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateAddAndGetWithImmutableAccumulator() throws Exception {
+
+		final AggregatingStateDescriptor<Long, Long, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new ImmutableAggregatingAddingFunction(), Long.class);
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			AggregatingState<Long, Long> state =
+				keyedBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescr);
+
+			keyedBackend.setCurrentKey("def");
+			assertNull(state.get());
+			state.add(17L);
+			state.add(11L);
+			assertEquals(28L, state.get().longValue());
+
+			keyedBackend.setCurrentKey("def");
+			assertEquals(28L, state.get().longValue());
+			state.clear();
+			assertNull(state.get());
+
+			keyedBackend.setCurrentKey("g");
+			assertNull(state.get());
+			state.add(1L);
+			state.add(2L);
+
+			keyedBackend.setCurrentKey("g");
+			state.add(3L);
+			state.add(2L);
+			state.add(1L);
+
+			keyedBackend.setCurrentKey("g");
+			assertEquals(9L, state.get().longValue());
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithImmutableAccumulatorOverThreeNamespaces() throws Exception {
+		final AggregatingStateDescriptor<Long, Long, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new ImmutableAggregatingAddingFunction(), Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - abc spreads the values over three namespaces
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.add(33L);
+			state.add(55L);
+
+			state.setCurrentNamespace(namespace2);
+			state.add(22L);
+			state.add(11L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(44L);
+
+			keyedBackend.setCurrentKey("abc");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("abc");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithImmutableAccumulatorWithEmpty() throws Exception {
+		final AggregatingStateDescriptor<Long, Long, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new ImmutableAggregatingAddingFunction(), Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - def spreads the values over two namespaces (one empty)
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(44L);
+
+			state.setCurrentNamespace(namespace3);
+			state.add(22L);
+			state.add(55L);
+			state.add(33L);
+
+			keyedBackend.setCurrentKey("def");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("def");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithImmutableAccumulatorEmpty() throws Exception {
+		final AggregatingStateDescriptor<Long, Long, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new ImmutableAggregatingAddingFunction(), Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - ghi is empty
+
+			keyedBackend.setCurrentKey("ghi");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithImmutableAccumulatorInTargetNamespace() throws Exception {
+		final AggregatingStateDescriptor<Long, Long, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new ImmutableAggregatingAddingFunction(), Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(
+					0,
+					IntSerializer.INSTANCE,
+					stateDescr);
+
+			// populate the different namespaces
+			//  - jkl has all elements already in the target namespace
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("jkl");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("jkl");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testAggregatingStateMergingWithImmutableAccumulatorInASingleNamespace() throws Exception {
+		final AggregatingStateDescriptor<Long, Long, Long> stateDescr =
+			new AggregatingStateDescriptor<>("my-state", new ImmutableAggregatingAddingFunction(), Long.class);
+
+		final Integer namespace1 = 1;
+		final Integer namespace2 = 2;
+		final Integer namespace3 = 3;
+
+		final Long expectedResult = 165L;
+
+		try (CheckpointableKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE)) {
+			InternalAggregatingState<String, Integer, Long, Long, Long> state =
+				(InternalAggregatingState<String, Integer, Long, Long, Long>) keyedBackend.getPartitionedState(0, IntSerializer.INSTANCE, stateDescr);
+
+			// populate the different namespaces
+			//  - mno has all elements already in one source namespace
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace3);
+			state.add(11L);
+			state.add(22L);
+			state.add(33L);
+			state.add(44L);
+			state.add(55L);
+
+			keyedBackend.setCurrentKey("mno");
+			state.mergeNamespaces(namespace1, asList(namespace2, namespace3));
+			state.setCurrentNamespace(namespace1);
+			assertEquals(expectedResult, state.get());
+
+			keyedBackend.setCurrentKey("mno");
+			state.setCurrentNamespace(namespace1);
+			state.clear();
+			assertNull(state.get());
+		}
+	}
+
+	@Test
+	public void testMapStateIsEmpty() throws Exception {
+		MapStateDescriptor<Integer, Long> kvId = new MapStateDescriptor<>("id", Integer.class, Long.class);
+
+		CheckpointableKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		try {
+			MapState<Integer, Long> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+			backend.setCurrentKey(1);
+			assertTrue(state.isEmpty());
+
+			int stateSize = 1024;
+			for (int i = 0; i < stateSize; i++) {
+				state.put(i, i * 2L);
+				assertFalse(state.isEmpty());
+			}
+
+			for (int i = 0; i < stateSize; i++) {
+				assertFalse(state.isEmpty());
+				state.remove(i);
+			}
+			assertTrue(state.isEmpty());
+
+		} finally {
+			backend.dispose();
+		}
+	}
+
+	/**
+	 * Verify iterator of {@link MapState} supporting arbitrary access, see [FLINK-10267] to know more details.
+	 */
+	@Test
+	public void testMapStateIteratorArbitraryAccess() throws Exception {
+		MapStateDescriptor<Integer, Long> kvId = new MapStateDescriptor<>("id", Integer.class, Long.class);
+
+		CheckpointableKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		try {
+			MapState<Integer, Long> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+			backend.setCurrentKey(1);
+			int stateSize = 4096;
+			for (int i = 0; i < stateSize; i++) {
+				state.put(i, i * 2L);
+			}
+			Iterator<Map.Entry<Integer, Long>> iterator = state.iterator();
+			int iteratorCount = 0;
+			while (iterator.hasNext()) {
+				Map.Entry<Integer, Long> entry = iterator.next();
+				assertEquals(iteratorCount, (int) entry.getKey());
+				switch (ThreadLocalRandom.current().nextInt() % 3) {
+					case 0: // remove twice
+						iterator.remove();
+						try {
+							iterator.remove();
+							fail();
+						} catch (IllegalStateException e) {
+							// ignore expected exception
+						}
+						break;
+					case 1: // hasNext -> remove
+						iterator.hasNext();
+						iterator.remove();
+						break;
+					case 2: // nothing to do
+						break;
+				}
+				iteratorCount++;
+			}
+			assertEquals(stateSize, iteratorCount);
+		} finally {
+			backend.dispose();
+		}
+	}
+
+	/**
+	 * Verify that {@link ValueStateDescriptor} allows {@code null} as default.
+	 */
+	@Test
+	public void testValueStateNullAsDefaultValue() throws Exception {
+		CheckpointableKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, null);
+
+		ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+
+		backend.setCurrentKey(1);
+		assertNull(state.value());
+
+		state.update("Ciao");
+		assertEquals("Ciao", state.value());
+
+		state.clear();
+		assertNull(state.value());
+
+		backend.dispose();
+	}
+
+
+	/**
+	 * Verify that an empty {@code ValueState} will yield the default value.
+	 */
+	@Test
+	public void testValueStateDefaultValue() throws Exception {
+		CheckpointableKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, "Hello");
+
+		ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+
+		backend.setCurrentKey(1);
+		assertEquals("Hello", state.value());
+
+		state.update("Ciao");
+		assertEquals("Ciao", state.value());
+
+		state.clear();
+		assertEquals("Hello", state.value());
+
+		backend.dispose();
+	}
+
+	/**
+	 * Verify that an empty {@code ReduceState} yields {@code null}.
+	 */
+	@Test
+	public void testReducingStateDefaultValue() throws Exception {
+		CheckpointableKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		ReducingStateDescriptor<String> kvId = new ReducingStateDescriptor<>("id", new AppendingReduce(), String.class);
+
+		ReducingState<String> state = backend.getPartitionedState(
+			VoidNamespace.INSTANCE,
+			VoidNamespaceSerializer.INSTANCE, kvId);
+
+		backend.setCurrentKey(1);
+		assertNull(state.get());
+
+		state.add("Ciao");
+		assertEquals("Ciao", state.get());
+
+		state.clear();
+		assertNull(state.get());
+
+		backend.dispose();
+	}
+
+	/**
+	 * Verify that an empty {@code ListState} yields {@code null}.
+	 */
+	@Test
+	public void testListStateDefaultValue() throws Exception {
+		CheckpointableKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
+
+		ListState<String> state = backend.getPartitionedState(
+			VoidNamespace.INSTANCE,
+			VoidNamespaceSerializer.INSTANCE, kvId);
+
+		backend.setCurrentKey(1);
+		assertNull(state.get());
+
+		state.update(Arrays.asList("Ciao", "Bello"));
+		assertThat(state.get(), containsInAnyOrder("Ciao", "Bello"));
+
+		state.clear();
+		assertNull(state.get());
+
+		backend.dispose();
+	}
+
+	/**
+	 * Verify that an empty {@code MapState} yields {@code null}.
+	 */
+	@Test
+	public void testMapStateDefaultValue() throws Exception {
+		CheckpointableKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		MapStateDescriptor<String, String> kvId = new MapStateDescriptor<>("id", String.class, String.class);
+
+		MapState<String, String> state = backend.getPartitionedState(
+			VoidNamespace.INSTANCE,
+			VoidNamespaceSerializer.INSTANCE, kvId);
+
+		backend.setCurrentKey(1);
+		assertNotNull(state.entries());
+		assertFalse(state.entries().iterator().hasNext());
+
+		state.put("Ciao", "Hello");
+		state.put("Bello", "Nice");
+
+		assertNotNull(state.entries());
+		assertEquals(state.get("Ciao"), "Hello");
+		assertEquals(state.get("Bello"), "Nice");
+
+		state.clear();
+		assertNotNull(state.entries());
+		assertFalse(state.entries().iterator().hasNext());
+
+		backend.dispose();
+	}
+
+	private static class AppendingReduce implements ReduceFunction<String> {
+		@Override
+		public String reduce(String value1, String value2) throws Exception {
+			return value1 + "," + value2;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static class MutableAggregatingAddingFunction implements AggregateFunction<Long, MutableLong, Long> {
+
+		@Override
+		public MutableLong createAccumulator() {
+			return new MutableLong();
+		}
+
+		@Override
+		public MutableLong add(Long value, MutableLong accumulator) {
+			accumulator.value += value;
+			return accumulator;
+		}
+
+		@Override
+		public Long getResult(MutableLong accumulator) {
+			return accumulator.value;
+		}
+
+		@Override
+		public MutableLong merge(MutableLong a, MutableLong b) {
+			a.value += b.value;
+			return a;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static class ImmutableAggregatingAddingFunction implements AggregateFunction<Long, Long, Long> {
+
+		@Override
+		public Long createAccumulator() {
+			return 0L;
+		}
+
+		@Override
+		public Long add(Long value, Long accumulator) {
+			return accumulator += value;
+		}
+
+		@Override
+		public Long getResult(Long accumulator) {
+			return accumulator;
+		}
+
+		@Override
+		public Long merge(Long a, Long b) {
+			return a + b;
+		}
+	}
+
+	private static final class MutableLong {
+		long value;
+	}
+
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that verify an exception is thrown in methods that are not supported in the BATCH runtime mode.
+ */
+public class BatchExecutionStateBackendVerificationTest extends TestLogger {
+
+	private static final LongSerializer LONG_SERIALIZER = new LongSerializer();
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void verifyGetKeysNotSupported() {
+		expectedException.expect(UnsupportedOperationException.class);
+		expectedException.expectMessage("getKeys() is not supported in BATCH execution mode.");
+
+		BatchExecutionKeyedStateBackend<Long> stateBackend = new BatchExecutionKeyedStateBackend<>(
+			LONG_SERIALIZER,
+			new KeyGroupRange(0, 9));
+
+		stateBackend.getKeys("state", VoidNamespace.INSTANCE);
+	}
+
+	@Test
+	public void verifyGetKeysAndNamespacesNotSupported() {
+		expectedException.expect(UnsupportedOperationException.class);
+		expectedException.expectMessage("getKeysAndNamespaces() is not supported in BATCH execution mode.");
+
+		BatchExecutionKeyedStateBackend<Long> stateBackend = new BatchExecutionKeyedStateBackend<>(
+			LONG_SERIALIZER,
+			new KeyGroupRange(0, 9));
+
+		stateBackend.getKeysAndNamespaces("state");
+	}
+
+	@Test
+	public void verifySnapshotNotSupported() {
+		expectedException.expect(UnsupportedOperationException.class);
+		expectedException.expectMessage("Snapshotting is not supported in BATCH runtime mode.");
+
+		BatchExecutionKeyedStateBackend<Long> stateBackend = new BatchExecutionKeyedStateBackend<>(
+			LONG_SERIALIZER,
+			new KeyGroupRange(0, 9));
+
+		long checkpointId = 0L;
+		CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(10);
+		stateBackend.snapshot(
+			checkpointId,
+			0L,
+			streamFactory,
+			CheckpointOptions.forCheckpointWithDefaultLocation()
+		);
+	}
+
+	@Test
+	public void verifyApplyToAllKeysNotSupported() {
+		expectedException.expect(UnsupportedOperationException.class);
+		expectedException.expectMessage("applyToAllKeys() is not supported in BATCH execution mode.");
+
+		BatchExecutionKeyedStateBackend<Long> stateBackend = new BatchExecutionKeyedStateBackend<>(
+			LONG_SERIALIZER,
+			new KeyGroupRange(0, 9));
+
+		ValueStateDescriptor<Long> stateDescriptor = new ValueStateDescriptor<>(
+			"state",
+			LONG_SERIALIZER
+		);
+
+		stateBackend.applyToAllKeys(
+			VoidNamespace.INSTANCE,
+			new VoidNamespaceSerializer(),
+			stateDescriptor,
+			(key, state) -> fail("Should never be called"));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This commit introduces a SingleKeyStateBackend. This state backend is a
simplified version of a state backend that can be used in a BATCH
runtime mode. It requires the input to be sorted, as it only ever
remembers the current key. If the key changes, the current state is
discarded. Moreover this state backend does not support checkpointing.


## Verifying this change

This change added tests:
* org.apache.flink.streaming.api.operators.sorted.state.SingleKeyStateBackendVerificationTest
* org.apache.flink.streaming.api.operators.sorted.state.SingleKeyStateBackendTest
* org.apache.flink.streaming.api.operators.sorted.state.SingleKeyKeyGroupedInternalPriorityQueueTest


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / **JavaDocs** / not documented)
