### PR TITLE
[FLINK-17341][runtime] Fixed ConcurrentModificationException in TaskExecutor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -62,6 +62,15 @@ public interface TaskSlotTable<T extends TaskSlotPayload> extends TimeoutListene
 	 */
 	Set<AllocationID> getAllocationIdsPerJob(JobID jobId);
 
+	/**
+	 * Returns the {@link AllocationID} of active {@link TaskSlot}s attached to the job with the given {@link JobID}.
+	 *
+	 * @param jobId The {@code JobID} of the job for which the {@code AllocationID}s of the attached active
+	 * {@link TaskSlot}s shall be returned.
+	 * @return A set of {@code AllocationID}s that belong to active {@code TaskSlot}s having the passed {@code JobID}.
+	 */
+	Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId);
+
 	SlotReport createSlotReport(ResourceID resourceId);
 
 	/**
@@ -194,14 +203,6 @@ public interface TaskSlotTable<T extends TaskSlotPayload> extends TimeoutListene
 	 * @return Iterator of allocated slots.
 	 */
 	Iterator<TaskSlot<T>> getAllocatedSlots(JobID jobId);
-
-	/**
-	 * Return an iterator of active slots (their application ids) for the given job id.
-	 *
-	 * @param jobId for which to return the active slots
-	 * @return Iterator of allocation ids of active slots
-	 */
-	Iterator<AllocationID> getActiveSlots(JobID jobId);
 
 	/**
 	 * Returns the owning job of the {@link TaskSlot} identified by the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
@@ -200,6 +200,17 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
 		}
 	}
 
+	@Override
+	public Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId) {
+		Iterator<TaskSlot<T>> taskSlotIterator = new TaskSlotIterator(jobId, TaskSlotState.ACTIVE);
+		Set<AllocationID> allocationIds = new HashSet<>();
+		while (taskSlotIterator.hasNext()) {
+			allocationIds.add(taskSlotIterator.next().getAllocationId());
+		}
+
+		return allocationIds;
+	}
+
 	// ---------------------------------------------------------------------
 	// Slot report methods
 	// ---------------------------------------------------------------------
@@ -463,11 +474,6 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
 	}
 
 	@Override
-	public Iterator<AllocationID> getActiveSlots(JobID jobId) {
-		return new AllocationIDIterator(jobId, TaskSlotState.ACTIVE);
-	}
-
-	@Override
 	@Nullable
 	public JobID getOwningJob(AllocationID allocationId) {
 		final TaskSlot<T> taskSlot = getTaskSlot(allocationId);
@@ -622,37 +628,6 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
 
 		public TaskSlot<T> getTaskSlot() {
 			return taskSlot;
-		}
-	}
-
-	/**
-	 * Iterator over {@link AllocationID} of the {@link TaskSlot} of a given job. Additionally,
-	 * the task slots identified by the allocation ids are in the given state.
-	 */
-	private final class AllocationIDIterator implements Iterator<AllocationID> {
-		private final Iterator<TaskSlot<T>> iterator;
-
-		private AllocationIDIterator(JobID jobId, TaskSlotState state) {
-			iterator = new TaskSlotIterator(jobId, state);
-		}
-
-		@Override
-		public boolean hasNext() {
-			return iterator.hasNext();
-		}
-
-		@Override
-		public AllocationID next() {
-			try {
-				return iterator.next().getAllocationId();
-			} catch (NoSuchElementException e) {
-				throw new NoSuchElementException("No more allocation ids.");
-			}
-		}
-
-		@Override
-		public void remove() {
-			throw new UnsupportedOperationException("Cannot remove allocation ids via this iterator.");
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.util.function.TriFunctionWithException;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 
-import org.apache.commons.collections.IteratorUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -80,13 +79,13 @@ public class TaskSlotTableImplTest extends TestLogger {
 			assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId2), is(true));
 			assertThat(taskSlotTable.isAllocated(2, jobId2, allocationId3), is(true));
 
-			assertThat(IteratorUtils.toList(taskSlotTable.getActiveSlots(jobId1)), is(equalTo(Arrays.asList(allocationId1))));
+			assertThat(taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId1), is(equalTo(Sets.newHashSet(allocationId1))));
 
 			assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId1), is(true));
 			assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId2), is(true));
 			assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId3), is(false));
 
