### PR TITLE
[FLINK-19416][python] Support Python datetime object in from_collection of Python DataStream

### DIFF
--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -78,9 +78,9 @@ class WrapperTypeInfo(TypeInformation):
         """
         return False
 
-    def to_wrapper_type(self, obj):
+    def to_internal_type(self, obj):
         """
-        Converts a Python object into an internal wrapper object.
+        Converts a Python object into an internal object.
         """
         return obj
 
@@ -349,22 +349,22 @@ class RowTypeInfo(WrapperTypeInfo):
     def need_conversion(self):
         return True
 
-    def to_wrapper_type(self, obj):
+    def to_internal_type(self, obj):
         if obj is None:
             return
 
         if self._need_serialize_any_field:
-            # Only calling to_wrapper_type function for fields that need conversion
+            # Only calling to_internal_type function for fields that need conversion
             if isinstance(obj, dict):
-                return tuple(f.to_wrapper_type(obj.get(n)) if c else obj.get(n)
+                return tuple(f.to_internal_type(obj.get(n)) if c else obj.get(n)
                              for n, f, c in zip(self._j_typeinfo.getFieldNames(), self.types,
                                                 self._need_conversion))
             elif isinstance(obj, (tuple, list)):
-                return tuple(f.to_wrapper_type(v) if c else v
+                return tuple(f.to_internal_type(v) if c else v
                              for f, v, c in zip(self.types, obj, self._need_conversion))
             elif hasattr(obj, "__dict__"):
                 d = obj.__dict__
-                return tuple(f.to_wrapper_type(d.get(n)) if c else d.get(n)
+                return tuple(f.to_internal_type(d.get(n)) if c else d.get(n)
                              for n, f, c in zip(self._j_typeinfo.getFieldNames(), self.types,
                                                 self._need_conversion))
             else:
@@ -424,7 +424,7 @@ class DateTypeInfo(WrapperTypeInfo):
     def need_conversion(self):
         return True
 
-    def to_wrapper_type(self, d):
+    def to_internal_type(self, d):
         if d is not None:
             return d.toordinal() - self.EPOCH_ORDINAL
 
@@ -442,7 +442,7 @@ class TimeTypeInfo(WrapperTypeInfo):
     def need_conversion(self):
         return True
 
-    def to_wrapper_type(self, t):
+    def to_internal_type(self, t):
         if t is not None:
             if t.tzinfo is not None:
                 offset = t.utcoffset()
@@ -467,7 +467,7 @@ class TimestampTypeInfo(WrapperTypeInfo):
     def need_conversion(self):
         return True
 
-    def to_wrapper_type(self, dt):
+    def to_internal_type(self, dt):
         if dt is not None:
             seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
                        else time.mktime(dt.timetuple()))

--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -15,7 +15,9 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
+import calendar
+import datetime
+import time
 from abc import ABC
 from typing import List, Union
 
@@ -69,6 +71,18 @@ class WrapperTypeInfo(TypeInformation):
 
     def __str__(self):
         return self._j_typeinfo.toString()
+
+    def need_conversion(self):
+        """
+        Does this type need to conversion between Python object and internal Wrapper object.
+        """
+        return False
+
+    def to_wrapper_type(self, obj):
+        """
+        Converts a Python object into an internal wrapper object.
+        """
+        return obj
 
 
 class BasicTypeInfo(TypeInformation, ABC):
@@ -140,17 +154,17 @@ class SqlTimeTypeInfo(TypeInformation, ABC):
 
     @staticmethod
     def DATE():
-        return WrapperTypeInfo(
+        return DateTypeInfo(
             get_gateway().jvm.org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.DATE)
 
     @staticmethod
     def TIME():
-        return WrapperTypeInfo(
+        return TimeTypeInfo(
             get_gateway().jvm.org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIME)
 
     @staticmethod
     def TIMESTAMP():
-        return WrapperTypeInfo(
+        return TimestampTypeInfo(
             get_gateway().jvm.org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIMESTAMP)
 
 
@@ -304,6 +318,8 @@ class RowTypeInfo(WrapperTypeInfo):
                 j_names_array[i] = field_names[i]
             self._j_typeinfo = get_gateway().jvm.org.apache.flink.api.java.typeutils.RowTypeInfo(
                 self.j_types_array, j_names_array)
+        self._need_conversion = [f.need_conversion() for f in types]
+        self._need_serialize_any_field = any(self._need_conversion)
         super(RowTypeInfo, self).__init__(self._j_typeinfo)
 
     def get_field_names(self) -> List[str]:
@@ -329,6 +345,40 @@ class RowTypeInfo(WrapperTypeInfo):
                                               for field_name, field_type in
                                               zip(self.get_field_names(),
                                                   self.get_field_types())])
+
+    def need_conversion(self):
+        return True
+
+    def to_wrapper_type(self, obj):
+        if obj is None:
+            return
+
+        if self._need_serialize_any_field:
+            # Only calling to_wrapper_type function for fields that need conversion
+            if isinstance(obj, dict):
+                return tuple(f.to_wrapper_type(obj.get(n)) if c else obj.get(n)
+                             for n, f, c in zip(self._j_typeinfo.getFieldNames(), self.types,
+                                                self._need_conversion))
+            elif isinstance(obj, (tuple, list)):
+                return tuple(f.to_wrapper_type(v) if c else v
+                             for f, v, c in zip(self.types, obj, self._need_conversion))
+            elif hasattr(obj, "__dict__"):
+                d = obj.__dict__
+                return tuple(f.to_wrapper_type(d.get(n)) if c else d.get(n)
+                             for n, f, c in zip(self._j_typeinfo.getFieldNames(), self.types,
+                                                self._need_conversion))
+            else:
+                raise ValueError("Unexpected tuple %r with RowTypeInfo" % obj)
+        else:
+            if isinstance(obj, dict):
+                return tuple(obj.get(n) for n in self._j_typeinfo.getFieldNames())
+            elif isinstance(obj, (list, tuple)):
+                return tuple(obj)
+            elif hasattr(obj, "__dict__"):
+                d = obj.__dict__
+                return tuple(d.get(n) for n in self._j_typeinfo.getFieldNames())
+            else:
+                raise ValueError("Unexpected tuple %r with RowTypeInfo" % obj)
 
 
 class TupleTypeInfo(WrapperTypeInfo):
@@ -359,6 +409,69 @@ class TupleTypeInfo(WrapperTypeInfo):
 
     def __str__(self) -> str:
         return "TupleTypeInfo(%s)" % ', '.join([field_type.__str__() for field_type in self.types])
+
+
+class DateTypeInfo(WrapperTypeInfo):
+    """
+    TypeInformation for Date.
+    """
+
+    def __init__(self, j_typeinfo):
+        super(DateTypeInfo, self).__init__(j_typeinfo)
+
+    EPOCH_ORDINAL = datetime.datetime(1970, 1, 1).toordinal()
+
+    def need_conversion(self):
+        return True
+
+    def to_wrapper_type(self, d):
+        if d is not None:
+            return d.toordinal() - self.EPOCH_ORDINAL
+
+
+class TimeTypeInfo(WrapperTypeInfo):
+    """
+    TypeInformation for Time.
+    """
+
+    EPOCH_ORDINAL = calendar.timegm(time.localtime(0)) * 10 ** 6
+
+    def __init__(self, j_typeinfo):
+        super(TimeTypeInfo, self).__init__(j_typeinfo)
+
+    def need_conversion(self):
+        return True
+
+    def to_wrapper_type(self, t):
+        if t is not None:
+            if t.tzinfo is not None:
+                offset = t.utcoffset()
+                offset = offset if offset else datetime.timedelta()
+                offset_microseconds =\
+                    (offset.days * 86400 + offset.seconds) * 10 ** 6 + offset.microseconds
+            else:
+                offset_microseconds = self.EPOCH_ORDINAL
+            minutes = t.hour * 60 + t.minute
+            seconds = minutes * 60 + t.second
+            return seconds * 10 ** 6 + t.microsecond - offset_microseconds
+
+
+class TimestampTypeInfo(WrapperTypeInfo):
+    """
+    TypeInformation for Timestamp.
+    """
+
+    def __init__(self, j_typeinfo):
+        super(TimestampTypeInfo, self).__init__(j_typeinfo)
+
+    def need_conversion(self):
+        return True
+
+    def to_wrapper_type(self, dt):
+        if dt is not None:
+            seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
+                       else time.mktime(dt.timetuple()))
+            return int(seconds) * 10 ** 6 + dt.microsecond
 
 
 class Types(object):
@@ -549,6 +662,8 @@ def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
         return Types.BASIC_ARRAY(Types.DOUBLE())
     elif _is_instance_of(j_type_info, JBasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO):
         return Types.BASIC_ARRAY(Types.CHAR())
+    elif _is_instance_of(j_type_info, JBasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO):
+        return Types.BASIC_ARRAY(Types.STRING())
 
     JPickledBytesTypeInfo = gateway.jvm \
         .org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo\

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -26,7 +26,7 @@ from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.job_client import JobClient
 from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies
-from pyflink.common.typeinfo import PickledBytesTypeInfo, TypeInformation
+from pyflink.common.typeinfo import PickledBytesTypeInfo, TypeInformation, _from_java_type
 from pyflink.datastream.checkpoint_config import CheckpointConfig
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.data_stream import DataStream
@@ -35,7 +35,6 @@ from pyflink.datastream.state_backend import _from_j_state_backend
 from pyflink.datastream.time_characteristic import TimeCharacteristic
 from pyflink.java_gateway import get_gateway
 from pyflink.serializers import PickleSerializer
-from pyflink.table.types import _from_java_type
 from pyflink.util.utils import load_java_class, add_jars_to_context_class_loader
 
 __all__ = ['StreamExecutionEnvironment']
@@ -713,8 +712,8 @@ class StreamExecutionEnvironment(object):
         :return: the data stream representing the given collection.
         """
         if type_info is not None:
