### PR TITLE
[FLINK-19306][coordination] Add DeclarativeSlotManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -66,6 +66,7 @@ import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.FileType;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -483,6 +484,27 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	}
 
 	@Override
+	public CompletableFuture<Acknowledge> declareRequiredResources(JobMasterId jobMasterId, ResourceRequirements resourceRequirements, Time timeout) {
+		final JobID jobId = resourceRequirements.getJobId();
+		final JobManagerRegistration jobManagerRegistration = jobManagerRegistrations.get(jobId);
+
+		if (null != jobManagerRegistration) {
+			if (Objects.equals(jobMasterId, jobManagerRegistration.getJobMasterId())) {
+				log.info("Received resource declaration for job {}: {}", jobId, resourceRequirements.getResourceRequirements());
+
+				slotManager.processResourceRequirements(resourceRequirements);
+
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			} else {
+				return FutureUtils.completedExceptionally(new ResourceManagerException("The job leader's id " +
+					jobManagerRegistration.getJobMasterId() + " does not match the received id " + jobMasterId + '.'));
+			}
+		} else {
+			return FutureUtils.completedExceptionally(new ResourceManagerException("Could not find registered job manager for job " + jobId + '.'));
+		}
+	}
+
+	@Override
 	public void cancelSlotRequest(AllocationID allocationID) {
 		// As the slot allocations are async, it can not avoid all redundant slots, but should best effort.
 		slotManager.unregisterSlotRequest(allocationID);
@@ -861,6 +883,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			jobManagerHeartbeatManager.unmonitorTarget(jobManagerResourceId);
 
 			jmResourceIdRegistrations.remove(jobManagerResourceId);
+
+			slotManager.processResourceRequirements(ResourceRequirements.empty(jobId, jobMasterGateway.getAddress()));
 
 			// tell the job manager about the disconnect
 			jobMasterGateway.disconnectResourceManager(getFencingToken(), cause);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -65,6 +65,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.FileType;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -1189,6 +1190,11 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			if (jobManagerRegistration != null) {
 				jobManagerRegistration.getJobManagerGateway().notifyAllocationFailure(allocationId, cause);
 			}
+		}
+
+		@Override
+		public void notifyNotEnoughResourcesAvailable(JobID jobId, Collection<ResourceRequirement> acquiredResources) {
+			validateRunsInMainThread();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.ThreadDumpInfo;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.FileType;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
@@ -81,6 +82,18 @@ public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManager
 	CompletableFuture<Acknowledge> requestSlot(
 		JobMasterId jobMasterId,
 		SlotRequest slotRequest,
+		@RpcTimeout Time timeout);
+
+	/**
+	 * Declares the absolute resource requirements for a job.
+	 *
+	 * @param jobMasterId id of the JobMaster
+	 * @param resourceRequirements resource requirements
+	 * @return The confirmation that the requirements have been processed
+	 */
+	CompletableFuture<Acknowledge> declareRequiredResources(
+		JobMasterId jobMasterId,
+		ResourceRequirements resourceRequirements,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.slotmanager.DeclarativeSlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.DefaultResourceTracker;
+import org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotTracker;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerImpl;
 import org.apache.flink.util.Preconditions;
@@ -66,7 +69,12 @@ public class ResourceManagerRuntimeServices {
 
 	private static SlotManager createSlotManager(ResourceManagerRuntimeServicesConfiguration configuration, ScheduledExecutor scheduledExecutor, SlotManagerMetricGroup slotManagerMetricGroup) {
 		if (configuration.isDeclarativeResourceManagementEnabled()) {
-			throw new UnsupportedOperationException("Declarative slot manager is not yet implemented.");
+			return new DeclarativeSlotManager(
+				scheduledExecutor,
+				configuration.getSlotManagerConfiguration(),
+				slotManagerMetricGroup,
+				new DefaultResourceTracker(),
+				new DefaultSlotTracker());
 		} else {
 			return new SlotManagerImpl(
 				scheduledExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -1,0 +1,638 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.slots.ResourceCounter;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link SlotManager} supporting declarative slot management.
+ */
+public class DeclarativeSlotManager implements SlotManager {
+	private static final Logger LOG = LoggerFactory.getLogger(DeclarativeSlotManager.class);
+
+	private final SlotTracker slotTracker;
+	private final ResourceTracker resourceTracker;
+	private final BiFunction<Executor, ResourceActions, TaskExecutorManager> taskExecutorManagerFactory;
+	private TaskExecutorManager taskExecutorManager;
+
+	/** Timeout for slot requests to the task manager. */
+	private final Time taskManagerRequestTimeout;
+
+	private final SlotMatchingStrategy slotMatchingStrategy;
+
+	private final SlotManagerMetricGroup slotManagerMetricGroup;
+
+	private final Map<JobID, String> jobMasterTargetAddresses = new HashMap<>();
+	private final HashMap<SlotID, CompletableFuture<Acknowledge>> pendingSlotAllocationFutures;
+
+	/** ResourceManager's id. */
+	private ResourceManagerId resourceManagerId;
+
+	/** Executor for future callbacks which have to be "synchronized". */
+	private Executor mainThreadExecutor;
+
+	/** Callbacks for resource (de-)allocations. */
+	private ResourceActions resourceActions;
+
+	/** True iff the component has been started. */
+	private boolean started;
+
+	public DeclarativeSlotManager(
+			ScheduledExecutor scheduledExecutor,
+			SlotManagerConfiguration slotManagerConfiguration,
+			SlotManagerMetricGroup slotManagerMetricGroup,
+			ResourceTracker resourceTracker,
+			SlotTracker slotTracker) {
+
+		Preconditions.checkNotNull(slotManagerConfiguration);
+		this.taskManagerRequestTimeout = slotManagerConfiguration.getTaskManagerRequestTimeout();
+		this.slotManagerMetricGroup = Preconditions.checkNotNull(slotManagerMetricGroup);
+		this.resourceTracker = Preconditions.checkNotNull(resourceTracker);
+
+		pendingSlotAllocationFutures = new HashMap<>(16);
+
+		this.slotTracker = Preconditions.checkNotNull(slotTracker);
+		slotTracker.registerSlotStatusUpdateListener(createSlotStatusUpdateListener());
+
+		slotMatchingStrategy = slotManagerConfiguration.getSlotMatchingStrategy();
+
+		taskExecutorManagerFactory = (executor, resourceActions) -> new TaskExecutorManager(
+			slotManagerConfiguration.getDefaultWorkerResourceSpec(),
+			slotManagerConfiguration.getNumSlotsPerWorker(),
+			slotManagerConfiguration.getMaxSlotNum(),
+			slotManagerConfiguration.isWaitResultConsumedBeforeRelease(),
+			slotManagerConfiguration.getRedundantTaskManagerNum(),
+			slotManagerConfiguration.getTaskManagerTimeout(),
+			scheduledExecutor,
+			executor,
+			resourceActions);
+
+		resourceManagerId = null;
+		resourceActions = null;
+		mainThreadExecutor = null;
+		taskExecutorManager = null;
+
+		started = false;
+	}
+
+	private SlotStatusUpdateListener createSlotStatusUpdateListener() {
+		return (taskManagerSlot, previous, current, jobId) -> {
+			if (previous == SlotState.PENDING) {
+				cancelAllocationFuture(taskManagerSlot.getSlotId());
+			}
+
+			if (current == SlotState.PENDING) {
+				resourceTracker.notifyAcquiredResource(jobId, taskManagerSlot.getResourceProfile());
+			}
+			if (current == SlotState.FREE) {
+				resourceTracker.notifyLostResource(jobId, taskManagerSlot.getResourceProfile());
+			}
+
+			if (current == SlotState.ALLOCATED) {
+				taskExecutorManager.occupySlot(taskManagerSlot.getInstanceId());
+			}
+			if (previous == SlotState.ALLOCATED && current == SlotState.FREE) {
+				taskExecutorManager.freeSlot(taskManagerSlot.getInstanceId());
+			}
+		};
+	}
+
+	private void cancelAllocationFuture(SlotID slotId) {
+		final CompletableFuture<Acknowledge> acknowledgeCompletableFuture = pendingSlotAllocationFutures.remove(slotId);
+		// the future may be null if we are just re-playing the state transitions due to a slot report
+		if (acknowledgeCompletableFuture != null) {
+			acknowledgeCompletableFuture.cancel(false);
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Component lifecycle methods
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * Starts the slot manager with the given leader id and resource manager actions.
+	 *
+	 * @param newResourceManagerId to use for communication with the task managers
+	 * @param newMainThreadExecutor to use to run code in the ResourceManager's main thread
+	 * @param newResourceActions to use for resource (de-)allocations
+	 */
+	@Override
+	public void start(ResourceManagerId newResourceManagerId, Executor newMainThreadExecutor, ResourceActions newResourceActions) {
+		LOG.info("Starting the slot manager.");
+
+		this.resourceManagerId = Preconditions.checkNotNull(newResourceManagerId);
+		mainThreadExecutor = Preconditions.checkNotNull(newMainThreadExecutor);
+		resourceActions = Preconditions.checkNotNull(newResourceActions);
+		taskExecutorManager = taskExecutorManagerFactory.apply(newMainThreadExecutor, newResourceActions);
+
+		started = true;
+
+		registerSlotManagerMetrics();
+	}
+
+	private void registerSlotManagerMetrics() {
+		slotManagerMetricGroup.gauge(
+			MetricNames.TASK_SLOTS_AVAILABLE,
+			() -> (long) getNumberFreeSlots());
+		slotManagerMetricGroup.gauge(
+			MetricNames.TASK_SLOTS_TOTAL,
+			() -> (long) getNumberRegisteredSlots());
+	}
+
+	/**
+	 * Suspends the component. This clears the internal state of the slot manager.
+	 */
+	@Override
+	public void suspend() {
+		LOG.info("Suspending the slot manager.");
+
+		resourceTracker.clear();
+		taskExecutorManager.close();
+
+		for (InstanceID registeredTaskManager : taskExecutorManager.getTaskExecutors()) {
+			unregisterTaskManager(registeredTaskManager, new SlotManagerException("The slot manager is being suspended."));
+		}
+
+		taskExecutorManager = null;
+		resourceManagerId = null;
+		resourceActions = null;
+		started = false;
+	}
+
+	/**
+	 * Closes the slot manager.
+	 *
+	 * @throws Exception if the close operation fails
+	 */
+	@Override
+	public void close() throws Exception {
+		LOG.info("Closing the slot manager.");
+
+		suspend();
+		slotManagerMetricGroup.close();
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Public API
+	// ---------------------------------------------------------------------------------------------
+
+	@Override
+	public void processResourceRequirements(ResourceRequirements resourceRequirements) {
+		checkInit();
+		LOG.debug("Received resource requirements from job {}: {}", resourceRequirements.getJobId(), resourceRequirements.getResourceRequirements());
+
+		if (resourceRequirements.getResourceRequirements().isEmpty()) {
+			jobMasterTargetAddresses.remove(resourceRequirements.getJobId());
+		} else {
+			jobMasterTargetAddresses.put(resourceRequirements.getJobId(), resourceRequirements.getTargetAddress());
+		}
+		resourceTracker.notifyResourceRequirements(resourceRequirements.getJobId(), resourceRequirements.getResourceRequirements());
+		checkResourceRequirements();
+	}
+
+	/**
+	 * Registers a new task manager at the slot manager. This will make the task managers slots
+	 * known and, thus, available for allocation.
+	 *
+	 * @param taskExecutorConnection for the new task manager
+	 * @param initialSlotReport for the new task manager
+	 * @return True if the task manager has not been registered before and is registered successfully; otherwise false
+	 */
+	@Override
+	public boolean registerTaskManager(final TaskExecutorConnection taskExecutorConnection, SlotReport initialSlotReport) {
+		checkInit();
+		LOG.debug("Registering task executor {} under {} at the slot manager.", taskExecutorConnection.getResourceID(), taskExecutorConnection.getInstanceID());
+
+		// we identify task managers by their instance id
+		if (taskExecutorManager.isTaskManagerRegistered(taskExecutorConnection.getInstanceID())) {
+			LOG.debug("Task executor {} was already registered.", taskExecutorConnection.getResourceID());
+			reportSlotStatus(taskExecutorConnection.getInstanceID(), initialSlotReport);
+			return false;
+		} else {
+			if (!taskExecutorManager.registerTaskManager(taskExecutorConnection, initialSlotReport)) {
+				LOG.debug("Task executor {} could not be registered.", taskExecutorConnection.getResourceID());
+				return false;
+			}
+
+			// register the new slots
+			for (SlotStatus slotStatus : initialSlotReport) {
+				slotTracker.addSlot(
+					slotStatus.getSlotID(),
+					slotStatus.getResourceProfile(),
+					taskExecutorConnection,
+					slotStatus.getJobID());
+			}
+
+			checkResourceRequirements();
+			return true;
+		}
+	}
+
+	@Override
+	public boolean unregisterTaskManager(InstanceID instanceId, Exception cause) {
+		checkInit();
+
+		LOG.debug("Unregistering task executor {} from the slot manager.", instanceId);
+
+		if (taskExecutorManager.isTaskManagerRegistered(instanceId)) {
+			slotTracker.removeSlots(taskExecutorManager.getSlotsOf(instanceId));
+			taskExecutorManager.unregisterTaskExecutor(instanceId);
+			checkResourceRequirements();
+
+			return true;
+		} else {
+			LOG.debug("There is no task executor registered with instance ID {}. Ignoring this message.", instanceId);
+
+			return false;
+		}
+	}
+
+	/**
+	 * Reports the current slot allocations for a task manager identified by the given instance id.
+	 *
+	 * @param instanceId identifying the task manager for which to report the slot status
+	 * @param slotReport containing the status for all of its slots
+	 * @return true if the slot status has been updated successfully, otherwise false
+	 */
+	@Override
+	public boolean reportSlotStatus(InstanceID instanceId, SlotReport slotReport) {
+		checkInit();
+
+		LOG.debug("Received slot report from instance {}: {}.", instanceId, slotReport);
+
+		if (taskExecutorManager.isTaskManagerRegistered(instanceId)) {
+			slotTracker.notifySlotStatus(slotReport);
+			checkResourceRequirements();
+			return true;
+		} else {
+			LOG.debug("Received slot report for unknown task manager with instance id {}. Ignoring this report.", instanceId);
+
+			return false;
+		}
+	}
+
+	/**
+	 * Free the given slot from the given allocation. If the slot is still allocated by the given
+	 * allocation id, then the slot will be marked as free and will be subject to new slot requests.
+	 *
+	 * @param slotId identifying the slot to free
+	 * @param allocationId with which the slot is presumably allocated
+	 */
+	@Override
+	public void freeSlot(SlotID slotId, AllocationID allocationId) {
+		checkInit();
+		LOG.debug("Freeing slot {}.", slotId);
+
+		slotTracker.notifyFree(slotId);
+		checkResourceRequirements();
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Requirement matching
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * Matches resource requirements against available resources. In a first round requirements are matched against free
+	 * slot, and any match results in a slot allocation.
+	 * The remaining unfulfilled requirements are matched against pending slots, allocating more workers if no matching
+	 * pending slot could be found.
+	 * If the requirements for a job could not be fulfilled then a notification is sent to the job master informing it
+	 * as such.
+	 *
+	 * <p>Performance notes: At it's core this method loops, for each job, over all free/pending slots for each required slot, trying to
+	 * find a matching slot. One should generally go in with the assumption that this runs in
+	 * numberOfJobsRequiringResources * numberOfRequiredSlots * numberOfFreeOrPendingSlots.
+	 * This is especially important when dealing with pending slots, as matches between requirements and pending slots
+	 * are not persisted and recomputed on each call.
+	 * This may required further refinements in the future; e.g., persisting the matches between requirements and pending slots,
+	 * or not matching against pending slots at all.
+	 *
+	 * <p>When dealing with unspecific resource profiles (i.e., {@link ResourceProfile#ANY}/{@link ResourceProfile#UNKNOWN}),
+	 * then the number of free/pending slots is not relevant because we only need exactly 1 comparison to determine whether
+	 * a slot can be fulfilled or not, since they are all the same anyway.
+	 *
+	 * <p>When dealing with specific resource profiles things can be a lot worse, with the classical cases
+	 * where either no matches are found, or only at the very end of the iteration.
+	 * In the absolute worst case, with J jobs, requiring R slots each with a unique resource profile such each pair
+	 * of these profiles is not matching, and S free/pending slots that don't fulfill any requirement, then this method
+	 * does a total of J*R*S resource profile comparisons.
+	 */
+	private void checkResourceRequirements() {
+		final Map<JobID, Collection<ResourceRequirement>> missingResources = resourceTracker.getMissingResources();
+		if (missingResources.isEmpty()) {
+			return;
+		}
+
+		final Map<JobID, ResourceCounter> unfulfilledRequirements = new LinkedHashMap<>();
+		for (Map.Entry<JobID, Collection<ResourceRequirement>> resourceRequirements : missingResources.entrySet()) {
+			final JobID jobId = resourceRequirements.getKey();
+
+			final ResourceCounter unfulfilledJobRequirements = tryAllocateSlotsForJob(jobId, resourceRequirements.getValue());
+			if (!unfulfilledJobRequirements.isEmpty()) {
+				unfulfilledRequirements.put(jobId, unfulfilledJobRequirements);
+			}
+		}
+		if (unfulfilledRequirements.isEmpty()) {
+			return;
+		}
+
+		final ResourceCounter pendingSlots = new ResourceCounter(taskExecutorManager.getPendingTaskManagerSlots().stream().collect(
+			Collectors.groupingBy(
+				PendingTaskManagerSlot::getResourceProfile,
+				Collectors.summingInt(x -> 1))));
+
+		for (Map.Entry<JobID, ResourceCounter> unfulfilledRequirement : unfulfilledRequirements.entrySet()) {
+			tryFulfillRequirementsWithPendingSlots(
+				unfulfilledRequirement.getKey(),
+				unfulfilledRequirement.getValue().getResourceProfilesWithCount(),
+				pendingSlots);
+		}
+	}
+
+	private ResourceCounter tryAllocateSlotsForJob(JobID jobId, Collection<ResourceRequirement> missingResources) {
+		final ResourceCounter outstandingRequirements = new ResourceCounter();
+
+		for (ResourceRequirement resourceRequirement : missingResources) {
+			int numMissingSlots = internalTryAllocateSlots(jobId, jobMasterTargetAddresses.get(jobId), resourceRequirement);
+			if (numMissingSlots > 0) {
+				outstandingRequirements.incrementCount(resourceRequirement.getResourceProfile(), numMissingSlots);
+			}
+		}
+		return outstandingRequirements;
+	}
+
+	/**
+	 * Tries to allocate slots for the given requirement. If there are not enough slots available, the
+	 * resource manager is informed to allocate more resources.
+	 *
+	 * @param jobId job to allocate slots for
+	 * @param targetAddress address of the jobmaster
+	 * @param resourceRequirement required slots
+	 * @return the number of missing slots
+	 */
+	private int internalTryAllocateSlots(JobID jobId, String targetAddress, ResourceRequirement resourceRequirement) {
+		final ResourceProfile requiredResource = resourceRequirement.getResourceProfile();
+		Collection<TaskManagerSlotInformation> freeSlots = slotTracker.getFreeSlots();
+
+		int numUnfulfilled = 0;
+		for (int x = 0; x < resourceRequirement.getNumberOfRequiredSlots(); x++) {
+
+			final Optional<TaskManagerSlotInformation> reservedSlot = slotMatchingStrategy.findMatchingSlot(requiredResource, freeSlots, this::getNumberRegisteredSlotsOf);
+			if (reservedSlot.isPresent()) {
+				// we do not need to modify freeSlots because it is indirectly modified by the allocation
+				allocateSlot(reservedSlot.get(), jobId, targetAddress, requiredResource);
+			} else {
+				// exit loop early; we won't find a matching slot for this requirement
+				int numRemaining = resourceRequirement.getNumberOfRequiredSlots() - x;
+				numUnfulfilled += numRemaining;
+				break;
+			}
+		}
+		return numUnfulfilled;
+	}
+
+	/**
+	 * Allocates the given slot. This entails sending a registration message to the task manager and treating failures.
+	 *
+	 * @param taskManagerSlot slot to allocate
+	 * @param jobId job for which the slot should be allocated for
+	 * @param targetAddress address of the job master
+	 * @param resourceProfile resource profile for the requirement for which the slot is used
+	 */
+	private void allocateSlot(TaskManagerSlotInformation taskManagerSlot, JobID jobId, String targetAddress, ResourceProfile resourceProfile) {
+		final SlotID slotId = taskManagerSlot.getSlotId();
+		LOG.debug("Starting allocation of slot {} for job {} with resource profile {}.", slotId, jobId, resourceProfile);
+
+		final InstanceID instanceId = taskManagerSlot.getInstanceId();
+		if (!taskExecutorManager.isTaskManagerRegistered(instanceId)) {
+			throw new IllegalStateException("Could not find a registered task manager for instance id " +
+				instanceId + '.');
+		}
+
+		final TaskExecutorConnection taskExecutorConnection = taskManagerSlot.getTaskManagerConnection();
+		final TaskExecutorGateway gateway = taskExecutorConnection.getTaskExecutorGateway();
+
+		final CompletableFuture<Acknowledge> completableFuture = new CompletableFuture<>();
+
+		slotTracker.notifyAllocationStart(slotId, jobId);
+		taskExecutorManager.markUsed(instanceId);
+		pendingSlotAllocationFutures.put(slotId, completableFuture);
+
+		// RPC call to the task manager
+		CompletableFuture<Acknowledge> requestFuture = gateway.requestSlot(
+			slotId,
+			jobId,
+			new AllocationID(),
+			resourceProfile,
+			targetAddress,
+			resourceManagerId,
+			taskManagerRequestTimeout);
+
+		requestFuture.whenComplete(
+			(Acknowledge acknowledge, Throwable throwable) -> {
+				if (acknowledge != null) {
+					completableFuture.complete(acknowledge);
+				} else {
+					completableFuture.completeExceptionally(throwable);
+				}
+			});
+
+		CompletableFuture<Void> slotAllocationResponseProcessingFuture = completableFuture.handleAsync(
+			(Acknowledge acknowledge, Throwable throwable) -> {
+				if (acknowledge != null) {
+					LOG.trace("Completed allocation of slot {} for job {}.", slotId, jobId);
+					slotTracker.notifyAllocationComplete(slotId, jobId);
+				} else {
+					if (throwable instanceof SlotOccupiedException) {
+						SlotOccupiedException exception = (SlotOccupiedException) throwable;
+						LOG.debug("Tried allocating slot {} for job {}, but it was already allocated for job {}.", slotId, jobId, exception.getJobId());
+						// report as a slot status to force the state transition
+						// this could be a problem if we ever assume that the task executor always reports about all slots
+						slotTracker.notifySlotStatus(Collections.singleton(new SlotStatus(slotId, taskManagerSlot.getResourceProfile(), exception.getJobId(), exception.getAllocationId())));
+					} else {
+						if (throwable instanceof CancellationException) {
+							LOG.debug("Cancelled allocation of slot {} for job {}.", slotId, jobId, throwable);
+						} else {
+							LOG.warn("Slot allocation for slot {} for job {} failed.", slotId, jobId, throwable);
+							slotTracker.notifyFree(slotId);
+						}
+					}
+					checkResourceRequirements();
+				}
+				return null;
+			},
+			mainThreadExecutor);
+		FutureUtils.assertNoException(slotAllocationResponseProcessingFuture);
+	}
+
+	private void tryFulfillRequirementsWithPendingSlots(JobID jobId, Map<ResourceProfile, Integer> missingResources, ResourceCounter pendingSlots) {
+		for (Map.Entry<ResourceProfile, Integer> missingResource : missingResources.entrySet()) {
+			ResourceProfile profile = missingResource.getKey();
+			for (int i = 0; i < missingResource.getValue(); i++) {
+				if (!tryFulfillWithPendingSlots(profile, pendingSlots)) {
+					boolean couldAllocateWorkerAndReserveSlot = tryAllocateWorkerAndReserveSlot(profile, pendingSlots);
+					if (!couldAllocateWorkerAndReserveSlot) {
+						LOG.warn("Could not fulfill resource requirements of job {}.", jobId);
+						resourceActions.notifyNotEnoughResourcesAvailable(jobId, resourceTracker.getAcquiredResources(jobId));
+						return;
+					}
+				}
+			}
+		}
+	}
+
+	private boolean tryFulfillWithPendingSlots(ResourceProfile resourceProfile, ResourceCounter pendingSlots) {
+		Set<ResourceProfile> pendingSlotProfiles = pendingSlots.getResourceProfiles();
+
+		// short-cut, pretty much only applicable to fine-grained resource management
+		if (pendingSlotProfiles.contains(resourceProfile)) {
+			pendingSlots.decrementCount(resourceProfile, 1);
+			return true;
+		}
+
+		for (ResourceProfile pendingSlotProfile : pendingSlotProfiles) {
+			if (pendingSlotProfile.isMatching(resourceProfile)) {
+				pendingSlots.decrementCount(pendingSlotProfile, 1);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean tryAllocateWorkerAndReserveSlot(ResourceProfile profile, ResourceCounter pendingSlots) {
+		Optional<ResourceRequirement> newlyFulfillableRequirements = taskExecutorManager.allocateWorker(profile);
+		if (newlyFulfillableRequirements.isPresent()) {
+			ResourceRequirement newSlots = newlyFulfillableRequirements.get();
+			// reserve one of the new slots
+			if (newSlots.getNumberOfRequiredSlots() > 1) {
+				pendingSlots.incrementCount(newSlots.getResourceProfile(), newSlots.getNumberOfRequiredSlots() - 1);
+			}
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Legacy APIs
+	// ---------------------------------------------------------------------------------------------
+
+	@Override
+	public int getNumberRegisteredSlots() {
+		return taskExecutorManager.getNumberRegisteredSlots();
+	}
+
+	@Override
+	public int getNumberRegisteredSlotsOf(InstanceID instanceId) {
+		return taskExecutorManager.getNumberRegisteredSlotsOf(instanceId);
+	}
+
+	@Override
+	public int getNumberFreeSlots() {
+		return taskExecutorManager.getNumberFreeSlots();
+	}
+
+	@Override
+	public int getNumberFreeSlotsOf(InstanceID instanceId) {
+		return taskExecutorManager.getNumberFreeSlotsOf(instanceId);
+	}
+
+	@Override
+	public Map<WorkerResourceSpec, Integer> getRequiredResources() {
+		return taskExecutorManager.getRequiredWorkers();
+	}
+
+	@Override
+	public ResourceProfile getRegisteredResource() {
+		return taskExecutorManager.getTotalRegisteredResources();
+	}
+
+	@Override
+	public ResourceProfile getRegisteredResourceOf(InstanceID instanceID) {
+		return taskExecutorManager.getTotalRegisteredResourcesOf(instanceID);
+	}
+
+	@Override
+	public ResourceProfile getFreeResource() {
+		return taskExecutorManager.getTotalFreeResources();
+	}
+
+	@Override
+	public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
+		return taskExecutorManager.getTotalFreeResourcesOf(instanceID);
+	}
+
+	@Override
+	public void setFailUnfulfillableRequest(boolean failUnfulfillableRequest) {
+		// we always send notifications if we cannot fulfill requests, and it is the responsibility of the JobManager
+		// to handle it (e.g., by reducing requirements and failing outright)
+	}
+
+	@Override
+	public int getNumberPendingSlotRequests() {
+		// only exists for testing purposes
+		throw new UnsupportedOperationException();
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Internal utility methods
+	// ---------------------------------------------------------------------------------------------
+
+	private void checkInit() {
+		Preconditions.checkState(started, "The slot manager has not been started.");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
@@ -42,7 +42,7 @@ import java.util.function.Consumer;
 /**
  * Default SlotTracker implementation.
  */
-class DefaultSlotTracker implements SlotTracker {
+public class DefaultSlotTracker implements SlotTracker {
 	private static final Logger LOG = LoggerFactory.getLogger(DefaultSlotTracker.class);
 
 	/**
@@ -192,6 +192,12 @@ class DefaultSlotTracker implements SlotTracker {
 	@VisibleForTesting
 	boolean areMapsEmpty() {
 		return slots.isEmpty() && freeSlots.isEmpty();
+	}
+
+	@VisibleForTesting
+	@Nullable
+	DeclarativeTaskManagerSlot getSlot(SlotID slotId) {
+		return slots.get(slotId);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -22,6 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+
+import java.util.Collection;
 
 /**
  * Resource related actions which the {@link SlotManager} can perform.
@@ -52,4 +55,12 @@ public interface ResourceActions {
 	 * @param cause of the allocation failure
 	 */
 	void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause);
+
+	/**
+	 * Notifies that not enough resources are available to fulfill the resource requirements of a job.
+	 *
+	 * @param jobId job for which not enough resources are available
+	 * @param acquiredResources the resources that have been acquired for the job
+	 */
+	void notifyNotEnoughResourcesAvailable(JobID jobId, Collection<ResourceRequirement> acquiredResources);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
@@ -141,7 +140,4 @@ public interface SlotManager extends AutoCloseable {
 	void freeSlot(SlotID slotId, AllocationID allocationId);
 
 	void setFailUnfulfillableRequest(boolean failUnfulfillableRequest);
-
-	@VisibleForTesting
-	void unregisterTaskManagersAndReleaseResources();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.Map;
@@ -84,13 +85,22 @@ public interface SlotManager extends AutoCloseable {
 	void suspend();
 
 	/**
+	 * Notifies the slot manager about the resource requirements of a job.
+	 *
+	 * @param resourceRequirements resource requirements of a job
+	 */
+	void processResourceRequirements(ResourceRequirements resourceRequirements);
+
+	/**
 	 * Requests a slot with the respective resource profile.
 	 *
 	 * @param slotRequest specifying the requested slot specs
 	 * @return true if the slot request was registered; false if the request is a duplicate
 	 * @throws ResourceManagerException if the slot request failed (e.g. not enough resources left)
 	 */
-	boolean registerSlotRequest(SlotRequest slotRequest) throws ResourceManagerException;
+	default boolean registerSlotRequest(SlotRequest slotRequest) throws ResourceManagerException {
+		throw new UnsupportedOperationException();
+	}
 
 	/**
 	 * Cancels and removes a pending slot request with the given allocation id. If there is no such
@@ -99,7 +109,9 @@ public interface SlotManager extends AutoCloseable {
 	 * @param allocationId identifying the pending slot request
 	 * @return True if a pending slot request was found; otherwise false
 	 */
-	boolean unregisterSlotRequest(AllocationID allocationId);
+	default boolean unregisterSlotRequest(AllocationID allocationId) {
+		throw new UnsupportedOperationException();
+	}
 
 	/**
 	 * Registers a new task manager at the slot manager. This will make the task managers slots

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnfulfillableSlotRequestException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -365,6 +366,12 @@ public class SlotManagerImpl implements SlotManager {
 	// ---------------------------------------------------------------------------------------------
 	// Public API
 	// ---------------------------------------------------------------------------------------------
+
+	@Override
+	public void processResourceRequirements(ResourceRequirements resourceRequirements) {
+		// no-op; don't throw an UnsupportedOperationException here because there are code paths where the resource
+		// manager calls this method regardless of whether declarative resource management is used or not
+	}
 
 	/**
 	 * Requests a slot with the respective resource profile.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -1371,21 +1371,4 @@ public class SlotManagerImpl implements SlotManager {
 		}
 	}
 
-	@Override
-	@VisibleForTesting
-	public void unregisterTaskManagersAndReleaseResources() {
-		Iterator<Map.Entry<InstanceID, TaskManagerRegistration>> taskManagerRegistrationIterator =
-				taskManagerRegistrations.entrySet().iterator();
-
-		while (taskManagerRegistrationIterator.hasNext()) {
-			TaskManagerRegistration taskManagerRegistration =
-					taskManagerRegistrationIterator.next().getValue();
-
-			taskManagerRegistrationIterator.remove();
-
-			final FlinkException cause = new FlinkException("Triggering of SlotManager#unregisterTaskManagersAndReleaseResources.");
-			internalUnregisterTaskManager(taskManagerRegistration, cause);
-			resourceActions.releaseResource(taskManagerRegistration.getInstanceId(), cause);
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/slots/ResourceCounter.java
@@ -40,7 +40,7 @@ public class ResourceCounter {
 		this(new HashMap<>());
 	}
 
-	private ResourceCounter(Map<ResourceProfile, Integer> resources) {
+	public ResourceCounter(Map<ResourceProfile, Integer> resources) {
 		this.resources = resources;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+import java.util.concurrent.Executor;
+
+/** Builder for {@link DeclarativeSlotManager}. */
+public class DeclarativeSlotManagerBuilder {
+	private SlotMatchingStrategy slotMatchingStrategy;
+	private ScheduledExecutor scheduledExecutor;
+	private Time taskManagerRequestTimeout;
+	private Time slotRequestTimeout;
+	private Time taskManagerTimeout;
+	private boolean waitResultConsumedBeforeRelease;
+	private WorkerResourceSpec defaultWorkerResourceSpec;
+	private int numSlotsPerWorker;
+	private SlotManagerMetricGroup slotManagerMetricGroup;
+	private int maxSlotNum;
+	private int redundantTaskManagerNum;
+	private ResourceTracker resourceTracker;
+	private SlotTracker slotTracker;
+
+	private DeclarativeSlotManagerBuilder() {
+		this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
+		this.scheduledExecutor = TestingUtils.defaultScheduledExecutor();
+		this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
+		this.slotRequestTimeout = TestingUtils.infiniteTime();
+		this.taskManagerTimeout = TestingUtils.infiniteTime();
+		this.waitResultConsumedBeforeRelease = true;
+		this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
+		this.numSlotsPerWorker = 1;
+		this.slotManagerMetricGroup = UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
+		this.maxSlotNum = ResourceManagerOptions.MAX_SLOT_NUM.defaultValue();
+		this.redundantTaskManagerNum = ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue();
+		this.resourceTracker = new DefaultResourceTracker();
+		this.slotTracker = new DefaultSlotTracker();
+	}
+
+	public static DeclarativeSlotManagerBuilder newBuilder() {
+		return new DeclarativeSlotManagerBuilder();
+	}
+
+	public DeclarativeSlotManagerBuilder setScheduledExecutor(ScheduledExecutor scheduledExecutor) {
+		this.scheduledExecutor = scheduledExecutor;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setTaskManagerRequestTimeout(Time taskManagerRequestTimeout) {
+		this.taskManagerRequestTimeout = taskManagerRequestTimeout;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setSlotRequestTimeout(Time slotRequestTimeout) {
+		this.slotRequestTimeout = slotRequestTimeout;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setTaskManagerTimeout(Time taskManagerTimeout) {
+		this.taskManagerTimeout = taskManagerTimeout;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setWaitResultConsumedBeforeRelease(boolean waitResultConsumedBeforeRelease) {
+		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setSlotMatchingStrategy(SlotMatchingStrategy slotMatchingStrategy) {
+		this.slotMatchingStrategy = slotMatchingStrategy;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setDefaultWorkerResourceSpec(WorkerResourceSpec defaultWorkerResourceSpec) {
+		this.defaultWorkerResourceSpec = defaultWorkerResourceSpec;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setNumSlotsPerWorker(int numSlotsPerWorker) {
+		this.numSlotsPerWorker = numSlotsPerWorker;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setSlotManagerMetricGroup(SlotManagerMetricGroup slotManagerMetricGroup) {
+		this.slotManagerMetricGroup = slotManagerMetricGroup;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setMaxSlotNum(int maxSlotNum) {
+		this.maxSlotNum = maxSlotNum;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setRedundantTaskManagerNum(int redundantTaskManagerNum) {
+		this.redundantTaskManagerNum = redundantTaskManagerNum;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setResourceTracker(ResourceTracker resourceTracker) {
+		this.resourceTracker = resourceTracker;
+		return this;
+	}
+
+	public DeclarativeSlotManagerBuilder setSlotTracker(SlotTracker slotTracker) {
+		this.slotTracker = slotTracker;
+		return this;
+	}
+
+	public DeclarativeSlotManager build() {
+		final SlotManagerConfiguration slotManagerConfiguration = new SlotManagerConfiguration(
+			taskManagerRequestTimeout,
+			slotRequestTimeout,
+			taskManagerTimeout,
+			waitResultConsumedBeforeRelease,
+			slotMatchingStrategy,
+			defaultWorkerResourceSpec,
+			numSlotsPerWorker,
+			maxSlotNum,
+			redundantTaskManagerNum);
+
+		return new DeclarativeSlotManager(
+			scheduledExecutor,
+			slotManagerConfiguration,
+			slotManagerMetricGroup,
+			resourceTracker,
+			slotTracker);
+	}
+
+	public DeclarativeSlotManager buildAndStartWithDirectExec() {
+		return buildAndStartWithDirectExec(ResourceManagerId.generate(), new TestingResourceActionsBuilder().build());
+	}
+
+	public DeclarativeSlotManager buildAndStartWithDirectExec(ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions) {
+		return buildAndStart(resourceManagerId, Executors.directExecutor(), resourceManagerActions);
+	}
+
+	public DeclarativeSlotManager buildAndStart(ResourceManagerId resourceManagerId, Executor executor, ResourceActions resourceManagerActions) {
+		final DeclarativeSlotManager slotManager = build();
+		slotManager.start(resourceManagerId, executor, resourceManagerActions);
+		return slotManager;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -1,0 +1,999 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple6;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
+import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionUtils;
+
+import akka.pattern.AskTimeoutException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link DeclarativeSlotManager}.
+ */
+public class DeclarativeSlotManagerTest extends TestLogger {
+
+	private static final FlinkException TEST_EXCEPTION = new FlinkException("Test exception");
+
+	private static final WorkerResourceSpec WORKER_RESOURCE_SPEC = new WorkerResourceSpec.Builder()
+		.setCpuCores(100.0)
+		.setTaskHeapMemoryMB(10000)
+		.setTaskOffHeapMemoryMB(10000)
+		.setNetworkMemoryMB(10000)
+		.setManagedMemoryMB(10000)
+		.build();
+
+	/**
+	 * Tests that we can register task manager and their slots at the slot manager.
+	 */
+	@Test
+	public void testTaskManagerRegistration() throws Exception {
+		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+		final ResourceID resourceId = ResourceID.generate();
+		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceId, taskExecutorGateway);
+
+		final SlotID slotId1 = new SlotID(resourceId, 0);
+		final SlotID slotId2 = new SlotID(resourceId, 1);
+		final SlotReport slotReport = new SlotReport(Arrays.asList(createFreeSlotStatus(slotId1), createFreeSlotStatus(slotId2)));
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			slotManager.registerTaskManager(taskManagerConnection, slotReport);
+
+			assertThat("The number registered slots does not equal the expected number.", slotManager.getNumberRegisteredSlots(), is(2));
+
+			assertNotNull(slotTracker.getSlot(slotId1));
+			assertNotNull(slotTracker.getSlot(slotId2));
+		}
+	}
+
+	/**
+	 * Tests that un-registration of task managers will free and remove all registered slots.
+	 */
+	@Test
+	public void testTaskManagerUnregistration() throws Exception {
+		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(tuple6 -> new CompletableFuture<>())
+			.createTestingTaskExecutorGateway();
+		final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection(taskExecutorGateway);
+		final ResourceID resourceId = taskManagerConnection.getResourceID();
+
+		final SlotID slotId1 = new SlotID(resourceId, 0);
+		final SlotID slotId2 = new SlotID(resourceId, 1);
+		final SlotReport slotReport = new SlotReport(Arrays.asList(createAllocatedSlotStatus(slotId1), createFreeSlotStatus(slotId2)));
+
+		final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			slotManager.registerTaskManager(taskManagerConnection, slotReport);
+
+			assertEquals("The number registered slots does not equal the expected number.", 2, slotManager.getNumberRegisteredSlots());
+
+			slotManager.processResourceRequirements(resourceRequirements);
+
+			slotManager.unregisterTaskManager(taskManagerConnection.getInstanceID(), TEST_EXCEPTION);
+
+			assertEquals(0, slotManager.getNumberRegisteredSlots());
+		}
+	}
+
+	/**
+	 * Tests that a slot request with no free slots will trigger the resource allocation.
+	 */
+	@Test
+	public void testRequirementDeclarationWithoutFreeSlotsTriggersWorkerAllocation() throws Exception {
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+
+		final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
+
+		CompletableFuture<WorkerResourceSpec> allocateResourceFuture = new CompletableFuture<>();
+		ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
+			.setAllocateResourceConsumer(allocateResourceFuture::complete)
+			.build();
+
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
+
+			slotManager.processResourceRequirements(resourceRequirements);
+
+			allocateResourceFuture.get();
+		}
+	}
+
+	/**
+	 * Tests that resources continue to be considered missing if we cannot allocate more resources.
+	 */
+	@Test
+	public void testRequirementDeclarationWithResourceAllocationFailure() throws Exception {
+		final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
+
+		ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
+			.setAllocateResourceFunction(value -> false)
+			.build();
+
+		final ResourceTracker resourceTracker = new DefaultResourceTracker();
+
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setResourceTracker(resourceTracker)
+			.buildAndStartWithDirectExec(ResourceManagerId.generate(), resourceManagerActions)) {
+
+			slotManager.processResourceRequirements(resourceRequirements);
+
+			final JobID jobId = resourceRequirements.getJobId();
+			assertThat(getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)), is(1));
+		}
+	}
+
+	/**
+	 * Tests that resource requirements can be fulfilled with slots that are currently free.
+	 */
+	@Test
+	public void testRequirementDeclarationWithFreeSlot() throws Exception {
+		testRequirementDeclaration(RequirementDeclarationScenario.TASK_EXECUTOR_REGISTRATION_BEFORE_REQUIREMENT_DECLARATION);
+	}
+
+	/**
+	 * Tests that resource requirements can be fulfilled with slots that are registered after the requirement declaration.
+	 */
+	@Test
+	public void testRequirementDeclarationWithPendingSlot() throws Exception {
+		testRequirementDeclaration(RequirementDeclarationScenario.TASK_EXECUTOR_REGISTRATION_AFTER_REQUIREMENT_DECLARATION);
+	}
+
+	private enum RequirementDeclarationScenario {
+		// Tests that a slot request which can be fulfilled will trigger a slot allocation
+		TASK_EXECUTOR_REGISTRATION_BEFORE_REQUIREMENT_DECLARATION,
+		// Tests that pending slot requests are tried to be fulfilled upon new slot registrations
+		TASK_EXECUTOR_REGISTRATION_AFTER_REQUIREMENT_DECLARATION
+	}
+
+	private void testRequirementDeclaration(RequirementDeclarationScenario scenario) throws Exception {
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+		final ResourceID resourceID = ResourceID.generate();
+		final JobID jobId = new JobID();
+		final SlotID slotId = new SlotID(resourceID, 0);
+		final String targetAddress = "localhost";
+		final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
+
+		final CompletableFuture<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>> requestFuture = new CompletableFuture<>();
+		// accept an incoming slot request
+		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(tuple6 -> {
+				requestFuture.complete(Tuple6.of(tuple6.f0, tuple6.f1, tuple6.f2, tuple6.f3, tuple6.f4, tuple6.f5));
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			})
+			.createTestingTaskExecutorGateway();
+
+		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
+
+		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
+		final SlotReport slotReport = new SlotReport(slotStatus);
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec(resourceManagerId, new TestingResourceActionsBuilder().build())) {
+
+			if (scenario == RequirementDeclarationScenario.TASK_EXECUTOR_REGISTRATION_BEFORE_REQUIREMENT_DECLARATION) {
+				slotManager.registerTaskManager(
+					taskExecutorConnection,
+					slotReport);
+			}
+
+			final ResourceRequirements requirements = ResourceRequirements.create(
+				jobId,
+				targetAddress,
+				Collections.singleton(ResourceRequirement.create(resourceProfile, 1)));
+			slotManager.processResourceRequirements(requirements);
+
+			if (scenario == RequirementDeclarationScenario.TASK_EXECUTOR_REGISTRATION_AFTER_REQUIREMENT_DECLARATION) {
+				slotManager.registerTaskManager(
+					taskExecutorConnection,
+					slotReport);
+			}
+
+			assertThat(requestFuture.get(), is(equalTo(Tuple6.of(slotId, jobId, requestFuture.get().f2, resourceProfile, targetAddress, resourceManagerId))));
+
+			DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
+
+			assertEquals("The slot has not been allocated to the expected allocation id.", jobId, slot.getJobId());
+		}
+	}
+
+	/**
+	 * Tests that freeing a slot will correctly reset the slot and mark it as a free slot.
+	 */
+	@Test
+	public void testFreeSlot() throws Exception {
+		final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
+		final ResourceID resourceID = taskExecutorConnection.getResourceID();
+		final SlotID slotId = new SlotID(resourceID, 0);
+
+		final SlotReport slotReport = new SlotReport(createAllocatedSlotStatus(slotId));
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			slotManager.registerTaskManager(
+				taskExecutorConnection,
+				slotReport);
+
+			DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
+
+			assertSame(SlotState.ALLOCATED, slot.getState());
+
+			slotManager.freeSlot(slotId, new AllocationID());
+
+			assertSame(SlotState.FREE, slot.getState());
+
+			assertEquals(1, slotManager.getNumberFreeSlots());
+		}
+	}
+
+	/**
+	 * Tests that duplicate resource requirement declaration do not result in additional slots being allocated after a
+	 * pending slot request has been fulfilled but not yet freed.
+	 */
+	@Test
+	public void testDuplicateResourceRequirementDeclarationAfterSuccessfulAllocation() throws Exception {
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+		final AtomicInteger allocateResourceCalls = new AtomicInteger(0);
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
+			.setAllocateResourceConsumer(ignored -> allocateResourceCalls.incrementAndGet())
+			.build();
+		ResourceRequirements requirements = createResourceRequirementsForSingleSlot();
+
+		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+
+		final ResourceID resourceID = ResourceID.generate();
+
+		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
+
+		final SlotID slotId = new SlotID(resourceID, 0);
+		final SlotReport slotReport = new SlotReport(createFreeSlotStatus(slotId));
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions)) {
+
+			slotManager.registerTaskManager(taskManagerConnection, slotReport);
+
+			slotManager.processResourceRequirements(requirements);
+
+			DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
+
+			assertThat(slot.getState(), is(SlotState.ALLOCATED));
+
+			slotManager.processResourceRequirements(requirements);
+		}
+
+		// check that we have only called the resource allocation only for the first slot request,
+		// since the second request is a duplicate
+		assertThat(allocateResourceCalls.get(), is(0));
+	}
+
+	/**
+	 * Tests that a slot allocated for one job can be allocated for another job after being freed.
+	 */
+	@Test
+	public void testSlotCanBeAllocatedForDifferentJobAfterFree() throws Exception {
+		testSlotCanBeAllocatedForDifferentJobAfterFree(SecondRequirementDeclarationTime.BEFORE_FREE);
+		testSlotCanBeAllocatedForDifferentJobAfterFree(SecondRequirementDeclarationTime.AFTER_FREE);
+	}
+
+	private enum SecondRequirementDeclarationTime {
+		BEFORE_FREE,
+		AFTER_FREE
+	}
+
+	private void testSlotCanBeAllocatedForDifferentJobAfterFree(SecondRequirementDeclarationTime secondRequirementDeclarationTime) throws Exception {
+		final AllocationID allocationId = new AllocationID();
+		final ResourceRequirements resourceRequirements1 = createResourceRequirementsForSingleSlot();
+		final ResourceRequirements resourceRequirements2 = createResourceRequirementsForSingleSlot();
+
+		final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection();
+		final ResourceID resourceID = taskManagerConnection.getResourceID();
+
+		final SlotID slotId = new SlotID(resourceID, 0);
+		final SlotReport slotReport = new SlotReport(createFreeSlotStatus(slotId));
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			slotManager.registerTaskManager(taskManagerConnection, slotReport);
+
+			slotManager.processResourceRequirements(resourceRequirements1);
+
+			DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
+
+			assertEquals("The slot has not been allocated to the expected job id.", resourceRequirements1.getJobId(), slot.getJobId());
+
+			if (secondRequirementDeclarationTime == SecondRequirementDeclarationTime.BEFORE_FREE) {
+				slotManager.processResourceRequirements(resourceRequirements2);
+			}
+
+			// clear resource requirements first so that the freed slot isn't immediately re-assigned to the job
+			slotManager.processResourceRequirements(ResourceRequirements.create(resourceRequirements1.getJobId(), resourceRequirements1.getTargetAddress(), Collections.emptyList()));
+			slotManager.freeSlot(slotId, allocationId);
+
+			if (secondRequirementDeclarationTime == SecondRequirementDeclarationTime.AFTER_FREE) {
+				slotManager.processResourceRequirements(resourceRequirements2);
+			}
+
+			assertEquals("The slot has not been allocated to the expected job id.", resourceRequirements2.getJobId(), slot.getJobId());
+		}
+	}
+
+	/**
+	 * Tests that the slot manager ignores slot reports of unknown origin (not registered
+	 * task managers).
+	 */
+	@Test
+	public void testReceivingUnknownSlotReport() throws Exception {
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
+
+		final InstanceID unknownInstanceID = new InstanceID();
+		final SlotID unknownSlotId = new SlotID(ResourceID.generate(), 0);
+		final SlotReport unknownSlotReport = new SlotReport(createFreeSlotStatus(unknownSlotId));
+
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
+			// check that we don't have any slots registered
+			assertThat(slotManager.getNumberRegisteredSlots(), is(0));
+
+			// this should not update anything since the instance id is not known to the slot manager
+			assertFalse(slotManager.reportSlotStatus(unknownInstanceID, unknownSlotReport));
+
+			assertThat(slotManager.getNumberRegisteredSlots(), is(0));
+		}
+	}
+
+	/**
+	 * Tests that slots are updated with respect to the latest incoming slot report. This means that
+	 * slots for which a report was received are updated accordingly.
+	 */
+	@Test
+	public void testUpdateSlotReport() throws Exception {
+		final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection();
+		final ResourceID resourceId = taskManagerConnection.getResourceID();
+
+		final SlotID slotId1 = new SlotID(resourceId, 0);
+		final SlotID slotId2 = new SlotID(resourceId, 1);
+
+		final SlotStatus slotStatus1 = createFreeSlotStatus(slotId1);
+		final SlotStatus slotStatus2 = createFreeSlotStatus(slotId2);
+
+		final SlotStatus newSlotStatus2 = createAllocatedSlotStatus(slotId2);
+		final JobID jobId = newSlotStatus2.getJobID();
+
+		final SlotReport slotReport1 = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
+		final SlotReport slotReport2 = new SlotReport(Arrays.asList(newSlotStatus2, slotStatus1));
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			// check that we don't have any slots registered
+			assertEquals(0, slotManager.getNumberRegisteredSlots());
+
+			slotManager.registerTaskManager(taskManagerConnection, slotReport1);
+
+			DeclarativeTaskManagerSlot slot1 = slotTracker.getSlot(slotId1);
+			DeclarativeTaskManagerSlot slot2 = slotTracker.getSlot(slotId2);
+
+			assertEquals(2, slotManager.getNumberRegisteredSlots());
+
+			assertSame(SlotState.FREE, slot1.getState());
+			assertSame(SlotState.FREE, slot2.getState());
+
+			assertTrue(slotManager.reportSlotStatus(taskManagerConnection.getInstanceID(), slotReport2));
+
+			assertEquals(2, slotManager.getNumberRegisteredSlots());
+
+			assertNotNull(slotTracker.getSlot(slotId1));
+			assertNotNull(slotTracker.getSlot(slotId2));
+
+			// slot1 should still be free, slot2 should have been allocated
+			assertSame(SlotState.FREE, slot1.getState());
+			assertEquals(jobId, slotTracker.getSlot(slotId2).getJobId());
+		}
+	}
+
+	/**
+	 * Tests that if a slot allocation times out we try to allocate another slot.
+	 */
+	@Test
+	public void testSlotAllocationTimeout() throws Exception {
+		final CompletableFuture<Void> secondSlotRequestFuture = new CompletableFuture<>();
+
+		final BlockingQueue<Supplier<CompletableFuture<Acknowledge>>> responseQueue = new ArrayBlockingQueue<>(2);
+		responseQueue.add(() -> FutureUtils.completedExceptionally(new AskTimeoutException("timeout")));
+		responseQueue.add(() -> {
+			secondSlotRequestFuture.complete(null);
+			return new CompletableFuture<>();
+		});
+
+		final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection(new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(ignored -> responseQueue.remove().get())
+			.createTestingTaskExecutorGateway());
+
+		final SlotReport slotReport = createSlotReport(taskManagerConnection.getResourceID(), 2);
+
+		final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
+
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.build()) {
+
+			slotManager.start(ResourceManagerId.generate(), mainThreadExecutor, new TestingResourceActionsBuilder().build());
+
+			CompletableFuture.runAsync(() -> slotManager.registerTaskManager(taskManagerConnection, slotReport), mainThreadExecutor)
+				.thenRun(() -> slotManager.processResourceRequirements(createResourceRequirementsForSingleSlot()))
+				.get(5, TimeUnit.SECONDS);
+
+			// a second request is only sent if the first request timed out
+			secondSlotRequestFuture.get();
+		}
+	}
+
+	/**
+	 * Tests that a slot allocation is retried if it times out on the task manager side.
+	 */
+	@Test
+	public void testTaskExecutorSlotAllocationTimeoutHandling() throws Exception {
+		final JobID jobId = new JobID();
+		final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot(jobId);
+		final CompletableFuture<Acknowledge> slotRequestFuture1 = new CompletableFuture<>();
+		final CompletableFuture<Acknowledge> slotRequestFuture2 = new CompletableFuture<>();
+		final Iterator<CompletableFuture<Acknowledge>> slotRequestFutureIterator = Arrays.asList(slotRequestFuture1, slotRequestFuture2).iterator();
+		final ArrayBlockingQueue<SlotID> slotIds = new ArrayBlockingQueue<>(2);
+
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(FunctionUtils.uncheckedFunction(
+				requestSlotParameters -> {
+					slotIds.put(requestSlotParameters.f0);
+					return slotRequestFutureIterator.next();
+				}))
+			.createTestingTaskExecutorGateway();
+
+		final ResourceID resourceId = ResourceID.generate();
+		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceId, taskExecutorGateway);
+
+		final SlotID slotId1 = new SlotID(resourceId, 0);
+		final SlotID slotId2 = new SlotID(resourceId, 1);
+		final SlotReport slotReport = new SlotReport(Arrays.asList(createFreeSlotStatus(slotId1), createFreeSlotStatus(slotId2)));
+
+		final ResourceTracker resourceTracker = new DefaultResourceTracker();
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setResourceTracker(resourceTracker)
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			slotManager.registerTaskManager(taskManagerConnection, slotReport);
+
+			slotManager.processResourceRequirements(resourceRequirements);
+
+			final SlotID firstSlotId = slotIds.take();
+			assertThat(slotIds, is(empty()));
+
+			DeclarativeTaskManagerSlot failedSlot = slotTracker.getSlot(firstSlotId);
+
+			// let the first attempt fail --> this should trigger a second attempt
+			slotRequestFuture1.completeExceptionally(new SlotAllocationException("Test exception."));
+
+			assertThat(getTotalResourceCount(resourceTracker.getAcquiredResources(jobId)), is(1));
+
+			// the second attempt succeeds
+			slotRequestFuture2.complete(Acknowledge.get());
+
+			final SlotID secondSlotId = slotIds.take();
+			assertThat(slotIds, is(empty()));
+
+			DeclarativeTaskManagerSlot slot = slotTracker.getSlot(secondSlotId);
+
+			assertThat(slot.getState(), is(SlotState.ALLOCATED));
+			assertEquals(jobId, slot.getJobId());
+
+			if (!failedSlot.getSlotId().equals(slot.getSlotId())) {
+				assertThat(failedSlot.getState(), is(SlotState.FREE));
+			}
+		}
+	}
+
+	/**
+	 * Tests that a pending slot allocation is cancelled if a slot report indicates that the slot is already allocated
+	 * by another job.
+	 */
+	@Test
+	public void testSlotReportWithConflictingJobIdDuringSlotAllocation() throws Exception {
+		final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
+		final ArrayBlockingQueue<SlotID> requestedSlotIds = new ArrayBlockingQueue<>(2);
+
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(FunctionUtils.uncheckedFunction(
+				requestSlotParameters -> {
+					requestedSlotIds.put(requestSlotParameters.f0);
+					return new CompletableFuture<>();
+				}))
+			.createTestingTaskExecutorGateway();
+
+		final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection(taskExecutorGateway);
+		final ResourceID resourceId = taskExecutorConnection.getResourceID();
+
+		final SlotID slotId1 = new SlotID(resourceId, 0);
+		final SlotID slotId2 = new SlotID(resourceId, 1);
+		final SlotReport slotReport = new SlotReport(Arrays.asList(createFreeSlotStatus(slotId1), createFreeSlotStatus(slotId2)));
+
+		final ScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
+
+		try (final DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setScheduledExecutor(mainThreadExecutor)
+			.build()) {
+
+			slotManager.start(ResourceManagerId.generate(), mainThreadExecutor, new TestingResourceActionsBuilder().build());
+
+			slotManager.registerTaskManager(taskExecutorConnection, slotReport);
+			slotManager.processResourceRequirements(resourceRequirements);
+
+			final SlotID firstRequestedSlotId = requestedSlotIds.take();
+			final SlotID freeSlotId = firstRequestedSlotId.equals(slotId1) ? slotId2 : slotId1;
+
+			final SlotReport newSlotReport = new SlotReport(Arrays.asList(createAllocatedSlotStatus(firstRequestedSlotId), createFreeSlotStatus(freeSlotId)));
+
+			slotManager.reportSlotStatus(taskExecutorConnection.getInstanceID(), newSlotReport);
+
+			final SlotID secondRequestedSlotId = requestedSlotIds.take();
+
+			assertEquals(freeSlotId, secondRequestedSlotId);
+		}
+	}
+
+	/**
+	 * Tests that free slots which are reported as allocated won't be considered for fulfilling
+	 * other pending slot requests.
+	 *
+	 * <p>See: FLINK-8505
+	 */
+	@Test
+	public void testReportAllocatedSlot() throws Exception {
+		final ResourceID taskManagerId = ResourceID.generate();
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(taskManagerId, taskExecutorGateway);
+
+		final ResourceTracker resourceTracker = new DefaultResourceTracker();
+
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setResourceTracker(resourceTracker)
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			// initially report a single slot as free
+			final SlotID slotId = new SlotID(taskManagerId, 0);
+			final SlotReport initialSlotReport = new SlotReport(createFreeSlotStatus(slotId));
+
+			slotManager.registerTaskManager(taskExecutorConnection, initialSlotReport);
+
+			assertThat(slotManager.getNumberRegisteredSlots(), is(equalTo(1)));
+
+			// Now report this slot as allocated
+			final SlotStatus slotStatus = createAllocatedSlotStatus(slotId);
+			final SlotReport slotReport = new SlotReport(slotStatus);
+
+			slotManager.reportSlotStatus(
+				taskExecutorConnection.getInstanceID(),
+				slotReport);
+
+			final JobID jobId = new JobID();
+			// this resource requirement should not be fulfilled
+			ResourceRequirements requirements = createResourceRequirementsForSingleSlot(jobId);
+
+			slotManager.processResourceRequirements(requirements);
+
+			assertThat(slotTracker.getSlot(slotId).getJobId(), is(slotStatus.getJobID()));
+			assertThat(getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)), is(1));
+		}
+	}
+
+	/**
+	 * Tests that the SlotManager retries allocating a slot if the TaskExecutor#requestSlot call
+	 * fails.
+	 */
+	@Test
+	public void testSlotRequestFailure() throws Exception {
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+		try (final DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			ResourceRequirements requirements = createResourceRequirementsForSingleSlot();
+			slotManager.processResourceRequirements(requirements);
+
+			final BlockingQueue<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>> requestSlotQueue = new ArrayBlockingQueue<>(1);
+			final BlockingQueue<CompletableFuture<Acknowledge>> responseQueue = new ArrayBlockingQueue<>(2);
+
+			final CompletableFuture<Acknowledge> firstManualSlotRequestResponse = new CompletableFuture<>();
+			responseQueue.offer(firstManualSlotRequestResponse);
+			final CompletableFuture<Acknowledge> secondManualSlotRequestResponse = new CompletableFuture<>();
+			responseQueue.offer(secondManualSlotRequestResponse);
+
+			final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+				.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple6 -> {
+					requestSlotQueue.offer(slotIDJobIDAllocationIDStringResourceManagerIdTuple6);
+					try {
+						return responseQueue.take();
+					} catch (InterruptedException ignored) {
+						return FutureUtils.completedExceptionally(new FlinkException("Response queue was interrupted."));
+					}
+				})
+				.createTestingTaskExecutorGateway();
+
+			final ResourceID taskExecutorResourceId = ResourceID.generate();
+			final TaskExecutorConnection taskExecutionConnection = new TaskExecutorConnection(taskExecutorResourceId, testingTaskExecutorGateway);
+			final SlotReport slotReport = new SlotReport(createFreeSlotStatus(new SlotID(taskExecutorResourceId, 0)));
+
+			slotManager.registerTaskManager(taskExecutionConnection, slotReport);
+
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> firstRequest = requestSlotQueue.take();
+
+			// fail first request
+			firstManualSlotRequestResponse.completeExceptionally(new SlotAllocationException("Test exception"));
+
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> secondRequest = requestSlotQueue.take();
+
+			assertThat(secondRequest.f1, equalTo(firstRequest.f1));
+			assertThat(secondRequest.f0, equalTo(firstRequest.f0));
+
+			secondManualSlotRequestResponse.complete(Acknowledge.get());
+
+			final DeclarativeTaskManagerSlot slot = slotTracker.getSlot(secondRequest.f0);
+			assertThat(slot.getState(), equalTo(SlotState.ALLOCATED));
+			assertThat(slot.getJobId(), equalTo(secondRequest.f1));
+		}
+	}
+
+	/**
+	 * Tests that pending request is removed if task executor reports a slot with the same job id.
+	 */
+	@Test
+	public void testSlotRequestRemovedIfTMReportsAllocation() throws Exception {
+		final ResourceTracker resourceTracker = new DefaultResourceTracker();
+		final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
+
+		try (final DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setResourceTracker(resourceTracker)
+			.setSlotTracker(slotTracker)
+			.buildAndStartWithDirectExec()) {
+
+			final JobID jobID = new JobID();
+			slotManager.processResourceRequirements(createResourceRequirementsForSingleSlot(jobID));
+
+			final BlockingQueue<Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>> requestSlotQueue = new ArrayBlockingQueue<>(1);
+			final BlockingQueue<CompletableFuture<Acknowledge>> responseQueue = new ArrayBlockingQueue<>(2);
+
+			final CompletableFuture<Acknowledge> firstManualSlotRequestResponse = new CompletableFuture<>();
+			responseQueue.offer(firstManualSlotRequestResponse);
+			final CompletableFuture<Acknowledge> secondManualSlotRequestResponse = new CompletableFuture<>();
+			responseQueue.offer(secondManualSlotRequestResponse);
+
+			final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+				.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple6 -> {
+					requestSlotQueue.offer(slotIDJobIDAllocationIDStringResourceManagerIdTuple6);
+					try {
+						return responseQueue.take();
+					} catch (InterruptedException ignored) {
+						return FutureUtils.completedExceptionally(new FlinkException("Response queue was interrupted."));
+					}
+				})
+				.createTestingTaskExecutorGateway();
+
+			final ResourceID taskExecutorResourceId = ResourceID.generate();
+			final TaskExecutorConnection taskExecutionConnection = new TaskExecutorConnection(taskExecutorResourceId, testingTaskExecutorGateway);
+			final SlotReport slotReport = new SlotReport(createFreeSlotStatus(new SlotID(taskExecutorResourceId, 0)));
+
+			slotManager.registerTaskManager(taskExecutionConnection, slotReport);
+
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> firstRequest = requestSlotQueue.take();
+
+			// fail first request
+			firstManualSlotRequestResponse.completeExceptionally(new TimeoutException("Test exception to fail first allocation"));
+
+			final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId> secondRequest = requestSlotQueue.take();
+
+			// fail second request
+			secondManualSlotRequestResponse.completeExceptionally(new SlotOccupiedException("Test exception", new AllocationID(), jobID));
+
+			assertThat(firstRequest.f1, equalTo(jobID));
+			assertThat(secondRequest.f1, equalTo(jobID));
+			assertThat(secondRequest.f0, equalTo(firstRequest.f0));
+
+			final DeclarativeTaskManagerSlot slot = slotTracker.getSlot(secondRequest.f0);
+			assertThat(slot.getState(), equalTo(SlotState.ALLOCATED));
+			assertThat(slot.getJobId(), equalTo(firstRequest.f1));
+
+			assertThat(slotManager.getNumberRegisteredSlots(), is(1));
+			assertThat(getTotalResourceCount(resourceTracker.getAcquiredResources(jobID)), is(1));
+		}
+	}
+
+	@Test
+	public void testTaskExecutorFailedHandling() throws Exception {
+		final ResourceTracker resourceTracker = new DefaultResourceTracker();
+
+		try (final DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setResourceTracker(resourceTracker)
+			.buildAndStartWithDirectExec()) {
+
+			JobID jobId = new JobID();
+			slotManager.processResourceRequirements(createResourceRequirements(jobId, 2));
+
+			final TaskExecutorConnection taskExecutionConnection1 = createTaskExecutorConnection();
+			final SlotReport slotReport1 = createSlotReport(taskExecutionConnection1.getResourceID(), 2);
+
+			slotManager.registerTaskManager(taskExecutionConnection1, slotReport1);
+
+			slotManager.unregisterTaskManager(taskExecutionConnection1.getInstanceID(), TEST_EXCEPTION);
+
+			assertThat(getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)), is(2));
+		}
+	}
+
+	/**
+	 * Tests that we only request new resources/containers once we have assigned
+	 * all pending task manager slots.
+	 */
+	@Test
+	public void testRequestNewResources() throws Exception {
+		final int numberSlots = 2;
+		final AtomicInteger resourceRequests = new AtomicInteger(0);
+		final TestingResourceActions testingResourceActions = new TestingResourceActionsBuilder()
+			.setAllocateResourceFunction(
+				ignored -> {
+					resourceRequests.incrementAndGet();
+					return true;
+				})
+			.build();
+
+		try (final DeclarativeSlotManager slotManager = createSlotManager(
+			ResourceManagerId.generate(),
+			testingResourceActions,
+			numberSlots)) {
+
+			final JobID jobId = new JobID();
+
+			// the first 2 requirements should be fulfillable with the pending slots of the first allocation (2 slots per worker)
+			slotManager.processResourceRequirements(createResourceRequirements(jobId, 1));
+			assertThat(resourceRequests.get(), is(1));
+
+			slotManager.processResourceRequirements(createResourceRequirements(jobId, 2));
+			assertThat(resourceRequests.get(), is(1));
+
+			slotManager.processResourceRequirements(createResourceRequirements(jobId, 3));
+			assertThat(resourceRequests.get(), is(2));
+		}
+	}
+
+	private TaskExecutorConnection createTaskExecutorConnection() {
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+		return createTaskExecutorConnection(taskExecutorGateway);
+	}
+
+	private TaskExecutorConnection createTaskExecutorConnection(TaskExecutorGateway taskExecutorGateway) {
+		return new TaskExecutorConnection(ResourceID.generate(), taskExecutorGateway);
+	}
+
+	/**
+	 * The spread out slot allocation strategy should spread out the allocated
+	 * slots across all available TaskExecutors. See FLINK-12122.
+	 */
+	@Test
+	public void testSpreadOutSlotAllocationStrategy() throws Exception {
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.setSlotMatchingStrategy(LeastUtilizationSlotMatchingStrategy.INSTANCE)
+			.buildAndStartWithDirectExec()) {
+
+			final List<CompletableFuture<JobID>> requestSlotFutures = new ArrayList<>();
+
+			final int numberTaskExecutors = 5;
+
+			// register n TaskExecutors with 2 slots each
+			for (int i = 0; i < numberTaskExecutors; i++) {
+				final CompletableFuture<JobID> requestSlotFuture = new CompletableFuture<>();
+				requestSlotFutures.add(requestSlotFuture);
+				registerTaskExecutorWithTwoSlots(slotManager, requestSlotFuture);
+			}
+
+			final JobID jobId = new JobID();
+
+			final ResourceRequirements resourceRequirements = createResourceRequirements(jobId, numberTaskExecutors);
+			slotManager.processResourceRequirements(resourceRequirements);
+
+			// check that every TaskExecutor has received a slot request
+			final Set<JobID> jobIds = new HashSet<>(FutureUtils.combineAll(requestSlotFutures).get(10L, TimeUnit.SECONDS));
+			assertThat(jobIds, hasSize(1));
+			assertThat(jobIds, containsInAnyOrder(jobId));
+		}
+	}
+
+	private void registerTaskExecutorWithTwoSlots(DeclarativeSlotManager slotManager, CompletableFuture<JobID> firstRequestSlotFuture) {
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(slotIDJobIDAllocationIDStringResourceManagerIdTuple6 -> {
+				firstRequestSlotFuture.complete(slotIDJobIDAllocationIDStringResourceManagerIdTuple6.f1);
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			})
+			.createTestingTaskExecutorGateway();
+		final TaskExecutorConnection firstTaskExecutorConnection = createTaskExecutorConnection(taskExecutorGateway);
+		final SlotReport firstSlotReport = createSlotReport(firstTaskExecutorConnection.getResourceID(), 2);
+		slotManager.registerTaskManager(firstTaskExecutorConnection, firstSlotReport);
+	}
+
+	@Test
+	public void testNotificationAboutNotEnoughResources() throws Exception {
+		final JobID jobId = new JobID();
+		final int numRequiredSlots = 3;
+		final int numExistingSlots = 1;
+
+		List<Tuple2<JobID, Collection<ResourceRequirement>>> notEnoughResourceNotifications = new ArrayList<>();
+		ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
+			.setAllocateResourceFunction(ignored -> false)
+			.setNotEnoughResourcesConsumer((jobId1, acquiredResources) -> notEnoughResourceNotifications.add(Tuple2.of(jobId1, acquiredResources)))
+			.build();
+
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
+			.buildAndStart(ResourceManagerId.generate(), new ManuallyTriggeredScheduledExecutor(), resourceManagerActions)) {
+
+			final ResourceID taskExecutorResourceId = ResourceID.generate();
+			final TaskExecutorConnection taskExecutionConnection = new TaskExecutorConnection(taskExecutorResourceId, new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
+			final SlotReport slotReport = createSlotReport(taskExecutorResourceId, numExistingSlots);
+			slotManager.registerTaskManager(taskExecutionConnection, slotReport);
+
+			ResourceRequirements resourceRequirements = createResourceRequirements(jobId, numRequiredSlots);
+			slotManager.processResourceRequirements(resourceRequirements);
+
+			assertThat(notEnoughResourceNotifications, hasSize(1));
+			Tuple2<JobID, Collection<ResourceRequirement>> notification = notEnoughResourceNotifications.get(0);
+			assertThat(notification.f0, is(jobId));
+			assertThat(notification.f1, hasItem(ResourceRequirement.create(ResourceProfile.ANY, numExistingSlots)));
+		}
+	}
+
+	private SlotReport createSlotReport(ResourceID taskExecutorResourceId, int numberSlots) {
+		final Set<SlotStatus> slotStatusSet = new HashSet<>(numberSlots);
+		for (int i = 0; i < numberSlots; i++) {
+			slotStatusSet.add(createFreeSlotStatus(new SlotID(taskExecutorResourceId, i)));
+		}
+
+		return new SlotReport(slotStatusSet);
+	}
+
+	private static SlotStatus createFreeSlotStatus(SlotID slotId) {
+		return new SlotStatus(slotId, ResourceProfile.ANY);
+	}
+
+	private static SlotStatus createAllocatedSlotStatus(SlotID slotId) {
+		return new SlotStatus(slotId, ResourceProfile.ANY, JobID.generate(), new AllocationID());
+	}
+
+	private DeclarativeSlotManager createSlotManager(ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions) {
+		return createSlotManager(resourceManagerId, resourceManagerActions, 1);
+	}
+
+	private DeclarativeSlotManager createSlotManager(ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions, int numSlotsPerWorker) {
+		return createDeclarativeSlotManagerBuilder()
+			.setNumSlotsPerWorker(numSlotsPerWorker)
+			.setRedundantTaskManagerNum(0)
+			.buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions);
+	}
+
+	private DeclarativeSlotManagerBuilder createDeclarativeSlotManagerBuilder() {
+		return DeclarativeSlotManagerBuilder.newBuilder().setDefaultWorkerResourceSpec(WORKER_RESOURCE_SPEC);
+	}
+
+	private static ResourceRequirements createResourceRequirementsForSingleSlot() {
+		return createResourceRequirementsForSingleSlot(new JobID());
+	}
+
+	private static ResourceRequirements createResourceRequirementsForSingleSlot(JobID jobId) {
+		return createResourceRequirements(jobId, 1);
+	}
+
+	private static ResourceRequirements createResourceRequirements(JobID jobId, int numRequiredSlots) {
+		return ResourceRequirements.create(
+			jobId,
+			"foobar",
+			Collections.singleton(ResourceRequirement.create(ResourceProfile.UNKNOWN, numRequiredSlots)));
+	}
+
+	private static int getTotalResourceCount(Collection<ResourceRequirement> resources) {
+		if (resources == null) {
+			return 0;
+		}
+		return resources.stream().map(ResourceRequirement::getNumberOfRequiredSlots).reduce(0, Integer::sum);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
@@ -23,9 +23,11 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -44,13 +46,18 @@ public class TestingResourceActions implements ResourceActions {
 	@Nonnull
 	private final Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer;
 
+	@Nonnull
+	private final BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer;
+
 	public TestingResourceActions(
 			@Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
 			@Nonnull Function<WorkerResourceSpec, Boolean> allocateResourceFunction,
-			@Nonnull Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer) {
+			@Nonnull Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer,
+			@Nonnull BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer) {
 		this.releaseResourceConsumer = releaseResourceConsumer;
 		this.allocateResourceFunction = allocateResourceFunction;
 		this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
+		this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
 	}
 
 	@Override
@@ -66,5 +73,10 @@ public class TestingResourceActions implements ResourceActions {
 	@Override
 	public void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause) {
 		notifyAllocationFailureConsumer.accept(Tuple3.of(jobId, allocationId, cause));
+	}
+
+	@Override
+	public void notifyNotEnoughResourcesAvailable(JobID jobId, Collection<ResourceRequirement> acquiredResources) {
+		notifyNotEnoughResourcesConsumer.accept(jobId, acquiredResources);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 
+import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -35,6 +37,7 @@ public class TestingResourceActionsBuilder {
 	private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
 	private Function<WorkerResourceSpec, Boolean> allocateResourceFunction = (ignored) -> true;
 	private Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer = (ignored) -> {};
+	private BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer = (ignoredA, ignoredB) -> {};
 
 	public TestingResourceActionsBuilder setReleaseResourceConsumer(BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
 		this.releaseResourceConsumer = releaseResourceConsumer;
@@ -59,7 +62,12 @@ public class TestingResourceActionsBuilder {
 		return this;
 	}
 
+	public TestingResourceActionsBuilder setNotEnoughResourcesConsumer(BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer) {
+		this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
+		return this;
+	}
+
 	public TestingResourceActions build() {
-		return new TestingResourceActions(releaseResourceConsumer, allocateResourceFunction, notifyAllocationFailureConsumer);
+		return new TestingResourceActions(releaseResourceConsumer, allocateResourceFunction, notifyAllocationFailureConsumer, notifyNotEnoughResourcesConsumer);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -144,11 +144,6 @@ public class TestingSlotManager implements SlotManager {
 	}
 
 	@Override
-	public void unregisterTaskManagersAndReleaseResources() {
-
-	}
-
-	@Override
 	public void close() throws Exception {
 
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.Map;
@@ -106,6 +107,10 @@ public class TestingSlotManager implements SlotManager {
 	@Override
 	public void suspend() {
 
+	}
+
+	@Override
+	public void processResourceRequirements(ResourceRequirements resourceRequirements) {
 	}
 
 	@Override


### PR DESCRIPTION
Based on #13544.

Adds the `DeclarativeSlotManager` (DSM), an alternative `SlotManager` implementation that supports FLIP-138.

The core difference to the existing implementation is that the DSM does not receive individual slot requests from the JobMaster, but a `ResourceRequirements` instead that outlines the absolute requirements for the job.
The DSM keeps track of these, along with all registered and pending slots, matches requirements to slots and initiates the allocation of the slot.

Most of this logic and book-keeping is handled by recently added components (`SlotTracker`, `ResourceTracker`, `TaskExecutorManager`).

What is left in the DSM itself is
a) a bunch of glue between these components and the `SlotManager` API
b) the logic for matching missing to available/pending resources and initiating the corresponding slot allocations.

The entry point for b) is `checkResourceRequirements()`, which is called on any significant change to the state of requirements or resources; it is called when requirements change, slots are added/removed, allocations are complete/failed.
This method essentially does the following:
- retrieve the currently missing resources from the `ResourceTracker`
- try assigning these resources to free slots, provided by the `SlotTracker`
  - if a match was found, start the allocation of the slot
- if at the end of this process there are still missing resource, match the remaining missing resources against the pending slots, provided by the `TaskExecutorManager`
  - if a match was found for a requirement, do nothing. We do not maintain a mapping of requirements to pending resources as it would double the book-keeping. We just consider this requirement as fulfilled within the scope of this check.
  - if no match was found for a requirement, try allocating a new worker (implicitly increasing the pool of pending slots)
- if at the end of this process missing resource are still present (== no more workers can be allocated) inform the JobMaster about there not being enough resources to fulfill the requirement

