### PR TITLE
[FLINK-19459] Run certain maven-enforcer-plugin executions only in release profile

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch-base/pom.xml
@@ -158,17 +158,6 @@ under the License.
 
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<!-- Bumped for security purposes and making it work with Jackson dependencies (2.10.1) -->
-				<groupId>org.yaml</groupId>
-				<artifactId>snakeyaml</artifactId>
-				<version>1.27</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -120,13 +120,6 @@ under the License.
 			<version>4.1.44.Final</version>
 		</dependency>
 
-		<dependency>
-			<!-- Bumped for security purposes and making it work with Jackson dependencies (2.10.1) -->
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.27</version>
-		</dependency>
-
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -64,13 +64,6 @@ under the License.
 			</exclusions>
 		</dependency>
 
-		<dependency>
-			<!-- Bumped for security purposes -->
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.27</version>
-		</dependency>
-
 		<!-- Dependency for Elasticsearch 6.x REST Client -->
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>

--- a/flink-connectors/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch7/pom.xml
@@ -64,13 +64,6 @@ under the License.
 			</exclusions>
 		</dependency>
 
-		<dependency>
-			<!-- Bumped for security purposes -->
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.27</version>
-		</dependency>
-
 		<!-- Dependency for Elasticsearch 7.x REST Client -->
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>

--- a/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
@@ -48,17 +48,6 @@ under the License.
 		</dependency>
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<!-- Bumped for dependency convergence -->
-				<groupId>org.yaml</groupId>
-				<artifactId>snakeyaml</artifactId>
-				<version>1.27</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/flink-end-to-end-tests/flink-elasticsearch7-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch7-test/pom.xml
@@ -48,17 +48,6 @@ under the License.
 		</dependency>
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<!-- Bumped for dependency convergence -->
-				<groupId>org.yaml</groupId>
-				<artifactId>snakeyaml</artifactId>
-				<version>1.27</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -43,12 +43,6 @@ under the License.
 				<artifactId>okhttp</artifactId>
 				<version>3.12.1</version>
 			</dependency>
-			<dependency>
-				<!-- Bumped for security purposes -->
-				<groupId>org.yaml</groupId>
-				<artifactId>snakeyaml</artifactId>
-				<version>1.27</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -818,6 +818,12 @@ under the License.
 				<artifactId>disruptor</artifactId>
 				<version>3.4.2</version>
 			</dependency>
+			<dependency>
+				<!-- Bumped for security purposes and making it work with Jackson dependencies (2.10.1) -->
+				<groupId>org.yaml</groupId>
+				<artifactId>snakeyaml</artifactId>
+				<version>1.27</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION

## What is the purpose of the change
Building Flink with Maven 3.3+ will fail, because the enforcer plugin detects banned dependencies. These dependencies are removed by shading, but since the dependency tree is immutable in these versions, the maven enforcer plugin won't see these removals.

## Brief change log

- Move the dependency ban into the release profile.


## Verifying this change

Manually verified locally with Maven 3.6.3

