### PR TITLE
Single task result partial record clean up

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -55,13 +55,26 @@ public class BufferBuilder {
 	 * @return created matching instance of {@link BufferConsumer} to this {@link BufferBuilder}.
 	 */
 	public BufferConsumer createBufferConsumer() {
+		return createBufferConsumer(positionMarker.cachedPosition);
+	}
+
+	/**
+	 * This method always creates a {@link BufferConsumer} starting from position 0 of {@link MemorySegment}.
+	 *
+	 * @return created matching instance of {@link BufferConsumer} to this {@link BufferBuilder}.
+	 */
+	public BufferConsumer createBufferConsumerFromBeginning() {
+		return createBufferConsumer(0);
+	}
+
+	private BufferConsumer createBufferConsumer(int currentReaderPosition) {
 		checkState(!bufferConsumerCreated, "Two BufferConsumer shouldn't exist for one BufferBuilder");
 		bufferConsumerCreated = true;
 		return new BufferConsumer(
 			memorySegment,
 			recycler,
 			positionMarker,
-			positionMarker.cachedPosition);
+			currentReaderPosition);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -115,7 +115,7 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public boolean add(BufferConsumer bufferConsumer) throws IOException {
+	public boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException {
 		if (isFinished()) {
 			bufferConsumer.close();
 			return false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -139,7 +139,7 @@ public class PipelinedSubpartition extends ResultSubpartition
 	}
 
 	@Override
-	public boolean add(BufferConsumer bufferConsumer) throws IOException {
+	public boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException {
 		return add(bufferConsumer, false);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -77,6 +77,11 @@ public abstract class ResultSubpartition {
 		parent.onConsumedSubpartition(getSubPartitionIndex());
 	}
 
+	@VisibleForTesting
+	public final boolean add(BufferConsumer bufferConsumer) throws IOException {
+		return add(bufferConsumer, 0);
+	}
+
 	/**
 	 * Adds the given buffer.
 	 *
@@ -89,11 +94,14 @@ public abstract class ResultSubpartition {
 	 *
 	 * @param bufferConsumer
 	 * 		the buffer to add (transferring ownership to this writer)
+	 * @param partialRecordLength
+	 * 		the length of bytes to skip in order to start with a complete record, from position index 0
+	 * 		of the underlying {@cite MemorySegment}.
 	 * @return true if operation succeeded and bufferConsumer was enqueued for consumption.
 	 * @throws IOException
 	 * 		thrown in case of errors while adding the buffer
 	 */
-	public abstract boolean add(BufferConsumer bufferConsumer) throws IOException;
+	public abstract boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException;
 
 	public abstract void flush();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -289,6 +289,44 @@ public class ResultPartitionTest {
 		verifyCreateSubpartitionViewThrowsException(manager, partition.getPartitionId());
 	}
 
+	@Test
+	public void testEmitRecordWithRecordSpanningMultipleBuffers() throws Exception {
+		BufferWritingResultPartition bufferWritingResultPartition = createResultPartition(ResultPartitionType.PIPELINED);
+		PipelinedSubpartition pipelinedSubpartition = (PipelinedSubpartition) bufferWritingResultPartition.subpartitions[0];
+		int partialLength = bufferSize / 3;
+
+		try {
+			// emit the first record, record length = partialLength
+			bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(partialLength), 0);
+			// emit the second record, record length = bufferSize
+			bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(bufferSize), 0);
+		} finally {
+			assertEquals(2, pipelinedSubpartition.getCurrentNumberOfBuffers());
+			assertEquals(0, pipelinedSubpartition.getNextBuffer().getPartialRecordLength());
+			assertEquals(partialLength, pipelinedSubpartition.getNextBuffer().getPartialRecordLength());
+		}
+	}
+
+	@Test
+	public void testBroadcastRecordWithRecordSpanningMultipleBuffers() throws Exception {
+		BufferWritingResultPartition bufferWritingResultPartition = createResultPartition(ResultPartitionType.PIPELINED);
+		int partialLength = bufferSize / 3;
+
+		try {
+			// emit the first record, record length = partialLength
+			bufferWritingResultPartition.broadcastRecord(ByteBuffer.allocate(partialLength));
+			// emit the second record, record length = bufferSize
+			bufferWritingResultPartition.broadcastRecord(ByteBuffer.allocate(bufferSize));
+		} finally {
+			for (ResultSubpartition resultSubpartition : bufferWritingResultPartition.subpartitions) {
+				PipelinedSubpartition pipelinedSubpartition = (PipelinedSubpartition) resultSubpartition;
+				assertEquals(2, pipelinedSubpartition.getCurrentNumberOfBuffers());
+				assertEquals(0, pipelinedSubpartition.getNextBuffer().getPartialRecordLength());
+				assertEquals(partialLength, pipelinedSubpartition.getNextBuffer().getPartialRecordLength());
+			}
+		}
+	}
+
 	/**
 	 * Tests {@link ResultPartition#emitRecord} on a working partition.
 	 *


### PR DESCRIPTION

## What is the purpose of the change

Partial records happen if a record can not fit into one buffer, then the remaining part of the same record is put into the next buffer. Hence partial records only exist at the beginning of a buffer. Partial record clean-up is needed in the mode of approximate local recovery. If a record is spanning over multiple buffers, and the first (several) buffers have got lost due to the failure of the receiver task, the remaining data belonging to the same record in transition should be cleaned up.

`partialRecordLength` is the length of bytes to skip in order to start with a complete record, from position index 0 of the underlying MemorySegment. `partialRecordLength` is used in approximate local recovery to find the start position of a complete record on a BufferConsumer, so-called `partial record clean-up`.

## Brief change log
- API change to add `partialRecordLength` when creating a BufferConsumer
- Add `partialRecordLength` in `BufferWritingResultPartition` when emitRecord and `broadcastRecord`
- Update the type of buffers in PipelinedSubpartition fr`PrioritizedDeque<BufferConsumer>` to `PrioritizedDeque<BufferConsumerWithPartialRecordLength>`

## Verifying this change

- add unit tests to test partial record length
- pass existing tests to make sure the changes do not affect data write/read/transition.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

