### PR TITLE
[FLINK-18570][hbase] improve log and exception message for hbase e2e test

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/AbstractTableInputFormat.java
@@ -222,7 +222,13 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
 			// Get the starting and ending row keys for every region in the currently open table
 			final Pair<byte[][], byte[][]> keys = table.getRegionLocator().getStartEndKeys();
 			if (keys == null || keys.getFirst() == null || keys.getFirst().length == 0) {
-				throw new IOException("Expecting at least one region.");
+				LOG.warn(
+						"Unexpected region keys: {} appeared in HBase table: {}, all region information are: {}.",
+						keys,
+						table,
+						table.getRegionLocator().getAllRegionLocations());
+				throw new IOException("HBase Table expects at least one region in scan," +
+						" please check the HBase table status in HBase cluster");
 			}
 			final byte[] startRow = scan.getStartRow();
 			final byte[] stopRow = scan.getStopRow();

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
@@ -222,7 +222,13 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
 			// Get the starting and ending row keys for every region in the currently open table
 			final Pair<byte[][], byte[][]> keys = regionLocator.getStartEndKeys();
 			if (keys == null || keys.getFirst() == null || keys.getFirst().length == 0) {
-				throw new IOException("Expecting at least one region.");
+				LOG.warn(
+						"Unexpected region keys: {} appeared in HBase table: {}, all region information are: {}.",
+						keys,
+						table,
+						regionLocator.getAllRegionLocations());
+				throw new IOException("HBase Table expects at least one region in scan," +
+						" please check the HBase table status in HBase cluster");
 			}
 			final byte[] startRow = scan.getStartRow();
 			final byte[] stopRow = scan.getStopRow();


### PR DESCRIPTION
## What is the purpose of the change

* As discussed under the [jira ticket](https://issues.apache.org/jira/browse/FLINK-18570?focusedCommentId=17218074&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17218074), the unstable e2e test **SQLClientHBaseITCase.testHBase** failed by getting wrong region information from HBase cluster without any valuable exception message. This pull request add log and improve exception message.

## Brief change log
  - Improve exception message and add warn log  for troubleshooting

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
