### PR TITLE
[FLINK-19455][build] Fix banned dependencies failed when building locally

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
@@ -59,6 +59,10 @@ under the License.
 					<groupId>org.pentaho</groupId>
 					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>kafka_2.10</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -43,12 +43,6 @@ under the License.
 				<artifactId>okhttp</artifactId>
 				<version>3.12.1</version>
 			</dependency>
-			<dependency>
-				<!-- Bumped for security purposes -->
-				<groupId>org.yaml</groupId>
-				<artifactId>snakeyaml</artifactId>
-				<version>1.27</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -74,6 +68,20 @@ under the License.
 			<groupId>io.fabric8</groupId>
 			<artifactId>kubernetes-client</artifactId>
 			<version>${kubernetes.client.version}</version>
+			<exclusions>
+				<!-- Exclude org.yaml:snakeyaml:1.24 for security purposes -->
+				<exclusion>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<!-- Bumped for security purposes. -->
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>1.27</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
## What is the purpose of the change

Fix banned dependencies failed when building locally [FLINK-19455](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-19455)


## Brief change log

1. For the banned dependencies 'org.apache.kafka:kafka_2.10:jar:0.10.2.0', just excluding from 'flink-sql-connector-hive-2.3.6' module.
2. For the banned dependencies 'org.yaml:snakeyaml:jar:1.24'. This occur when other modules depend on  'flink-kubernetes' module. For 'maven-enforcer-plugin' is unable to recognize the discrepancy since the transitive dependency's version was altered by 'dependencyManagement'. 
    So just excluding 'org.yaml:snakeyaml:jar:1.24' from 'io.fabric8:kubernetes-client' and depend on the version of 1.27.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
