### PR TITLE
[FLINK-19315][coordination] Add AllocatedSlotPool

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotPool.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * The slot pool is responsible for maintaining a set of
+ * {@link AllocatedSlot AllocatedSlots}.
+ */
+public interface AllocatedSlotPool {
+
+	/**
+	 * Adds the given collection of slots to the slot pool.
+	 *
+	 * @param slots slots to add to the slot pool
+	 * @param currentTime currentTime when the slots have been added to the slot pool
+	 * @throws IllegalStateException if the slot pool already contains a to be added slot
+	 */
+	void addSlots(Collection<AllocatedSlot> slots, long currentTime);
+
+	/**
+	 * Removes the slot with the given allocationId from the slot pool.
+	 *
+	 * @param allocationId allocationId identifying the slot to remove from the slot pool
+	 * @return the removed slot if there was a slot with the given allocationId; otherwise {@link Optional#empty()}
+	 */
+	Optional<AllocatedSlot> removeSlot(AllocationID allocationId);
+
+	/**
+	 * Removes all slots belonging to the owning TaskExecutor identified by owner.
+	 *
+	 * @param owner owner identifies the TaskExecutor whose slots shall be removed
+	 * @return the collection of removed slots
+	 */
+	Collection<AllocatedSlot> removeSlots(ResourceID owner);
+
+	/**
+	 * Checks whether the slot pool contains at least one slot belonging to the specified owner.
+	 *
+	 * @param owner owner for which to check whether the slot pool contains slots
+	 * @return {@code true} if the slot pool contains a slot from the given owner; otherwise {@code false}
+	 */
+	boolean containsSlots(ResourceID owner);
+
+	/**
+	 * Checks whether the slot pool contains a slot with the given allocationId.
+	 *
+	 * @param allocationId allocationId identifying the slot for which to check whether it is contained
+	 * @return {@code true} if the slot pool contains the slot with the given allocationId; otherwise {@code false}
+	 */
+	boolean containsSlot(AllocationID allocationId);
+
+	/**
+	 * Reserves the free slot specified by the given allocationId.
+	 *
+	 * @param allocationId allocationId identifying the free slot to reserve
+	 * @return the {@link AllocatedSlot} which has been reserved
+	 * @throws IllegalStateException if there is no free slot with the given allocationId
+	 */
+	AllocatedSlot reserveFreeSlot(AllocationID allocationId);
+
+	/**
+	 * Frees the reserved slot, adding it back into the set of free slots.
+	 *
+	 * @param allocationId identifying the reserved slot to freed
+	 * @param currentTime currentTime when the slot has been freed
+	 * @return the freed {@link AllocatedSlot} if there was an allocated with the given allocationId;
+	 * otherwise {@link Optional#empty()}.
+	 */
+	Optional<AllocatedSlot> freeReservedSlot(AllocationID allocationId, long currentTime);
+
+	/**
+	 * Returns information about all currently free slots.
+	 *
+	 * @return collection of free slot information
+	 */
+	Collection<FreeSlotInfo> getFreeSlotsInformation();
+
+	/**
+	 * Returns information about all slots in this pool.
+	 *
+	 * @return collection of all slot information
+	 */
+	Collection<? extends SlotInfo> getAllSlotsInformation();
+
+	/**
+	 * Information about a free slot.
+	 */
+	interface FreeSlotInfo {
+		SlotInfoWithUtilization asSlotInfo();
+
+		/**
+		 * Returns since when this slot is free.
+		 *
+		 * @return the time since when the slot is free
+		 */
+		long getFreeSince();
+
+		default AllocationID getAllocationId() {
+			return asSlotInfo().getAllocationId();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
@@ -76,10 +76,6 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
 	private void addSlotInternal(AllocatedSlot slot, long currentTime) {
 		registeredSlots.put(slot.getAllocationId(), slot);
 		freeSlotsSince.put(slot.getAllocationId(), currentTime);
-
-		slotsPerTaskExecutor
-			.computeIfAbsent(slot.getTaskManagerId(), resourceID -> new HashSet<>())
-			.add(slot.getAllocationId());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Default {@link AllocatedSlotPool} implementation.
+ */
+public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
+
+	private final Map<AllocationID, AllocatedSlot> registeredSlots;
+
+	/**
+	 * Map containing all free slots and since when they are free.
+	 */
+	private final Map<AllocationID, Long> freeSlotsSince;
+
+	/**
+	 * Index containing a mapping between TaskExecutors and their slots.
+	 */
+	private final Map<ResourceID, Set<AllocationID>> slotsPerTaskExecutor;
+
+	public DefaultAllocatedSlotPool() {
+		this.registeredSlots = new HashMap<>();
+		this.slotsPerTaskExecutor = new HashMap<>();
+		this.freeSlotsSince = new HashMap<>();
+	}
+
+	@Override
+	public void addSlots(Collection<AllocatedSlot> slots, long currentTime) {
+		for (AllocatedSlot slot : slots) {
+			addSlot(slot, currentTime);
+		}
+	}
+
+	private void addSlot(AllocatedSlot slot, long currentTime) {
+		Preconditions.checkState(!registeredSlots.containsKey(slot.getAllocationId()), "The slot pool already contains a slot with id %s", slot.getAllocationId());
+		addSlotInternal(slot, currentTime);
+
+		slotsPerTaskExecutor
+			.computeIfAbsent(slot.getTaskManagerId(), resourceID -> new HashSet<>())
+			.add(slot.getAllocationId());
+	}
+
+	private void addSlotInternal(AllocatedSlot slot, long currentTime) {
+		registeredSlots.put(slot.getAllocationId(), slot);
+		freeSlotsSince.put(slot.getAllocationId(), currentTime);
+
+		slotsPerTaskExecutor
+			.computeIfAbsent(slot.getTaskManagerId(), resourceID -> new HashSet<>())
+			.add(slot.getAllocationId());
+	}
+
+	@Override
+	public Optional<AllocatedSlot> removeSlot(AllocationID allocationId) {
+		final AllocatedSlot removedSlot = removeSlotInternal(allocationId);
+
+		if (removedSlot != null) {
+			final ResourceID owner = removedSlot.getTaskManagerId();
+
+			slotsPerTaskExecutor.computeIfPresent(owner, (resourceID, allocationIds) -> {
+				allocationIds.remove(allocationId);
+
+				if (allocationIds.isEmpty()) {
+					return null;
+				}
+
+				return allocationIds;
+			});
+
+			return Optional.of(removedSlot);
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	@Nullable
+	private AllocatedSlot removeSlotInternal(AllocationID allocationId) {
+		final AllocatedSlot removedSlot = registeredSlots.remove(allocationId);
+		freeSlotsSince.remove(allocationId);
+		return removedSlot;
+	}
+
+	@Override
+	public Collection<AllocatedSlot> removeSlots(ResourceID owner) {
+		final Set<AllocationID> slotsOfTaskExecutor = slotsPerTaskExecutor.remove(owner);
+
+		if (slotsOfTaskExecutor != null) {
+			final Collection<AllocatedSlot> removedSlots = new ArrayList<>();
+
+			for (AllocationID allocationId : slotsOfTaskExecutor) {
+				removedSlots.add(Preconditions.checkNotNull(removeSlotInternal(allocationId)));
+			}
+
+			return removedSlots;
+		} else {
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public boolean containsSlots(ResourceID owner) {
+		return slotsPerTaskExecutor.containsKey(owner);
+	}
+
+	@Override
+	public boolean containsSlot(AllocationID allocationId) {
+		return registeredSlots.containsKey(allocationId);
+	}
+
+	@Override
+	public AllocatedSlot reserveFreeSlot(AllocationID allocationId) {
+		Preconditions.checkState(freeSlotsSince.remove(allocationId) != null, "The slot with id %s was not free.", allocationId);
+		return registeredSlots.get(allocationId);
+	}
+
+	@Override
+	public Optional<AllocatedSlot> freeReservedSlot(AllocationID allocationId, long currentTime) {
+		final AllocatedSlot allocatedSlot = registeredSlots.get(allocationId);
+
+		if (allocatedSlot != null && !freeSlotsSince.containsKey(allocationId)) {
+			freeSlotsSince.put(allocationId, currentTime);
+			return Optional.of(allocatedSlot);
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public Collection<FreeSlotInfo> getFreeSlotsInformation() {
+		final Map<ResourceID, Integer> freeSlotsPerTaskExecutor = new HashMap<>();
+
+		for (AllocationID allocationId : freeSlotsSince.keySet()) {
+			final ResourceID owner = Preconditions.checkNotNull(registeredSlots.get(allocationId)).getTaskManagerId();
+			final int newCount = freeSlotsPerTaskExecutor.getOrDefault(owner, 0) + 1;
+			freeSlotsPerTaskExecutor.put(owner, newCount);
+		}
+
+		final Collection<FreeSlotInfo> freeSlotInfos = new ArrayList<>();
+
+		for (Map.Entry<AllocationID, Long> freeSlot : freeSlotsSince.entrySet()) {
+			final AllocatedSlot allocatedSlot = Preconditions.checkNotNull(registeredSlots.get(freeSlot.getKey()));
+
+			final ResourceID owner = allocatedSlot.getTaskManagerId();
+			final int numberOfSlotsOnOwner = slotsPerTaskExecutor.get(owner).size();
+			final int numberOfFreeSlotsOnOwner = freeSlotsPerTaskExecutor.get(owner);
+			final double taskExecutorUtilization = (double) (numberOfSlotsOnOwner - numberOfFreeSlotsOnOwner) / numberOfSlotsOnOwner;
+
+			final SlotInfoWithUtilization slotInfoWithUtilization = SlotInfoWithUtilization.from(allocatedSlot, taskExecutorUtilization);
+
+			freeSlotInfos.add(DefaultFreeSlotInfo.create(slotInfoWithUtilization, freeSlot.getValue()));
+		}
+
+		return freeSlotInfos;
+	}
+
+	@Override
+	public Collection<? extends SlotInfo> getAllSlotsInformation() {
+		return registeredSlots.values();
+	}
+
+	private static final class DefaultFreeSlotInfo implements AllocatedSlotPool.FreeSlotInfo {
+
+		private final SlotInfoWithUtilization slotInfoWithUtilization;
+
+		private final long freeSince;
+
+		private DefaultFreeSlotInfo(SlotInfoWithUtilization slotInfoWithUtilization, long freeSince) {
+			this.slotInfoWithUtilization = slotInfoWithUtilization;
+			this.freeSince = freeSince;
+		}
+
+		@Override
+		public SlotInfoWithUtilization asSlotInfo() {
+			return slotInfoWithUtilization;
+		}
+
+		@Override
+		public long getFreeSince() {
+			return freeSince;
+		}
+
+		private static DefaultFreeSlotInfo create(SlotInfoWithUtilization slotInfoWithUtilization, long idleSince) {
+			return new DefaultFreeSlotInfo(Preconditions.checkNotNull(slotInfoWithUtilization), idleSince);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link DefaultAllocatedSlotPool}.
+ */
+public class DefaultAllocatedSlotPoolTest extends TestLogger {
+
+	@Test
+	public void testAddSlots() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+
+		final Collection<AllocatedSlot> slots = createAllocatedSlots();
+
+		slotPool.addSlots(slots, 0);
+
+		assertSlotPoolContainsSlots(slotPool, slots);
+		assertSlotPoolContainsFreeSlots(slotPool, slots);
+	}
+
+	@Test
+	public void testRemoveSlot() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+
+		final Collection<AllocatedSlot> slots = createAllocatedSlots();
+
+		slotPool.addSlots(slots, 0);
+
+		final Iterator<AllocatedSlot> iterator = slots.iterator();
+		final AllocatedSlot removedSlot = iterator.next();
+		iterator.remove();
+
+		slotPool.removeSlot(removedSlot.getAllocationId());
+
+		assertSlotPoolContainsSlots(slotPool, slots);
+	}
+
+	@Test
+	public void testRemoveSlots() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+
+		final ResourceID owner = ResourceID.generate();
+		final Collection<AllocatedSlot> slots = createAllocatedSlotsWithOwner(owner);
+		final AllocatedSlot otherSlot = createAllocatedSlot(ResourceID.generate());
+		slots.add(otherSlot);
+
+		slotPool.addSlots(slots, 0);
+
+		slotPool.removeSlots(owner);
+
+		assertSlotPoolContainsSlots(slotPool, Collections.singleton(otherSlot));
+	}
+
+	@Test
+	public void testContainsSlots() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+		final ResourceID owner = ResourceID.generate();
+		final AllocatedSlot allocatedSlot = createAllocatedSlot(owner);
+
+		slotPool.addSlots(Collections.singleton(allocatedSlot), 0);
+
+		assertTrue(slotPool.containsSlots(owner));
+		assertFalse(slotPool.containsSlots(ResourceID.generate()));
+	}
+
+	@Test
+	public void testContainsSlot() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+		final AllocatedSlot allocatedSlot = createAllocatedSlot(null);
+
+		slotPool.addSlots(Collections.singleton(allocatedSlot), 0);
+
+		assertTrue(slotPool.containsSlot(allocatedSlot.getAllocationId()));
+		assertFalse(slotPool.containsSlot(new AllocationID()));
+	}
+
+	@Test
+	public void testReserveFreeSlot() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+		final Collection<AllocatedSlot> allSlots = createAllocatedSlots();
+		final Collection<AllocatedSlot> freeSlots = new ArrayList<>(allSlots);
+		final Iterator<AllocatedSlot> iterator = freeSlots.iterator();
+		final AllocatedSlot allocatedSlot = iterator.next();
+		iterator.remove();
+
+		slotPool.addSlots(allSlots, 0);
+
+		assertThat(slotPool.reserveFreeSlot(allocatedSlot.getAllocationId()), sameInstance(allocatedSlot));
+
+		assertSlotPoolContainsFreeSlots(slotPool, freeSlots);
+		assertSlotPoolContainsSlots(slotPool, allSlots);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReserveNonFreeSlotFails() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+		final AllocatedSlot slot = createAllocatedSlot(null);
+
+		slotPool.addSlots(Collections.singleton(slot), 0);
+
+		slotPool.reserveFreeSlot(slot.getAllocationId());
+		slotPool.reserveFreeSlot(slot.getAllocationId());
+	}
+
+	@Test
+	public void testFreeReservedSlot() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+		final Collection<AllocatedSlot> slots = createAllocatedSlots();
+
+		final int initialTime = 0;
+		slotPool.addSlots(slots, initialTime);
+
+		final AllocatedSlot slot = slots.iterator().next();
+
+		slotPool.reserveFreeSlot(slot.getAllocationId());
+
+		final int releaseTime = 1;
+		assertTrue(slotPool.freeReservedSlot(slot.getAllocationId(), releaseTime).isPresent());
+		assertSlotPoolContainsFreeSlots(slotPool, slots);
+
+		for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : slotPool.getFreeSlotsInformation()) {
+			final long time;
+			if (freeSlotInfo.getAllocationId().equals(slot.getAllocationId())) {
+				time = releaseTime;
+			} else {
+				time = initialTime;
+			}
+
+			assertThat(freeSlotInfo.getFreeSince(), is(time));
+		}
+	}
+
+	@Test
+	public void testFreeFreeSlotIsIgnored() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+		final AllocatedSlot slot = createAllocatedSlot(null);
+
+		slotPool.addSlots(Collections.singleton(slot), 0);
+
+		assertFalse(slotPool.freeReservedSlot(slot.getAllocationId(), 1).isPresent());
+
+		final AllocatedSlotPool.FreeSlotInfo freeSlotInfo = Iterables.getOnlyElement(slotPool.getFreeSlotsInformation());
+
+		assertThat(freeSlotInfo.getFreeSince(), is(0L));
+	}
+
+	@Test
+	public void testSlotUtilizationCalculation() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+		final ResourceID owner = ResourceID.generate();
+		final Collection<AllocatedSlot> slots = createAllocatedSlotsWithOwner(owner);
+
+		slotPool.addSlots(slots, 0);
+
+		for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : slotPool.getFreeSlotsInformation()) {
+			assertThat(freeSlotInfo.asSlotInfo().getTaskExecutorUtilization(), closeTo(0, 0.1));
+		}
+
+		int numAllocatedSlots = 0;
+		for (AllocatedSlot slot : slots) {
+			assertThat(slotPool.reserveFreeSlot(slot.getAllocationId()), sameInstance(slot));
+			numAllocatedSlots++;
+
+			for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : slotPool.getFreeSlotsInformation()) {
+				final double utilization = (double) numAllocatedSlots / slots.size();
+				assertThat(freeSlotInfo.asSlotInfo().getTaskExecutorUtilization(), closeTo(utilization, 0.1));
+			}
+		}
+	}
+
+	@Test
+	public void testRemoveSlotsOfUnknownOwnerIsIgnored() {
+		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+
+		slotPool.removeSlots(ResourceID.generate());
+	}
+
+	private void assertSlotPoolContainsSlots(DefaultAllocatedSlotPool slotPool, Collection<AllocatedSlot> slots) {
+		assertThat(slotPool.getAllSlotsInformation(), hasSize(slots.size()));
+
+		final Map<AllocationID, AllocatedSlot> slotsPerAllocationId = slots.stream().collect(Collectors.toMap(AllocatedSlot::getAllocationId, Function.identity()));
+
+		for (SlotInfo slotInfo : slotPool.getAllSlotsInformation()) {
+			assertTrue(slotsPerAllocationId.containsKey(slotInfo.getAllocationId()));
+			final AllocatedSlot allocatedSlot = slotsPerAllocationId.get(slotInfo.getAllocationId());
+
+			assertThat(slotInfo, matchesPhysicalSlot(allocatedSlot));
+		}
+	}
+
+	private void assertSlotPoolContainsFreeSlots(DefaultAllocatedSlotPool slotPool, Collection<AllocatedSlot> allocatedSlots) {
+		final Collection<AllocatedSlotPool.FreeSlotInfo> freeSlotsInformation = slotPool.getFreeSlotsInformation();
+
+		assertThat(freeSlotsInformation, hasSize(allocatedSlots.size()));
+
+		final Map<AllocationID, AllocatedSlot> allocatedSlotMap = allocatedSlots.stream().collect(Collectors.toMap(AllocatedSlot::getAllocationId, Function.identity()));
+
+		for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : freeSlotsInformation) {
+			assertTrue(allocatedSlotMap.containsKey(freeSlotInfo.getAllocationId()));
+
+			assertThat(freeSlotInfo.asSlotInfo(), matchesPhysicalSlot(allocatedSlotMap.get(freeSlotInfo.getAllocationId())));
+		}
+	}
+
+	static Matcher<SlotInfo> matchesPhysicalSlot(PhysicalSlot allocatedSlot) {
+		return new SlotInfoMatcher(allocatedSlot);
+	}
+
+	private Collection<AllocatedSlot> createAllocatedSlots() {
+		return new ArrayList<>(Arrays.asList(
+			createAllocatedSlot(null),
+			createAllocatedSlot(null),
+			createAllocatedSlot(null)));
+	}
+
+	private Collection<AllocatedSlot> createAllocatedSlotsWithOwner(ResourceID owner) {
+		return new ArrayList<>(Arrays.asList(
+			createAllocatedSlot(owner),
+			createAllocatedSlot(owner),
+			createAllocatedSlot(owner)));
+	}
+
+	@Nonnull
+	private AllocatedSlot createAllocatedSlot(@Nullable ResourceID owner) {
+		return new AllocatedSlot(
+			new AllocationID(),
+			owner == null ? new LocalTaskManagerLocation() : new TaskManagerLocation(owner, InetAddress.getLoopbackAddress(), 41),
+			0,
+			ResourceProfile.UNKNOWN,
+			new RpcTaskManagerGateway(new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway(), JobMasterId.generate()));
+	}
+
+	static class SlotInfoMatcher extends TypeSafeMatcher<SlotInfo> {
+
+		private final PhysicalSlot physicalSlot;
+
+		SlotInfoMatcher(PhysicalSlot physicalSlot) {
+			this.physicalSlot = physicalSlot;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("SlotInfo with values: ");
+			description.appendValueList("{", ",", "}",
+				physicalSlot.getAllocationId(),
+				physicalSlot.getPhysicalSlotNumber(),
+				physicalSlot.getResourceProfile(),
+				physicalSlot.getTaskManagerLocation());
+		}
+
+		@Override
+		protected boolean matchesSafely(SlotInfo item) {
+			return item.getAllocationId().equals(physicalSlot.getAllocationId()) &&
+				item.getPhysicalSlotNumber() == physicalSlot.getPhysicalSlotNumber() &&
+				item.getResourceProfile().equals(physicalSlot.getResourceProfile()) &&
+				item.getTaskManagerLocation().equals(physicalSlot.getTaskManagerLocation());
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
@@ -159,7 +159,7 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
 	}
 
 	@Test
-	public void testFreeReservedSlot() {
+	public void testFreeingOfReservedSlot() {
 		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 		final Collection<AllocatedSlot> slots = createAllocatedSlots();
 
@@ -187,7 +187,7 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
 	}
 
 	@Test
-	public void testFreeFreeSlotIsIgnored() {
+	public void testFreeingOfFreeSlotIsIgnored() {
 		final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 		final AllocatedSlot slot = createAllocatedSlot(null);
 


### PR DESCRIPTION
Adds the `AllocatedSlotPool`, a component of the new declarative slot pool, providing basic book-keeping for allocated slots.

With this PR I'm also proposing a change in terminology in regards to `allocate`. Currently, "allocating a slot" has different meanings as it both describes a slot being assigned to a job by the ResourceManager, and an (allocated) slot being allocated for a task by the JobMaster.
I'd like to get rid of this duality, and propose for the job master to "reserve" allocated slots when using them for a task.