-            data_type = _from_java_type(type_info.get_java_type_info())
-            collection = [data_type.to_sql_type(element) for element in collection]
+            wrapper_type = _from_java_type(type_info.get_java_type_info())
+            collection = [wrapper_type.to_wrapper_type(element) for element in collection]
         return self._from_collection(collection, type_info)
 
     def _from_collection(self, elements: List[Any],

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -731,7 +731,7 @@ class StreamExecutionEnvironment(object):
                 j_objs = gateway.jvm.PythonBridgeUtils.readPickledBytes(temp_file.name)
                 out_put_type_info = PickledBytesTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO()
             else:
-                j_objs = gateway.jvm.PythonBridgeUtils.readPythonObjects(temp_file.name, False)
+                j_objs = gateway.jvm.PythonBridgeUtils.readPythonObjects(temp_file.name)
                 out_put_type_info = type_info
             # Since flink python module depends on table module, we can make use of utils of it when
             # implementing python DataStream API.

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -35,6 +35,7 @@ from pyflink.datastream.state_backend import _from_j_state_backend
 from pyflink.datastream.time_characteristic import TimeCharacteristic
 from pyflink.java_gateway import get_gateway
 from pyflink.serializers import PickleSerializer
+from pyflink.table.types import _from_java_type
 from pyflink.util.utils import load_java_class, add_jars_to_context_class_loader
 
 __all__ = ['StreamExecutionEnvironment']
@@ -711,6 +712,9 @@ class StreamExecutionEnvironment(object):
         :param type_info: The TypeInformation for the produced data stream
         :return: the data stream representing the given collection.
         """
+        if type_info is not None:
+            data_type = _from_java_type(type_info.get_java_type_info())
+            collection = [data_type.to_sql_type(element) for element in collection]
         return self._from_collection(collection, type_info)
 
     def _from_collection(self, elements: List[Any],

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -713,7 +713,7 @@ class StreamExecutionEnvironment(object):
         """
         if type_info is not None:
             wrapper_type = _from_java_type(type_info.get_java_type_info())
-            collection = [wrapper_type.to_wrapper_type(element) for element in collection]
+            collection = [wrapper_type.to_internal_type(element) for element in collection]
         return self._from_collection(collection, type_info)
 
     def _from_collection(self, elements: List[Any],

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -252,30 +252,39 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         # verify from_collection for the collection with multiple objects like tuple.
         ds = self.env.from_collection([(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
                                         bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
-                                        datetime.time(hour=12, minute=0, second=0, microsecond=123000),
+                                        datetime.time(hour=12, minute=0, second=0,
+                                                      microsecond=123000),
                                         datetime.datetime(2018, 3, 11, 3, 0, 0, 123000), [1, 2, 3],
                                         decimal.Decimal('1000000000000000000.05'),
-                                        decimal.Decimal('1000000000000000000.05999999999999999899999999999')),
+                                        decimal.Decimal('1000000000000000000.0599999999999'
+                                                        '9999899999999999')),
                                        (2, None, 2, True, 43878, 9147483648, 9.87, 2.98936,
                                         bytearray(b'flink'), 'pyflink', datetime.date(2015, 10, 14),
-                                        datetime.time(hour=11, minute=2, second=2, microsecond=234500),
+                                        datetime.time(hour=11, minute=2, second=2,
+                                                      microsecond=234500),
                                         datetime.datetime(2020, 4, 15, 8, 2, 6, 235000), [2, 4, 6],
                                         decimal.Decimal('2000000000000000000.74'),
-                                        decimal.Decimal('2000000000000000000.06111111111111111111111111111'))],
+                                        decimal.Decimal('2000000000000000000.061111111111111'
+                                                        '11111111111111'))],
                                       type_info=Types.ROW(
-                                          [Types.LONG(), Types.LONG(), Types.SHORT(), Types.BOOLEAN(), Types.SHORT(),
-                                           Types.INT(), Types.FLOAT(), Types.DOUBLE(), Types.BYTE(), Types.STRING(),
-                                           Types.SQL_DATE(), Types.SQL_TIME(), Types.SQL_TIMESTAMP(),
-                                           Types.BASIC_ARRAY(Types.LONG()), Types.BIG_DEC(), Types.BIG_DEC()]))
+                                          [Types.LONG(), Types.LONG(), Types.SHORT(),
+                                           Types.BOOLEAN(), Types.SHORT(), Types.INT(),
+                                           Types.FLOAT(), Types.DOUBLE(), Types.BYTE(),
+                                           Types.STRING(), Types.SQL_DATE(), Types.SQL_TIME(),
+                                           Types.SQL_TIMESTAMP(),
+                                           Types.BASIC_ARRAY(Types.LONG()), Types.BIG_DEC(),
+                                           Types.BIG_DEC()]))
         ds.add_sink(self.test_sink)
         self.env.execute("test from collection with tuple object")
         results = self.test_sink.get_results(False)
         # if user specifies data types of input data, the collected result should be in row format.
         expected = [
-            '1,null,1,true,32767,-2147483648,1.23,1.98932,null,pyflink,2014-09-13,12:00:00,2018-03-11 03:00:00.123,'
-            '[1, 2, 3],1000000000000000000.05,1000000000000000000.05999999999999999899999999999',
-            '2,null,2,true,-21658,557549056,9.87,2.98936,null,pyflink,2015-10-14,11:02:02,2020-04-15 08:02:06.235,'
-            '[2, 4, 6],2000000000000000000.74,2000000000000000000.06111111111111111111111111111']
+            '1,null,1,true,32767,-2147483648,1.23,1.98932,null,pyflink,2014-09-13,12:00:00,'
+            '2018-03-11 03:00:00.123,[1, 2, 3],1000000000000000000.05,'
+            '1000000000000000000.05999999999999999899999999999',
+            '2,null,2,true,-21658,557549056,9.87,2.98936,null,pyflink,2015-10-14,11:02:02,'
+            '2020-04-15 08:02:06.235,[2, 4, 6],2000000000000000000.74,'
+            '2000000000000000000.06111111111111111111111111111']
         results.sort()
         expected.sort()
         self.assertEqual(expected, results)

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1804,19 +1804,7 @@ def _from_java_type(j_data_type):
             BasicArrayTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo.\
                 BasicArrayTypeInfo
             BasicTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo
