### PR TITLE
[FLINK-19531] Implement the sink writer operator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractWriterOperator.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.List;
+
+/**
+ * Abstract base class for operators that work with a {@link Writer}.
+ *
+ * <p>Sub-classes are responsible for creating the specific {@link Writer} by implementing {@link
+ * #createWriter()}.
+ *
+ * @param <InputT> The input type of the {@link Writer}.
+ * @param <CommT> The committable type of the {@link Writer}.
+ */
+@Internal
+abstract class AbstractWriterOperator<InputT, CommT> extends AbstractStreamOperator<CommT>
+	implements OneInputStreamOperator<InputT, CommT>, BoundedOneInput {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The runtime information of the input element. */
+	private final Context<InputT> context;
+
+	// ------------------------------- runtime fields ---------------------------------------
+
+	/** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
+	private Long currentWatermark;
+
+	/** The sink writer that does most of the work. */
+	protected Writer<InputT, CommT, ?> writer;
+
+	AbstractWriterOperator() {
+		this.context = new Context<>();
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		this.currentWatermark = Long.MIN_VALUE;
+
+		writer = createWriter();
+	}
+
+	@Override
+	public void processElement(StreamRecord<InputT> element) throws Exception {
+		context.element = element;
+		writer.write(element.getValue(), context);
+	}
+
+	@Override
+	public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+		super.prepareSnapshotPreBarrier(checkpointId);
+		sendCommittables(writer.prepareCommit(false));
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		super.processWatermark(mark);
+		this.currentWatermark = mark.getTimestamp();
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		sendCommittables(writer.prepareCommit(true));
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		writer.close();
+	}
+
+	protected Sink.InitContext createInitContext() {
+		return new Sink.InitContext() {
+			@Override
+			public int getSubtaskId() {
+				return getRuntimeContext().getIndexOfThisSubtask();
+			}
+
+			@Override
+			public MetricGroup metricGroup() {
+				return getMetricGroup();
+			}
+		};
+	}
+
+	/**
+	 * Creates and returns a {@link Writer}.
+	 *
+	 * @throws Exception If creating {@link Writer} fail
+	 */
+	abstract Writer<InputT, CommT, ?> createWriter() throws Exception;
+
+	private void sendCommittables(final List<CommT> committables) {
+		for (CommT committable : committables) {
+			output.collect(new StreamRecord<>(committable));
+		}
+	}
+
+	private class Context<IN> implements Writer.Context {
+
+		private StreamRecord<IN> element;
+
+		@Override
+		public long currentWatermark() {
+			return currentWatermark;
+		}
+
+		@Override
+		public Long timestamp() {
+			if (element.hasTimestamp()) {
+				return element.getTimestamp();
+			}
+			return null;
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractWriterOperatorFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+/**
+ * Base {@link OneInputStreamOperatorFactory} for subclasses of {@link AbstractWriterOperator}.
+ *
+ * @param <InputT> The input type of the {@link Writer}.
+ * @param <CommT> The committable type of the {@link Writer}.
+ */
+abstract class AbstractWriterOperatorFactory<InputT, CommT> extends AbstractStreamOperatorFactory<CommT>
+	implements OneInputStreamOperatorFactory<InputT, CommT> {
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends StreamOperator<CommT>> T createStreamOperator(StreamOperatorParameters<CommT> parameters) {
+		final AbstractWriterOperator<InputT, CommT> writerOperator = createWriterOperator();
+		writerOperator.setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
+		return (T) writerOperator;
+	}
+
+	abstract AbstractWriterOperator<InputT, CommT> createWriterOperator();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
+import org.apache.flink.util.CollectionUtil;
+
+import java.util.List;
+
+/**
+ * Runtime {@link org.apache.flink.streaming.api.operators.StreamOperator} for executing {@link
+ * Writer Writers} that have state.
+ *
+ * @param <InputT> The input type of the {@link Writer}.
+ * @param <CommT> The committable type of the {@link Writer}.
+ * @param <WriterStateT> The type of the {@link Writer Writer's} state.
+ */
+@Internal
+final class StatefulWriterOperator<InputT, CommT, WriterStateT> extends AbstractWriterOperator<InputT, CommT> {
+
+	/** The operator's state descriptor. */
+	private static final ListStateDescriptor<byte[]> WRITER_RAW_STATES_DESC =
+		new ListStateDescriptor<>("writer_raw_states", BytePrimitiveArraySerializer.INSTANCE);
+
+	/** Used to create the stateful {@link Writer}. */
+	private final Sink<InputT, CommT, WriterStateT, ?> sink;
+
+	/** The writer operator's state serializer. */
+	private final SimpleVersionedSerializer<WriterStateT> writerStateSimpleVersionedSerializer;
+
+	// ------------------------------- runtime fields ---------------------------------------
+
+	/** The operator's state. */
+	private ListState<WriterStateT> writerState;
+
+	StatefulWriterOperator(
+		final Sink<InputT, CommT, WriterStateT, ?> sink,
+		final SimpleVersionedSerializer<WriterStateT> writerStateSimpleVersionedSerializer) {
+		this.sink = sink;
+		this.writerStateSimpleVersionedSerializer = writerStateSimpleVersionedSerializer;
+	}
+
+	@Override
+	public void initializeState(StateInitializationContext context) throws Exception {
+		super.initializeState(context);
+
+		final ListState<byte[]> rawState = context.getOperatorStateStore().getListState(WRITER_RAW_STATES_DESC);
+		writerState = new SimpleVersionedListState<>(rawState, writerStateSimpleVersionedSerializer);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		writerState.update((List<WriterStateT>) writer.snapshotState());
+	}
+
+	@Override
+	Writer<InputT, CommT, WriterStateT> createWriter() throws Exception {
+		final List<WriterStateT> committables = CollectionUtil.iterableToList(writerState.get());
+		return sink.createWriter(createInitContext(), committables);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperatorFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+
+/**
+ * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link
+ * StatefulWriterOperator}.
+ *
+ * @param <InputT> The input type of the {@link Writer}.
+ * @param <CommT> The committable type of the {@link Writer}.
+ * @param <WriterStateT> The type of the {@link Writer Writer's} state.
+ */
+public final class StatefulWriterOperatorFactory<InputT, CommT, WriterStateT> extends AbstractWriterOperatorFactory<InputT, CommT> {
+
+	private final Sink<InputT, CommT, WriterStateT, ?> sink;
+
+	public StatefulWriterOperatorFactory(Sink<InputT, CommT, WriterStateT, ?> sink) {
+		this.sink = sink;
+	}
+
+	@Override
+	AbstractWriterOperator<InputT, CommT> createWriterOperator() {
+		return new StatefulWriterOperator<>(sink, sink.getWriterStateSerializer().get());
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return StatefulWriterOperator.class;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+
+import java.util.Collections;
+
+/**
+ * Runtime {@link org.apache.flink.streaming.api.operators.StreamOperator} for executing {@link
+ * Writer Writers} that don't have state.
+ *
+ * @param <InputT> The input type of the {@link Writer}.
+ * @param <CommT> The committable type of the {@link Writer}.
+ */
+@Internal
+final class StatelessWriterOperator<InputT, CommT> extends AbstractWriterOperator<InputT, CommT>{
+
+	/** Used to create the stateless {@link Writer}. */
+	private final Sink<InputT, CommT, ?, ?> sink;
+
+	StatelessWriterOperator(final Sink<InputT, CommT, ?, ?> sink) {
+		this.sink = sink;
+	}
+
+	@Override
+	Writer<InputT, CommT, ?> createWriter() {
+		return sink.createWriter(createInitContext(), Collections.emptyList());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+
+/**
+ * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link
+ * StatelessWriterOperator}.
+ *
+ * @param <InputT> The input type of the {@link Writer}.
+ * @param <CommT> The committable type of the {@link Writer}.
+ */
+public final class StatelessWriterOperatorFactory<InputT, CommT> extends AbstractWriterOperatorFactory<InputT, CommT> {
+
+	private final Sink<InputT, CommT, ?, ?> sink;
+
+	public StatelessWriterOperatorFactory(Sink<InputT, CommT, ?, ?> sink) {
+		this.sink = sink;
+	}
+
+	@Override
+	AbstractWriterOperator<InputT, CommT> createWriterOperator() {
+		return new StatelessWriterOperator<>(sink);
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return StatelessWriterOperator.class;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperatorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link StatefulWriterOperator}.
+ */
+public class StatefulWriterOperatorTest extends WriterOperatorTestBase {
+
+	@Override
+	protected <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
+			TestSink<InputT, CommT, ?, ?> sink) {
+		return new StatefulWriterOperatorFactory<>(sink);
+	}
+
+	@Test
+	public void stateIsRestored() throws Exception {
+		final long initialTime = 0;
+
+		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
+				createTestHarness(TestSink.create(
+						SnapshottingBufferingWriter::new,
+						stateSerializer()));
+		testHarness.open();
+
+		testHarness.processWatermark(initialTime);
+		testHarness.processElement(1, initialTime + 1);
+		testHarness.processElement(2, initialTime + 2);
+
+		testHarness.prepareSnapshotPreBarrier(1L);
+		OperatorSubtaskState snapshot = testHarness.snapshot(1L, 1L);
+
+		// we only see the watermark, so the committables must be stored in state
+		assertThat(
+				testHarness.getOutput(),
+				contains(
+						new Watermark(initialTime)));
+
+		testHarness.close();
+
+		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> restoredTestHarness =
+				createTestHarness(TestSink.create(
+						SnapshottingBufferingWriter::new,
+						stateSerializer()));
+
+		restoredTestHarness.initializeState(snapshot);
+		restoredTestHarness.open();
+
+		// this will flush out the committables that were restored
+		restoredTestHarness.endInput();
+
+		assertThat(
+				restoredTestHarness.getOutput(),
+				contains(
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+	}
+
+	/**
+	 * A {@link Writer} buffers elements and snapshots them when asked.
+	 */
+	static class SnapshottingBufferingWriter extends BufferingWriter {
+		public SnapshottingBufferingWriter(List<Tuple3<Integer, Long, Long>> state) {
+			this.elements = state;
+		}
+
+		@Override
+		public List<Tuple3<Integer, Long, Long>> snapshotState() {
+			return elements;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+/**
+ * Tests for {@link StatelessWriterOperator}.
+ *
+ * <p>This has no tests of its own because {@link StatelessWriterOperator} has no functionality
+ * beyond what {@link AbstractWriterOperator} provides.
+ */
+public class StatelessWriterOperatorTest extends WriterOperatorTestBase {
+	@Override
+	protected <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
+			TestSink<InputT, CommT, ?, ?> sink) {
+		return new StatelessWriterOperatorFactory<>(sink);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.function.FunctionUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+
+/**
+ * Test the writer operator.
+ */
+public class WriterOperatorTest {
+
+	@Test
+	public void testStatelessWriter() throws Exception {
+		final long initialTime = 0;
+		final ConcurrentLinkedQueue<Object> expectedPreCommitOutput =
+			new ConcurrentLinkedQueue<>(
+				Arrays.asList(
+					new Watermark(initialTime),
+					new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
+					new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+
+		final ConcurrentLinkedQueue<Object> expectedEndOutput = new ConcurrentLinkedQueue<>(expectedPreCommitOutput);
+		expectedEndOutput.add(new StreamRecord<>(DummyWriter.LAST_ELEMENT));
+
+		final Consumer<OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>>> process =
+			FunctionUtils.uncheckedConsumer(
+				task -> {
+					task.processWatermark(initialTime);
+					task.processElement(1, initialTime + 1);
+					task.processElement(2, initialTime + 2);
+				});
+
+		final OperatorSubtaskState operatorSubtaskState = processElements(
+			null,
+			new StatelessWriterOperatorFactory<>(new StatelessWriterSink()),
+			process,
+			expectedPreCommitOutput,
+			expectedEndOutput);
+
+		// test after restoring
+		processElements(
+			operatorSubtaskState,
+			new StatelessWriterOperatorFactory<>(new StatelessWriterSink()),
+			process,
+			expectedPreCommitOutput,
+			expectedEndOutput);
+
+	}
+
+	@Test
+	public void testStatefulWriter() throws Exception {
+
+		final long initialTime = 0;
+
+		final ConcurrentLinkedQueue<Object> expectedEndOutput1 =
+			new ConcurrentLinkedQueue<>(
+				Arrays.asList(
+					new StreamRecord<>(Tuple3.of(1, initialTime + 1, Long.MIN_VALUE)),
+					new StreamRecord<>(Tuple3.of(2, initialTime + 2, Long.MIN_VALUE)),
+					new StreamRecord<>(DummyWriter.LAST_ELEMENT)));
+
+		final Consumer<OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>>> process1 =
+			FunctionUtils.uncheckedConsumer(
+				task -> {
+					task.processElement(new StreamRecord<>(1, initialTime + 1));
+					task.processElement(new StreamRecord<>(2, initialTime + 2));
+				});
+
+		final OperatorSubtaskState operatorSubtaskState = processElements(null,
+			new StatefulWriterOperatorFactory<>(new StatefulWriterSink()),
+			process1,
+			new ConcurrentLinkedQueue<>(),
+			expectedEndOutput1);
+
+		final Consumer<OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>>> process2 =
+			FunctionUtils.uncheckedConsumer(task -> task.processElement(new StreamRecord<>(3, initialTime + 3)));
+
+		final ConcurrentLinkedQueue<Object> expectedPreCommitOutput2 =
+			new ConcurrentLinkedQueue<>(
+				Arrays.asList(
+					new StreamRecord<>(Tuple3.of(1, initialTime + 1, Long.MIN_VALUE)),
+					new StreamRecord<>(Tuple3.of(2, initialTime + 2, Long.MIN_VALUE)),
+					new StreamRecord<>(Tuple3.of(3, initialTime + 3, Long.MIN_VALUE))));
+
+		final ConcurrentLinkedQueue<Object> expectedEndOutput2 = new ConcurrentLinkedQueue<>(expectedPreCommitOutput2);
+		expectedEndOutput2.add(new StreamRecord<>(DummyWriter.LAST_ELEMENT));
+
+		processElements(operatorSubtaskState,
+			new StatefulWriterOperatorFactory<>(new StatefulWriterSink()),
+			process2,
+			expectedPreCommitOutput2,
+			expectedEndOutput2);
+	}
+
+	private OperatorSubtaskState processElements(
+		@Nullable OperatorSubtaskState restoredOperatorSubtaskState,
+		OneInputStreamOperatorFactory<Integer, Tuple3<Integer, Long, Long>> factory,
+		Consumer<OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>>> process,
+		ConcurrentLinkedQueue<Object> expectedPreCommitOutput,
+		ConcurrentLinkedQueue<Object> expectedEndOutput) throws Exception {
+
+		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
+			new OneInputStreamOperatorTestHarness<>(factory, IntSerializer.INSTANCE);
+
+		if (restoredOperatorSubtaskState != null) {
+			testHarness.initializeState(restoredOperatorSubtaskState);
+		}
+
+		testHarness.open();
+		process.accept(testHarness);
+		//verify pre-commit output
+		testHarness.prepareSnapshotPreBarrier(1L);
+		final OperatorSubtaskState operatorSubtaskState = testHarness.snapshot(1L, 1L);
+		Assert.assertArrayEquals(expectedPreCommitOutput.toArray(), testHarness.getOutput().toArray());
+
+		//verify end-of-input output
+		testHarness.endInput();
+		Assert.assertArrayEquals(expectedEndOutput.toArray(), testHarness.getOutput().toArray());
+
+		//verify the close
+		testHarness.close();
+		AbstractWriterOperator<Integer, Tuple3<Integer, Long, Long>> s = (AbstractWriterOperator<Integer, Tuple3<Integer, Long, Long>>) testHarness.getOneInputOperator();
+		DummyWriter writer = (DummyWriter) s.writer;
+		Assert.assertTrue(writer.isClosed());
+
+		return operatorSubtaskState;
+	}
+
+	static final class StatelessWriterSink
+		implements TestSink<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>, Void> {
+
+		@Override
+		public Writer<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>> createWriter(
+			InitContext context, List<Tuple3<Integer, Long, Long>> states) {
+			return new DummyWriter();
+		}
+	}
+
+	static final class StatefulWriterSink
+		implements TestSink<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>, Void> {
+
+		@Override
+		public Writer<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>> createWriter(
+			InitContext context,
+			List<Tuple3<Integer, Long, Long>> states) {
+			return new DummyWriter(3, states);
+		}
+
+		@Override
+		public Optional<SimpleVersionedSerializer<Tuple3<Integer, Long, Long>>> getWriterStateSerializer() {
+			return Optional.of(new WriterStateSerializer());
+		}
+	}
+
+	static final class DummyWriter
+		implements Writer<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>> {
+
+		static final Tuple3<Integer, Long, Long> LAST_ELEMENT =
+			Tuple3.of(Integer.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE);
+
+		private boolean isClosed;
+
+		private final int maxCacheElementNum;
+
+		// element, timestamp, watermark
+		private List<Tuple3<Integer, Long, Long>> elements;
+
+		DummyWriter(int maxCacheElementNum, List<Tuple3<Integer, Long, Long>> restoreElements) {
+			this.isClosed = false;
+			this.elements = new ArrayList<>(restoreElements);
+			this.maxCacheElementNum = maxCacheElementNum;
+		}
+
+		DummyWriter() {
+			this(0, Collections.emptyList());
+		}
+
+		@Override
+		public void write(Integer element, Context context) {
+			elements.add(Tuple3.of(element, context.timestamp(), context.currentWatermark()));
+		}
+
+		@Override
+		public List<Tuple3<Integer, Long, Long>> prepareCommit(boolean flush) {
+			final List<Tuple3<Integer, Long, Long>> r = elements;
+			if (flush) {
+				elements.add(LAST_ELEMENT);
+				return elements;
+			} else if (elements.size() >= maxCacheElementNum) {
+				elements = new ArrayList<>();
+				return r;
+			} else {
+				return Collections.emptyList();
+			}
+		}
+
+		@Override
+		public List<Tuple3<Integer, Long, Long>> snapshotState() {
+			return elements;
+		}
+
+		@Override
+		public void close() {
+			isClosed = true;
+		}
+
+		public boolean isClosed() {
+			return isClosed;
+		}
+	}
+
+	static final class WriterStateSerializer implements SimpleVersionedSerializer<Tuple3<Integer, Long, Long>> {
+
+		@Override
+		public int getVersion() {
+			return 0;
+		}
+
+		@Override
+		public byte[] serialize(Tuple3<Integer, Long, Long> tuple3) throws IOException {
+			return InstantiationUtil.serializeObject(tuple3);
+
+		}
+
+		@Override
+		public Tuple3<Integer, Long, Long>  deserialize(int version, byte[] serialized) throws IOException {
+			try {
+				return InstantiationUtil.deserializeObject(serialized, getClass().getClassLoader());
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Failed to deserialize the writer's state.", e);
+			}
+		}
+	}
+
+	interface TestSink<InputT, CommT, WriterStateT, GlobalCommT> extends Sink<InputT, CommT, WriterStateT, GlobalCommT> {
+
+		@Override
+		default Optional<Committer<CommT>> createCommitter() {
+			return Optional.empty();
+		}
+
+		@Override
+		default Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
+			return Optional.empty();
+		}
+
+		@Override
+		default Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
+			return Optional.empty();
+		}
+
+		@Override
+		default Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
+			return Optional.empty();
+		}
+
+		@Override
+		default Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
+			return Optional.empty();
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTestBase.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Base class for Tests for subclasses of {@link AbstractWriterOperator}.
+ */
+public abstract class WriterOperatorTestBase extends TestLogger {
+
+	protected abstract <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
+			TestSink<InputT, CommT, ?, ?> sink);
+
+	@Test
+	public void nonBufferingWriterEmitsWithoutFlush() throws Exception {
+		final long initialTime = 0;
+
+		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
+				createTestHarness(TestSink.create(NonBufferingWriter::new, stateSerializer()));
+		testHarness.open();
+
+		testHarness.processWatermark(initialTime);
+		testHarness.processElement(1, initialTime + 1);
+		testHarness.processElement(2, initialTime + 2);
+
+		testHarness.prepareSnapshotPreBarrier(1L);
+		testHarness.snapshot(1L, 1L);
+
+		assertThat(
+				testHarness.getOutput(),
+				contains(
+						new Watermark(initialTime),
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+	}
+
+	@Test
+	public void nonBufferingWriterEmitsOnFlush() throws Exception {
+		final long initialTime = 0;
+
+		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
+				createTestHarness(TestSink.create(NonBufferingWriter::new, stateSerializer()));
+		testHarness.open();
+
+		testHarness.processWatermark(initialTime);
+		testHarness.processElement(1, initialTime + 1);
+		testHarness.processElement(2, initialTime + 2);
+
+		testHarness.endInput();
+
+		assertThat(
+				testHarness.getOutput(),
+				contains(
+						new Watermark(initialTime),
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+	}
+
+	@Test
+	public void bufferingWriterDoesNotEmitWithoutFlush() throws Exception {
+		final long initialTime = 0;
+
+		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
+				createTestHarness(TestSink.create(BufferingWriter::new, stateSerializer()));
+		testHarness.open();
+
+		testHarness.processWatermark(initialTime);
+		testHarness.processElement(1, initialTime + 1);
+		testHarness.processElement(2, initialTime + 2);
+
+		testHarness.prepareSnapshotPreBarrier(1L);
+		testHarness.snapshot(1L, 1L);
+
+		assertThat(
+				testHarness.getOutput(),
+				contains(
+						new Watermark(initialTime)));
+	}
+
+	@Test
+	public void bufferingWriterEmitsOnFlush() throws Exception {
+		final long initialTime = 0;
+
+		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
+				createTestHarness(TestSink.create(BufferingWriter::new, stateSerializer()));
+		testHarness.open();
+
+		testHarness.processWatermark(initialTime);
+		testHarness.processElement(1, initialTime + 1);
+		testHarness.processElement(2, initialTime + 2);
+
+		testHarness.endInput();
+
+		assertThat(
+				testHarness.getOutput(),
+				contains(
+						new Watermark(initialTime),
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+	}
+
+	/**
+	 * A {@link Writer} that returns all committables from {@link #prepareCommit(boolean)} without
+	 * waiting for {@code flush} to be {@code true}.
+	 */
+	static class NonBufferingWriter extends TestWriter {
+		@Override
+		public List<Tuple3<Integer, Long, Long>> prepareCommit(boolean flush) {
+			List<Tuple3<Integer, Long, Long>> result = elements;
+			elements = new ArrayList<>();
+			return result;
+		}
+	}
+
+	/**
+	 * A {@link Writer} that only returns committables from {@link #prepareCommit(boolean)} when
+	 * {@code flush} is {@code true}.
+	 */
+	static class BufferingWriter extends TestWriter {
+		@Override
+		public List<Tuple3<Integer, Long, Long>> prepareCommit(boolean flush) {
+			if (flush) {
+				List<Tuple3<Integer, Long, Long>> result = elements;
+				elements = new ArrayList<>();
+				return result;
+			} else {
+				return Collections.emptyList();
+			}
+		}
+	}
+
+	/**
+	 * Base class for out testing {@link Writer Writers}.
+	 */
+	abstract static class TestWriter
+			implements Writer<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>> {
+
+		// element, timestamp, watermark
+		protected List<Tuple3<Integer, Long, Long>> elements;
+
+		TestWriter() {
+			this.elements = new ArrayList<>();
+		}
+
+		@Override
+		public void write(Integer element, Context context) {
+			elements.add(Tuple3.of(element, context.timestamp(), context.currentWatermark()));
+		}
+
+		@Override
+		public List<Tuple3<Integer, Long, Long>> snapshotState() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void close() throws Exception {
+		}
+	}
+
+	/**
+	 * A {@link Sink} for testing that uses {@link Supplier Suppliers} to create various components
+	 * under test.
+	 */
+	protected static class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
+			implements Sink<InputT, CommT, WriterStateT, GlobalCommT> {
+
+		private final Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier;
+		private final Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier;
+
+		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+				Supplier<Writer<InputT, CommT, WriterStateT>> writer) {
+			// We cannot replace this by a method reference because the Java compiler will not be
+			// able to typecheck it.
+			//noinspection Convert2MethodRef
+			return new TestSink<>((state) -> writer.get(), () -> Optional.empty());
+		}
+
+		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+				Supplier<Writer<InputT, CommT, WriterStateT>> writer,
+				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+			return new TestSink<>((state) -> writer.get(), writerStateSerializerSupplier);
+		}
+
+		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+				Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
+				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+			return new TestSink<>(writer, writerStateSerializerSupplier);
+		}
+
+		private TestSink(
+				Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
+				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+			this.writerSupplier = writer;
+			this.writerStateSerializerSupplier = writerStateSerializerSupplier;
+		}
+
+		public Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> getWriterSupplier() {
+			return writerSupplier;
+		}
+
+		public Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> getWriterStateSerializerSupplier() {
+			return writerStateSerializerSupplier;
+		}
+
+		@Override
+		public Writer<InputT, CommT, WriterStateT> createWriter(
+				InitContext context,
+				List<WriterStateT> states) {
+			return writerSupplier.apply(states);
+		}
+
+		@Override
+		public Optional<Committer<CommT>> createCommitter() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
+			return writerStateSerializerSupplier.get();
+		}
+	}
+
+	public static Supplier<Optional<SimpleVersionedSerializer<Tuple3<Integer, Long, Long>>>> stateSerializer() {
+		return () -> Optional.of(new WriterStateSerializer());
+	}
+
+	static final class WriterStateSerializer implements SimpleVersionedSerializer<Tuple3<Integer, Long, Long>> {
+
+		@Override
+		public int getVersion() {
+			return 0;
+		}
+
+		@Override
+		public byte[] serialize(Tuple3<Integer, Long, Long> tuple3) throws IOException {
+			return InstantiationUtil.serializeObject(tuple3);
+
+		}
+
+		@Override
+		public Tuple3<Integer, Long, Long> deserialize(
+				int version,
+				byte[] serialized) throws IOException {
+			try {
+				return InstantiationUtil.deserializeObject(serialized, getClass().getClassLoader());
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Failed to deserialize the writer's state.", e);
+			}
+		}
+	}
+
+	protected <CommT> OneInputStreamOperatorTestHarness<Integer, CommT> createTestHarness(
+			TestSink<Integer, CommT, ?, ?> sink) throws Exception {
+
+		return new OneInputStreamOperatorTestHarness<>(
+				createWriterOperator(sink),
+				IntSerializer.INSTANCE);
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This patch introduces two types of sink writer operators:
1. The `StatelessWriterOperator` is for the case where the writer state serializer is not provided.
2. The `StatefulWriterOperator` is for the case where the writer state serializer is provided.

The `AbstractWriterOperator` is the base class of the two operators.

## Brief change log

1. Introduce the base writer operator class `AbstractWriterOperator`
2. Introduce the `StatelessWriterOperator`
3. introduce the `StatefulWriterOperator`


## Verifying this change

1. `WriterOperatorTest::testStatelessWriter` tests the whole process of 'open/process/presnapshot/snapshot/close/restore' of the  `StatelessWriterOperator`.
1. `WriterOperatorTest::testStatefulWriter` tests the whole process of `open/process/presnapshot/snapshot/close/restore` of the `StatefulWriterOperator`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
