### PR TITLE
[FLINK-19582][network] Introduce sort-merge based blocking shuffle to Flink

### DIFF
--- a/docs/_includes/generated/all_taskmanager_network_section.html
+++ b/docs/_includes/generated/all_taskmanager_network_section.html
@@ -104,5 +104,17 @@
             <td>Integer</td>
             <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
         </tr>
+        <tr>
+            <td><h5>taskmanager.network.sort-shuffle.min-buffers</h5></td>
+            <td style="word-wrap: break-word;">64</td>
+            <td>Integer</td>
+            <td>Minimum number of network buffers required per sort-merge blocking result partition. For large scale batch jobs, it is suggested to increase this config value to improve compression ratio and reduce small network packets. Note: to increase this config value, you may also need to increase the size of total network memory to avoid "insufficient number of network buffers" error.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.sort-shuffle.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">2147483647</td>
+            <td>Integer</td>
+            <td>Parallelism threshold to switch between sort-merge blocking shuffle and the default hash-based blocking shuffle, which means for small parallelism, hash-based blocking shuffle will be used and for large parallelism, sort-merge blocking shuffle will be used. Note: sort-merge blocking shuffle uses unmanaged direct memory for shuffle data writing and reading so just increase the size of direct memory if direct memory OOM error occurs.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -122,5 +122,17 @@
             <td>Integer</td>
             <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
         </tr>
