### PR TITLE
[FLINK-18323] Add a Kafka source implementation based on FLIP-27.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -94,4 +94,23 @@ public abstract class SingleThreadMultiplexSourceReaderBase<E, T, SplitT extends
 			config,
 			context);
 	}
+
+	/**
+	 * This constructor behaves like
+	 * {@link #SingleThreadMultiplexSourceReaderBase(Supplier, RecordEmitter, Configuration, SourceReaderContext)},
+	 * but accepts a specific {@link FutureCompletingBlockingQueue} and {@link SingleThreadFetcherManager}.
+	 */
+	public SingleThreadMultiplexSourceReaderBase(
+			FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+			SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
+			RecordEmitter<E, T, SplitStateT> recordEmitter,
+			Configuration config,
+			SourceReaderContext context) {
+		super(
+			elementsQueue,
+			splitFetcherManager,
+			recordEmitter,
+			config,
+			context);
+	}
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
@@ -62,8 +62,10 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 				// The order matters here. We must first put the last records into the queue.
 				// This ensures the handling of the fetched records is atomic to wakeup.
 				if (elementsQueue.put(fetcherIndex, lastRecords)) {
-					// The callback does not throw InterruptedException.
-					splitFinishedCallback.accept(lastRecords.finishedSplits());
+					if (!lastRecords.finishedSplits().isEmpty()) {
+						// The callback does not throw InterruptedException.
+						splitFinishedCallback.accept(lastRecords.finishedSplits());
+					}
 					lastRecords = null;
 				}
 			}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -149,6 +149,7 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 			Map.Entry<Integer, SplitFetcher<E, SplitT>> entry = iter.next();
 			SplitFetcher<E, SplitT> fetcher = entry.getValue();
 			if (fetcher.isIdle()) {
+				LOG.info("Closing splitFetcher {} because it is idle.", entry.getKey());
 				fetcher.shutdown();
 				iter.remove();
 			}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/utils/SerdeUtils.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/utils/SerdeUtils.java
