### PR TITLE
[FLINK-19482][format-orc] Define serialVersionUID for OrcRowInputFormat

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
@@ -37,6 +37,8 @@ import java.io.IOException;
  */
 public class OrcRowInputFormat extends OrcInputFormat<Row> implements ResultTypeQueryable<Row> {
 
+	private static final long serialVersionUID = 1L;
+
 	private static final Logger LOG = LoggerFactory.getLogger(OrcRowInputFormat.class);
 
 	// the number of rows read in a batch


### PR DESCRIPTION

## What is the purpose of the change

Define serialVersionUID for OrcRowInputFormat

## Brief change log

Define serialVersionUID for OrcRowInputFormat

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