+        <tr>
+            <td><h5>taskmanager.network.sort-shuffle.min-buffers</h5></td>
+            <td style="word-wrap: break-word;">64</td>
+            <td>Integer</td>
+            <td>Minimum number of network buffers required per sort-merge blocking result partition. For large scale batch jobs, it is suggested to increase this config value to improve compression ratio and reduce small network packets. Note: to increase this config value, you may also need to increase the size of total network memory to avoid "insufficient number of network buffers" error.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.sort-shuffle.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">2147483647</td>
+            <td>Integer</td>
+            <td>Parallelism threshold to switch between sort-merge blocking shuffle and the default hash-based blocking shuffle, which means for small parallelism, hash-based blocking shuffle will be used and for large parallelism, sort-merge blocking shuffle will be used. Note: sort-merge blocking shuffle uses unmanaged direct memory for shuffle data writing and reading so just increase the size of direct memory if direct memory OOM error occurs.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/ops/memory/mem_tuning.md
+++ b/docs/ops/memory/mem_tuning.md
@@ -88,3 +88,23 @@ on the performance of your applications. Flink will attempt to allocate and use 
 as configured for batch jobs but not go beyond its limits. This prevents `OutOfMemoryError`'s because Flink knows precisely
 how much memory it has to leverage. If the [managed memory](../memory/mem_setup_tm.html#managed-memory) is not sufficient,
 Flink will gracefully spill to disk.
+
+## Configure memory for sort-merge blocking shuffle
+
+The number of required network buffers per sort-merge blocking result partition is controlled by 
+[taskmanager.network.sort-shuffle.min-buffers](../config.html#taskmanager-network-sort-shuffle-min-buffers)
+and the default value is 64 which is quite small. Though it can work for arbitrary parallelism, the 
+performance may not be the best. For large scale jobs, it is suggested to increase this config value 
+to improve compression ratio and reduce small network packets which is good for performance. To increase 
+this value, you may also need to increase the size of total network memory by adjusting the config 
+values of [taskmanager.memory.network.fraction](../config.html#taskmanager-memory-network-fraction),
+[taskmanager.memory.network.min](../config.html#taskmanager-memory-network-min) and [taskmanager.
+memory.network.max](../config.html#taskmanager-memory-network-max) to avoid `insufficient number of 
+network buffers` error.
+
+Except for network memory, the sort-merge blocking shuffle implementation also uses some unmanaged 
+direct memory for shuffle data writing and reading. So to use sort-merge blocking shuffle, you may 
+need to reserve some direct memory for it by increasing the config value of [taskmanager.memory.task
+.off-heap.size](../config.html#taskmanager-memory-task-off-heap-size). If direct memory OOM error 
+occurs after you enable the sort-merge blocking shuffle, you can just give more direct memory until 
+the OOM error disappears.

--- a/docs/ops/memory/mem_tuning.zh.md
+++ b/docs/ops/memory/mem_tuning.zh.md
@@ -85,3 +85,20 @@ Flink 批处理算子使用[托管内存](../memory/mem_setup_tm.html#managed-me
 因此 Flink 会在不超过其配置限额的前提下，尽可能分配更多的[托管内存](../memory/mem_setup_tm.html#managed-memory)。
 Flink 明确知道可以使用的内存大小，因此可以有效避免 `OutOfMemoryError` 的发生。
 当[托管内存](../memory/mem_setup_tm.html#managed-memory)不足时，Flink 会优雅地将数据落盘。
+
+## SortMerge数据Shuffle内存配置
+
+对于SortMerge数据Shuffle，每个ResultPartition需要的网络缓冲区（Buffer）数目是由[taskmanager.network.sort-
+shuffle.min-buffers](../config.html#taskmanager-network-sort-shuffle-min-buffers)这个配置决定的。它的
+默认值是64，是比较小的。虽然64个网络Buffer已经可以支持任意规模的并发，但性能可能不是最好的。对于大并发的作业，通
+过增大这个配置值，可以提高落盘数据的压缩率并且减少网络小包的数量，从而有利于提高Shuffle性能。为了增大这个配置值，
+你可能需要通过调整[taskmanager.memory.network.fraction](../config.html#taskmanager-memory-network-fraction)，
+[taskmanager.memory.network.min](../config.html#taskmanager-memory-network-min)和[taskmanager.memory
+.network.max](../config.html#taskmanager-memory-network-max)这三个参数来增大总的网络内存大小从而避免出现
+`insufficient number of network buffers`错误。
+
+除了网络内存，SortMerge数据Shuffle还需要使用一些JVM Direct Memory来进行Shuffle数据的写出与读取。所以，为了使
+用SortMerge数据Shuffle你可能还需要通过增大这个配置值[taskmanager.memory.task.off-heap.size
+](../config.html#taskmanager-memory-task-off-heap-size)来为其来预留一些JVM Direct Memory。如果在你开启
+SortMerge数据Shuffle之后出现了Direct Memory OOM的错误，你只需要继续加大上面的配置值来预留更多的Direct Memory
+直到不再发生Direct Memory OOM的错误为止。

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -174,6 +174,36 @@ public class NettyShuffleEnvironmentOptions {
 				" increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.");
 
 	/**
+	 * Minimum number of network buffers required per sort-merge blocking result partition.
+	 */
+	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+	public static final ConfigOption<Integer> NETWORK_SORT_SHUFFLE_MIN_BUFFERS =
+		key("taskmanager.network.sort-shuffle.min-buffers")
+			.intType()
+			.defaultValue(64)
+			.withDescription("Minimum number of network buffers required per sort-merge blocking "
+				+ "result partition. For large scale batch jobs, it is suggested to increase this"
+				+ " config value to improve compression ratio and reduce small network packets. "
+				+ "Note: to increase this config value, you may also need to increase the size of "
+				+ "total network memory to avoid \"insufficient number of network buffers\" error.");
+
+	/**
+	 * Parallelism threshold to switch between sort-merge based blocking shuffle and the default
+	 * hash-based blocking shuffle.
+	 */
+	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+	public static final ConfigOption<Integer> NETWORK_SORT_SHUFFLE_MIN_PARALLELISM =
+		key("taskmanager.network.sort-shuffle.min-parallelism")
+			.intType()
+			.defaultValue(Integer.MAX_VALUE)
+			.withDescription("Parallelism threshold to switch between sort-merge blocking shuffle "
+				+ "and the default hash-based blocking shuffle, which means for small parallelism,"
+				+ " hash-based blocking shuffle will be used and for large parallelism, sort-merge"
+				+ " blocking shuffle will be used. Note: sort-merge blocking shuffle uses unmanaged"
+				+ " direct memory for shuffle data writing and reading so just increase the size of"
+				+ " direct memory if direct memory OOM error occurs.");
+
+	/**
 	 * Number of max buffers can be used for each output subparition.
 	 */
 	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)

--- a/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static java.util.Arrays.asList;
 
@@ -278,6 +280,17 @@ public final class IOUtils {
 			if (closeable != null) {
 				closeable.close();
 			}
+		} catch (Throwable ignored) {}
+	}
+
+	/**
+	 * Deletes the given file.
+	 *
+	 * <p><b>Important:</b> This method is expected to never throw an exception.
+	 */
+	public static void deleteFileQuietly(Path path) {
+		try {
+			Files.deleteIfExists(path);
 		} catch (Throwable ignored) {}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -126,7 +126,9 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 			config.networkBufferSize(),
 			config.isBlockingShuffleCompressionEnabled(),
 			config.getCompressionCodec(),
-			config.getMaxBuffersPerChannel());
+			config.getMaxBuffersPerChannel(),
+			config.sortShuffleMinBuffers(),
+			config.sortShuffleMinParallelism());
 
 		SingleInputGateFactory singleInputGateFactory = new SingleInputGateFactory(
 			taskExecutorResourceId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -149,7 +149,7 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 		try {
 			final Buffer buffer = bufferConsumer.build();
 			try {
-				if (canBeCompressed(buffer)) {
+				if (parent.canBeCompressed(buffer)) {
 					final Buffer compressedBuffer = parent.bufferCompressor.compressToIntermediateBuffer(buffer);
 					data.writeBuffer(compressedBuffer);
 					if (compressedBuffer != buffer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -90,6 +90,15 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 	}
 
 	@Override
+	public void setup() throws IOException {
+		super.setup();
+
+		checkState(bufferPool.getNumberOfRequiredMemorySegments() >= getNumberOfSubpartitions(),
+			"Bug in result partition setup logic: Buffer pool has not enough guaranteed buffers for"
+				+ " this result partition.");
+	}
+
+	@Override
 	public int getNumberOfQueuedBuffers() {
 		int totalBuffers = 0;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBuffer.java
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link SortBuffer} implementation which sorts all appended records only by subpartition index.
+ * Records of the same subpartition keep the appended order.
+ *
+ * <p>It maintains a list of {@link MemorySegment}s as a joint buffer. Data will be appended to the
+ * joint buffer sequentially. When writing a record, an index entry will be appended first. An index
+ * entry consists of 4 fields: 4 bytes for record length, 4 bytes for {@link DataType} and 8 bytes
+ * for address pointing to the next index entry of the same channel which will be used to index the
+ * next record to read when coping data from this {@link SortBuffer}. For simplicity, no index entry
+ * can span multiple segments. The corresponding record data is seated right after its index entry
+ * and different from the index entry, records have variable length thus may span multiple segments.
+ */
+@NotThreadSafe
+public class PartitionSortedBuffer implements SortBuffer {
+
+	private final Object lock = new Object();
+
+	/**
+	 * Size of an index entry: 4 bytes for record length, 4 bytes for data type and 8 bytes
+	 * for pointer to next entry.
+	 */
+	private static final int INDEX_ENTRY_SIZE = 4 + 4 + 8;
+
+	/** A buffer pool to request memory segments from. */
+	private final BufferPool bufferPool;
+
+	/** A segment list as a joint buffer which stores all records and index entries. */
+	@GuardedBy("lock")
+	private final ArrayList<MemorySegment> buffers = new ArrayList<>();
+
+	/** Addresses of the first record's index entry for each subpartition. */
+	private final long[] firstIndexEntryAddresses;
+
+	/** Addresses of the last record's index entry for each subpartition. */
+	private final long[] lastIndexEntryAddresses;
+
+	/** Size of buffers requested from buffer pool. All buffers must be of the same size. */
+	private final int bufferSize;
+
+	// ---------------------------------------------------------------------------------------------
+	// Statistics and states
+	// ---------------------------------------------------------------------------------------------
+
+	/** Total number of bytes already appended to this sort buffer. */
+	private long numTotalBytes;
+
+	/** Total number of records already appended to this sort buffer. */
+	private long numTotalRecords;
+
+	/** Total number of bytes already read from this sort buffer. */
+	private long numTotalBytesRead;
+
+	/** Whether this sort buffer is finished. One can only read a finished sort buffer. */
+	private boolean isFinished;
+
+	/** Whether this sort buffer is released. A released sort buffer can not be used. */
+	@GuardedBy("lock")
+	private boolean isReleased;
+
+	// ---------------------------------------------------------------------------------------------
+	// For writing
+	// ---------------------------------------------------------------------------------------------
+
+	/** Array index in the segment list of the current available buffer for writing. */
+	private int writeSegmentIndex;
+
+	/** Next position in the current available buffer for writing. */
+	private int writeSegmentOffset;
+
+	// ---------------------------------------------------------------------------------------------
+	// For reading
+	// ---------------------------------------------------------------------------------------------
+
+	/** Data of different subpartitions in this sort buffer will be read in this order. */
+	private final int[] subpartitionReadOrder;
+
+	/** Index entry address of the current record or event to be read. */
+	private long readIndexEntryAddress;
+
+	/** Record bytes remaining after last copy, which must be read first in next copy. */
+	private int recordRemainingBytes;
+
+	/** Used to index the current available channel to read data from. */
+	private int readOrderIndex = -1;
+
+	public PartitionSortedBuffer(
+			BufferPool bufferPool,
+			int numSubpartitions,
+			int bufferSize,
+			@Nullable int[] customReadOrder) {
+		checkArgument(bufferSize > INDEX_ENTRY_SIZE, "Buffer size is too small.");
+
+		this.bufferPool = checkNotNull(bufferPool);
+		this.bufferSize = bufferSize;
+		this.firstIndexEntryAddresses = new long[numSubpartitions];
+		this.lastIndexEntryAddresses = new long[numSubpartitions];
+
+		// initialized with -1 means the corresponding channel has no data
+		Arrays.fill(firstIndexEntryAddresses, -1L);
+		Arrays.fill(lastIndexEntryAddresses, -1L);
+
+		this.subpartitionReadOrder = new int[numSubpartitions];
+		if (customReadOrder != null) {
+			checkArgument(customReadOrder.length == numSubpartitions, "Illegal data read order.");
+			System.arraycopy(customReadOrder, 0, this.subpartitionReadOrder, 0, numSubpartitions);
+		} else {
+			for (int channel = 0; channel < numSubpartitions; ++channel) {
+				this.subpartitionReadOrder[channel] = channel;
+			}
+		}
+	}
+
+	@Override
+	public boolean append(ByteBuffer source, int targetChannel, DataType dataType) throws IOException {
+		checkArgument(source.hasRemaining(), "Cannot append empty data.");
+		checkState(!isFinished, "Sort buffer is already finished.");
+		checkState(!isReleased, "Sort buffer is already released.");
+
+		int totalBytes = source.remaining();
+
+		// return false directly if it can not allocate enough buffers for the given record
+		if (!allocateBuffersForRecord(totalBytes)) {
+			return false;
+		}
+
+		// write the index entry and record or event data
+		writeIndex(targetChannel, totalBytes, dataType);
+		writeRecord(source);
+
+		++numTotalRecords;
+		numTotalBytes += totalBytes;
+
+		return true;
+	}
+
+	private void writeIndex(int channelIndex, int numRecordBytes, Buffer.DataType dataType) {
+		MemorySegment segment = buffers.get(writeSegmentIndex);
+
+		// record length takes the high 32 bits and data type takes the low 32 bits
+		segment.putLong(writeSegmentOffset, ((long) numRecordBytes << 32) | dataType.ordinal());
+
+		// segment index takes the high 32 bits and segment offset takes the low 32 bits
+		long indexEntryAddress = ((long) writeSegmentIndex << 32) | writeSegmentOffset;
+
+		long lastIndexEntryAddress =  lastIndexEntryAddresses[channelIndex];
+		lastIndexEntryAddresses[channelIndex] = indexEntryAddress;
+
+		if (lastIndexEntryAddress >= 0) {
+			// link the previous index entry of the given channel to the new index entry
+			segment = buffers.get(getSegmentIndexFromPointer(lastIndexEntryAddress));
+			segment.putLong(getSegmentOffsetFromPointer(lastIndexEntryAddress) + 8, indexEntryAddress);
+		} else {
+			firstIndexEntryAddresses[channelIndex] = indexEntryAddress;
+		}
+
+		// move the write position forward so as to write the corresponding record
+		updateWriteSegmentIndexAndOffset(INDEX_ENTRY_SIZE);
+	}
+
+	private void writeRecord(ByteBuffer source) {
+		while (source.hasRemaining()) {
+			MemorySegment segment = buffers.get(writeSegmentIndex);
+			int toCopy = Math.min(bufferSize - writeSegmentOffset, source.remaining());
+			segment.put(writeSegmentOffset, source, toCopy);
+
+			// move the write position forward so as to write the remaining bytes or next record
+			updateWriteSegmentIndexAndOffset(toCopy);
+		}
+	}
+
+	private boolean allocateBuffersForRecord(int numRecordBytes) throws IOException {
+		int numBytesRequired = INDEX_ENTRY_SIZE + numRecordBytes;
+		int availableBytes = writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
+
+		// return directly if current available bytes is adequate
+		if (availableBytes >= numBytesRequired) {
+			return true;
+		}
+
+		// skip the remaining free space if the available bytes is not enough for an index entry
+		if (availableBytes < INDEX_ENTRY_SIZE) {
+			updateWriteSegmentIndexAndOffset(availableBytes);
+			availableBytes = 0;
+		}
+
+		// allocate exactly enough buffers for the appended record
+		do {
+			MemorySegment segment = requestBufferFromPool();
+			if (segment == null) {
+				// return false if we can not allocate enough buffers for the appended record
+				return false;
+			}
+
+			availableBytes += bufferSize;
+			addBuffer(segment);
+		} while (availableBytes < numBytesRequired);
+
+		return true;
+	}
+
+	private void addBuffer(MemorySegment segment) {
+		synchronized (lock) {
+			if (segment.size() != bufferSize) {
+				bufferPool.recycle(segment);
+				throw new IllegalStateException("Illegal memory segment size.");
+			}
+
+			if (isReleased) {
+				bufferPool.recycle(segment);
+				throw new IllegalStateException("Sort buffer is already released.");
+			}
+
+			buffers.add(segment);
+		}
+	}
+
+	private MemorySegment requestBufferFromPool() throws IOException {
+		try {
+			// blocking request buffers if there is still guaranteed memory
+			if (buffers.size() < bufferPool.getNumberOfRequiredMemorySegments()) {
+				return bufferPool.requestBufferBuilderBlocking().getMemorySegment();
+			}
+		} catch (InterruptedException e) {
+			throw new IOException("Interrupted while requesting buffer.");
+		}
+
+		BufferBuilder buffer = bufferPool.requestBufferBuilder();
+		return buffer != null ? buffer.getMemorySegment() : null;
+	}
+
+	private void updateWriteSegmentIndexAndOffset(int numBytes) {
+		writeSegmentOffset += numBytes;
+
+		// using the next available free buffer if the current is full
+		if (writeSegmentOffset == bufferSize) {
+			++writeSegmentIndex;
+			writeSegmentOffset = 0;
+		}
+	}
+
+	@Override
+	public BufferWithChannel copyIntoSegment(MemorySegment target) {
+		checkState(hasRemaining(), "No data remaining.");
+		checkState(isFinished, "Should finish the sort buffer first before coping any data.");
+		checkState(!isReleased, "Sort buffer is already released.");
+
+		int numBytesCopied = 0;
+		DataType bufferDataType = DataType.DATA_BUFFER;
+		int channelIndex = subpartitionReadOrder[readOrderIndex];
+
+		do {
+			int sourceSegmentIndex = getSegmentIndexFromPointer(readIndexEntryAddress);
+			int sourceSegmentOffset = getSegmentOffsetFromPointer(readIndexEntryAddress);
+			MemorySegment sourceSegment = buffers.get(sourceSegmentIndex);
+
+			long lengthAndDataType = sourceSegment.getLong(sourceSegmentOffset);
+			int length = getSegmentIndexFromPointer(lengthAndDataType);
+			DataType dataType = DataType.values()[getSegmentOffsetFromPointer(lengthAndDataType)];
+
+			// return the data read directly if the next to read is an event
+			if (dataType.isEvent() && numBytesCopied > 0) {
+				break;
+			}
+			bufferDataType = dataType;
+
+			// get the next index entry address and move the read position forward
+			long nextReadIndexEntryAddress = sourceSegment.getLong(sourceSegmentOffset + 8);
+			sourceSegmentOffset += INDEX_ENTRY_SIZE;
+
+			// allocate a temp buffer for the event if the target buffer is not big enough
+			if (bufferDataType.isEvent() && target.size() < length) {
+				target = MemorySegmentFactory.allocateUnpooledSegment(length);
+			}
+
+			numBytesCopied += copyRecordOrEvent(
+				target, numBytesCopied, sourceSegmentIndex, sourceSegmentOffset, length);
+
+			if (recordRemainingBytes == 0) {
+				// move to next channel if the current channel has been finished
+				if (readIndexEntryAddress == lastIndexEntryAddresses[channelIndex]) {
+					updateReadChannelAndIndexEntryAddress();
+					break;
+				}
+				readIndexEntryAddress = nextReadIndexEntryAddress;
+			}
+		} while (numBytesCopied < target.size() && bufferDataType.isBuffer());
+
+		numTotalBytesRead += numBytesCopied;
+		Buffer buffer = new NetworkBuffer(target, (buf) -> {}, bufferDataType, numBytesCopied);
+		return new BufferWithChannel(buffer, channelIndex);
+	}
+
+	private int copyRecordOrEvent(
+			MemorySegment targetSegment,
+			int targetSegmentOffset,
+			int sourceSegmentIndex,
+			int sourceSegmentOffset,
+			int recordLength) {
+		if (recordRemainingBytes > 0) {
+			// skip the data already read if there is remaining partial record after the previous copy
+			long position = (long) sourceSegmentOffset + (recordLength - recordRemainingBytes);
+			sourceSegmentIndex += (position / bufferSize);
+			sourceSegmentOffset = (int) (position % bufferSize);
+		} else {
+			recordRemainingBytes = recordLength;
+		}
+
+		int targetSegmentSize = targetSegment.size();
+		int numBytesToCopy = Math.min(targetSegmentSize - targetSegmentOffset, recordRemainingBytes);
+		do {
+			// move to next data buffer if all data of the current buffer has been copied
+			if (sourceSegmentOffset == bufferSize) {
+				++sourceSegmentIndex;
+				sourceSegmentOffset = 0;
+			}
+
+			int sourceRemainingBytes = Math.min(bufferSize - sourceSegmentOffset, recordRemainingBytes);
+			int numBytes = Math.min(targetSegmentSize - targetSegmentOffset, sourceRemainingBytes);
+			MemorySegment sourceSegment = buffers.get(sourceSegmentIndex);
+			sourceSegment.copyTo(sourceSegmentOffset, targetSegment, targetSegmentOffset, numBytes);
+
+			recordRemainingBytes -= numBytes;
+			targetSegmentOffset += numBytes;
+			sourceSegmentOffset += numBytes;
+		} while ((recordRemainingBytes > 0 && targetSegmentOffset < targetSegmentSize));
+
+		return numBytesToCopy;
+	}
+
+	private void updateReadChannelAndIndexEntryAddress() {
+		// skip the channels without any data
+		while (++readOrderIndex < firstIndexEntryAddresses.length) {
+			int channelIndex = subpartitionReadOrder[readOrderIndex];
+			if ((readIndexEntryAddress = firstIndexEntryAddresses[channelIndex]) >= 0) {
+				break;
+			}
+		}
+	}
+
+	private int getSegmentIndexFromPointer(long value) {
+		return (int) (value >>> 32);
+	}
+
+	private int getSegmentOffsetFromPointer(long value) {
+		return (int) (value);
+	}
+
+	@Override
+	public long numRecords() {
+		return numTotalRecords;
+	}
+
+	@Override
+	public long numBytes() {
+		return numTotalBytes;
+	}
+
+	@Override
+	public boolean hasRemaining() {
+		return numTotalBytesRead < numTotalBytes;
+	}
+
+	@Override
+	public void finish() {
+		checkState(!isFinished, "SortBuffer is already finished.");
+
+		isFinished = true;
+
+		// prepare for reading
+		updateReadChannelAndIndexEntryAddress();
+	}
+
+	@Override
+	public boolean isFinished() {
+		return isFinished;
+	}
+
+	@Override
+	public void release() {
+		// the sort buffer can be released by other threads
+		synchronized (lock) {
+			if (isReleased) {
+				return;
+			}
+
+			isReleased = true;
+
+			for (MemorySegment segment : buffers) {
+				bufferPool.recycle(segment);
+			}
+			buffers.clear();
+
+			numTotalBytes = 0;
+			numTotalRecords = 0;
+		}
+	}
+
+	@Override
+	public boolean isReleased() {
+		synchronized (lock) {
+			return isReleased;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBuffer.java
@@ -54,7 +54,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 @NotThreadSafe
 public class PartitionSortedBuffer implements SortBuffer {
 
-	private final Object lock = new Object();
+	private final Object lock;
 
 	/**
 	 * Size of an index entry: 4 bytes for record length, 4 bytes for data type and 8 bytes
@@ -125,12 +125,14 @@ public class PartitionSortedBuffer implements SortBuffer {
 	private int readOrderIndex = -1;
 
 	public PartitionSortedBuffer(
+			Object lock,
 			BufferPool bufferPool,
 			int numSubpartitions,
 			int bufferSize,
 			@Nullable int[] customReadOrder) {
 		checkArgument(bufferSize > INDEX_ENTRY_SIZE, "Buffer size is too small.");
 
+		this.lock = checkNotNull(lock);
 		this.bufferPool = checkNotNull(bufferPool);
 		this.bufferSize = bufferSize;
 		this.firstIndexEntryAddresses = new long[numSubpartitions];

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFile.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * {@link PartitionedFile} is the persistent file type of sort-merge based blocking shuffle. Each
+ * {@link PartitionedFile} contains two physical files: one is the data file and the other is the
+ * index file. Both the data file and the index file have multiple regions. Data belonging to the
+ * same subpartition are stored together in each data region and the corresponding index region
+ * contains index entries of all subpartitions. Each index entry is a (long, integer) value tuple
+ * of which the long value represents the file offset of the target subpartition and the integer
+ * value is the number of buffers.
+ */
+public class PartitionedFile {
+
+	public static final String DATA_FILE_SUFFIX = ".shuffle.data";
+
+	public static final String INDEX_FILE_SUFFIX = ".shuffle.index";
+
+	/**
+	 * Size of each index entry in the index file: 8 bytes for file offset and 4 bytes for number
+	 * of buffers.
+	 */
+	public static final int INDEX_ENTRY_SIZE = 8 + 4;
+
+	/** Number of data regions in this {@link PartitionedFile}. */
+	private final int numRegions;
+
+	/** Number of subpartitions of this {@link PartitionedFile}. */
+	private final int numSubpartitions;
+
+	/** Path of the data file which stores all data in this {@link PartitionedFile}. */
+	private final Path dataFilePath;
+
+	/** Path of the index file which stores all index entries in this {@link PartitionedFile}. */
+	private final Path indexFilePath;
+
+	/** Used to accelerate index data access. */
+	@Nullable
+	private final ByteBuffer indexEntryCache;
+
+	public PartitionedFile(
+			int numRegions,
+			int numSubpartitions,
+			Path dataFilePath,
+			Path indexFilePath,
+			@Nullable ByteBuffer indexEntryCache) {
+		checkArgument(numRegions >= 0, "Illegal number of data regions.");
+		checkArgument(numSubpartitions > 0, "Illegal number of subpartitions.");
+
+		this.numRegions = numRegions;
+		this.numSubpartitions = numSubpartitions;
+		this.dataFilePath = checkNotNull(dataFilePath);
+		this.indexFilePath = checkNotNull(indexFilePath);
+		this.indexEntryCache = indexEntryCache;
+	}
+
+	public Path getDataFilePath() {
+		return dataFilePath;
+	}
+
+	public Path getIndexFilePath() {
+		return indexFilePath;
+	}
+
+	public int getNumRegions() {
+		return numRegions;
+	}
+
+	/**
+	 * Returns the index entry offset of the target region and subpartition in the index file. Both
+	 * region index and subpartition index start from 0.
+	 */
+	private long getIndexEntryOffset(int region, int subpartition) {
+		checkArgument(region >= 0 && region < getNumRegions(), "Illegal target region.");
+		checkArgument(subpartition >= 0 && subpartition < numSubpartitions,
+			"Subpartition index out of bound.");
+
+		return (((long) region) * numSubpartitions + subpartition) * INDEX_ENTRY_SIZE;
+	}
+
+	/**
+	 * Gets the index entry of the target region and subpartition either from the index data cache
+	 * or the index data file.
+	 */
+	void getIndexEntry(
+			FileChannel indexFile,
+			ByteBuffer target,
+			int region,
+			int subpartition) throws IOException {
+		checkArgument(target.capacity() == INDEX_ENTRY_SIZE, "Illegal target buffer size.");
+
+		target.clear();
+		long indexEntryOffset = getIndexEntryOffset(region, subpartition);
+		if (indexEntryCache != null) {
+			for (int i = 0; i < INDEX_ENTRY_SIZE; ++i) {
+				target.put(indexEntryCache.get((int) indexEntryOffset + i));
+			}
+		} else {
+			indexFile.position(indexEntryOffset);
+			BufferReaderWriterUtil.readByteBufferFully(indexFile, target);
+		}
+		target.flip();
+	}
+
+	public void deleteQuietly() {
+		IOUtils.deleteFileQuietly(dataFilePath);
+		IOUtils.deleteFileQuietly(indexFilePath);
+	}
+
+	@Override
+	public String toString() {
+		return "PartitionedFile{" +
+			"numRegions=" + numRegions +
+			", numSubpartitions=" + numSubpartitions +
+			", dataFilePath=" + dataFilePath +
+			", indexFilePath=" + indexFilePath +
+			", indexDataCache=" + indexEntryCache +
+			'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.readFromByteChannel;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Reader which can read all data of the target subpartition from a {@link PartitionedFile}.
+ */
+public class PartitionedFileReader implements AutoCloseable {
+
+	/** Used to read buffers from file channel. */
+	private final ByteBuffer headerBuf = BufferReaderWriterUtil.allocatedHeaderBuffer();
+
+	/** Used to read index entry from index file. */
+	private final ByteBuffer indexEntryBuf;
+
+	/** Target {@link PartitionedFile} to read. */
+	private final PartitionedFile partitionedFile;
+
+	/** Target subpartition to read. */
+	private final int targetSubpartition;
+
+	/** Data file channel of the target {@link PartitionedFile}. */
+	private final FileChannel dataFileChannel;
+
+	/** Index file channel of the target {@link PartitionedFile}. */
+	private final FileChannel indexFileChannel;
+
+	/** Next data region to be read. */
+	private int nextRegionToRead;
+
+	/** Number of remaining buffers in the current data region read. */
+	private int currentRegionRemainingBuffers;
+
+	/** Whether this partitioned file reader is closed. */
+	private boolean isClosed;
+
+	public PartitionedFileReader(
+			PartitionedFile partitionedFile,
+			int targetSubpartition) throws IOException {
+		this.partitionedFile = checkNotNull(partitionedFile);
+		this.targetSubpartition = targetSubpartition;
+
+		this.indexEntryBuf = ByteBuffer.allocateDirect(PartitionedFile.INDEX_ENTRY_SIZE);
+		BufferReaderWriterUtil.configureByteBuffer(indexEntryBuf);
+
+		this.dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
+		try {
+			this.indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
+		} catch (Throwable throwable) {
+			IOUtils.closeQuietly(dataFileChannel);
+			throw throwable;
+		}
+	}
+
+	private FileChannel openFileChannel(Path path) throws IOException {
+		return FileChannel.open(path, StandardOpenOption.READ);
+	}
+
+	private boolean moveToNextReadableRegion() throws IOException {
+		if (currentRegionRemainingBuffers > 0) {
+			return true;
+		}
+
+		while (nextRegionToRead < partitionedFile.getNumRegions()) {
+			partitionedFile.getIndexEntry(
+				indexFileChannel, indexEntryBuf, nextRegionToRead, targetSubpartition);
+			long dataOffset = indexEntryBuf.getLong();
+			currentRegionRemainingBuffers = indexEntryBuf.getInt();
+			++nextRegionToRead;
+
+			if (currentRegionRemainingBuffers > 0) {
+				dataFileChannel.position(dataOffset);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Reads a buffer from the {@link PartitionedFile} and moves the read position forward.
+	 *
+	 * <p>Note: The caller is responsible for recycling the target buffer if any exception occurs.
+	 */
+	@Nullable
+	public Buffer readBuffer(MemorySegment target, BufferRecycler recycler) throws IOException {
+		checkState(!isClosed, "File reader is already closed.");
+
+		if (moveToNextReadableRegion()) {
+			--currentRegionRemainingBuffers;
+			return readFromByteChannel(dataFileChannel, headerBuf, target, recycler);
+		}
+
+		return null;
+	}
+
+	@VisibleForTesting
+	public boolean hasRemaining() throws IOException {
+		checkState(!isClosed, "File reader is already closed.");
+
+		return moveToNextReadableRegion();
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (isClosed) {
+			return;
+		}
+		isClosed = true;
+
+		IOException exception = null;
+		try {
+			if (dataFileChannel != null) {
+				dataFileChannel.close();
+			}
+		} catch (IOException ioException) {
+			exception = ioException;
+		}
+
+		try {
+			if (indexFileChannel != null) {
+				indexFileChannel.close();
+			}
+		} catch (IOException ioException) {
+			exception = ExceptionUtils.firstOrSuppressed(ioException, exception);
+		}
+
+		if (exception != null) {
+			throw exception;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriter.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.writeToByteChannel;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * File writer which can write buffers and generate {@link PartitionedFile}. Data is written region
+ * by region. Before writing a new region, the method {@link PartitionedFileWriter#startNewRegion}
+ * must be called. After writing all data, the method {@link PartitionedFileWriter#finish} must be
+ * called to close all opened files and return the target {@link PartitionedFile}.
+ */
+@NotThreadSafe
+public class PartitionedFileWriter implements AutoCloseable {
+
+	private static final int MIN_INDEX_BUFFER_SIZE = 50 * PartitionedFile.INDEX_ENTRY_SIZE;
+
+	/** Used when writing data buffers. */
+	private final ByteBuffer[] header = BufferReaderWriterUtil.allocatedWriteBufferArray();
+
+	/** Number of channels. When writing a buffer, target subpartition must be in this range. */
+	private final int numSubpartitions;
+
+	/** Opened data file channel of the target {@link PartitionedFile}. */
+	private final FileChannel dataFileChannel;
+
+	/** Opened index file channel of the target {@link PartitionedFile}. */
+	private final FileChannel indexFileChannel;
+
+	/** Data file path of the target {@link PartitionedFile}. */
+	private final Path dataFilePath;
+
+	/** Index file path of the target {@link PartitionedFile}. */
+	private final Path indexFilePath;
+
+	/** Offset in the data file for each subpartition in the current region. */
+	private final long[] subpartitionOffsets;
+
+	/** Number of buffers written for each subpartition in the current region. */
+	private final int[] subpartitionBuffers;
+
+	/** Used to cache data before writing to disk for better read performance. */
+	private ByteBuffer writeDataCache;
+
+	/** Maximum number of bytes can be used to buffer index entries. */
+	private final int maxIndexBufferSize;
+
+	/** A piece of unmanaged memory for caching of region index entries. */
+	private ByteBuffer indexBuffer;
+
+	/** Whether all index entries are cached in the index buffer or not. */
+	private boolean allIndexEntriesCached = true;
+
+	/** Number of bytes written to the target {@link PartitionedFile}. */
+	private long totalBytesWritten;
+
+	/** Number of regions written to the target {@link PartitionedFile}. */
+	private int numRegions;
+
+	/** Current subpartition to write buffers to. */
+	private int currentSubpartition = -1;
+
+	/** Whether this file writer is finished or not. */
+	private boolean isFinished;
+
+	/** Whether this file writer is closed or not. */
+	private boolean isClosed;
+
+	public PartitionedFileWriter(
+			int numSubpartitions,
+			int maxIndexBufferSize,
+			String basePath) throws IOException {
+		checkArgument(numSubpartitions > 0, "Illegal number of subpartitions.");
+		checkArgument(maxIndexBufferSize > 0, "Illegal maximum index cache size.");
+		checkArgument(basePath != null, "Base path must not be null.");
+
+		this.numSubpartitions = numSubpartitions;
+		this.maxIndexBufferSize = alignMaxIndexBufferSize(maxIndexBufferSize);
+		this.subpartitionOffsets = new long[numSubpartitions];
+		this.subpartitionBuffers = new int[numSubpartitions];
+		this.dataFilePath = new File(basePath + PartitionedFile.DATA_FILE_SUFFIX).toPath();
+		this.indexFilePath = new File(basePath + PartitionedFile.INDEX_FILE_SUFFIX).toPath();
+
+		this.indexBuffer = ByteBuffer.allocateDirect(MIN_INDEX_BUFFER_SIZE);
+		BufferReaderWriterUtil.configureByteBuffer(indexBuffer);
+
+		// allocate 4M unmanaged direct memory for caching of data before writing
+		// to disk because bulk writing is helpful to allocate consecutive blocks
+		// on disk which can improve read performance
+		this.writeDataCache = ByteBuffer.allocateDirect(4 * 1024 * 1024);
+		BufferReaderWriterUtil.configureByteBuffer(writeDataCache);
+
+		this.dataFileChannel = openFileChannel(dataFilePath);
+		try {
+			this.indexFileChannel = openFileChannel(indexFilePath);
+		} catch (Throwable throwable) {
+			// ensure that the data file channel is closed if any exception occurs
+			IOUtils.closeQuietly(dataFileChannel);
+			IOUtils.deleteFileQuietly(dataFilePath);
+			throw throwable;
+		}
+	}
+
+	private FileChannel openFileChannel(Path path) throws IOException {
+		return FileChannel.open(path, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+	}
+
+	private int alignMaxIndexBufferSize(int maxIndexBufferSize) {
+		return maxIndexBufferSize / PartitionedFile.INDEX_ENTRY_SIZE * PartitionedFile.INDEX_ENTRY_SIZE;
+	}
+
+	/**
+	 * Persists the region index of the current data region and starts a new region to write.
+	 *
+	 * <p>Note: The caller is responsible for releasing the failed {@link PartitionedFile} if any
+	 * exception occurs.
+	 */
+	public void startNewRegion() throws IOException {
+		checkState(!isFinished, "File writer is already finished.");
+		checkState(!isClosed, "File writer is already closed.");
+
+		writeRegionIndex();
+	}
+
+	private void writeIndexEntry(long subpartitionOffset, int numBuffers) throws IOException {
+		if (!indexBuffer.hasRemaining()) {
+			if (!extendIndexBufferIfPossible()) {
+				flushIndexBuffer();
+				indexBuffer.clear();
+				allIndexEntriesCached = false;
+			}
+		}
+
+		indexBuffer.putLong(subpartitionOffset);
+		indexBuffer.putInt(numBuffers);
+	}
+
+	private boolean extendIndexBufferIfPossible() {
+		if (indexBuffer.capacity() >= maxIndexBufferSize) {
+			return false;
+		}
+
+		int newIndexBufferSize = Math.min(maxIndexBufferSize, 2 * indexBuffer.capacity());
+		ByteBuffer newIndexBuffer = ByteBuffer.allocateDirect(newIndexBufferSize);
+		indexBuffer.flip();
+		newIndexBuffer.put(indexBuffer);
+		BufferReaderWriterUtil.configureByteBuffer(newIndexBuffer);
+		indexBuffer = newIndexBuffer;
+
+		return true;
+	}
+
+	private void writeRegionIndex() throws IOException {
+		if (Arrays.stream(subpartitionBuffers).sum() > 0) {
+			for (int channel = 0; channel < numSubpartitions; ++channel) {
+				writeIndexEntry(subpartitionOffsets[channel], subpartitionBuffers[channel]);
+			}
+
+			currentSubpartition = -1;
+			++numRegions;
+			Arrays.fill(subpartitionBuffers, 0);
+		}
+	}
+
+	private void flushIndexBuffer() throws IOException {
+		indexBuffer.flip();
+		if (indexBuffer.limit() > 0) {
+			BufferReaderWriterUtil.writeBuffer(indexFileChannel, indexBuffer);
+		}
+	}
+
+	/**
+	 * Writes a {@link Buffer} of the given subpartition to the this {@link PartitionedFile}. In a
+	 * data region, all data of the same subpartition must be written together.
+	 *
+	 * <p>Note: The caller is responsible for recycling the target buffer and releasing the failed
+	 * {@link PartitionedFile} if any exception occurs.
+	 */
+	public void writeBuffer(Buffer target, int targetSubpartition) throws IOException {
+		checkState(!isFinished, "File writer is already finished.");
+		checkState(!isClosed, "File writer is already closed.");
+
+		if (targetSubpartition != currentSubpartition) {
+			checkState(subpartitionBuffers[targetSubpartition] == 0,
+				"Must write data of the same channel together.");
+			subpartitionOffsets[targetSubpartition] = totalBytesWritten;
+			currentSubpartition = targetSubpartition;
+		}
+
+		totalBytesWritten += writeToByteChannel(dataFileChannel, target, writeDataCache, header);
+		++subpartitionBuffers[targetSubpartition];
+	}
+
+	/**
+	 * Finishes writing the {@link PartitionedFile} which closes the file channel and returns the
+	 * corresponding {@link PartitionedFile}.
+	 *
+	 * <p>Note: The caller is responsible for releasing the failed {@link PartitionedFile} if any
+	 * exception occurs.
+	 */
+	public PartitionedFile finish() throws IOException {
+		checkState(!isFinished, "File writer is already finished.");
+		checkState(!isClosed, "File writer is already closed.");
+
+		isFinished = true;
+
+		writeDataCache.flip();
+		if (writeDataCache.hasRemaining()) {
+			BufferReaderWriterUtil.writeBuffer(dataFileChannel, writeDataCache);
+		}
+		writeDataCache = null;
+
+		writeRegionIndex();
+		flushIndexBuffer();
+		indexBuffer.rewind();
+
+		close();
+
+		ByteBuffer indexEntryCache = null;
+		if (allIndexEntriesCached) {
+			indexEntryCache = indexBuffer;
+		}
+		indexBuffer = null;
+		return new PartitionedFile(
+			numRegions, numSubpartitions, dataFilePath, indexFilePath, indexEntryCache);
+	}
+
+	/**
+	 * Used to close and delete the failed {@link PartitionedFile} when any exception occurs.
+	 */
+	public void releaseQuietly() {
+		IOUtils.closeQuietly(this);
+		IOUtils.deleteFileQuietly(dataFilePath);
+		IOUtils.deleteFileQuietly(indexFilePath);
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (isClosed) {
+			return;
+		}
+		isClosed = true;
+
+		IOException exception = null;
+		try {
+			dataFileChannel.close();
+		} catch (IOException ioException) {
+			exception = ioException;
+		}
+
+		try {
+			indexFileChannel.close();
+		} catch (IOException ioException) {
+			exception = ExceptionUtils.firstOrSuppressed(ioException, exception);
+		}
+
+		if (exception != null) {
+			throw exception;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -307,4 +307,12 @@ public abstract class ResultPartition implements ResultPartitionWriter {
 	public ResultPartitionManager getPartitionManager() {
 		return partitionManager;
 	}
+
+	/**
+	 * Whether the buffer can be compressed or not. Note that event is not compressed because it
+	 * is usually small and the size can become even larger after compression.
+	 */
+	protected boolean canBeCompressed(Buffer buffer) {
+		return bufferCompressor != null && buffer.isBuffer() && buffer.readableBytes() > 0;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -145,11 +144,7 @@ public abstract class ResultPartition implements ResultPartitionWriter {
 	public void setup() throws IOException {
 		checkState(this.bufferPool == null, "Bug in result partition setup logic: Already registered buffer pool.");
 
-		BufferPool bufferPool = checkNotNull(bufferPoolFactory.get());
-		checkArgument(bufferPool.getNumberOfRequiredMemorySegments() >= getNumberOfSubpartitions(),
-			"Bug in result partition setup logic: Buffer pool has not enough guaranteed buffers for this result partition.");
-
-		this.bufferPool = bufferPool;
+		this.bufferPool = checkNotNull(bufferPoolFactory.get());
 		partitionManager.registerResultPartition(this);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -64,6 +64,10 @@ public class ResultPartitionFactory {
 
 	private final int maxBuffersPerChannel;
 
+	private final int sortShuffleMinBuffers;
+
+	private final int sortShuffleMinParallelism;
+
 	public ResultPartitionFactory(
 		ResultPartitionManager partitionManager,
 		FileChannelManager channelManager,
@@ -74,7 +78,9 @@ public class ResultPartitionFactory {
 		int networkBufferSize,
 		boolean blockingShuffleCompressionEnabled,
 		String compressionCodec,
-		int maxBuffersPerChannel) {
+		int maxBuffersPerChannel,
+		int sortShuffleMinBuffers,
+		int sortShuffleMinParallelism) {
 
 		this.partitionManager = partitionManager;
 		this.channelManager = channelManager;
@@ -86,6 +92,8 @@ public class ResultPartitionFactory {
 		this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;
 		this.compressionCodec = compressionCodec;
 		this.maxBuffersPerChannel = maxBuffersPerChannel;
+		this.sortShuffleMinBuffers = sortShuffleMinBuffers;
+		this.sortShuffleMinParallelism = sortShuffleMinParallelism;
 	}
 
 	public ResultPartition create(
@@ -146,25 +154,40 @@ public class ResultPartitionFactory {
 			partition = pipelinedPartition;
 		}
 		else if (type == ResultPartitionType.BLOCKING || type == ResultPartitionType.BLOCKING_PERSISTENT) {
-			final BoundedBlockingResultPartition blockingPartition = new BoundedBlockingResultPartition(
-				taskNameWithSubtaskAndId,
-				partitionIndex,
-				id,
-				type,
-				subpartitions,
-				maxParallelism,
-				partitionManager,
-				bufferCompressor,
-				bufferPoolFactory);
+			if (numberOfSubpartitions >= sortShuffleMinParallelism) {
+				partition = new SortMergeResultPartition(
+					taskNameWithSubtaskAndId,
+					partitionIndex,
+					id,
+					type,
+					subpartitions.length,
+					maxParallelism,
+					networkBufferSize,
+					partitionManager,
+					channelManager.createChannel().getPath(),
+					bufferCompressor,
+					bufferPoolFactory);
+			} else {
+				final BoundedBlockingResultPartition blockingPartition = new BoundedBlockingResultPartition(
+					taskNameWithSubtaskAndId,
+					partitionIndex,
+					id,
+					type,
+					subpartitions,
+					maxParallelism,
+					partitionManager,
+					bufferCompressor,
+					bufferPoolFactory);
 
-			initializeBoundedBlockingPartitions(
-				subpartitions,
-				blockingPartition,
-				blockingSubpartitionType,
-				networkBufferSize,
-				channelManager);
+				initializeBoundedBlockingPartitions(
+					subpartitions,
+					blockingPartition,
+					blockingSubpartitionType,
+					networkBufferSize,
+					channelManager);
 
-			partition = blockingPartition;
+				partition = blockingPartition;
+			}
 		}
 		else {
 			throw new IllegalArgumentException("Unrecognized ResultPartitionType: " + type);
@@ -224,10 +247,13 @@ public class ResultPartitionFactory {
 		return () -> {
 			int maxNumberOfMemorySegments = type.isBounded() ?
 				numberOfSubpartitions * networkBuffersPerChannel + floatingNetworkBuffersPerGate : Integer.MAX_VALUE;
+			int numRequiredBuffers = !type.isPipelined() && numberOfSubpartitions >= sortShuffleMinParallelism ?
+				sortShuffleMinBuffers : numberOfSubpartitions + 1;
+
 			// If the partition type is back pressure-free, we register with the buffer pool for
 			// callbacks to release memory.
 			return bufferPoolFactory.createBufferPool(
-				numberOfSubpartitions + 1,
+				numRequiredBuffers,
 				maxNumberOfMemorySegments,
 				numberOfSubpartitions,
 				maxBuffersPerChannel);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -47,14 +47,6 @@ public abstract class ResultSubpartition {
 		this.subpartitionInfo = new ResultSubpartitionInfo(parent.getPartitionIndex(), index);
 	}
 
-	/**
-	 * Whether the buffer can be compressed or not. Note that event is not compressed because it
-	 * is usually small and the size can become even larger after compression.
-	 */
-	protected boolean canBeCompressed(Buffer buffer) {
-		return parent.bufferCompressor != null && buffer.isBuffer() && buffer.readableBytes() > 0;
-	}
-
 	public ResultSubpartitionInfo getSubpartitionInfo() {
 		return subpartitionInfo;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortBuffer.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Data of different channels can be appended to a {@link SortBuffer} and after the {@link SortBuffer}
+ * is finished, the appended data can be copied from it in channel index order.
+ */
+public interface SortBuffer {
+
+	/**
+	 * Appends data of the specified channel to this {@link SortBuffer} and returns true if all bytes
+	 * of the source buffer is copied to this {@link SortBuffer} successfully, otherwise if returns
+	 * false, nothing will be copied.
+	 */
+	boolean append(ByteBuffer source, int targetChannel, Buffer.DataType dataType) throws IOException;
+
+	/**
+	 * Copies data in this {@link SortBuffer} to the target {@link MemorySegment} in channel index
+	 * order and returns {@link BufferWithChannel} which contains the copied data and the corresponding
+	 * channel index.
+	 */
+	BufferWithChannel copyIntoSegment(MemorySegment target);
+
+	/**
+	 * Returns the number of records written to this {@link SortBuffer}.
+	 */
+	long numRecords();
+
+	/**
+	 * Returns the number of bytes written to this {@link SortBuffer}.
+	 */
+	long numBytes();
+
+	/**
+	 * Returns true if there is still data can be consumed in this {@link SortBuffer}.
+	 */
+	boolean hasRemaining();
+
+	/**
+	 * Finishes this {@link SortBuffer} which means no record can be appended any more.
+	 */
+	void finish();
+
+	/**
+	 * Whether this {@link SortBuffer} is finished or not.
+	 */
+	boolean isFinished();
+
+	/**
+	 * Releases this {@link SortBuffer} which releases all resources.
+	 */
+	void release();
+
+	/**
+	 * Whether this {@link SortBuffer} is released or not.
+	 */
+	boolean isReleased();
+
+	/**
+	 * Buffer and the corresponding channel index returned to reader.
+	 */
+	class BufferWithChannel {
+
+		private final Buffer buffer;
+
+		private final int channelIndex;
+
+		BufferWithChannel(Buffer buffer, int channelIndex) {
+			this.buffer = checkNotNull(buffer);
+			this.channelIndex = channelIndex;
+		}
+
+		public Buffer getBuffer() {
+			return buffer;
+		}
+
+		public int getChannelIndex() {
+			return channelIndex;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.function.SupplierWithException;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
+import static org.apache.flink.runtime.io.network.partition.SortBuffer.BufferWithChannel;
+import static org.apache.flink.util.Preconditions.checkElementIndex;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * {@link SortMergeResultPartition} appends records and events to {@link SortBuffer} and after the
+ * {@link SortBuffer} is full, all data in the {@link SortBuffer} will be copied and spilled to a
+ * {@link PartitionedFile} in subpartition index order sequentially. Large records that can not be
+ * appended to an empty {@link SortBuffer} will be spilled to the result {@link PartitionedFile}
+ * separately.
+ */
+@NotThreadSafe
+public class SortMergeResultPartition extends ResultPartition {
+
+	private final Object lock = new Object();
+
+	/** All active readers which are consuming data from this result partition now. */
+	@GuardedBy("lock")
+	private final Set<SortMergeSubpartitionReader> readers = new HashSet<>();
+
+	/** {@link PartitionedFile} produced by this result partition. */
+	@GuardedBy("lock")
+	private PartitionedFile resultFile;
+
+	/** Number of data buffers (excluding events) written for each subpartition. */
+	private final int[] numDataBuffers;
+
+	/** A piece of unmanaged memory for data writing. */
+	private final MemorySegment writeBuffer;
+
+	/** Size of network buffer and write buffer. */
+	private final int networkBufferSize;
+
+	/** File writer for this result partition. */
+	private final PartitionedFileWriter fileWriter;
+
+	/** Current {@link SortBuffer} to append records to. */
+	private SortBuffer currentSortBuffer;
+
+	public SortMergeResultPartition(
+			String owningTaskName,
+			int partitionIndex,
+			ResultPartitionID partitionId,
+			ResultPartitionType partitionType,
+			int numSubpartitions,
+			int numTargetKeyGroups,
+			int networkBufferSize,
+			ResultPartitionManager partitionManager,
+			String resultFileBasePath,
+			@Nullable BufferCompressor bufferCompressor,
+			SupplierWithException<BufferPool, IOException> bufferPoolFactory) {
+
+		super(
+			owningTaskName,
+			partitionIndex,
+			partitionId,
+			partitionType,
+			numSubpartitions,
+			numTargetKeyGroups,
+			partitionManager,
+			bufferCompressor,
+			bufferPoolFactory);
+
+		this.networkBufferSize = networkBufferSize;
+		this.numDataBuffers = new int[numSubpartitions];
+		this.writeBuffer = MemorySegmentFactory.allocateUnpooledOffHeapMemory(networkBufferSize);
+
+		PartitionedFileWriter fileWriter = null;
+		try {
+			// allocate at most 4M direct memory for caching of index entries
+			fileWriter = new PartitionedFileWriter(numSubpartitions, 4194304, resultFileBasePath);
+		} catch (Throwable throwable) {
+			ExceptionUtils.rethrow(throwable);
+		}
+		this.fileWriter = fileWriter;
+	}
+
+	@Override
+	protected void releaseInternal() {
+		synchronized (lock) {
+			if (resultFile == null) {
+				fileWriter.releaseQuietly();
+			}
+
+			// delete the produced file only when no reader is reading now
+			if (readers.isEmpty()) {
+				if (resultFile != null) {
+					resultFile.deleteQuietly();
+					resultFile = null;
+				}
+			}
+		}
+	}
+
+	@Override
+	public void emitRecord(ByteBuffer record, int targetSubpartition) throws IOException {
+		emit(record, targetSubpartition, DataType.DATA_BUFFER);
+	}
+
+	@Override
+	public void broadcastRecord(ByteBuffer record) throws IOException {
+		broadcast(record, DataType.DATA_BUFFER);
+	}
+
+	@Override
+	public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {
+		Buffer buffer = EventSerializer.toBuffer(event, isPriorityEvent);
+		try {
+			ByteBuffer serializedEvent = buffer.getNioBufferReadable();
+			broadcast(serializedEvent, buffer.getDataType());
+		} finally {
+			buffer.recycleBuffer();
+		}
+	}
+
+	private void broadcast(ByteBuffer record, DataType dataType) throws IOException {
+		for (int channelIndex = 0; channelIndex < numSubpartitions; ++channelIndex) {
+			record.rewind();
+			emit(record, channelIndex, dataType);
+		}
+	}
+
+	private void emit(
+			ByteBuffer record,
+			int targetSubpartition,
+			DataType dataType) throws IOException {
+		checkInProduceState();
+
+		SortBuffer sortBuffer = getSortBuffer();
+		if (sortBuffer.append(record, targetSubpartition, dataType)) {
+			return;
+		}
+
+		if (!sortBuffer.hasRemaining()) {
+			// the record can not be appended to the free sort buffer because it is too large
+			currentSortBuffer.finish();
+			currentSortBuffer.release();
+			writeLargeRecord(record, targetSubpartition, dataType);
+			return;
+		}
+
+		flushCurrentSortBuffer();
+		emit(record, targetSubpartition, dataType);
+	}
+
+	private void releaseCurrentSortBuffer() {
+		if (currentSortBuffer != null) {
+			currentSortBuffer.release();
+		}
+	}
+
+	private SortBuffer getSortBuffer() {
+		if (currentSortBuffer != null && !currentSortBuffer.isFinished()) {
+			return currentSortBuffer;
+		}
+
+		currentSortBuffer = new PartitionSortedBuffer(
+			lock, bufferPool, numSubpartitions, networkBufferSize, null);
+		return currentSortBuffer;
+	}
+
+	private void flushCurrentSortBuffer() throws IOException {
+		if (currentSortBuffer == null) {
+			return;
+		}
+		currentSortBuffer.finish();
+
+		if (currentSortBuffer.hasRemaining()) {
+			fileWriter.startNewRegion();
+
+			while (currentSortBuffer.hasRemaining()) {
+				BufferWithChannel bufferWithChannel = currentSortBuffer.copyIntoSegment(writeBuffer);
+				Buffer buffer = bufferWithChannel.getBuffer();
+				int subpartitionIndex = bufferWithChannel.getChannelIndex();
+
+				fileWriter.writeBuffer(buffer, subpartitionIndex);
+				updateStatistics(buffer, subpartitionIndex);
+			}
+		}
+
+		currentSortBuffer.release();
+	}
+
+	private void updateStatistics(Buffer buffer, int subpartitionIndex) {
+		numBuffersOut.inc();
+		numBytesOut.inc(buffer.readableBytes());
+		if (buffer.isBuffer()) {
+			++numDataBuffers[subpartitionIndex];
+		}
+	}
+
+	/**
+	 * Spills the large record into the target {@link PartitionedFile} as a separate data region.
+	 */
+	private void writeLargeRecord(
+			ByteBuffer record,
+			int targetSubpartition,
+			DataType dataType) throws IOException {
+		fileWriter.startNewRegion();
+
+		while (record.hasRemaining()) {
+			int toCopy = Math.min(record.remaining(), writeBuffer.size());
+			writeBuffer.put(0, record, toCopy);
+
+			NetworkBuffer buffer = new NetworkBuffer(writeBuffer, (buf) -> {}, dataType, toCopy);
+			fileWriter.writeBuffer(buffer, targetSubpartition);
+			updateStatistics(buffer, targetSubpartition);
+		}
+	}
+
+	void releaseReader(SortMergeSubpartitionReader reader) {
+		synchronized (lock) {
+			readers.remove(reader);
+
+			// release the result partition if it has been marked as released
+			if (readers.isEmpty() && isReleased()) {
+				releaseInternal();
+			}
+		}
+	}
+
+	@Override
+	public void finish() throws IOException {
+		broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
+		flushCurrentSortBuffer();
+
+		synchronized (lock) {
+			checkState(!isReleased(), "Result partition is already released.");
+
+			resultFile = fileWriter.finish();
+			LOG.info("New partitioned file produced: {}.", resultFile);
+		}
+
+		super.finish();
+	}
+
+	@Override
+	public void close() {
+		releaseCurrentSortBuffer();
+		super.close();
+
+		IOUtils.closeQuietly(fileWriter);
+	}
+
+	@Override
+	public ResultSubpartitionView createSubpartitionView(
+			int subpartitionIndex,
+			BufferAvailabilityListener availabilityListener) throws IOException {
+		synchronized (lock) {
+			checkElementIndex(subpartitionIndex, numSubpartitions, "Subpartition not found.");
+			checkState(!isReleased(), "Partition released.");
+			checkState(isFinished(), "Trying to read unfinished blocking partition.");
+
+			SortMergeSubpartitionReader reader = new SortMergeSubpartitionReader(
+				subpartitionIndex,
+				numDataBuffers[subpartitionIndex],
+				networkBufferSize,
+				this,
+				availabilityListener,
+				resultFile);
+			readers.add(reader);
+			availabilityListener.notifyDataAvailable();
+
+			return reader;
+		}
+	}
+
+	@Override
+	public void flushAll() {
+		try {
+			flushCurrentSortBuffer();
+		} catch (IOException e) {
+			LOG.error("Failed to flush the current sort buffer.", e);
+		}
+	}
+
+	@Override
+	public void flush(int subpartitionIndex) {
+		try {
+			flushCurrentSortBuffer();
+		} catch (IOException e) {
+			LOG.error("Failed to flush the current sort buffer.", e);
+		}
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		return AVAILABLE;
+	}
+
+	@Override
+	public int getNumberOfQueuedBuffers() {
+		return 0;
+	}
+
+	@Override
+	public int getNumberOfQueuedBuffers(int targetSubpartition) {
+		return 0;
+	}
+
+	@VisibleForTesting
+	PartitionedFile getResultFile() {
+		return resultFile;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Subpartition data reader for {@link SortMergeResultPartition}.
+ */
+public class SortMergeSubpartitionReader implements ResultSubpartitionView, BufferRecycler {
+
+	private static final int NUM_READ_BUFFERS = 2;
+
+	/** Target {@link SortMergeResultPartition} to read data from. */
+	private final SortMergeResultPartition partition;
+
+	/** Listener to notify when data is available. */
+	private final BufferAvailabilityListener availabilityListener;
+
+	/** Unmanaged memory used as read buffers. */
+	private final Queue<MemorySegment> readBuffers = new ArrayDeque<>();
+
+	/** Buffers read by the file reader. */
+	private final Queue<Buffer> buffersRead = new ArrayDeque<>();
+
+	/** File reader used to read buffer from. */
+	private final PartitionedFileReader fileReader;
+
+	/** Number of remaining non-event buffers to read. */
+	private int dataBufferBacklog;
+
+	/** Whether this reader is released or not. */
+	private boolean isReleased;
+
+	/** Sequence number of the next buffer to be sent to the consumer. */
+	private int sequenceNumber;
+
+	public SortMergeSubpartitionReader(
+			int subpartitionIndex,
+			int dataBufferBacklog,
+			int bufferSize,
+			SortMergeResultPartition partition,
+			BufferAvailabilityListener listener,
+			PartitionedFile partitionedFile) throws IOException {
+		this.partition = checkNotNull(partition);
+		this.availabilityListener = checkNotNull(listener);
+		this.dataBufferBacklog = dataBufferBacklog;
+
+		// allocate two pieces of unmanaged segments for data reading
+		for (int i = 0; i < NUM_READ_BUFFERS; i++) {
+			this.readBuffers.add(MemorySegmentFactory.allocateUnpooledOffHeapMemory(bufferSize, null));
+		}
+
+		this.fileReader = new PartitionedFileReader(partitionedFile, subpartitionIndex);
+		try {
+			readBuffers();
+		} catch (Throwable throwable) {
+			// ensure that the file reader is closed when any exception occurs
+			IOUtils.closeQuietly(fileReader);
+			throw throwable;
+		}
+	}
+
+	@Nullable
+	@Override
+	public BufferAndBacklog getNextBuffer() {
+		checkState(!isReleased, "Reader is already released.");
+
+		Buffer buffer = buffersRead.poll();
+		if (buffer == null) {
+			return null;
+		}
+
+		if (buffer.isBuffer()) {
+			--dataBufferBacklog;
+		}
+
+		return BufferAndBacklog.fromBufferAndLookahead(
+			buffer, buffersRead.peek(), dataBufferBacklog, sequenceNumber++);
+	}
+
+	void readBuffers() throws IOException {
+		// we do not need to recycle the allocated segment here if any exception occurs
+		// for this subpartition reader will be released so no resource will be leaked
+		MemorySegment segment;
+		while ((segment = readBuffers.poll()) != null) {
+			Buffer buffer = fileReader.readBuffer(segment, this);
+			if (buffer == null) {
+				readBuffers.add(segment);
+				break;
+			}
+			buffersRead.add(buffer);
+		}
+	}
+
+	@Override
+	public void notifyDataAvailable() {
+		if (!buffersRead.isEmpty()) {
+			availabilityListener.notifyDataAvailable();
+		}
+	}
+
+	@Override
+	public void recycle(MemorySegment segment) {
+		readBuffers.add(segment);
+
+		// notify data available if the reader is unavailable currently
+		if (!isReleased && readBuffers.size() == NUM_READ_BUFFERS) {
+			try {
+				readBuffers();
+			} catch (IOException exception) {
+				ExceptionUtils.rethrow(exception, "Failed to read next buffer.");
+			}
+			notifyDataAvailable();
+		}
+	}
+
+	@Override
+	public void releaseAllResources() {
+		isReleased = true;
+
+		IOUtils.closeQuietly(fileReader);
+		partition.releaseReader(this);
+	}
+
+	@Override
+	public boolean isReleased() {
+		return isReleased;
+	}
+
+	@Override
+	public void resumeConsumption() {
+		throw new UnsupportedOperationException("Method should never be called.");
+	}
+
+	@Override
+	public Throwable getFailureCause() {
+		// we can never throw an error after this was created
+		return null;
+	}
+
+	@Override
+	public boolean isAvailable(int numCreditsAvailable) {
+		if (numCreditsAvailable > 0) {
+			return !buffersRead.isEmpty();
+		}
+
+		return !buffersRead.isEmpty() && !buffersRead.peek().isBuffer();
+	}
+
+	@Override
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		return 0;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -58,6 +58,10 @@ public class NettyShuffleEnvironmentConfiguration {
 	/** Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). */
 	private final int floatingNetworkBuffersPerGate;
 
+	private final int sortShuffleMinBuffers;
+
+	private final int sortShuffleMinParallelism;
+
 	private final Duration requestSegmentsTimeout;
 
 	private final boolean isNetworkDetailedMetrics;
@@ -88,7 +92,9 @@ public class NettyShuffleEnvironmentConfiguration {
 			BoundedBlockingSubpartitionType blockingSubpartitionType,
 			boolean blockingShuffleCompressionEnabled,
 			String compressionCodec,
-			int maxBuffersPerChannel) {
+			int maxBuffersPerChannel,
+			int sortShuffleMinBuffers,
+			int sortShuffleMinParallelism) {
 
 		this.numNetworkBuffers = numNetworkBuffers;
 		this.networkBufferSize = networkBufferSize;
@@ -104,6 +110,8 @@ public class NettyShuffleEnvironmentConfiguration {
 		this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;
 		this.compressionCodec = Preconditions.checkNotNull(compressionCodec);
 		this.maxBuffersPerChannel = maxBuffersPerChannel;
+		this.sortShuffleMinBuffers = sortShuffleMinBuffers;
+		this.sortShuffleMinParallelism = sortShuffleMinParallelism;
 	}
 
 	// ------------------------------------------------------------------------
@@ -130,6 +138,14 @@ public class NettyShuffleEnvironmentConfiguration {
 
 	public int floatingNetworkBuffersPerGate() {
 		return floatingNetworkBuffersPerGate;
+	}
+
+	public int sortShuffleMinBuffers() {
+		return sortShuffleMinBuffers;
+	}
+
+	public int sortShuffleMinParallelism() {
+		return sortShuffleMinParallelism;
 	}
 
 	public Duration getRequestSegmentsTimeout() {
@@ -201,6 +217,11 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		int maxBuffersPerChannel = configuration.getInteger(NettyShuffleEnvironmentOptions.NETWORK_MAX_BUFFERS_PER_CHANNEL);
 
+		int sortShuffleMinBuffers = configuration.getInteger(
+			NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
+		int sortShuffleMinParallelism = configuration.getInteger(
+			NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM);
+
 		boolean isNetworkDetailedMetrics = configuration.getBoolean(NettyShuffleEnvironmentOptions.NETWORK_DETAILED_METRICS);
 
 		String[] tempDirs = ConfigurationUtils.parseTempDirectories(configuration);
@@ -228,7 +249,9 @@ public class NettyShuffleEnvironmentConfiguration {
 			blockingSubpartitionType,
 			blockingShuffleCompressionEnabled,
 			compressionCodec,
-			maxBuffersPerChannel);
+			maxBuffersPerChannel,
+			sortShuffleMinBuffers,
+			sortShuffleMinParallelism);
 	}
 
 	/**
@@ -350,6 +373,8 @@ public class NettyShuffleEnvironmentConfiguration {
 		result = 31 * result + (blockingShuffleCompressionEnabled ? 1 : 0);
 		result = 31 * result + Objects.hashCode(compressionCodec);
 		result = 31 * result + maxBuffersPerChannel;
+		result = 31 * result + sortShuffleMinBuffers;
+		result = 31 * result + sortShuffleMinParallelism;
 		return result;
 	}
 
@@ -370,6 +395,8 @@ public class NettyShuffleEnvironmentConfiguration {
 					this.partitionRequestMaxBackoff == that.partitionRequestMaxBackoff &&
 					this.networkBuffersPerChannel == that.networkBuffersPerChannel &&
 					this.floatingNetworkBuffersPerGate == that.floatingNetworkBuffersPerGate &&
+					this.sortShuffleMinBuffers == that.sortShuffleMinBuffers &&
+					this.sortShuffleMinParallelism == that.sortShuffleMinParallelism &&
 					this.requestSegmentsTimeout.equals(that.requestSegmentsTimeout) &&
 					(nettyConfig != null ? nettyConfig.equals(that.nettyConfig) : that.nettyConfig == null) &&
 					Arrays.equals(this.tempDirs, that.tempDirs) &&
@@ -394,6 +421,8 @@ public class NettyShuffleEnvironmentConfiguration {
 				", blockingShuffleCompressionEnabled=" + blockingShuffleCompressionEnabled +
 				", compressionCodec=" + compressionCodec +
 				", maxBuffersPerChannel=" + maxBuffersPerChannel +
+				", sortShuffleMinBuffers=" + sortShuffleMinBuffers +
+				", sortShuffleMinParallelism=" + sortShuffleMinParallelism +
 				'}';
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -54,6 +54,10 @@ public class NettyShuffleEnvironmentBuilder {
 
 	private int floatingNetworkBuffersPerGate = 8;
 
+	private int sortShuffleMinBuffers = 100;
+
+	private int sortShuffleMinParallelism = Integer.MAX_VALUE;
+
 	private int maxBuffersPerChannel = Integer.MAX_VALUE;
 
 	private boolean blockingShuffleCompressionEnabled = false;
@@ -110,6 +114,16 @@ public class NettyShuffleEnvironmentBuilder {
 		return this;
 	}
 
+	public NettyShuffleEnvironmentBuilder setSortShuffleMinBuffers(int sortShuffleMinBuffers) {
+		this.sortShuffleMinBuffers = sortShuffleMinBuffers;
+		return this;
+	}
+
+	public NettyShuffleEnvironmentBuilder setSortShuffleMinParallelism(int sortShuffleMinParallelism) {
+		this.sortShuffleMinParallelism = sortShuffleMinParallelism;
+		return this;
+	}
+
 	public NettyShuffleEnvironmentBuilder setBlockingShuffleCompressionEnabled(boolean blockingShuffleCompressionEnabled) {
 		this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;
 		return this;
@@ -156,7 +170,9 @@ public class NettyShuffleEnvironmentBuilder {
 				BoundedBlockingSubpartitionType.AUTO,
 				blockingShuffleCompressionEnabled,
 				compressionCodec,
-				maxBuffersPerChannel),
+				maxBuffersPerChannel,
+				sortShuffleMinBuffers,
+				sortShuffleMinParallelism),
 			taskManagerLocation,
 			new TaskEventDispatcher(),
 			resultPartitionManager,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
@@ -344,7 +344,7 @@ public class PartitionSortedBufferTest {
 		return new PartitionSortedBuffer(bufferPool, numSubpartitions, bufferSize, customReadOrder);
 	}
 
-	private int[] getRandomSubpartitionOrder(int numSubpartitions) {
+	public static int[] getRandomSubpartitionOrder(int numSubpartitions) {
 		Random random = new Random(1111);
 		int[] subpartitionReadOrder = new int[numSubpartitions];
 		int shift = random.nextInt(numSubpartitions);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
@@ -310,7 +310,7 @@ public class PartitionSortedBufferTest {
 		NetworkBufferPool globalPool = new NetworkBufferPool(bufferPoolSize, bufferSize);
 		BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
 
-		SortBuffer sortBuffer = new PartitionSortedBuffer(bufferPool, 1, bufferSize, null);
+		SortBuffer sortBuffer = new PartitionSortedBuffer(new Object(), bufferPool, 1, bufferSize, null);
 		sortBuffer.append(ByteBuffer.allocate(recordSize), 0, Buffer.DataType.DATA_BUFFER);
 
 		assertEquals(bufferPoolSize, bufferPool.bestEffortGetNumOfUsedBuffers());
@@ -341,7 +341,8 @@ public class PartitionSortedBufferTest {
 		NetworkBufferPool globalPool = new NetworkBufferPool(bufferPoolSize, bufferSize);
 		BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
 
-		return new PartitionSortedBuffer(bufferPool, numSubpartitions, bufferSize, customReadOrder);
+		return new PartitionSortedBuffer(
+			new Object(), bufferPool, numSubpartitions, bufferSize, customReadOrder);
 	}
 
 	public static int[] getRandomSubpartitionOrder(int numSubpartitions) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link PartitionSortedBuffer}.
+ */
+public class PartitionSortedBufferTest {
+
+	@Test
+	public void testWriteAndReadSortBuffer() throws Exception {
+		int numSubpartitions = 10;
+		int bufferSize = 1024;
+		int bufferPoolSize = 1000;
+		Random random = new Random(1111);
+
+		// used to store data written to and read from sort buffer for correctness check
+		Queue<DataAndType>[] dataWritten = new Queue[numSubpartitions];
+		Queue<Buffer>[] buffersRead = new Queue[numSubpartitions];
+		for (int i = 0; i < numSubpartitions; ++i) {
+			dataWritten[i] = new ArrayDeque<>();
+			buffersRead[i] = new ArrayDeque<>();
+		}
+
+		int[] numBytesWritten = new int[numSubpartitions];
+		int[] numBytesRead = new int[numSubpartitions];
+		Arrays.fill(numBytesWritten, 0);
+		Arrays.fill(numBytesRead, 0);
+
+		// fill the sort buffer with randomly generated data
+		int totalBytesWritten = 0;
+		SortBuffer sortBuffer = createSortBuffer(
+			bufferPoolSize, bufferSize, numSubpartitions, getRandomSubpartitionOrder(numSubpartitions));
+		while (true) {
+			// record size may be larger than buffer size so a record may span multiple segments
+			int recordSize = random.nextInt(bufferSize * 4 - 1) + 1;
+			byte[] bytes = new byte[recordSize];
+
+			// fill record with random value
+			random.nextBytes(bytes);
+			ByteBuffer record = ByteBuffer.wrap(bytes);
+
+			// select a random subpartition to write
+			int subpartition = random.nextInt(numSubpartitions);
+
+			// select a random data type
+			boolean isBuffer = random.nextBoolean();
+			DataType dataType = isBuffer ? DataType.DATA_BUFFER : DataType.EVENT_BUFFER;
+			if (!sortBuffer.append(record, subpartition, dataType)) {
+				sortBuffer.finish();
+				break;
+			}
+			record.rewind();
+			dataWritten[subpartition].add(new DataAndType(record, dataType));
+			numBytesWritten[subpartition] += recordSize;
+			totalBytesWritten += recordSize;
+		}
+
+		// read all data from the sort buffer
+		while (sortBuffer.hasRemaining()) {
+			MemorySegment readBuffer = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+			SortBuffer.BufferWithChannel bufferAndChannel = sortBuffer.copyIntoSegment(readBuffer);
+			int subpartition = bufferAndChannel.getChannelIndex();
+			buffersRead[subpartition].add(bufferAndChannel.getBuffer());
+			numBytesRead[subpartition] += bufferAndChannel.getBuffer().readableBytes();
+		}
+
+		assertEquals(totalBytesWritten, sortBuffer.numBytes());
+		checkWriteReadResult(numSubpartitions, numBytesWritten, numBytesRead, dataWritten, buffersRead);
+	}
+
+	public static void checkWriteReadResult(
+			int numSubpartitions,
+			int[] numBytesWritten,
+			int[] numBytesRead,
+			Queue<DataAndType>[] dataWritten,
+			Queue<Buffer>[] buffersRead) {
+		for (int subpartitionIndex = 0; subpartitionIndex < numSubpartitions; ++subpartitionIndex) {
+			assertEquals(numBytesWritten[subpartitionIndex], numBytesRead[subpartitionIndex]);
+
+			List<DataAndType> eventsWritten = new ArrayList<>();
+			List<Buffer> eventsRead = new ArrayList<>();
+
+			ByteBuffer subpartitionDataWritten = ByteBuffer.allocate(numBytesWritten[subpartitionIndex]);
+			for (DataAndType dataAndType: dataWritten[subpartitionIndex]) {
+				subpartitionDataWritten.put(dataAndType.data);
+				dataAndType.data.rewind();
+				if (dataAndType.dataType.isEvent()) {
+					eventsWritten.add(dataAndType);
+				}
+			}
+
+			ByteBuffer subpartitionDataRead = ByteBuffer.allocate(numBytesRead[subpartitionIndex]);
+			for (Buffer buffer: buffersRead[subpartitionIndex]) {
+				subpartitionDataRead.put(buffer.getNioBufferReadable());
+				if (!buffer.isBuffer()) {
+					eventsRead.add(buffer);
+				}
+			}
+
+			subpartitionDataWritten.flip();
+			subpartitionDataRead.flip();
+			assertEquals(subpartitionDataWritten, subpartitionDataRead);
+
+			assertEquals(eventsWritten.size(), eventsRead.size());
+			for (int i = 0; i < eventsWritten.size(); ++i) {
+				assertEquals(eventsWritten.get(i).dataType, eventsRead.get(i).getDataType());
+				assertEquals(eventsWritten.get(i).data, eventsRead.get(i).getNioBufferReadable());
+			}
+		}
+	}
+
+	@Test
+	public void testWriteReadWithEmptyChannel() throws Exception {
+		int bufferPoolSize = 10;
+		int bufferSize = 1024;
+		int numSubpartitions = 5;
+
+		ByteBuffer[] subpartitionRecords = {
+			ByteBuffer.allocate(128), null, ByteBuffer.allocate(1536), null, ByteBuffer.allocate(1024)};
+
+		SortBuffer sortBuffer = createSortBuffer(bufferPoolSize, bufferSize, numSubpartitions);
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			ByteBuffer record = subpartitionRecords[subpartition];
+			if (record != null) {
+				sortBuffer.append(record, subpartition, Buffer.DataType.DATA_BUFFER);
+				record.rewind();
+			}
+		}
+		sortBuffer.finish();
+
+		checkReadResult(sortBuffer, subpartitionRecords[0], 0, bufferSize);
+
+		ByteBuffer expected1 = subpartitionRecords[2].duplicate();
+		expected1.limit(bufferSize);
+		checkReadResult(sortBuffer, expected1.slice(), 2, bufferSize);
+
+		ByteBuffer expected2 = subpartitionRecords[2].duplicate();
+		expected2.position(bufferSize);
+		checkReadResult(sortBuffer, expected2.slice(), 2, bufferSize);
+
+		checkReadResult(sortBuffer, subpartitionRecords[4], 4, bufferSize);
+	}
+
+	private void checkReadResult(
+			SortBuffer sortBuffer,
+			ByteBuffer expectedBuffer,
+			int expectedChannel,
+			int bufferSize) {
+		MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+		SortBuffer.BufferWithChannel bufferWithChannel = sortBuffer.copyIntoSegment(segment);
+		assertEquals(expectedChannel, bufferWithChannel.getChannelIndex());
+		assertEquals(expectedBuffer, bufferWithChannel.getBuffer().getNioBufferReadable());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testWriteEmptyData() throws Exception {
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(1, bufferSize, 1);
+
+		ByteBuffer record = ByteBuffer.allocate(1);
+		record.position(1);
+
+		sortBuffer.append(record, 0, Buffer.DataType.DATA_BUFFER);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testWriteFinishedSortBuffer() throws Exception {
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(1, bufferSize, 1);
+		sortBuffer.finish();
+
+		sortBuffer.append(ByteBuffer.allocate(1), 0, Buffer.DataType.DATA_BUFFER);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testWriteReleasedSortBuffer() throws Exception {
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(1, bufferSize, 1);
+		sortBuffer.release();
+
+		sortBuffer.append(ByteBuffer.allocate(1), 0, Buffer.DataType.DATA_BUFFER);
+	}
+
+	@Test
+	public void testWriteMoreDataThanCapacity() throws Exception {
+		int bufferPoolSize = 10;
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(bufferPoolSize, bufferSize, 1);
+
+		for (int i = 1; i < bufferPoolSize; ++i) {
+			appendAndCheckResult(sortBuffer, bufferSize, true, bufferSize * i, i, true);
+		}
+
+		// append should fail for insufficient capacity
+		int numRecords = bufferPoolSize - 1;
+		appendAndCheckResult(sortBuffer, bufferSize, false, bufferSize * numRecords, numRecords, true);
+	}
+
+	@Test
+	public void testWriteLargeRecord() throws Exception {
+		int bufferPoolSize = 10;
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(bufferPoolSize, bufferSize, 1);
+		// append should fail for insufficient capacity
+		appendAndCheckResult(sortBuffer, bufferPoolSize * bufferSize, false, 0, 0, false);
+	}
+
+	private void appendAndCheckResult(
+			SortBuffer sortBuffer,
+			int recordSize,
+			boolean isSuccessful,
+			long numBytes,
+			long numRecords,
+			boolean hasRemaining) throws IOException {
+		ByteBuffer largeRecord = ByteBuffer.allocate(recordSize);
+
+		assertEquals(isSuccessful, sortBuffer.append(largeRecord, 0, Buffer.DataType.DATA_BUFFER));
+		assertEquals(numBytes, sortBuffer.numBytes());
+		assertEquals(numRecords, sortBuffer.numRecords());
+		assertEquals(hasRemaining, sortBuffer.hasRemaining());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReadUnfinishedSortBuffer() throws Exception {
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(1, bufferSize, 1);
+		sortBuffer.append(ByteBuffer.allocate(1), 0, Buffer.DataType.DATA_BUFFER);
+
+		assertTrue(sortBuffer.hasRemaining());
+		sortBuffer.copyIntoSegment(MemorySegmentFactory.allocateUnpooledSegment(bufferSize));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReadReleasedSortBuffer() throws Exception {
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(1, bufferSize, 1);
+		sortBuffer.append(ByteBuffer.allocate(1), 0, Buffer.DataType.DATA_BUFFER);
+		sortBuffer.finish();
+		assertTrue(sortBuffer.hasRemaining());
+
+		sortBuffer.release();
+		assertFalse(sortBuffer.hasRemaining());
+
+		sortBuffer.copyIntoSegment(MemorySegmentFactory.allocateUnpooledSegment(bufferSize));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReadEmptySortBuffer() throws Exception {
+		int bufferSize = 1024;
+
+		SortBuffer sortBuffer = createSortBuffer(1, bufferSize, 1);
+		sortBuffer.finish();
+
+		assertFalse(sortBuffer.hasRemaining());
+		sortBuffer.copyIntoSegment(MemorySegmentFactory.allocateUnpooledSegment(bufferSize));
+	}
+
+	@Test
+	public void testReleaseSortBuffer() throws Exception {
+		int bufferPoolSize = 10;
+		int bufferSize = 1024;
+		int recordSize = (bufferPoolSize - 1) * bufferSize;
+
+		NetworkBufferPool globalPool = new NetworkBufferPool(bufferPoolSize, bufferSize);
+		BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
+
+		SortBuffer sortBuffer = new PartitionSortedBuffer(bufferPool, 1, bufferSize, null);
+		sortBuffer.append(ByteBuffer.allocate(recordSize), 0, Buffer.DataType.DATA_BUFFER);
+
+		assertEquals(bufferPoolSize, bufferPool.bestEffortGetNumOfUsedBuffers());
+		assertTrue(sortBuffer.hasRemaining());
+		assertEquals(1, sortBuffer.numRecords());
+		assertEquals(recordSize, sortBuffer.numBytes());
+
+		// should release all data and resources
+		sortBuffer.release();
+		assertEquals(0, bufferPool.bestEffortGetNumOfUsedBuffers());
+		assertFalse(sortBuffer.hasRemaining());
+		assertEquals(0, sortBuffer.numRecords());
+		assertEquals(0, sortBuffer.numBytes());
+	}
+
+	private SortBuffer createSortBuffer(
+			int bufferPoolSize,
+			int bufferSize,
+			int numSubpartitions) throws IOException {
+		return createSortBuffer(bufferPoolSize, bufferSize, numSubpartitions, null);
+	}
+
+	private SortBuffer createSortBuffer(
+			int bufferPoolSize,
+			int bufferSize,
+			int numSubpartitions,
+			int[] customReadOrder) throws IOException {
+		NetworkBufferPool globalPool = new NetworkBufferPool(bufferPoolSize, bufferSize);
+		BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
+
+		return new PartitionSortedBuffer(bufferPool, numSubpartitions, bufferSize, customReadOrder);
+	}
+
+	private int[] getRandomSubpartitionOrder(int numSubpartitions) {
+		Random random = new Random(1111);
+		int[] subpartitionReadOrder = new int[numSubpartitions];
+		int shift = random.nextInt(numSubpartitions);
+		for (int i = 0; i < numSubpartitions; ++i) {
+			subpartitionReadOrder[i] = (i + shift) % numSubpartitions;
+		}
+		return subpartitionReadOrder;
+	}
+
+	/**
+	 * Data written and its {@link Buffer.DataType}.
+	 */
+	public static class DataAndType {
+		private final ByteBuffer data;
+		private final Buffer.DataType dataType;
+
+		DataAndType(ByteBuffer data, Buffer.DataType dataType) {
+			this.data = data;
+			this.dataType = dataType;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for writing and reading {@link PartitionedFile} with {@link PartitionedFileWriter} and
+ * {@link PartitionedFileReader}.
+ */
+public class PartitionedFileWriteReadTest {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testWriteAndReadPartitionedFile() throws Exception {
+		int numSubpartitions = 10;
+		int bufferSize = 1024;
+		int numBuffers = 1000;
+		int numRegions = 10;
+		Random random = new Random(1111);
+
+		List<Buffer>[] buffersWritten = new List[numSubpartitions];
+		List<Buffer>[] buffersRead = new List[numSubpartitions];
+		Queue<Buffer>[] regionBuffers = new Queue[numSubpartitions];
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			buffersWritten[subpartition] = new ArrayList<>();
+			buffersRead[subpartition] = new ArrayList<>();
+			regionBuffers[subpartition] = new ArrayDeque<>();
+		}
+
+		PartitionedFileWriter fileWriter = createPartitionedFileWriter(numSubpartitions);
+		for (int region = 0; region < numRegions; ++region) {
+			fileWriter.startNewRegion();
+
+			for (int i = 0; i < numBuffers; ++i) {
+				Buffer buffer = createBuffer(random, bufferSize);
+
+				int subpartition = random.nextInt(numSubpartitions);
+				buffersWritten[subpartition].add(buffer);
+				regionBuffers[subpartition].add(buffer);
+			}
+
+			int[] writeOrder = PartitionSortedBufferTest.getRandomSubpartitionOrder(numSubpartitions);
+			for (int index = 0; index < numSubpartitions; ++index) {
+				int subpartition = writeOrder[index];
+				while (!regionBuffers[subpartition].isEmpty()) {
+					fileWriter.writeBuffer(regionBuffers[subpartition].poll(), subpartition);
+				}
+			}
+		}
+		PartitionedFile partitionedFile = fileWriter.finish();
+
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			PartitionedFileReader fileReader = new PartitionedFileReader(partitionedFile, subpartition);
+			while (fileReader.hasRemaining()) {
+				MemorySegment readBuffer = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+				Buffer buffer = fileReader.readBuffer(readBuffer, (buf) -> {});
+				buffersRead[subpartition].add(buffer);
+			}
+			fileReader.close();
+		}
+
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			assertEquals(buffersWritten[subpartition].size(), buffersRead[subpartition].size());
+			for (int i = 0; i < buffersWritten[subpartition].size(); ++i) {
+				assertBufferEquals(buffersWritten[subpartition].get(i), buffersRead[subpartition].get(i));
+			}
+		}
+	}
+
+	@Test
+	public void testWriteAndReadWithEmptySubpartition() throws Exception {
+		int numRegions = 10;
+		int numSubpartitions = 5;
+		int bufferSize = 1024;
+		Random random = new Random(1111);
+
+		Queue<Buffer>[] subpartitionBuffers = new ArrayDeque[numSubpartitions];
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			subpartitionBuffers[subpartition] = new ArrayDeque<>();
+		}
+
+		PartitionedFileWriter fileWriter = createPartitionedFileWriter(numSubpartitions);
+		for (int region = 0; region < numRegions; ++region) {
+			fileWriter.startNewRegion();
+			for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+				if (random.nextBoolean()) {
+					Buffer buffer = createBuffer(random, bufferSize);
+					subpartitionBuffers[subpartition].add(buffer);
+					fileWriter.writeBuffer(buffer, subpartition);
+				}
+			}
+		}
+		PartitionedFile partitionedFile = fileWriter.finish();
+
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			PartitionedFileReader fileReader = new PartitionedFileReader(partitionedFile, subpartition);
+			while (fileReader.hasRemaining()) {
+				MemorySegment readBuffer = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+				Buffer buffer = checkNotNull(fileReader.readBuffer(readBuffer, (buf) -> {}));
+				assertBufferEquals(checkNotNull(subpartitionBuffers[subpartition].poll()), buffer);
+			}
+			fileReader.close();
+			assertTrue(subpartitionBuffers[subpartition].isEmpty());
+		}
+	}
+
+	private void assertBufferEquals(Buffer expected, Buffer actual) {
+		assertEquals(expected.getDataType(), actual.getDataType());
+		assertEquals(expected.getNioBufferReadable(), actual.getNioBufferReadable());
+	}
+
+	private Buffer createBuffer(Random random, int bufferSize) {
+		boolean isBuffer = random.nextBoolean();
+		Buffer.DataType dataType = isBuffer ? Buffer.DataType.DATA_BUFFER : Buffer.DataType.EVENT_BUFFER;
+
+		int dataSize = random.nextInt(bufferSize) + 1;
+		byte[] data = new byte[dataSize];
+		return new NetworkBuffer(MemorySegmentFactory.wrap(data), (buf) -> {}, dataType, dataSize);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testNotWriteDataOfTheSameSubpartitionTogether() throws Exception {
+		PartitionedFileWriter partitionedFileWriter = createPartitionedFileWriter(2);
+		try {
+			MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(1024);
+
+			NetworkBuffer buffer1 = new NetworkBuffer(segment, (buf) -> {});
+			partitionedFileWriter.writeBuffer(buffer1, 1);
+
+			NetworkBuffer buffer2 = new NetworkBuffer(segment, (buf) -> {});
+			partitionedFileWriter.writeBuffer(buffer2, 0);
+
+			NetworkBuffer buffer3 = new NetworkBuffer(segment, (buf) -> {});
+			partitionedFileWriter.writeBuffer(buffer3, 1);
+		} finally {
+			partitionedFileWriter.finish();
+		}
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testWriteFinishedPartitionedFile() throws Exception {
+		PartitionedFileWriter partitionedFileWriter = createAndFinishPartitionedFileWriter();
+
+		MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(1024);
+		NetworkBuffer buffer = new NetworkBuffer(segment, (buf) -> {});
+
+		partitionedFileWriter.writeBuffer(buffer, 0);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testFinishPartitionedFileWriterTwice() throws Exception {
+		PartitionedFileWriter partitionedFileWriter = createAndFinishPartitionedFileWriter();
+		partitionedFileWriter.finish();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReadClosedPartitionedFile() throws Exception {
+		PartitionedFileReader partitionedFileReader = createAndClosePartitionedFiledReader();
+
+		MemorySegment target = MemorySegmentFactory.allocateUnpooledSegment(1024);
+		partitionedFileReader.readBuffer(target, FreeingBufferRecycler.INSTANCE);
+	}
+
+	@Test
+	public void testReadEmptyPartitionedFile() throws Exception {
+		try (PartitionedFileReader partitionedFileReader = createPartitionedFiledReader()) {
+			MemorySegment target = MemorySegmentFactory.allocateUnpooledSegment(1024);
+			assertNull(partitionedFileReader.readBuffer(target, FreeingBufferRecycler.INSTANCE));
+		}
+	}
+
+	private PartitionedFileReader createAndClosePartitionedFiledReader() throws IOException {
+		PartitionedFileReader fileReader = createPartitionedFiledReader();
+		fileReader.close();
+		return fileReader;
+	}
+
+	private PartitionedFileReader createPartitionedFiledReader() throws IOException {
+		PartitionedFile partitionedFile = createPartitionedFile();
+		return new PartitionedFileReader(partitionedFile, 1);
+	}
+
+	private PartitionedFile createPartitionedFile() throws IOException {
+		PartitionedFileWriter partitionedFileWriter = createPartitionedFileWriter(2);
+		return partitionedFileWriter.finish();
+	}
+
+	private PartitionedFileWriter createPartitionedFileWriter(int numSubpartitions) throws IOException {
+		String basePath = temporaryFolder.newFile().getPath();
+		return new PartitionedFileWriter(numSubpartitions, 640, basePath);
+	}
+
+	private PartitionedFileWriter createAndFinishPartitionedFileWriter() throws IOException {
+		PartitionedFileWriter partitionedFileWriter = createPartitionedFileWriter(1);
+		partitionedFileWriter.finish();
+		return partitionedFileWriter;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -55,6 +55,10 @@ public class ResultPartitionBuilder {
 
 	private int floatingNetworkBuffersPerGate = 1;
 
+	private int sortShuffleMinBuffers = 100;
+
+	private int sortShuffleMinParallelism = Integer.MAX_VALUE;
+
 	private int maxBuffersPerChannel = Integer.MAX_VALUE;
 
 	private int networkBufferSize = 1;
@@ -105,7 +109,9 @@ public class ResultPartitionBuilder {
 		return setNetworkBuffersPerChannel(environment.getConfiguration().networkBuffersPerChannel())
 			.setFloatingNetworkBuffersPerGate(environment.getConfiguration().floatingNetworkBuffersPerGate())
 			.setNetworkBufferSize(environment.getConfiguration().networkBufferSize())
-			.setNetworkBufferPool(environment.getNetworkBufferPool());
+			.setNetworkBufferPool(environment.getNetworkBufferPool())
+			.setSortShuffleMinBuffers(environment.getConfiguration().sortShuffleMinBuffers())
+			.setSortShuffleMinParallelism(environment.getConfiguration().sortShuffleMinParallelism());
 	}
 
 	public ResultPartitionBuilder setNetworkBufferPool(NetworkBufferPool networkBufferPool) {
@@ -139,6 +145,16 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
+	public ResultPartitionBuilder setSortShuffleMinBuffers(int sortShuffleMinBuffers) {
+		this.sortShuffleMinBuffers = sortShuffleMinBuffers;
+		return this;
+	}
+
+	public ResultPartitionBuilder setSortShuffleMinParallelism(int sortShuffleMinParallelism) {
+		this.sortShuffleMinParallelism = sortShuffleMinParallelism;
+		return this;
+	}
+
 	public ResultPartitionBuilder setCompressionCodec(String compressionCodec) {
 		this.compressionCodec = compressionCodec;
 		return this;
@@ -161,7 +177,9 @@ public class ResultPartitionBuilder {
 			networkBufferSize,
 			blockingShuffleCompressionEnabled,
 			compressionCodec,
-			maxBuffersPerChannel);
+			maxBuffersPerChannel,
+			sortShuffleMinBuffers,
+			sortShuffleMinParallelism);
 
 		SupplierWithException<BufferPool, IOException> factory = bufferPoolFactory.orElseGet(() ->
 			resultPartitionFactory.createBufferPoolFactory(numberOfSubpartitions, partitionType));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -72,7 +72,13 @@ public class ResultPartitionFactoryTest extends TestLogger {
 	}
 
 	@Test
-	public void testConsumptionOnReleaseForPipelined() {
+	public void testSortMergePartitionCreated() {
+		ResultPartition resultPartition = createResultPartition(ResultPartitionType.BLOCKING, 1);
+		assertTrue(resultPartition instanceof SortMergeResultPartition);
+	}
+
+	@Test
+	public void testReleaseOnConsumptionForPipelinedPartition() {
 		final ResultPartition resultPartition = createResultPartition(ResultPartitionType.PIPELINED);
 
 		resultPartition.onConsumedSubpartition(0);
@@ -81,7 +87,7 @@ public class ResultPartitionFactoryTest extends TestLogger {
 	}
 
 	@Test
-	public void testNoConsumptionOnReleaseForBlocking() {
+	public void testNoReleaseOnConsumptionForBoundedBlockingPartition() {
 		final ResultPartition resultPartition = createResultPartition(ResultPartitionType.BLOCKING);
 
 		resultPartition.onConsumedSubpartition(0);
@@ -89,7 +95,22 @@ public class ResultPartitionFactoryTest extends TestLogger {
 		assertFalse(resultPartition.isReleased());
 	}
 
+	@Test
+	public void testNoReleaseOnConsumptionForSortMergePartition() {
+		final ResultPartition resultPartition = createResultPartition(ResultPartitionType.BLOCKING, 1);
+
+		resultPartition.onConsumedSubpartition(0);
+
+		assertFalse(resultPartition.isReleased());
+	}
+
 	private static ResultPartition createResultPartition(ResultPartitionType partitionType) {
+		return createResultPartition(partitionType, Integer.MAX_VALUE);
+	}
+
+	private static ResultPartition createResultPartition(
+			ResultPartitionType partitionType,
+			int sortShuffleMinParallelism) {
 		final ResultPartitionManager manager = new ResultPartitionManager();
 
 		final ResultPartitionFactory factory = new ResultPartitionFactory(
@@ -102,7 +123,9 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			SEGMENT_SIZE,
 			false,
 			"LZ4",
-			Integer.MAX_VALUE);
+			Integer.MAX_VALUE,
+			10,
+			sortShuffleMinParallelism);
 
 		final ResultPartitionDeploymentDescriptor descriptor = new ResultPartitionDeploymentDescriptor(
 			PartitionDescriptorBuilder

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.disk.FileChannelManager;
+import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.Random;
+
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link SortMergeResultPartition}.
+ */
+public class SortMergeResultPartitionTest {
+
+	private static final BufferAvailabilityListener listener = new NoOpBufferAvailablityListener();
+
+	private static final int bufferSize = 1024;
+
+	private static final int totalBuffers = 1000;
+
+	private FileChannelManager fileChannelManager;
+
+	private NetworkBufferPool globalPool;
+
+	@Rule
+	public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	@Before
+	public void setUp() {
+		fileChannelManager = new FileChannelManagerImpl(
+			new String[] {tmpFolder.getRoot().getPath()}, "testing");
+		globalPool = new NetworkBufferPool(totalBuffers, bufferSize);
+	}
+
+	@After
+	public void shutdown() throws Exception {
+		fileChannelManager.close();
+		globalPool.destroy();
+	}
+
+	@Test
+	public void testWriteAndRead() throws Exception {
+		int numSubpartitions = 10;
+		int numBuffers = 100;
+		int numRecords = 1000;
+		Random random = new Random();
+
+		BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+		SortMergeResultPartition partition = createSortMergedPartition(numSubpartitions, bufferPool);
+
+		Queue<PartitionSortedBufferTest.DataAndType>[] dataWritten = new Queue[numSubpartitions];
+		Queue<Buffer>[] buffersRead = new Queue[numSubpartitions];
+		for (int i = 0; i < numSubpartitions; ++i) {
+			dataWritten[i] = new ArrayDeque<>();
+			buffersRead[i] = new ArrayDeque<>();
+		}
+
+		int[] numBytesWritten = new int[numSubpartitions];
+		int[] numBytesRead = new int[numSubpartitions];
+		Arrays.fill(numBytesWritten, 0);
+		Arrays.fill(numBytesRead, 0);
+
+		for (int i = 0; i < numRecords; ++i) {
+			byte[] data  = new byte[random.nextInt(2 * bufferSize) + 1];
+			random.nextBytes(data);
+			ByteBuffer record = ByteBuffer.wrap(data);
+			boolean isBroadCast = random.nextBoolean();
+
+			if (isBroadCast) {
+				partition.broadcastRecord(record);
+				for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+					recordDataWritten(
+						record, dataWritten, subpartition, numBytesWritten, DataType.DATA_BUFFER);
+				}
+			} else {
+				int subpartition = random.nextInt(numSubpartitions);
+				partition.emitRecord(record, subpartition);
+				recordDataWritten(
+					record, dataWritten, subpartition, numBytesWritten, DataType.DATA_BUFFER);
+			}
+		}
+
+		partition.finish();
+		partition.close();
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			ByteBuffer record = EventSerializer.toSerializedEvent(EndOfPartitionEvent.INSTANCE);
+			recordDataWritten(
+				record, dataWritten, subpartition, numBytesWritten, DataType.EVENT_BUFFER);
+		}
+
+		for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+			ResultSubpartitionView view = partition.createSubpartitionView(subpartition, listener);
+			while (view.isAvailable(Integer.MAX_VALUE)) {
+				Buffer buffer = view.getNextBuffer().buffer();
+				int numBytes = buffer.readableBytes();
+				numBytesRead[subpartition] += numBytes;
+
+				MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(numBytes);
+				segment.put(0, buffer.getNioBufferReadable(), numBytes);
+				buffersRead[subpartition].add(
+					new NetworkBuffer(segment, (buf) -> {}, buffer.getDataType(), numBytes));
+				buffer.recycleBuffer();
+			}
+			view.releaseAllResources();
+		}
+
+		PartitionSortedBufferTest.checkWriteReadResult(
+			numSubpartitions, numBytesWritten, numBytesRead, dataWritten, buffersRead);
+	}
+
+	private void recordDataWritten(
+			ByteBuffer record,
+			Queue<PartitionSortedBufferTest.DataAndType>[] dataWritten,
+			int subpartition,
+			int[] numBytesWritten,
+			Buffer.DataType dataType) {
+		record.rewind();
+		dataWritten[subpartition].add(
+			new PartitionSortedBufferTest.DataAndType(record, dataType));
+		numBytesWritten[subpartition] += record.remaining();
+	}
+
+	@Test
+	public void testWriteLargeRecord() throws Exception {
+		int numBuffers = 100;
+		BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+		SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+
+		byte[] dataWritten  = new byte[bufferSize * numBuffers];
+		Random random = new Random();
+		random.nextBytes(dataWritten);
+		ByteBuffer recordWritten = ByteBuffer.wrap(dataWritten);
+		partition.emitRecord(recordWritten, 0);
+		assertEquals(0, bufferPool.bestEffortGetNumOfUsedBuffers());
+
+		partition.finish();
+		partition.close();
+
+		ResultSubpartitionView view = partition.createSubpartitionView(0, listener);
+		ByteBuffer recordRead = ByteBuffer.allocate(bufferSize * numBuffers);
+		while (view.isAvailable(Integer.MAX_VALUE)) {
+			Buffer buffer = view.getNextBuffer().buffer();
+			if (buffer.isBuffer()) {
+				recordRead.put(buffer.getNioBufferReadable());
+			}
+			buffer.recycleBuffer();
+		}
+		view.releaseAllResources();
+
+		recordWritten.rewind();
+		recordRead.flip();
+		assertEquals(recordWritten, recordRead);
+	}
+
+	@Test
+	public void testFlush() throws Exception {
+		int numBuffers = 10;
+		BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+		SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+
+		partition.emitRecord(ByteBuffer.allocate(bufferSize), 0);
+		partition.emitRecord(ByteBuffer.allocate(bufferSize), 1);
+		assertEquals(3, bufferPool.bestEffortGetNumOfUsedBuffers());
+
+		partition.flush(0);
+		assertEquals(0, bufferPool.bestEffortGetNumOfUsedBuffers());
+
+		partition.emitRecord(ByteBuffer.allocate(bufferSize), 2);
+		partition.emitRecord(ByteBuffer.allocate(bufferSize), 3);
+		assertEquals(3, bufferPool.bestEffortGetNumOfUsedBuffers());
+
+		partition.flushAll();
+		assertEquals(0, bufferPool.bestEffortGetNumOfUsedBuffers());
+
+		assertNull(partition.getResultFile());
+		partition.finish();
+		assertEquals(3, partition.getResultFile().getNumRegions());
+
+		partition.close();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReleaseWhileWriting() throws Exception {
+		int numBuffers = 10;
+		BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+		SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+
+		partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 0);
+		partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 1);
+
+		partition.emitRecord(ByteBuffer.allocate(bufferSize), 2);
+		assertNull(partition.getResultFile());
+		assertEquals(2, fileChannelManager.getPaths()[0].list().length);
+
+		partition.release();
+		try {
+			partition.emitRecord(ByteBuffer.allocate(bufferSize * numBuffers), 2);
+		} catch (IllegalStateException exception) {
+			assertEquals(0, fileChannelManager.getPaths()[0].list().length);
+
+			throw exception;
+		}
+
+		fail("Should throw ClosedChannelException.");
+	}
+
+	@Test
+	public void testReleaseWhileReading() throws Exception {
+		int numBuffers = 10;
+		BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+		SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+
+		partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 0);
+		partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 1);
+		partition.finish();
+		partition.close();
+
+		assertEquals(2, partition.getResultFile().getNumRegions());
+		assertEquals(2, fileChannelManager.getPaths()[0].list().length);
+
+		ResultSubpartitionView view = partition.createSubpartitionView(0, listener);
+		view.getNextBuffer().buffer().recycleBuffer();
+		partition.release();
+
+		assertEquals(2, partition.getResultFile().getNumRegions());
+		assertEquals(2, fileChannelManager.getPaths()[0].list().length);
+
+		while (view.isAvailable(Integer.MAX_VALUE)) {
+			view.getNextBuffer().buffer().recycleBuffer();
+		}
+		view.releaseAllResources();
+
+		assertNull(partition.getResultFile());
+		assertEquals(0, fileChannelManager.getPaths()[0].list().length);
+	}
+
+	@Test
+	public void testCloseReleasesAllBuffers() throws Exception {
+		int numBuffers = 100;
+		BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+		SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+
+		partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 5);
+		assertEquals(numBuffers, bufferPool.bestEffortGetNumOfUsedBuffers());
+
+		partition.close();
+		assertTrue(bufferPool.isDestroyed());
+		assertEquals(totalBuffers, globalPool.getNumberOfAvailableMemorySegments());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReadUnfinishedPartition() throws Exception {
+		BufferPool bufferPool = globalPool.createBufferPool(10, 10);
+		try {
+			SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+			partition.createSubpartitionView(0, listener);
+		} finally {
+			bufferPool.lazyDestroy();
+		}
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testReadReleasedPartition() throws Exception {
+		BufferPool bufferPool = globalPool.createBufferPool(10, 10);
+		try {
+			SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+			partition.finish();
+			partition.release();
+			partition.createSubpartitionView(0, listener);
+		} finally {
+			bufferPool.lazyDestroy();
+		}
+	}
+
+	private SortMergeResultPartition createSortMergedPartition(
+			int numSubpartitions,
+			BufferPool bufferPool) throws IOException {
+		SortMergeResultPartition sortMergedResultPartition = new SortMergeResultPartition(
+			"SortMergedResultPartitionTest",
+			0,
+			new ResultPartitionID(),
+			ResultPartitionType.BLOCKING,
+			numSubpartitions,
+			numSubpartitions,
+			bufferSize,
+			new ResultPartitionManager(),
+			fileChannelManager.createChannel().getPath(),
+			null,
+			() -> bufferPool);
+		sortMergedResultPartition.setup();
+		return sortMergedResultPartition;
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for blocking shuffle.
+ */
+public class BlockingShuffleITCase {
+
+	private static final String RECORD = "hello, world!";
+
+	private final int numTaskManagers = 2;
+
+	private final int numSlotsPerTaskManager = 4;
+
+	@Test
+	public void testBoundedBlockingShuffle() throws Exception {
+		JobGraph jobGraph = createJobGraph(1000000);
+		Configuration configuration = new Configuration();
+		JobGraphRunningUtil.execute(jobGraph, configuration, numTaskManagers, numSlotsPerTaskManager);
+	}
+
+	@Test
+	public void testBoundedBlockingShuffleWithoutData() throws Exception {
+		JobGraph jobGraph = createJobGraph(0);
+		Configuration configuration = new Configuration();
+		JobGraphRunningUtil.execute(jobGraph, configuration, numTaskManagers, numSlotsPerTaskManager);
+	}
+
+	@Test
+	public void testSortMergeBlockingShuffle() throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM, 1);
+
+		JobGraph jobGraph = createJobGraph(1000000);
+		JobGraphRunningUtil.execute(jobGraph, configuration, numTaskManagers, numSlotsPerTaskManager);
+	}
+
+	@Test
+	public void testSortMergeBlockingShuffleWithoutData() throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM, 1);
+
+		JobGraph jobGraph = createJobGraph(0);
+		JobGraphRunningUtil.execute(jobGraph, configuration, numTaskManagers, numSlotsPerTaskManager);
+	}
+
+	private JobGraph createJobGraph(int numRecordsToSend) {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(numTaskManagers * numSlotsPerTaskManager);
+		DataStream<String> source = env.addSource(new StringSource(numRecordsToSend));
+		source
+			.rebalance().map((MapFunction<String, String>) value -> value)
+			.broadcast().addSink(new VerifySink());
+
+		StreamGraph streamGraph = env.getStreamGraph();
+		streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_BLOCKING);
+		streamGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES);
+		return StreamingJobGraphGenerator.createJobGraph(streamGraph);
+	}
+
+	private static class StringSource implements ParallelSourceFunction<String> {
+		private volatile boolean isRunning = true;
+		private int numRecordsToSend;
+
+		StringSource(int numRecordsToSend) {
+			this.numRecordsToSend = numRecordsToSend;
+		}
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			while (isRunning && numRecordsToSend-- > 0) {
+				ctx.collect(RECORD);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+	}
+
+	private static class VerifySink implements SinkFunction<String> {
+
+		@Override
+		public void invoke(String value) throws Exception {
+			assertEquals(RECORD, value);
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.MiniClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+
+/**
+ * Utils to run {@link JobGraph} on {@link MiniCluster}.
+ */
+public class JobGraphRunningUtil {
+
+	public static void execute(
+			JobGraph jobGraph,
+			Configuration configuration,
+			int numTaskManagers,
+			int numSlotsPerTaskManager) throws Exception {
+		configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
+
+		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
+			.setConfiguration(configuration)
+			.setNumTaskManagers(numTaskManagers)
+			.setNumSlotsPerTaskManager(numSlotsPerTaskManager)
+			.build();
+
+		try (MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration)) {
+			miniCluster.start();
+
+			MiniClusterClient miniClusterClient = new MiniClusterClient(configuration, miniCluster);
+			// wait for the submission to succeed
+			JobID jobID = miniClusterClient.submitJob(jobGraph).get();
+
+			JobResult jobResult = miniClusterClient.requestJobResult(jobID).get();
+			if (jobResult.getSerializedThrowable().isPresent()) {
+				throw new AssertionError(jobResult.getSerializedThrowable().get());
+			}
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
@@ -78,9 +78,20 @@ public class ShuffleCompressionITCase {
 	}
 
 	@Test
-	public void testDataCompressionForBlockingShuffle() throws Exception {
+	public void testDataCompressionForBoundedBlockingShuffle() throws Exception {
 		Configuration configuration = new Configuration();
 		configuration.setBoolean(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED, true);
+
+		JobGraph jobGraph = createJobGraph(
+			ScheduleMode.LAZY_FROM_SOURCES, ResultPartitionType.BLOCKING, ExecutionMode.BATCH);
+		JobGraphRunningUtil.execute(jobGraph, configuration, NUM_TASKMANAGERS, NUM_SLOTS);
+	}
+
+	@Test
+	public void testDataCompressionForSortMergeBlockingShuffle() throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setBoolean(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED, true);
+		configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM, 1);
 
 		JobGraph jobGraph = createJobGraph(
 			ScheduleMode.LAZY_FROM_SOURCES, ResultPartitionType.BLOCKING, ExecutionMode.BATCH);


### PR DESCRIPTION
## What is the purpose of the change

Hash-based blocking shuffle and sort-merge based blocking shuffle are two main blocking shuffle implementations wildly adopted by existing distributed data processing frameworks. Hash-based implementation writes data sent to different reducer tasks into separate files concurrently while sort-merge based approach writes those data together into a single file and merges those small files into bigger ones. Compared to sort-merge based approach, hash-based approach has several weak points when it comes to running large scale batch jobs. By introducing the sort-merge based approach to Flink, we can improve Flink’s capability of running large scale batch jobs.


## Brief change log

  - Introduce SortBuffer and its implementation PartitionSortedBuffer for sort-merge based blocking shuffle
  - Introduce PartitionedFile and the corresponding writer/reader for sort-merge based blocking shuffle
  - Introduce sort-merge based result partition SortMergeResultPartition and the corresponding subpartition reader
  - Introduce new config options to enable sort-merge based blocking shuffle
  - Introduce shuffle data compression to sort-merge based blocking shuffle


## Verifying this change

Several new tests are added to verify this change, including PartitionSortedBufferTest, PartitionedFileWriteReadTest, SortMergeResultPartitionTest and BlockingShuffleITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
