### PR TITLE
[FLINK-17331] Explicitly get the ByteBuf length of all classes which …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
@@ -30,6 +30,9 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 public class ExecutionAttemptID implements java.io.Serializable {
 
     private static final long serialVersionUID = -1169683445778281344L;
+    // Represent the number of bytes occupied when writes ExecutionAttemptID to the ByteBuf.
+    // It is the sum of two long types(lowerPart and upperPart of the executionAttemptId).
+    private static final int BYTEBUF_LEN = 16;
 
     private final AbstractID executionAttemptId;
 
@@ -53,6 +56,10 @@ public class ExecutionAttemptID implements java.io.Serializable {
 
     public static ExecutionAttemptID fromByteBuf(ByteBuf buf) {
         return new ExecutionAttemptID(new AbstractID(buf.readLong(), buf.readLong()));
+    }
+
+    public static int getByteBufLength() {
+        return BYTEBUF_LEN;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -257,7 +257,13 @@ public abstract class NettyMessage {
 
         // receiver ID (16), sequence number (4), backlog (4), dataType (1), isCompressed (1),
         // buffer size (4)
-        static final int MESSAGE_HEADER_LENGTH = 16 + 4 + 4 + 1 + 1 + 4;
+        static final int MESSAGE_HEADER_LENGTH =
+                InputChannelID.getByteBufLength()
+                        + Integer.BYTES
+                        + Integer.BYTES
+                        + Byte.BYTES
+                        + Byte.BYTES
+                        + Integer.BYTES;
 
         final Buffer buffer;
 
@@ -518,7 +524,17 @@ public abstract class NettyMessage {
                         bb.writeInt(credit);
                     };
 
-            writeToChannel(out, promise, allocator, consumer, ID, 20 + 16 + 4 + 16 + 4);
+            writeToChannel(
+                    out,
+                    promise,
+                    allocator,
+                    consumer,
+                    ID,
+                    IntermediateResultPartitionID.getByteBufLength()
+                            + ExecutionAttemptID.getByteBufLength()
+                            + Integer.BYTES
+                            + InputChannelID.getByteBufLength()
+                            + Integer.BYTES);
         }
 
         static PartitionRequest readFrom(ByteBuf buffer) {
@@ -578,7 +594,11 @@ public abstract class NettyMessage {
                     allocator,
                     consumer,
                     ID,
-                    4 + serializedEvent.remaining() + 20 + 16 + 16);
+                    Integer.BYTES
+                            + serializedEvent.remaining()
+                            + IntermediateResultPartitionID.getByteBufLength()
+                            + ExecutionAttemptID.getByteBufLength()
+                            + InputChannelID.getByteBufLength());
         }
 
         static TaskEventRequest readFrom(ByteBuf buffer, ClassLoader classLoader)
@@ -623,7 +643,13 @@ public abstract class NettyMessage {
         @Override
         void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator)
                 throws IOException {
-            writeToChannel(out, promise, allocator, receiverId::writeTo, ID, 16);
+            writeToChannel(
+                    out,
+                    promise,
+                    allocator,
+                    receiverId::writeTo,
+                    ID,
+                    InputChannelID.getByteBufLength());
         }
 
         static CancelPartitionRequest readFrom(ByteBuf buffer) throws Exception {
@@ -669,7 +695,9 @@ public abstract class NettyMessage {
             ByteBuf result = null;
 
             try {
-                result = allocateBuffer(allocator, ID, 4 + 16);
+                result =
+                        allocateBuffer(
+                                allocator, ID, Integer.BYTES + InputChannelID.getByteBufLength());
                 result.writeInt(credit);
                 receiverId.writeTo(result);
 
@@ -706,7 +734,13 @@ public abstract class NettyMessage {
         @Override
         void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator)
                 throws IOException {
-            writeToChannel(out, promise, allocator, receiverId::writeTo, ID, 16);
+            writeToChannel(
+                    out,
+                    promise,
+                    allocator,
+                    receiverId::writeTo,
+                    ID,
+                    InputChannelID.getByteBufLength());
         }
 
         static ResumeConsumption readFrom(ByteBuf buffer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelID.java
@@ -26,6 +26,9 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 public class InputChannelID extends AbstractID {
 
     private static final long serialVersionUID = 1L;
+    // Represent the number of bytes occupied when writes InputChannelID to the ByteBuf.
+    // It is the sum of two long types(lowerPart and upperPart).
+    private static final int BYTEBUF_LEN = 16;
 
     public InputChannelID() {
         super();
@@ -48,5 +51,9 @@ public class InputChannelID extends AbstractID {
         long lower = buf.readLong();
         long upper = buf.readLong();
         return new InputChannelID(lower, upper);
+    }
+
+    public static int getByteBufLength() {
+        return BYTEBUF_LEN;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateResultPartitionID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateResultPartitionID.java
@@ -28,6 +28,11 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 public class IntermediateResultPartitionID implements ResultID {
 
     private static final long serialVersionUID = 1L;
+    // Represent the number of bytes occupied when writes IntermediateResultPartitionID to the
+    // ByteBuf.
+    // It is the sum of two long types(lowerPart and upperPart of the intermediateDataSetID) and one
+    // int type(partitionNum).
+    private static final int BYTEBUF_LEN = 20;
 
     private final IntermediateDataSetID intermediateDataSetID;
     private final int partitionNum;
@@ -58,6 +63,10 @@ public class IntermediateResultPartitionID implements ResultID {
         final IntermediateDataSetID intermediateDataSetID = IntermediateDataSetID.fromByteBuf(buf);
         final int partitionNum = buf.readInt();
         return new IntermediateResultPartitionID(intermediateDataSetID, partitionNum);
+    }
+
+    public static int getByteBufLength() {
+        return BYTEBUF_LEN;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptIDTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptIDTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.io.network.netty.NettyBufferPool;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link ExecutionAttemptID}. */
+public class ExecutionAttemptIDTest {
+    private static final NettyBufferPool ALLOCATOR = new NettyBufferPool(1);
+
+    @Test
+    public void testByteBufWriteAndRead() {
+        final ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+        final int byteBufLen = ExecutionAttemptID.getByteBufLength();
+        final ByteBuf byteBuf = ALLOCATOR.directBuffer(byteBufLen, byteBufLen);
+        executionAttemptID.writeTo(byteBuf);
+
+        assertThat(byteBuf.writerIndex(), is(equalTo(ExecutionAttemptID.getByteBufLength())));
+        assertThat(ExecutionAttemptID.fromByteBuf(byteBuf), is(equalTo(executionAttemptID)));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelIDTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelIDTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.io.network.netty.NettyBufferPool;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link InputChannelID}. */
+public class InputChannelIDTest {
+    private static final NettyBufferPool ALLOCATOR = new NettyBufferPool(1);
+
+    @Test
+    public void testByteBufWriteAndRead() {
+        final InputChannelID inputChannelID = new InputChannelID();
+        final int byteBufLen = InputChannelID.getByteBufLength();
+        final ByteBuf byteBuf = ALLOCATOR.directBuffer(byteBufLen, byteBufLen);
+        inputChannelID.writeTo(byteBuf);
+
+        assertThat(byteBuf.writerIndex(), is(equalTo(InputChannelID.getByteBufLength())));
+        assertThat(InputChannelID.fromByteBuf(byteBuf), is(equalTo(inputChannelID)));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/IntermediateResultPartitionIDTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/IntermediateResultPartitionIDTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph;
+
+import org.apache.flink.runtime.io.network.netty.NettyBufferPool;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link IntermediateResultPartitionID}. */
+public class IntermediateResultPartitionIDTest {
+    private static final NettyBufferPool ALLOCATOR = new NettyBufferPool(1);
+
+    @Test
+    public void testByteBufWriteAndRead() {
+        final IntermediateResultPartitionID intermediateResultPartitionID =
+                new IntermediateResultPartitionID();
+        final int byteBufLen = IntermediateResultPartitionID.getByteBufLength();
+        final ByteBuf byteBuf = ALLOCATOR.directBuffer(byteBufLen, byteBufLen);
+        intermediateResultPartitionID.writeTo(byteBuf);
+
+        assertThat(
+                byteBuf.writerIndex(),
+                is(equalTo(IntermediateResultPartitionID.getByteBufLength())));
+        assertThat(
+                IntermediateResultPartitionID.fromByteBuf(byteBuf),
+                is(equalTo(intermediateResultPartitionID)));
+    }
+}


### PR DESCRIPTION
…is written to NettyMessage

Currently, the length of some header fields in NettyMessage is hardcoded: InputChannelID, ExecutionAttemptID, e.t.c.
So if we make some changes for such field, then we are not ware that it also needs to change the respective length for related netty messages component.
This PR explicitly get the ByteBuf length of all classes which is written to NettyMessage to avoid such problems.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Explicitly get the ByteBuf length of all classes which is written to NettyMessage