@@ -1,0 +1,131 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.utils;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A util class with some helper method for serde in the sources.
+ */
+public class SerdeUtils {
+
+	/** Private constructor for util class. */
+	private SerdeUtils() { }
+
+	/**
+	 * Serialize a mapping from subtask ids to lists of assigned splits.
+	 * The serialized format is following:
+	 * <pre>
+	 * 4 bytes - number of subtasks
+	 * 4 bytes - split serializer version
+	 * N bytes - [assignment_for_subtask]
+	 * 		4 bytes - subtask id
+	 * 		4 bytes - number of assigned splits
+	 * 		N bytes - [assigned_splits]
+	 * 			4 bytes - serialized split length
+	 * 			N bytes - serialized splits
+	 * </pre>
+	 *
+	 * @param splitAssignments a mapping from subtask ids to lists of assigned splits.
+	 * @param splitSerializer the serializer of the split.
+	 * @param <SplitT> the type of the splits.
+	 * @param <C> the type of the collection to hold the assigned splits for a subtask.
+	 * @return the serialized bytes of the given subtask to splits assignment mapping.
+	 * @throws IOException when serialization failed.
+	 */
+	public static <SplitT extends SourceSplit, C extends Collection<SplitT>> byte[] serializeSplitAssignments(
+			Map<Integer, C> splitAssignments,
+			SimpleVersionedSerializer<SplitT> splitSerializer) throws IOException {
+		try (
+				ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputStream out = new DataOutputStream(baos)) {
+
+			out.writeInt(splitAssignments.size());
+			// Split serializer version.
+			out.writeInt(splitSerializer.getVersion());
+			// Write assignments for subtasks.
+			for (Map.Entry<Integer, C> entry : splitAssignments.entrySet()) {
+				// Subtask ID
+				int subtaskId = entry.getKey();
+				Collection<SplitT> splitsForSubtask = entry.getValue();
+				// Number of the splits.
+				out.writeInt(subtaskId);
+				out.writeInt(splitsForSubtask.size());
+				for (SplitT split : splitsForSubtask) {
+					byte[] serializedSplit = splitSerializer.serialize(split);
+					out.writeInt(serializedSplit.length);
+					out.write(serializedSplit);
+				}
+			}
+			return baos.toByteArray();
+		}
+	}
+
+	/**
+	 * Deserialize the given bytes returned by {@link #serializeSplitAssignments(Map, SimpleVersionedSerializer)}.
+	 *
+	 * @param serialized the serialized bytes returned by
+	 * 					 {@link #serializeSplitAssignments(Map, SimpleVersionedSerializer)}.
+	 * @param splitSerializer the split serializer for the splits.
+	 * @param collectionSupplier the supplier for the {@link Collection} instance to hold the assigned splits for a
+	 *                           subtask.
+	 * @param <SplitT> the type of the splits.
+	 * @param <C> the type of the collection to hold the assigned splits for a subtask.
+	 * @return A mapping from subtask id to its assigned splits.
+	 * @throws IOException when deserialization failed.
+	 */
+	public static <SplitT extends SourceSplit, C extends Collection<SplitT>> Map<Integer, C> deserializeSplitAssignments(
+			byte[] serialized,
+			SimpleVersionedSerializer<SplitT> splitSerializer,
+			Function<Integer, C> collectionSupplier) throws IOException {
+		try (
+				ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+				DataInputStream in = new DataInputStream(bais)) {
+
+			int numSubtasks = in.readInt();
+			Map<Integer, C> splitsAssignments = new HashMap<>(numSubtasks);
+			int serializerVersion = in.readInt();
+			for (int i = 0; i < numSubtasks; i++) {
+				int subtaskId = in.readInt();
+				int numAssignedSplits = in.readInt();
+				C assignedSplits = collectionSupplier.apply(numAssignedSplits);
+				for (int j = 0; j < numAssignedSplits; j++) {
+					int serializedSplitSize = in.readInt();
+					byte[] serializedSplit = new byte[serializedSplitSize];
+					in.readFully(serializedSplit);
+					SplitT split = splitSerializer.deserialize(serializerVersion, serializedSplit);
+					assignedSplits.add(split);
+				}
+				splitsAssignments.put(subtaskId, assignedSplits);
+			}
+			return splitsAssignments;
+		}
+	}
+}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.connector.base.source.reader.mocks.TestingSplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.testutils.source.reader.SourceReaderTestBase;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -83,6 +83,13 @@ under the License.
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>
@@ -126,6 +133,13 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -189,8 +203,7 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-
-	</dependencies>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumState;
+import org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumStateSerializer;
+import org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumerator;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
+import org.apache.flink.connector.kafka.source.reader.KafkaPartitionSplitReader;
+import org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter;
+import org.apache.flink.connector.kafka.source.reader.KafkaSourceReader;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+/**
+ * The Source implementation of Kafka. Please use a {@link KafkaSourceBuilder} to construct a {@link KafkaSource}.
+ * The following example shows how to create a KafkaSource emitting records of <code>String</code> type.
+ *
+ * <pre>{@code
+ * KafkaSource<String> source = KafkaSource
+ *     .<String>builder()
+ *     .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
+ *     .setGroupId("MyGroup")
+ *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
+ *     .setDeserializer(new TestingKafkaRecordDeserializer())
+ *     .setStartingOffsetInitializer(OffsetsInitializer.earliest())
+ *     .build();
+ * }</pre>
+ *
+ * <p>See {@link KafkaSourceBuilder} for more details.
+ *
+ * @param <OUT> the output type of the source.
+ */
+public class KafkaSource<OUT> implements Source<OUT, KafkaPartitionSplit, KafkaSourceEnumState> {
+	private static final long serialVersionUID = -8755372893283732098L;
+	// Users can choose only one of the following ways to specify the topics to consume from.
+	private final KafkaSubscriber subscriber;
+	// Users can specify the starting / stopping offset initializer.
+	private final OffsetsInitializer startingOffsetsInitializer;
+	private final OffsetsInitializer stoppingOffsetsInitializer;
+	// Boundedness
+	private final Boundedness boundedness;
+	private final KafkaRecordDeserializer<OUT> deserializationSchema;
+	// The configurations.
+	private final Properties props;
+
+	KafkaSource(
+			KafkaSubscriber subscriber,
+			OffsetsInitializer startingOffsetsInitializer,
+			@Nullable OffsetsInitializer stoppingOffsetsInitializer,
+			Boundedness boundedness,
+			KafkaRecordDeserializer<OUT> deserializationSchema,
+			Properties props) {
+		this.subscriber = subscriber;
+		this.startingOffsetsInitializer = startingOffsetsInitializer;
+		this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
+		this.boundedness = boundedness;
+		this.deserializationSchema = deserializationSchema;
+		this.props = props;
+	}
+
+	/**
+	 * Get a kafkaSourceBuilder to build a {@link KafkaSource}.
+	 *
+	 * @return a Kafka source builder.
+	 */
+	public static <OUT> KafkaSourceBuilder<OUT> builder() {
+		return new KafkaSourceBuilder<>();
+	}
+
+	@Override
+	public Boundedness getBoundedness() {
+		return this.boundedness;
+	}
+
+	@Override
+	public SourceReader<OUT, KafkaPartitionSplit> createReader(SourceReaderContext readerContext) {
+		FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<OUT, Long, Long>>> elementsQueue =
+				new FutureCompletingBlockingQueue<>();
+		Supplier<KafkaPartitionSplitReader<OUT>> splitReaderSupplier =
+			() -> new KafkaPartitionSplitReader<>(
+				props,
+				deserializationSchema,
+				readerContext.getIndexOfSubtask());
+		KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>();
+
+		return new KafkaSourceReader<>(
+				elementsQueue,
+				splitReaderSupplier,
+				recordEmitter,
+				toConfiguration(props),
+				readerContext);
+	}
+
+	@Override
+	public SplitEnumerator<KafkaPartitionSplit, KafkaSourceEnumState> createEnumerator(
+			SplitEnumeratorContext<KafkaPartitionSplit> enumContext) {
+		return new KafkaSourceEnumerator(
+				subscriber,
+				startingOffsetsInitializer,
+				stoppingOffsetsInitializer,
+				props,
+				enumContext);
+	}
+
+	@Override
+	public SplitEnumerator<KafkaPartitionSplit, KafkaSourceEnumState> restoreEnumerator(
+			SplitEnumeratorContext<KafkaPartitionSplit> enumContext,
+			KafkaSourceEnumState checkpoint) throws IOException {
+		return new KafkaSourceEnumerator(
+				subscriber,
+				startingOffsetsInitializer,
+				stoppingOffsetsInitializer,
+				props,
+				enumContext,
+				checkpoint.getCurrentAssignment());
+	}
+
+	@Override
+	public SimpleVersionedSerializer<KafkaPartitionSplit> getSplitSerializer() {
+		return new KafkaPartitionSplitSerializer();
+	}
+
+	@Override
+	public SimpleVersionedSerializer<KafkaSourceEnumState> getEnumeratorCheckpointSerializer() {
+		return new KafkaSourceEnumStateSerializer();
+	}
+
+	// ----------- private helper methods ---------------
+
+	private Configuration toConfiguration(Properties props) {
+		Configuration config = new Configuration();
+		props.stringPropertyNames().forEach(key -> config.setString(key, props.getProperty(key)));
+		return config;
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -1,0 +1,489 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStoppingOffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The @builder class for {@link KafkaSource} to make it easier for the users to construct
+ * a {@link KafkaSource}.
+ *
+ * <p>The following example shows the minimum setup to create a KafkaSource that reads the
+ * String values from a Kafka topic.
+ * <pre>{@code
+ * KafkaSource<String> source = KafkaSource
+ *     .<String>builder()
+ *     .setBootstrapServers(MY_BOOTSTRAP_SERVERS)
+ *     .setGroupId("myGroup")
+ *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
+ *     .setDeserializer(KafkaRecordDeserializer.valueOnly(StringDeserializer.class))
+ *     .build();
+ * }</pre>
+ * The bootstrap servers, group id, topics/partitions to consume, and the record deserializer
+ * are required fields that must be set.
+ *
+ * <p>To specify the starting offsets of the KafkaSource, one can call
+ * {@link #setStartingOffsets(OffsetsInitializer)}.
+ *
+ * <p>By default the KafkaSource runs in an {@link Boundedness#CONTINUOUS_UNBOUNDED} mode
+ * and never stops until the Flink job is canceled or fails. To let the KafkaSource run
+ * in {@link Boundedness#CONTINUOUS_UNBOUNDED} but stops at some given offsets, one can
+ * call {@link #setUnbounded(OffsetsInitializer)}. For example the following KafkaSource
+ * stops after it consumes up to the latest partition offsets at the point when the Flink
+ * started.
+ * <pre>{@code
+ * KafkaSource<String> source = KafkaSource
+ *     .<String>builder()
+ *     .setBootstrapServers(MY_BOOTSTRAP_SERVERS)
+ *     .setGroupId("myGroup")
+ *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
+ *     .setDeserializer(KafkaRecordDeserializer.valueOnly(StringDeserializer.class))
+ *     .setUnbounded(OffsetsInitializer.latest())
+ *     .build();
+ * }</pre>
+ *
+ * <p>Check the Java docs of each individual methods to learn more about the settings to
+ * build a KafkaSource.
+ */
+public class KafkaSourceBuilder<OUT> {
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceBuilder.class);
+	private static final String[] REQUIRED_CONFIGS = {
+		ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+		ConsumerConfig.GROUP_ID_CONFIG};
+	// The subscriber specifies the partitions to subscribe to.
+	private KafkaSubscriber subscriber;
+	// Users can specify the starting / stopping offset initializer.
+	private OffsetsInitializer startingOffsetsInitializer;
+	private OffsetsInitializer stoppingOffsetsInitializer;
+	// Boundedness
+	private Boundedness boundedness;
+	private KafkaRecordDeserializer<OUT> deserializationSchema;
+	// The configurations.
+	protected Properties props;
+
+	KafkaSourceBuilder() {
+		this.subscriber = null;
+		this.startingOffsetsInitializer = OffsetsInitializer.earliest();
+		this.stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
+		this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
+		this.deserializationSchema = null;
+		this.props = new Properties();
+	}
+
+	/**
+	 * Sets the bootstrap servers for the KafkaConsumer of the KafkaSource.
+	 *
+	 * @param bootstrapServers the bootstrap servers of the Kafka cluster.
+	 * @return this KafkaSourceBuilder.
+	 */
+	public KafkaSourceBuilder<OUT> setBootstrapServers(String bootstrapServers) {
+		return setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+	}
+
+	/**
+	 * Sets the consumer group id of the KafkaSource.
+	 *
+	 * @param groupId the group id of the KafkaSource.
+	 * @return this KafkaSourceBuilder.
+	 */
+	public KafkaSourceBuilder<OUT> setGroupId(String groupId) {
+		return setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+	}
+
+	/**
+	 * Set a list of topics the KafkaSource should consume from. All the topics
+	 * in the list should have existed in the Kafka cluster. Otherwise an
+	 * exception will be thrown. To allow some of the topics to be created lazily,
+	 * please use {@link #setTopicPattern(Pattern)} instead.
+	 *
+	 * @param topics the list of topics to consume from.
+	 * @return this KafkaSourceBuilder.
+	 * @see org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(Collection)
+	 */
+	public KafkaSourceBuilder<OUT> setTopics(List<String> topics) {
+		ensureSubscriberIsNull("topics");
+		subscriber = KafkaSubscriber.getTopicListSubscriber(topics);
+		return this;
+	}
+
+	/**
+	 * Set a list of topics the KafkaSource should consume from. All the topics
+	 * in the list should have existed in the Kafka cluster. Otherwise an
+	 * exception will be thrown. To allow some of the topics to be created lazily,
+	 * please use {@link #setTopicPattern(Pattern)} instead.
+	 *
+	 * @param topics the list of topics to consume from.
+	 * @return this KafkaSourceBuilder.
+	 * @see org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(Collection)
+	 */
+	public KafkaSourceBuilder<OUT> setTopics(String... topics) {
+		return setTopics(Arrays.asList(topics));
+	}
+
+	/**
+	 * Set a topic pattern to consume from use the java {@link Pattern}.
+	 *
+	 * @param topicPattern the pattern of the topic name to consume from.
+	 * @return this KafkaSourceBuilder.
+	 * @see org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(Pattern)
+	 */
+	public KafkaSourceBuilder<OUT> setTopicPattern(Pattern topicPattern) {
+		ensureSubscriberIsNull("topic pattern");
+		subscriber = KafkaSubscriber.getTopicPatternSubscriber(topicPattern);
+		return this;
+	}
+
+	/**
+	 * Set a set of partitions to consume from.
+	 *
+	 * @param partitions the set of partitions to consume from.
+	 * @return this KafkaSourceBuilder.
+	 * @see org.apache.kafka.clients.consumer.KafkaConsumer#assign(Collection)
+	 */
+	public KafkaSourceBuilder<OUT> setPartitions(Set<TopicPartition> partitions) {
+		ensureSubscriberIsNull("partitions");
+		subscriber = KafkaSubscriber.getPartitionSetSubscriber(partitions);
+		return this;
+	}
+
+	/**
+	 * Specify from which offsets the KafkaSource should start consume from by providing
+	 * an {@link OffsetsInitializer}.
+	 *
+	 * <p>The following {@link OffsetsInitializer}s are commonly used and provided out of the box.
+	 * Users can also implement their own {@link OffsetsInitializer} for custom behaviors.
+	 * <ul>
+	 *     <li>{@link OffsetsInitializer#earliest()} - starting from the earliest offsets. This is also the default
+	 *         {@link OffsetsInitializer} of the KafkaSource for starting offsets.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#latest()} - starting from the latest offsets.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#committedOffsets()} - starting from the committed offsets of the
+	 *         consumer group.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#committedOffsets(org.apache.kafka.clients.consumer.OffsetResetStrategy)}
+	 *         - starting from the committed offsets of the consumer group. If there is no committed offsets,
+	 *         starting from the offsets specified by the
+	 *         {@link org.apache.kafka.clients.consumer.OffsetResetStrategy OffsetResetStrategy}.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#offsets(Map)} - starting from the specified offsets for each partition.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#timestamp(long)} - starting from the specified timestamp for each partition.
+	 *         Note that the guarantee here is that all the records in Kafka whose
+	 *         {@link org.apache.kafka.clients.consumer.ConsumerRecord#timestamp()} is greater than the given
+	 *         starting timestamp will be consumed. However, it is possible that some consumer records
+	 *         whose timestamp is smaller than the given starting timestamp are also consumed.
+	 *     </li>
+	 * </ul>
+	 *
+	 * @param startingOffsetsInitializer the {@link OffsetsInitializer} setting the starting offsets for the Source.
+	 * @return this KafkaSourceBuilder.
+	 */
+	public KafkaSourceBuilder<OUT> setStartingOffsets(OffsetsInitializer startingOffsetsInitializer) {
+		this.startingOffsetsInitializer = startingOffsetsInitializer;
+		return this;
+	}
+
+	/**
+	 * By default the KafkaSource is set to run in {@link Boundedness#CONTINUOUS_UNBOUNDED} manner
+	 * and thus never stops until the Flink job fails or is canceled. To let the KafkaSource run as
+	 * a streaming source but still stops at some point, one can set an {@link OffsetsInitializer}
+	 * to specify the stopping offsets for each partition. When all the partitions have reached
+	 * their stopping offsets, the KafkaSource will then exit.
+	 *
+	 * <p>This method is different from {@link #setBounded(OffsetsInitializer)} that after
+	 * setting the stopping offsets with this method, {@link KafkaSource#getBoundedness()}
+	 * will still return {@link Boundedness#CONTINUOUS_UNBOUNDED} even though it will stop at
+	 * the stopping offsets specified by the stopping offsets {@link OffsetsInitializer}.
+	 *
+	 * <p>The following {@link OffsetsInitializer} are commonly used and provided out of the box.
+	 * Users can also implement their own {@link OffsetsInitializer} for custom behaviors.
+	 * <ul>
+	 *     <li>
+	 *         {@link OffsetsInitializer#latest()} - stop at the latest offsets of the partitions
+	 *         when the KafkaSource starts to run.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#committedOffsets()} - stops at the committed offsets of the consumer group.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#offsets(Map)} - stops at the specified offsets for each partition.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#timestamp(long)} - stops at the specified timestamp for
+	 *         each partition. The guarantee of setting the stopping timestamp is that no Kafka records
+	 *         whose {@link org.apache.kafka.clients.consumer.ConsumerRecord#timestamp()} is greater
+	 *         than the given stopping timestamp will be consumed. However, it is possible that
+	 *         some records whose timestamp is smaller than the specified stopping timestamp are
+	 *         not consumed.
+	 *     </li>
+	 * </ul>
+	 *
+	 * @param stoppingOffsetsInitializer The {@link OffsetsInitializer} to specify the stopping offset.
+	 * @return this KafkaSourceBuilder.
+	 * @see #setBounded(OffsetsInitializer)
+	 */
+	public KafkaSourceBuilder<OUT> setUnbounded(OffsetsInitializer stoppingOffsetsInitializer) {
+		this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
+		this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
+		return this;
+	}
+
+	/**
+	 * By default the KafkaSource is set to run in {@link Boundedness#CONTINUOUS_UNBOUNDED} manner
+	 * and thus never stops until the Flink job fails or is canceled. To let the KafkaSource run in
+	 * {@link Boundedness#BOUNDED} manner and stops at some point, one can set an
+	 * {@link OffsetsInitializer} to specify the stopping offsets for each partition. When all the
+	 * partitions have reached their stopping offsets, the KafkaSource will then exit.
+	 *
+	 * <p>This method is different from {@link #setUnbounded(OffsetsInitializer)} that after
+	 * setting the stopping offsets with this method, {@link KafkaSource#getBoundedness()}
+	 * will return {@link Boundedness#BOUNDED} instead of {@link Boundedness#CONTINUOUS_UNBOUNDED}.
+	 *
+	 * <p>The following {@link OffsetsInitializer} are commonly used and provided out of the box.
+	 * Users can also implement their own {@link OffsetsInitializer} for custom behaviors.
+	 * <ul>
+	 *     <li>
+	 *         {@link OffsetsInitializer#latest()} - stop at the latest offsets of the partitions
+	 *         when the KafkaSource starts to run.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#committedOffsets()} - stops at the committed offsets
+	 *         of the consumer group.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#offsets(Map)} - stops at the specified offsets for each partition.
+	 *     </li>
+	 *     <li>
+	 *         {@link OffsetsInitializer#timestamp(long)} - stops at the specified timestamp for
+	 *         each partition. The guarantee of setting the stopping timestamp is that no Kafka records
+	 *         whose {@link org.apache.kafka.clients.consumer.ConsumerRecord#timestamp()} is greater
+	 *         than the given stopping timestamp will be consumed. However, it is possible that
+	 *         some records whose timestamp is smaller than the specified stopping timestamp are
+	 *         not consumed.
+	 *     </li>
+	 * </ul>
+	 *
+	 * @param stoppingOffsetsInitializer the {@link OffsetsInitializer} to specify the stopping offsets.
+	 * @return this KafkaSourceBuilder.
+	 * @see #setUnbounded(OffsetsInitializer)
+	 */
+	public KafkaSourceBuilder<OUT> setBounded(OffsetsInitializer stoppingOffsetsInitializer) {
+		this.boundedness = Boundedness.BOUNDED;
+		this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
+		return this;
+	}
+
+	/**
+	 * Sets the {@link KafkaRecordDeserializer deserializer} of the
+	 * {@link org.apache.kafka.clients.consumer.ConsumerRecord ConsumerRecord} for KafkaSource.
+	 *
+	 * @param recordDeserializer the deserializer for Kafka
+	 *                           {@link org.apache.kafka.clients.consumer.ConsumerRecord ConsumerRecord}.
+	 * @return this KafkaSourceBuilder.
+	 */
+	public KafkaSourceBuilder<OUT> setDeserializer(KafkaRecordDeserializer<OUT> recordDeserializer) {
+		this.deserializationSchema = recordDeserializer;
+		return this;
+	}
+
+	/**
+	 * Sets the client id prefix of this KafkaSource.
+	 *
+	 * @param prefix the client id prefix to use for this KafkaSource.
+	 * @return this KafkaSourceBuilder.
+	 */
+	public KafkaSourceBuilder<OUT> setClientIdPrefix(String prefix) {
+		return setProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key(), prefix);
+	}
+
+	/**
+	 * Set an arbitrary property for the KafkaSource and KafkaConsumer. The valid keys can be found
+	 * in {@link ConsumerConfig} and {@link KafkaSourceOptions}.
+	 *
+	 * <p>Note that the following keys will be overridden by the builder when the KafkaSource is
+	 * created.
+	 * <ul>
+	 *    <li>
+	 *        <code>key.deserializer</code> is always set to {@link ByteArrayDeserializer}.
+	 *    </li>
+	 *    <li>
+	 *        <code>value.deserializer</code> is always set to {@link ByteArrayDeserializer}.
+	 *    </li>
+	 *    <li>
+	 *        <code>auto.offset.reset.strategy</code> is overridden by {@link OffsetsInitializer#getAutoOffsetResetStrategy()}
+	 *        for the starting offsets, which is by default {@link OffsetsInitializer#earliest()}.
+	 *    </li>
+	 *    <li>
+	 *        <code>partition.discovery.interval.ms</code> is overridden to -1 when
+	 *        {@link #setBounded(OffsetsInitializer)} has been invoked.
+	 *    </li>
+	 * </ul>
+	 *
+	 * @param key the key of the property.
+	 * @param value the value of the property.
+	 * @return this KafkaSourceBuilder.
+	 */
+	public KafkaSourceBuilder<OUT> setProperty(String key, String value) {
+		props.setProperty(key, value);
+		return this;
+	}
+
+	/**
+	 * Set arbitrary properties for the KafkaSource and KafkaConsumer. The valid keys can be found
+	 * in {@link ConsumerConfig} and {@link KafkaSourceOptions}.
+	 *
+	 * <p>Note that the following keys will be overridden by the builder when the KafkaSource is
+	 * created.
+	 * <ul>
+	 *    <li>
+	 *        <code>key.deserializer</code> is always set to {@link ByteArrayDeserializer}.
+	 *    </li>
+	 *    <li>
+	 *        <code>value.deserializer</code> is always set to {@link ByteArrayDeserializer}.
+	 *    </li>
+	 *    <li>
+	 *        <code>auto.offset.reset.strategy</code> is overridden by {@link OffsetsInitializer#getAutoOffsetResetStrategy()}
+	 *        for the starting offsets, which is by default {@link OffsetsInitializer#earliest()}.
+	 *    </li>
+	 *    <li>
+	 *        <code>partition.discovery.interval.ms</code> is overridden to -1 when
+	 *        {@link #setBounded(OffsetsInitializer)} has been invoked.
+	 *    </li>
+	 *    <li>
+	 *        <code>client.id</code> is overridden to the "client.id.prefix-RANDOM_LONG", or "group.id-RANDOM_LONG" if
+	 *        the client id prefix is not set.
+	 *    </li>
+	 * </ul>
+	 *
+	 * @param props the properties to set for the KafkaSource.
+	 * @return this KafkaSourceBuilder.
+	 */
+	public KafkaSourceBuilder<OUT> setProperties(Properties props) {
+		this.props.putAll(props);
+		return this;
+	}
+
+	/**
+	 * Build the {@link KafkaSource}.
+	 *
+	 * @return a KafkaSource with the settings made for this builder.
+	 */
+	public KafkaSource<OUT> build() {
+		sanityCheck();
+		parseAndSetRequiredProperties();
+		return new KafkaSource<>(
+				subscriber,
+				startingOffsetsInitializer,
+				stoppingOffsetsInitializer,
+				boundedness,
+				deserializationSchema,
+				props);
+	}
+
+	// ------------- private helpers  --------------
+
+	private void ensureSubscriberIsNull(String attemptingSubscribeMode) {
+		if (subscriber != null) {
+			throw new IllegalStateException(String.format(
+					"Cannot use %s for consumption because a %s is already set for consumption.",
+					attemptingSubscribeMode, subscriber.getClass().getSimpleName()));
+		}
+	}
+
+	private void parseAndSetRequiredProperties() {
+		maybeOverride(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName(), true);
+		maybeOverride(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName(), true);
+		maybeOverride(ConsumerConfig.GROUP_ID_CONFIG, "KafkaSource-" + new Random().nextLong(), false);
+		maybeOverride(
+				ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+				startingOffsetsInitializer.getAutoOffsetResetStrategy().name().toLowerCase(),
+				true);
+
+		// If the source is bounded, do not run periodic partition discovery.
+		if (maybeOverride(
+				KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(),
+				"-1",
+				boundedness == Boundedness.BOUNDED)) {
+			LOG.warn("{} property is overridden to -1 because the source is bounded.",
+					KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS);
+		}
+
+		// If the client id prefix is not set, reuse the consumer group id as the client id prefix.
+		maybeOverride(
+				KafkaSourceOptions.CLIENT_ID_PREFIX.key(),
+				props.getProperty(ConsumerConfig.GROUP_ID_CONFIG),
+				false);
+	}
+
+	private boolean maybeOverride(String key, String value, boolean override) {
+		boolean overridden = false;
+		String userValue = props.getProperty(key);
+		if (userValue != null) {
+			if (override) {
+				LOG.warn(String.format("Property %s is provided but will be overridden from %s to %s",
+						key, userValue, value));
+				props.setProperty(key, value);
+				overridden = true;
+			}
+		} else {
+			props.setProperty(key, value);
+		}
+		return overridden;
+	}
+
+	private void sanityCheck() {
+		// Check required configs.
+		for (String requiredConfig : REQUIRED_CONFIGS) {
+			checkNotNull(props.getProperty(
+					requiredConfig,
+					String.format("Property %s is required but not provided", requiredConfig)));
+		}
+		// Check required settings.
+		checkNotNull(subscriber, "No subscribe mode is specified, " +
+				"should be one of topics, topic pattern and partition set.");
+		checkNotNull(deserializationSchema, "Deserialization schema is required but not provided.");
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.util.Properties;
+import java.util.function.Function;
+
+/**
+ * Configurations for KafkaSource.
+ */
+public class KafkaSourceOptions {
+
+	public static final ConfigOption<String> CLIENT_ID_PREFIX =
+			ConfigOptions
+					.key("client.id.prefix")
+					.stringType()
+					.noDefaultValue()
+					.withDescription("The prefix to use for the Kafka consumers.");
+
+	public static final ConfigOption<Long> PARTITION_DISCOVERY_INTERVAL_MS =
+			ConfigOptions
+					.key("partition.discovery.interval.ms")
+					.longType()
+					.defaultValue(30000L)
+					.withDescription("The interval in milliseconds for the Kafka source to discover " +
+							"the new partitions. A non-positive value disables the partition discovery.");
+
+	public static final ConfigOption<Long> CLOSE_TIMEOUT_MS =
+			ConfigOptions
+					.key("close.timeout.ms")
+					.longType()
+					.defaultValue(10000L)
+					.withDescription("The max time to wait when closing components.");
+
+	@SuppressWarnings("unchecked")
+	public static <T> T getOption(Properties props, ConfigOption configOption, Function<String, T> parser) {
+		String value = props.getProperty(configOption.key());
+		return (T) (value == null ? configOption.defaultValue() : parser.apply(value));
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The state of Kafka source enumerator.
+ */
+public class KafkaSourceEnumState {
+	private final Map<Integer, Set<KafkaPartitionSplit>> currentAssignment;
+
+	KafkaSourceEnumState(Map<Integer, Set<KafkaPartitionSplit>> currentAssignment) {
+		this.currentAssignment = currentAssignment;
+	}
+
+	public Map<Integer, Set<KafkaPartitionSplit>> getCurrentAssignment() {
+		return currentAssignment;
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializer.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.flink.connector.base.source.utils.SerdeUtils;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The {@link org.apache.flink.core.io.SimpleVersionedSerializer Serializer} for the enumerator state of
+ * Kafka source.
+ */
+public class KafkaSourceEnumStateSerializer implements SimpleVersionedSerializer<KafkaSourceEnumState> {
+
+	private static final int CURRENT_VERSION = 0;
+
+	@Override
+	public int getVersion() {
+		return CURRENT_VERSION;
+	}
+
+	@Override
+	public byte[] serialize(KafkaSourceEnumState enumState) throws IOException {
+		return SerdeUtils.serializeSplitAssignments(
+				enumState.getCurrentAssignment(),
+				new KafkaPartitionSplitSerializer());
+	}
+
+	@Override
+	public KafkaSourceEnumState deserialize(int version, byte[] serialized) throws IOException {
+		if (version == 0) {
+			Map<Integer, Set<KafkaPartitionSplit>> currentPartitionAssignment =
+					SerdeUtils.deserializeSplitAssignments(
+							serialized,
+							new KafkaPartitionSplitSerializer(),
+							HashSet::new);
+			return new KafkaSourceEnumState(currentPartitionAssignment);
+		}
+		throw new IOException(String.format("The bytes are serialized with version %d, " +
+				"while this deserializer only supports version up to %d", version, CURRENT_VERSION));
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -1,0 +1,382 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.api.connector.source.event.NoMoreSplitsEvent;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * The enumerator class for Kafka source.
+ */
+@Internal
+public class KafkaSourceEnumerator implements SplitEnumerator<KafkaPartitionSplit, KafkaSourceEnumState> {
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceEnumerator.class);
+	private final KafkaSubscriber subscriber;
+	private final OffsetsInitializer startingOffsetInitializer;
+	private final OffsetsInitializer stoppingOffsetInitializer;
+	private final Properties properties;
+	private final long partitionDiscoveryIntervalMs;
+	private final SplitEnumeratorContext<KafkaPartitionSplit> context;
+
+	// The internal states of the enumerator.
+	/** This set is only accessed by the partition discovery callable in the callAsync() method, i.e worker thread. */
+	private final Set<TopicPartition> discoveredPartitions;
+	/** The current assignment by reader id. Only accessed by the coordinator thread. */
+	private final Map<Integer, Set<KafkaPartitionSplit>> readerIdToSplitAssignments;
+	/** The discovered and initialized partition splits that are waiting for owner reader to be ready. */
+	private final Map<Integer, Set<KafkaPartitionSplit>> pendingPartitionSplitAssignment;
+	/** The consumer group id used for this KafkaSource. */
+	private final String consumerGroupId;
+
+	// Lazily instantiated or mutable fields.
+	private KafkaConsumer<byte[], byte[]> consumer;
+	private AdminClient adminClient;
+	private boolean noMoreNewPartitionSplits = false;
+
+	public KafkaSourceEnumerator(
+			KafkaSubscriber subscriber,
+			OffsetsInitializer startingOffsetInitializer,
+			OffsetsInitializer stoppingOffsetInitializer,
+			Properties properties,
+			SplitEnumeratorContext<KafkaPartitionSplit> context) {
+		this(subscriber, startingOffsetInitializer, stoppingOffsetInitializer, properties, context, new HashMap<>());
+	}
+
+	public KafkaSourceEnumerator(
+			KafkaSubscriber subscriber,
+			OffsetsInitializer startingOffsetInitializer,
+			OffsetsInitializer stoppingOffsetInitializer,
+			Properties properties,
+			SplitEnumeratorContext<KafkaPartitionSplit> context,
+			Map<Integer, Set<KafkaPartitionSplit>> currentSplitsAssignments) {
+		this.subscriber = subscriber;
+		this.startingOffsetInitializer = startingOffsetInitializer;
+		this.stoppingOffsetInitializer = stoppingOffsetInitializer;
+		this.properties = properties;
+		this.context = context;
+
+		this.discoveredPartitions = new HashSet<>();
+		this.readerIdToSplitAssignments = new HashMap<>(currentSplitsAssignments);
+		this.readerIdToSplitAssignments.forEach((reader, splits) ->
+				splits.forEach(s -> discoveredPartitions.add(s.getTopicPartition())));
+		this.pendingPartitionSplitAssignment = new HashMap<>();
+		this.partitionDiscoveryIntervalMs = KafkaSourceOptions.getOption(
+				properties,
+				KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS,
+				Long::parseLong);
+		this.consumerGroupId = properties.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+	}
+
+	@Override
+	public void start() {
+		consumer = getKafkaConsumer();
+		adminClient = getKafkaAdminClient();
+		if (partitionDiscoveryIntervalMs > 0) {
+			LOG.info("Starting the KafkaSourceEnumerator for consumer group {} " +
+				"with partition discovery interval of {} ms.", consumerGroupId, partitionDiscoveryIntervalMs);
+			context.callAsync(
+					this::discoverAndInitializePartitionSplit,
+					this::handlePartitionSplitChanges,
+					0,
+					partitionDiscoveryIntervalMs);
+		} else {
+			LOG.info("Starting the KafkaSourceEnumerator for consumer group {} " +
+				"without periodic partition discovery.", consumerGroupId);
+			context.callAsync(
+					this::discoverAndInitializePartitionSplit,
+					this::handlePartitionSplitChanges);
+		}
+	}
+
+	@Override
+	public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+
+	}
+
+	@Override
+	public void addSplitsBack(List<KafkaPartitionSplit> splits, int subtaskId) {
+		addPartitionSplitChangeToPendingAssignments(splits);
+		assignPendingPartitionSplits();
+	}
+
+	@Override
+	public void addReader(int subtaskId) {
+		LOG.debug("Adding reader {} to KafkaSourceEnumerator for consumer group {}.", subtaskId, consumerGroupId);
+		assignPendingPartitionSplits();
+	}
+
+	@Override
+	public KafkaSourceEnumState snapshotState() throws Exception {
+		return new KafkaSourceEnumState(readerIdToSplitAssignments);
+	}
+
+	@Override
+	public void close() {
+		if (consumer != null) {
+			consumer.close();
+		}
+		if (adminClient != null) {
+			adminClient.close();
+		}
+	}
+
+	// ----------------- private methods -------------------
+
+	private PartitionSplitChange discoverAndInitializePartitionSplit() {
+		// Make a copy of the partitions to owners
+		KafkaSubscriber.PartitionChange partitionChange =
+				subscriber.getPartitionChanges(adminClient, Collections.unmodifiableSet(discoveredPartitions));
+
+		Set<TopicPartition> newPartitions = Collections.unmodifiableSet(partitionChange.getNewPartitions());
+		OffsetsInitializer.PartitionOffsetsRetriever offsetsRetriever = getOffsetsRetriever();
+
+		Map<TopicPartition, Long> startingOffsets =
+				startingOffsetInitializer.getPartitionOffsets(newPartitions, offsetsRetriever);
+		Map<TopicPartition, Long> stoppingOffsets =
+				stoppingOffsetInitializer.getPartitionOffsets(newPartitions, offsetsRetriever);
+
+		Set<KafkaPartitionSplit> partitionSplits = new HashSet<>(newPartitions.size());
+		for (TopicPartition tp : newPartitions) {
+			Long startingOffset = startingOffsets.get(tp);
+			long stoppingOffset = stoppingOffsets.getOrDefault(tp, KafkaPartitionSplit.NO_STOPPING_OFFSET);
+			partitionSplits.add(new KafkaPartitionSplit(tp, startingOffset, stoppingOffset));
+		}
+		discoveredPartitions.addAll(newPartitions);
+		return new PartitionSplitChange(partitionSplits, partitionChange.getRemovedPartitions());
+	}
+
+	// This method should only be invoked in the coordinator executor thread.
+	private void handlePartitionSplitChanges(PartitionSplitChange partitionSplitChange, Throwable t) {
+		if (t != null) {
+			throw new FlinkRuntimeException("Failed to handle partition splits change due to ", t);
+		}
+		if (partitionDiscoveryIntervalMs < 0) {
+			LOG.debug("");
+			noMoreNewPartitionSplits = true;
+		}
+		// TODO: Handle removed partitions.
+		addPartitionSplitChangeToPendingAssignments(partitionSplitChange.newPartitionSplits);
+		assignPendingPartitionSplits();
+	}
+
+	// This method should only be invoked in the coordinator executor thread.
+	private void addPartitionSplitChangeToPendingAssignments(Collection<KafkaPartitionSplit> newPartitionSplits) {
+		int numReaders = context.currentParallelism();
+		for (KafkaPartitionSplit split : newPartitionSplits) {
+			int ownerReader = getSplitOwner(split.getTopicPartition(), numReaders);
+			pendingPartitionSplitAssignment.computeIfAbsent(ownerReader, r -> new HashSet<>()).add(split);
+		}
+		LOG.debug("Assigned {} to {} readers of consumer group {}.", newPartitionSplits, numReaders, consumerGroupId);
+	}
+
+	// This method should only be invoked in the coordinator executor thread.
+	private void assignPendingPartitionSplits() {
+		Map<Integer, List<KafkaPartitionSplit>> incrementalAssignment = new HashMap<>();
+		pendingPartitionSplitAssignment.forEach((ownerReader, pendingSplits) -> {
+			if (!pendingSplits.isEmpty() && context.registeredReaders().containsKey(ownerReader)) {
+				// The owner reader is ready, assign the split to the owner reader.
+				incrementalAssignment.computeIfAbsent(ownerReader, r -> new ArrayList<>()).addAll(pendingSplits);
+			}
+		});
+		if (incrementalAssignment.isEmpty()) {
+			// No assignment is made.
+			return;
+		}
+
+		LOG.info("Assigning splits to readers {}", incrementalAssignment);
+		context.assignSplits(new SplitsAssignment<>(incrementalAssignment));
+		incrementalAssignment.forEach((readerOwner, newPartitionSplits) -> {
+			// Update the split assignment.
+			readerIdToSplitAssignments.computeIfAbsent(readerOwner, r -> new HashSet<>()).addAll(newPartitionSplits);
+			// Clear the pending splits for the reader owner.
+			pendingPartitionSplitAssignment.remove(readerOwner);
+			// Sends NoMoreSplitsEvent to the readers if there is no more partition splits to be assigned.
+			if (noMoreNewPartitionSplits) {
+				LOG.debug("No more KafkaPartitionSplits to assign. Sending NoMoreSplitsEvent to the readers " +
+					"in consumer group {}.", consumerGroupId);
+				context.sendEventToSourceReader(readerOwner, new NoMoreSplitsEvent());
+			}
+		});
+	}
+
+	private KafkaConsumer<byte[], byte[]> getKafkaConsumer() {
+		Properties consumerProps = new Properties();
+		copyProperty(properties, consumerProps, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+		// set client id prefix
+		String clientIdPrefix = consumerProps.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key());
+		consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientIdPrefix + "-enumerator-consumer");
+		consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+		consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+		// Disable auto topic creation.
+		consumerProps.setProperty(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
+		return new KafkaConsumer<>(consumerProps);
+	}
+
+	private AdminClient getKafkaAdminClient() {
+		Properties adminClientProps = new Properties();
+		copyProperty(properties, adminClientProps, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+		// set client id prefix
+		String clientIdPrefix = adminClientProps.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key());
+		adminClientProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientIdPrefix + "-enumerator-admin-client");
+		return AdminClient.create(adminClientProps);
+	}
+
+	private OffsetsInitializer.PartitionOffsetsRetriever getOffsetsRetriever() {
+		String groupId = properties.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+		return new PartitionOffsetsRetrieverImpl(consumer, adminClient, groupId);
+	}
+
+	/**
+	 * Returns the index of the target subtask that a specific Kafka partition should be
+	 * assigned to.
+	 *
+	 * <p>The resulting distribution of partitions of a single topic has the following contract:
+	 * <ul>
+	 *     <li>1. Uniformly distributed across subtasks</li>
+	 *     <li>2. Partitions are round-robin distributed (strictly clockwise w.r.t. ascending
+	 *     subtask indices) by using the partition id as the offset from a starting index
+	 *     (i.e., the index of the subtask which partition 0 of the topic will be assigned to,
+	 *     determined using the topic name).</li>
+	 * </ul>
+	 *
+	 * @param tp the Kafka partition to assign.
+	 * @param numReaders the total number of readers.
+	 * @return the id of the subtask that owns the split.
+	 */
+	@VisibleForTesting
+	static int getSplitOwner(TopicPartition tp, int numReaders) {
+		int startIndex = ((tp.topic().hashCode() * 31) & 0x7FFFFFFF) % numReaders;
+
+		// here, the assumption is that the id of Kafka partitions are always ascending
+		// starting from 0, and therefore can be used directly as the offset clockwise from the start index
+		return (startIndex + tp.partition()) % numReaders;
+	}
+
+	private static void copyProperty(Properties from, Properties to, String key) {
+		to.setProperty(key, from.getProperty(key));
+	}
+
+	// --------------- private class ---------------
+
+	private static class PartitionSplitChange {
+		private final Set<KafkaPartitionSplit> newPartitionSplits;
+		private final Set<TopicPartition> removedPartitions;
+
+		private PartitionSplitChange(
+				Set<KafkaPartitionSplit> newPartitionSplits,
+				Set<TopicPartition> removedPartitions) {
+			this.newPartitionSplits = Collections.unmodifiableSet(newPartitionSplits);
+			this.removedPartitions = Collections.unmodifiableSet(removedPartitions);
+		}
+	}
+
+	/**
+	 * The implementation for offsets retriever with a consumer and an admin client.
+	 */
+	@VisibleForTesting
+	public static class PartitionOffsetsRetrieverImpl
+			implements OffsetsInitializer.PartitionOffsetsRetriever, AutoCloseable {
+		private final KafkaConsumer<?, ?> consumer;
+		private final AdminClient adminClient;
+		private final String groupId;
+
+		public PartitionOffsetsRetrieverImpl(
+				KafkaConsumer<?, ?> consumer,
+				AdminClient adminClient,
+				String groupId) {
+			this.consumer = consumer;
+			this.adminClient = adminClient;
+			this.groupId = groupId;
+		}
+
+		@Override
+		public Map<TopicPartition, Long> committedOffsets(Collection<TopicPartition> partitions) {
+			ListConsumerGroupOffsetsOptions options =
+					new ListConsumerGroupOffsetsOptions().topicPartitions(new ArrayList<>(partitions));
+			try {
+				return adminClient
+						.listConsumerGroupOffsets(groupId, options)
+						.partitionsToOffsetAndMetadata()
+						.thenApply(result -> {
+							Map<TopicPartition, Long> offsets = new HashMap<>();
+							result.forEach((tp, oam) -> offsets.put(tp, oam.offset()));
+							return offsets;
+						}).get();
+			} catch (InterruptedException e) {
+				throw new FlinkRuntimeException("Interrupted while listing offsets for consumer group " + groupId, e);
+			} catch (ExecutionException e) {
+				throw new FlinkRuntimeException("Failed to fetch committed offsets for consumer group "
+						+ groupId + " due to", e);
+			}
+		}
+
+		@Override
+		public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+			return consumer.endOffsets(partitions);
+		}
+
+		@Override
+		public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
+			return consumer.beginningOffsets(partitions);
+		}
+
+		@Override
+		public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch) {
+			return consumer.offsetsForTimes(timestampsToSearch);
+		}
+
+		@Override
+		public void close() throws Exception {
+			consumer.close(Duration.ZERO);
+			adminClient.close(Duration.ZERO);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/NoStoppingOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/NoStoppingOffsetsInitializer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An implementation of {@link OffsetsInitializer} which does not initialize anything.
+ *
+ * <p>This class is used as the default stopping offsets initializer for unbounded Kafka sources.
+ */
+@Internal
+public class NoStoppingOffsetsInitializer implements OffsetsInitializer {
+	private static final long serialVersionUID = 4186323669290142732L;
+
+	@Override
+	public Map<TopicPartition, Long> getPartitionOffsets(
+			Collection<TopicPartition> partitions,
+			PartitionOffsetsRetriever partitionOffsetsRetriever) {
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public OffsetResetStrategy getAutoOffsetResetStrategy() {
+		throw new UnsupportedOperationException(
+			"The NoStoppingOffsetsInitializer does not have an OffsetResetStrategy. It should only be used " +
+				"to end offset.");
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A interface for users to specify the starting / stopping offset of a {@link KafkaPartitionSplit}.
+ *
+ * @see ReaderHandledOffsetsInitializer
+ * @see SpecifiedOffsetsInitializer
+ * @see TimestampOffsetsInitializer
+ */
+@PublicEvolving
+public interface OffsetsInitializer extends Serializable {
+
+	/**
+	 * Get the initial offsets for the given Kafka partitions. These offsets will be used
+	 * as either starting offsets or stopping offsets of the Kafka partitions.
+	 *
+	 * <p>If the implementation returns a starting offset which causes
+	 * {@code OffsetsOutOfRangeException} from Kafka. The {@link OffsetResetStrategy}
+	 * provided by the {@link #getAutoOffsetResetStrategy()} will be used to reset the
+	 * offset.
+	 *
+	 * @param partitions the Kafka partitions to get the starting offsets.
+	 * @param partitionOffsetsRetriever a helper to retrieve information of the Kafka partitions.
+	 * @return A mapping from Kafka partition to their offsets to start consuming from.
+	 */
+	Map<TopicPartition, Long> getPartitionOffsets(
+			Collection<TopicPartition> partitions,
+			PartitionOffsetsRetriever partitionOffsetsRetriever);
+
+	/**
+	 * Get the auto offset reset strategy in case the initialized offsets falls out of the range.
+	 *
+	 * <p>The OffsetStrategy is only used when the offset initializer is used to initialize the
+	 * starting offsets and the starting offsets is out of range.
+	 *
+	 * @return An {@link OffsetResetStrategy} to use if the initialized offsets are out of the range.
+	 */
+	OffsetResetStrategy getAutoOffsetResetStrategy();
+
+	/**
+	 * An interface that provides necessary information to the {@link OffsetsInitializer} to get the
+	 * initial offsets of the Kafka partitions.
+	 */
+	interface PartitionOffsetsRetriever {
+
+		/**
+		 * The group id should be the set for {@link KafkaSource KafkaSource}
+		 * before invoking this method. Otherwise an {@code IllegalStateException} will be thrown.
+		 *
+		 * @see KafkaAdminClient#listConsumerGroupOffsets(String, ListConsumerGroupOffsetsOptions)
+		 * @throws IllegalStateException if the group id is not set for the {@code KafkaSource}.
+		 */
+		Map<TopicPartition, Long> committedOffsets(Collection<TopicPartition> partitions);
+
+		/**
+		 * @see KafkaConsumer#endOffsets(Collection)
+		 */
+		Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions);
+
+		/**
+		 * @see KafkaConsumer#beginningOffsets(Collection)
+		 */
+		Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions);
+
+		/**
+		 * @see KafkaConsumer#offsetsForTimes(Map)
+		 */
+		Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch);
+	}
+
+	// --------------- factory methods ---------------
+
+	/**
+	 * Get an {@link OffsetsInitializer} which initializes the offsets to the committed offsets.
+	 * An exception will be thrown at runtime if there is no committed offsets.
+	 *
+	 * @return an offset initializer which initialize the offsets to the committed offsets.
+	 */
+	static OffsetsInitializer committedOffsets() {
+		return committedOffsets(OffsetResetStrategy.NONE);
+	}
+
+	/**
+	 * Get an {@link OffsetsInitializer} which initializes the offsets to the committed offsets.
+	 * Use the given {@link OffsetResetStrategy} to initialize the offsets if the committed
+	 * offsets does not exist.
+	 *
+	 * @param offsetResetStrategy the offset reset strategy to use when the committed offsets do not exist.
+	 * @return an {@link OffsetsInitializer} which initializes the offsets to the committed offsets.
+	 */
+	static OffsetsInitializer committedOffsets(OffsetResetStrategy offsetResetStrategy) {
+		return new ReaderHandledOffsetsInitializer(KafkaPartitionSplit.COMMITTED_OFFSET, offsetResetStrategy);
+	}
+
+	/**
+	 * Get an {@link OffsetsInitializer} which initializes the offsets in each partition so that the initialized
+	 * offset is the offset of the first record whose record timestamp is greater than or equals the
+	 * give timestamp.
+	 *
+	 * @param timestamp the timestamp to start the consumption.
+	 * @return an {@link OffsetsInitializer} which initializes the offsets based on the given timestamp.
+	 * @see KafkaConsumer#offsetsForTimes(Map)
+	 */
+	static OffsetsInitializer timestamp(long timestamp) {
+		return new TimestampOffsetsInitializer(timestamp);
+	}
+
+	/**
+	 * Get an {@link OffsetsInitializer} which initializes the offsets to the earliest available offsets of each
+	 * partition.
+	 *
+	 * @return an {@link OffsetsInitializer} which initializes the offsets to the earliest available offsets.
+	 */
+	static OffsetsInitializer earliest() {
+		return new ReaderHandledOffsetsInitializer(KafkaPartitionSplit.EARLIEST_OFFSET, OffsetResetStrategy.EARLIEST);
+	}
+
+	/**
+	 * Get an {@link OffsetsInitializer} which initializes the offsets to the latest offsets of each
+	 * partition.
+	 *
+	 * @return an {@link OffsetsInitializer} which initializes the offsets to the latest offsets.
+	 */
+	static OffsetsInitializer latest() {
+		return new ReaderHandledOffsetsInitializer(KafkaPartitionSplit.LATEST_OFFSET, OffsetResetStrategy.LATEST);
+	}
+
+	/**
+	 * Get an {@link OffsetsInitializer} which initializes the offsets to the specified offsets.
+	 *
+	 * @param offsets the specified offsets for each partition.
+	 * @return an {@link OffsetsInitializer} which initializes the offsets to the specified offsets.
+	 */
+	static OffsetsInitializer offsets(Map<TopicPartition, Long> offsets) {
+		return new SpecifiedOffsetsInitializer(offsets, OffsetResetStrategy.EARLIEST);
+	}
+
+	/**
+	 * Get an {@link OffsetsInitializer} which initializes the offsets to the specified offsets.
+	 * Use the given {@link OffsetResetStrategy} to initialize the offsets in case the specified
+	 * offset is out of range.
+	 *
+	 * @param offsets the specified offsets for each partition.
+	 * @param offsetResetStrategy the {@link OffsetResetStrategy} to use when the specified offset is out of range.
+	 * @return an {@link OffsetsInitializer} which initializes the offsets to the specified offsets.
+	 */
+	static OffsetsInitializer offsets(Map<TopicPartition, Long> offsets, OffsetResetStrategy offsetResetStrategy) {
+		return new SpecifiedOffsetsInitializer(offsets, offsetResetStrategy);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A initializer that initialize the partitions to the earliest / latest / last-committed offsets.
+ * The offsets initialization are taken care of by the {@code KafkaPartitionSplitReader} instead
+ * of by the {@code KafkaSourceEnumerator}.
+ *
+ * <P>Package private and should be instantiated via {@link OffsetsInitializer}.
+ */
+class ReaderHandledOffsetsInitializer implements OffsetsInitializer {
+	private static final long serialVersionUID = 172938052008787981L;
+	private final long startingOffset;
+	private final OffsetResetStrategy offsetResetStrategy;
+
+	/**
+	 * The only valid value for startingOffset is following.
+	 * {@link KafkaPartitionSplit#EARLIEST_OFFSET EARLIEST_OFFSET},
+	 * {@link KafkaPartitionSplit#LATEST_OFFSET LATEST_OFFSET},
+	 * {@link KafkaPartitionSplit#COMMITTED_OFFSET COMMITTED_OFFSET}
+	 */
+	ReaderHandledOffsetsInitializer(long startingOffset, OffsetResetStrategy offsetResetStrategy) {
+		this.startingOffset = startingOffset;
+		this.offsetResetStrategy = offsetResetStrategy;
+	}
+
+	@Override
+	public Map<TopicPartition, Long> getPartitionOffsets(
+			Collection<TopicPartition> partitions,
+			PartitionOffsetsRetriever partitionOffsetsRetriever) {
+		Map<TopicPartition, Long> initialOffsets = new HashMap<>();
+		for (TopicPartition tp : partitions) {
+			initialOffsets.put(tp, startingOffset);
+		}
+		return initialOffsets;
+	}
+
+	@Override
+	public OffsetResetStrategy getAutoOffsetResetStrategy() {
+		return offsetResetStrategy;
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An implementation of {@link OffsetsInitializer} which initializes the offsets
+ * of the partition according to the user specified offsets.
+ *
+ * <P>Package private and should be instantiated via {@link OffsetsInitializer}.
+ */
+class SpecifiedOffsetsInitializer implements OffsetsInitializer {
+	private static final long serialVersionUID = 1649702397250402877L;
+	private final Map<TopicPartition, Long> initialOffsets;
+	private final OffsetResetStrategy offsetResetStrategy;
+
+	SpecifiedOffsetsInitializer(
+			Map<TopicPartition, Long> initialOffsets,
+			OffsetResetStrategy offsetResetStrategy) {
+		this.initialOffsets = Collections.unmodifiableMap(initialOffsets);
+		this.offsetResetStrategy = offsetResetStrategy;
+	}
+
+	@Override
+	public Map<TopicPartition, Long> getPartitionOffsets(
+			Collection<TopicPartition> partitions,
+			PartitionOffsetsRetriever partitionOffsetsRetriever) {
+		Map<TopicPartition, Long> offsets = new HashMap<>();
+		List<TopicPartition> toLookup = new ArrayList<>();
+		for (TopicPartition tp : partitions) {
+			Long offset = initialOffsets.get(tp);
+			if (offset == null) {
+				toLookup.add(tp);
+			} else {
+				offsets.put(tp, offset);
+			}
+		}
+		if (!toLookup.isEmpty()) {
+			switch (offsetResetStrategy) {
+				case EARLIEST:
+					offsets.putAll(partitionOffsetsRetriever.beginningOffsets(toLookup));
+					break;
+				case LATEST:
+					offsets.putAll(partitionOffsetsRetriever.endOffsets(toLookup));
+					break;
+				default:
+					throw new IllegalStateException("Cannot find initial offsets for partitions: " + toLookup);
+			}
+		}
+		return offsets;
+	}
+
+	@Override
+	public OffsetResetStrategy getAutoOffsetResetStrategy() {
+		return offsetResetStrategy;
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/TimestampOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/TimestampOffsetsInitializer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An implementation of {@link OffsetsInitializer} to initialize the offsets
+ * based on a timestamp.
+ *
+ * <P>Package private and should be instantiated via {@link OffsetsInitializer}.
+ */
+class TimestampOffsetsInitializer implements OffsetsInitializer {
+	private static final long serialVersionUID = 2932230571773627233L;
+	private final long startingTimestamp;
+
+	TimestampOffsetsInitializer(long startingTimestamp) {
+		this.startingTimestamp = startingTimestamp;
+	}
+
+	@Override
+	public Map<TopicPartition, Long> getPartitionOffsets(
+			Collection<TopicPartition> partitions,
+			PartitionOffsetsRetriever partitionOffsetsRetriever) {
+		Map<TopicPartition, Long> startingTimestamps = new HashMap<>();
+		Map<TopicPartition, Long> initialOffsets = new HashMap<>();
+
+		// First get the current end offsets of the partitions. This is going to be used
+		// in case we cannot find a suitable offsets based on the timestamp, i.e. the message
+		// meeting the requirement of the timestamp have not been produced to Kafka yet, in
+		// this case, we just use the latest offset.
+		// We need to get the latest offsets before querying offsets by time to ensure that
+		// no message is going to be missed.
+		Map<TopicPartition, Long> endOffsets = partitionOffsetsRetriever.endOffsets(partitions);
+		partitions.forEach(tp -> startingTimestamps.put(tp, startingTimestamp));
+		partitionOffsetsRetriever.offsetsForTimes(startingTimestamps).forEach((tp, offsetMetadata) -> {
+			if (offsetMetadata != null) {
+				initialOffsets.put(tp, offsetMetadata.offset());
+			} else {
+				// The timestamp does not exist in the partition yet, we will just consume from the latest.
+				initialOffsets.put(tp, endOffsets.get(tp));
+			}
+		});
+		return initialOffsets;
+	}
+
+	@Override
+	public OffsetResetStrategy getAutoOffsetResetStrategy() {
+		return OffsetResetStrategy.NONE;
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.subscriber;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Kafka consumer allows a few different ways to consume from the topics, including:
+ * <ol>
+ *     <li>Subscribe from a collection of topics. </li>
+ *     <li>Subscribe to a topic pattern using Java {@code Regex}. </li>
+ *     <li>Assign specific partitions. </li>
+ * </ol>
+ *
+ * <p>The KafkaSubscriber provides a unified interface for the Kafka source to
+ * support all these three types of subscribing mode.
+ */
+public interface KafkaSubscriber extends Serializable {
+
+	/**
+	 * Get the partitions changes compared to the current partition assignment.
+	 *
+	 * <p>Although Kafka partitions can only expand and will not shrink, the partitions
+	 * may still disappear when the topic is deleted.
+	 *
+	 * @param adminClient The admin client used to retrieve partition information.
+	 * @param currentAssignment the partitions that are currently assigned to the source readers.
+	 * @return The partition changes compared with the currently assigned partitions.
+	 */
+	PartitionChange getPartitionChanges(AdminClient adminClient, Set<TopicPartition> currentAssignment);
+
+	/**
+	 * A container class to hold the newly added partitions and removed partitions.
+	 */
+	class PartitionChange {
+		private final Set<TopicPartition> newPartitions;
+		private final Set<TopicPartition> removedPartitions;
+
+		PartitionChange(Set<TopicPartition> newPartitions, Set<TopicPartition> removedPartitions) {
+			this.newPartitions = newPartitions;
+			this.removedPartitions = removedPartitions;
+		}
+
+		public Set<TopicPartition> getNewPartitions() {
+			return newPartitions;
+		}
+
+		public Set<TopicPartition> getRemovedPartitions() {
+			return removedPartitions;
+		}
+	}
+
+	// ----------------- factory methods --------------
+
+	static KafkaSubscriber getTopicListSubscriber(List<String> topics) {
+		return new TopicListSubscriber(topics);
+	}
+
+	static KafkaSubscriber getTopicPatternSubscriber(Pattern topicPattern) {
+		return new TopicPatternSubscriber(topicPattern);
+	}
+
+	static KafkaSubscriber getPartitionSetSubscriber(Set<TopicPartition> partitions) {
+		return new PartitionSetSubscriber(partitions);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.subscriber;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The base implementations of {@link KafkaSubscriber}.
+ */
+class KafkaSubscriberUtils {
+
+	private KafkaSubscriberUtils() {}
+
+	static void updatePartitionChanges(
+			String topic,
+			Set<TopicPartition> newPartitions,
+			Set<TopicPartition> removedPartitions,
+			List<TopicPartitionInfo> partitionInfoList) {
+		for (TopicPartitionInfo pi : partitionInfoList) {
+			TopicPartition tp = new TopicPartition(topic, pi.partition());
+			if (!removedPartitions.remove(tp)) {
+				newPartitions.add(tp);
+			}
+		}
+	}
+
+	static Map<String, TopicDescription> getTopicMetadata(AdminClient adminClient) {
+		try {
+			Set<String> topicNames = adminClient.listTopics().names().get();
+			return adminClient.describeTopics(topicNames).all().get();
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to get topic metadata.", e);
+		}
+	}
+
+	static void maybeLog(Set<TopicPartition> newPartitions, Set<TopicPartition> removedPartitions, Logger logger) {
+		if (!removedPartitions.isEmpty()) {
+			logger.warn("The following partitions have been removed from the Kafka cluster. {}", removedPartitions);
+		}
+		if (!newPartitions.isEmpty()) {
+			logger.info("The following partitions have been added to the Kafka cluster. {}", newPartitions);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/PartitionSetSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/PartitionSetSubscriber.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.subscriber;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getTopicMetadata;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.maybeLog;
+
+/**
+ * A subscriber for a partition set.
+ */
+class PartitionSetSubscriber implements KafkaSubscriber {
+	private static final long serialVersionUID = 390970375272146036L;
+	private static final Logger LOG = LoggerFactory.getLogger(PartitionSetSubscriber.class);
+	private final Set<TopicPartition> partitions;
+
+	PartitionSetSubscriber(Set<TopicPartition> partitions) {
+		this.partitions = partitions;
+	}
+
+	@Override
+	public PartitionChange getPartitionChanges(
+			AdminClient adminClient,
+			Set<TopicPartition> currentAssignment) {
+		Set<TopicPartition> newPartitions = new HashSet<>();
+		Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
+
+		Map<String, TopicDescription> topicMetadata = getTopicMetadata(adminClient);
+		for (TopicPartition tp : partitions) {
+			TopicDescription topicDescription = topicMetadata.get(tp.topic());
+			if (topicDescription != null && topicDescription.partitions().size() > tp.partition()) {
+				if (!removedPartitions.remove(tp)) {
+					newPartitions.add(tp);
+				}
+			}
+		}
+		maybeLog(newPartitions, removedPartitions, LOG);
+		return new PartitionChange(newPartitions, removedPartitions);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.subscriber;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.maybeLog;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.updatePartitionChanges;
+
+/**
+ * A subscriber to a fixed list of topics. The subscribed topics must hav existed
+ * in the Kafka cluster, otherwise an exception will be thrown.
+ */
+class TopicListSubscriber implements KafkaSubscriber {
+	private static final long serialVersionUID = -6917603843104947866L;
+	private static final Logger LOG = LoggerFactory.getLogger(TopicListSubscriber.class);
+	private final List<String> topics;
+
+	TopicListSubscriber(List<String> topics) {
+		this.topics = topics;
+	}
+
+	@Override
+	public PartitionChange getPartitionChanges(
+			AdminClient adminClient,
+			Set<TopicPartition> currentAssignment) {
+		Set<TopicPartition> newPartitions = new HashSet<>();
+		Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
+
+		Map<String, TopicDescription> topicMetadata;
+		try {
+			topicMetadata = adminClient.describeTopics(topics).all().get();
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to get topic metadata.", e);
+		}
+		topics.forEach(topic -> {
+			List<TopicPartitionInfo> partitions = topicMetadata.get(topic).partitions();
+			if (partitions != null) {
+				updatePartitionChanges(topic, newPartitions, removedPartitions, partitions);
+			}
+		});
+		maybeLog(newPartitions, removedPartitions, LOG);
+		return new PartitionChange(newPartitions, removedPartitions);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.subscriber;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getTopicMetadata;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.maybeLog;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.updatePartitionChanges;
+
+/**
+ * A subscriber to a topic pattern.
+ */
+class TopicPatternSubscriber implements KafkaSubscriber {
+	private static final long serialVersionUID = -7471048577725467797L;
+	private static final Logger LOG = LoggerFactory.getLogger(TopicPatternSubscriber.class);
+	private final Pattern topicPattern;
+
+	TopicPatternSubscriber(Pattern topicPattern) {
+		this.topicPattern = topicPattern;
+	}
+
+	@Override
+	public PartitionChange getPartitionChanges(
+			AdminClient adminClient,
+			Set<TopicPartition> currentAssignment) {
+		Set<TopicPartition> newPartitions = new HashSet<>();
+		Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
+
+		Map<String, TopicDescription> topicMetadata = getTopicMetadata(adminClient);
+		for (Map.Entry<String, TopicDescription> topicEntry : topicMetadata.entrySet()) {
+			String topic = topicEntry.getKey();
+			if (topicPattern.matcher(topic).matches()) {
+				updatePartitionChanges(topic, newPartitions, removedPartitions, topicEntry.getValue().partitions());
+			}
+		}
+		maybeLog(newPartitions, removedPartitions, LOG);
+		return new PartitionChange(newPartitions, removedPartitions);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * A {@link SplitReader} implementation that reads records from Kafka partitions.
+ *
+ * <p>The returned type are in the format of {@code tuple3(record, offset and timestamp}.
+ *
+ * @param <T> the type of the record to be emitted from the Source.
+ */
+public class KafkaPartitionSplitReader<T> implements SplitReader<Tuple3<T, Long, Long>, KafkaPartitionSplit> {
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaPartitionSplitReader.class);
+	private static final long POLL_TIMEOUT = 10000L;
+
+	private final KafkaConsumer<byte[], byte[]> consumer;
+	private final KafkaRecordDeserializer<T> deserializationSchema;
+	private final Map<TopicPartition, Long> stoppingOffsets;
+	private final SimpleCollector<T> collector;
+	private final String groupId;
+	private final int subtaskId;
+
+	public KafkaPartitionSplitReader(
+			Properties props,
+			KafkaRecordDeserializer<T> deserializationSchema,
+			int subtaskId) {
+		Properties consumerProps = new Properties();
+		consumerProps.putAll(props);
+		consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
+		this.consumer = new KafkaConsumer<>(consumerProps);
+		this.stoppingOffsets = new HashMap<>();
+		this.deserializationSchema = deserializationSchema;
+		this.collector = new SimpleCollector<>();
+		this.groupId = consumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+		this.subtaskId = subtaskId;
+	}
+
+	@Override
+	public RecordsWithSplitIds<Tuple3<T, Long, Long>> fetch() throws IOException {
+		KafkaPartitionSplitRecords<Tuple3<T, Long, Long>> recordsBySplits = new KafkaPartitionSplitRecords<>();
+		ConsumerRecords<byte[], byte[]> consumerRecords;
+		try {
+			consumerRecords = consumer.poll(Duration.ofMillis(POLL_TIMEOUT));
+		} catch (WakeupException we) {
+			return recordsBySplits;
+		}
+
+		List<TopicPartition> finishedPartitions = new ArrayList<>();
+		for (TopicPartition tp : consumerRecords.partitions()) {
+			long stoppingOffset = getStoppingOffset(tp);
+			String splitId = tp.toString();
+			Collection<Tuple3<T, Long, Long>> recordsForSplit = recordsBySplits.recordsForSplit(splitId);
+			for (ConsumerRecord<byte[], byte[]> consumerRecord : consumerRecords.records(tp)) {
+				// Stop consuming from this partition if the offsets has reached the stopping offset.
+				// Note that there are two cases, either case finishes a split:
+				// 1. After processing a record with offset of "stoppingOffset - 1". The split reader
+				//    should not continue fetching because the record with stoppingOffset may not exist.
+				// 2. Before processing a record whose offset is greater than or equals to the stopping
+				//    offset. This should only happens when case 1 was not met due to log compaction or
+				//    log retention.
+				// Case 2 is handled here. Case 1 is handled after the record is processed.
+				if (consumerRecord.offset() >= stoppingOffset) {
+					finishSplitAtRecord(tp, stoppingOffset, consumerRecord.offset(),
+							finishedPartitions, recordsBySplits);
+					break;
+				}
+				// Add the record to the partition collector.
+				try {
+					deserializationSchema.deserialize(consumerRecord, collector);
+					collector.getRecords().forEach(r ->
+							recordsForSplit.add(new Tuple3<>(r,
+									consumerRecord.offset(),
+									consumerRecord.timestamp())));
+					// Finish the split because there might not be any message after this point. Keep polling
+					// will just block forever.
+					if (consumerRecord.offset() == stoppingOffset - 1) {
+						finishSplitAtRecord(tp, stoppingOffset, consumerRecord.offset(),
+								finishedPartitions, recordsBySplits);
+					}
+				} catch (Exception e) {
+					throw new IOException("Failed to deserialize consumer record due to", e);
+				} finally {
+					collector.reset();
+				}
+			}
+		}
+		// Unassign the partitions that has finished.
+		if (!finishedPartitions.isEmpty()) {
+			unassignPartitions(finishedPartitions);
+		}
+		recordsBySplits.prepareForRead();
+		return recordsBySplits;
+	}
+
+	@Override
+	public void handleSplitsChanges(SplitsChange<KafkaPartitionSplit> splitsChange) {
+		// Get all the partition assignments and stopping offsets.
+		if (!(splitsChange instanceof SplitsAddition)) {
+			throw new UnsupportedOperationException(String.format(
+				"The SplitChange type of %s is not supported.", splitsChange.getClass()));
+		}
+
+		// Assignment.
+		List<TopicPartition> newPartitionAssignments = new ArrayList<>();
+		// Starting offsets.
+		Map<TopicPartition, Long> partitionsStartingFromSpecifiedOffsets = new HashMap<>();
+		List<TopicPartition> partitionsStartingFromEarliest = new ArrayList<>();
+		List<TopicPartition> partitionsStartingFromLatest = new ArrayList<>();
+		// Stopping offsets.
+		List<TopicPartition> partitionsStoppingAtLatest = new ArrayList<>();
+		Set<TopicPartition> partitionsStoppingAtCommitted = new HashSet<>();
+
+		// Parse the starting and stopping offsets.
+		splitsChange.splits().forEach(s -> {
+			newPartitionAssignments.add(s.getTopicPartition());
+			parseStartingOffsets(s, partitionsStartingFromEarliest, partitionsStartingFromLatest, partitionsStartingFromSpecifiedOffsets);
+			parseStoppingOffsets(s, partitionsStoppingAtLatest, partitionsStoppingAtCommitted);
+		});
+
+		// Assign new partitions.
+		newPartitionAssignments.addAll(consumer.assignment());
+		consumer.assign(newPartitionAssignments);
+
+		// Seek on the newly assigned partitions to their stating offsets.
+		seekToStartingOffsets(partitionsStartingFromEarliest, partitionsStartingFromLatest, partitionsStartingFromSpecifiedOffsets);
+		// Setup the stopping offsets.
+		acquireAndSetStoppingOffsets(partitionsStoppingAtLatest, partitionsStoppingAtCommitted);
+
+		// After acquiring the starting and stopping offsets, remove the empty splits if necessary.
+		removeEmptySplits();
+
+		maybeLogSplitChangesHandlingResult(splitsChange);
+	}
+
+	@Override
+	public void wakeUp() {
+		consumer.wakeup();
+	}
+
+	@Override
+	public void close() throws Exception {
+		consumer.close();
+	}
+
+	// ---------------
+
+	public void notifyCheckpointComplete(
+			Map<TopicPartition, OffsetAndMetadata> offsetsToCommit,
+			OffsetCommitCallback offsetCommitCallback) {
+		consumer.commitAsync(offsetsToCommit, offsetCommitCallback);
+	}
+
+	// --------------- private helper method ----------------------
+
+	private void parseStartingOffsets(
+			KafkaPartitionSplit split,
+			List<TopicPartition> partitionsStartingFromEarliest,
+			List<TopicPartition> partitionsStartingFromLatest,
+			Map<TopicPartition, Long> partitionsStartingFromSpecifiedOffsets) {
+		TopicPartition tp = split.getTopicPartition();
+		// Parse starting offsets.
+		if (split.getStartingOffset() == KafkaPartitionSplit.EARLIEST_OFFSET) {
+			partitionsStartingFromEarliest.add(tp);
+		} else if (split.getStartingOffset() == KafkaPartitionSplit.LATEST_OFFSET) {
+			partitionsStartingFromLatest.add(tp);
+		} else if (split.getStartingOffset() == KafkaPartitionSplit.COMMITTED_OFFSET) {
+			// Do nothing here, the consumer will first try to get the committed offsets of
+			// these partitions by default.
+		} else {
+			partitionsStartingFromSpecifiedOffsets.put(tp, split.getStartingOffset());
+		}
+	}
+
+	private void parseStoppingOffsets(
+			KafkaPartitionSplit split,
+			List<TopicPartition> partitionsStoppingAtLatest,
+			Set<TopicPartition> partitionsStoppingAtCommitted) {
+		TopicPartition tp = split.getTopicPartition();
+		split.getStoppingOffset().ifPresent(stoppingOffset -> {
+			if (stoppingOffset >= 0) {
+				stoppingOffsets.put(tp, stoppingOffset);
+			} else if (stoppingOffset == KafkaPartitionSplit.LATEST_OFFSET) {
+				partitionsStoppingAtLatest.add(tp);
+			} else if (stoppingOffset == KafkaPartitionSplit.COMMITTED_OFFSET) {
+				partitionsStoppingAtCommitted.add(tp);
+			} else {
+				// This should not happen.
+				throw new FlinkRuntimeException(String.format(
+					"Invalid stopping offset %d for partition %s", stoppingOffset, tp));
+			}
+		});
+	}
+
+	private void seekToStartingOffsets(
+			List<TopicPartition> partitionsStartingFromEarliest,
+			List<TopicPartition> partitionsStartingFromLatest,
+			Map<TopicPartition, Long> partitionsStartingFromSpecifiedOffsets) {
+
+		if (!partitionsStartingFromEarliest.isEmpty()) {
+			LOG.trace("Seeking starting offsets to beginning: {}", partitionsStartingFromEarliest);
+			consumer.seekToBeginning(partitionsStartingFromEarliest);
+		}
+
+		if (!partitionsStartingFromLatest.isEmpty()) {
+			LOG.trace("Seeking starting offsets to end: {}", partitionsStartingFromLatest);
+			consumer.seekToEnd(partitionsStartingFromLatest);
+		}
+
+		if (!partitionsStartingFromSpecifiedOffsets.isEmpty()) {
+			LOG.trace("Seeking starting offsets to specified offsets: {}", partitionsStartingFromSpecifiedOffsets);
+			partitionsStartingFromSpecifiedOffsets.forEach(consumer::seek);
+		}
+	}
+
+	private void acquireAndSetStoppingOffsets(
+			List<TopicPartition> partitionsStoppingAtLatest,
+			Set<TopicPartition> partitionsStoppingAtCommitted) {
+		Map<TopicPartition, Long> endOffset = consumer.endOffsets(partitionsStoppingAtLatest);
+		stoppingOffsets.putAll(endOffset);
+		consumer.committed(partitionsStoppingAtCommitted).forEach((tp, offsetAndMetadata) -> {
+			Preconditions.checkNotNull(offsetAndMetadata, String.format(
+				"Partition %s should stop at committed offset. " +
+					"But there is no committed offset of this partition for group %s", tp, groupId));
+			stoppingOffsets.put(tp, offsetAndMetadata.offset());
+		});
+	}
+
+	private void removeEmptySplits() {
+		List<TopicPartition> emptySplits = new ArrayList<>();
+		// If none of the partitions have any records,
+		for (TopicPartition tp : consumer.assignment()) {
+			if (consumer.position(tp) >= getStoppingOffset(tp)) {
+				emptySplits.add(tp);
+			}
+		}
+		if (!emptySplits.isEmpty()) {
+			unassignPartitions(emptySplits);
+		}
+	}
+
+	private void maybeLogSplitChangesHandlingResult(SplitsChange<KafkaPartitionSplit> splitsChange) {
+		if (LOG.isDebugEnabled()) {
+			StringJoiner splitsInfo = new StringJoiner(",");
+			for (KafkaPartitionSplit split : splitsChange.splits()) {
+				long startingOffset = consumer.position(split.getTopicPartition());
+				long stoppingOffset = getStoppingOffset(split.getTopicPartition());
+				splitsInfo.add(String.format("[%s, start:%d, stop: %d]",
+					split.getTopicPartition(), startingOffset, stoppingOffset));
+			}
+			LOG.debug("SplitsChange handling result: {}", splitsInfo.toString());
+		}
+	}
+
+	private void unassignPartitions(Collection<TopicPartition> partitionsToUnassign) {
+		Collection<TopicPartition> newAssignment = new HashSet<>(consumer.assignment());
+		newAssignment.removeAll(partitionsToUnassign);
+		consumer.assign(newAssignment);
+	}
+
+	private String createConsumerClientId(Properties props) {
+		String prefix = props.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key());
+		return prefix + "-" + subtaskId;
+	}
+
+	private void finishSplitAtRecord(
+			TopicPartition tp,
+			long stoppingOffset,
+			long currentOffset,
+			List<TopicPartition> finishedPartitions,
+			KafkaPartitionSplitRecords<Tuple3<T, Long, Long>> recordsBySplits) {
+		LOG.debug("{} has reached stopping offset {}, current offset is {}", tp, stoppingOffset, currentOffset);
+		finishedPartitions.add(tp);
+		recordsBySplits.addFinishedSplit(KafkaPartitionSplit.toSplitId(tp));
+	}
+
+	private long getStoppingOffset(TopicPartition tp) {
+		return stoppingOffsets.getOrDefault(tp, Long.MAX_VALUE);
+	}
+
+	// ---------------- private helper class ------------------------
+
+	private static class KafkaPartitionSplitRecords<T> implements RecordsWithSplitIds<T> {
+		private final Map<String, Collection<T>> recordsBySplits;
+		private final Set<String> finishedSplits;
+		private Iterator<Map.Entry<String, Collection<T>>> splitIterator;
+		private String currentSplitId;
+		private Iterator<T> recordIterator;
+
+		private KafkaPartitionSplitRecords() {
+			this.recordsBySplits = new HashMap<>();
+			this.finishedSplits = new HashSet<>();
+		}
+
+		private Collection<T> recordsForSplit(String splitId) {
+			return recordsBySplits.computeIfAbsent(splitId, id -> new ArrayList<>());
+		}
+
+		private void addFinishedSplit(String splitId) {
+			finishedSplits.add(splitId);
+		}
+
+		private void prepareForRead() {
+			splitIterator = recordsBySplits.entrySet().iterator();
+		}
+
+		@Override
+		@Nullable
+		public String nextSplit() {
+			if (splitIterator.hasNext()) {
+				Map.Entry<String, Collection<T>> entry = splitIterator.next();
+				currentSplitId = entry.getKey();
+				recordIterator = entry.getValue().iterator();
+				return currentSplitId;
+			} else {
+				currentSplitId = null;
+				recordIterator = null;
+				return null;
+			}
+		}
+
+		@Override
+		@Nullable
+		public T nextRecordFromSplit() {
+			Preconditions.checkNotNull(currentSplitId, "Make sure nextSplit() did not return null before " +
+				"iterate over the records split.");
+			if (recordIterator.hasNext()) {
+				return recordIterator.next();
+			} else {
+				return null;
+			}
+		}
+
+		@Override
+		public Set<String> finishedSplits() {
+			return finishedSplits;
+		}
+	}
+
+	private static class SimpleCollector<T> implements Collector<T> {
+		private final List<T> records = new ArrayList<>();
+
+		@Override
+		public void collect(T record) {
+			records.add(record);
+		}
+
+		@Override
+		public void close() {
+
+		}
+
+		private List<T> getRecords() {
+			return records;
+		}
+
+		private void reset() {
+			records.clear();
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader;
+
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link KafkaSourceReader}.
+ */
+public class KafkaRecordEmitter<T> implements RecordEmitter<Tuple3<T, Long, Long>, T, KafkaPartitionSplitState> {
+
+	@Override
+	public void emitRecord(
+			Tuple3<T, Long, Long> element,
+			SourceOutput<T> output,
+			KafkaPartitionSplitState splitState) throws Exception {
+		output.collect(element.f0, element.f2);
+		splitState.setCurrentOffset(element.f1 + 1);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+/**
+ * The source reader for Kafka partitions.
+ */
+public class KafkaSourceReader<T>
+		extends SingleThreadMultiplexSourceReaderBase<Tuple3<T, Long, Long>, T, KafkaPartitionSplit, KafkaPartitionSplitState> {
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceReader.class);
+	private final SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> offsetsToCommit;
+
+	public KafkaSourceReader(
+			FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
+			Supplier<KafkaPartitionSplitReader<T>> splitReaderSupplier,
+			RecordEmitter<Tuple3<T, Long, Long>, T, KafkaPartitionSplitState> recordEmitter,
+			Configuration config,
+			SourceReaderContext context) {
+		super(
+			elementsQueue,
+			new KafkaSourceFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+			recordEmitter,
+			config,
+			context);
+		this.offsetsToCommit = new TreeMap<>();
+	}
+
+	@Override
+	protected void onSplitFinished(Collection<String> finishedSplitIds) {
+
+	}
+
+	@Override
+	public List<KafkaPartitionSplit> snapshotState(long checkpointId) {
+		List<KafkaPartitionSplit> splits = super.snapshotState(checkpointId);
+		for (KafkaPartitionSplit split : splits) {
+			offsetsToCommit
+				.compute(checkpointId, (ignoredKey, ignoredValue) -> new HashMap<>())
+				.put(
+					split.getTopicPartition(),
+					new OffsetAndMetadata(split.getStartingOffset(), null));
+		}
+		return splits;
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		((KafkaSourceFetcherManager<T>) splitFetcherManager).commitOffsets(
+				offsetsToCommit.get(checkpointId),
+				(ignored, e) -> {
+					if (e != null) {
+						LOG.warn(
+							"Failed to commit consumer offsets for checkpoint {}",
+							checkpointId);
+					} else {
+						while (!offsetsToCommit.isEmpty() && offsetsToCommit.firstKey() <= checkpointId) {
+							offsetsToCommit.remove(offsetsToCommit.firstKey());
+						}
+					}
+				});
+	}
+
+	@Override
+	protected KafkaPartitionSplitState initializedState(KafkaPartitionSplit split) {
+		return new KafkaPartitionSplitState(split);
+	}
+
+	@Override
+	protected KafkaPartitionSplit toSplitType(String splitId, KafkaPartitionSplitState splitState) {
+		return splitState.toKafkaPartitionSplit();
+	}
+
+	// ------------------------
+
+	@VisibleForTesting
+	SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> getOffsetsToCommit() {
+		return offsetsToCommit;
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader.deserializer;
+
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An interface for the deserialization of Kafka records.
+ */
+public interface KafkaRecordDeserializer<T> extends Serializable, ResultTypeQueryable<T> {
+
+	/**
+	 * Deserialize a consumer record into the given collector.
+	 *
+	 * @param record the {@code ConsumerRecord} to deserialize.
+	 * @throws Exception if the deserialization failed.
+	 */
+	void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<T> collector) throws Exception;
+
+	/**
+	 * Wraps a Kafka {@link Deserializer} to a {@link KafkaRecordDeserializer}.
+	 * @param valueDeserializerClass the deserializer class used to deserialize the value.
+	 * @param <V> the value type.
+	 * @return A {@link KafkaRecordDeserializer} that deserialize the value with the given deserializer.
+	 */
+	static <V> KafkaRecordDeserializer<V> valueOnly(
+			Class<? extends Deserializer<V>> valueDeserializerClass) {
+		return new ValueDeserializerWrapper<>(valueDeserializerClass, Collections.emptyMap());
+	}
+
+	/**
+	 * Wraps a Kafka {@link Deserializer} to a {@link KafkaRecordDeserializer}.
+	 * @param valueDeserializerClass the deserializer class used to deserialize the value.
+	 * @param config the configuration of the value deserializer, only valid when the deserializer
+	 *               is an implementation of {@code Configurable}.
+	 * @param <V> the value type.
+	 * @param <D> the type of the deserializer.
+	 * @return A {@link KafkaRecordDeserializer} that deserialize the value with the given deserializer.
+	 */
+	static <V, D extends Configurable & Deserializer<V>> KafkaRecordDeserializer<V> valueOnly(
+			Class<D> valueDeserializerClass,
+			Map<String, String> config) {
+		return new ValueDeserializerWrapper<>(valueDeserializerClass, config);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/ValueDeserializerWrapper.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/ValueDeserializerWrapper.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader.deserializer;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * A package private class to wrap {@link Deserializer}.
+ */
+class ValueDeserializerWrapper<T> implements KafkaRecordDeserializer<T> {
+	private static final long serialVersionUID = 5409547407386004054L;
+	private static final Logger LOG = LoggerFactory.getLogger(ValueDeserializerWrapper.class);
+	private final String deserializerClass;
+	private final Map<String, String> config;
+
+	private transient Deserializer<T> deserializer;
+
+	ValueDeserializerWrapper(
+			Class<? extends Deserializer<T>> deserializerClass,
+			Map<String, String> config) {
+		this.deserializerClass = deserializerClass.getName();
+		this.config = config;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<T> collector) throws Exception {
+		if (deserializer == null) {
+			deserializer = (Deserializer<T>) InstantiationUtil.instantiate(
+					deserializerClass, Deserializer.class, getClass().getClassLoader());
+			if (deserializer instanceof Configurable) {
+				((Configurable) deserializer).configure(config);
+			}
+		}
+
+		T value = deserializer.deserialize(record.topic(), record.value());
+		LOG.trace("Deserialized [partition: {}-{}, offset: {}, timestamp: {}, value: {}]",
+				record.topic(), record.partition(), record.offset(), record.timestamp(), value);
+		collector.collect(value);
+	}
+
+	@Override
+	public TypeInformation<T> getProducedType() {
+		return TypeExtractor.createTypeInfo(
+				Deserializer.class,
+				deserializer.getClass(), 0, null, null);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader.fetcher;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherTask;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kafka.source.reader.KafkaPartitionSplitReader;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * The SplitFetcherManager for Kafka source. This class is needed to help
+ * commit the offsets to Kafka using the KafkaConsumer inside the
+ * {@link org.apache.flink.connector.kafka.source.reader.KafkaPartitionSplitReader}.
+ */
+public class KafkaSourceFetcherManager<T>
+		extends SingleThreadFetcherManager<Tuple3<T, Long, Long>, KafkaPartitionSplit> {
+
+	/**
+	 * Creates a new SplitFetcherManager with a single I/O threads.
+	 *
+	 * @param elementsQueue       The queue that is used to hand over data from the I/O thread (the fetchers)
+	 *                            to the reader (which emits the records and book-keeps the state.
+	 *                            This must be the same queue instance that is also passed to the {@link SourceReaderBase}.
+	 * @param splitReaderSupplier The factory for the split reader that connects to the source system.
+	 */
+	public KafkaSourceFetcherManager(
+		FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
+		Supplier<SplitReader<Tuple3<T, Long, Long>, KafkaPartitionSplit>> splitReaderSupplier) {
+		super(elementsQueue, splitReaderSupplier);
+	}
+
+	public void commitOffsets(
+			Map<TopicPartition, OffsetAndMetadata> offsetsToCommit,
+			OffsetCommitCallback callback) {
+		SplitFetcher<Tuple3<T, Long, Long>, KafkaPartitionSplit> splitFetcher = fetchers.get(0);
+		KafkaPartitionSplitReader<T> kafkaReader =
+			(KafkaPartitionSplitReader<T>) splitFetcher.getSplitReader();
+
+		splitFetcher.enqueueTask(new SplitFetcherTask() {
+			@Override
+			public boolean run() throws IOException {
+				kafkaReader.notifyCheckpointComplete(offsetsToCommit, callback);
+				return true;
+			}
+
+			@Override
+			public void wakeUp() {}
+		});
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.split;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A {@link SourceSplit} for a Kafka partition.
+ */
+public class KafkaPartitionSplit implements SourceSplit {
+	public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
+	// Indicating the split should consume from the earliest.
+	public static final long LATEST_OFFSET = -1;
+	// Indicating the split should consume from the latest.
+	public static final long EARLIEST_OFFSET = -2;
+	// Indicating the split should consume from the last committed offset.
+	public static final long COMMITTED_OFFSET = -3;
+
+	// Valid special starting offsets
+	public static final Set<Long> VALID_STARTING_OFFSET_MARKERS =
+			new HashSet<>(Arrays.asList(EARLIEST_OFFSET, LATEST_OFFSET, COMMITTED_OFFSET));
+	public static final Set<Long> VALID_STOPPING_OFFSET_MARKERS =
+			new HashSet<>(Arrays.asList(LATEST_OFFSET, COMMITTED_OFFSET, NO_STOPPING_OFFSET));
+
+	private final TopicPartition tp;
+	private final long startingOffset;
+	private final long stoppingOffset;
+
+	public KafkaPartitionSplit(TopicPartition tp, long startingOffset) {
+		this(tp, startingOffset, NO_STOPPING_OFFSET);
+	}
+
+	public KafkaPartitionSplit(TopicPartition tp, long startingOffset, long stoppingOffset) {
+		verifyInitialOffset(tp, startingOffset, stoppingOffset);
+		this.tp = tp;
+		this.startingOffset = startingOffset;
+		this.stoppingOffset = stoppingOffset;
+	}
+
+	public String getTopic() {
+		return tp.topic();
+	}
+
+	public int getPartition() {
+		return tp.partition();
+	}
+
+	public TopicPartition getTopicPartition() {
+		return tp;
+	}
+
+	public long getStartingOffset() {
+		return startingOffset;
+	}
+
+	public Optional<Long> getStoppingOffset() {
+		return stoppingOffset > 0 || stoppingOffset == LATEST_OFFSET || stoppingOffset == COMMITTED_OFFSET
+				? Optional.of(stoppingOffset)
+				: Optional.empty();
+	}
+
+	@Override
+	public String splitId() {
+		return toSplitId(tp);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("[Partition: %s, StartingOffset: %d, StoppingOffset: %d]",
+				tp, startingOffset, stoppingOffset);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(tp, startingOffset, stoppingOffset);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof KafkaPartitionSplit)) {
+			return false;
+		}
+		KafkaPartitionSplit other = (KafkaPartitionSplit) obj;
+		return tp.equals(other.tp)
+				&& startingOffset == other.startingOffset
+				&& stoppingOffset == other.stoppingOffset;
+	}
+
+	public static String toSplitId(TopicPartition tp) {
+		return tp.toString();
+	}
+
+	// ------------ private methods ---------------
+
+	private static void verifyInitialOffset(TopicPartition tp, Long startingOffset, long stoppingOffset) {
+		if (startingOffset == null) {
+			throw new FlinkRuntimeException("Cannot initialize starting offset for partition " + tp);
+		}
+
+		if (startingOffset < 0 && !VALID_STARTING_OFFSET_MARKERS.contains(startingOffset)) {
+			throw new FlinkRuntimeException(String.format(
+					"Invalid starting offset %d is specified for partition %s. " +
+							"It should either be non-negative or be one of the " +
+							"[%d(earliest), %d(latest), %d(committed)].",
+					startingOffset, tp, LATEST_OFFSET, EARLIEST_OFFSET, COMMITTED_OFFSET));
+		}
+
+		if (stoppingOffset < 0
+				&& !VALID_STOPPING_OFFSET_MARKERS.contains(stoppingOffset)) {
+			throw new FlinkRuntimeException(String.format(
+					"Illegal stopping offset %d is specified for partition %s. " +
+							"It should either be non-negative or be one of the " +
+							"[%d(latest), %d(committed), %d(Long.MIN_VALUE, no_stopping_offset)].",
+					stoppingOffset, tp, LATEST_OFFSET, COMMITTED_OFFSET, NO_STOPPING_OFFSET));
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.split;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * The {@link org.apache.flink.core.io.SimpleVersionedSerializer serializer} for {@link KafkaPartitionSplit}.
+ */
+public class KafkaPartitionSplitSerializer implements SimpleVersionedSerializer<KafkaPartitionSplit> {
+
+	private static final int CURRENT_VERSION = 0;
+
+	@Override
+	public int getVersion() {
+		return CURRENT_VERSION;
+	}
+
+	@Override
+	public byte[] serialize(KafkaPartitionSplit split) throws IOException {
+		try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputStream out = new DataOutputStream(baos)) {
+			out.writeUTF(split.getTopic());
+			out.writeInt(split.getPartition());
+			out.writeLong(split.getStartingOffset());
+			out.writeLong(split.getStoppingOffset().orElse(KafkaPartitionSplit.NO_STOPPING_OFFSET));
+			out.flush();
+			return baos.toByteArray();
+		}
+	}
+
+	@Override
+	public KafkaPartitionSplit deserialize(int version, byte[] serialized) throws IOException {
+		try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+				DataInputStream in = new DataInputStream(bais)) {
+			String topic = in.readUTF();
+			int partition = in.readInt();
+			long offset = in.readLong();
+			long stoppingOffset = in.readLong();
+			return new KafkaPartitionSplit(new TopicPartition(topic, partition), offset, stoppingOffset);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitState.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitState.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.split;
+
+/**
+ * This class extends KafkaPartitionSplit to track a mutable current offset.
+ */
+public class KafkaPartitionSplitState extends KafkaPartitionSplit {
+
+	private long currentOffset;
+
+	public KafkaPartitionSplitState(KafkaPartitionSplit partitionSplit) {
+		super(
+				partitionSplit.getTopicPartition(),
+				partitionSplit.getStartingOffset(),
+				partitionSplit.getStoppingOffset().orElse(NO_STOPPING_OFFSET));
+		this.currentOffset = partitionSplit.getStartingOffset();
+	}
+
+	public long getCurrentOffset() {
+		return currentOffset;
+	}
+
+	public void setCurrentOffset(long currentOffset) {
+		this.currentOffset = currentOffset;
+	}
+
+	/**
+	 * Use the current offset as the starting offset to create a new KafkaPartitionSplit.
+	 * @return a new KafkaPartitionSplit which uses the current offset as its starting offset.
+	 */
+	public KafkaPartitionSplit toKafkaPartitionSplit() {
+		return new KafkaPartitionSplit(
+				getTopicPartition(),
+				getCurrentOffset(),
+				getStoppingOffset().orElse(NO_STOPPING_OFFSET));
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.api.common.accumulators.ListAccumulator;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unite test class for {@link KafkaSource}.
+ */
+public class KafkaSourceITCase {
+	private static final String TOPIC1 = "topic1";
+	private static final String TOPIC2 = "topic2";
+
+	@BeforeClass
+	public static void setup() throws Throwable {
+		KafkaSourceTestEnv.setup();
+		KafkaSourceTestEnv.setupTopic(TOPIC1, true, true);
+		KafkaSourceTestEnv.setupTopic(TOPIC2, true, true);
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		KafkaSourceTestEnv.tearDown();
+	}
+
+	@Test
+	public void testBasicRead() throws Exception {
+		KafkaSource<PartitionAndValue> source = KafkaSource
+				.<PartitionAndValue>builder()
+				.setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
+				.setGroupId("testBasicRead")
+				.setTopics(Arrays.asList(TOPIC1, TOPIC2))
+				.setDeserializer(new TestingKafkaRecordDeserializer())
+				.setStartingOffsets(OffsetsInitializer.earliest())
+				.setBounded(OffsetsInitializer.latest())
+				.build();
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		DataStream<PartitionAndValue> stream = env.fromSource(
+				source,
+				WatermarkStrategy.noWatermarks(),
+				"testBasicRead",
+				TypeInformation.of(PartitionAndValue.class));
+		executeAndVerify(env, stream);
+	}
+
+	// -----------------
+
+	private static class PartitionAndValue implements Serializable {
+		private static final long serialVersionUID = 4813439951036021779L;
+		private final String tp;
+		private final int value;
+
+		private PartitionAndValue(TopicPartition tp, int value) {
+			this.tp = tp.toString();
+			this.value = value;
+		}
+	}
+
+	private static class TestingKafkaRecordDeserializer implements KafkaRecordDeserializer<PartitionAndValue> {
+		private static final long serialVersionUID = -3765473065594331694L;
+		private transient Deserializer<Integer> deserializer;
+
+		@Override
+		public void deserialize(
+				ConsumerRecord<byte[], byte[]> record,
+				Collector<PartitionAndValue> collector) throws Exception {
+			if (deserializer == null) {
+				deserializer = new IntegerDeserializer();
+			}
+			collector.collect(new PartitionAndValue(
+					new TopicPartition(record.topic(), record.partition()),
+					deserializer.deserialize(record.topic(), record.value())));
+		}
+
+		@Override
+		public TypeInformation<PartitionAndValue> getProducedType() {
+			return TypeInformation.of(PartitionAndValue.class);
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private void executeAndVerify(StreamExecutionEnvironment env, DataStream<PartitionAndValue> stream) throws Exception {
+		stream.addSink(new RichSinkFunction<PartitionAndValue>() {
+			@Override
+			public void open(Configuration parameters) throws Exception {
+				getRuntimeContext().addAccumulator("result", new ListAccumulator<PartitionAndValue>());
+			}
+
+			@Override
+			public void invoke(PartitionAndValue value, Context context) throws Exception {
+				getRuntimeContext().getAccumulator("result").add(value);
+			}
+		});
+		List<PartitionAndValue> result = env.execute().getAccumulatorResult("result");
+		Map<String, List<Integer>> resultPerPartition = new HashMap<>();
+		result.forEach(partitionAndValue -> resultPerPartition.computeIfAbsent(
+			partitionAndValue.tp, ignored -> new ArrayList<>()).add(partitionAndValue.value));
+		resultPerPartition.forEach((tp, values) -> {
+			int firstExpectedValue = Integer.parseInt(tp.substring(tp.indexOf('-') + 1));
+			for (int i = 0; i < values.size(); i++) {
+				assertEquals(String.format("The %d-th value for partition %s should be %d", i, tp, i),
+						firstExpectedValue + i, (int) values.get(i));
+			}
+		});
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestEnv.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestEnv.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.streaming.connectors.kafka.KafkaTestBase;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
+import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Base class for KafkaSource unit tests.
+ */
+public class KafkaSourceTestEnv extends KafkaTestBase {
+	public static final String GROUP_ID = "KafkaSourceTestEnv";
+	public static final int NUM_PARTITIONS = 10;
+	public static final int NUM_RECORDS_PER_PARTITION = 10;
+
+	private static AdminClient adminClient;
+	private static KafkaConsumer<String, Integer> consumer;
+
+	public static void setup() throws Throwable {
+		prepare();
+		adminClient = getAdminClient();
+		consumer = getConsumer();
+	}
+
+	public static void tearDown() throws Exception {
+		consumer.close();
+		adminClient.close();
+		shutDownServices();
+	}
+
+	// --------------------- public client related helpers ------------------
+
+	public static AdminClient getAdminClient() {
+		Properties props = new Properties();
+		props.putAll(standardProps);
+		return AdminClient.create(props);
+	}
+
+	public static KafkaConsumer<String, Integer> getConsumer() {
+		Properties props = new Properties();
+		props.putAll(standardProps);
+		props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+		props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+		props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class.getName());
+		return new KafkaConsumer<>(props);
+	}
+
+	public static Properties getConsumerProperties(Class<?> deserializerClass) {
+		Properties props = new Properties();
+		props.putAll(standardProps);
+		props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+		props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, deserializerClass.getName());
+		props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializerClass.getName());
+		return props;
+	}
+
+	// ------------------- topic information helpers -------------------
+
+	public static Map<Integer, Map<String, KafkaPartitionSplit>> getSplitsByOwners(
+			final Collection<String> topics,
+			final int numSubtasks) {
+		final Map<Integer, Map<String, KafkaPartitionSplit>> splitsByOwners = new HashMap<>();
+		for (String topic : topics) {
+			getPartitionsForTopic(topic).forEach(tp -> {
+				int ownerReader = Math.abs(tp.hashCode()) % numSubtasks;
+				KafkaPartitionSplit split = new KafkaPartitionSplit(
+						tp, getEarliestOffset(tp), (long) NUM_RECORDS_PER_PARTITION);
+				splitsByOwners
+						.computeIfAbsent(ownerReader, r -> new HashMap<>())
+						.put(KafkaPartitionSplit.toSplitId(tp), split);
+			});
+		}
+		return splitsByOwners;
+	}
+
+	/**
+	 * For a given partition {@code TOPIC-PARTITION} the {@code i}-th records looks like following.
+	 *
+	 * <pre>{@code
+	 *     topic: TOPIC
+	 *     partition: PARTITION
+	 *     timestamp: 1000 * PARTITION
+	 *     key: TOPIC-PARTITION
+	 *     value: i
+	 * }</pre>
+	 */
+	public static List<ProducerRecord<String, Integer>> getRecordsForPartition(TopicPartition tp) {
+		List<ProducerRecord<String, Integer>> records = new ArrayList<>();
+		for (int i = 0; i < NUM_RECORDS_PER_PARTITION; i++) {
+			records.add(new ProducerRecord<>(tp.topic(), tp.partition(), i * 1000L, tp.toString(), i));
+		}
+		return records;
+	}
+
+	public static List<ProducerRecord<String, Integer>> getRecordsForTopic(String topic) {
+		List<ProducerRecord<String, Integer>> records = new ArrayList<>();
+		for (TopicPartition tp : getPartitionsForTopic(topic)) {
+			records.addAll(getRecordsForPartition(tp));
+		}
+		return records;
+	}
+
+	public static List<TopicPartition> getPartitionsForTopics(Collection<String> topics) {
+		List<TopicPartition> partitions = new ArrayList<>();
+		topics.forEach(t -> partitions.addAll(getPartitionsForTopic(t)));
+		return partitions;
+	}
+
+	public static List<TopicPartition> getPartitionsForTopic(String topic) {
+		return consumer
+				.partitionsFor(topic)
+				.stream()
+				.map(pi -> new TopicPartition(pi.topic(), pi.partition()))
+				.collect(Collectors.toList());
+	}
+
+	public static Map<TopicPartition, Long> getEarliestOffsets(List<TopicPartition> partitions) {
+		Map<TopicPartition, Long> earliestOffsets = new HashMap<>();
+		for (TopicPartition tp : partitions) {
+			earliestOffsets.put(tp, getEarliestOffset(tp));
+		}
+		return earliestOffsets;
+	}
+
+	public static Map<TopicPartition, OffsetAndMetadata> getCommittedOffsets(List<TopicPartition> partitions) {
+		Map<TopicPartition, OffsetAndMetadata> committedOffsets = new HashMap<>();
+		for (TopicPartition tp : partitions) {
+			committedOffsets.put(tp, new OffsetAndMetadata(tp.partition() + 2));
+		}
+		return committedOffsets;
+	}
+
+	public static long getEarliestOffset(TopicPartition tp) {
+		return tp.partition();
+	}
+
+	// --------------- topic manipulation helpers ---------------
+
+	public static void createTestTopic(String topic) {
+		createTestTopic(topic, NUM_PARTITIONS, 1);
+	}
+
+	public static void setupEarliestOffsets(String topic) throws Throwable {
+		// Delete some records to move the starting partition.
+		List<TopicPartition> partitions = getPartitionsForTopic(topic);
+		Map<TopicPartition, RecordsToDelete> toDelete = new HashMap<>();
+		getEarliestOffsets(partitions).forEach((tp, offset) -> toDelete.put(tp, RecordsToDelete.beforeOffset(offset)));
+		adminClient.deleteRecords(toDelete).all().get();
+	}
+
+	public static void setupCommittedOffsets(String topic) throws ExecutionException, InterruptedException {
+		List<TopicPartition> partitions = getPartitionsForTopic(topic);
+		Map<TopicPartition, OffsetAndMetadata> committedOffsets = getCommittedOffsets(partitions);
+		consumer.commitSync(committedOffsets);
+		Map<TopicPartition, OffsetAndMetadata> toVerify = adminClient
+				.listConsumerGroupOffsets(
+						GROUP_ID,
+						new ListConsumerGroupOffsetsOptions()
+								.topicPartitions(new ArrayList<>(committedOffsets.keySet())))
+				.partitionsToOffsetAndMetadata().get();
+		assertEquals("The offsets are not committed", committedOffsets, toVerify);
+	}
+
+	public static void produceToKafka(Collection<ProducerRecord<String, Integer>> records) throws Throwable {
+		produceToKafka(records, StringSerializer.class, IntegerSerializer.class);
+	}
+
+	public static void setupTopic(
+			String topic,
+			boolean setupEarliestOffsets,
+			boolean setupCommittedOffsets) throws Throwable {
+		createTestTopic(topic);
+		produceToKafka(getRecordsForTopic(topic));
+		if (setupEarliestOffsets) {
+			setupEarliestOffsets(topic);
+		}
+		if (setupCommittedOffsets) {
+			setupCommittedOffsets(topic);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStoppingOffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link KafkaSourceEnumerator}.
+ */
+public class KafkaEnumeratorTest {
+	private static final int NUM_SUBTASKS = 3;
+	private static final String DYNAMIC_TOPIC_NAME = "dynamic_topic";
+	private static final int NUM_PARTITIONS_DYNAMIC_TOPIC = 4;
+
+	private static final String TOPIC1 = "topic";
+	private static final String TOPIC2 = "pattern-topic";
+
+	private static final int READER0 = 0;
+	private static final int READER1 = 1;
+	private static final Set<String> PRE_EXISTING_TOPICS =
+			new HashSet<>(Arrays.asList(TOPIC1, TOPIC2));
+	private static final int PARTITION_DISCOVERY_CALLABLE_INDEX = 0;
+	private static final boolean ENABLE_PERIODIC_PARTITION_DISCOVERY = true;
+	private static final boolean DISABLE_PERIODIC_PARTITION_DISCOVERY = false;
+	private static final boolean INCLUDE_DYNAMIC_TOPIC = true;
+	private static final boolean EXCLUDE_DYNAMIC_TOPIC = false;
+
+	@BeforeClass
+	public static void setup() throws Throwable {
+		KafkaSourceTestEnv.setup();
+		KafkaSourceTestEnv.setupTopic(TOPIC1, true, true);
+		KafkaSourceTestEnv.setupTopic(TOPIC2, true, true);
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		KafkaSourceTestEnv.tearDown();
+	}
+
+	@Test
+	public void testStartWithDiscoverPartitionsOnce() throws IOException {
+		MockSplitEnumeratorContext<KafkaPartitionSplit> context = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		try (KafkaSourceEnumerator enumerator = createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+			// Start the enumerator and it should schedule a one time task to discover and assign partitions.
+			enumerator.start();
+			assertTrue(context.getPeriodicCallables().isEmpty());
+			assertEquals("A one time partition discovery callable should have been scheduled",
+					1, context.getOneTimeCallables().size());
+		}
+	}
+
+	@Test
+	public void testStartWithPeriodicPartitionDiscovery() throws IOException {
+		MockSplitEnumeratorContext<KafkaPartitionSplit> context = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		try (KafkaSourceEnumerator enumerator = createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+			// Start the enumerator and it should schedule a one time task to discover and assign partitions.
+			enumerator.start();
+			assertTrue(context.getOneTimeCallables().isEmpty());
+			assertEquals("A periodic partition discovery callable should have been scheduled",
+					1, context.getPeriodicCallables().size());
+		}
+	}
+
+	@Test
+	public void testDiscoverPartitionsTriggersAssignments() throws Throwable {
+		MockSplitEnumeratorContext<KafkaPartitionSplit> context = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		try (KafkaSourceEnumerator enumerator = createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+			// Start the enumerator and it should schedule a one time task to discover and assign partitions.
+			enumerator.start();
+
+			// register reader 0.
+			registerReader(context, enumerator, READER0);
+			registerReader(context, enumerator, READER1);
+			assertTrue(context.getSplitsAssignmentSequence().isEmpty());
+
+			// Run the partition discover callable and check the partition assignment.
+			context.runNextOneTimeCallable();
+
+			// Verify assignments for reader 0.
+			verifyLastReadersAssignments(context, Arrays.asList(READER0, READER1), PRE_EXISTING_TOPICS, 1);
+		}
+	}
+
+	@Test
+	public void testReaderRegistrationTriggersAssignments() throws Throwable {
+		MockSplitEnumeratorContext<KafkaPartitionSplit> context = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		try (KafkaSourceEnumerator enumerator = createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+			// Start the enumerator and it should schedule a one time task to discover and assign partitions.
+			enumerator.start();
+			context.runNextOneTimeCallable();
+			assertTrue(context.getSplitsAssignmentSequence().isEmpty());
+
+			registerReader(context, enumerator, READER0);
+			verifyLastReadersAssignments(context, Collections.singleton(READER0), PRE_EXISTING_TOPICS, 1);
+
+			registerReader(context, enumerator, READER1);
+			verifyLastReadersAssignments(context, Collections.singleton(READER1), PRE_EXISTING_TOPICS, 2);
+		}
+	}
+
+	@Test(timeout = 30000L)
+	public void testDiscoverPartitionsPeriodically() throws Throwable {
+		MockSplitEnumeratorContext<KafkaPartitionSplit> context = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		try (KafkaSourceEnumerator enumerator =
+					createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY, INCLUDE_DYNAMIC_TOPIC);
+				AdminClient adminClient = KafkaSourceTestEnv.getAdminClient()) {
+
+			startEnumeratorAndRegisterReaders(context, enumerator);
+
+			// invoke partition discovery callable again and there should be no new assignments.
+			context.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+			assertEquals("No assignments should be made because there is no partition change",
+					2, context.getSplitsAssignmentSequence().size());
+
+			// create the dynamic topic.
+			adminClient
+					.createTopics(Collections.singleton(
+							new NewTopic(DYNAMIC_TOPIC_NAME, NUM_PARTITIONS_DYNAMIC_TOPIC, (short) 1)))
+					.all().get();
+
+			// invoke partition discovery callable again.
+			while (true) {
+				context.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+				if (context.getSplitsAssignmentSequence().size() < 3) {
+					Thread.sleep(10);
+				} else {
+					break;
+				}
+			}
+			verifyLastReadersAssignments(
+					context,
+					Arrays.asList(READER0, READER1),
+					Collections.singleton(DYNAMIC_TOPIC_NAME),
+					3);
+		} finally {
+			try (AdminClient adminClient = KafkaSourceTestEnv.getAdminClient()) {
+				adminClient.deleteTopics(Collections.singleton(DYNAMIC_TOPIC_NAME)).all().get();
+			} catch (Exception e) {
+				// Let it go.
+			}
+		}
+	}
+
+	@Test
+	public void testAddSplitsBack() throws Throwable {
+		MockSplitEnumeratorContext<KafkaPartitionSplit> context = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		try (KafkaSourceEnumerator enumerator = createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+			startEnumeratorAndRegisterReaders(context, enumerator);
+
+			// Simulate a reader failure.
+			context.unregisterReader(READER0);
+			enumerator.addSplitsBack(
+					context.getSplitsAssignmentSequence().get(0).assignment().get(READER0),
+					READER0);
+			assertEquals("The added back splits should have not been assigned",
+					2, context.getSplitsAssignmentSequence().size());
+
+			// Simulate a reader recovery.
+			registerReader(context, enumerator, READER0);
+			verifyLastReadersAssignments(context, Collections.singleton(READER0), PRE_EXISTING_TOPICS, 3);
+		}
+	}
+
+	@Test
+	public void testWorkWithPreexistingAssignments() throws Throwable {
+		final MockSplitEnumeratorContext<KafkaPartitionSplit> context1 = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		Map<Integer, Set<KafkaPartitionSplit>> preexistingAssignments;
+		try (KafkaSourceEnumerator enumerator = createEnumerator(context1, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+			startEnumeratorAndRegisterReaders(context1, enumerator);
+			preexistingAssignments = asEnumState(context1.getSplitsAssignmentSequence().get(0).assignment());
+		}
+
+		final MockSplitEnumeratorContext<KafkaPartitionSplit> context2 = new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+		try (KafkaSourceEnumerator enumerator =
+					createEnumerator(context2, ENABLE_PERIODIC_PARTITION_DISCOVERY, PRE_EXISTING_TOPICS, preexistingAssignments)) {
+			enumerator.start();
+			context2.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+
+			registerReader(context2, enumerator, READER0);
+			assertTrue(context2.getSplitsAssignmentSequence().isEmpty());
+
+			registerReader(context2, enumerator, READER1);
+			verifyLastReadersAssignments(context2, Collections.singleton(READER1), PRE_EXISTING_TOPICS, 1);
+		}
+	}
+
+	// -------------- some common startup sequence ---------------
+
+	private void startEnumeratorAndRegisterReaders(
+			MockSplitEnumeratorContext<KafkaPartitionSplit> context,
+			KafkaSourceEnumerator enumerator) throws Throwable {
+		// Start the enumerator and it should schedule a one time task to discover and assign partitions.
+		enumerator.start();
+
+		// register reader 0 before the partition discovery.
+		registerReader(context, enumerator, READER0);
+		assertTrue(context.getSplitsAssignmentSequence().isEmpty());
+
+		// Run the partition discover callable and check the partition assignment.
+		context.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+		verifyLastReadersAssignments(context, Collections.singleton(READER0), PRE_EXISTING_TOPICS, 1);
+
+		// Register reader 1 after first partition discovery.
+		registerReader(context, enumerator, READER1);
+		verifyLastReadersAssignments(context, Collections.singleton(READER1), PRE_EXISTING_TOPICS, 2);
+
+	}
+
+	// ----------------------------------------
+
+	private KafkaSourceEnumerator createEnumerator(
+			MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
+			boolean enablePeriodicPartitionDiscovery) {
+		return createEnumerator(enumContext, enablePeriodicPartitionDiscovery, EXCLUDE_DYNAMIC_TOPIC);
+	}
+
+	private KafkaSourceEnumerator createEnumerator(
+			MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
+			boolean enablePeriodicPartitionDiscovery,
+			boolean includeDynamicTopic) {
+		List<String> topics = new ArrayList<>(PRE_EXISTING_TOPICS);
+		if (includeDynamicTopic) {
+			topics.add(DYNAMIC_TOPIC_NAME);
+		}
+		return createEnumerator(enumContext, enablePeriodicPartitionDiscovery, topics, Collections.emptyMap());
+	}
+
+	/**
+	 * Create the enumerator. For the purpose of the tests in this class we don't care about
+	 * the subscriber and offsets initializer, so just use arbitrary settings.
+	 */
+	private KafkaSourceEnumerator createEnumerator(
+			MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
+			boolean enablePeriodicPartitionDiscovery,
+			Collection<String> topicsToSubscribe,
+			Map<Integer, Set<KafkaPartitionSplit>> currentAssignments) {
+		// Use a TopicPatternSubscriber so that no exception if a subscribed topic hasn't been created yet.
+		StringJoiner topicNameJoiner = new StringJoiner("|");
+		topicsToSubscribe.forEach(topicNameJoiner::add);
+		Pattern topicPattern = Pattern.compile(topicNameJoiner.toString());
+		KafkaSubscriber subscriber = KafkaSubscriber.getTopicPatternSubscriber(topicPattern);
+
+		OffsetsInitializer startingOffsetsInitializer = OffsetsInitializer.earliest();
+		OffsetsInitializer stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
+
+		Properties props = new Properties(KafkaSourceTestEnv.getConsumerProperties(StringDeserializer.class));
+		String partitionDiscoverInterval = enablePeriodicPartitionDiscovery ? "1" : "-1";
+		props.setProperty(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), partitionDiscoverInterval);
+
+		return new KafkaSourceEnumerator(
+				subscriber,
+				startingOffsetsInitializer,
+				stoppingOffsetsInitializer,
+				props,
+				enumContext,
+				currentAssignments);
+	}
+
+	// ---------------------
+
+	private void registerReader(
+			MockSplitEnumeratorContext<KafkaPartitionSplit> context,
+			KafkaSourceEnumerator enumerator,
+			int reader) {
+		context.registerReader(new ReaderInfo(reader, "location 0"));
+		enumerator.addReader(reader);
+	}
+
+	private void verifyLastReadersAssignments(
+		MockSplitEnumeratorContext<KafkaPartitionSplit> context,
+		Collection<Integer> readers,
+		Set<String> topics,
+		int expectedAssignmentSeqSize) {
+		verifyAssignments(
+				getExpectedAssignments(new HashSet<>(readers), topics),
+				context.getSplitsAssignmentSequence().get(expectedAssignmentSeqSize - 1).assignment());
+	}
+
+	private void verifyAssignments(
+			Map<Integer, Set<TopicPartition>> expectedAssignments,
+			Map<Integer, List<KafkaPartitionSplit>> actualAssignments) {
+		actualAssignments.forEach((reader, splits) -> {
+			Set<TopicPartition> expectedAssignmentsForReader = expectedAssignments.get(reader);
+			assertNotNull(expectedAssignmentsForReader);
+			assertEquals(expectedAssignmentsForReader.size(), splits.size());
+			for (KafkaPartitionSplit split : splits) {
+				assertTrue(expectedAssignmentsForReader.contains(split.getTopicPartition()));
+			}
+		});
+	}
+
+	private Map<Integer, Set<TopicPartition>> getExpectedAssignments(
+			Set<Integer> readers,
+			Set<String> topics) {
+		Map<Integer, Set<TopicPartition>> expectedAssignments = new HashMap<>();
+		Set<TopicPartition> allPartitions = new HashSet<>();
+
+		if (topics.contains(DYNAMIC_TOPIC_NAME)) {
+			for (int i = 0; i < NUM_PARTITIONS_DYNAMIC_TOPIC; i++) {
+				allPartitions.add(new TopicPartition(DYNAMIC_TOPIC_NAME, i));
+			}
+		}
+
+		for (TopicPartition tp : KafkaSourceTestEnv.getPartitionsForTopics(PRE_EXISTING_TOPICS)) {
+			if (topics.contains(tp.topic())) {
+				allPartitions.add(tp);
+			}
+		}
+
+		for (TopicPartition tp : allPartitions) {
+			int ownerReader = KafkaSourceEnumerator.getSplitOwner(tp, NUM_SUBTASKS);
+			if (readers.contains(ownerReader)) {
+				expectedAssignments.computeIfAbsent(ownerReader, r -> new HashSet<>()).add(tp);
+			}
+		}
+		return expectedAssignments;
+	}
+
+	private Map<Integer, Set<KafkaPartitionSplit>> asEnumState(Map<Integer, List<KafkaPartitionSplit>> assignments) {
+		Map<Integer, Set<KafkaPartitionSplit>> enumState = new HashMap<>();
+		assignments.forEach((reader, assignment) -> enumState.put(reader, new HashSet<>(assignment)));
+		return enumState;
+	}
+
+	// -------------- private class ----------------
+
+	private static class BlockingClosingContext extends MockSplitEnumeratorContext<KafkaPartitionSplit> {
+
+		public BlockingClosingContext(int parallelism) {
+			super(parallelism);
+		}
+
+		@Override
+		public void close() {
+			try {
+				Thread.sleep(Long.MAX_VALUE);
+			} catch (InterruptedException e) {
+				// let it go.
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+import org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumerator;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link OffsetsInitializer}.
+ */
+public class OffsetsInitializerTest {
+	private static final String TOPIC = "topic";
+	private static KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl retriever;
+
+	@BeforeClass
+	public static void setup() throws Throwable {
+		KafkaSourceTestEnv.setup();
+		KafkaSourceTestEnv.setupTopic(TOPIC, true, true);
+		retriever = new KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl(
+				KafkaSourceTestEnv.getConsumer(),
+				KafkaSourceTestEnv.getAdminClient(),
+				KafkaSourceTestEnv.GROUP_ID);
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		retriever.close();
+		KafkaSourceTestEnv.tearDown();
+	}
+
+	@Test
+	public void testEarliestOffsetsInitializer() {
+		OffsetsInitializer initializer = OffsetsInitializer.earliest();
+		List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
+		Map<TopicPartition, Long> offsets =
+				initializer.getPartitionOffsets(partitions, retriever);
+		assertEquals(partitions.size(), offsets.size());
+		assertTrue(offsets.keySet().containsAll(partitions));
+		for (long offset : offsets.values()) {
+			Assert.assertEquals(KafkaPartitionSplit.EARLIEST_OFFSET, offset);
+		}
+		assertEquals(OffsetResetStrategy.EARLIEST, initializer.getAutoOffsetResetStrategy());
+	}
+
+	@Test
+	public void testLatestOffsetsInitializer() {
+		OffsetsInitializer initializer = OffsetsInitializer.latest();
+		List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
+		Map<TopicPartition, Long> offsets =
+				initializer.getPartitionOffsets(partitions, retriever);
+		assertEquals(partitions.size(), offsets.size());
+		assertTrue(offsets.keySet().containsAll(partitions));
+		for (long offset : offsets.values()) {
+			assertEquals(KafkaPartitionSplit.LATEST_OFFSET, offset);
+		}
+		assertEquals(OffsetResetStrategy.LATEST, initializer.getAutoOffsetResetStrategy());
+	}
+
+	@Test
+	public void testCommittedGroupOffsetsInitializer() {
+		OffsetsInitializer initializer = OffsetsInitializer.committedOffsets();
+		List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
+		Map<TopicPartition, Long> offsets =
+				initializer.getPartitionOffsets(partitions, retriever);
+		assertEquals(partitions.size(), offsets.size());
+		offsets.forEach((tp, offset) ->
+				assertEquals(KafkaPartitionSplit.COMMITTED_OFFSET, (long) offset));
+		assertEquals(OffsetResetStrategy.NONE, initializer.getAutoOffsetResetStrategy());
+	}
+
+	@Test
+	public void testTimestampOffsetsInitializer() {
+		OffsetsInitializer initializer = OffsetsInitializer.timestamp(2001);
+		List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
+		Map<TopicPartition, Long> offsets =
+				initializer.getPartitionOffsets(partitions, retriever);
+		offsets.forEach((tp, offset) -> {
+			long expectedOffset = tp.partition() > 2 ? tp.partition() : 3L;
+			assertEquals(expectedOffset, (long) offset);
+		});
+		assertEquals(OffsetResetStrategy.NONE, initializer.getAutoOffsetResetStrategy());
+	}
+
+	@Test
+	public void testSpecificOffsetsInitializer() {
+		Map<TopicPartition, Long> specifiedOffsets = new HashMap<>();
+		List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
+		Map<TopicPartition, OffsetAndMetadata> committedOffsets = KafkaSourceTestEnv.getCommittedOffsets(partitions);
+		committedOffsets.forEach((tp, oam) -> specifiedOffsets.put(tp, oam.offset()));
+		// Remove the specified offsets for partition 0.
+		TopicPartition missingPartition = new TopicPartition(TOPIC, 0);
+		specifiedOffsets.remove(missingPartition);
+		OffsetsInitializer initializer = OffsetsInitializer.offsets(specifiedOffsets);
+
+		assertEquals(OffsetResetStrategy.EARLIEST, initializer.getAutoOffsetResetStrategy());
+
+		Map<TopicPartition, Long> offsets =
+				initializer.getPartitionOffsets(partitions, retriever);
+		for (TopicPartition tp : partitions) {
+			Long offset = offsets.get(tp);
+			long expectedOffset = tp.equals(missingPartition) ? 0L : committedOffsets.get(tp).offset();
+			assertEquals(String.format("%s has incorrect offset.", tp), expectedOffset, (long) offset);
+		}
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testSpecifiedOffsetsInitializerWithoutOffsetResetStrategy() {
+		OffsetsInitializer initializer = OffsetsInitializer.offsets(Collections.emptyMap(), OffsetResetStrategy.NONE);
+		initializer.getPartitionOffsets(KafkaSourceTestEnv.getPartitionsForTopic(TOPIC), retriever);
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.subscriber;
+
+import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link KafkaSubscriber}.
+ */
+public class KafkaSubscriberTest {
+	private static final String TOPIC1 = "topic1";
+	private static final String TOPIC2 = "pattern-topic";
+	private static final TopicPartition assignedPartition1 = new TopicPartition(TOPIC1, 2);
+	private static final TopicPartition assignedPartition2 = new TopicPartition(TOPIC2, 2);
+	private static final TopicPartition removedPartition = new TopicPartition("removed", 0);
+	private static final Set<TopicPartition> currentAssignment =
+			new HashSet<>(Arrays.asList(assignedPartition1, assignedPartition2, removedPartition));
+	private static AdminClient adminClient;
+
+	@BeforeClass
+	public static void setup() throws Throwable {
+		KafkaSourceTestEnv.setup();
+		KafkaSourceTestEnv.createTestTopic(TOPIC1);
+		KafkaSourceTestEnv.createTestTopic(TOPIC2);
+		adminClient = KafkaSourceTestEnv.getAdminClient();
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		adminClient.close();
+		KafkaSourceTestEnv.tearDown();
+	}
+
+	@Test
+	public void testTopicListSubscriber() {
+		List<String> topics = Arrays.asList(TOPIC1, TOPIC2);
+		KafkaSubscriber subscriber =
+				KafkaSubscriber.getTopicListSubscriber(Arrays.asList(TOPIC1, TOPIC2));
+		KafkaSubscriber.PartitionChange change =
+				subscriber.getPartitionChanges(adminClient, currentAssignment);
+		Set<TopicPartition> expectedNewPartitions = new HashSet<>(KafkaSourceTestEnv.getPartitionsForTopics(topics));
+		expectedNewPartitions.remove(assignedPartition1);
+		expectedNewPartitions.remove(assignedPartition2);
+		assertEquals(expectedNewPartitions, change.getNewPartitions());
+		assertEquals(Collections.singleton(removedPartition), change.getRemovedPartitions());
+	}
+
+	@Test
+	public void testTopicPatternSubscriber() {
+		KafkaSubscriber subscriber = KafkaSubscriber.getTopicPatternSubscriber(Pattern.compile("pattern.*"));
+		KafkaSubscriber.PartitionChange change =
+				subscriber.getPartitionChanges(adminClient, currentAssignment);
+
+		Set<TopicPartition> expectedNewPartitions = new HashSet<>();
+		for (int i = 0; i < KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION; i++) {
+			if (i != assignedPartition2.partition()) {
+				expectedNewPartitions.add(new TopicPartition(TOPIC2, i));
+			}
+		}
+		Set<TopicPartition> expectedRemovedPartitions =
+				new HashSet<>(Arrays.asList(assignedPartition1, removedPartition));
+
+		assertEquals(expectedNewPartitions, change.getNewPartitions());
+		assertEquals(expectedRemovedPartitions, change.getRemovedPartitions());
+	}
+
+	@Test
+	public void testPartitionSetSubscriber() {
+		List<String> topics = Arrays.asList(TOPIC1, TOPIC2);
+		Set<TopicPartition> partitions = new HashSet<>(KafkaSourceTestEnv.getPartitionsForTopics(topics));
+		partitions.remove(new TopicPartition(TOPIC1, 1));
+
+		KafkaSubscriber subscriber = KafkaSubscriber.getPartitionSetSubscriber(partitions);
+		KafkaSubscriber.PartitionChange change =
+				subscriber.getPartitionChanges(adminClient, currentAssignment);
+
+		Set<TopicPartition> expectedNewPartitions = new HashSet<>(partitions);
+		expectedNewPartitions.remove(assignedPartition1);
+		expectedNewPartitions.remove(assignedPartition2);
+		assertEquals(expectedNewPartitions, change.getNewPartitions());
+		assertEquals(Collections.singleton(removedPartition), change.getRemovedPartitions());
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link KafkaPartitionSplitReader}.
+ */
+public class KafkaPartitionSplitReaderTest {
+	private static final int NUM_SUBTASKS = 3;
+	private static final String TOPIC1 = "topic1";
+	private static final String TOPIC2 = "topic2";
+
+	private static Map<Integer, Map<String, KafkaPartitionSplit>> splitsByOwners;
+	private static Map<TopicPartition, Long> earliestOffsets;
+
+	@BeforeClass
+	public static void setup() throws Throwable {
+		KafkaSourceTestEnv.setup();
+		KafkaSourceTestEnv.setupTopic(TOPIC1, true, true);
+		KafkaSourceTestEnv.setupTopic(TOPIC2, true, true);
+		splitsByOwners = KafkaSourceTestEnv.getSplitsByOwners(Arrays.asList(TOPIC1, TOPIC2), NUM_SUBTASKS);
+		earliestOffsets = KafkaSourceTestEnv
+				.getEarliestOffsets(KafkaSourceTestEnv.getPartitionsForTopics(Arrays.asList(TOPIC1, TOPIC2)));
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		KafkaSourceTestEnv.tearDown();
+	}
+
+	@Test
+	public void testHandleSplitChangesAndFetch() throws IOException {
+		KafkaPartitionSplitReader<Integer> reader = createReader();
+		assignSplitsAndFetchUntilFinish(reader, 0);
+		assignSplitsAndFetchUntilFinish(reader, 1);
+	}
+
+	@Test
+	public void testWakeUp() throws InterruptedException {
+		KafkaPartitionSplitReader<Integer> reader = createReader();
+		TopicPartition nonExistingTopicPartition = new TopicPartition("NotExist", 0);
+		assignSplits(
+				reader,
+				Collections.singletonMap(
+						KafkaPartitionSplit.toSplitId(nonExistingTopicPartition),
+						new KafkaPartitionSplit(nonExistingTopicPartition, 0)));
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		Thread t = new Thread(() -> {
+			try {
+				reader.fetch();
+			} catch (Throwable e) {
+				error.set(e);
+			}
+		}, "testWakeUp-thread");
+		t.start();
+		long deadline = System.currentTimeMillis() + 5000L;
+		while (t.isAlive() && System.currentTimeMillis() < deadline) {
+			reader.wakeUp();
+			Thread.sleep(10);
+		}
+		assertNull(error.get());
+	}
+
+	// ------------------
+
+	private void assignSplitsAndFetchUntilFinish(KafkaPartitionSplitReader<Integer> reader, int readerId)
+			throws IOException {
+		Map<String, KafkaPartitionSplit> splits = assignSplits(reader, splitsByOwners.get(readerId));
+
+		Map<String, Integer> numConsumedRecords = new HashMap<>();
+		Set<String> finishedSplits = new HashSet<>();
+		while (finishedSplits.size() < splits.size()) {
+			RecordsWithSplitIds<Tuple3<Integer, Long, Long>> recordsBySplitIds = reader.fetch();
+			String splitId = recordsBySplitIds.nextSplit();
+			while (splitId != null) {
+				// Collect the records in this split.
+				List<Tuple3<Integer, Long, Long>> splitFetch = new ArrayList<>();
+				Tuple3<Integer, Long, Long> record;
+				while ((record = recordsBySplitIds.nextRecordFromSplit()) != null) {
+					splitFetch.add(record);
+				}
+
+				// Compute the expected next offset for the split.
+				TopicPartition tp = splits.get(splitId).getTopicPartition();
+				long earliestOffset = earliestOffsets.get(tp);
+				int numConsumedRecordsForSplit = numConsumedRecords.getOrDefault(splitId, 0);
+				long expectedStartingOffset = earliestOffset + numConsumedRecordsForSplit;
+
+				// verify the consumed records.
+				if (verifyConsumed(splits.get(splitId), expectedStartingOffset, splitFetch)) {
+					finishedSplits.add(splitId);
+				}
+				numConsumedRecords.compute(splitId, (ignored, recordCount) ->
+														recordCount == null ? splitFetch.size() : recordCount + splitFetch.size());
+				splitId = recordsBySplitIds.nextSplit();
+			}
+		}
+
+		// Verify the number of records consumed from each split.
+		numConsumedRecords.forEach((splitId, recordCount) -> {
+			TopicPartition tp = splits.get(splitId).getTopicPartition();
+			long earliestOffset = earliestOffsets.get(tp);
+			long expectedRecordCount = KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION - earliestOffset;
+			assertEquals(String.format("%s should have %d records.", splits.get(splitId), expectedRecordCount),
+					expectedRecordCount, (long) recordCount);
+		});
+	}
+
+	// ------------------
+
+	private KafkaPartitionSplitReader<Integer> createReader() {
+		Properties props = new Properties();
+		props.putAll(KafkaSourceTestEnv.getConsumerProperties(ByteArrayDeserializer.class));
+		props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+		return new KafkaPartitionSplitReader<>(
+				props,
+				KafkaRecordDeserializer.valueOnly(IntegerDeserializer.class),
+				0);
+	}
+
+	private Map<String, KafkaPartitionSplit> assignSplits(
+			KafkaPartitionSplitReader<Integer> reader,
+			Map<String, KafkaPartitionSplit> splits) {
+		SplitsChange<KafkaPartitionSplit> splitsChange = new SplitsAddition<>(new ArrayList<>(splits.values()));
+		reader.handleSplitsChanges(splitsChange);
+		return splits;
+	}
+
+	private boolean verifyConsumed(
+			final KafkaPartitionSplit split,
+			final long expectedStartingOffset,
+			final Collection<Tuple3<Integer, Long, Long>> consumed) {
+		long expectedOffset = expectedStartingOffset;
+
+		for (Tuple3<Integer, Long, Long> record : consumed) {
+			int expectedValue = (int) expectedOffset;
+			long expectedTimestamp = expectedOffset * 1000L;
+
+			assertEquals(expectedValue, (int) record.f0);
+			assertEquals(expectedOffset, (long) record.f1);
+			assertEquals(expectedTimestamp, (long) record.f2);
+
+			expectedOffset++;
+		}
+		if (split.getStoppingOffset().isPresent()) {
+			return expectedOffset == split.getStoppingOffset().get();
+		} else {
+			return false;
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
+import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.testutils.source.reader.SourceReaderTestBase;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link KafkaSourceReader}.
+ */
+public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSplit> {
+	private static final String TOPIC = "KafkaSourceReaderTest";
+	private static final String GROUP_ID = "KafkaSourceReaderTestConsumerGroup";
+
+	@BeforeClass
+	public static void setup() throws Throwable {
+		KafkaSourceTestEnv.setup();
+		try (AdminClient adminClient = KafkaSourceTestEnv.getAdminClient()) {
+			adminClient.createTopics(Collections.singleton(new NewTopic(TOPIC, NUM_SPLITS, (short) 1)));
+		}
+		KafkaSourceTestEnv.produceToKafka(getRecords(), StringSerializer.class, IntegerSerializer.class);
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		KafkaSourceTestEnv.tearDown();
+	}
+
+	// -----------------------------------------
+
+	@Test
+	public void testOffsetCommitOnCheckpointComplete() throws Exception {
+		try (KafkaSourceReader<Integer> reader =
+				(KafkaSourceReader<Integer>) createReader(Boundedness.CONTINUOUS_UNBOUNDED)) {
+			reader.addSplits(getSplits(NUM_SPLITS, NUM_RECORDS_PER_SPLIT, Boundedness.CONTINUOUS_UNBOUNDED));
+			ValidatingSourceOutput output = new ValidatingSourceOutput();
+			long checkpointId = 0;
+			do {
+				checkpointId++;
+				reader.pollNext(output);
+				// Create a checkpoint for each message consumption, but not complete them.
+				reader.snapshotState(checkpointId);
+			} while (output.count() < TOTAL_NUM_RECORDS);
+
+			// The completion of the last checkpoint should subsume all the previous checkpoitns.
+			assertEquals(checkpointId, reader.getOffsetsToCommit().size());
+			reader.notifyCheckpointComplete(checkpointId);
+		}
+
+		// Verify the committed offsets.
+		try (AdminClient adminClient = KafkaSourceTestEnv.getAdminClient()) {
+			Map<TopicPartition, OffsetAndMetadata> committedOffsets =
+				adminClient.listConsumerGroupOffsets(GROUP_ID).partitionsToOffsetAndMetadata().get();
+			assertEquals(NUM_SPLITS, committedOffsets.size());
+			committedOffsets.forEach(
+				(tp, offsetAndMetadata) -> assertEquals(NUM_RECORDS_PER_SPLIT, offsetAndMetadata.offset()));
+		}
+	}
+
+	// ------------------------------------------
+
+	@Override
+	protected SourceReader<Integer, KafkaPartitionSplit> createReader() {
+		return createReader(Boundedness.BOUNDED);
+	}
+
+	@Override
+	protected List<KafkaPartitionSplit> getSplits(int numSplits, int numRecordsPerSplit, Boundedness boundedness) {
+		List<KafkaPartitionSplit> splits = new ArrayList<>();
+		for (int i = 0; i < numRecordsPerSplit; i++) {
+			splits.add(getSplit(i, numRecordsPerSplit, boundedness));
+		}
+		return splits;
+	}
+
+	@Override
+	protected KafkaPartitionSplit getSplit(int splitId, int numRecords, Boundedness boundedness) {
+		long stoppingOffset =
+				boundedness == Boundedness.BOUNDED ? NUM_RECORDS_PER_SPLIT : KafkaPartitionSplit.NO_STOPPING_OFFSET;
+		return new KafkaPartitionSplit(
+				new TopicPartition(TOPIC, splitId),
+				0L,
+				stoppingOffset);
+	}
+
+	@Override
+	protected long getNextRecordIndex(KafkaPartitionSplit split) {
+		return split.getStartingOffset();
+	}
+
+	// ---------------------
+
+	private SourceReader<Integer, KafkaPartitionSplit> createReader(Boundedness boundedness) {
+		KafkaSourceBuilder<Integer> builder = KafkaSource.<Integer>builder()
+			.setClientIdPrefix("KafkaSourceReaderTest")
+			.setDeserializer(KafkaRecordDeserializer.valueOnly(IntegerDeserializer.class))
+			.setPartitions(Collections.singleton(new TopicPartition("AnyTopic", 0)))
+			.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaSourceTestEnv.brokerConnectionStrings)
+			.setProperty(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+
+		if (boundedness == Boundedness.BOUNDED) {
+			builder.setBounded(OffsetsInitializer.latest());
+		}
+
+		return builder.build().createReader(new SourceReaderContext() {
+			@Override
+			public MetricGroup metricGroup() {
+				return new UnregisteredMetricsGroup();
+			}
+
+			@Override
+			public Configuration getConfiguration() {
+				return null;
+			}
+
+			@Override
+			public String getLocalHostName() {
+				return null;
+			}
+
+			@Override
+			public int getIndexOfSubtask() {
+				return 0;
+			}
+
+			@Override
+			public void sendSourceEventToCoordinator(SourceEvent sourceEvent) {
+
+			}
+		});
+	}
+
+	// ---------------------
+
+	private static List<ProducerRecord<String, Integer>> getRecords() {
+		List<ProducerRecord<String, Integer>> records = new ArrayList<>();
+		for (int part = 0; part < NUM_SPLITS; part++) {
+			for (int i = 0; i < NUM_RECORDS_PER_SPLIT; i++) {
+				records.add(new ProducerRecord<>(
+						TOPIC,
+						part,
+						TOPIC + "-" + part,
+						part * NUM_RECORDS_PER_SPLIT + i));
+			}
+		}
+		return records;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/ComponentClosingUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ComponentClosingUtils.java
@@ -1,0 +1,117 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A util class to help with a clean component shutdown.
+ */
+public class ComponentClosingUtils {
+	private static final Logger LOG = LoggerFactory.getLogger(ComponentClosingUtils.class);
+	// A shared watchdog executor to handle the timeout closing.
+	private static final ScheduledExecutorService watchDog =
+			Executors.newSingleThreadScheduledExecutor((ThreadFactory) r -> {
+				Thread t = new Thread(r, "ComponentClosingUtil");
+				t.setUncaughtExceptionHandler((thread, exception) -> {
+					LOG.error("FATAL: The component closing util thread caught exception ", exception);
+					System.exit(-17);
+				});
+				return t;
+			});
+
+	private ComponentClosingUtils() {}
+
+	/**
+	 * Close a component with a timeout.
+	 *
+	 * @param componentName the name of the component.
+	 * @param closingSequence the closing logic which is a callable that can throw exceptions.
+	 * @param closeTimeoutMs the timeout in milliseconds to waif for the component to close.
+	 * @return An optional throwable which is non-empty if an error occurred when closing the component.
+	 */
+	public static CompletableFuture<Void> closeAsyncWithTimeout(
+			String componentName,
+			ThrowingRunnable<Exception> closingSequence,
+			long closeTimeoutMs) {
+		return closeAsyncWithTimeout(
+				componentName,
+				(Runnable) () -> {
+					try {
+						closingSequence.run();
+					} catch (Exception e) {
+						throw new ClosingException(componentName, e);
+					}
+				}, closeTimeoutMs);
+	}
+
+	/**
+	 * Close a component with a timeout.
+	 *
+	 * @param componentName the name of the component.
+	 * @param closingSequence the closing logic.
+	 * @param closeTimeoutMs the timeout in milliseconds to waif for the component to close.
+	 * @return An optional throwable which is non-empty if an error occurred when closing the component.
+	 */
+	public static CompletableFuture<Void> closeAsyncWithTimeout(
+			String componentName,
+			Runnable closingSequence,
+			long closeTimeoutMs) {
+		final CompletableFuture<Void> future = new CompletableFuture<>();
+		// Start a dedicate thread to close the component.
+		Thread t = new Thread(() -> {
+			closingSequence.run();
+			future.complete(null);
+		});
+		// Use uncaught exception handler to handle exceptions during closing.
+		t.setUncaughtExceptionHandler((thread, error) -> future.completeExceptionally(error));
+		t.start();
+		// Schedule a watch dog job to the watching executor to detect timeout when
+		// closing the component.
+		watchDog.schedule(() -> {
+				if (t.isAlive()) {
+					t.interrupt();
+					future.completeExceptionally(new TimeoutException(
+							String.format("Failed to close the %s before timeout of %d milliseconds",
+									componentName, closeTimeoutMs)));
+				}
+			}, closeTimeoutMs, TimeUnit.MILLISECONDS);
+		return future;
+	}
+
+	// ---------------------------
+
+	private static class ClosingException extends RuntimeException {
+		private static final long serialVersionUID = 2527474477287706295L;
+
+		private ClosingException(String componentName, Exception e) {
+			super(String.format("Caught exception when closing %s", componentName), e);
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
@@ -1,0 +1,249 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source.mocks;
+
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.util.ThrowableCatchingRunnable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+/**
+ * A mock class for {@link SplitEnumeratorContext}.
+ */
+public class MockSplitEnumeratorContext<SplitT extends SourceSplit> implements SplitEnumeratorContext<SplitT> {
+	private final Map<Integer, List<SourceEvent>> sentSourceEvent;
+	private final ConcurrentMap<Integer, ReaderInfo> registeredReaders;
+	private final List<SplitsAssignment<SplitT>> splitsAssignmentSequence;
+	private final ExecutorService workerExecutor;
+	private final ExecutorService mainExecutor;
+	private final TestingExecutorThreadFactory mainThreadFactory;
+	private final AtomicReference<Throwable> errorInWorkerThread;
+	private final AtomicReference<Throwable> errorInMainThread;
+	private final BlockingQueue<Callable<Future<?>>> oneTimeCallables;
+	private final List<Callable<Future<?>>> periodicCallables;
+	private final AtomicBoolean stoppedAcceptAsyncCalls;
+
+	private final int parallelism;
+
+	public MockSplitEnumeratorContext(int parallelism) {
+		this.sentSourceEvent = new HashMap<>();
+		this.registeredReaders = new ConcurrentHashMap<>();
+		this.splitsAssignmentSequence = new ArrayList<>();
+		this.parallelism = parallelism;
+		this.errorInWorkerThread = new AtomicReference<>();
+		this.errorInMainThread = new AtomicReference<>();
+		this.oneTimeCallables = new ArrayBlockingQueue<>(100);
+		this.periodicCallables = Collections.synchronizedList(new ArrayList<>());
+		this.mainThreadFactory = getThreadFactory("SplitEnumerator-main", errorInMainThread);
+		this.workerExecutor = getExecutor(getThreadFactory("SplitEnumerator-worker", errorInWorkerThread));
+		this.mainExecutor = getExecutor(mainThreadFactory);
+		this.stoppedAcceptAsyncCalls = new AtomicBoolean(false);
+	}
+
+	@Override
+	public MetricGroup metricGroup() {
+		return new UnregisteredMetricsGroup();
+	}
+
+	@Override
+	public void sendEventToSourceReader(int subtaskId, SourceEvent event) {
+		try {
+			if (!mainThreadFactory.isCurrentThreadMainExecutorThread()) {
+				mainExecutor.submit(() ->
+						sentSourceEvent.computeIfAbsent(subtaskId, id -> new ArrayList<>()).add(event)).get();
+			} else {
+				sentSourceEvent.computeIfAbsent(subtaskId, id -> new ArrayList<>()).add(event);
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to assign splits", e);
+		}
+	}
+
+	@Override
+	public int currentParallelism() {
+		return parallelism;
+	}
+
+	@Override
+	public Map<Integer, ReaderInfo> registeredReaders() {
+		return registeredReaders;
+	}
+
+	@Override
+	public void assignSplits(SplitsAssignment<SplitT> newSplitAssignments) {
+		splitsAssignmentSequence.add(newSplitAssignments);
+	}
+
+	@Override
+	public <T> void callAsync(Callable<T> callable, BiConsumer<T, Throwable> handler) {
+		if (stoppedAcceptAsyncCalls.get()) {
+			return;
+		}
+		oneTimeCallables.add(() ->
+				workerExecutor.submit(wrap(errorInWorkerThread, () -> {
+					try {
+						T result = callable.call();
+						mainExecutor.submit(wrap(errorInMainThread, () -> handler.accept(result, null))).get();
+					} catch (Throwable t) {
+						handler.accept(null, t);
+					}
+				})));
+	}
+
+	@Override
+	public <T> void callAsync(Callable<T> callable, BiConsumer<T, Throwable> handler, long initialDelay, long period) {
+		if (stoppedAcceptAsyncCalls.get()) {
+			return;
+		}
+		periodicCallables.add(() ->
+				workerExecutor.submit(wrap(errorInWorkerThread, () -> {
+					try {
+						T result = callable.call();
+						mainExecutor.submit(wrap(errorInMainThread, () -> handler.accept(result, null))).get();
+					} catch (Throwable t) {
+						handler.accept(null, t);
+					}
+				})));
+	}
+
+	public void close() {
+		stoppedAcceptAsyncCalls.set(true);
+	}
+
+	// ------------ helper method to manipulate the context -------------
+
+	public void runNextOneTimeCallable() throws Throwable {
+		oneTimeCallables.take().call().get();
+		checkError();
+	}
+
+	public void runPeriodicCallable(int index) throws Throwable {
+		periodicCallables.get(index).call().get();
+		checkError();
+	}
+
+	public Map<Integer, List<SourceEvent>> getSentSourceEvent() throws Exception {
+		return workerExecutor.submit(() -> new HashMap<>(sentSourceEvent)).get();
+	}
+
+	public void registerReader(ReaderInfo readerInfo) {
+		registeredReaders.put(readerInfo.getSubtaskId(), readerInfo);
+	}
+
+	public void unregisterReader(int readerId) {
+		registeredReaders.remove(readerId);
+	}
+
+	public List<Callable<Future<?>>> getPeriodicCallables() {
+		return periodicCallables;
+	}
+
+	public BlockingQueue<Callable<Future<?>>> getOneTimeCallables() {
+		return oneTimeCallables;
+	}
+
+	public List<SplitsAssignment<SplitT>> getSplitsAssignmentSequence() {
+		return splitsAssignmentSequence;
+	}
+
+	// ------------- private helpers -------------
+
+	private void checkError() throws Throwable {
+		if (errorInMainThread.get() != null) {
+			throw errorInMainThread.get();
+		}
+		if (errorInWorkerThread.get() != null) {
+			throw errorInWorkerThread.get();
+		}
+	}
+
+	private static TestingExecutorThreadFactory getThreadFactory(String threadName, AtomicReference<Throwable> error) {
+		return new TestingExecutorThreadFactory(threadName, error);
+	}
+
+	private static ExecutorService getExecutor(TestingExecutorThreadFactory threadFactory) {
+		return Executors.newSingleThreadScheduledExecutor(threadFactory);
+	}
+
+	private static ThrowableCatchingRunnable wrap(AtomicReference<Throwable> error, Runnable r) {
+		return new ThrowableCatchingRunnable(t -> {
+			if (!error.compareAndSet(null, t)) {
+				error.get().addSuppressed(t);
+			}
+		}, r);
+	}
+
+	// -------- private class -----------
+
+	/**
+	 * A thread factory class that provides some helper methods.
+	 */
+	public static class TestingExecutorThreadFactory implements ThreadFactory {
+		private final String coordinatorThreadName;
+		private final AtomicReference<Throwable> error;
+		private Thread t;
+
+		TestingExecutorThreadFactory(String coordinatorThreadName, AtomicReference<Throwable> error) {
+			this.coordinatorThreadName = coordinatorThreadName;
+			this.error = error;
+			this.t = null;
+		}
+
+		@Override
+		public Thread newThread(Runnable r) {
+			if (t != null) {
+				throw new IllegalStateException("Should never happen. This factory should only be used by a " +
+						"SingleThreadExecutor.");
+			}
+			t = new Thread(r, coordinatorThreadName);
+			t.setUncaughtExceptionHandler((t1, e) -> {
+				if (!error.compareAndSet(null, e)) {
+					error.get().addSuppressed(e);
+				}
+			});
+			return t;
+		}
+
+		boolean isCurrentThreadMainExecutorThread() {
+			return Thread.currentThread() == t;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -21,30 +21,46 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.util.function.ThrowingConsumer;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.apache.flink.util.ComponentClosingUtils.closeAsyncWithTimeout;
 
 /**
  * A class that will recreate a new {@link OperatorCoordinator} instance when
  * reset to checkpoint.
  */
 public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
-
+	private static final Logger LOG = LoggerFactory.getLogger(RecreateOnResetOperatorCoordinator.class);
+	private static final long CLOSING_TIMEOUT_MS = 60000L;
 	private final Provider provider;
-	private QuiesceableContext quiesceableContext;
-	private OperatorCoordinator coordinator;
-
-	private boolean started;
+	private final long closingTimeoutMs;
+	private final OperatorCoordinator.Context context;
+	private DeferrableCoordinator coordinator;
+	private volatile boolean started;
+	private volatile boolean closed;
 
 	private RecreateOnResetOperatorCoordinator(
-			QuiesceableContext context,
-			Provider provider) throws Exception {
-		this.quiesceableContext = context;
+			OperatorCoordinator.Context context,
+			Provider provider,
+			long closingTimeoutMs) throws Exception {
+		this.context = context;
 		this.provider = provider;
-		this.coordinator = provider.getCoordinator(context);
+		this.coordinator = new DeferrableCoordinator(context.getOperatorId());
+		this.coordinator.createNewInternalCoordinator(context, provider);
+		this.coordinator.processPendingCalls();
+		this.closingTimeoutMs = closingTimeoutMs;
 		this.started = false;
+		this.closed = false;
 	}
 
 	@Override
@@ -55,55 +71,80 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 
 	@Override
 	public void close() throws Exception {
-		coordinator.close();
+		closed = true;
+		coordinator.closeAsync(closingTimeoutMs);
 	}
 
 	@Override
 	public void handleEventFromOperator(int subtask, OperatorEvent event) throws Exception {
-		coordinator.handleEventFromOperator(subtask, event);
+		coordinator.applyCall(
+				"handleEventFromOperator",
+				c -> c.handleEventFromOperator(subtask, event));
 	}
 
 	@Override
 	public void subtaskFailed(int subtask, @Nullable Throwable reason) {
-		coordinator.subtaskFailed(subtask, reason);
+		coordinator.applyCall(
+				"subtaskFailed",
+				c -> c.subtaskFailed(subtask, reason));
 	}
 
 	@Override
 	public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> resultFuture) throws Exception {
-		coordinator.checkpointCoordinator(checkpointId, resultFuture);
+		coordinator.applyCall(
+				"checkpointCoordinator",
+				c -> c.checkpointCoordinator(checkpointId, resultFuture));
 	}
 
 	@Override
 	public void notifyCheckpointComplete(long checkpointId) {
-		coordinator.notifyCheckpointComplete(checkpointId);
+		coordinator.applyCall(
+				"checkpointComplete",
+				c -> c.notifyCheckpointComplete(checkpointId));
 	}
 
 	@Override
 	public void resetToCheckpoint(byte[] checkpointData) throws Exception {
-		// Quiesce the context so the coordinator cannot interact with the job master anymore.
-		quiesceableContext.quiesce();
-		// Close the coordinator.
-		coordinator.close();
-		// Create a new coordinator and reset to the checkpoint.
-		quiesceableContext = new QuiesceableContext(quiesceableContext.getContext());
-		coordinator = provider.getCoordinator(quiesceableContext);
-		coordinator.resetToCheckpoint(checkpointData);
-		// Start the new coordinator if this coordinator has been started before reset to the checkpoint.
-		if (started) {
-			coordinator.start();
-		}
+		// First bump up the coordinator epoch to fence out the active coordinator.
+		LOG.info("Resetting coordinator to checkpoint.");
+		// Replace the coordinator variable with a new DeferrableCoordinator instance.
+		// At this point the internal coordinator of the new coordinator has not been created.
+		// After this point all the subsequent calls will be made to the new coordinator.
+		final DeferrableCoordinator oldCoordinator = coordinator;
+		final DeferrableCoordinator newCoordinator =
+			new DeferrableCoordinator(context.getOperatorId());
+		coordinator = newCoordinator;
+		// Close the old coordinator asynchronously in a separate closing thread.
+		// The future will be completed when the old coordinator closes.
+		CompletableFuture<Void> closingFuture = oldCoordinator.closeAsync(closingTimeoutMs);
+		// Create and
+		closingFuture.thenRun(() -> {
+			if (!closed) {
+				// The previous coordinator has closed. Create a new one.
+				newCoordinator.createNewInternalCoordinator(context, provider);
+				newCoordinator.resetAndStart(checkpointData, started);
+				newCoordinator.processPendingCalls();
+			}
+		});
 	}
 
 	// ---------------------
 
 	@VisibleForTesting
 	public OperatorCoordinator getInternalCoordinator() {
-		return coordinator;
+		return coordinator.internalCoordinator;
 	}
 
 	@VisibleForTesting
 	QuiesceableContext getQuiesceableContext() {
-		return quiesceableContext;
+		return coordinator.internalQuiesceableContext;
+	}
+
+	@VisibleForTesting
+	void waitForAllAsyncCallsFinish() throws Exception {
+		CompletableFuture<Void> future = new CompletableFuture<>();
+		coordinator.applyCall("waitForAllAsyncCallsFinish", c -> future.complete(null));
+		future.get();
 	}
 
 	// ---------------------
@@ -123,8 +164,12 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 
 		@Override
 		public OperatorCoordinator create(Context context) throws Exception {
-			QuiesceableContext quiesceableContext = new QuiesceableContext(context);
-			return new RecreateOnResetOperatorCoordinator(quiesceableContext, this);
+			return create(context, CLOSING_TIMEOUT_MS);
+		}
+
+		@VisibleForTesting
+		protected OperatorCoordinator create(Context context, long closingTimeoutMs) throws Exception {
+			return new RecreateOnResetOperatorCoordinator(context, this, closingTimeoutMs);
 		}
 
 		protected abstract OperatorCoordinator getCoordinator(OperatorCoordinator.Context context) throws Exception;
@@ -191,6 +236,169 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 
 		private OperatorCoordinator.Context getContext() {
 			return context;
+		}
+	}
+
+	/**
+	 * A class that helps realize the fully async {@link #resetToCheckpoint(byte[])} behavior.
+	 * The class wraps an {@link OperatorCoordinator} instance. It is going to be accessed
+	 * by two different thread: the scheduler thread and the closing thread created in
+	 * {@link #closeAsync(long)}. A DeferrableCoordinator could be in three states:
+	 *
+	 * <ul>
+	 *     <li><b>deferred:</b> The internal {@link OperatorCoordinator} has not been
+	 *     created and all the method calls to the RecreateOnResetOperatorCoordinator are
+	 *     added to a Queue.</li>
+	 *     <li><b>catching up:</b> The internal {@link OperatorCoordinator} has been created
+	 *     and is processing the queued up method calls. In this state, all the method calls
+	 *     to the RecreateOnResetOperatorCoordinator are still going to be enqueued to
+	 *     ensure the correct execution order.</li>
+	 *     <li><b>caught up:</b> The internal {@link OperatorCoordinator} has finished
+	 *     processing all the queued up method calls. From this point on, the method calls
+	 *     to this coordinator will be executed in the caller thread directly instead of
+	 *     being put into the queue.</li>
+	 * </ul>
+	 */
+	private static class DeferrableCoordinator {
+		private final OperatorID operatorId;
+		private final BlockingQueue<NamedCall> pendingCalls;
+		private QuiesceableContext internalQuiesceableContext;
+		private OperatorCoordinator internalCoordinator;
+		private boolean hasCaughtUp;
+		private boolean closed;
+		private volatile boolean failed;
+
+		private DeferrableCoordinator(OperatorID operatorId) {
+			this.operatorId = operatorId;
+			this.pendingCalls = new LinkedBlockingQueue<>();
+			this.hasCaughtUp = false;
+			this.closed = false;
+			this.failed = false;
+		}
+
+		synchronized <T extends Exception> void applyCall(
+				String name,
+				ThrowingConsumer<OperatorCoordinator, T> call) throws T {
+			synchronized (this) {
+				if (hasCaughtUp) {
+					// The new coordinator has caught up.
+					call.accept(internalCoordinator);
+				} else {
+					pendingCalls.add(new NamedCall(name, call));
+				}
+			}
+		}
+
+		synchronized void createNewInternalCoordinator(
+				OperatorCoordinator.Context context,
+				Provider provider) {
+			if (closed) {
+				return;
+			}
+			// Create a new internal coordinator and a new quiesceable context.
+			// We assume that the coordinator creation is fast. Otherwise the creation
+			// of the new internal coordinator may block the applyCall() method
+			// which is invoked in the scheduler main thread.
+			try {
+				internalQuiesceableContext = new QuiesceableContext(context);
+				internalCoordinator = provider.getCoordinator(internalQuiesceableContext);
+			} catch (Exception e) {
+				LOG.error("Failed to create new internal coordinator due to ", e);
+				cleanAndFailJob(e);
+			}
+		}
+
+		synchronized CompletableFuture<Void> closeAsync(long timeoutMs) {
+			closed = true;
+			if (internalCoordinator != null) {
+				internalQuiesceableContext.quiesce();
+				pendingCalls.clear();
+				return closeAsyncWithTimeout(
+					"SourceCoordinator for " + operatorId,
+					(ThrowingRunnable<Exception>) internalCoordinator::close,
+					timeoutMs).exceptionally(e -> {
+						cleanAndFailJob(e);
+						return null;
+					});
+			} else {
+				return CompletableFuture.completedFuture(null);
+			}
+		}
+
+		void processPendingCalls() {
+			if (failed || closed || internalCoordinator == null) {
+				return;
+			}
+			String name = "Unknown Call Name";
+			try {
+				while (!hasCaughtUp) {
+					while (!pendingCalls.isEmpty()) {
+						NamedCall namedCall = pendingCalls.poll();
+						if (namedCall != null) {
+							name = namedCall.name;
+							namedCall.getConsumer().accept(internalCoordinator);
+						}
+					}
+					synchronized (this) {
+						// We need to check the pending calls queue again in case a new
+						// pending call is added after we process the last one and before
+						// we grab the lock.
+						if (pendingCalls.isEmpty()) {
+							hasCaughtUp = true;
+						}
+					}
+				}
+			} catch (Throwable t) {
+				LOG.error("Failed to process pending calls {} on coordinator.", name, t);
+				cleanAndFailJob(t);
+			}
+		}
+
+		void start() throws Exception {
+			internalCoordinator.start();
+		}
+
+		void resetAndStart(byte[] checkpointData, boolean started) {
+			if (failed || closed || internalCoordinator == null) {
+				return;
+			}
+			try {
+				internalCoordinator.resetToCheckpoint(checkpointData);
+				// Start the new coordinator if this coordinator has been started before reset to the checkpoint.
+				if (started) {
+					internalCoordinator.start();
+				}
+			} catch (Exception e) {
+				LOG.error("Failed to reset the coordinator to checkpoint and start.", e);
+				cleanAndFailJob(e);
+			}
+		}
+
+		private void cleanAndFailJob(Throwable t) {
+			// Don't repeatedly fail the job.
+			if (!failed) {
+				failed = true;
+				internalQuiesceableContext.getContext().failJob(t);
+				pendingCalls.clear();
+			}
+		}
+	}
+
+	private static class NamedCall {
+		private final String name;
+		private final ThrowingConsumer<OperatorCoordinator, ?> consumer;
+
+		private NamedCall(String name, ThrowingConsumer<OperatorCoordinator, ?> consumer) {
+			this.name = name;
+			this.consumer = consumer;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public ThrowingConsumer<OperatorCoordinator, ?> getConsumer() {
+			return consumer;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -46,7 +46,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.readAndVerifyCoordinatorSerdeVersion;
 import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.readBytes;
@@ -103,14 +102,16 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 	@Override
 	public void start() throws Exception {
 		LOG.info("Starting split enumerator for source {}.", operatorName);
-		enumerator.start();
+		// The start sequence is the first task in the coordinator executor.
+		// We rely on the single-threaded coordinator executor to guarantee
+		// the other methods are invoked after the enumerator has started.
+		coordinatorExecutor.execute(() -> enumerator.start());
 		started = true;
 	}
 
 	@Override
 	public void close() throws Exception {
 		LOG.info("Closing SourceCoordinator for source {}.", operatorName);
-		boolean successfullyClosed = false;
 		try {
 			if (started) {
 				context.close();
@@ -118,12 +119,9 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 			}
 		} finally {
 			coordinatorExecutor.shutdownNow();
-			// We do not expect this to actually block for long. At this point, there should be very few task running
-			// in the executor, if any.
-			successfullyClosed = coordinatorExecutor.awaitTermination(10, TimeUnit.SECONDS);
-		}
-		if (!successfullyClosed) {
-			throw new TimeoutException("The source coordinator failed to close before timeout.");
+			// We do not expect this to actually block for long. At this point, there should
+			// be very few task running in the executor, if any.
+			coordinatorExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
 		}
 		LOG.info("Source coordinator for source {} closed.", operatorName);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
@@ -18,11 +18,17 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 
 import org.junit.Test;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -70,7 +76,7 @@ public class RecreateOnResetOperatorCoordinatorTest {
 
 	@Test
 	public void testResetToCheckpoint() throws Exception {
-		TestingCoordinatorProvider provider = new TestingCoordinatorProvider();
+		TestingCoordinatorProvider provider = new TestingCoordinatorProvider(null);
 		MockOperatorCoordinatorContext context = new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SUBTASKS);
 		RecreateOnResetOperatorCoordinator coordinator = createCoordinator(provider, context);
 
@@ -80,11 +86,149 @@ public class RecreateOnResetOperatorCoordinatorTest {
 		byte[] stateToRestore = new byte[0];
 		coordinator.resetToCheckpoint(stateToRestore);
 
+		// Use the checkpoint to ensure all the previous method invocation has succeeded.
+		coordinator.waitForAllAsyncCallsFinish();
+
 		assertTrue(contextBeforeReset.isQuiesced());
 		assertNull(internalCoordinatorBeforeReset.getLastRestoredCheckpointState());
 
 		TestingOperatorCoordinator internalCoordinatorAfterReset = getInternalCoordinator(coordinator);
 		assertEquals(stateToRestore, internalCoordinatorAfterReset.getLastRestoredCheckpointState());
+	}
+
+	@Test
+	public void testResetToCheckpointTimeout() throws Exception {
+		final long closingTimeoutMs = 1L;
+		// Let the user coordinator block on close.
+		TestingCoordinatorProvider provider = new TestingCoordinatorProvider(new CountDownLatch(1));
+		MockOperatorCoordinatorContext context = new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SUBTASKS);
+		RecreateOnResetOperatorCoordinator coordinator =
+				(RecreateOnResetOperatorCoordinator) provider.create(context, closingTimeoutMs);
+
+		coordinator.resetToCheckpoint(new byte[0]);
+		CommonTestUtils.waitUtil(
+			context::isJobFailed,
+			Duration.ofSeconds(5),
+			"The job should fail due to resetToCheckpoint() timeout.");
+	}
+
+	@Test
+	public void testMethodCallsOnLongResetToCheckpoint() throws Exception {
+		final long closingTimeoutMs = Long.MAX_VALUE;
+		final CountDownLatch blockOnCloseLatch = new CountDownLatch(1);
+		// Let the user coordinator block on close.
+		TestingCoordinatorProvider provider = new TestingCoordinatorProvider(blockOnCloseLatch);
+		MockOperatorCoordinatorContext context = new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SUBTASKS);
+		RecreateOnResetOperatorCoordinator coordinator =
+				(RecreateOnResetOperatorCoordinator) provider.create(context, closingTimeoutMs);
+
+		// Set up the testing variables.
+		final byte[] restoredState = new byte[0];
+		final TestingEvent testingEvent = new TestingEvent();
+		final long completedCheckpointId = 1234L;
+
+		// Reset the coordinator which closes the current internal coordinator
+		// and then create a new one. The closing of the current internal
+		// coordinator will block until the blockOnCloseLatch is pulled.
+		coordinator.resetToCheckpoint(restoredState);
+
+		// The following method calls should be applied to the new internal
+		// coordinator asynchronously because the current coordinator has not
+		// been successfully closed yet.
+		coordinator.handleEventFromOperator(1, testingEvent);
+		coordinator.subtaskFailed(1, new Exception("Subtask Failure Exception."));
+		coordinator.notifyCheckpointComplete(completedCheckpointId);
+
+		// The new coordinator should not have been created because the resetToCheckpoint()
+		// should block on closing the current coordinator.
+		assertEquals(1, provider.getCreatedCoordinators().size());
+
+		// Now unblock the closing of the current coordinator.
+		blockOnCloseLatch.countDown();
+
+		// Take a checkpoint on the coordinator after reset.
+		CompletableFuture<byte[]> checkpointFuture = new CompletableFuture<>();
+		coordinator.checkpointCoordinator(5678L, checkpointFuture);
+		coordinator.waitForAllAsyncCallsFinish();
+
+		// Verify that the methods calls have been made against the new coordinator.
+		TestingOperatorCoordinator internalCoordinatorAfterReset = getInternalCoordinator(coordinator);
+		// The internal coordinator after reset should have triggered a new checkpoint.
+		assertEquals(checkpointFuture, internalCoordinatorAfterReset.getLastTriggeredCheckpoint());
+		// The internal coordinator after reset should be the second coordinator created by the provider.
+		assertEquals(provider.getCreatedCoordinators().get(1), internalCoordinatorAfterReset);
+		// The internal coordinator after reset should have been reset to the restored state.
+		assertEquals(restoredState, internalCoordinatorAfterReset.getLastRestoredCheckpointState());
+		// The internal coordinator after reset should have received the testing event.
+		assertEquals(testingEvent, internalCoordinatorAfterReset.getNextReceivedOperatorEvent());
+		// The internal coordinator after reset should have handled the failure of subtask 1.
+		assertEquals(Collections.singletonList(1), internalCoordinatorAfterReset.getFailedTasks());
+		// The internal coordinator after reset should have the completedCheckpointId.
+		assertEquals(completedCheckpointId, internalCoordinatorAfterReset.getLastCheckpointComplete());
+
+	}
+
+	@Test(timeout = 30000L)
+	public void testConsecutiveResetToCheckpoint() throws Exception {
+		final long closingTimeoutMs = Long.MAX_VALUE;
+		final int numResets = 1000;
+		// Let the user coordinator block on close.
+		TestingCoordinatorProvider provider = new TestingCoordinatorProvider();
+		MockOperatorCoordinatorContext context = new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SUBTASKS);
+		RecreateOnResetOperatorCoordinator coordinator =
+				(RecreateOnResetOperatorCoordinator) provider.create(context, closingTimeoutMs);
+
+		// Loop to get some interleaved method invocations on multiple instances
+		// of active coordinators.
+		for (int i = 0; i < numResets; i++) {
+			coordinator.handleEventFromOperator(1, new TestingEvent(i));
+			coordinator.subtaskFailed(i, new Exception());
+			CompletableFuture<byte[]> future = CompletableFuture.completedFuture(new byte[i]);
+			coordinator.checkpointCoordinator(i, future);
+			final int loop = i;
+			future.thenRun(() -> coordinator.notifyCheckpointComplete(loop));
+			// The reset bytes has a length of i+1 here because this will be reset to the
+			// next internal coordinator.
+			coordinator.resetToCheckpoint(new byte[i + 1]);
+		}
+
+		coordinator.waitForAllAsyncCallsFinish();
+
+		// Verify that the methods calls have been made against the coordinators.
+		for (TestingOperatorCoordinator internalCoordinator : provider.getCreatedCoordinators()) {
+			// The indexOfCoordinator is set to 0 by default because:
+			// 1. For the initial internal coordinator, its index is 0.
+			// 2. For all the subsequent internal coordinators, there are two cases:
+			//    a. they have processed at least one method call. In that case the coordinator
+			//       must have been restored to the given state. So the indexOfCoordinator will
+			//       be updated correctly.
+			//    b. no method call was processed. In this case the indexOfCoordinator does not
+			//       matter because all the fields will either be empty or null.
+			int indexOfCoordinator = 0;
+			byte[] lastRestoredState = internalCoordinator.getLastRestoredCheckpointState();
+			if (lastRestoredState != null) {
+				indexOfCoordinator = lastRestoredState.length;
+			}
+			TestingEvent testingEvent = (TestingEvent) internalCoordinator.getNextReceivedOperatorEvent();
+			List<Integer> failedTasks = internalCoordinator.getFailedTasks();
+
+			assertTrue(testingEvent == null || testingEvent.getId() == indexOfCoordinator);
+			assertTrue(failedTasks.isEmpty() || (failedTasks.size() == 1 && failedTasks.get(0) == indexOfCoordinator));
+			assertTrue(!internalCoordinator.hasCompleteCheckpoint() ||
+							   internalCoordinator.getLastCheckpointComplete() == indexOfCoordinator);
+			assertTrue(!internalCoordinator.hasTriggeredCheckpoint() ||
+							   internalCoordinator.getLastTriggeredCheckpoint().get().length == indexOfCoordinator);
+		}
+		coordinator.close();
+		TestingOperatorCoordinator internalCoordinator = getInternalCoordinator(coordinator);
+		CommonTestUtils.waitUtil(
+			internalCoordinator::isClosed,
+			Duration.ofSeconds(5),
+			"Timed out when waiting for the coordinator to close.");
+	}
+
+	public void testFailureInCreateCoordinator() {
+
 	}
 
 	// ---------------
@@ -103,18 +247,47 @@ public class RecreateOnResetOperatorCoordinatorTest {
 
 	private static class TestingCoordinatorProvider extends RecreateOnResetOperatorCoordinator.Provider {
 		private static final long serialVersionUID = 4184184580789587013L;
+		private final CountDownLatch blockOnCloseLatch;
+		private final List<TestingOperatorCoordinator> createdCoordinators;
 
 		public TestingCoordinatorProvider() {
+			this(null);
+		}
+
+		public TestingCoordinatorProvider(
+				CountDownLatch blockOnCloseLatch) {
 			super(OPERATOR_ID);
+			this.blockOnCloseLatch = blockOnCloseLatch;
+			this.createdCoordinators = new ArrayList<>();
 		}
 
 		@Override
 		protected OperatorCoordinator getCoordinator(OperatorCoordinator.Context context) {
-			return new TestingOperatorCoordinator(context);
+			TestingOperatorCoordinator testingCoordinator =
+					new TestingOperatorCoordinator(context, blockOnCloseLatch);
+			createdCoordinators.add(testingCoordinator);
+			return testingCoordinator;
+		}
+
+		private List<TestingOperatorCoordinator> getCreatedCoordinators() {
+			return createdCoordinators;
 		}
 	}
 
 	private static class TestingEvent implements OperatorEvent {
 		private static final long serialVersionUID = -3289352911927668275L;
+		private final int id;
+
+		private TestingEvent() {
+			this(-1);
+		}
+
+		private TestingEvent(int id) {
+			this.id = id;
+		}
+
+		private int getId() {
+			return id;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -24,9 +24,10 @@ import org.apache.flink.runtime.util.SerializableFunction;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
@@ -38,6 +39,8 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 
 	private final ArrayList<Integer> failedTasks = new ArrayList<>();
 
+	private final CountDownLatch blockOnCloseLatch;
+
 	@Nullable
 	private byte[] lastRestoredCheckpointState;
 
@@ -45,13 +48,23 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 
 	private BlockingQueue<Long> lastCheckpointComplete;
 
+	private BlockingQueue<OperatorEvent> receivedOperatorEvents;
+
 	private boolean started;
 	private boolean closed;
 
 	public TestingOperatorCoordinator(OperatorCoordinator.Context context) {
+		this(context, null);
+	}
+
+	public TestingOperatorCoordinator(
+			OperatorCoordinator.Context context,
+			CountDownLatch blockOnCloseLatch) {
 		this.context = context;
 		this.triggeredCheckpoints = new LinkedBlockingQueue<>();
 		this.lastCheckpointComplete = new LinkedBlockingQueue<>();
+		this.receivedOperatorEvents = new LinkedBlockingQueue<>();
+		this.blockOnCloseLatch = blockOnCloseLatch;
 	}
 
 	// ------------------------------------------------------------------------
@@ -62,12 +75,17 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
-	public void close() {
+	public void close() throws InterruptedException {
 		closed = true;
+		if (blockOnCloseLatch != null) {
+			blockOnCloseLatch.await();
+		}
 	}
 
 	@Override
-	public void handleEventFromOperator(int subtask, OperatorEvent event) {}
+	public void handleEventFromOperator(int subtask, OperatorEvent event) {
+		receivedOperatorEvents.add(event);
+	}
 
 	@Override
 	public void subtaskFailed(int subtask, @Nullable Throwable reason) {
@@ -104,7 +122,7 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 		return closed;
 	}
 
-	public Collection<Integer> getFailedTasks() {
+	public List<Integer> getFailedTasks() {
 		return failedTasks;
 	}
 
@@ -123,6 +141,11 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 
 	public long getLastCheckpointComplete() throws InterruptedException {
 		return lastCheckpointComplete.take();
+	}
+
+	@Nullable
+	public OperatorEvent getNextReceivedOperatorEvent() {
+		return receivedOperatorEvents.poll();
 	}
 
 	public boolean hasCompleteCheckpoint() throws InterruptedException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -74,11 +74,13 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 						"only be reset to a checkpoint before it starts.", OPERATOR_NAME));
 	}
 
-	@Test
+	@Test(timeout = 10000L)
 	public void testStart() throws Exception {
 		assertFalse(enumerator.started());
 		sourceCoordinator.start();
-		assertTrue(enumerator.started());
+		while (!enumerator.started()) {
+			Thread.sleep(1);
+		}
 	}
 
 	@Test

--- a/flink-test-utils-parent/flink-connector-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-connector-test-utils/pom.xml
@@ -24,17 +24,16 @@
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-connectors</artifactId>
+		<artifactId>flink-test-utils-parent</artifactId>
 		<version>1.12-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-connector-base</artifactId>
-	<name>Flink : Connectors : Base</name>
+	<!-- This module is the test module separated from flink-connector-base to avoid introducing
+	 Scala version bindings to the flink-connector-base. -->
+	<artifactId>flink-connector-test-utils</artifactId>
+	<name>Flink : Connectors : Base-Test</name>
 
-	<packaging>jar</packaging>
-
-	<!-- Allow users to pass custom connector versions -->
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -42,27 +41,18 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- test dependency -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-core</artifactId>
+			<artifactId>flink-test-utils-junit</artifactId>
 			<version>${project.version}</version>
-			<scope>test</scope>
-			<type>test-jar</type>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-test-utils</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/SourceReaderTestBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/SourceReaderTestBase.java
@@ -1,22 +1,22 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
-package org.apache.flink.connector.base.source.reader;
+package org.apache.flink.connector.testutils.source.reader;
 
 import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.source.Boundedness;
@@ -170,7 +170,7 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 	/**
 	 * A source output that validates the output.
 	 */
-	protected static class ValidatingSourceOutput implements ReaderOutput<Integer> {
+	public static class ValidatingSourceOutput implements ReaderOutput<Integer> {
 		private Set<Integer> consumedValues = new HashSet<>();
 		private int max = Integer.MIN_VALUE;
 		private int min = Integer.MAX_VALUE;

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/resources/log4j2-test.properties
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-test-utils-parent/pom.xml
+++ b/flink-test-utils-parent/pom.xml
@@ -38,6 +38,7 @@ under the License.
 	<modules>
 		<module>flink-test-utils-junit</module>
 		<module>flink-test-utils</module>
+		<module>flink-connector-test-utils</module>
 	</modules>
 
 </project>


### PR DESCRIPTION
## What is the purpose of the change
This patch adds an implementation of Kafka source based on FLIP-27.

A few clarifications:
1. Package paths. The patch reuses the current module of `flink-connectors/flink-connector-kafka`, but with a new package path `org.apache.flink.connector.kafka.source`.
2. The serialization schema. This patch currently creates a new `KafkaRecordDeserializer` class instead of reusing the `org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema`. This is to make future deprecation of old KafkaDeserializationSchema easier. We will migrate the existing implementation of `KafkaDeserializationSchema` in a separate patch. Also, ideally we should unify the `KafkaRecordDeserializer` with the interface of `DeserializationSchema`. At this point `DeserializationSchema` assumes each serialized record is represented by a single byte array, so it is not suitable for the Kafka case where a serialized record is a `ConsumerRecord<byte[], byte[]>`.
3. The patch did not add some necessary API in the SplitEnumerator and SplitReader, namely the following: 1) a `close()` method in `SplitReader`; 2) the `onCheckpointComplete()` callback in the `SplitEnumerator` and `SourceReader`. These API changes will be done in a separate patch.
4. This patch still needs more integration tests. I'll add more tests either while the PR is in review or in followup patches.
5. The docs will be added later in a separate commit in this PR once the code is reviewed.

## Brief change log
77c6b0a0a7039ab Move the test code of flink-connector-base to a separate module of flink-connector-base-test.
440dcbefdf9a56eb Make RecreateOnResetOperatorCoordinator fully asynchronous.
80ff3b43afa00f011 [FLINK-18323][connector/kafka] Add Kafka Source based on FLIP-27.

## Verifying this change
The changes in this patch are mostly in `flink-connectors/flink-connector-kafka/` module. Unit tests and basic IT cases are added under `org.apache.flink.connector.kafka.source` package in the test directory.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (No)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
