### PR TITLE
[FLINK-19522][Table SQL / Ecosystem] Add auto-commit option for Table/SQL API

### DIFF
--- a/docs/dev/table/connectors/jdbc.md
+++ b/docs/dev/table/connectors/jdbc.md
@@ -187,9 +187,11 @@ Connector Options
     <tr>
       <td><h5>scan.auto-commit</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">true</td>
       <td>Boolean</td>
-      <td>Sets the auto commit flag on the JDBC driver.</td>
+      <td>Sets the <a href="https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html#commit_transactions">auto-commit</a> flag on the JDBC driver,
+      which determines whether each statement is committed in a transaction automatically. Some JDBC drivers, specifically
+      <a href="https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor">Postgres</a>, may require this to be set to false in order to stream results.</td>
     </tr>
     <tr>
       <td><h5>lookup.cache.max-rows</h5></td>

--- a/docs/dev/table/connectors/jdbc.md
+++ b/docs/dev/table/connectors/jdbc.md
@@ -183,7 +183,14 @@ Connector Options
       <td style="word-wrap: break-word;">0</td>
       <td>Integer</td>
       <td>The number of rows that should be fetched from the database when reading per round trip. If the value specified is zero, then the hint is ignored.</td>
-    </tr>     
+    </tr>
+    <tr>
+      <td><h5>scan.auto-commit</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Boolean</td>
+      <td>Sets the auto commit flag on the JDBC driver.</td>
+    </tr>
     <tr>
       <td><h5>lookup.cache.max-rows</h5></td>
       <td>optional</td>

--- a/docs/dev/table/connectors/jdbc.zh.md
+++ b/docs/dev/table/connectors/jdbc.zh.md
@@ -187,9 +187,11 @@ Connector Options
     <tr>
       <td><h5>scan.auto-commit</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">true</td>
       <td>Boolean</td>
-      <td>Sets the auto commit flag on the JDBC driver.</td>
+      <td>Sets the <a href="https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html#commit_transactions">auto-commit</a> flag on the JDBC driver,
+      which determines whether each statement is committed in a transaction automatically. Some JDBC drivers, specifically
+      <a href="https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor">Postgres</a>, may require this to be set to false in order to stream results.</td>
     </tr>
     <tr>
       <td><h5>lookup.cache.max-rows</h5></td>

--- a/docs/dev/table/connectors/jdbc.zh.md
+++ b/docs/dev/table/connectors/jdbc.zh.md
@@ -185,6 +185,13 @@ Connector Options
       <td>The number of rows that should be fetched from the database when reading per round trip. If the value specified is zero, then the hint is ignored.</td>
     </tr>
     <tr>
+      <td><h5>scan.auto-commit</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Boolean</td>
+      <td>Sets the auto commit flag on the JDBC driver.</td>
+    </tr>
+    <tr>
       <td><h5>lookup.cache.max-rows</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