-            if type_info == BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO:
-                data_type = DataTypes.ARRAY(DataTypes.BOOLEAN())
-            elif type_info == BasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO:
-                data_type = DataTypes.ARRAY(DataTypes.SMALLINT())
-            elif type_info == BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO:
-                data_type = DataTypes.ARRAY(DataTypes.INT())
-            elif type_info == BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO:
-                data_type = DataTypes.ARRAY(DataTypes.BIGINT())
-            elif type_info == BasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO:
-                data_type = DataTypes.ARRAY(DataTypes.FLOAT())
-            elif type_info == BasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO:
-                data_type = DataTypes.ARRAY(DataTypes.DOUBLE())
-            elif type_info == BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO:
+            if type_info == BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO:
                 data_type = DataTypes.ARRAY(DataTypes.STRING())
             elif type_info == BasicTypeInfo.BIG_DEC_TYPE_INFO:
                 data_type = DataTypes.DECIMAL(38, 18)
@@ -1824,14 +1812,6 @@ def _from_java_type(j_data_type):
                 get_java_class(gateway.jvm.org.apache.flink.table.runtime.typeutils
                                .BigDecimalTypeInfo):
                 data_type = DataTypes.DECIMAL(type_info.precision(), type_info.scale())
-            elif type_info.getClass() == \
-                    get_java_class(gateway.jvm.org.apache.flink.api.java.typeutils.TupleTypeInfo):
-                field_data_types = []
-                for i in range(type_info.getArity()):
-                    field_data_types.append(type_info.getTypeAt(i))
-                fields = [DataTypes.FIELD(name, _from_java_type(field_data_types[idx]))
-                          for idx, name in enumerate(type_info.getFieldNames())]
-                data_type = DataTypes.ROW(fields, logical_type.isNullable())
             else:
                 raise TypeError("Unsupported type: %s, it is recognized as a legacy type."
                                 % type_info)

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1804,7 +1804,19 @@ def _from_java_type(j_data_type):
             BasicArrayTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo.\
                 BasicArrayTypeInfo
             BasicTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo
