### PR TITLE
[hotfix][doc] the first FSDataOutputStream should be FSDataInputStream in FileSystem#L178

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -175,7 +175,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * is frequently shared across multiple threads in Flink and must be able to concurrently
  * create input/output streams and list file metadata.
  *
- * <p>The {@link FSDataOutputStream} and {@link FSDataOutputStream} implementations are strictly
+ * <p>The {@link FSDataInputStream} and {@link FSDataOutputStream} implementations are strictly
  * <b>not thread-safe</b>. Instances of the streams should also not be passed between threads
  * in between read or write operations, because there are no guarantees about the visibility of
  * operations across threads (many operations do not create memory fences).


### PR DESCRIPTION

## What is the purpose of the change

*fix the typo in the doc of FileSystem*


## Brief change log

  - change the first `FSDataOutputStream` to `FSDataInputStream`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
