### PR TITLE
[FLINK-18836][python] Support Python UDTF return type is Row

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -171,7 +171,9 @@ class TableFunctionRowCoderImpl(StreamCoderImpl):
     def encode_to_stream(self, iter_value, out_stream, nested):
         for value in iter_value:
             if value:
-                if self._field_count == 1:
+                if isinstance(value, (tuple, Row)):
+                    value = [value]
+                elif self._field_count == 1:
                     value = self._create_tuple_result(value)
                 self._flatten_row_coder.encode_to_stream(value, out_stream, nested)
             out_stream.write_var_int64(1)

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -42,9 +42,13 @@ cdef class TableFunctionRowCoderImpl(FlattenRowCoderImpl):
         self._end_message[0] = 0x00
 
     cpdef void encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
+        cdef is_row_or_tuple = False
         if iter_value:
+            if isinstance(iter_value, (tuple, Row)):
+                iter_value = [iter_value]
+                is_row_or_tuple = True
             for value in iter_value:
-                if self._field_count == 1:
+                if self._field_count == 1 and not is_row_or_tuple:
                     value = (value,)
                 self._encode_one_row(value, output_stream)
         # write 0x00 as end message

--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -37,6 +37,8 @@ class UserDefinedTableFunctionTests(object):
         t = t.join_lateral(multi_emit(t.a, multi_num(t.b)).alias('x', 'y'))
         t = t.left_outer_join_lateral(condition_multi_emit(t.x, t.y).alias('m')) \
             .select("x, y, m")
+        t = t.left_outer_join_lateral(identity(t.m).alias('n')) \
+            .select("x, y, n")
         actual = self._get_output(t)
         self.assert_equals(actual,
                            ["1,0,null", "1,1,null", "2,0,null", "2,1,null", "3,0,0", "3,0,1",
@@ -104,6 +106,13 @@ class MultiEmit(TableFunction, unittest.TestCase):
         self.assertEqual(self.counter_sum, self.counter.get_count())
         for i in range(y):
             yield x, i
+
+
+@udtf(result_types=[DataTypes.BIGINT()])
+def identity(x):
+    if x is not None:
+        from pyflink.common import Row
+        return Row(x)
 
 
 # test specify the input_types


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support Python UDTF return type is Row*


## Brief change log

  - *Add the support of UDTF return type is Row*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add the it test in test_udtf.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
