### PR TITLE
[FLINK-19475] Implement a time service for the batch execution mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -94,6 +95,7 @@ public class StreamConfig implements Serializable {
 	private static final String CHECKPOINT_MODE = "checkpointMode";
 
 	private static final String STATE_BACKEND = "statebackend";
+	private static final String TIMER_SERVICE_PROVIDER = "timerservice";
 	private static final String STATE_PARTITIONER = "statePartitioner";
 
 	private static final String STATE_KEY_SERIALIZER = "statekeyser";
@@ -533,6 +535,24 @@ public class StreamConfig implements Serializable {
 			return InstantiationUtil.readObjectFromConfig(this.config, STATE_BACKEND, cl);
 		} catch (Exception e) {
 			throw new StreamTaskException("Could not instantiate statehandle provider.", e);
+		}
+	}
+
+	public void setTimerServiceProvider(InternalTimeServiceManager.Provider timerServiceProvider) {
+		if (timerServiceProvider != null) {
+			try {
+				InstantiationUtil.writeObjectToConfig(timerServiceProvider, this.config, TIMER_SERVICE_PROVIDER);
+			} catch (Exception e) {
+				throw new StreamTaskException("Could not serialize timer service provider.", e);
+			}
+		}
+	}
+
+	public InternalTimeServiceManager.Provider getTimerServiceProvider(ClassLoader cl) {
+		try {
+			return InstantiationUtil.readObjectFromConfig(this.config, TIMER_SERVICE_PROVIDER, cl);
+		} catch (Exception e) {
+			throw new StreamTaskException("Could not instantiate timer service provider.", e);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.OutputFormatOperatorFactory;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -114,6 +115,7 @@ public class StreamGraph implements Pipeline {
 	protected Map<Integer, Long> vertexIDtoLoopTimeout;
 	private StateBackend stateBackend;
 	private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
+	private InternalTimeServiceManager.Provider timerServiceProvider;
 
 	public StreamGraph(ExecutionConfig executionConfig, CheckpointConfig checkpointConfig, SavepointRestoreSettings savepointRestoreSettings) {
 		this.executionConfig = checkNotNull(executionConfig);
@@ -172,6 +174,14 @@ public class StreamGraph implements Pipeline {
 
 	public StateBackend getStateBackend() {
 		return this.stateBackend;
+	}
+
+	public InternalTimeServiceManager.Provider getTimerServiceProvider() {
+		return timerServiceProvider;
+	}
+
+	public void setTimerServiceProvider(InternalTimeServiceManager.Provider timerServiceProvider) {
+		this.timerServiceProvider = checkNotNull(timerServiceProvider);
 	}
 
 	public ScheduleMode getScheduleMode() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -608,6 +608,7 @@ public class StreamingJobGraphGenerator {
 		final CheckpointConfig checkpointCfg = streamGraph.getCheckpointConfig();
 
 		config.setStateBackend(streamGraph.getStateBackend());
+		config.setTimerServiceProvider(streamGraph.getTimerServiceProvider());
 		config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
 		config.setCheckpointMode(getCheckpointingMode(checkpointCfg));
 		config.setUnalignedCheckpointsEnabled(checkpointCfg.isUnalignedCheckpointsEnabled());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
@@ -102,11 +102,6 @@ public class InternalTimeServiceManagerImpl<K> implements InternalTimeServiceMan
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
 			Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
-
-		if (keyedStatedBackend == null) {
-			return null;
-		}
-
 		final KeyGroupRange keyGroupRange = keyedStatedBackend.getKeyGroupRange();
 		final boolean requiresSnapshotLegacyTimers = keyedStatedBackend instanceof AbstractKeyedStateBackend &&
 			((AbstractKeyedStateBackend<K>) keyedStatedBackend).requiresLegacySynchronousTimerSnapshots();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -110,7 +110,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		this.taskStateManager = Preconditions.checkNotNull(environment.getTaskStateManager());
 		this.stateBackend = Preconditions.checkNotNull(stateBackend);
 		this.ttlTimeProvider = ttlTimeProvider;
-		this.timeServiceManagerProvider = timeServiceManagerProvider;
+		this.timeServiceManagerProvider = Preconditions.checkNotNull(timeServiceManagerProvider);
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
@@ -172,12 +172,16 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 			streamTaskCloseableRegistry.registerCloseable(rawOperatorStateInputs);
 
 			// -------------- Internal Timer Service Manager --------------
-			timeServiceManager = timeServiceManagerProvider.create(
-				keyedStatedBackend,
-				environment.getUserCodeClassLoader().asClassLoader(),
-				keyContext,
-				processingTimeService,
-				rawKeyedStateInputs);
+			if (keyedStatedBackend != null) {
+				timeServiceManager = timeServiceManagerProvider.create(
+					keyedStatedBackend,
+					environment.getUserCodeClassLoader().asClassLoader(),
+					keyContext,
+					processingTimeService,
+					rawKeyedStateInputs);
+			} else {
+				timeServiceManager = null;
+			}
 
 			// -------------- Preparing return value --------------
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeService.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.TimerHeapInternalTimer;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An implementation of a {@link InternalTimerService} that manages timers with a single active key at a time.
+ * Can be used in a BATCH execution mode.
+ */
+public class BatchExecutionInternalTimeService<K, N> implements InternalTimerService<N> {
+	private static final Logger LOG = LoggerFactory.getLogger(BatchExecutionInternalTimeService.class);
+
+	private final ProcessingTimeService processingTimeService;
+
+	/**
+	 * Processing time timers that are currently in-flight.
+	 */
+	private final KeyGroupedInternalPriorityQueue<TimerHeapInternalTimer<K, N>> processingTimeTimersQueue;
+
+	/**
+	 * Event time timers that are currently in-flight.
+	 */
+	private final KeyGroupedInternalPriorityQueue<TimerHeapInternalTimer<K, N>> eventTimeTimersQueue;
+
+	/**
+	 * The local event time, as denoted by the last received
+	 * {@link org.apache.flink.streaming.api.watermark.Watermark Watermark}.
+	 */
+	private long currentWatermark = Long.MIN_VALUE;
+
+	private final Triggerable<K, N> triggerTarget;
+
+	private K currentKey;
+
+	BatchExecutionInternalTimeService(
+			ProcessingTimeService processingTimeService,
+			Triggerable<K, N> triggerTarget) {
+
+		this.processingTimeService = checkNotNull(processingTimeService);
+		this.triggerTarget = checkNotNull(triggerTarget);
+
+		this.processingTimeTimersQueue = new BatchExecutionInternalPriorityQueueSet<>(
+			PriorityComparator.forPriorityComparableObjects(),
+			128
+		);
+		this.eventTimeTimersQueue = new BatchExecutionInternalPriorityQueueSet<>(
+			PriorityComparator.forPriorityComparableObjects(),
+			128
+		);
+	}
+
+	@Override
+	public long currentProcessingTime() {
+		return processingTimeService.getCurrentProcessingTime();
+	}
+
+	@Override
+	public long currentWatermark() {
+		return currentWatermark;
+	}
+
+	@Override
+	public void registerProcessingTimeTimer(N namespace, long time) {
+		// the currentWatermark == Long.MAX_VALUE indicates the timer was registered from the callback
+		// we quiesce the TimerService to prohibit infinite loops at the end of a key
+		if (currentWatermark == Long.MAX_VALUE) {
+			LOG.warn("Timer service is quiesced. Processing time timer for timestamp '{}' will be ignored.", time);
+			return;
+		}
+		processingTimeTimersQueue.add(new TimerHeapInternalTimer<>(time, currentKey, namespace));
+	}
+
+	@Override
+	public void registerEventTimeTimer(N namespace, long time) {
+		// the currentWatermark == Long.MAX_VALUE indicates the timer was registered from the callback
+		// we quiesce the TimerService to prohibit infinite loops at the end of a key
+		if (currentWatermark == Long.MAX_VALUE) {
+			LOG.warn("Timer service is quiesced. Event time timer for timestamp '{}' will be ignored.", time);
+			return;
+		}
+		eventTimeTimersQueue.add(new TimerHeapInternalTimer<>(time, currentKey, namespace));
+	}
+
+	@Override
+	public void deleteProcessingTimeTimer(N namespace, long time) {
+		processingTimeTimersQueue.remove(new TimerHeapInternalTimer<>(time, currentKey, namespace));
+	}
+
+	@Override
+	public void deleteEventTimeTimer(N namespace, long time) {
+		eventTimeTimersQueue.remove(new TimerHeapInternalTimer<>(time, currentKey, namespace));
+	}
+
+	@Override
+	public void forEachEventTimeTimer(BiConsumerWithException<N, Long, Exception> consumer) {
+		throw new UnsupportedOperationException(
+			"The BatchExecutionInternalTimeService should not be used in State Processor API.");
+	}
+
+	@Override
+	public void forEachProcessingTimeTimer(BiConsumerWithException<N, Long, Exception> consumer) {
+		throw new UnsupportedOperationException(
+			"The BatchExecutionInternalTimeService should not be used in State Processor API.");
+	}
+
+	public void setCurrentKey(K currentKey) throws Exception {
+		if (currentKey != null && currentKey.equals(this.currentKey)) {
+			return;
+		}
+
+		currentWatermark = Long.MAX_VALUE;
+		InternalTimer<K, N> timer;
+		while ((timer = eventTimeTimersQueue.poll()) != null) {
+			triggerTarget.onEventTime(timer);
+		}
+		while ((timer = processingTimeTimersQueue.poll()) != null) {
+			triggerTarget.onProcessingTime(timer);
+		}
+		currentWatermark = Long.MIN_VALUE;
+		this.currentKey = currentKey;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.KeyContext;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.WrappingRuntimeException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An implementation of a {@link InternalTimeServiceManager} that manages timers with a single active key at a time.
+ * Can be used in a BATCH execution mode.
+ */
+public class BatchExecutionInternalTimeServiceManager<K> implements InternalTimeServiceManager<K>,
+		KeyedStateBackend.KeySelectionListener<K> {
+
+	private final ProcessingTimeService processingTimeService;
+	private final Map<String, BatchExecutionInternalTimeService<K, ?>> timerServices = new HashMap<>();
+
+	public BatchExecutionInternalTimeServiceManager(ProcessingTimeService processingTimeService) {
+		this.processingTimeService = checkNotNull(processingTimeService);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <N> InternalTimerService<N> getInternalTimerService(
+			String name,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			Triggerable<K, N> triggerable) {
+		BatchExecutionInternalTimeService<K, N> timerService =
+			(BatchExecutionInternalTimeService<K, N>) timerServices.get(name);
+		if (timerService == null) {
+			timerService = new BatchExecutionInternalTimeService<>(
+				processingTimeService,
+				triggerable
+			);
+			timerServices.put(name, timerService);
+		}
+
+		return timerService;
+	}
+
+	@Override
+	public void advanceWatermark(Watermark watermark) {
+		if (watermark.getTimestamp() == Long.MAX_VALUE) {
+			keySelected(null);
+		}
+	}
+
+	@Override
+	public void snapshotState(
+			StateSnapshotContext context,
+			String operatorName) throws Exception {
+		throw new UnsupportedOperationException("Checkpoints are not supported in BATCH execution");
+	}
+
+	public static <K> InternalTimeServiceManager<K> create(
+			CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+			ClassLoader userClassloader,
+			KeyContext keyContext, //the operator
+			ProcessingTimeService processingTimeService,
+			Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) {
+		checkState(
+			keyedStatedBackend instanceof BatchExecutionKeyedStateBackend,
+			"Batch execution specific time service can work only with BatchExecutionKeyedStateBackend");
+
+		BatchExecutionInternalTimeServiceManager<K> timeServiceManager = new BatchExecutionInternalTimeServiceManager<>(
+			processingTimeService
+		);
+		keyedStatedBackend.registerKeySelectionListener(timeServiceManager);
+		return timeServiceManager;
+	}
+
+	@Override
+	public void keySelected(K newKey) {
+		try {
+			for (BatchExecutionInternalTimeService<K, ?> value : timerServices.values()) {
+				value.setCurrentKey(newKey);
+			}
+		} catch (Exception e) {
+			throw new WrappingRuntimeException(e);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
@@ -1,0 +1,487 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sorted.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.KeyContext;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link BatchExecutionInternalTimeServiceManager} and {@link BatchExecutionInternalTimeService}.
+ */
+public class BatchExecutionInternalTimeServiceTest extends TestLogger {
+	public static final IntSerializer KEY_SERIALIZER = new IntSerializer();
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void testBatchExecutionManagerCanBeInstantiatedWithBatchStateBackend() throws Exception {
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(
+			"Batch execution specific time service can work only with BatchExecutionKeyedStateBackend");
+
+		MockEnvironment mockEnvironment = MockEnvironment.builder().build();
+		AbstractKeyedStateBackend<Integer> stateBackend = new MemoryStateBackend()
+			.createKeyedStateBackend(
+				mockEnvironment,
+				new JobID(),
+				"dummy",
+				KEY_SERIALIZER,
+				2,
+				new KeyGroupRange(0, 1),
+				mockEnvironment.getTaskKvStateRegistry(),
+				TtlTimeProvider.DEFAULT,
+				new UnregisteredMetricsGroup(),
+				Collections.emptyList(),
+				new CloseableRegistry()
+			);
+		BatchExecutionInternalTimeServiceManager
+			.create(
+				stateBackend,
+				this.getClass().getClassLoader(),
+				new DummyKeyContext(),
+				new TestProcessingTimeService(),
+				Collections.emptyList()
+			);
+	}
+
+	@Test
+	public void testForEachEventTimeTimerUnsupported() {
+		expectedException.expect(UnsupportedOperationException.class);
+		expectedException.expectMessage(
+			"The BatchExecutionInternalTimeService should not be used in State Processor API");
+
+		BatchExecutionInternalTimeService<Object, Object> timeService = new BatchExecutionInternalTimeService<>(
+			new TestProcessingTimeService(),
+			LambdaTrigger.eventTimeTrigger(timer -> {}));
+
+		timeService.forEachEventTimeTimer((o, aLong) -> fail("The forEachEventTimeTimer() should not be supported"));
+	}
+
+	@Test
+	public void testForEachProcessingTimeTimerUnsupported() {
+		expectedException.expect(UnsupportedOperationException.class);
+		expectedException.expectMessage(
+			"The BatchExecutionInternalTimeService should not be used in State Processor API");
+
+		BatchExecutionInternalTimeService<Object, Object> timeService = new BatchExecutionInternalTimeService<>(
+			new TestProcessingTimeService(),
+			LambdaTrigger.eventTimeTrigger(timer -> {}));
+
+		timeService.forEachEventTimeTimer((o, aLong) -> fail("The forEachProcessingTimeTimer() should not be supported"));
+	}
+
+	@Test
+	public void testFiringEventTimeTimers() throws Exception {
+		BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend = new BatchExecutionKeyedStateBackend<>(
+			KEY_SERIALIZER,
+			new KeyGroupRange(0, 1));
+		InternalTimeServiceManager<Integer> timeServiceManager = BatchExecutionInternalTimeServiceManager
+			.create(
+				keyedStatedBackend,
+				this.getClass().getClassLoader(),
+				new DummyKeyContext(),
+				new TestProcessingTimeService(),
+				Collections.emptyList()
+			);
+
+		List<Long> timers = new ArrayList<>();
+		InternalTimerService<VoidNamespace> timerService = timeServiceManager.getInternalTimerService(
+			"test",
+			KEY_SERIALIZER,
+			new VoidNamespaceSerializer(),
+			LambdaTrigger.eventTimeTrigger(timer -> timers.add(timer.getTimestamp()))
+		);
+
+		keyedStatedBackend.setCurrentKey(1);
+		timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, 123);
+
+		// advancing the watermark should not fire timers
+		timeServiceManager.advanceWatermark(new Watermark(1000));
+		timerService.deleteEventTimeTimer(VoidNamespace.INSTANCE, 123);
+		timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, 150);
+
+		// changing the current key fires all timers
+		keyedStatedBackend.setCurrentKey(2);
+
+		assertThat(
+			timers,
+			equalTo(
+				Collections.singletonList(
+					150L
+				)
+			)
+		);
+	}
+
+	@Test
+	public void testSettingSameKeyDoesNotFireTimers() {
+		BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend = new BatchExecutionKeyedStateBackend<>(
+			KEY_SERIALIZER,
+			new KeyGroupRange(0, 1));
+		InternalTimeServiceManager<Integer> timeServiceManager = BatchExecutionInternalTimeServiceManager
+			.create(
+				keyedStatedBackend,
+				this.getClass().getClassLoader(),
+				new DummyKeyContext(),
+				new TestProcessingTimeService(),
+				Collections.emptyList()
+			);
+
+		List<Long> timers = new ArrayList<>();
+		InternalTimerService<VoidNamespace> timerService = timeServiceManager.getInternalTimerService(
+			"test",
+			KEY_SERIALIZER,
+			new VoidNamespaceSerializer(),
+			LambdaTrigger.eventTimeTrigger(timer -> timers.add(timer.getTimestamp()))
+		);
+
+		keyedStatedBackend.setCurrentKey(1);
+		timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, 123);
+		keyedStatedBackend.setCurrentKey(1);
+
+		assertThat(
+			timers,
+			equalTo(
+				Collections.emptyList()
+			)
+		);
+	}
+
+	@Test
+	public void testCurrentWatermark() throws Exception {
+		BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend = new BatchExecutionKeyedStateBackend<>(
+			KEY_SERIALIZER,
+			new KeyGroupRange(0, 1));
+		InternalTimeServiceManager<Integer> timeServiceManager = BatchExecutionInternalTimeServiceManager
+			.create(
+				keyedStatedBackend,
+				this.getClass().getClassLoader(),
+				new DummyKeyContext(),
+				new TestProcessingTimeService(),
+				Collections.emptyList()
+			);
+
+		List<Long> timers = new ArrayList<>();
+		TriggerWithTimerServiceAccess<Integer, VoidNamespace> eventTimeTrigger = TriggerWithTimerServiceAccess
+			.eventTimeTrigger((timer, timerService) -> {
+				assertThat(timerService.currentWatermark(), equalTo(Long.MAX_VALUE));
+				timers.add(timer.getTimestamp());
+			});
+		InternalTimerService<VoidNamespace> timerService = timeServiceManager.getInternalTimerService(
+			"test",
+			KEY_SERIALIZER,
+			new VoidNamespaceSerializer(),
+			eventTimeTrigger
+		);
+		eventTimeTrigger.setTimerService(timerService);
+
+		assertThat(timerService.currentWatermark(), equalTo(Long.MIN_VALUE));
+		keyedStatedBackend.setCurrentKey(1);
+		timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, 123);
+		assertThat(timerService.currentWatermark(), equalTo(Long.MIN_VALUE));
+
+		// advancing the watermark to a value different than Long.MAX_VALUE should have no effect
+		timeServiceManager.advanceWatermark(new Watermark(1000));
+		assertThat(timerService.currentWatermark(), equalTo(Long.MIN_VALUE));
+
+		// changing the current key fires all timers
+		keyedStatedBackend.setCurrentKey(2);
+		assertThat(timerService.currentWatermark(), equalTo(Long.MIN_VALUE));
+		timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, 124);
+
+		// advancing the watermark to Long.MAX_VALUE should fire remaining key
+		timeServiceManager.advanceWatermark(Watermark.MAX_WATERMARK);
+
+		assertThat(
+			timers,
+			equalTo(
+				Arrays.asList(
+					123L,
+					124L
+				)
+			)
+		);
+	}
+
+	@Test
+	public void testProcessingTimeTimers() {
+		BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend = new BatchExecutionKeyedStateBackend<>(
+			KEY_SERIALIZER,
+			new KeyGroupRange(0, 1));
+		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+		InternalTimeServiceManager<Integer> timeServiceManager = BatchExecutionInternalTimeServiceManager
+			.create(
+				keyedStatedBackend,
+				this.getClass().getClassLoader(),
+				new DummyKeyContext(),
+				processingTimeService,
+				Collections.emptyList()
+			);
+
+		List<Long> timers = new ArrayList<>();
+		InternalTimerService<VoidNamespace> timerService = timeServiceManager.getInternalTimerService(
+			"test",
+			KEY_SERIALIZER,
+			new VoidNamespaceSerializer(),
+			LambdaTrigger.processingTimeTrigger(timer -> timers.add(timer.getTimestamp()))
+		);
+
+		keyedStatedBackend.setCurrentKey(1);
+		timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, 150);
+
+		// we should never register physical timers
+		assertThat(processingTimeService.getNumActiveTimers(), equalTo(0));
+		// changing the current key fires all timers
+		keyedStatedBackend.setCurrentKey(2);
+
+		assertThat(
+			timers,
+			equalTo(
+				Collections.singletonList(
+					150L
+				)
+			)
+		);
+	}
+
+	@Test
+	public void testIgnoringEventTimeTimersFromWithinCallback() {
+		BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend = new BatchExecutionKeyedStateBackend<>(
+			KEY_SERIALIZER,
+			new KeyGroupRange(0, 1));
+		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+		InternalTimeServiceManager<Integer> timeServiceManager = BatchExecutionInternalTimeServiceManager
+			.create(
+				keyedStatedBackend,
+				this.getClass().getClassLoader(),
+				new DummyKeyContext(),
+				processingTimeService,
+				Collections.emptyList()
+			);
+
+		List<Long> timers = new ArrayList<>();
+		TriggerWithTimerServiceAccess<Integer, VoidNamespace> trigger =
+			TriggerWithTimerServiceAccess.eventTimeTrigger(
+				(timer, ts) -> {
+					timers.add(timer.getTimestamp());
+					ts.registerEventTimeTimer(VoidNamespace.INSTANCE, timer.getTimestamp() + 20);
+				});
+		InternalTimerService<VoidNamespace> timerService = timeServiceManager.getInternalTimerService(
+			"test",
+			KEY_SERIALIZER,
+			new VoidNamespaceSerializer(),
+			trigger
+		);
+		trigger.setTimerService(timerService);
+
+		keyedStatedBackend.setCurrentKey(1);
+		timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, 150);
+
+		// we should never register physical timers
+		assertThat(processingTimeService.getNumActiveTimers(), equalTo(0));
+		// changing the current key fires all timers
+		keyedStatedBackend.setCurrentKey(2);
+
+		// We check that the timer from the callback is ignored
+		assertThat(
+			timers,
+			equalTo(
+				Collections.singletonList(
+					150L
+				)
+			)
+		);
+	}
+
+	@Test
+	public void testIgnoringProcessingTimeTimersFromWithinCallback() {
+		BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend = new BatchExecutionKeyedStateBackend<>(
+			KEY_SERIALIZER,
+			new KeyGroupRange(0, 1));
+		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+		InternalTimeServiceManager<Integer> timeServiceManager = BatchExecutionInternalTimeServiceManager
+			.create(
+				keyedStatedBackend,
+				this.getClass().getClassLoader(),
+				new DummyKeyContext(),
+				processingTimeService,
+				Collections.emptyList()
+			);
+
+		List<Long> timers = new ArrayList<>();
+		TriggerWithTimerServiceAccess<Integer, VoidNamespace> trigger =
+			TriggerWithTimerServiceAccess.processingTimeTrigger(
+				(timer, ts) -> {
+					timers.add(timer.getTimestamp());
+					ts.registerProcessingTimeTimer(VoidNamespace.INSTANCE, timer.getTimestamp() + 20);
+				});
+		InternalTimerService<VoidNamespace> timerService = timeServiceManager.getInternalTimerService(
+			"test",
+			KEY_SERIALIZER,
+			new VoidNamespaceSerializer(),
+			trigger
+		);
+		trigger.setTimerService(timerService);
+
+		keyedStatedBackend.setCurrentKey(1);
+		timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, 150);
+
+		// we should never register physical timers
+		assertThat(processingTimeService.getNumActiveTimers(), equalTo(0));
+		// changing the current key fires all timers
+		keyedStatedBackend.setCurrentKey(2);
+
+		// We check that the timer from the callback is ignored
+		assertThat(
+			timers,
+			equalTo(
+				Collections.singletonList(
+					150L
+				)
+			)
+		);
+	}
+
+	private static class TriggerWithTimerServiceAccess<K, N> implements Triggerable<K, N> {
+
+		private InternalTimerService<N> timerService;
+		private final BiConsumer<InternalTimer<K, N>, InternalTimerService<N>> eventTimeHandler;
+		private final BiConsumer<InternalTimer<K, N>, InternalTimerService<N>> processingTimeHandler;
+
+		private TriggerWithTimerServiceAccess(
+				BiConsumer<InternalTimer<K, N>, InternalTimerService<N>> eventTimeHandler,
+				BiConsumer<InternalTimer<K, N>, InternalTimerService<N>> processingTimeHandler) {
+			this.eventTimeHandler = eventTimeHandler;
+			this.processingTimeHandler = processingTimeHandler;
+		}
+
+		public static <K, N> TriggerWithTimerServiceAccess<K, N> eventTimeTrigger(
+				BiConsumer<InternalTimer<K, N>, InternalTimerService<N>> eventTimeHandler) {
+			return new TriggerWithTimerServiceAccess<>(
+				eventTimeHandler,
+				(timer, timeService) -> Assert.fail("We did not expect processing timer to be triggered.")
+			);
+		}
+
+		public static <K, N> TriggerWithTimerServiceAccess<K, N> processingTimeTrigger(
+				BiConsumer<InternalTimer<K, N>, InternalTimerService<N>> processingTimeHandler) {
+			return new TriggerWithTimerServiceAccess<>(
+				(timer, timeService) -> Assert.fail("We did not expect event timer to be triggered."),
+				processingTimeHandler
+			);
+		}
+
+		public void setTimerService(InternalTimerService<N> timerService) {
+			this.timerService = timerService;
+		}
+
+		@Override
+		public void onEventTime(InternalTimer<K, N> timer) throws Exception {
+			this.eventTimeHandler.accept(timer, timerService);
+		}
+
+		@Override
+		public void onProcessingTime(InternalTimer<K, N> timer) throws Exception {
+			this.processingTimeHandler.accept(timer, timerService);
+		}
+	}
+
+	private static class LambdaTrigger<K, N> implements Triggerable<K, N> {
+
+		private final Consumer<InternalTimer<K, N>> eventTimeHandler;
+		private final Consumer<InternalTimer<K, N>> processingTimeHandler;
+
+		public static <K, N> LambdaTrigger<K, N> eventTimeTrigger(Consumer<InternalTimer<K, N>> eventTimeHandler) {
+			return new LambdaTrigger<>(
+				eventTimeHandler,
+				timer -> Assert.fail("We did not expect processing timer to be triggered.")
+			);
+		}
+
+		public static <K, N> LambdaTrigger<K, N> processingTimeTrigger(Consumer<InternalTimer<K, N>> processingTimeHandler) {
+			return new LambdaTrigger<>(
+				timer -> Assert.fail("We did not expect event timer to be triggered."),
+				processingTimeHandler
+			);
+		}
+
+		private LambdaTrigger(
+				Consumer<InternalTimer<K, N>> eventTimeHandler,
+				Consumer<InternalTimer<K, N>> processingTimeHandler) {
+			this.eventTimeHandler = eventTimeHandler;
+			this.processingTimeHandler = processingTimeHandler;
+		}
+
+		@Override
+		public void onEventTime(InternalTimer<K, N> timer) throws Exception {
+			this.eventTimeHandler.accept(timer);
+		}
+
+		@Override
+		public void onProcessingTime(InternalTimer<K, N> timer) throws Exception {
+			this.processingTimeHandler.accept(timer);
+		}
+	}
+
+	private static class DummyKeyContext implements KeyContext {
+		@Override
+		public void setCurrentKey(Object key) {
+
+		}
+
+		@Override
+		public Object getCurrentKey() {
+			return null;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -137,6 +137,25 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			RoundRobinOperatorStateRepartitioner.INSTANCE;
 
 	private InternalTimeServiceManagerImpl<?> timeServiceManager;
+	private InternalTimeServiceManager.Provider timeServiceManagerProvider = new InternalTimeServiceManager.Provider() {
+		@Override
+		public <K> InternalTimeServiceManager<K> create(
+				CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+				ClassLoader userClassloader,
+				KeyContext keyContext,
+				ProcessingTimeService processingTimeService,
+				Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+			InternalTimeServiceManagerImpl<K> typedTimeServiceManager = InternalTimeServiceManagerImpl.create(
+				keyedStatedBackend,
+				userClassloader,
+				keyContext,
+				processingTimeService,
+				rawKeyedStates
+			);
+			timeServiceManager = typedTimeServiceManager;
+			return typedTimeServiceManager;
+		}
+	};
 
 	/**
 	 * Whether setup() was called on the operator. This is reset when calling close().
@@ -259,7 +278,11 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		ttlTimeProvider = new MockTtlTimeProvider();
 		ttlTimeProvider.setCurrentTimestamp(0);
 
-		this.streamTaskStateInitializer = createStreamTaskStateManager(environment, stateBackend, ttlTimeProvider);
+		this.streamTaskStateInitializer = createStreamTaskStateManager(
+			environment,
+			stateBackend,
+			ttlTimeProvider,
+			timeServiceManagerProvider);
 
 		BiConsumer<String, Throwable> handleAsyncException = (message, t) -> {
 			wasFailedExternally = true;
@@ -279,33 +302,17 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			.build();
 	}
 
-	protected StreamTaskStateInitializer createStreamTaskStateManager(
+	private StreamTaskStateInitializer createStreamTaskStateManager(
 		Environment env,
 		StateBackend stateBackend,
-		TtlTimeProvider ttlTimeProvider) {
+		TtlTimeProvider ttlTimeProvider,
+		InternalTimeServiceManager.Provider timeServiceManagerProvider) {
 		return new StreamTaskStateInitializerImpl(
 			env,
 			stateBackend,
 			ttlTimeProvider,
-			new InternalTimeServiceManager.Provider() {
-				@Override
-				public <K> InternalTimeServiceManager<K> create(
-						CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-						ClassLoader userClassloader,
-						KeyContext keyContext,
-						ProcessingTimeService processingTimeService,
-						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
-					InternalTimeServiceManagerImpl<K> typedTimeServiceManager = InternalTimeServiceManagerImpl.create(
-						keyedStatedBackend,
-						userClassloader,
-						keyContext,
-						processingTimeService,
-						rawKeyedStates
-					);
-					timeServiceManager = typedTimeServiceManager;
-					return typedTimeServiceManager;
-				}
-			});
+			timeServiceManagerProvider
+		);
 	}
 
 	public void setStateBackend(StateBackend stateBackend) {
@@ -389,7 +396,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	public void setup(TypeSerializer<OUT> outputSerializer) {
 		if (!setupCalled) {
 			streamTaskStateInitializer =
-				createStreamTaskStateManager(environment, stateBackend, ttlTimeProvider);
+				createStreamTaskStateManager(environment, stateBackend, ttlTimeProvider, timeServiceManagerProvider);
 			mockTask.setStreamTaskStateInitializer(streamTaskStateInitializer);
 
 			if (operator == null) {
@@ -722,6 +729,10 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	@VisibleForTesting
 	public TaskMailbox getTaskMailbox() {
 		return taskMailbox;
+	}
+
+	public void setTimeServiceManagerProvider(InternalTimeServiceManager.Provider timeServiceManagerProvider) {
+		this.timeServiceManagerProvider = timeServiceManagerProvider;
 	}
 
 	private class MockOutput implements Output<StreamRecord<OUT>> {

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
@@ -50,15 +49,12 @@ import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
-import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.KeyContext;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
 import org.apache.flink.streaming.api.operators.StreamOperator;
-import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
-import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
@@ -223,37 +219,26 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 		//-------------------------------------------------------------------------- restore
 
 		op = new TestOneInputStreamOperator(true);
-		testHarness = new KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer>(
+		testHarness = new KeyedOneInputStreamOperatorTestHarness<>(
 			op,
 			(KeySelector<Integer, Integer>) value -> value,
 			TypeInformation.of(Integer.class),
 			MAX_PARALLELISM,
 			1 /* num subtasks */,
-			0 /* subtask index */) {
-
-			@Override
-			protected StreamTaskStateInitializer createStreamTaskStateManager(
-				Environment env,
-				StateBackend stateBackend,
-				TtlTimeProvider ttlTimeProvider) {
-
-				return new StreamTaskStateInitializerImpl(
-						env,
-						stateBackend,
-						ttlTimeProvider,
-						new InternalTimeServiceManager.Provider() {
-							@Override
-							public <K> InternalTimeServiceManager<K> create(
-								CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-								ClassLoader userClassloader,
-								KeyContext keyContext,
-								ProcessingTimeService processingTimeService,
-								Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
-								return null;
-							}
-						});
+			0 /* subtask index */);
+		testHarness.setTimeServiceManagerProvider(
+			new InternalTimeServiceManager.Provider() {
+				@Override
+				public <K> InternalTimeServiceManager<K> create(
+					CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+					ClassLoader userClassloader,
+					KeyContext keyContext,
+					ProcessingTimeService processingTimeService,
+					Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws IOException {
+					return null;
+				}
 			}
-		};
+		);
 
 		testHarness.setStateBackend(stateBackend);
 


### PR DESCRIPTION
## What is the purpose of the change

I introduce a BatchExecutionInternalTimeServiceManager and
BatchExecutionInternalTimeService which can be used in the batch
execution mode along with the BatchExecutionStateBackend. These services
only ever keep state for a single key at a time. They assume a perfect
Watermark and fire timers only upon switching the current key. Therefore
they require the input to be sorted/grouped by the key.


## Verifying this change

This change added tests and can be verified as follows:
* tests in `BatchExecutionInternalTimeServiceTest`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
