### PR TITLE
[FLINK-19493] In CliFrontend, make flow of Configuration more obvious

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -22,9 +22,7 @@ import org.apache.flink.client.deployment.executors.RemoteExecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
@@ -42,16 +40,6 @@ public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 	protected final Option zookeeperNamespaceOption = new Option("z", "zookeeperNamespace", true,
 		"Namespace to create the Zookeeper sub-paths for high availability mode");
 
-	protected final Configuration configuration;
-
-	protected AbstractCustomCommandLine(Configuration configuration) {
-		this.configuration = new UnmodifiableConfiguration(Preconditions.checkNotNull(configuration));
-	}
-
-	public Configuration getConfiguration() {
-		return configuration;
-	}
-
 	@Override
 	public void addRunOptions(Options baseOptions) {
 		// nothing to add here
@@ -63,8 +51,8 @@ public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 	}
 
 	@Override
-	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
-		final Configuration resultingConfiguration = new Configuration(configuration);
+	public Configuration toConfiguration(CommandLine commandLine) throws FlinkException {
+		final Configuration resultingConfiguration = new Configuration();
 		resultingConfiguration.setString(DeploymentOptions.TARGET, RemoteExecutor.NAME);
 
 		if (commandLine.hasOption(zookeeperNamespaceOption.getOpt())) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -935,7 +935,7 @@ public class CliFrontend {
 	 * @param args command line arguments of the client.
 	 * @return The return code of the program
 	 */
-	public int parseParameters(String[] args) {
+	public int parseAndRun(String[] args) {
 
 		// check for action
 		if (args.length < 1) {
@@ -1030,7 +1030,7 @@ public class CliFrontend {
 
 			SecurityUtils.install(new SecurityConfiguration(cli.configuration));
 			int retCode = SecurityUtils.getInstalledContext()
-					.runSecured(() -> cli.parseParameters(args));
+					.runSecured(() -> cli.parseAndRun(args));
 			System.exit(retCode);
 		}
 		catch (Throwable t) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -275,21 +275,33 @@ public class CliFrontend {
 
 	private <T> Configuration getEffectiveConfiguration(
 			final CustomCommandLine activeCustomCommandLine,
+			final CommandLine commandLine) throws FlinkException {
+
+		final Configuration effectiveConfiguration = new Configuration(configuration);
+
+		final Configuration commandLineConfiguration =
+				checkNotNull(activeCustomCommandLine).toConfiguration(commandLine);
+
+		effectiveConfiguration.addAll(commandLineConfiguration);
+
+		return effectiveConfiguration;
+	}
+
+	private <T> Configuration getEffectiveConfiguration(
+			final CustomCommandLine activeCustomCommandLine,
 			final CommandLine commandLine,
 			final ProgramOptions programOptions,
 			final List<T> jobJars) throws FlinkException {
+
+		final Configuration effectiveConfiguration = getEffectiveConfiguration(activeCustomCommandLine, commandLine);
 
 		final ExecutionConfigAccessor executionParameters = ExecutionConfigAccessor.fromProgramOptions(
 				checkNotNull(programOptions),
 				checkNotNull(jobJars));
 
-		final Configuration executorConfig = checkNotNull(activeCustomCommandLine)
-				.applyCommandLineOptionsToConfiguration(commandLine);
-
-		final Configuration effectiveConfiguration = new Configuration(executorConfig);
-
 		executionParameters.applyToConfiguration(effectiveConfiguration);
-		LOG.debug("Effective executor configuration: {}", effectiveConfiguration);
+
+		LOG.debug("Effective configuration after Flink conf, custom commandline, and program options: {}", effectiveConfiguration);
 		return effectiveConfiguration;
 	}
 
@@ -892,15 +904,17 @@ public class CliFrontend {
 	 * @throws FlinkException if something goes wrong
 	 */
 	private <ClusterID> void runClusterAction(CustomCommandLine activeCommandLine, CommandLine commandLine, ClusterAction<ClusterID> clusterAction) throws FlinkException {
-		final Configuration executorConfig = activeCommandLine.applyCommandLineOptionsToConfiguration(commandLine);
-		final ClusterClientFactory<ClusterID> clusterClientFactory = clusterClientServiceLoader.getClusterClientFactory(executorConfig);
+		final Configuration effectiveConfiguration = getEffectiveConfiguration(activeCommandLine, commandLine);
+		LOG.debug("Effective configuration after Flink conf, and custom commandline: {}", effectiveConfiguration);
 
-		final ClusterID clusterId = clusterClientFactory.getClusterId(executorConfig);
+		final ClusterClientFactory<ClusterID> clusterClientFactory = clusterClientServiceLoader.getClusterClientFactory(effectiveConfiguration);
+
+		final ClusterID clusterId = clusterClientFactory.getClusterId(effectiveConfiguration);
 		if (clusterId == null) {
 			throw new FlinkException("No cluster id was specified. Please specify a cluster to which you would like to connect.");
 		}
 
-		try (final ClusterDescriptor<ClusterID> clusterDescriptor = clusterClientFactory.createClusterDescriptor(executorConfig)) {
+		try (final ClusterDescriptor<ClusterID> clusterDescriptor = clusterClientFactory.createClusterDescriptor(effectiveConfiguration)) {
 			try (final ClusterClient<ClusterID> clusterClient = clusterDescriptor.retrieve(clusterId).getClusterClient()) {
 				clusterAction.runAction(clusterClient);
 			}
@@ -1111,7 +1125,7 @@ public class CliFrontend {
 
 		//	Tips: DefaultCLI must be added at last, because getActiveCustomCommandLine(..) will get the
 		//	      active CustomCommandLine in order and DefaultCLI isActive always return true.
-		customCommandLines.add(new DefaultCLI(configuration));
+		customCommandLines.add(new DefaultCLI());
 
 		return customCommandLines;
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -56,12 +56,10 @@ public interface CustomCommandLine {
 	void addGeneralOptions(Options baseOptions);
 
 	/**
-	 * Override configuration settings by specified command line options.
-	 *
-	 * @param commandLine containing the overriding values
-	 * @return the effective configuration with the overridden configuration settings
+	 * Materializes the command line arguments in the given {@link CommandLine} to a {@link
+	 * Configuration} and returns it.
 	 */
-	Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException;
+	Configuration toConfiguration(CommandLine commandLine) throws FlinkException;
 
 	default CommandLine parseCommandLineOptions(String[] args, boolean stopAtNonOptions) throws CliArgsException {
 		final Options options = new Options();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -44,10 +44,6 @@ public class DefaultCLI extends AbstractCustomCommandLine {
 
 	public static final String ID = "default";
 
-	public DefaultCLI(Configuration configuration) {
-		super(configuration);
-	}
-
 	@Override
 	public boolean isActive(CommandLine commandLine) {
 		// always active because we can try to read a JobManager address from the config
@@ -55,9 +51,9 @@ public class DefaultCLI extends AbstractCustomCommandLine {
 	}
 
 	@Override
-	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
+	public Configuration toConfiguration(CommandLine commandLine) throws FlinkException {
 
-		final Configuration resultingConfiguration = super.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration resultingConfiguration = super.toConfiguration(commandLine);
 		if (commandLine.hasOption(addressOption.getOpt())) {
 			String addressWithPort = commandLine.getOptionValue(addressOption.getOpt());
 			InetSocketAddress jobManagerAddress = NetUtils.parseHostPortAddress(addressWithPort);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -37,12 +37,12 @@ import static org.apache.flink.client.cli.CliFrontend.setJobManagerAddressInConf
  */
 public class DefaultCLI extends AbstractCustomCommandLine {
 
+	public static final String ID = "default";
+
 	private static final Option addressOption = new Option("m", "jobmanager", true,
 		"Address of the JobManager to which to connect. " +
 			"Use this flag to connect to a different JobManager than the one specified in the configuration. " +
 			"Attention: This option is respected only if the high-availability configuration is NONE.");
-
-	public static final String ID = "default";
 
 	@Override
 	public boolean isActive(CommandLine commandLine) {
@@ -60,6 +60,9 @@ public class DefaultCLI extends AbstractCustomCommandLine {
 			setJobManagerAddressInConfig(resultingConfiguration, jobManagerAddress);
 		}
 		resultingConfiguration.setString(DeploymentOptions.TARGET, RemoteExecutor.NAME);
+
+		DynamicPropertiesUtil.encodeDynamicProperties(commandLine, resultingConfiguration);
+
 		return resultingConfiguration;
 	}
 
@@ -72,5 +75,6 @@ public class DefaultCLI extends AbstractCustomCommandLine {
 	public void addGeneralOptions(Options baseOptions) {
 		super.addGeneralOptions(baseOptions);
 		baseOptions.addOption(addressOption);
+		baseOptions.addOption(DynamicPropertiesUtil.DYNAMIC_PROPERTIES);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DynamicPropertiesUtil.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DynamicPropertiesUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+
+import java.util.Properties;
+
+/**
+ * Helper class for supporting dynamic property commandline options in {@link CustomCommandLine
+ * CustomCommandLines}.
+ */
+class DynamicPropertiesUtil {
+
+	/**
+	 * Dynamic properties allow the user to specify additional configuration values with -D, such
+	 * as
+	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.network.min=536346624</tt>.
+	 */
+	static final Option DYNAMIC_PROPERTIES = Option.builder("D")
+			.argName("property=value")
+			.numberOfArgs(2)
+			.valueSeparator('=')
+			.desc("Allows specifying multiple generic configuration options. The available " +
+					"options can be found at https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html")
+			.build();
+
+	/**
+	 * Parses dynamic properties from the given {@link CommandLine} and sets them on the {@link
+	 * Configuration}.
+	 */
+	static void encodeDynamicProperties(
+			final CommandLine commandLine,
+			final Configuration effectiveConfiguration) {
+
+		final Properties properties = commandLine.getOptionProperties(DYNAMIC_PROPERTIES.getOpt());
+
+		properties.stringPropertyNames()
+				.forEach(key -> {
+					final String value = properties.getProperty(key);
+					if (value != null) {
+						effectiveConfiguration.setString(key, value);
+					} else {
+						effectiveConfiguration.setString(key, "true");
+					}
+				});
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
@@ -30,7 +30,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -57,19 +56,6 @@ public class GenericCLI implements CustomCommandLine {
 					"to the \"" + DeploymentOptions.TARGET.key() + "\" config option. The " +
 					"currently available targets are: " + getExecutorFactoryNames() +
 					", \"yarn-application\" and \"kubernetes-application\".");
-
-	/**
-	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.network.min=536346624</tt>.
-	 */
-	private final Option dynamicProperties = Option.builder("D")
-			.argName("property=value")
-			.numberOfArgs(2)
-			.valueSeparator('=')
-			.desc("Generic configuration options for execution/deployment and for the configured " +
-					"executor. The available options can be found at " +
-					"https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html")
-			.build();
 
 	private final Configuration configuration;
 
@@ -101,7 +87,7 @@ public class GenericCLI implements CustomCommandLine {
 	public void addGeneralOptions(Options baseOptions) {
 		baseOptions.addOption(executorOption);
 		baseOptions.addOption(targetOption);
-		baseOptions.addOption(dynamicProperties);
+		baseOptions.addOption(DynamicPropertiesUtil.DYNAMIC_PROPERTIES);
 	}
 
 	@Override
@@ -124,23 +110,10 @@ public class GenericCLI implements CustomCommandLine {
 			resultConfiguration.setString(DeploymentOptions.TARGET, targetName);
 		}
 
-		encodeDynamicProperties(commandLine, resultConfiguration);
+		DynamicPropertiesUtil.encodeDynamicProperties(commandLine, resultConfiguration);
 		resultConfiguration.set(DeploymentOptionsInternal.CONF_DIR, configurationDir);
 
 		return resultConfiguration;
-	}
-
-	private void encodeDynamicProperties(final CommandLine commandLine, final Configuration effectiveConfiguration) {
-		final Properties properties = commandLine.getOptionProperties(dynamicProperties.getOpt());
-		properties.stringPropertyNames()
-				.forEach(key -> {
-					final String value = properties.getProperty(key);
-					if (value != null) {
-						effectiveConfiguration.setString(key, value);
-					} else {
-						effectiveConfiguration.setString(key, "true");
-					}
-				});
 	}
 
 	private static String getExecutorFactoryNames() {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
@@ -94,12 +94,6 @@ public class GenericCLI implements CustomCommandLine {
 	public Configuration toConfiguration(final CommandLine commandLine) {
 		final Configuration resultConfiguration = new Configuration();
 
-		if (configuration.getOptional(DeploymentOptions.TARGET).isPresent()) {
-			resultConfiguration.set(
-					DeploymentOptions.TARGET,
-					configuration.get(DeploymentOptions.TARGET));
-		}
-
 		final String executorName = commandLine.getOptionValue(executorOption.getOpt());
 		if (executorName != null) {
 			resultConfiguration.setString(DeploymentOptions.TARGET, executorName);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
@@ -29,8 +29,6 @@ import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -45,8 +43,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class GenericCLI implements CustomCommandLine {
-
-	private static final Logger LOG = LoggerFactory.getLogger(GenericCLI.class);
 
 	private static final String ID = "Generic CLI";
 
@@ -75,18 +71,18 @@ public class GenericCLI implements CustomCommandLine {
 					"https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html")
 			.build();
 
-	private final Configuration baseConfiguration;
+	private final Configuration configuration;
 
 	private final String configurationDir;
 
 	public GenericCLI(final Configuration configuration, final String configDir) {
-		this.baseConfiguration = new UnmodifiableConfiguration(checkNotNull(configuration));
+		this.configuration = new UnmodifiableConfiguration(checkNotNull(configuration));
 		this.configurationDir =  checkNotNull(configDir);
 	}
 
 	@Override
 	public boolean isActive(CommandLine commandLine) {
-		return baseConfiguration.getOptional(DeploymentOptions.TARGET).isPresent()
+		return configuration.getOptional(DeploymentOptions.TARGET).isPresent()
 				|| commandLine.hasOption(executorOption.getOpt())
 				|| commandLine.hasOption(targetOption.getOpt());
 	}
@@ -109,27 +105,29 @@ public class GenericCLI implements CustomCommandLine {
 	}
 
 	@Override
-	public Configuration applyCommandLineOptionsToConfiguration(final CommandLine commandLine) {
-		final Configuration effectiveConfiguration = new Configuration(baseConfiguration);
+	public Configuration toConfiguration(final CommandLine commandLine) {
+		final Configuration resultConfiguration = new Configuration();
+
+		if (configuration.getOptional(DeploymentOptions.TARGET).isPresent()) {
+			resultConfiguration.set(
+					DeploymentOptions.TARGET,
+					configuration.get(DeploymentOptions.TARGET));
+		}
 
 		final String executorName = commandLine.getOptionValue(executorOption.getOpt());
 		if (executorName != null) {
-			effectiveConfiguration.setString(DeploymentOptions.TARGET, executorName);
+			resultConfiguration.setString(DeploymentOptions.TARGET, executorName);
 		}
 
 		final String targetName = commandLine.getOptionValue(targetOption.getOpt());
 		if (targetName != null) {
-			effectiveConfiguration.setString(DeploymentOptions.TARGET, targetName);
+			resultConfiguration.setString(DeploymentOptions.TARGET, targetName);
 		}
 
-		encodeDynamicProperties(commandLine, effectiveConfiguration);
-		effectiveConfiguration.set(DeploymentOptionsInternal.CONF_DIR, configurationDir);
+		encodeDynamicProperties(commandLine, resultConfiguration);
+		resultConfiguration.set(DeploymentOptionsInternal.CONF_DIR, configurationDir);
 
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("Effective Configuration: {}", effectiveConfiguration);
-		}
-
-		return effectiveConfiguration;
+		return resultConfiguration;
 	}
 
 	private void encodeDynamicProperties(final CommandLine commandLine, final Configuration effectiveConfiguration) {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -77,7 +77,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.cancel(parameters);
 	}
 
@@ -87,7 +87,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.cancel(parameters);
 	}
 
@@ -140,7 +140,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.cancel(parameters);
 	}
 
@@ -151,7 +151,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.cancel(parameters);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendITCase.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.client.deployment.executors.LocalExecutor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Integration tests for {@link CliFrontend}.
+ */
+public class CliFrontendITCase {
+
+	private PrintStream originalPrintStream;
+
+	private ByteArrayOutputStream testOutputStream;
+
+	@Before
+	public void before() {
+		originalPrintStream = System.out;
+		testOutputStream = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(testOutputStream));
+	}
+
+	@After
+	public void finalize() {
+		System.setOut(originalPrintStream);
+	}
+
+	private String getStdoutString() {
+		return testOutputStream.toString();
+	}
+
+	@Test
+	public void configurationIsForwarded() throws Exception {
+		Configuration config = new Configuration();
+		CustomCommandLine commandLine = new DefaultCLI();
+
+		config.set(PipelineOptions.AUTO_WATERMARK_INTERVAL, Duration.ofMillis(42L));
+
+		CliFrontend cliFrontend = new CliFrontend(config, Collections.singletonList(commandLine));
+
+		cliFrontend.parseAndRun(new String[]{"run", "-c", TestingJob.class.getName(), CliFrontendTestUtils.getTestJarPath()});
+
+		assertThat(getStdoutString(), containsString("Watermark interval is 42"));
+	}
+
+	@Test
+	public void commandlineOverridesConfiguration() throws Exception {
+		Configuration config = new Configuration();
+
+		// we use GenericCli because it allows specifying arbitrary options via "-Dfoo=bar" syntax
+		CustomCommandLine commandLine = new GenericCLI(config, "/dev/null");
+
+		config.set(PipelineOptions.AUTO_WATERMARK_INTERVAL, Duration.ofMillis(42L));
+
+		CliFrontend cliFrontend = new CliFrontend(config, Collections.singletonList(commandLine));
+
+		cliFrontend.parseAndRun(new String[]{
+				"run",
+				"-t", LocalExecutor.NAME,
+				"-c", TestingJob.class.getName(),
+				"-D" + PipelineOptions.AUTO_WATERMARK_INTERVAL.key() + "=142",
+				CliFrontendTestUtils.getTestJarPath()});
+
+		assertThat(getStdoutString(), containsString("Watermark interval is 142"));
+	}
+
+	/**
+	 * Testing job that the watermark interval from the {@link org.apache.flink.api.common.ExecutionConfig}.
+	 */
+	public static class TestingJob {
+		public static void main(String[] args) {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			System.out.println(
+					"Watermark interval is " + env.getConfig().getAutoWatermarkInterval());
+		}
+	}
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
@@ -44,7 +44,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.cancel(parameters);
 	}
 
@@ -54,7 +54,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.cancel(parameters);
 	}
 
@@ -67,7 +67,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 			Configuration configuration = getConfiguration();
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
-				Collections.singletonList(getCli(configuration)));
+				Collections.singletonList(getCli()));
 			testFrontend.info(parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\" : 4"));
 		}
@@ -84,7 +84,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 			Configuration configuration = getConfiguration();
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
-				Collections.singletonList(getCli(configuration)));
+				Collections.singletonList(getCli()));
 			testFrontend.info(parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\" : 17"));
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -94,7 +94,7 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.list(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -75,7 +75,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		final Configuration configuration = new Configuration();
 		frontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(new DefaultCLI()));
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -58,24 +58,24 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		// test without parallelism, should use parallelism default
 		{
 			String[] parameters = {"-v",  getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 4, false);
+			verifyCliFrontend(configuration, getCli(), parameters, 4, false);
 		}
 		//  test parallelism in detached mode, should use parallelism default
 		{
 			String[] parameters = {"-v", "-d", getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 4, true);
+			verifyCliFrontend(configuration, getCli(), parameters, 4, true);
 		}
 
 		// test configure parallelism
 		{
 			String[] parameters = {"-v", "-p", "42",  getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 42, false);
+			verifyCliFrontend(configuration, getCli(), parameters, 42, false);
 		}
 
 		// test detached mode
 		{
 			String[] parameters = {"-p", "2", "-d", getTestJarPath()};
-			verifyCliFrontend(getCli(configuration), parameters, 2, true);
+			verifyCliFrontend(configuration, getCli(), parameters, 2, true);
 		}
 
 		// test configure savepoint path (no ignore flag)
@@ -129,7 +129,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.run(parameters);
 	}
 
@@ -140,7 +140,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.run(parameters);
 	}
 
@@ -151,30 +151,42 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.run(parameters);
 	}
 
 	// --------------------------------------------------------------------------------------------
 
 	public static void verifyCliFrontend(
-		AbstractCustomCommandLine cli,
-		String[] parameters,
-		int expectedParallelism,
-		boolean isDetached) throws Exception {
+			Configuration configuration,
+			AbstractCustomCommandLine cli,
+			String[] parameters,
+			int expectedParallelism,
+			boolean isDetached) throws Exception {
 		RunTestingCliFrontend testFrontend =
-			new RunTestingCliFrontend(new DefaultClusterClientServiceLoader(), cli, expectedParallelism, isDetached);
+				new RunTestingCliFrontend(
+						configuration,
+						new DefaultClusterClientServiceLoader(),
+						cli,
+						expectedParallelism,
+						isDetached);
 		testFrontend.run(parameters); // verifies the expected values (see below)
 	}
 
 	public static void verifyCliFrontend(
-		ClusterClientServiceLoader clusterClientServiceLoader,
-		AbstractCustomCommandLine cli,
-		String[] parameters,
-		int expectedParallelism,
-		boolean isDetached) throws Exception {
+			Configuration configuration,
+			ClusterClientServiceLoader clusterClientServiceLoader,
+			AbstractCustomCommandLine cli,
+			String[] parameters,
+			int expectedParallelism,
+			boolean isDetached) throws Exception {
 		RunTestingCliFrontend testFrontend =
-			new RunTestingCliFrontend(clusterClientServiceLoader, cli, expectedParallelism, isDetached);
+				new RunTestingCliFrontend(
+						configuration,
+						clusterClientServiceLoader,
+						cli,
+						expectedParallelism,
+						isDetached);
 		testFrontend.run(parameters); // verifies the expected values (see below)
 	}
 
@@ -184,12 +196,13 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		private final boolean isDetached;
 
 		private RunTestingCliFrontend(
+				Configuration configuration,
 				ClusterClientServiceLoader clusterClientServiceLoader,
 				AbstractCustomCommandLine cli,
 				int expectedParallelism,
 				boolean isDetached) {
 			super(
-				cli.getConfiguration(),
+				configuration,
 				clusterClientServiceLoader,
 				Collections.singletonList(cli));
 			this.expectedParallelism = expectedParallelism;

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
@@ -184,7 +184,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.stop(parameters);
 	}
 
@@ -195,7 +195,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(getCli(configuration)));
+			Collections.singletonList(getCli()));
 		testFrontend.stop(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
@@ -31,7 +31,7 @@ public abstract class CliFrontendTestBase extends TestLogger {
 		return GlobalConfiguration.loadConfiguration(CliFrontendTestUtils.getConfigDir());
 	}
 
-	static AbstractCustomCommandLine getCli(Configuration configuration) {
-		return new DefaultCLI(configuration);
+	static AbstractCustomCommandLine getCli() {
+		return new DefaultCLI();
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 
@@ -44,7 +46,9 @@ public class CliFrontendTestUtils {
 	private static final PrintStream previousSysout = System.out;
 
 	public static String getTestJarPath() throws FileNotFoundException, MalformedURLException {
-		File f = new File("target/maven-test-jar.jar");
+		String projectBaseDir = System.getProperty("project.basedir");
+		Path testJarPath = Paths.get(projectBaseDir, "target", "maven-test-jar.jar");
+		File f = testJarPath.toFile();
 		if (!f.exists()) {
 			throw new FileNotFoundException("Test jar not present. Invoke tests using maven "
 					+ "or build the jar using 'mvn process-test-classes' in flink-clients");

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -19,10 +19,13 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.RestOptions;
 
 import org.apache.commons.cli.CommandLine;
 import org.junit.Test;
+
+import java.time.Duration;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -48,5 +51,21 @@ public class DefaultCLITest {
 
 		assertThat(configuration.get(RestOptions.ADDRESS), is(hostname));
 		assertThat(configuration.get(RestOptions.PORT), is(port));
+	}
+
+	@Test
+	public void testDynamicPropertyMaterialization() throws Exception {
+		final String[] args = {
+				"-D" + PipelineOptions.AUTO_WATERMARK_INTERVAL.key() + "=42",
+				"-D" + PipelineOptions.AUTO_GENERATE_UIDS.key() + "=true"
+		};
+
+		final AbstractCustomCommandLine defaultCLI = new DefaultCLI();
+		final CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+
+		Configuration configuration = defaultCLI.toConfiguration(commandLine);
+
+		assertThat(configuration.get(PipelineOptions.AUTO_WATERMARK_INTERVAL), is(Duration.ofMillis(42L)));
+		assertThat(configuration.get(PipelineOptions.AUTO_GENERATE_UIDS), is(true));
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -18,97 +18,35 @@
 
 package org.apache.flink.client.cli;
 
-import org.apache.flink.client.deployment.ClusterClientFactory;
-import org.apache.flink.client.deployment.ClusterClientServiceLoader;
-import org.apache.flink.client.deployment.ClusterDescriptor;
-import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
-import org.apache.flink.client.deployment.StandaloneClusterId;
-import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
-import org.hamcrest.Matchers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import java.net.URL;
-
-import static org.apache.flink.util.Preconditions.checkState;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
  * Tests for the {@link DefaultCLI}.
  */
-public class DefaultCLITest extends CliFrontendTestBase {
-
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+public class DefaultCLITest {
 
 	/**
-	 * Tests that the configuration is properly passed via the DefaultCLI to the
-	 * created ClusterDescriptor.
+	 * Verifies command line options are correctly materialized.
 	 */
 	@Test
-	public void testConfigurationPassing() throws Exception {
-		final Configuration configuration = getConfiguration();
-
-		final String localhost = "localhost";
+	public void testCommandLineMaterialization() throws Exception {
+		final String hostname = "home-sweet-home";
 		final int port = 1234;
+		final String[] args = {"-m", hostname + ':' + port};
 
-		configuration.setString(RestOptions.ADDRESS, localhost);
-		configuration.setInteger(RestOptions.PORT, port);
-
-		final AbstractCustomCommandLine defaultCLI = getCli(configuration);
-
-		final String[] args = {};
-
+		final AbstractCustomCommandLine defaultCLI = new DefaultCLI();
 		final CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
-		final ClusterClient<?> clusterClient = getClusterClient(defaultCLI, commandLine);
 
-		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
+		Configuration configuration = defaultCLI.toConfiguration(commandLine);
 
-		assertThat(webInterfaceUrl.getHost(), Matchers.equalTo(localhost));
-		assertThat(webInterfaceUrl.getPort(), Matchers.equalTo(port));
-	}
-
-	/**
-	 * Tests that command line options override the configuration settings.
-	 */
-	@Test
-	public void testManualConfigurationOverride() throws Exception {
-		final String localhost = "localhost";
-		final int port = 1234;
-		final Configuration configuration = getConfiguration();
-
-		configuration.setString(JobManagerOptions.ADDRESS, localhost);
-		configuration.setInteger(JobManagerOptions.PORT, port);
-
-		final AbstractCustomCommandLine defaultCLI = getCli(configuration);
-
-		final String manualHostname = "123.123.123.123";
-		final int manualPort = 4321;
-		final String[] args = {"-m", manualHostname + ':' + manualPort};
-
-		final CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
-		final ClusterClient<?> clusterClient = getClusterClient(defaultCLI, commandLine);
-
-		final URL webInterfaceUrl = new URL(clusterClient.getWebInterfaceURL());
-
-		assertThat(webInterfaceUrl.getHost(), Matchers.equalTo(manualHostname));
-		assertThat(webInterfaceUrl.getPort(), Matchers.equalTo(manualPort));
-	}
-
-	private ClusterClient<?> getClusterClient(AbstractCustomCommandLine defaultCLI, CommandLine commandLine) throws FlinkException {
-		final ClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
-		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
-		final ClusterClientFactory<StandaloneClusterId> clusterFactory = serviceLoader.getClusterClientFactory(executorConfig);
-		checkState(clusterFactory != null);
-
-		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor = clusterFactory.createClusterDescriptor(executorConfig);
-		return clusterDescriptor.retrieve(clusterFactory.getClusterId(executorConfig)).getClusterClient();
+		assertThat(configuration.get(RestOptions.ADDRESS), is(hostname));
+		assertThat(configuration.get(RestOptions.PORT), is(port));
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/GenericCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/GenericCLITest.java
@@ -69,7 +69,7 @@ public class GenericCLITest {
 				tmp.getRoot().getAbsolutePath());
 		final CommandLine emptyCommandLine = CliFrontendParser.parse(testOptions, new String[0], true);
 
-		final Configuration configuration = cliUnderTest.applyCommandLineOptionsToConfiguration(emptyCommandLine);
+		final Configuration configuration = cliUnderTest.toConfiguration(emptyCommandLine);
 		assertEquals(expectedExecutorName, configuration.get(DeploymentOptions.TARGET));
 	}
 
@@ -101,7 +101,7 @@ public class GenericCLITest {
 				tmp.getRoot().getAbsolutePath());
 		final CommandLine commandLine = CliFrontendParser.parse(testOptions, args, true);
 
-		final Configuration configuration = cliUnderTest.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration configuration = cliUnderTest.toConfiguration(commandLine);
 
 		assertEquals("test-executor", configuration.getString(DeploymentOptions.TARGET));
 		assertEquals(5, configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM));
@@ -131,7 +131,7 @@ public class GenericCLITest {
 		final String[] args = {executorOption, expectedExecutorName, "-D" + configOption.key() + "=" + expectedValue};
 		final CommandLine commandLine = CliFrontendParser.parse(testOptions, args, true);
 
-		final Configuration configuration = cliUnderTest.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration configuration = cliUnderTest.toConfiguration(commandLine);
 		assertEquals(expectedExecutorName, configuration.get(DeploymentOptions.TARGET));
 		assertEquals(expectedValue, configuration.getInteger(configOption));
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/GenericCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/GenericCLITest.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the {@link GenericCLI}.
@@ -59,7 +60,7 @@ public class GenericCLITest {
 	}
 
 	@Test
-	public void testExecutorInBaseConfigIsPickedUp() throws CliArgsException {
+	public void isActiveWhenTargetOnlyInConfig() throws CliArgsException {
 		final String expectedExecutorName = "test-executor";
 		final Configuration loadedConfig = new Configuration();
 		loadedConfig.set(DeploymentOptions.TARGET, expectedExecutorName);
@@ -69,8 +70,7 @@ public class GenericCLITest {
 				tmp.getRoot().getAbsolutePath());
 		final CommandLine emptyCommandLine = CliFrontendParser.parse(testOptions, new String[0], true);
 
-		final Configuration configuration = cliUnderTest.toConfiguration(emptyCommandLine);
-		assertEquals(expectedExecutorName, configuration.get(DeploymentOptions.TARGET));
+		assertTrue(cliUnderTest.isActive(emptyCommandLine));
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -51,7 +51,7 @@ public class DummyCustomCommandLine implements CustomCommandLine {
 	}
 
 	@Override
-	public Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) {
+	public Configuration toConfiguration(CommandLine commandLine) {
 		final Configuration configuration = new Configuration();
 		configuration.setString(DeploymentOptions.TARGET, DummyClusterClientFactory.ID);
 		return configuration;

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -419,7 +419,7 @@ public class RestClusterClientTest extends TestLogger {
 		configuration.setString(RestOptions.ADDRESS, configuredHostname);
 		configuration.setInteger(RestOptions.PORT, configuredPort);
 
-		final DefaultCLI defaultCLI = new DefaultCLI(configuration);
+		final DefaultCLI defaultCLI = new DefaultCLI();
 
 		final String manualHostname = "123.123.123.123";
 		final int manualPort = 4321;
@@ -428,7 +428,7 @@ public class RestClusterClientTest extends TestLogger {
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
 
 		final ClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
-		final Configuration executorConfig = defaultCLI.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = defaultCLI.toConfiguration(commandLine);
 
 		final ClusterClientFactory<StandaloneClusterId> clusterFactory = serviceLoader.getClusterClientFactory(executorConfig);
 		checkState(clusterFactory != null);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -81,7 +81,8 @@ public class KubernetesSessionCli {
 
 	public Configuration getEffectiveConfiguration(String[] args) throws CliArgsException {
 		final CommandLine commandLine = cli.parseCommandLineOptions(args, true);
-		final Configuration effectiveConfiguration = cli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration effectiveConfiguration = new Configuration(baseConfiguration);
+		effectiveConfiguration.addAll(cli.toConfiguration(commandLine));
 		effectiveConfiguration.set(DeploymentOptions.TARGET, KubernetesSessionClusterExecutor.NAME);
 		return effectiveConfiguration;
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -79,7 +79,7 @@ public class KubernetesSessionCli {
 		this.cli = new GenericCLI(baseConfiguration, configDir);
 	}
 
-	public Configuration getEffectiveConfiguration(String[] args) throws CliArgsException {
+	Configuration getEffectiveConfiguration(String[] args) throws CliArgsException {
 		final CommandLine commandLine = cli.parseCommandLineOptions(args, true);
 		final Configuration effectiveConfiguration = new Configuration(baseConfiguration);
 		effectiveConfiguration.addAll(cli.toConfiguration(commandLine));

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -243,23 +243,23 @@ object FlinkShell {
     val commandLine = CliFrontendParser.parse(commandLineOptions, args, true)
 
     val customCLI = frontend.validateAndGetActiveCommandLine(commandLine)
-    val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine)
+    effectiveConfig.addAll(customCLI.toConfiguration(commandLine))
 
     val serviceLoader = new DefaultClusterClientServiceLoader
-    val clientFactory = serviceLoader.getClusterClientFactory(executorConfig)
-    val clusterDescriptor = clientFactory.createClusterDescriptor(executorConfig)
-    val clusterSpecification = clientFactory.getClusterSpecification(executorConfig)
+    val clientFactory = serviceLoader.getClusterClientFactory(effectiveConfig)
+    val clusterDescriptor = clientFactory.createClusterDescriptor(effectiveConfig)
+    val clusterSpecification = clientFactory.getClusterSpecification(effectiveConfig)
 
     val clusterClient = try {
       clusterDescriptor
         .deploySessionCluster(clusterSpecification)
         .getClusterClient
     } finally {
-      executorConfig.set(DeploymentOptions.TARGET, "yarn-session")
+      effectiveConfig.set(DeploymentOptions.TARGET, "yarn-session")
       clusterDescriptor.close()
     }
 
-    (executorConfig, Some(clusterClient))
+    (effectiveConfig, Some(clusterClient))
   }
 
   private def fetchDeployedYarnClusterInfo(
@@ -282,9 +282,9 @@ object FlinkShell {
     val commandLine = CliFrontendParser.parse(commandLineOptions, args, true)
 
     val customCLI = frontend.validateAndGetActiveCommandLine(commandLine)
-    val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine);
+    effectiveConfig.addAll(customCLI.toConfiguration(commandLine))
 
-    (executorConfig, None)
+    (effectiveConfig, None)
   }
 
   def parseArgList(config: Config, mode: String): Array[String] = {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -341,8 +341,7 @@ public class ExecutionContext<ClusterID> {
 				availableCommandLines,
 				activeCommandLine);
 
-		Configuration executionConfig = activeCommandLine.applyCommandLineOptionsToConfiguration(
-				commandLine);
+		Configuration executionConfig = activeCommandLine.toConfiguration(commandLine);
 
 		try {
 			final ProgramOptions programOptions = ProgramOptions.create(commandLine);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -141,7 +141,7 @@ public class DependencyTest {
 			env,
 			Collections.singletonList(dependency),
 			new Configuration(),
-			new DefaultCLI(new Configuration()),
+			new DefaultCLI(),
 			new DefaultClusterClientServiceLoader());
 	}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -330,7 +330,7 @@ public class ExecutionContextTest {
 				flinkConfig,
 				new DefaultClusterClientServiceLoader(),
 				new Options(),
-				Collections.singletonList(new DefaultCLI(flinkConfig))).build();
+				Collections.singletonList(new DefaultCLI())).build();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -346,7 +346,7 @@ public class ExecutionContextTest {
 				flinkConfig,
 				new DefaultClusterClientServiceLoader(),
 				new Options(),
-				Collections.singletonList(new DefaultCLI(flinkConfig)))
+				Collections.singletonList(new DefaultCLI()))
 				.build();
 	}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -1493,7 +1493,7 @@ public class LocalExecutorITCase extends TestLogger {
 				EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
 				Collections.emptyList(),
 				clusterClient.getFlinkConfiguration(),
-				new DefaultCLI(clusterClient.getFlinkConfiguration()),
+				new DefaultCLI(),
 				new DefaultClusterClientServiceLoader());
 	}
 
@@ -1503,7 +1503,7 @@ public class LocalExecutorITCase extends TestLogger {
 				EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
 				Collections.singletonList(udfDependency),
 				clusterClient.getFlinkConfiguration(),
-				new DefaultCLI(clusterClient.getFlinkConfiguration()),
+				new DefaultCLI(),
 				new DefaultClusterClientServiceLoader());
 	}
 
@@ -1514,7 +1514,7 @@ public class LocalExecutorITCase extends TestLogger {
 				EnvironmentFileUtil.parseModified(yamlFile, replaceVars),
 				Collections.emptyList(),
 				clusterClient.getFlinkConfiguration(),
-				new DefaultCLI(clusterClient.getFlinkConfiguration()),
+				new DefaultCLI(),
 				new DefaultClusterClientServiceLoader());
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
@@ -80,13 +80,13 @@ public class CliFrontendRunWithYarnTest extends CliFrontendTestBase {
 		// test detached mode
 		{
 			String[] parameters = {"-m", "yarn-cluster", "-p", "2", "-d", testJarPath};
-			verifyCliFrontend(testServiceLoader, yarnCLI, parameters, 2, true);
+			verifyCliFrontend(configuration, testServiceLoader, yarnCLI, parameters, 2, true);
 		}
 
 		// test detached mode
 		{
 			String[] parameters = {"-m", "yarn-cluster", "-p", "2", "-yd", testJarPath};
-			verifyCliFrontend(testServiceLoader, yarnCLI, parameters, 2, true);
+			verifyCliFrontend(configuration, testServiceLoader, yarnCLI, parameters, 2, true);
 		}
 	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -954,7 +954,7 @@ public abstract class YarnTestBase extends TestLogger {
 							CliFrontend cli = new CliFrontend(
 								configuration,
 								CliFrontend.loadCustomCommandLines(configuration, configurationDirectory));
-							returnValue = cli.parseParameters(args);
+							returnValue = cli.parseAndRun(args);
 						} catch (Exception e) {
 							throw new RuntimeException("Failed to execute the following args with CliFrontend: "
 								+ Arrays.toString(args), e);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/AbstractYarnCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/AbstractYarnCli.java
@@ -39,8 +39,10 @@ abstract class AbstractYarnCli extends AbstractCustomCommandLine {
 	protected Option addressOption =
 		new Option("m", "jobmanager", true, "Set to " + ID + " to use YARN execution mode.");
 
+	protected final Configuration configuration;
+
 	protected AbstractYarnCli(Configuration configuration) {
-		super(configuration);
+		this.configuration = configuration;
 	}
 
 	@Override

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -104,7 +104,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 				"-D", CoreOptions.FLINK_JVM_OPTIONS.key() + "=-DappName=foobar",
 				"-D", SecurityOptions.SSL_INTERNAL_KEY_PASSWORD.key() + "=changeit"});
 
-		Configuration executorConfig = cli.applyCommandLineOptionsToConfiguration(cmd);
+		Configuration executorConfig = cli.toConfiguration(cmd);
 		assertEquals("5 min", executorConfig.get(AkkaOptions.ASK_TIMEOUT));
 		assertEquals("-DappName=foobar", executorConfig.get(CoreOptions.FLINK_JVM_OPTIONS));
 		assertEquals("changeit", executorConfig.get(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD));
@@ -112,16 +112,17 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 	@Test
 	public void testCorrectSettingOfMaxSlots() throws Exception {
-		String[] params =
-			new String[] {"-ys", "3"};
+		String[] params = new String[] {"-ys", "3"};
 
-		FlinkYarnSessionCli yarnCLI = createFlinkYarnSessionCliWithJmAndTmTotalMemory(2048);
+		final Configuration configuration = createConfigurationWithJmAndTmTotalMemory(2048);
+		final FlinkYarnSessionCli yarnCLI = createFlinkYarnSessionCli(configuration);
 
 		final CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
 
-		final Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
-		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
-		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+		configuration.addAll(yarnCLI.toConfiguration(commandLine));
+
+		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(configuration);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(configuration);
 
 		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
 		assertEquals(3, clusterSpecification.getSlotsPerTaskManager());
@@ -133,7 +134,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		FlinkYarnSessionCli yarnCLI = createFlinkYarnSessionCli();
 
 		final CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
-		final Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = yarnCLI.toConfiguration(commandLine);
 
 		assertThat(executorConfig.get(DeploymentOptions.ATTACHED), is(false));
 	}
@@ -148,7 +149,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
 
-		Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
+		Configuration executorConfig = yarnCLI.toConfiguration(commandLine);
 		ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		YarnClusterDescriptor descriptor = (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
@@ -165,7 +166,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
 
-		Configuration executorConfig = yarnCLI.applyCommandLineOptionsToConfiguration(commandLine);
+		Configuration executorConfig = yarnCLI.toConfiguration(commandLine);
 		ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		YarnClusterDescriptor descriptor = (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
@@ -222,7 +223,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {}, true);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		final ApplicationId clusterId = clientFactory.getClusterId(executorConfig);
 
@@ -250,7 +251,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString()}, true);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		final ApplicationId clusterId = clientFactory.getClusterId(executorConfig);
 
@@ -263,7 +264,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString()}, true);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		final YarnClusterDescriptor clusterDescriptor = (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
@@ -280,7 +281,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final String overrideZkNamespace = "my_cluster";
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString(), "-yz", overrideZkNamespace}, true);
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 
 		final YarnClusterDescriptor clusterDescriptor = (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
@@ -300,7 +301,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCli(configuration);
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID_2.toString() }, true);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		final ApplicationId clusterId = clientFactory.getClusterId(executorConfig);
 
@@ -327,7 +328,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
-		Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
 
@@ -355,9 +356,10 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
-		Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
-		ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
-		ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+		configuration.addAll(flinkYarnSessionCli.toConfiguration(commandLine));
+
+		ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(configuration);
+		ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(configuration);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(jobManagerMemory));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(taskManagerMemory));
@@ -374,7 +376,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
 
@@ -391,7 +393,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCli();
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
 
@@ -408,7 +410,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCli();
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
 
@@ -429,9 +431,10 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[0], false);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
-		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
-		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+		configuration.addAll(flinkYarnSessionCli.toConfiguration(commandLine));
+
+		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(configuration);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(configuration);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(2048));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(4096));
@@ -443,13 +446,15 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	@Test
 	public void testJobManagerMemoryPropertyWithConfigDefaultValue() throws Exception {
 		int procMemory = 2048;
-		final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCliWithJmAndTmTotalMemory(procMemory);
+		final Configuration configuration = createConfigurationWithJmAndTmTotalMemory(procMemory);
+		final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCli(configuration);
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[0], false);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
-		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
-		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(executorConfig);
+		configuration.addAll(flinkYarnSessionCli.toConfiguration(commandLine));
+
+		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(configuration);
+		final ClusterSpecification clusterSpecification = clientFactory.getClusterSpecification(configuration);
 
 		assertThat(clusterSpecification.getMasterMemoryMB(), is(procMemory));
 		assertThat(clusterSpecification.getTaskManagerMemoryMB(), is(procMemory));
@@ -462,7 +467,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		YarnClusterDescriptor flinkYarnDescriptor = (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
@@ -478,7 +483,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
-		final Configuration executorConfig = flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+		final Configuration executorConfig = flinkYarnSessionCli.toConfiguration(commandLine);
 		final ClusterClientFactory<ApplicationId> clientFactory = getClusterClientFactory(executorConfig);
 		YarnClusterDescriptor flinkYarnDescriptor = (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
@@ -494,7 +499,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(args, false);
 
 		try {
-			flinkYarnSessionCli.applyCommandLineOptionsToConfiguration(commandLine);
+			flinkYarnSessionCli.toConfiguration(commandLine);
 			fail("Expected error for missing file");
 		} catch (ConfigurationException ce) {
 			assertEquals("Ship file missing.file does not exist", ce.getMessage());
@@ -526,10 +531,14 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	}
 
 	private FlinkYarnSessionCli createFlinkYarnSessionCliWithJmAndTmTotalMemory(int totalMemomory) throws FlinkException {
+		return createFlinkYarnSessionCli(createConfigurationWithJmAndTmTotalMemory(totalMemomory));
+	}
+
+	private Configuration createConfigurationWithJmAndTmTotalMemory(int totalMemomory) throws FlinkException {
 		Configuration configuration = new Configuration();
 		configuration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(totalMemomory));
 		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(totalMemomory));
-		return createFlinkYarnSessionCli(configuration);
+		return configuration;
 	}
 
 	private FlinkYarnSessionCli createFlinkYarnSessionCli(Configuration configuration) throws FlinkException {

--- a/pom.xml
+++ b/pom.xml
@@ -1548,6 +1548,7 @@ under the License.
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 						<hadoop.version>${hadoop.version}</hadoop.version>
 						<execution.checkpointing.unaligned>true</execution.checkpointing.unaligned>
+						<project.basedir>${project.basedir}</project.basedir>
 					</systemPropertyVariables>
 					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
 				</configuration>


### PR DESCRIPTION
## What is the purpose of the change

Before, it was up to the `CustomCommandLine` implementation whether any `Configuration` was passed through from the flink-conf.yaml or wherever the base `Configuration` came from.

Now, we make the flow of the `Configuration` explicit in `CliFrontend.getEffectiveConfiguration()`. Instead of relying on the `Configuration` we get from the `CustomCommandLine` we ask the `CustomCommandLine` to materialize its settings and add them manually to an effective `Configuration` that the `CliFrontend` controls.

This removes the `Configuration` parameter from `CustomCommandLines` that don't need it anymore, such as `DefaultCLI`, which means we also have to touch tests. Also, the test for `DefaultCLI` is vastly simplified because the behaviour we were testing there is now in the new ITCase.

This adds a new integration test in `CliFrontendITCase` that verifies correct parameter passing and also verifies that command line arguments override base settings

I'm also addressing https://issues.apache.org/jira/browse/FLINK-19521 here because I noticed and filed that during implementation. It's a small change but should make the CLI more consistent. 

## Verifying this change

- A new ITCase was added.
- Added test for dynamic properties on `DefaultCLI`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes, dynamic properties for the DefaultCLI
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
