### PR TITLE
[FLINK-19512] Introduce the new sink API

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/Committer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/Committer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.api.connector.sink;
+
+import org.apache.flink.annotation.Experimental;
+
+/**
+ * This interface is responsible for committing the data to the external system.
+ *
+ * @param <CommT> The type of the committable data.
+ */
+@Experimental
+public interface Committer<CommT> extends AutoCloseable {
+	/**
+	 * Commit the committable data to the external system.
+	 * @param committable the data needed to be committed.
+	 * @throws Exception if the commit operation fail.
+	 */
+	void commit(CommT committable) throws Exception;
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/GlobalCommitter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/GlobalCommitter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.api.connector.sink;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.util.List;
+
+/**
+ * The {@link GlobalCommitter} is responsible for committing an aggregated committable, which we called global committable.
+ *
+ * @param <CommT>         The type of the committable data
+ * @param <GlobalCommT>   The type of the aggregated committable
+ */
+@Experimental
+public interface GlobalCommitter<CommT, GlobalCommT> extends AutoCloseable {
+
+	/**
+	 * Find out which global committables need to be retried when recovering from the failure.
+	 * @param globalCommittables the global committable that are properly not committed in the previous attempt.
+	 * @return the global committables that should be committed again.
+	 */
+	List<GlobalCommT> filterRecoveredCommittables(List<GlobalCommT> globalCommittables);
+
+	/**
+	 * Compute an aggregated committable from a collection of committables.
+	 * @param committables a collection of committables that are needed to combine
+	 * @return an aggregated committable
+	 */
+	GlobalCommT combine(List<CommT> committables);
+
+	/**
+	 * Commit the given collection of {@link GlobalCommT}.
+	 * @param globalCommittables a collection of {@link GlobalCommT}.
+	 * @return a collection of {@link GlobalCommT} that is needed to re-commit latter.
+	 * @throws Exception if the commit operation fail and do not want to retry any more.
+	 */
+	List<GlobalCommT> commit(List<GlobalCommT> globalCommittables) throws Exception;
+
+	/**
+	 * There is no committable any more.
+	 */
+	void endOfInput();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/Sink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/Sink.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.api.connector.sink;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.MetricGroup;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This interface lets the sink developer build a simple sink topology, which could guarantee the exactly once
+ * semantics in both batch and stream execution mode if there is a {@link Committer} or {@link GlobalCommitter}.
+ * 1. The {@link Writer} is responsible for producing the committable.
+ * 2. The {@link Committer} is responsible for committing a single committable.
+ * 3. The {@link GlobalCommitter} is responsible for committing an aggregated committable, which we called the global
+ *    committable. There is only one instance of the {@link GlobalCommitter}.
+ * Note: Developers need to ensure the idempotence of {@link Committer} and {@link GlobalCommitter}.
+ *
+ * @param <InputT>        The type of the sink's input
+ * @param <CommT>         The type of the committable data
+ * @param <GlobalCommT>   The type of the aggregated committable
+ * @param <WriterStateT>  The type of the writer's state
+ */
+@Experimental
+public interface Sink<InputT, CommT, GlobalCommT, WriterStateT> {
+
+	/**
+	 * Create a {@link Writer}.
+	 * @param context the runtime context.
+	 * @param states the writer's state.
+	 * @return A sink writer.
+	 */
+	Writer<InputT, CommT, WriterStateT> createWriter(InitContext context, List<WriterStateT> states);
+
+	/**
+	 * @return a {@link Committer}.
+	 */
+	Optional<Committer<CommT>> createCommitter();
+
+	/**
+	 * @return a {@link GlobalCommitter}.
+	 */
+	Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter();
+
+	/**
+	 * @return the serializer of the committable type.
+	 */
+	Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer();
+
+	/**
+	 * @return the serializer of the aggregated committable type.
+	 */
+	Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer();
+
+	/**
+	 * @return the serializer of the writer's state type.
+	 */
+	Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer();
+
+	/**
+	 * The interface exposes some runtime info for creating a {@link Writer}.
+	 */
+	interface InitContext {
+
+		/**
+		 * @return The id of task where the writer is.
+		 */
+		int getSubtaskId();
+
+		/**
+		 * @return The metric group this writer belongs to.
+		 */
+		MetricGroup metricGroup();
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/Writer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/Writer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.api.connector.sink;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.util.List;
+
+/**
+ * The interface is responsible for writing data and handling any potential tmp area used to write yet un-staged data, e.g. in-progress files.
+ * The data (or metadata pointing to where the actual data is staged) ready to commit is returned to the system by the {@link #prepareCommit(boolean)}.
+ *
+ * @param <InputT>         The type of the writer's input
+ * @param <CommT>          The type of the committable data
+ * @param <WriterStateT>   The type of the writer's state
+ */
+@Experimental
+public interface Writer<InputT, CommT, WriterStateT> extends AutoCloseable {
+
+	/**
+	 * Add an element to the writer.
+	 * @param element The input record
+	 * @param context The additional information about the input record
+	 */
+	void write(InputT element, Context context);
+
+	/**
+	 * Prepare for a commit.
+	 * @param flush whether flushing the un-staged data or not
+	 * @return The data is ready to commit.
+	 */
+	List<CommT> prepareCommit(boolean flush);
+
+	/**
+	 * @return the writer's state.
+	 */
+	List<WriterStateT> snapshotState();
+
+
+	/**
+	 * Context that {@link #write} can use for getting additional data about an input record.
+	 */
+	interface Context {
+
+		/**
+		 * Returns the current event-time watermark.
+		 */
+		long currentWatermark();
+
+		/**
+		 * Returns the timestamp of the current input record or {@code null} if the element does not
+		 * have an assigned timestamp.
+		 */
+		Long timestamp();
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