-			assertThat(Sets.newHashSet(taskSlotTable.getActiveSlots(jobId1)), is(equalTo(new HashSet<>(Arrays.asList(allocationId2, allocationId1)))));
+			assertThat(taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId1), is(equalTo(new HashSet<>(Arrays.asList(allocationId2, allocationId1)))));
 		} finally {
 			taskSlotTable.close();
 			assertThat(taskSlotTable.isClosed(), is(true));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTaskSlotTable.java
@@ -51,7 +51,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 	private final Function<AllocationID, MemoryManager> memoryManagerGetter;
 	private final Supplier<CompletableFuture<Void>> closeAsyncSupplier;
 	private final Function<JobID, Iterator<T>> tasksForJobFunction;
-	private final Function<JobID, Iterator<AllocationID>> activeSlotsForJobFunction;
+	private final Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction;
 
 	private TestingTaskSlotTable(
 			Supplier<SlotReport> createSlotReportSupplier,
@@ -61,7 +61,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 			Function<AllocationID, MemoryManager> memoryManagerGetter,
 			Supplier<CompletableFuture<Void>> closeAsyncSupplier,
 			Function<JobID, Iterator<T>> tasksForJobFunction,
-			Function<JobID, Iterator<AllocationID>> activeSlotsForJobFunction) {
+			Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction) {
 		this.createSlotReportSupplier = createSlotReportSupplier;
 		this.allocateSlotSupplier = allocateSlotSupplier;
 		this.tryMarkSlotActiveBiFunction = tryMarkSlotActiveBiFunction;
@@ -69,7 +69,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 		this.memoryManagerGetter = memoryManagerGetter;
 		this.closeAsyncSupplier = closeAsyncSupplier;
 		this.tasksForJobFunction = tasksForJobFunction;
-		this.activeSlotsForJobFunction = activeSlotsForJobFunction;
+		this.activeSlotAllocationIdsForJobFunction = activeSlotAllocationIdsForJobFunction;
 	}
 
 	@Override
@@ -80,6 +80,11 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 	@Override
 	public Set<AllocationID> getAllocationIdsPerJob(JobID jobId) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId) {
+		return activeSlotAllocationIdsForJobFunction.apply(jobId);
 	}
 
 	@Override
@@ -140,11 +145,6 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 	@Override
 	public Iterator<TaskSlot<T>> getAllocatedSlots(JobID jobId) {
 		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Iterator<AllocationID> getActiveSlots(JobID jobId) {
-		return activeSlotsForJobFunction.apply(jobId);
 	}
 
 	@Nullable
@@ -210,7 +210,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 		};
 		private Supplier<CompletableFuture<Void>> closeAsyncSupplier = FutureUtils::completedVoidFuture;
 		private Function<JobID, Iterator<T>> tasksForJobFunction = ignored -> Collections.emptyIterator();
-		private Function<JobID, Iterator<AllocationID>> activeSlotsForJobFunction = ignored -> Collections.emptyIterator();
+		private Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction = ignored -> Collections.emptySet();
 
 		public TestingTaskSlotTableBuilder<T> createSlotReportSupplier(Supplier<SlotReport> createSlotReportSupplier) {
 			this.createSlotReportSupplier = createSlotReportSupplier;
@@ -247,8 +247,8 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 			return this;
 		}
 
-		public TestingTaskSlotTableBuilder<T> activeSlotsForJobReturns(Function<JobID, Iterator<AllocationID>> activeSlotsForJobFunction) {
-			this.activeSlotsForJobFunction = activeSlotsForJobFunction;
+		public TestingTaskSlotTableBuilder<T> activeSlotsForJobReturns(Function<JobID, Set<AllocationID>> activeSlotAllocationIdsForJobFunction) {
+			this.activeSlotAllocationIdsForJobFunction = activeSlotAllocationIdsForJobFunction;
 			return this;
 		}
 
@@ -261,7 +261,7 @@ public class TestingTaskSlotTable<T extends TaskSlotPayload> implements TaskSlot
 				memoryManagerGetter,
 				closeAsyncSupplier,
 				tasksForJobFunction,
-				activeSlotsForJobFunction);
+				activeSlotAllocationIdsForJobFunction);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
@@ -81,6 +81,11 @@ public class ThreadSafeTaskSlotTable<T extends TaskSlotPayload> implements TaskS
 	}
 
 	@Override
+	public Set<AllocationID> getActiveTaskAllocationIdsPerJob(JobID jobId) {
+		return callAsync(() -> taskSlotTable.getActiveTaskAllocationIdsPerJob(jobId));
+	}
+
+	@Override
 	public SlotReport createSlotReport(ResourceID resourceId) {
 		return callAsync(() -> taskSlotTable.createSlotReport(resourceId));
 	}
@@ -143,11 +148,6 @@ public class ThreadSafeTaskSlotTable<T extends TaskSlotPayload> implements TaskS
 	@Override
 	public Iterator<TaskSlot<T>> getAllocatedSlots(JobID jobId) {
 		return callAsync(() -> taskSlotTable.getAllocatedSlots(jobId));
-	}
-
-	@Override
-	public Iterator<AllocationID> getActiveSlots(JobID jobId) {
-		return callAsync(() -> taskSlotTable.getActiveSlots(jobId));
 	}
 
 	@Nullable


### PR DESCRIPTION
## What is the purpose of the change

The fix is necessary since there is a possibility that a `ConcurrentModificationException` is thrown as described in FLINK-17341.

## Brief change log

The solution includes switching from `Iterator` to a `Set` of `AllocationID`s:
- Introduced `TaskSlotTable.getActiveTaskAllocationIdsPerJob(JobID)`
- Replaced usage of `TaskSlotTable.getActiveSlots(JobID)` by `TaskSlotTable.getActiveTaskAllocationIdsPerJob(JobID)`
- Removed `TaskSlotTable.getActiveSlots(JobID)` and `TaskSlotTable.AllocationIDIterator`

## Verifying this change

This change is already covered by existing tests, such as `TaskSlotTableImplTest.testTryMarkSlotActive`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