-            if type_info == BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO:
+            if type_info == BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO:
+                data_type = DataTypes.ARRAY(DataTypes.BOOLEAN())
+            elif type_info == BasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO:
+                data_type = DataTypes.ARRAY(DataTypes.SMALLINT())
+            elif type_info == BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO:
+                data_type = DataTypes.ARRAY(DataTypes.INT())
+            elif type_info == BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO:
+                data_type = DataTypes.ARRAY(DataTypes.BIGINT())
+            elif type_info == BasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO:
+                data_type = DataTypes.ARRAY(DataTypes.FLOAT())
+            elif type_info == BasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO:
+                data_type = DataTypes.ARRAY(DataTypes.DOUBLE())
+            elif type_info == BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO:
                 data_type = DataTypes.ARRAY(DataTypes.STRING())
             elif type_info == BasicTypeInfo.BIG_DEC_TYPE_INFO:
                 data_type = DataTypes.DECIMAL(38, 18)
@@ -1812,6 +1824,14 @@ def _from_java_type(j_data_type):
                 get_java_class(gateway.jvm.org.apache.flink.table.runtime.typeutils
                                .BigDecimalTypeInfo):
                 data_type = DataTypes.DECIMAL(type_info.precision(), type_info.scale())
+            elif type_info.getClass() == \
+                    get_java_class(gateway.jvm.org.apache.flink.api.java.typeutils.TupleTypeInfo):
+                field_data_types = []
+                for i in range(type_info.getArity()):
+                    field_data_types.append(type_info.getTypeAt(i))
+                fields = [DataTypes.FIELD(name, _from_java_type(field_data_types[idx]))
+                          for idx, name in enumerate(type_info.getFieldNames())]
+                data_type = DataTypes.ROW(fields, logical_type.isNullable())
             else:
                 raise TypeError("Unsupported type: %s, it is recognized as a legacy type."
                                 % type_info)

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
@@ -33,6 +33,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Utility class that contains helper methods to create a TableSource from
@@ -72,6 +73,20 @@ public final class PythonBridgeUtils {
 			}
 		}
 		return unpickledData;
