### PR TITLE
[FLINK-19336][Table SQL / Planner] EncodingUtils#encodeObjectToString should propagate inner exception

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
@@ -68,7 +68,7 @@ public abstract class EncodingUtils {
 			return new String(BASE64_ENCODER.encode(bytes), UTF_8);
 		} catch (Exception e) {
 			throw new ValidationException(
-				"Unable to serialize object '" + obj.toString() + "' of class '" + obj.getClass().getName() + "'.");
+				"Unable to serialize object '" + obj.toString() + "' of class '" + obj.getClass().getName() + "'.", e);
 		}
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

*Currently EncodingUtils#encodeObjectToString swallows the inner exception, which makes it hard to track the root cause.*


## Brief change log

  - add root casue to ValidationException


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not documented)
