### PR TITLE
[FLINK-19584][Connector-hbase] Not starting flush thread when bufferFlushMaxMutations = 1

### DIFF
--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkFunction.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkFunction.java
@@ -123,7 +123,7 @@ public class HBaseSinkFunction<T>
 			}
 			this.mutator = connection.getBufferedMutator(params);
 
-			if (bufferFlushIntervalMillis > 0) {
+			if (bufferFlushIntervalMillis > 0 && bufferFlushMaxMutations != 1) {
 				this.executor = Executors.newScheduledThreadPool(
 					1, new ExecutorThreadFactory("hbase-upsert-sink-flusher"));
 				this.scheduledFuture = this.executor.scheduleWithFixedDelay(() -> {


### PR DESCRIPTION

## What is the purpose of the change

Not starting flush thread when bufferFlushMaxMutations = 1

## Brief change log

Not starting flush thread when bufferFlushMaxMutations = 1

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