@@ -34,7 +34,7 @@ public class JdbcReadOptions implements Serializable {
 	private final Integer numPartitions;
 
 	private final int fetchSize;
-	private final Boolean autoCommit;
+	private final boolean autoCommit;
 
 	private JdbcReadOptions(
 			String query,
@@ -43,7 +43,7 @@ public class JdbcReadOptions implements Serializable {
 			Long partitionUpperBound,
 			Integer numPartitions,
 			int fetchSize,
-			Boolean autoCommit) {
+			boolean autoCommit) {
 		this.query = query;
 		this.partitionColumnName = partitionColumnName;
 		this.partitionLowerBound = partitionLowerBound;
@@ -78,8 +78,8 @@ public class JdbcReadOptions implements Serializable {
 		return fetchSize;
 	}
 
-	public Optional<Boolean> getAutoCommit() {
-		return Optional.ofNullable(autoCommit);
+	public boolean getAutoCommit() {
+		return autoCommit;
 	}
 
 	public static Builder builder() {
@@ -113,7 +113,7 @@ public class JdbcReadOptions implements Serializable {
 		protected Integer numPartitions;
 
 		protected int fetchSize = 0;
-		protected Boolean autoCommit;
+		protected boolean autoCommit = true;
 
 		/**
 		 * optional, SQL query statement for this JDBC source.
@@ -167,7 +167,7 @@ public class JdbcReadOptions implements Serializable {
 		/**
 		 * optional, whether to set auto commit on the JDBC driver.
 		 */
-		public Builder setAutoCommit(Boolean autoCommit) {
+		public Builder setAutoCommit(boolean autoCommit) {
 			this.autoCommit = autoCommit;
 			return this;
 		}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
@@ -34,6 +34,7 @@ public class JdbcReadOptions implements Serializable {
 	private final Integer numPartitions;
 
 	private final int fetchSize;
+	private final Boolean autoCommit;
 
 	private JdbcReadOptions(
 			String query,
@@ -41,7 +42,8 @@ public class JdbcReadOptions implements Serializable {
 			Long partitionLowerBound,
 			Long partitionUpperBound,
 			Integer numPartitions,
-			int fetchSize) {
+			int fetchSize,
+			Boolean autoCommit) {
 		this.query = query;
 		this.partitionColumnName = partitionColumnName;
 		this.partitionLowerBound = partitionLowerBound;
@@ -49,6 +51,7 @@ public class JdbcReadOptions implements Serializable {
 		this.numPartitions = numPartitions;
 
 		this.fetchSize = fetchSize;
+		this.autoCommit = autoCommit;
 	}
 
 	public Optional<String> getQuery() {
@@ -75,6 +78,10 @@ public class JdbcReadOptions implements Serializable {
 		return fetchSize;
 	}
 
+	public Optional<Boolean> getAutoCommit() {
+		return Optional.ofNullable(autoCommit);
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -88,7 +95,8 @@ public class JdbcReadOptions implements Serializable {
 					Objects.equals(partitionLowerBound, options.partitionLowerBound) &&
 					Objects.equals(partitionUpperBound, options.partitionUpperBound) &&
 					Objects.equals(numPartitions, options.numPartitions) &&
-					Objects.equals(fetchSize, options.fetchSize);
+					Objects.equals(fetchSize, options.fetchSize) &&
+					Objects.equals(autoCommit, options.autoCommit);
 		} else {
 			return false;
 		}
@@ -105,6 +113,7 @@ public class JdbcReadOptions implements Serializable {
 		protected Integer numPartitions;
 
 		protected int fetchSize = 0;
+		protected Boolean autoCommit;
 
 		/**
 		 * optional, SQL query statement for this JDBC source.
@@ -155,9 +164,17 @@ public class JdbcReadOptions implements Serializable {
 			return this;
 		}
 
+		/**
+		 * optional, whether to set auto commit on the JDBC driver.
+		 */
+		public Builder setAutoCommit(Boolean autoCommit) {
+			this.autoCommit = autoCommit;
+			return this;
+		}
+
 		public JdbcReadOptions build() {
 			return new JdbcReadOptions(
-				query, partitionColumnName, partitionLowerBound, partitionUpperBound, numPartitions, fetchSize);
+				query, partitionColumnName, partitionLowerBound, partitionUpperBound, numPartitions, fetchSize, autoCommit);
 		}
 	}
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
@@ -112,8 +112,9 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 	private static final ConfigOption<Boolean> SCAN_AUTO_COMMIT = ConfigOptions
 		.key("scan.auto-commit")
 		.booleanType()
-		.noDefaultValue()
-		.withDescription("sets whether the driver is in auto-commit mode.");
+		.defaultValue(true)
+		.withDescription("sets whether the driver is in auto-commit mode. The default value is true, per" +
+			" the JDBC spec.");
 
 	// look up config options
 	private static final ConfigOption<Long> LOOKUP_CACHE_MAX_ROWS = ConfigOptions
@@ -208,7 +209,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 			builder.setNumPartitions(readableConfig.get(SCAN_PARTITION_NUM));
 		}
 		readableConfig.getOptional(SCAN_FETCH_SIZE).ifPresent(builder::setFetchSize);
-		readableConfig.getOptional(SCAN_AUTO_COMMIT).ifPresent(builder::setAutoCommit);
+		builder.setAutoCommit(readableConfig.get(SCAN_AUTO_COMMIT));
 		return builder.build();
 	}
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
@@ -109,6 +109,11 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 		.withDescription("gives the reader a hint as to the number of rows that should be fetched, from" +
 			" the database when reading per round trip. If the value specified is zero, then the hint is ignored. The" +
 			" default value is zero.");
+	private static final ConfigOption<Boolean> SCAN_AUTO_COMMIT = ConfigOptions
+		.key("scan.auto-commit")
+		.booleanType()
+		.noDefaultValue()
+		.withDescription("sets whether the driver is in auto-commit mode.");
 
 	// look up config options
 	private static final ConfigOption<Long> LOOKUP_CACHE_MAX_ROWS = ConfigOptions
@@ -203,6 +208,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 			builder.setNumPartitions(readableConfig.get(SCAN_PARTITION_NUM));
 		}
 		readableConfig.getOptional(SCAN_FETCH_SIZE).ifPresent(builder::setFetchSize);
+		readableConfig.getOptional(SCAN_AUTO_COMMIT).ifPresent(builder::setAutoCommit);
 		return builder.build();
 	}
 
@@ -258,6 +264,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 		optionalOptions.add(SCAN_PARTITION_UPPER_BOUND);
 		optionalOptions.add(SCAN_PARTITION_NUM);
 		optionalOptions.add(SCAN_FETCH_SIZE);
+		optionalOptions.add(SCAN_AUTO_COMMIT);
 		optionalOptions.add(LOOKUP_CACHE_MAX_ROWS);
 		optionalOptions.add(LOOKUP_CACHE_TTL);
 		optionalOptions.add(LOOKUP_MAX_RETRIES);

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
@@ -92,7 +92,8 @@ public class JdbcDynamicTableSource implements ScanTableSource, LookupTableSourc
 			.setDrivername(options.getDriverName())
 			.setDBUrl(options.getDbURL())
 			.setUsername(options.getUsername().orElse(null))
-			.setPassword(options.getPassword().orElse(null));
+			.setPassword(options.getPassword().orElse(null))
+			.setAutoCommit(readOptions.getAutoCommit().orElse(null));
 
 		if (readOptions.getFetchSize() != 0) {
 			builder.setFetchSize(readOptions.getFetchSize());

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
@@ -93,7 +93,7 @@ public class JdbcDynamicTableSource implements ScanTableSource, LookupTableSourc
 			.setDBUrl(options.getDbURL())
 			.setUsername(options.getUsername().orElse(null))
 			.setPassword(options.getPassword().orElse(null))
-			.setAutoCommit(readOptions.getAutoCommit().orElse(null));
+			.setAutoCommit(readOptions.getAutoCommit());
 
 		if (readOptions.getFetchSize() != 0) {
 			builder.setFetchSize(readOptions.getFetchSize());

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataInputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataInputFormat.java
@@ -363,7 +363,7 @@ public class JdbcRowDataInputFormat extends RichInputFormat<RowData, InputSplit>
 			return this;
 		}
 
-		public Builder setAutoCommit(Boolean autoCommit) {
+		public Builder setAutoCommit(boolean autoCommit) {
 			this.autoCommit = autoCommit;
 			return this;
 		}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
@@ -115,6 +115,7 @@ public class JdbcDynamicTableFactoryTest {
 		properties.put("scan.partition.upper-bound", "100");
 		properties.put("scan.partition.num", "10");
 		properties.put("scan.fetch-size", "20");
+		properties.put("scan.auto-commit", "false");
 
 		DynamicTableSource actual = createTableSource(properties);
 
@@ -128,6 +129,7 @@ public class JdbcDynamicTableFactoryTest {
 			.setPartitionUpperBound(100)
 			.setNumPartitions(10)
 			.setFetchSize(20)
+			.setAutoCommit(false)
 			.build();
 		JdbcLookupOptions lookupOptions = JdbcLookupOptions.builder()
 			.setCacheMaxSize(-1)


### PR DESCRIPTION
This commit adds an option in the SQL API to set the auto-commit flag.

## What is the purpose of the change
Allows the user to set the auto-commit flag on the SQL api when reading data in. For postgres, this is required to be set to false for streaming to work properly.

## Brief change log
  - Update JdbcReadOptions to have an auto-commit setting
  - Update JdbcDynamicTableSource to read in the config option to set auto-commit
  - Update unit tests and documentation

## Verifying this change
Amended JdbcReadOptions unit test to also test to ensure auto-commit can be set

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
