### PR TITLE
[hotfix][typo] Fix typo in MiniCluster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -263,7 +263,7 @@ public class MiniCluster implements AutoCloseableAsync {
 				// bring up all the RPC services
 				LOG.info("Starting RPC Service(s)");
 
-				final RpcServiceFactory dispatcherResourceManagreComponentRpcServiceFactory;
+				final RpcServiceFactory dispatcherResourceManagerComponentRpcServiceFactory;
 				final RpcService metricQueryServiceRpcService;
 
 				if (useSingleRpcService) {
@@ -271,7 +271,7 @@ public class MiniCluster implements AutoCloseableAsync {
 					commonRpcService = createLocalRpcService(configuration);
 					final CommonRpcServiceFactory commonRpcServiceFactory = new CommonRpcServiceFactory(commonRpcService);
 					taskManagerRpcServiceFactory = commonRpcServiceFactory;
-					dispatcherResourceManagreComponentRpcServiceFactory = commonRpcServiceFactory;
+					dispatcherResourceManagerComponentRpcServiceFactory = commonRpcServiceFactory;
 					metricQueryServiceRpcService = MetricUtils.startLocalMetricsRpcService(configuration);
 				} else {
 
@@ -283,7 +283,7 @@ public class MiniCluster implements AutoCloseableAsync {
 					final String jobManagerBindAddress = miniClusterConfiguration.getJobManagerBindAddress();
 					final String taskManagerBindAddress = miniClusterConfiguration.getTaskManagerBindAddress();
 
-					dispatcherResourceManagreComponentRpcServiceFactory =
+					dispatcherResourceManagerComponentRpcServiceFactory =
 						new DedicatedRpcServiceFactory(
 							configuration,
 							jobManagerExternalAddress,
@@ -329,7 +329,7 @@ public class MiniCluster implements AutoCloseableAsync {
 
 				MetricQueryServiceRetriever metricQueryServiceRetriever = new RpcMetricQueryServiceRetriever(metricRegistry.getMetricQueryServiceRpcService());
 
-				setupDispatcherResourceManagerComponents(configuration, dispatcherResourceManagreComponentRpcServiceFactory, metricQueryServiceRetriever);
+				setupDispatcherResourceManagerComponents(configuration, dispatcherResourceManagerComponentRpcServiceFactory, metricQueryServiceRetriever);
 
 				resourceManagerLeaderRetriever = haServices.getResourceManagerLeaderRetriever();
 				dispatcherLeaderRetriever = haServices.getDispatcherLeaderRetriever();


### PR DESCRIPTION
## What is the purpose of the change

Fix typo in `org.apache.flink.runtime.minicluster.MiniCluster.java`


## Brief change log

`ResourceManagre` --> `ResourceManager`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
