### PR TITLE
[FLINK-19516] Let MiniClusterJobClient.jobResultFuture complete after MiniCluster shut down

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobClient.java
@@ -65,13 +65,14 @@ public final class MiniClusterJobClient implements JobClient, CoordinationReques
 		this.jobID = jobID;
 		this.miniCluster = miniCluster;
 		this.classLoader = classLoader;
-		this.jobResultFuture = miniCluster.requestJobResult(jobID);
 
 		if (finalizationBehaviour == JobFinalizationBehavior.SHUTDOWN_CLUSTER) {
 			// Make sure to shutdown the cluster when the job completes.
-			jobResultFuture.whenComplete((result, throwable) -> shutDownCluster(miniCluster));
+			jobResultFuture = miniCluster
+				.requestJobResult(jobID)
+				.whenComplete((result, throwable) -> shutDownCluster(miniCluster));
 		} else if (finalizationBehaviour == JobFinalizationBehavior.NOTHING) {
-			// fine
+			jobResultFuture = miniCluster.requestJobResult(jobID);
 		} else {
 			throw new IllegalArgumentException(
 					"Unexpected shutdown behavior: " + finalizationBehaviour);


### PR DESCRIPTION
This commit changes the MiniClusterJobClient.jobResultFuture such that it completes after
the MiniCluster's shut down has been triggered.