### PR TITLE
[FLINK-17458] Stop TaskSubmissionTestEnvironment.testingRpcService when closing the environment

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -44,7 +44,6 @@ import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.rpc.MainThreadExecutable;
 import org.apache.flink.runtime.rpc.RpcService;
-import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
@@ -277,7 +276,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
 	@Override
 	public void close() throws Exception {
-		RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+		testingRpcService.stopService().join();
 
 		timerService.stop();
 


### PR DESCRIPTION
Stop TaskSubmissionTestEnvironment.testingRpcService when closing the environment