### PR TITLE
[FLINK-19547][runtime] Clean up partial record when reconnecting for Approximate Local Recovery 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -101,7 +101,7 @@ class ResultSubpartitionRecoveredStateHandler implements RecoveredChannelStateHa
 	public void recover(ResultSubpartitionInfo subpartitionInfo, Tuple2<BufferBuilder, BufferConsumer> bufferBuilderAndConsumer) throws IOException {
 		bufferBuilderAndConsumer.f0.finish();
 		if (bufferBuilderAndConsumer.f1.isDataAvailable()) {
-			boolean added = getSubpartition(subpartitionInfo).add(bufferBuilderAndConsumer.f1);
+			boolean added = getSubpartition(subpartitionInfo).add(bufferBuilderAndConsumer.f1, Integer.MIN_VALUE);
 			if (!added) {
 				throw new IOException("Buffer consumer couldn't be added to ResultSubpartition");
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -55,13 +55,26 @@ public class BufferBuilder {
 	 * @return created matching instance of {@link BufferConsumer} to this {@link BufferBuilder}.
 	 */
 	public BufferConsumer createBufferConsumer() {
+		return createBufferConsumer(positionMarker.cachedPosition);
+	}
+
+	/**
+	 * This method always creates a {@link BufferConsumer} starting from position 0 of {@link MemorySegment}.
+	 *
+	 * @return created matching instance of {@link BufferConsumer} to this {@link BufferBuilder}.
+	 */
+	public BufferConsumer createBufferConsumerFromBeginning() {
+		return createBufferConsumer(0);
+	}
+
+	private BufferConsumer createBufferConsumer(int currentReaderPosition) {
 		checkState(!bufferConsumerCreated, "Two BufferConsumer shouldn't exist for one BufferBuilder");
 		bufferConsumerCreated = true;
 		return new BufferConsumer(
 			memorySegment,
 			recycler,
 			positionMarker,
-			positionMarker.cachedPosition);
+			currentReaderPosition);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -25,6 +25,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Closeable;
 
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.DATA_BUFFER;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -88,7 +89,7 @@ public class BufferConsumer implements Closeable {
 	 * Checks whether the {@link BufferBuilder} has already been finished.
 	 *
 	 * <p>BEWARE: this method accesses the cached value of the position marker which is only updated
-	 * after calls to {@link #build()}!
+	 * after calls to {@link #build()} and {@link #skip(int)}!
 	 *
 	 * @return <tt>true</tt> if the buffer was finished, <tt>false</tt> otherwise
 	 */
@@ -106,6 +107,17 @@ public class BufferConsumer implements Closeable {
 		Buffer slice = buffer.readOnlySlice(currentReaderPosition, cachedWriterPosition - currentReaderPosition);
 		currentReaderPosition = cachedWriterPosition;
 		return slice.retainBuffer();
+	}
+
+	/**
+	 * @param bytesToSkip number of bytes to skip from currentReaderPosition
+	 */
+	void skip(int bytesToSkip) {
+		writerPosition.update();
+		int cachedWriterPosition = writerPosition.getCached();
+		int bytesReadable = cachedWriterPosition - currentReaderPosition;
+		checkState(bytesToSkip <= bytesReadable, "bytes to skip beyond readable range");
+		currentReaderPosition += bytesToSkip;
 	}
 
 	/**
@@ -157,6 +169,14 @@ public class BufferConsumer implements Closeable {
 
 	int getCurrentReaderPosition() {
 		return currentReaderPosition;
+	}
+
+	boolean isStartOfDataBuffer() {
+		return buffer.getDataType() == DATA_BUFFER && currentReaderPosition == 0;
+	}
+
+	int getBufferSize() {
+		return buffer.getMaxCapacity();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumerWithPartialRecordLength.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumerWithPartialRecordLength.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * BufferConsumer with partial record length if a record is spanning over buffers
+ *
+ * <p>`partialRecordLength` is the length of bytes to skip in order to start with a complete record,
+ * from position index 0 of the underlying MemorySegment. `partialRecordLength` is used in approximate
+ * local recovery to find the start position of a complete record on a BufferConsumer, so called
+ * `partial record clean-up`.
+ *
+ * <p>Partial records happen if a record can not fit into one buffer, then the remaining part of the same record
+ * is put into the next buffer. Hence partial records only exist at the beginning of a buffer.
+ * Partial record clean-up is needed in the mode of approximate local recovery.
+ * If a record is spanning over multiple buffers, and the first (several) buffers have got lost due to the failure
+ * of the receiver task, the remaining data belonging to the same record in transition should be cleaned up.
+ *
+ * <p> If partialRecordLength == 0, the buffer starts with a complete record</p>
+ * <p> If partialRecordLength > 0, the buffer starts with a partial record, its length = partialRecordLength</p>
+ * <p> If partialRecordLength < 0, partialRecordLength is undefined. It is currently used in
+ * 									{@cite ResultSubpartitionRecoveredStateHandler#recover}</p>
+ */
+@NotThreadSafe
+public class BufferConsumerWithPartialRecordLength {
+	private final BufferConsumer bufferConsumer;
+	private final int partialRecordLength;
+
+	public BufferConsumerWithPartialRecordLength(BufferConsumer bufferConsumer, int partialRecordLength) {
+		this.bufferConsumer = checkNotNull(bufferConsumer);
+		this.partialRecordLength = partialRecordLength;
+	}
+
+	public BufferConsumer getBufferConsumer() {
+		return bufferConsumer;
+	}
+
+	public int getPartialRecordLength() {
+		return partialRecordLength;
+	}
+
+	public Buffer build() {
+		return bufferConsumer.build();
+	}
+
+	public boolean cleanupPartialRecord() {
+
+		checkState(partialRecordLength >= 0, "Approximate local recovery does not yet work with unaligned checkpoint!");
+
+		// partial record can happen only at the beginning of a buffer, because a buffer can end with
+		// either a full record or full buffer after each write and read. Partial records occur only when a
+		// bufferBuilder ends with a full buffer but not a full record (a record spanning multiple buffers).
+		if (partialRecordLength == 0 || !bufferConsumer.isStartOfDataBuffer()) {
+			return true;
+		}
+
+		// partial data is appendAndCommit before bufferConsumer is created,
+		// so we do not have the case that data is written but not visible.
+
+		checkState(partialRecordLength <= bufferConsumer.getBufferSize(), "Partial record length beyond max buffer capacity!");
+		bufferConsumer.skip(partialRecordLength);
+		// CASE: partialRecordLength < max buffer size,
+		// partial record ends within the buffer, cleanup successful, skip the partial record
+		if (partialRecordLength < bufferConsumer.getBufferSize()) {
+			return true;
+		} else {
+			// two cases: 1). long record spanning multiple buffers, cleanup not successful, return an empty buffer
+	 		//            2). partial record ending at the end of the buffer (full record, full buffer)
+			//            		cleaned up not successful, return an empty buffer. Notice that next buffer
+			//            		will start with a full record, and cleanup will be success in the next call.
+			return false;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -115,7 +115,7 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public boolean add(BufferConsumer bufferConsumer) throws IOException {
+	public boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException {
 		if (isFinished()) {
 			bufferConsumer.close();
 			return false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -128,26 +128,38 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 
 	@Override
 	public void emitRecord(ByteBuffer record, int targetSubpartition) throws IOException {
-		do {
-			final BufferBuilder bufferBuilder = getSubpartitionBufferBuilder(targetSubpartition);
-			bufferBuilder.appendAndCommit(record);
+		BufferBuilder buffer = appendUnicastDataForNewRecord(record, targetSubpartition);
 
-			if (bufferBuilder.isFull()) {
-				finishSubpartitionBufferBuilder(targetSubpartition);
-			}
-		} while (record.hasRemaining());
+		while (record.hasRemaining()) {
+			// full buffer, partial record
+			finishSubpartitionBufferBuilder(targetSubpartition);
+			buffer = appendUnicastDataForRecordContinuation(record, targetSubpartition);
+		}
+
+		if (buffer.isFull()) {
+			// full buffer, full record
+			finishSubpartitionBufferBuilder(targetSubpartition);
+		}
+
+		// partial buffer, full record
 	}
 
 	@Override
 	public void broadcastRecord(ByteBuffer record) throws IOException {
-		do {
-			final BufferBuilder bufferBuilder = getBroadcastBufferBuilder();
-			bufferBuilder.appendAndCommit(record);
+		BufferBuilder buffer = appendBroadcastDataForNewRecord(record);
 
-			if (bufferBuilder.isFull()) {
-				finishBroadcastBufferBuilder();
-			}
-		} while (record.hasRemaining());
+		while (record.hasRemaining()) {
+			// full buffer, partial record
+			finishBroadcastBufferBuilder();
+			buffer = appendBroadcastDataForRecordContinuation(record);
+		}
+
+		if (buffer.isFull()) {
+			// full buffer, full record
+			finishBroadcastBufferBuilder();
+		}
+
+		// partial buffer, full record
 	}
 
 	@Override
@@ -159,7 +171,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 		try (BufferConsumer eventBufferConsumer = EventSerializer.toBufferConsumer(event, isPriorityEvent)) {
 			for (ResultSubpartition subpartition : subpartitions) {
 				// Retain the buffer so that it can be recycled by each channel of targetPartition
-				subpartition.add(eventBufferConsumer.copy());
+				subpartition.add(eventBufferConsumer.copy(), 0);
 			}
 		}
 	}
@@ -211,46 +223,84 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 		}
 	}
 
-	private BufferBuilder getSubpartitionBufferBuilder(int targetSubpartition) throws IOException {
-		final BufferBuilder bufferBuilder = subpartitionBufferBuilders[targetSubpartition];
-		if (bufferBuilder != null) {
-			return bufferBuilder;
+	private BufferBuilder appendUnicastDataForNewRecord(
+			final ByteBuffer record,
+			final int targetSubpartition) throws IOException {
+		BufferBuilder buffer = subpartitionBufferBuilders[targetSubpartition];
+
+		if (buffer == null) {
+			buffer = requestNewUnicastBufferBuilder(targetSubpartition);
+			subpartitions[targetSubpartition].add(buffer.createBufferConsumerFromBeginning(), 0);
 		}
 
-		return getNewSubpartitionBufferBuilder(targetSubpartition);
+		buffer.appendAndCommit(record);
+
+		return buffer;
 	}
 
-	private BufferBuilder getNewSubpartitionBufferBuilder(int targetSubpartition) throws IOException {
+	private BufferBuilder appendUnicastDataForRecordContinuation(
+			final ByteBuffer remainingRecordBytes,
+			final int targetSubpartition) throws IOException {
+		final BufferBuilder buffer = requestNewUnicastBufferBuilder(targetSubpartition);
+		// !! Be aware, in case of partialRecordBytes != 0, partial length and data has to `appendAndCommit` first
+		// before consumer is created. Otherwise it would be confused with the case the buffer starting
+		// with a complete record.
+		// !! The next two lines can not change order.
+		final int partialRecordBytes = buffer.appendAndCommit(remainingRecordBytes);
+		subpartitions[targetSubpartition].add(buffer.createBufferConsumerFromBeginning(), partialRecordBytes);
+
+		return buffer;
+	}
+
+	private BufferBuilder appendBroadcastDataForNewRecord(final ByteBuffer record) throws IOException {
+		BufferBuilder buffer = broadcastBufferBuilder;
+
+		if (buffer == null) {
+			buffer = requestNewBroadcastBufferBuilder();
+			createBroadcastBufferConsumers(buffer, 0);
+		}
+
+		buffer.appendAndCommit(record);
+
+		return buffer;
+	}
+
+	private BufferBuilder appendBroadcastDataForRecordContinuation(
+			final ByteBuffer remainingRecordBytes) throws IOException {
+		final BufferBuilder buffer = requestNewBroadcastBufferBuilder();
+		// !! Be aware, in case of partialRecordBytes != 0, partial length and data has to `appendAndCommit` first
+		// before consumer is created. Otherwise it would be confused with the case the buffer starting
+		// with a complete record.
+		// !! The next two lines can not change order.
+		final int partialRecordBytes = buffer.appendAndCommit(remainingRecordBytes);
+		createBroadcastBufferConsumers(buffer, partialRecordBytes);
+
+		return buffer;
+	}
+
+	private void createBroadcastBufferConsumers(BufferBuilder buffer, int partialRecordBytes) throws IOException {
+		try (final BufferConsumer consumer = buffer.createBufferConsumerFromBeginning()) {
+			for (ResultSubpartition subpartition : subpartitions) {
+				subpartition.add(consumer.copy(), partialRecordBytes);
+			}
+		}
+	}
+
+	private BufferBuilder requestNewUnicastBufferBuilder(int targetSubpartition) throws IOException {
 		checkInProduceState();
 		ensureUnicastMode();
-
 		final BufferBuilder bufferBuilder = requestNewBufferBuilderFromPool(targetSubpartition);
-		subpartitions[targetSubpartition].add(bufferBuilder.createBufferConsumer());
 		subpartitionBufferBuilders[targetSubpartition] = bufferBuilder;
+
 		return bufferBuilder;
 	}
 
-	private BufferBuilder getBroadcastBufferBuilder() throws IOException {
-		if (broadcastBufferBuilder != null) {
-			return broadcastBufferBuilder;
-		}
-
-		return getNewBroadcastBufferBuilder();
-	}
-
-	private BufferBuilder getNewBroadcastBufferBuilder() throws IOException {
+	private BufferBuilder requestNewBroadcastBufferBuilder() throws IOException {
 		checkInProduceState();
 		ensureBroadcastMode();
 
 		final BufferBuilder bufferBuilder = requestNewBufferBuilderFromPool(0);
 		broadcastBufferBuilder = bufferBuilder;
-
-		try (final BufferConsumer consumer = bufferBuilder.createBufferConsumer()) {
-			for (ResultSubpartition subpartition : subpartitions) {
-				subpartition.add(consumer.copy());
-			}
-		}
-
 		return bufferBuilder;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultSubpartition.java
@@ -33,5 +33,5 @@ public interface CheckpointedResultSubpartition {
 
 	BufferBuilder requestBufferBuilderBlocking() throws IOException, RuntimeException, InterruptedException;
 
-	boolean add(BufferConsumer bufferConsumer);
+	boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -114,7 +114,7 @@ public class PipelinedSubpartition extends ResultSubpartition
 	}
 
 	@Override
-	public boolean add(BufferConsumer bufferConsumer) {
+	public boolean add(BufferConsumer bufferConsumer, int partialRecordLength) {
 		return add(bufferConsumer, false);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -77,6 +77,11 @@ public abstract class ResultSubpartition {
 		parent.onConsumedSubpartition(getSubPartitionIndex());
 	}
 
+	@VisibleForTesting
+	public final boolean add(BufferConsumer bufferConsumer) throws IOException {
+		return add(bufferConsumer, 0);
+	}
+
 	/**
 	 * Adds the given buffer.
 	 *
@@ -89,11 +94,14 @@ public abstract class ResultSubpartition {
 	 *
 	 * @param bufferConsumer
 	 * 		the buffer to add (transferring ownership to this writer)
+	 * @param partialRecordLength
+	 * 		the length of bytes to skip in order to start with a complete record, from position index 0
+	 *		of the underlying {@cite MemorySegment}.
 	 * @return true if operation succeeded and bufferConsumer was enqueued for consumption.
 	 * @throws IOException
 	 * 		thrown in case of errors while adding the buffer
 	 */
-	public abstract boolean add(BufferConsumer bufferConsumer) throws IOException;
+	public abstract boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException;
 
 	public abstract void flush();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferConsumerWithPartialRecordLengthTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferConsumerWithPartialRecordLengthTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderAndConsumerTest.assertContent;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderAndConsumerTest.toByteBuffer;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link BufferConsumerWithPartialRecordLength}.
+ */
+public class BufferConsumerWithPartialRecordLengthTest {
+	private static final int BUFFER_INT_SIZE = 4;
+	private static final int BUFFER_SIZE = BUFFER_INT_SIZE * Integer.BYTES;
+	private final PrioritizedDeque<BufferConsumerWithPartialRecordLength> buffers = new PrioritizedDeque<>();
+
+	private BufferBuilder builder = null;
+
+	@After
+	public void clear() {
+		buffers.clear();
+		builder = null;
+	}
+
+	@Test
+	public void partialRecordTestCase() {
+		writeToBuffer(toByteBuffer(0, 1, 2, 3, 42));
+
+		assertEquals(buffers.size(), 2);
+
+		// buffer starts with a full record
+		BufferConsumerWithPartialRecordLength consumer1 = buffers.poll();
+		assertEquals(0, requireNonNull(consumer1).getPartialRecordLength());
+		assertTrue(consumer1.cleanupPartialRecord());
+		assertContent(consumer1.build(), FreeingBufferRecycler.INSTANCE, 0, 1, 2, 3);
+
+		// buffer starts with partial record, partial record ends within the buffer
+		// skip the partial record, return an empty buffer
+		BufferConsumerWithPartialRecordLength consumer2 = buffers.poll();
+		assertTrue(requireNonNull(consumer2).cleanupPartialRecord());
+		assertEquals(consumer2.build().readableBytes(), 0);
+	}
+
+	@Test
+	public void partialLongRecordSpanningBufferTestCase() {
+		writeToBuffer(toByteBuffer(0, 1, 2, 3, 4, 5, 6, 7, 42));
+		writeToBuffer(toByteBuffer(8, 9));
+
+		assertEquals(buffers.size(), 3);
+		buffers.poll();
+
+		// long partial record spanning over the entire buffer, clean up not successful
+		BufferConsumerWithPartialRecordLength consumer2 = buffers.poll();
+		assertEquals(BUFFER_SIZE, requireNonNull(consumer2).getPartialRecordLength());
+		assertFalse(consumer2.cleanupPartialRecord());
+		assertEquals(consumer2.build().readableBytes(), 0);
+
+		BufferConsumerWithPartialRecordLength consumer3 = buffers.poll();
+		assertTrue(requireNonNull(consumer3).cleanupPartialRecord());
+		assertContent(consumer3.build(), FreeingBufferRecycler.INSTANCE, 8, 9);
+	}
+
+	@Test
+	public void partialLongRecordEndsWithFullBufferTestCase() {
+		writeToBuffer(toByteBuffer(0, 1, 2, 3, 4, 5, 6, 42));
+		writeToBuffer(toByteBuffer(8, 9));
+
+		assertEquals(buffers.size(), 3);
+		buffers.poll();
+
+		// long partial record ends at the end of the buffer, clean up not successful
+		BufferConsumerWithPartialRecordLength consumer2 = buffers.poll();
+		assertEquals(BUFFER_SIZE, requireNonNull(consumer2).getPartialRecordLength());
+		assertFalse(consumer2.cleanupPartialRecord());
+		assertEquals(consumer2.build().readableBytes(), 0);
+
+		BufferConsumerWithPartialRecordLength consumer3 = buffers.poll();
+		assertTrue(requireNonNull(consumer3).cleanupPartialRecord());
+		assertContent(consumer3.build(), FreeingBufferRecycler.INSTANCE, 8, 9);
+	}
+
+	@Test
+	public void readPositionNotAtTheBeginningOfTheBufferTestCase() {
+		writeToBuffer(toByteBuffer(0, 1, 2, 3, 42));
+
+		assertEquals(buffers.size(), 2);
+		buffers.poll();
+
+		BufferConsumerWithPartialRecordLength consumer2 = buffers.poll();
+		requireNonNull(consumer2).build();
+
+		// read not start from the beginning of the buffer
+		writeToBuffer(toByteBuffer(8, 9));
+		assertEquals(4, consumer2.getPartialRecordLength());
+		assertTrue(consumer2.cleanupPartialRecord());
+		assertContent(consumer2.build(), FreeingBufferRecycler.INSTANCE, 8, 9);
+	}
+
+	private void writeToBuffer(ByteBuffer record) {
+		if (builder == null) {
+			builder = createBufferBuilder();
+			buffers.add(new BufferConsumerWithPartialRecordLength(builder.createBufferConsumerFromBeginning(), 0));
+		}
+		builder.appendAndCommit(record);
+
+		while (record.hasRemaining()) {
+			builder.finish();
+			builder = createBufferBuilder();
+			final int partialRecordBytes = builder.appendAndCommit(record);
+			buffers.add(new BufferConsumerWithPartialRecordLength(builder.createBufferConsumerFromBeginning(), partialRecordBytes));
+		}
+
+		if (builder.isFull()) {
+			builder.finish();
+			builder = null;
+		}
+	}
+
+	private BufferBuilder createBufferBuilder() {
+		return new BufferBuilder(MemorySegmentFactory.allocateUnpooledSegment(BUFFER_SIZE), FreeingBufferRecycler.INSTANCE);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Partial records happen if a record can not fit into one buffer, then the remaining part of the same record is put into the next buffer. Hence partial records only exist at the beginning of a buffer. Partial record clean-up is needed in the mode of approximate local recovery. If a record is spanning over multiple buffers, and the first (several) buffers have got lost due to the failure of the receiver task, the remaining data belonging to the same record in transition should be cleaned up.

`partialRecordLength` is the length of bytes to skip in order to start with a complete record, from position index 0 of the underlying MemorySegment. `partialRecordLength` is used in approximate local recovery to find the start position of a complete record on a BufferConsumer, so-called `partial record clean-up`.

## Brief change log
- API change to add `partialRecordLength` when creating a BufferConsumer
- Add `partialRecordLength` in `BufferWritingResultPartition` when emitRecord and `broadcastRecord`
- Update the type of buffers in PipelinedSubpartition fr`PrioritizedDeque<BufferConsumer>` to `PrioritizedDeque<BufferConsumerWithPartialRecordLength>`
- Implement partial record clean-up logic in BufferConsumerWithPartialRecordLength

## Verifying this change

- add unit tests to test partial record length
- pass existing tests to make sure the changes do not affect data write/read/transition.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