+	}
+
+	public static List<?> readPythonObjects(String fileName) throws IOException {
+		List<byte[]> data = readPickledBytes(fileName);
+		Unpickler unpickle = new Unpickler();
+		initialize();
+		return data.stream().map(pickledData -> {
+			try {
+				Object obj = unpickle.loads(pickledData);
+				return obj.getClass().isArray() || obj instanceof List ? getObjectArrayFromUnpickledData(obj) : obj;
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}).collect(Collectors.toList());
 	}
 
 	public static byte[] convertLiteralToPython(RexLiteral o, SqlTypeName typeName) {


### PR DESCRIPTION
## What is the purpose of the change

*Currently Python DataStream doesn't support Python datetime object in `from_collection` of `StreamExecutionEnvironment`. It should support datetime object by coverting datetime elements in collection based on `to_sql_type` of `DataType`.*

## Brief change log

  - *`from_collection` of `StreamExecutionEnvironment` adds converter of elements in collection with `to_sql_type` of `DataType` to support datetime object.*

## Verifying this change

  - *`test_from_collection_with_data_types` and `test_from_collection_without_data_types` in `StreamExecutionEnvironmentTests` adds test cases for datetime object to verify whether `from_collection` of `StreamExecutionEnvironment` supports datetime object in DataStream.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)