### PR TITLE
[FLINK-19606][table-runtime] Implement streaming window join operator

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -124,7 +124,11 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
 	// Utility Classes
 	// ----------------------------------------------------------------------------------------
 
-	private class JoinConditionWithNullFilters extends AbstractRichFunction implements JoinCondition {
+	/**
+	 * Code generated condition function for [[org.apache.calcite.rel.core.Join]]
+	 * that can handle nulls.
+	 */
+	protected class JoinConditionWithNullFilters extends AbstractRichFunction implements JoinCondition {
 
 		final JoinCondition backingJoinCondition;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/assigners/ExplicitBoundsWindowAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/assigners/ExplicitBoundsWindowAssigner.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A {@link WindowAssigner} that windows elements into the given window.
+ */
+public class ExplicitBoundsWindowAssigner
+		extends WindowAssigner<TimeWindow>
+		implements InternalTimeWindowAssigner {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Attribute window-start index.
+	 */
+	private final int windowStartRef;
+
+	/**
+	 * Attribute window-end index.
+	 */
+	private final int windowEndRef;
+
+	/**
+	 * Whether the time attribute is event-time.
+	 */
+	private final boolean isEventTime;
+
+	protected ExplicitBoundsWindowAssigner(
+			int windowStartRef,
+			int windowEndRef,
+			boolean isEventTime) {
+		this.windowStartRef = windowStartRef;
+		this.windowEndRef = windowEndRef;
+		this.isEventTime = isEventTime;
+	}
+
+	@Override
+	public Collection<TimeWindow> assignWindows(RowData element, long timestamp) {
+		TimeWindow window = new TimeWindow(element.getLong(windowStartRef),
+				element.getLong(windowEndRef));
+		return Collections.singletonList(window);
+	}
+
+	@Override
+	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new TimeWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return isEventTime;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ExplicitBoundsWindow(%d, %d)", windowStartRef, windowEndRef);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new {@code ExplicitBoundsWindowAssigner} that assigns
+	 * elements to the given time window.
+	 *
+	 * @return The time policy.
+	 */
+	public static ExplicitBoundsWindowAssigner of(int windowStartRef, int windowEndRef) {
+		return new ExplicitBoundsWindowAssigner(windowStartRef, windowEndRef, true);
+	}
+
+	public ExplicitBoundsWindowAssigner withEventTime() {
+		return new ExplicitBoundsWindowAssigner(windowStartRef, windowEndRef, true);
+	}
+
+	public ExplicitBoundsWindowAssigner withProcessingTime() {
+		return new ExplicitBoundsWindowAssigner(windowStartRef, windowEndRef, false);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AbstractWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AbstractWindowProcessFunction.java
@@ -18,25 +18,43 @@
 
 package org.apache.flink.table.runtime.operators.window.internal;
 
-import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
 import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
 
+import java.io.Serializable;
 import java.util.Collection;
 
 /**
  * The internal interface for functions that process over grouped windows.
  *
+ * @param <K> type of the context key
  * @param <W> type of window
  */
-public interface InternalWindowProcessFunction<K, W extends Window> {
+public abstract class AbstractWindowProcessFunction<K, W extends Window>
+		implements InternalWindowProcessFunction<K, W>, Serializable {
+
+	private static final long serialVersionUID = 5191040787066951059L;
+
+	protected final WindowAssigner<W> windowAssigner;
+	protected final long allowedLateness;
+	protected Context<K, W> ctx;
+
+	protected AbstractWindowProcessFunction(
+			WindowAssigner<W> windowAssigner,
+			long allowedLateness) {
+		this.windowAssigner = windowAssigner;
+		this.allowedLateness = allowedLateness;
+	}
 
 	/**
 	 * Initialization method for the function. It is called before the actual working methods.
 	 */
-	void open(Context<K, W> ctx) throws Exception;
+	public void open(Context<K, W> ctx) throws Exception {
+		this.ctx = ctx;
+		this.windowAssigner.open(ctx);
+	}
 
 	/**
 	 * Assigns the input element into the state namespace which the input element should be
@@ -47,7 +65,7 @@ public interface InternalWindowProcessFunction<K, W extends Window> {
 	 *                  assigner)
 	 * @return the state namespace
 	 */
-	Collection<W> assignStateNamespace(RowData inputRow,
+	public abstract Collection<W> assignStateNamespace(RowData inputRow,
 			long timestamp) throws Exception;
 
 	/**
@@ -59,7 +77,7 @@ public interface InternalWindowProcessFunction<K, W extends Window> {
 	 *                  assigner)
 	 * @return the actual windows
 	 */
-	Collection<W> assignActualWindows(RowData inputRow,
+	public abstract Collection<W> assignActualWindows(RowData inputRow,
 			long timestamp) throws Exception;
 
 	/**
@@ -68,61 +86,46 @@ public interface InternalWindowProcessFunction<K, W extends Window> {
 	 * @param window      the window to cleanup
 	 * @param currentTime the current timestamp
 	 */
-	void cleanWindowIfNeeded(W window, long currentTime) throws Exception;
+	public abstract void cleanWindowIfNeeded(W window, long currentTime) throws Exception;
 
 	/**
 	 * The tear-down method of the function. It is called after the last call to the main working
 	 * methods.
 	 */
-	void close() throws Exception;
+	public void close() throws Exception {
+		// default do nothing.
+	}
 
 	/**
-	 * Information available in an invocation of methods of {@link InternalWindowProcessFunction}.
-	 * @param <W>
+	 * Returns {@code true} if the given time is the cleanup time for the given window.
 	 */
-	interface Context<K, W extends Window> {
+	protected final boolean isCleanupTime(W window, long time) {
+		return time == cleanupTime(window);
+	}
 
-		/**
-		 * Creates a partitioned state handle, using the state backend configured for this task.
-		 *
-		 * @throws IllegalStateException Thrown, if the key/value state was already initialized.
-		 * @throws Exception Thrown, if the state backend cannot create the key/value state.
-		 */
-		<S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception;
+	/**
+	 * Returns {@code true} if the watermark is after the end timestamp plus the allowed lateness
+	 * of the given window.
+	 */
+	protected boolean isWindowLate(W window) {
+		return (windowAssigner.isEventTime() && (cleanupTime(window) <= ctx.currentWatermark()));
+	}
 
-		/**
-		 * @return current key of current processed element.
-		 */
-		K currentKey();
-
-		/**
-		 * Returns the current processing time.
-		 */
-		long currentProcessingTime();
-
-		/**
-		 * Returns the current event-time watermark.
-		 */
-		long currentWatermark();
-
-		/**
-		 * Clear window state of the given window.
-		 */
-		void clearWindowState(W window) throws Exception;
-
-		/**
-		 * Call {@link Trigger#clear(Window)}} on trigger.
-		 */
-		void clearTrigger(W window) throws Exception;
-
-		/**
-		 * Call {@link Trigger#onMerge(Window, Trigger.OnMergeContext)} on trigger.
-		 */
-		void onMerge(W newWindow, Collection<W> mergedWindows) throws Exception;
-
-		/**
-		 * Deletes the cleanup timer set for the contents of the provided window.
-		 */
-		void deleteCleanupTimer(W window) throws Exception;
+	/**
+	 * Returns the cleanup time for a window, which is
+	 * {@code window.maxTimestamp + allowedLateness}. In
+	 * case this leads to a value greated than {@link Long#MAX_VALUE}
+	 * then a cleanup time of {@link Long#MAX_VALUE} is
+	 * returned.
+	 *
+	 * @param window the window whose cleanup time we are computing.
+	 */
+	private long cleanupTime(W window) {
+		if (windowAssigner.isEventTime()) {
+			long cleanupTime = window.maxTimestamp() + allowedLateness;
+			return cleanupTime >= window.maxTimestamp() ? cleanupTime : Long.MAX_VALUE;
+		} else {
+			return window.maxTimestamp();
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AggregateGeneralWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AggregateGeneralWindowProcessFunction.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * The general implementation of {@link InternalWindowProcessFunction}
+ * for window aggregate.
+ *
+ * <p>The {@link WindowAssigner} should be a regular assigner without implement
+ * {@code PanedWindowAssigner} or {@code MergingWindowAssigner}.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class AggregateGeneralWindowProcessFunction<K, W extends Window>
+		extends GeneralWindowProcessFunction<K, W>
+		implements WindowAggregateProcessFunction<K, W>, WindowCleanAware<W> {
+
+	private static final long serialVersionUID = 5992545519395844485L;
+
+	private final NamespaceAggsHandleFunctionBase<W> windowAggregator;
+	// A typed copy to have aggregate specific operations.
+	protected WindowAggregateProcessFunction.Context<K, W> ctx;
+
+	public AggregateGeneralWindowProcessFunction(
+			WindowAssigner<W> windowAssigner,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
+			long allowedLateness) {
+		super(windowAssigner, allowedLateness);
+		this.windowAggregator = windowAggregator;
+	}
+
+	@Override
+	public void open(InternalWindowProcessFunction.Context<K, W> ctx) throws Exception {
+		Preconditions.checkArgument(ctx instanceof WindowAggregateProcessFunction.Context,
+				"The context must implement WindowAggregateProcessFunction.Context");
+		super.open(ctx);
+		this.ctx = (WindowAggregateProcessFunction.Context<K, W>) ctx;
+	}
+
+	public void prepareAggregateAccumulatorForEmit(W window) throws Exception {
+		RowData acc = ctx.getWindowAccumulators(window);
+		if (acc == null) {
+			acc = windowAggregator.createAccumulators();
+		}
+		windowAggregator.setAccumulators(window, acc);
+	}
+
+	@Override
+	public void onWindowCleaning(W window) throws Exception {
+		ctx.clearPreviousState(window);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AggregateMergingWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AggregateMergingWindowProcessFunction.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.MergingWindowAssigner;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
+
+/**
+ * The implementation of {@link InternalWindowProcessFunction} for
+ * window aggregate {@link MergingWindowAssigner}.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class AggregateMergingWindowProcessFunction<K, W extends Window>
+		extends MergingWindowProcessFunction<K, W>
+		implements WindowAggregateProcessFunction<K, W> {
+
+	private static final long serialVersionUID = -2866771637946397223L;
+
+	private final NamespaceAggsHandleFunctionBase<W> windowAggregator;
+	// A typed copy to have aggregate specific operations.
+	protected WindowAggregateProcessFunction.Context<K, W> ctx;
+
+	public AggregateMergingWindowProcessFunction(
+			MergingWindowAssigner<W> windowAssigner,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
+			TypeSerializer<W> windowSerializer,
+			long allowedLateness) {
+		super(windowAssigner, windowSerializer, allowedLateness);
+		this.windowAggregator = windowAggregator;
+	}
+
+	@Override
+	public void open(InternalWindowProcessFunction.Context<K, W> ctx) throws Exception {
+		Preconditions.checkArgument(ctx instanceof WindowAggregateProcessFunction.Context,
+				"The context must implement WindowAggregateProcessFunction.Context");
+		super.open(ctx);
+		this.ctx = (WindowAggregateProcessFunction.Context<K, W>) ctx;
+	}
+
+	public void prepareAggregateAccumulatorForEmit(W window) throws Exception {
+		W stateWindow = mergingWindows.getStateWindow(window);
+		RowData acc = ctx.getWindowAccumulators(stateWindow);
+		if (acc == null) {
+			acc = windowAggregator.createAccumulators();
+		}
+		windowAggregator.setAccumulators(stateWindow, acc);
+	}
+
+	@Override
+	protected void mergeNamespaces(W stateWindowResult, Collection<W> stateWindowsToBeMerged)
+			throws Exception {
+		if (!stateWindowsToBeMerged.isEmpty()) {
+			RowData targetAcc = ctx.getWindowAccumulators(stateWindowResult);
+			if (targetAcc == null) {
+				targetAcc = windowAggregator.createAccumulators();
+			}
+			windowAggregator.setAccumulators(stateWindowResult, targetAcc);
+			for (W w : stateWindowsToBeMerged) {
+				RowData acc = ctx.getWindowAccumulators(w);
+				if (acc != null) {
+					windowAggregator.merge(w, acc);
+				}
+				// clear merged window
+				ctx.clearWindowState(w);
+				ctx.clearPreviousState(w);
+			}
+			targetAcc = windowAggregator.getAccumulators();
+			ctx.setWindowAccumulators(stateWindowResult, targetAcc);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AggregatePanedWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/AggregatePanedWindowProcessFunction.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.PanedWindowAssigner;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * The implementation of {@link InternalWindowProcessFunction} for
+ * window aggregate {@link PanedWindowAssigner}.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class AggregatePanedWindowProcessFunction<K, W extends Window>
+		extends PanedWindowProcessFunction<K, W>
+		implements WindowAggregateProcessFunction<K, W> {
+
+	private static final long serialVersionUID = 4259335376102569987L;
+
+	private final NamespaceAggsHandleFunctionBase<W> windowAggregator;
+	private final PanedWindowAssigner<W> windowAssigner;
+	// A typed copy to have aggregate specific operations.
+	private WindowAggregateProcessFunction.Context<K, W> ctx;
+
+	public AggregatePanedWindowProcessFunction(
+			PanedWindowAssigner<W> windowAssigner,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
+			long allowedLateness) {
+		super(windowAssigner, allowedLateness);
+		this.windowAssigner = windowAssigner;
+		this.windowAggregator = windowAggregator;
+	}
+
+	@Override
+	public void open(InternalWindowProcessFunction.Context<K, W> ctx) throws Exception {
+		Preconditions.checkArgument(ctx instanceof WindowAggregateProcessFunction.Context,
+				"The context must implement WindowAggregateProcessFunction.Context");
+		super.open(ctx);
+		this.ctx = (WindowAggregateProcessFunction.Context<K, W>) ctx;
+	}
+
+	public void prepareAggregateAccumulatorForEmit(W window) throws Exception {
+		Iterable<W> panes = windowAssigner.splitIntoPanes(window);
+		RowData acc = windowAggregator.createAccumulators();
+		// null namespace means use heap data views
+		windowAggregator.setAccumulators(null, acc);
+		for (W pane : panes) {
+			RowData paneAcc = ctx.getWindowAccumulators(pane);
+			if (paneAcc != null) {
+				windowAggregator.merge(pane, paneAcc);
+			}
+		}
+	}
+
+	@Override
+	public void onWindowCleaning(W window) throws Exception {
+		ctx.clearPreviousState(window);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/GeneralWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/GeneralWindowProcessFunction.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.operators.window.internal;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.operators.window.Window;
 import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
 
@@ -30,20 +29,21 @@ import java.util.List;
 /**
  * The general implementation of {@link InternalWindowProcessFunction}. The {@link WindowAssigner}
  * should be a regular assigner without implement {@code PanedWindowAssigner} or {@code MergingWindowAssigner}.
+ *
  * @param <W> The type of {@code Window} that assigner assigns.
  */
-public class GeneralWindowProcessFunction<K, W extends Window>
-	extends InternalWindowProcessFunction<K, W> {
+public abstract class GeneralWindowProcessFunction<K, W extends Window>
+		extends AbstractWindowProcessFunction<K, W>
+		implements WindowCleanAware<W> {
 
 	private static final long serialVersionUID = 5992545519395844485L;
 
 	private List<W> reuseAffectedWindows;
 
 	public GeneralWindowProcessFunction(
-			WindowAssigner<W> windowAssigner,
-			NamespaceAggsHandleFunctionBase<W> windowAggregator,
-			long allowedLateness) {
-		super(windowAssigner, windowAggregator, allowedLateness);
+		WindowAssigner<W> windowAssigner,
+		long allowedLateness) {
+		super(windowAssigner, allowedLateness);
 	}
 
 	@Override
@@ -59,25 +59,16 @@ public class GeneralWindowProcessFunction<K, W extends Window>
 	}
 
 	@Override
-	public Collection<W> assignActualWindows(RowData inputRow, long timestamp) throws Exception {
+	public Collection<W> assignActualWindows(RowData inputRow, long timestamp) {
 		// actual windows is equal to affected window, reuse it
 		return reuseAffectedWindows;
-	}
-
-	@Override
-	public void prepareAggregateAccumulatorForEmit(W window) throws Exception {
-		RowData acc = ctx.getWindowAccumulators(window);
-		if (acc == null) {
-			acc = windowAggregator.createAccumulators();
-		}
-		windowAggregator.setAccumulators(window, acc);
 	}
 
 	@Override
 	public void cleanWindowIfNeeded(W window, long time) throws Exception {
 		if (isCleanupTime(window, time)) {
 			ctx.clearWindowState(window);
-			ctx.clearPreviousState(window);
+			onWindowCleaning(window);
 			ctx.clearTrigger(window);
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/JoinGeneralWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/JoinGeneralWindowProcessFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateView;
+
+/**
+ * The general implementation of {@link InternalWindowProcessFunction}
+ * for window join.
+ *
+ * <p>The {@link WindowAssigner} should be a regular assigner without implement
+ * {@code PanedWindowAssigner} or {@code MergingWindowAssigner}.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class JoinGeneralWindowProcessFunction<K, W extends Window>
+		extends GeneralWindowProcessFunction<K, W>
+		implements WindowJoinProcessFunction<K, W> {
+
+	private static final long serialVersionUID = 5992545519395844485L;
+
+	private final WindowJoinRecordStateView<W> view;
+
+	public JoinGeneralWindowProcessFunction(
+			WindowAssigner<W> windowAssigner,
+			WindowJoinRecordStateView<W> view,
+			long allowedLateness) {
+		super(windowAssigner, allowedLateness);
+		this.view = view;
+	}
+
+	@Override
+	public Iterable<RowData> prepareInputsToJoin(W window) throws Exception {
+		view.setCurrentNamespace(window);
+		return view.getRecords();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/JoinMergingWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/JoinMergingWindowProcessFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.MergingWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateView;
+
+import java.util.Collection;
+
+/**
+ * The implementation of {@link InternalWindowProcessFunction} for
+ * window aggregate {@link MergingWindowAssigner}.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class JoinMergingWindowProcessFunction<K, W extends Window>
+		extends MergingWindowProcessFunction<K, W>
+		implements WindowJoinProcessFunction<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final WindowJoinRecordStateView<W> view;
+
+	public JoinMergingWindowProcessFunction(
+			MergingWindowAssigner<W> windowAssigner,
+			String mergingWindowStateName,
+			WindowJoinRecordStateView<W> view,
+			TypeSerializer<W> windowSerializer,
+			long allowedLateness) {
+		super(mergingWindowStateName, windowAssigner, windowSerializer, allowedLateness);
+		this.view = view;
+	}
+
+	@Override
+	public Iterable<RowData> prepareInputsToJoin(W window) throws Exception {
+		W stateWindow = mergingWindows.getStateWindow(window);
+		this.view.setCurrentNamespace(stateWindow);
+		return this.view.getRecords();
+	}
+
+	@Override
+	protected void mergeNamespaces(W stateWindowResult, Collection<W> stateWindowsToBeMerged)
+			throws Exception {
+		if (!stateWindowsToBeMerged.isEmpty()) {
+			this.view.mergeNamespaces(stateWindowResult, stateWindowsToBeMerged);
+			for (W w : stateWindowsToBeMerged) {
+				// clear merged window
+				this.view.setCurrentNamespace(w);
+				this.view.clear();
+			}
+			this.view.setCurrentNamespace(stateWindowResult);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/JoinPanedWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/JoinPanedWindowProcessFunction.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.PanedWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateView;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The implementation of {@link InternalWindowProcessFunction} for
+ * window aggregate {@link PanedWindowAssigner}.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public class JoinPanedWindowProcessFunction<K, W extends Window>
+		extends PanedWindowProcessFunction<K, W>
+		implements WindowJoinProcessFunction<K, W> {
+
+	private static final long serialVersionUID = 4259335376102569987L;
+
+	private final WindowJoinRecordStateView<W> view;
+	private final PanedWindowAssigner<W> windowAssigner;
+
+	public JoinPanedWindowProcessFunction(
+			PanedWindowAssigner<W> windowAssigner,
+			WindowJoinRecordStateView<W> view,
+			long allowedLateness) {
+		super(windowAssigner, allowedLateness);
+		this.windowAssigner = windowAssigner;
+		this.view = view;
+	}
+
+	public Iterable<RowData> prepareInputsToJoin(W window) throws Exception {
+		Iterable<W> panes = windowAssigner.splitIntoPanes(window);
+		List<Iterable<RowData>> recordsIterables = new ArrayList<>();
+		while (panes.iterator().hasNext()) {
+			this.view.setCurrentNamespace(panes.iterator().next());
+			Iterable<RowData> records = this.view.getRecords();
+			if (records.iterator().hasNext()) {
+				recordsIterables.add(records);
+			}
+		}
+		return Iterables.concat(recordsIterables);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/WindowAggregateProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/WindowAggregateProcessFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.Window;
+
+/**
+ * The {@link InternalWindowProcessFunction} for window aggregate should implement this interface.
+ * It defines the methods to merge the state namespaces.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public interface WindowAggregateProcessFunction<K, W extends Window>
+		extends InternalWindowProcessFunction<K, W> {
+
+	/**
+	 * Prepares the accumulator of the given window before emit the final result. The accumulator
+	 * is stored in the state or will be created if there is no corresponding accumulator in state.
+	 *
+	 * @param window the window
+	 */
+	void prepareAggregateAccumulatorForEmit(W window) throws Exception;
+
+	/**
+	 * Information available in an invocation of methods of {@link WindowAggregateProcessFunction}.
+	 *
+	 * @param <W>
+	 */
+	interface Context<K, W extends Window>
+			extends InternalWindowProcessFunction.Context<K, W> {
+		/**
+		 * Gets the accumulators of the given window.
+		 */
+		RowData getWindowAccumulators(W window) throws Exception;
+
+		/**
+		 * Sets the accumulators of the given window.
+		 */
+		void setWindowAccumulators(W window, RowData acc) throws Exception;
+
+		/**
+		 * Clear previous agg state (used for retraction) of the given window.
+		 */
+		void clearPreviousState(W window) throws Exception;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/WindowCleanAware.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/WindowCleanAware.java
@@ -1,0 +1,12 @@
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.table.runtime.operators.window.Window;
+
+/** Components that want to have some custom logic when
+ * window cleaning should implement this interface. */
+public interface WindowCleanAware<W extends Window> {
+	/** Give a change for sub-class to do some additional work when doing window cleaning. */
+	default void onWindowCleaning(W window) throws Exception {
+		// default do nothing.
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/WindowJoinProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/WindowJoinProcessFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.internal;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.Window;
+
+/**
+ * The {@link InternalWindowProcessFunction} for window join should implement this interface.
+ * It defines the methods to merge the state namespaces before joining the inputs.
+ *
+ * @param <W> The type of {@code Window} that assigner assigns.
+ */
+public interface WindowJoinProcessFunction<K, W extends Window>
+		extends InternalWindowProcessFunction<K, W> {
+
+	/**
+	 * Prepares the records of the given window before join. The join inputs
+	 * are stored in the state and in some scenario the records are scattered
+	 * in multiple panes(e.g. the HOP window).
+	 *
+	 * @param window the window
+	 * @return join input records as an Iterable
+	 */
+	Iterable<RowData> prepareInputsToJoin(W window) throws Exception;
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowAttrCollectors.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowAttrCollectors.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.JoinedRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+
+/** Collectors used for patching up the window attributes of join LHS and RHS. **/
+public class WindowAttrCollectors {
+	private WindowAttrCollectors() {}
+
+	public static WindowAttrCollector getWindowAttrCollector(WindowAttribute windowAttribute) {
+		switch (windowAttribute) {
+		case NONE:
+			return new NoneWindowAttrCollector();
+		case START:
+			return new StartWindowAttrCollector();
+		case END:
+			return new EndWindowAttrCollector();
+		case START_END:
+			return new StartEndWindowAttrCollector();
+		default:
+			throw new IllegalArgumentException("Unexpected window attribute kind: "
+					+ windowAttribute);
+		}
+	}
+
+	/** The window attribute collector. */
+	public interface WindowAttrCollector {
+		RowData collect(RowData dataRow, TimeWindow window);
+	}
+
+	/** Patches up the "window_start" attribute. */
+	public static class StartWindowAttrCollector implements WindowAttrCollector {
+		private final GenericRowData reusedWindowAttrs = new GenericRowData(1);
+		private final JoinedRowData reusedWrapperRow = new JoinedRowData();
+
+		public RowData collect(
+				RowData dataRow,
+				TimeWindow window) {
+			reusedWindowAttrs.setField(0, TimestampData.fromEpochMillis(window.getStart()));
+			return reusedWrapperRow.replace(dataRow, reusedWindowAttrs);
+		}
+	}
+
+	/** Patches up the "window_end" attribute. */
+	public static class EndWindowAttrCollector implements WindowAttrCollector {
+		private final GenericRowData reusedWindowAttrs = new GenericRowData(1);
+		private final JoinedRowData reusedWrapperRow = new JoinedRowData();
+
+		public RowData collect(
+				RowData dataRow,
+				TimeWindow window) {
+			reusedWindowAttrs.setField(0, TimestampData.fromEpochMillis(window.getEnd()));
+			return reusedWrapperRow.replace(dataRow, reusedWindowAttrs);
+		}
+	}
+
+	/** Patches up the "window_start" and "window_end" attributes. */
+	public static class StartEndWindowAttrCollector implements WindowAttrCollector {
+		private final GenericRowData reusedWindowAttrs = new GenericRowData(2);
+		private final JoinedRowData reusedWrapperRow = new JoinedRowData();
+
+		public RowData collect(
+				RowData dataRow,
+				TimeWindow window) {
+			reusedWindowAttrs.setField(0, TimestampData.fromEpochMillis(window.getStart()));
+			reusedWindowAttrs.setField(1, TimestampData.fromEpochMillis(window.getEnd()));
+			return reusedWrapperRow.replace(dataRow, reusedWindowAttrs);
+		}
+	}
+
+	/** Does not patch up any window attributes. */
+	public static class NoneWindowAttrCollector implements WindowAttrCollector {
+
+		public RowData collect(
+				RowData dataRow,
+				TimeWindow window) {
+			return dataRow;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowAttribute.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowAttribute.java
@@ -1,0 +1,29 @@
+package org.apache.flink.table.runtime.operators.window.join;
+
+/**
+ * Enumerations to indicate the output of window
+ * attributes of the window join side(LHS and RHS).
+ *
+ * @see WindowAttrCollectors
+ */
+public enum WindowAttribute {
+	/** Does not output any window attributes. */
+	NONE(0),
+	/** Outputs the window_start. */
+	START(1),
+	/** Outputs the window_end. */
+	END(1),
+	/** Outputs the window_start and window_end. */
+	START_END(2);
+
+	// Count of the window attributes.
+	private final int cnt;
+
+	WindowAttribute(int cnt) {
+		this.cnt = cnt;
+	}
+
+	public int count() {
+		return cnt;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperator.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.InternalTimeWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.MergingWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.PanedWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.SessionWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.SlidingWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.TumblingWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.internal.JoinGeneralWindowProcessFunction;
+import org.apache.flink.table.runtime.operators.window.internal.JoinMergingWindowProcessFunction;
+import org.apache.flink.table.runtime.operators.window.internal.JoinPanedWindowProcessFunction;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateView;
+import org.apache.flink.table.runtime.operators.window.triggers.EventTimeTriggers;
+import org.apache.flink.table.runtime.operators.window.triggers.ProcessingTimeTriggers;
+import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.util.Preconditions;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * An operator that implements the logic for join streams windowing
+ * based on a {@link WindowAssigner} and {@link Trigger}.
+ *
+ * <p>When an element arrives it gets assigned a key using a {@link KeySelector} and it gets
+ * assigned to zero or more windows using a {@link WindowAssigner}. Based on this, the element
+ * is put into panes. A pane is the bucket of elements that have the same key and same
+ * {@code Window}. An element can be in multiple panes if it was assigned to multiple windows by
+ * the {@code WindowAssigner}.
+ *
+ * <p>Each input side of the join window the streams individually. They expect to
+ * have the same windowing strategy, e.g. the window type and window parameters.
+ * When the LHS element triggers the window firing
+ * (e.g. window1 max timestamp >= current watermark),
+ * that means the same window on the RHS also meet the condition and should be fired.
+ * We then get the triggered window records from the views of both sides,
+ * join them with the given condition and emit. Note that the inputs are buffered in the state
+ * and only emitted when a window fires. The buffered data is cleaned atomically when the window
+ * expires.
+ *
+ * <pre>
+ *                    input1                 input2
+ *                      |                      |
+ *                |  window1 |  &lt;= join =&gt; | window2 |
+ * </pre>
+ *
+ * <p>A window join triggers when:
+ * <ul>
+ *     <li>Element from LHS or RHS triggers and fires the window</li>
+ *     <li>Registered event-time timers trigger</li>
+ *     <li>Registered processing-time timers trigger</li>
+ * </ul>
+ *
+ * <p>Each pane gets its own instance of the provided {@code Trigger}. This trigger determines when
+ * the contents of the pane should be processed to emit results. When a trigger fires,
+ * the input views {@link WindowJoinRecordStateView} produces the join records
+ * under the current trigger namespace to join and emit for the pane to which the {@code Trigger}
+ * belongs.
+ *
+ * <p>The join output type should be: (left_type, right_type, window_start, window_end).
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public class WindowJoinOperator<K, W extends Window>
+		extends WindowJoinOperatorBase<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int leftRowtimeIndex;
+
+	private final int rightRowtimeIndex;
+
+	private WindowJoinOperator(
+			WindowAssigner<W> windowAssigner,
+			Trigger<W> trigger,
+			TypeSerializer<W> windowSerializer,
+			long allowedLateness,
+			InternalTypeInfo<RowData> leftType,
+			InternalTypeInfo<RowData> rightType,
+			GeneratedJoinCondition generatedJoinCondition,
+			JoinInputSideSpec leftInputSideSpec,
+			JoinInputSideSpec rightInputSideSpec,
+			boolean generateNullsOnLeft,
+			boolean generateNullsOnRight,
+			int leftRowtimeIndex,
+			int rightRowtimeIndex,
+			WindowAttribute leftWindowAttr,
+			WindowAttribute rightWindowAttr,
+			boolean[] filterNullKeys) {
+		super(windowAssigner, windowAssigner, trigger, windowSerializer, allowedLateness,
+				leftType, rightType, generatedJoinCondition, leftInputSideSpec,
+				rightInputSideSpec, generateNullsOnLeft, generateNullsOnRight,
+				leftWindowAttr, rightWindowAttr, filterNullKeys);
+		checkArgument(!windowAssigner.isEventTime()
+				|| leftRowtimeIndex >= 0 && rightRowtimeIndex >= 0);
+		this.leftRowtimeIndex = leftRowtimeIndex;
+		this.rightRowtimeIndex = rightRowtimeIndex;
+	}
+
+	protected void initializeProcessFunction() {
+		if (leftAssigner instanceof MergingWindowAssigner) {
+			this.windowFunction1 = new JoinMergingWindowProcessFunction<>(
+					(MergingWindowAssigner<W>) leftAssigner,
+					"window-to-state-1",
+					joinInputView1,
+					windowSerializer,
+					allowedLateness);
+			this.windowFunction2 = new JoinMergingWindowProcessFunction<>(
+					(MergingWindowAssigner<W>) rightAssigner,
+					"window-to-state-2",
+					joinInputView2,
+					windowSerializer,
+					allowedLateness);
+		} else if (leftAssigner instanceof PanedWindowAssigner) {
+			this.windowFunction1 = new JoinPanedWindowProcessFunction<>(
+					(PanedWindowAssigner<W>) leftAssigner,
+					joinInputView1,
+					allowedLateness);
+			this.windowFunction2 = new JoinPanedWindowProcessFunction<>(
+					(PanedWindowAssigner<W>) rightAssigner,
+					joinInputView2,
+					allowedLateness);
+		} else {
+			this.windowFunction1 = new JoinGeneralWindowProcessFunction<>(
+					leftAssigner,
+					joinInputView1,
+					allowedLateness);
+			this.windowFunction2 = new JoinGeneralWindowProcessFunction<>(
+					rightAssigner,
+					joinInputView2,
+					allowedLateness);
+		}
+	}
+
+	public long getRecordTimestamp(RowData inputRow, boolean isLeft) {
+		int rowtimeIndex = isLeft ? leftRowtimeIndex : rightRowtimeIndex;
+		return isEventTime()
+				? inputRow.getLong(rowtimeIndex)
+				: internalTimerService.currentProcessingTime();
+	}
+
+	// -------------------------------------------------------------------------
+	//  Inner Class
+	// -------------------------------------------------------------------------
+
+	/** Builder for {@link WindowJoinOperator}. */
+	public static class Builder {
+		private WindowAssigner<?> windowAssigner;
+		private Trigger<?> trigger;
+		private GeneratedJoinCondition joinCondition;
+		private InternalTypeInfo<RowData> type1;
+		private InternalTypeInfo<RowData> type2;
+		private JoinInputSideSpec inputSideSpec1;
+		private JoinInputSideSpec inputSideSpec2;
+		private Boolean generateNullsOnLeft;
+		private Boolean generateNullsOnRight;
+		private long allowedLateness = 0L;
+		private int rowtimeIndex1 = -1;
+		private int rowtimeIndex2 = -1;
+		private WindowAttribute leftAttr = WindowAttribute.NONE;
+		private WindowAttribute rightAttr = WindowAttribute.START_END;
+		private boolean[] filterNullKeys;
+
+		public Builder inputType(
+				InternalTypeInfo<RowData> type1,
+				InternalTypeInfo<RowData> type2) {
+			this.type1 = Objects.requireNonNull(type1);
+			this.type2 = Objects.requireNonNull(type2);
+			return this;
+		}
+
+		public Builder joinType(FlinkJoinType joinType) {
+			checkArgument(joinType != FlinkJoinType.ANTI && joinType != FlinkJoinType.SEMI,
+					"Unsupported join type: " + joinType);
+			this.generateNullsOnLeft = joinType.isRightOuter();
+			this.generateNullsOnRight = joinType.isLeftOuter();
+			return this;
+		}
+
+		public Builder joinCondition(GeneratedJoinCondition joinCondition) {
+			this.joinCondition = Objects.requireNonNull(joinCondition);
+			return this;
+		}
+
+		public Builder joinInputSpec(
+				JoinInputSideSpec inputSideSpec1,
+				JoinInputSideSpec inputSideSpec2) {
+			this.inputSideSpec1 = Objects.requireNonNull(inputSideSpec1);
+			this.inputSideSpec2 = Objects.requireNonNull(inputSideSpec2);
+			return this;
+		}
+
+		/** Array of booleans to describe whether each equal join key needs to filter out nulls,
+		 * thus, we can distinguish between EQUALS and IS NOT DISTINCT FROM. */
+		public Builder filterNullKeys(boolean... filterNullKeys) {
+			this.filterNullKeys = Objects.requireNonNull(filterNullKeys);
+			return this;
+		}
+
+		public Builder assigner(WindowAssigner<?> assigner) {
+			this.windowAssigner = Objects.requireNonNull(assigner);
+			return this;
+		}
+
+		public Builder trigger(Trigger<?> trigger) {
+			this.trigger = Objects.requireNonNull(trigger);
+			return this;
+		}
+
+		public Builder tumble(Duration size) {
+			checkArgument(
+					windowAssigner == null,
+					"Tumbling window properties already been set");
+			this.windowAssigner = TumblingWindowAssigner.of(size);
+			return this;
+		}
+
+		public Builder sliding(Duration size, Duration slide) {
+			checkArgument(
+					windowAssigner == null,
+					"Sliding window properties already been set");
+			this.windowAssigner = SlidingWindowAssigner.of(size, slide);
+			return this;
+		}
+
+		public Builder session(Duration sessionGap) {
+			checkArgument(
+					windowAssigner == null,
+					"Session window properties already been set");
+			this.windowAssigner = SessionWindowAssigner.withGap(sessionGap);
+			return this;
+		}
+
+		public Builder eventTime(int leftIndex, int rightIndex) {
+			checkArgument(windowAssigner != null,
+					"Use Builder.tumble, Builder.sliding or Builder.session or Builder.assigner to "
+							+ "set up the window assigning strategies first");
+			if (windowAssigner instanceof InternalTimeWindowAssigner) {
+				InternalTimeWindowAssigner timeWindowAssigner = (InternalTimeWindowAssigner) windowAssigner;
+				this.windowAssigner = (WindowAssigner<?>) timeWindowAssigner.withEventTime();
+			}
+			this.rowtimeIndex1 = leftIndex;
+			this.rowtimeIndex2 = rightIndex;
+			if (trigger == null) {
+				this.trigger = EventTimeTriggers.afterEndOfWindow();
+			}
+			return this;
+		}
+
+		public Builder processingTime() {
+			checkArgument(windowAssigner != null,
+					"Use Builder.tumble, Builder.sliding or Builder.session or Builder.assigner to "
+							+ "set up the window assigning strategies first");
+			if (windowAssigner instanceof InternalTimeWindowAssigner) {
+				InternalTimeWindowAssigner timeWindowAssigner = (InternalTimeWindowAssigner) windowAssigner;
+				this.windowAssigner = (WindowAssigner<?>) timeWindowAssigner.withProcessingTime();
+			}
+			if (trigger == null) {
+				this.trigger = ProcessingTimeTriggers.afterEndOfWindow();
+			}
+			return this;
+		}
+
+		public Builder allowedLateness(Duration allowedLateness) {
+			checkArgument(!allowedLateness.isNegative());
+			if (allowedLateness.toMillis() > 0) {
+				this.allowedLateness = allowedLateness.toMillis();
+			}
+			return this;
+		}
+
+		public Builder windowAttribute(WindowAttribute leftAttr, WindowAttribute rightAttr) {
+			this.leftAttr = Objects.requireNonNull(leftAttr);
+			this.rightAttr = Objects.requireNonNull(rightAttr);
+			return this;
+		}
+
+		@SuppressWarnings("unchecked")
+		public <K, W extends Window> WindowJoinOperator<K, W> build() {
+			Preconditions.checkState(this.type1 != null && this.type2 != null,
+					"Use Builder.inputType to set up the join input data types");
+			Preconditions.checkState(this.generateNullsOnLeft != null,
+					"Use Builder.joinType to set up the join type");
+			Preconditions.checkState(this.joinCondition != null,
+					"Use Builder.joinCondition to set up the join condition");
+			Preconditions.checkState(this.inputSideSpec1 != null && this.inputSideSpec2 != null,
+					"Use Builder.joinInputSpec to set up the join input specifications");
+			Preconditions.checkState(this.filterNullKeys != null,
+					"Use Builder.filterNullKeys to set up the which join keys need to filter nulls");
+			Preconditions.checkState(this.windowAssigner != null,
+					"Use Builder.tumble, Builder.sliding or Builder.session or Builder.assigner to "
+							+ "set up the window assigning strategies");
+			Preconditions.checkState(this.trigger != null,
+					"Use Builder.eventTime or Builder.processingTime or Builder.trigger "
+							+ "to set up the window triggering strategy");
+			return new WindowJoinOperator<>(
+					(WindowAssigner<W>) this.windowAssigner,
+					(Trigger<W>) this.trigger,
+					(TypeSerializer<W>) this.windowAssigner.getWindowSerializer(new ExecutionConfig()),
+					this.allowedLateness,
+					this.type1,
+					this.type2,
+					this.joinCondition,
+					this.inputSideSpec1,
+					this.inputSideSpec2,
+					this.generateNullsOnLeft,
+					this.generateNullsOnRight,
+					this.rowtimeIndex1,
+					this.rowtimeIndex2,
+					this.leftAttr,
+					this.rightAttr,
+					this.filterNullKeys);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	//  Utilities
+	// -------------------------------------------------------------------------
+
+	/** Returns the builder of {@link WindowJoinOperator}. */
+	public static Builder builder() {
+		return new Builder();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorBase.java
@@ -1,0 +1,675 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.MergingState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalMergingState;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.JoinedRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.operators.join.stream.AbstractStreamingJoinOperator;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.internal.InternalWindowProcessFunction;
+import org.apache.flink.table.runtime.operators.window.internal.WindowJoinProcessFunction;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateView;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateViews;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowedStateView;
+import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.types.RowKind;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Base class for window-join operators.
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public abstract class WindowJoinOperatorBase<K, W extends Window>
+		extends AbstractStreamingJoinOperator
+		implements Triggerable<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+	private static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
+	private static final String WATERMARK_LATENCY_METRIC_NAME = "watermarkLatency";
+
+	// -------------------------------------------------------------------------
+	//  Window Configuration
+	// -------------------------------------------------------------------------
+
+	protected final WindowAssigner<W> leftAssigner;
+
+	protected final WindowAssigner<W> rightAssigner;
+
+	private final Trigger<W> trigger;
+
+	/** For serializing the window in checkpoints. */
+	protected final TypeSerializer<W> windowSerializer;
+
+	/**
+	 * The allowed lateness for elements. This is used for:
+	 * <ul>
+	 * <li>Deciding if an element should be dropped from a window due to lateness.
+	 * <li>Clearing the state of a window if the system time passes the
+	 * {@code window.maxTimestamp + allowedLateness} landmark.
+	 * </ul>
+	 */
+	protected final long allowedLateness;
+
+	/** Process function for first input. **/
+	protected transient WindowJoinProcessFunction<K, W> windowFunction1;
+
+	/** Process function for second input. **/
+	protected transient WindowJoinProcessFunction<K, W> windowFunction2;
+
+	protected transient InternalTimerService<W> internalTimerService;
+
+	private transient TriggerContext triggerContext;
+
+	// -------------------------------------------------------------------------
+	//  Join Configuration
+	// -------------------------------------------------------------------------
+
+	// whether left hand side can generate nulls
+	private final boolean generateNullsOnLeft;
+	// whether right hand side can generate nulls
+	private final boolean generateNullsOnRight;
+
+	private final WindowAttribute leftWindowAttr;
+	private final WindowAttribute rightWindowAttr;
+	// used to output left data row and window attributes
+	private transient WindowAttrCollectors.WindowAttrCollector leftCollector;
+	// used to output right data row and window attributes
+	private transient WindowAttrCollectors.WindowAttrCollector rightCollector;
+
+	private transient RowData leftNullRow;
+	private transient RowData rightNullRow;
+	// output row: data row + window attributes
+	private transient JoinedRowData outputRow;
+
+	// left join state
+	protected transient WindowJoinRecordStateView<W> joinInputView1;
+	// right join state
+	protected transient WindowJoinRecordStateView<W> joinInputView2;
+
+	// ------------------------------------------------------------------------
+	// Metrics
+	// ------------------------------------------------------------------------
+
+	private transient Counter numLateRecordsDropped;
+	private transient Meter lateRecordsDroppedRate;
+	private transient Gauge<Long> watermarkLatency;
+
+	protected WindowJoinOperatorBase(
+			WindowAssigner<W> leftAssigner,
+			WindowAssigner<W> rightAssigner,
+			Trigger<W> trigger,
+			TypeSerializer<W> windowSerializer,
+			long allowedLateness,
+			InternalTypeInfo<RowData> leftType,
+			InternalTypeInfo<RowData> rightType,
+			GeneratedJoinCondition generatedJoinCondition,
+			JoinInputSideSpec leftInputSideSpec,
+			JoinInputSideSpec rightInputSideSpec,
+			boolean generateNullsOnLeft,
+			boolean generateNullsOnRight,
+			WindowAttribute leftWindowAttr,
+			WindowAttribute rightWindowAttr,
+			boolean[] filterNullKeys) {
+		super(leftType, rightType, generatedJoinCondition, leftInputSideSpec,
+				rightInputSideSpec, filterNullKeys, -1);
+		this.leftAssigner = checkNotNull(leftAssigner);
+		this.rightAssigner = checkNotNull(rightAssigner);
+		this.trigger = checkNotNull(trigger);
+		this.windowSerializer = checkNotNull(windowSerializer);
+		checkArgument(allowedLateness >= 0);
+		this.allowedLateness = allowedLateness;
+		this.generateNullsOnLeft = generateNullsOnLeft;
+		this.generateNullsOnRight = generateNullsOnRight;
+		this.leftWindowAttr = checkNotNull(leftWindowAttr);
+		this.rightWindowAttr = checkNotNull(rightWindowAttr);
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		internalTimerService = getInternalTimerService("window-join-timers",
+				windowSerializer, this);
+
+		triggerContext = new TriggerContext();
+		triggerContext.open();
+
+		this.outputRow = new JoinedRowData();
+		this.leftNullRow = new GenericRowData(leftType.toRowType().getFieldCount());
+		this.rightNullRow = new GenericRowData(rightType.toRowType().getFieldCount());
+		this.leftCollector = WindowAttrCollectors.getWindowAttrCollector(leftWindowAttr);
+		this.rightCollector = WindowAttrCollectors.getWindowAttrCollector(rightWindowAttr);
+		ViewContext viewContext = new ViewContext();
+		// initialize states
+		this.joinInputView1 = WindowJoinRecordStateViews.create(
+				viewContext,
+				windowSerializer,
+				"left-records",
+				leftInputSideSpec,
+				leftType);
+
+		this.joinInputView2 = WindowJoinRecordStateViews.create(
+				viewContext,
+				windowSerializer,
+				"right-records",
+				rightInputSideSpec,
+				rightType);
+
+		WindowContext windowContext1 = new WindowContext(this.joinInputView1);
+		WindowContext windowContext2 = new WindowContext(this.joinInputView2);
+		initializeProcessFunction();
+		this.windowFunction1.open(windowContext1);
+		this.windowFunction2.open(windowContext2);
+
+		// metrics
+		numLateRecordsDropped = metrics.counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
+		this.lateRecordsDroppedRate = metrics.meter(
+				LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
+				new MeterView(numLateRecordsDropped));
+		this.watermarkLatency = metrics.gauge(WATERMARK_LATENCY_METRIC_NAME, () -> {
+			long watermark = internalTimerService.currentWatermark();
+			if (watermark < 0) {
+				return 0L;
+			} else {
+				return internalTimerService.currentProcessingTime() - watermark;
+			}
+		});
+	}
+
+	/**
+	 * Initialize the window process function. This function is invoked in the {@link #open()}.
+	 *
+	 * @see #open()
+	 */
+	protected abstract void initializeProcessFunction();
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		collector = null;
+		triggerContext = null;
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		super.dispose();
+		collector = null;
+		triggerContext = null;
+	}
+
+	@Override
+	public void processElement1(StreamRecord<RowData> element) throws Exception {
+		processElement(element, true);
+	}
+
+	@Override
+	public void processElement2(StreamRecord<RowData> element) throws Exception {
+		processElement(element, false);
+	}
+
+	/**
+	 * Get the timestamp of the record, this method is invoked
+	 * in the {@link #processElement(StreamRecord, boolean)}.
+	 *
+	 * @see #processElement(StreamRecord, boolean)
+	 */
+	protected abstract long getRecordTimestamp(RowData inputRow, boolean isLeft);
+
+	private void processElement (StreamRecord<RowData> element, boolean isLeft)
+			throws Exception {
+		final InternalWindowProcessFunction<K, W> windowFunction = isLeft ? windowFunction1 : windowFunction2;
+		final WindowJoinRecordStateView<W> joinInputView = isLeft ? joinInputView1 : joinInputView2;
+		RowData inputRow = element.getValue();
+		long timestamp = getRecordTimestamp(inputRow, isLeft);
+
+		// the windows which the input row should be placed into
+		Collection<W> stateWindows = windowFunction.assignStateNamespace(inputRow, timestamp);
+		boolean isElementDropped = true;
+		for (W window : stateWindows) {
+			isElementDropped = false;
+			joinInputView.setCurrentNamespace(window);
+			if (inputRow.getRowKind() == RowKind.UPDATE_BEFORE) {
+				// Ignore update before message.
+				continue;
+			}
+			if (inputRow.getRowKind() == RowKind.DELETE) {
+				// Erase RowKind for state updating
+				inputRow.setRowKind(RowKind.INSERT);
+				joinInputView.retractRecord(inputRow);
+			} else {
+				joinInputView.addRecord(inputRow);
+			}
+		}
+
+		// the actual window which the input row is belongs to
+		Collection<W> actualWindows = windowFunction.assignActualWindows(inputRow, timestamp);
+		for (W window : actualWindows) {
+			isElementDropped = false;
+			triggerContext.window = window;
+			boolean triggerResult = triggerContext.onElement(inputRow, timestamp);
+			if (triggerResult) {
+				joinWindowInputsAndEmit(window);
+			}
+			// register a clean up timer for the window
+			registerCleanupTimer(window);
+		}
+
+		if (isElementDropped) {
+			// markEvent will increase numLateRecordsDropped
+			lateRecordsDroppedRate.markEvent();
+		}
+	}
+
+	@Override
+	public void onEventTime(InternalTimer<K, W> timer) throws Exception {
+		setCurrentKey(timer.getKey());
+
+		triggerContext.window = timer.getNamespace();
+		if (triggerContext.onEventTime(timer.getTimestamp())) {
+			// fire
+			joinWindowInputsAndEmit(triggerContext.window);
+		}
+
+		if (leftAssigner.isEventTime()) {
+			windowFunction1.cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+			windowFunction2.cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+		}
+	}
+
+	@Override
+	public void onProcessingTime(InternalTimer<K, W> timer) throws Exception {
+		setCurrentKey(timer.getKey());
+
+		triggerContext.window = timer.getNamespace();
+		if (triggerContext.onProcessingTime(timer.getTimestamp())) {
+			// fire
+			joinWindowInputsAndEmit(triggerContext.window);
+		}
+
+		if (!isEventTime()) {
+			windowFunction1.cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+			windowFunction2.cleanWindowIfNeeded(triggerContext.window, timer.getTimestamp());
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	//  Inner Class
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Context of window.
+	 */
+	private class WindowContext implements InternalWindowProcessFunction.Context<K, W> {
+		private WindowJoinRecordStateView<W> view;
+
+		WindowContext(WindowJoinRecordStateView<W> view) {
+			this.view = view;
+		}
+
+		@Override
+		public <S extends State> S getPartitionedState(
+				StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			requireNonNull(stateDescriptor, "The state properties must not be null");
+			return WindowJoinOperatorBase.this.getPartitionedState(stateDescriptor);
+		}
+
+		@Override
+		public K currentKey() {
+			return WindowJoinOperatorBase.this.currentKey();
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return internalTimerService.currentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return internalTimerService.currentWatermark();
+		}
+
+		@Override
+		public void clearWindowState(W window) {
+			this.view.setCurrentNamespace(window);
+			this.view.clear();
+		}
+
+		@Override
+		public void clearTrigger(W window) throws Exception {
+			triggerContext.window = window;
+			triggerContext.clear();
+		}
+
+		@Override
+		public void deleteCleanupTimer(W window) {
+			long cleanupTime = cleanupTime(window);
+			if (cleanupTime == Long.MAX_VALUE) {
+				// no need to clean up because we didn't set one
+				return;
+			}
+			if (isEventTime()) {
+				triggerContext.deleteEventTimeTimer(cleanupTime);
+			} else {
+				triggerContext.deleteProcessingTimeTimer(cleanupTime);
+			}
+		}
+
+		@Override
+		public void onMerge(W newWindow, Collection<W> mergedWindows) throws Exception {
+			triggerContext.window = newWindow;
+			triggerContext.mergedWindows = mergedWindows;
+			triggerContext.onMerge();
+		}
+	}
+
+	/**
+	 * {@code TriggerContext} is a utility for handling {@code Trigger} invocations. It can be
+	 * reused by setting the {@code key} and {@code window} fields.
+	 * Non-internal state must be kept in the {@code TriggerContext}.
+	 */
+	private class TriggerContext implements Trigger.OnMergeContext {
+
+		private W window;
+		private Collection<W> mergedWindows;
+
+		public void open() throws Exception {
+			trigger.open(this);
+		}
+
+		boolean onElement(RowData row, long timestamp) throws Exception {
+			return trigger.onElement(row, timestamp, window);
+		}
+
+		boolean onProcessingTime(long time) throws Exception {
+			return trigger.onProcessingTime(time, window);
+		}
+
+		boolean onEventTime(long time) throws Exception {
+			return trigger.onEventTime(time, window);
+		}
+
+		void onMerge() throws Exception {
+			trigger.onMerge(window, this);
+		}
+
+		@Override
+		public long getCurrentProcessingTime() {
+			return internalTimerService.currentProcessingTime();
+		}
+
+		@Override
+		public long getCurrentWatermark() {
+			return internalTimerService.currentWatermark();
+		}
+
+		@Override
+		public MetricGroup getMetricGroup() {
+			return WindowJoinOperatorBase.this.getMetricGroup();
+		}
+
+		@Override
+		public void registerProcessingTimeTimer(long time) {
+			internalTimerService.registerProcessingTimeTimer(window, time);
+		}
+
+		@Override
+		public void registerEventTimeTimer(long time) {
+			internalTimerService.registerEventTimeTimer(window, time);
+		}
+
+		@Override
+		public void deleteProcessingTimeTimer(long time) {
+			internalTimerService.deleteProcessingTimeTimer(window, time);
+		}
+
+		@Override
+		public void deleteEventTimeTimer(long time) {
+			internalTimerService.deleteEventTimeTimer(window, time);
+		}
+
+		public void clear() throws Exception {
+			trigger.clear(window);
+		}
+
+		@Override
+		public <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+			try {
+				return WindowJoinOperatorBase.this.getPartitionedState(window, windowSerializer, stateDescriptor);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not retrieve state", e);
+			}
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <S extends MergingState<?, ?>> void mergePartitionedState(
+				StateDescriptor<S, ?> stateDescriptor) {
+			if (mergedWindows != null && mergedWindows.size() > 0) {
+				try {
+					State state =
+							WindowJoinOperatorBase.this.getOrCreateKeyedState(
+									windowSerializer,
+									stateDescriptor);
+					if (state instanceof InternalMergingState) {
+						((InternalMergingState<K, W, ?, ?, ?>) state).mergeNamespaces(window, mergedWindows);
+					} else {
+						throw new IllegalArgumentException(
+								"The given state descriptor does not refer to a mergeable state (MergingState)");
+					}
+				}
+				catch (Exception e) {
+					throw new RuntimeException("Error while merging state.", e);
+				}
+			}
+		}
+	}
+
+	/** Context of {@code WindowedStateView}. */
+	private class ViewContext implements WindowedStateView.Context {
+		@Override
+		public <S extends State, N extends Window> S getOrCreateKeyedState(
+				TypeSerializer<N> windowSerializer,
+				StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			return WindowJoinOperatorBase.this.getOrCreateKeyedState(windowSerializer, stateDescriptor);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	//  Utilities
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Emits the window result of the given window.
+	 */
+	private void joinWindowInputsAndEmit(W window) throws Exception {
+		Iterable<RowData> leftInputs = this.windowFunction1.prepareInputsToJoin(window);
+		Iterable<RowData> rightInputs = this.windowFunction2.prepareInputsToJoin(window);
+		if (generateNullsOnLeft) {
+			joinLeftIsOuter(window, leftInputs, rightInputs, generateNullsOnRight);
+		} else {
+			joinLeftNonOuter(window, leftInputs, rightInputs, generateNullsOnRight);
+		}
+	}
+
+	private void joinLeftNonOuter(
+			W window,
+			Iterable<RowData> leftInputs,
+			Iterable<RowData> rightInputs,
+			boolean rightGeneratesNulls) {
+		for (RowData left : leftInputs) {
+			boolean leftMatched = false;
+			for (RowData right : rightInputs) {
+				boolean matches = joinCondition.apply(left, right);
+				if (matches) {
+					leftMatched = true;
+					output(left, right, window);
+				}
+			}
+			if (!leftMatched && rightGeneratesNulls) {
+				outputNullPadding(left, true, window);
+			}
+		}
+	}
+
+	private void joinLeftIsOuter(
+			W window,
+			Iterable<RowData> leftInputs,
+			Iterable<RowData> rightInputs,
+			boolean rightGeneratesNulls) {
+		Set<Integer> rightMatchedIndices = new HashSet<>();
+		for (RowData left : leftInputs) {
+			boolean leftMatched = false;
+			int idx = 0;
+			for (RowData right : rightInputs) {
+				boolean matches = joinCondition.apply(left, right);
+				if (matches) {
+					leftMatched = true;
+					output(left, right, window);
+					rightMatchedIndices.add(idx);
+				}
+				idx++;
+			}
+			if (!leftMatched && rightGeneratesNulls) {
+				outputNullPadding(left, true, window);
+			}
+		}
+		int idx = 0;
+		for (RowData right : rightInputs) {
+			if (!rightMatchedIndices.contains(idx)) {
+				outputNullPadding(right, false, window);
+			}
+			idx++;
+		}
+	}
+
+	/** Returns whether the time-attribute is event-time. */
+	protected boolean isEventTime() {
+		return this.leftAssigner.isEventTime();
+	}
+
+	/**
+	 * Registers a timer to cleanup the content of the window.
+	 *
+	 * @param window the window whose state to discard
+	 */
+	private void registerCleanupTimer(W window) {
+		long cleanupTime = cleanupTime(window);
+		if (cleanupTime == Long.MAX_VALUE) {
+			// don't set a GC timer for "end of time"
+			return;
+		}
+
+		if (isEventTime()) {
+			triggerContext.registerEventTimeTimer(cleanupTime);
+		} else {
+			triggerContext.registerProcessingTimeTimer(cleanupTime);
+		}
+	}
+
+	/**
+	 * Returns the cleanup time for a window, which is
+	 * {@code window.maxTimestamp + allowedLateness}. In
+	 * case this leads to a value greater than {@link Long#MAX_VALUE}
+	 * then a cleanup time of {@link Long#MAX_VALUE} is
+	 * returned.
+	 *
+	 * @param window the window whose cleanup time we are computing.
+	 */
+	private long cleanupTime(W window) {
+		if (isEventTime()) {
+			long cleanupTime = Math.max(0, window.maxTimestamp() + allowedLateness);
+			return cleanupTime >= window.maxTimestamp() ? cleanupTime : Long.MAX_VALUE;
+		} else {
+			return Math.max(0, window.maxTimestamp());
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private K currentKey() {
+		return (K) getCurrentKey();
+	}
+
+	private void output(RowData inputRow, RowData otherRow, W window) {
+		RowData left = leftCollector.collect(inputRow, (TimeWindow) window);
+		RowData right = rightCollector.collect(otherRow, (TimeWindow) window);
+
+		outputRow.replace(left, right);
+		collector.collect(outputRow);
+	}
+
+	private void outputNullPadding(RowData row, boolean isLeft, W window) {
+		RowData leftData;
+		RowData rightData;
+		if (isLeft) {
+			leftData = leftCollector.collect(row, (TimeWindow) window);
+			rightData = rightCollector.collect(rightNullRow, (TimeWindow) window);
+		} else {
+			leftData = leftCollector.collect(leftNullRow, (TimeWindow) window);
+			rightData = rightCollector.collect(row, (TimeWindow) window);
+		}
+		outputRow.replace(leftData, rightData);
+		collector.collect(outputRow);
+	}
+
+	// ------------------------------------------------------------------------------
+	// Visible For Testing
+	// ------------------------------------------------------------------------------
+
+	@VisibleForTesting
+	protected Counter getNumLateRecordsDropped() {
+		return numLateRecordsDropped;
+	}
+
+	@VisibleForTesting
+	protected Gauge<Long> getWatermarkLatency() {
+		return watermarkLatency;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorSimple.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorSimple.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.assigners.ExplicitBoundsWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.InternalTimeWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.internal.JoinGeneralWindowProcessFunction;
+import org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateView;
+import org.apache.flink.table.runtime.operators.window.triggers.EventTimeTriggers;
+import org.apache.flink.table.runtime.operators.window.triggers.ProcessingTimeTriggers;
+import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * An operator that implements the logic for join streams windowing
+ * based on a {@link WindowAssigner} and {@link Trigger}.
+ *
+ * <p>This is a simple version of {@link WindowJoinOperator} that assumes all its input has given
+ * window attributes.
+ *
+ * <p>When an element arrives it gets assigned a key using a {@link KeySelector} and it gets
+ * assigned to zero or more windows using the inputs given window attributes:
+ * {@code window_start}, {@code window_end}. Based on this, the element
+ * is put into panes. A pane is the bucket of elements that have the same key and same
+ * {@code Window}. An element can be in multiple panes if it was assigned to multiple windows.
+ * For the simple version
+ *
+ * <p>Each input side of the join window the streams individually. They expect to
+ * have the same windowing strategy, e.g. the window type and window parameters.
+ * When the LHS element triggers the window firing
+ * (e.g. window1 max timestamp >= current watermark),
+ * that means the same window on the RHS also meet the condition and should be fired.
+ * We then get the triggered window records from the views of both sides,
+ * join them with the given condition and emit. Note that the inputs are buffered in the state
+ * and only emitted when a window fires. The buffered data is cleaned atomically when the window
+ * expires.
+ *
+ * <pre>
+ *                    input1                 input2
+ *                      |                      |
+ *                |  window1 |  &lt;= join =&gt; | window2 |
+ * </pre>
+ *
+ * <p>A window join triggers when:
+ * <ul>
+ *     <li>Element from LHS or RHS triggers and fires the window</li>
+ *     <li>Registered event-time timers trigger</li>
+ *     <li>Registered processing-time timers trigger</li>
+ * </ul>
+ *
+ * <p>Each pane gets its own instance of the provided {@code Trigger}. This trigger determines when
+ * the contents of the pane should be processed to emit results. When a trigger fires,
+ * the input views {@link WindowJoinRecordStateView} produces the join records
+ * under the current trigger namespace to join and emit for the pane to which the {@code Trigger}
+ * belongs.
+ *
+ * <p>The join output type should be: (left_type, right_type).
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public class WindowJoinOperatorSimple<K, W extends Window>
+		extends WindowJoinOperatorBase<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	private WindowJoinOperatorSimple(
+			WindowAssigner<W> leftAssigner,
+			WindowAssigner<W> rightAssigner,
+			Trigger<W> trigger,
+			TypeSerializer<W> windowSerializer,
+			InternalTypeInfo<RowData> leftType,
+			InternalTypeInfo<RowData> rightType,
+			GeneratedJoinCondition generatedJoinCondition,
+			JoinInputSideSpec leftInputSideSpec,
+			JoinInputSideSpec rightInputSideSpec,
+			boolean generateNullsOnLeft,
+			boolean generateNullsOnRight,
+			boolean[] filterNullKeys) {
+		super(leftAssigner, rightAssigner, trigger, windowSerializer, 0,
+				leftType, rightType, generatedJoinCondition, leftInputSideSpec,
+				rightInputSideSpec, generateNullsOnLeft, generateNullsOnRight,
+				WindowAttribute.NONE, WindowAttribute.NONE, filterNullKeys);
+	}
+
+	@Override
+	protected void initializeProcessFunction() {
+		this.windowFunction1 = new JoinGeneralWindowProcessFunction<>(
+				leftAssigner,
+				joinInputView1,
+				allowedLateness);
+		this.windowFunction2 = new JoinGeneralWindowProcessFunction<>(
+				rightAssigner,
+				joinInputView2,
+				allowedLateness);
+	}
+
+	@Override
+	protected long getRecordTimestamp(RowData inputRow, boolean isLeft) {
+		// the timestamp never expects to be used.
+		return -1;
+	}
+
+	// -------------------------------------------------------------------------
+	//  Inner Class
+	// -------------------------------------------------------------------------
+
+	/** Builder for {@link WindowJoinOperatorSimple}. */
+	public static class Builder {
+		private WindowAssigner<?> leftAssigner;
+		private WindowAssigner<?> rightAssigner;
+		private Trigger<?> trigger;
+		private GeneratedJoinCondition joinCondition;
+		private InternalTypeInfo<RowData> type1;
+		private InternalTypeInfo<RowData> type2;
+		private JoinInputSideSpec inputSideSpec1;
+		private JoinInputSideSpec inputSideSpec2;
+		private Boolean generateNullsOnLeft;
+		private Boolean generateNullsOnRight;
+		private boolean[] filterNullKeys;
+
+		public Builder inputType(
+				InternalTypeInfo<RowData> type1,
+				InternalTypeInfo<RowData> type2) {
+			this.type1 = Objects.requireNonNull(type1);
+			this.type2 = Objects.requireNonNull(type2);
+			return this;
+		}
+
+		public Builder joinType(FlinkJoinType joinType) {
+			checkArgument(joinType != FlinkJoinType.ANTI && joinType != FlinkJoinType.SEMI,
+					"Unsupported join type: " + joinType);
+			this.generateNullsOnLeft = joinType.isRightOuter();
+			this.generateNullsOnRight = joinType.isLeftOuter();
+			return this;
+		}
+
+		public Builder joinCondition(GeneratedJoinCondition joinCondition) {
+			this.joinCondition = Objects.requireNonNull(joinCondition);
+			return this;
+		}
+
+		public Builder joinInputSpec(
+				JoinInputSideSpec inputSideSpec1,
+				JoinInputSideSpec inputSideSpec2) {
+			this.inputSideSpec1 = Objects.requireNonNull(inputSideSpec1);
+			this.inputSideSpec2 = Objects.requireNonNull(inputSideSpec2);
+			return this;
+		}
+
+		/** Array of booleans to describe whether each equal join key needs to filter out nulls,
+		 * thus, we can distinguish between EQUALS and IS NOT DISTINCT FROM. */
+		public Builder filterNullKeys(boolean... filterNullKeys) {
+			this.filterNullKeys = Objects.requireNonNull(filterNullKeys);
+			return this;
+		}
+
+		public Builder windowAttributeRefs(int[] leftWindowAttrRefs, int[] rightWindowAttrRefs) {
+			checkArgument(
+					leftWindowAttrRefs.length == 2
+							&& rightWindowAttrRefs.length == 2,
+					"window attributes should be exactly window_start and window_end");
+			for (int ref : leftWindowAttrRefs) {
+				checkArgument(ref > 0, "Window attribute input ref is invalid: " + ref);
+			}
+			for (int ref : rightWindowAttrRefs) {
+				checkArgument(ref > 0, "Window attribute input ref is invalid: " + ref);
+			}
+
+			this.leftAssigner = ExplicitBoundsWindowAssigner.of(
+					leftWindowAttrRefs[0], leftWindowAttrRefs[1]);
+			this.rightAssigner = ExplicitBoundsWindowAssigner.of(
+					rightWindowAttrRefs[0], rightWindowAttrRefs[1]);
+			return this;
+		}
+
+		public Builder trigger(Trigger<?> trigger) {
+			this.trigger = Objects.requireNonNull(trigger);
+			return this;
+		}
+
+		public Builder eventTime() {
+			checkArgument(leftAssigner != null,
+					"Use Builder.assigner to set up the window assigning strategies first");
+			if (leftAssigner instanceof InternalTimeWindowAssigner) {
+				InternalTimeWindowAssigner timeWindowAssigner = (InternalTimeWindowAssigner) leftAssigner;
+				this.leftAssigner = (WindowAssigner<?>) timeWindowAssigner.withEventTime();
+			}
+			if (trigger == null) {
+				this.trigger = EventTimeTriggers.afterEndOfWindow();
+			}
+			return this;
+		}
+
+		public Builder processingTime() {
+			checkArgument(leftAssigner != null,
+					"Use Builder.assigner to set up the window assigning strategies first");
+			if (leftAssigner instanceof InternalTimeWindowAssigner) {
+				InternalTimeWindowAssigner timeWindowAssigner = (InternalTimeWindowAssigner) leftAssigner;
+				this.leftAssigner = (WindowAssigner<?>) timeWindowAssigner.withProcessingTime();
+			}
+			if (trigger == null) {
+				this.trigger = ProcessingTimeTriggers.afterEndOfWindow();
+			}
+			return this;
+		}
+
+		@SuppressWarnings("unchecked")
+		public <K, W extends Window> WindowJoinOperatorSimple<K, W> build() {
+			Preconditions.checkState(this.type1 != null && this.type2 != null,
+					"Use Builder.inputType to set up the join input data types");
+			Preconditions.checkState(this.generateNullsOnLeft != null,
+					"Use Builder.joinType to set up the join type");
+			Preconditions.checkState(this.joinCondition != null,
+					"Use Builder.joinCondition to set up the join condition");
+			Preconditions.checkState(this.inputSideSpec1 != null && this.inputSideSpec2 != null,
+					"Use Builder.joinInputSpec to set up the join input specifications");
+			Preconditions.checkState(this.filterNullKeys != null,
+					"Use Builder.filterNullKeys to set up the which join keys need to filter nulls");
+			Preconditions.checkState(this.leftAssigner != null && this.rightAssigner != null,
+					"Use Builder.tumble, Builder.sliding or Builder.session or Builder.assigner to "
+							+ "set up the window assigning strategies");
+			Preconditions.checkState(this.trigger != null,
+					"Use Builder.eventTime or Builder.processingTime or Builder.trigger "
+							+ "to set up the window triggering strategy");
+			return new WindowJoinOperatorSimple<>(
+					(WindowAssigner<W>) this.leftAssigner,
+					(WindowAssigner<W>) this.rightAssigner,
+					(Trigger<W>) this.trigger,
+					(TypeSerializer<W>) this.leftAssigner.getWindowSerializer(new ExecutionConfig()),
+					this.type1,
+					this.type2,
+					this.joinCondition,
+					this.inputSideSpec1,
+					this.inputSideSpec2,
+					this.generateNullsOnLeft,
+					this.generateNullsOnRight,
+					this.filterNullKeys);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	//  Utilities
+	// -------------------------------------------------------------------------
+
+	/** Returns the builder of {@link WindowJoinOperatorSimple}. */
+	public static Builder builder() {
+		return new Builder();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/state/WindowJoinRecordStateView.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/state/WindowJoinRecordStateView.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join.state;
+
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
+import org.apache.flink.table.runtime.operators.window.Window;
+
+/**
+ * A {@link WindowJoinRecordStateView} is a view to the window join state.
+ *
+ * <p>It provides the operations to manage the join input states which contain the join inputs
+ * and the operations to manage the state namespace, e.g. the set up or merge.
+ */
+public interface WindowJoinRecordStateView<W extends Window>
+		extends WindowedStateView<W>, JoinRecordStateView {
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/state/WindowJoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/state/WindowJoinRecordStateViews.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join.state;
+
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.util.IterableIterator;
+
+import org.apache.commons.compress.utils.Lists;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility to create a  {@link WindowedStateView} for join depends on {@link JoinInputSideSpec}.
+ */
+public final class WindowJoinRecordStateViews {
+
+	/**
+	 * Creates a {@link JoinRecordStateView} depends on {@link JoinInputSideSpec}.
+	 */
+	public static <W extends Window> WindowJoinRecordStateView<W> create(
+			WindowedStateView.Context ctx,
+			TypeSerializer<W> windowSerializer,
+			String stateName,
+			JoinInputSideSpec inputSideSpec,
+			InternalTypeInfo<RowData> recordType) throws Exception {
+		if (inputSideSpec.joinKeyContainsUniqueKey()) {
+			return new JoinKeyContainsUniqueKey<>(
+					ctx,
+					windowSerializer,
+					stateName,
+					recordType);
+		} else if (inputSideSpec.hasUniqueKey()) {
+			return new InputSideHasUniqueKey<>(
+					ctx,
+					windowSerializer,
+					stateName,
+					recordType,
+					inputSideSpec.getUniqueKeyType(),
+					inputSideSpec.getUniqueKeySelector());
+		} else {
+			return new InputSideHasNoUniqueKey<>(
+					ctx,
+					windowSerializer,
+					stateName,
+					recordType);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+    //  Inner Classes
+    // -------------------------------------------------------------------------
+
+	/**
+	 * View for join input whose join key are unique (contains unique key).
+	 */
+	private static final class JoinKeyContainsUniqueKey<W extends Window>
+			implements WindowJoinRecordStateView<W> {
+
+		private final InternalValueState<RowData, W, RowData> recordState;
+
+		private JoinKeyContainsUniqueKey(
+				WindowedStateView.Context ctx,
+				TypeSerializer<W> windowSerializer,
+				String stateName,
+				InternalTypeInfo<RowData> recordType) throws Exception {
+			ValueStateDescriptor<RowData> recordStateDesc = new ValueStateDescriptor<>(
+					stateName,
+					recordType);
+			this.recordState = (InternalValueState<RowData, W, RowData>)
+					ctx.getOrCreateKeyedState(windowSerializer, recordStateDesc);
+		}
+
+		@Override
+		public void addRecord(RowData record) throws Exception {
+			recordState.update(record);
+		}
+
+		@Override
+		public void retractRecord(RowData record) {
+			recordState.clear();
+		}
+
+		@Override
+		public Iterable<RowData> getRecords() throws Exception {
+			RowData record = recordState.value();
+			if (record != null) {
+				return Collections.singletonList(record);
+			}
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void setCurrentNamespace(W window) {
+			recordState.setCurrentNamespace(window);
+		}
+
+		@Override
+		public void clear() {
+			recordState.clear();
+		}
+
+		@Override
+		public void mergeNamespaces(W target, Iterable<W> sources) {
+			throw new UnsupportedOperationException("Window merge should never happen because the join keys are unique");
+		}
+	}
+
+	/**
+	 * View for join input which are unique for each row by the unique key.
+	 */
+	private static final class InputSideHasUniqueKey<W extends Window>
+			implements WindowJoinRecordStateView<W> {
+
+		// stores record in the mapping <UK, Record>
+		private final InternalMapState<RowData, W, RowData, RowData> recordState;
+		private final KeySelector<RowData, RowData> uniqueKeySelector;
+
+		private InputSideHasUniqueKey(
+				WindowedStateView.Context ctx,
+				TypeSerializer<W> windowSerializer,
+				String stateName,
+				InternalTypeInfo<RowData> recordType,
+				InternalTypeInfo<RowData> uniqueKeyType,
+				KeySelector<RowData, RowData> uniqueKeySelector) throws Exception {
+			checkNotNull(uniqueKeyType);
+			checkNotNull(uniqueKeySelector);
+			MapStateDescriptor<RowData, RowData> recordStateDesc = new MapStateDescriptor<>(
+				stateName,
+				uniqueKeyType,
+				recordType);
+			this.recordState = (InternalMapState<RowData, W, RowData, RowData>)
+					ctx.getOrCreateKeyedState(windowSerializer, recordStateDesc);
+			this.uniqueKeySelector = uniqueKeySelector;
+		}
+
+		@Override
+		public void addRecord(RowData record) throws Exception {
+			RowData uniqueKey = uniqueKeySelector.getKey(record);
+			recordState.put(uniqueKey, record);
+		}
+
+		@Override
+		public void retractRecord(RowData record) throws Exception {
+			RowData uniqueKey = uniqueKeySelector.getKey(record);
+			recordState.remove(uniqueKey);
+		}
+
+		@Override
+		public Iterable<RowData> getRecords() throws Exception {
+			return recordState.values();
+		}
+
+		@Override
+		public void setCurrentNamespace(W window) {
+			recordState.setCurrentNamespace(window);
+		}
+
+		@Override
+		public void clear() {
+			recordState.clear();
+		}
+
+		@Override
+		public void mergeNamespaces(W target, Iterable<W> sources) throws Exception {
+			for (W window : sources) {
+				recordState.setCurrentNamespace(window);
+				Iterable<RowData> rows = recordState.values();
+				recordState.setCurrentNamespace(target);
+				for (RowData r : rows) {
+					RowData uniqueKey = uniqueKeySelector.getKey(r);
+					recordState.put(uniqueKey, r);
+				}
+			}
+		}
+	}
+
+	/**
+	 * View for join input which has duplicates within rows.
+	 */
+	private static final class InputSideHasNoUniqueKey<W extends Window>
+			implements WindowJoinRecordStateView<W> {
+
+		// stores record in the mapping <Record, duplicates>
+		private final InternalMapState<RowData, W, RowData, Integer> recordState;
+
+		private InputSideHasNoUniqueKey(
+				WindowedStateView.Context ctx,
+				TypeSerializer<W> windowSerializer,
+				String stateName,
+				InternalTypeInfo<RowData> recordType) throws Exception {
+			MapStateDescriptor<RowData, Integer> recordStateDesc = new MapStateDescriptor<>(
+				stateName,
+				recordType,
+				Types.INT);
+			this.recordState = (InternalMapState<RowData, W, RowData, Integer>)
+					ctx.getOrCreateKeyedState(windowSerializer, recordStateDesc);
+		}
+
+		@Override
+		public void addRecord(RowData record) throws Exception {
+			Integer cnt = recordState.get(record);
+			if (cnt != null) {
+				cnt += 1;
+			} else {
+				cnt = 1;
+			}
+			recordState.put(record, cnt);
+		}
+
+		@Override
+		public void retractRecord(RowData record) throws Exception {
+			Integer cnt = recordState.get(record);
+			if (cnt != null) {
+				if (cnt > 1) {
+					recordState.put(record, cnt - 1);
+				} else {
+					recordState.remove(record);
+				}
+			}
+			// ignore cnt == null, which means state may be expired
+		}
+
+		@Override
+		public Iterable<RowData> getRecords() {
+			return new IterableIterator<RowData>() {
+
+				private Iterator<Map.Entry<RowData, Integer>> backingIterator;
+				private List<Map.Entry<RowData, Integer>> backingRecords;
+				private RowData record;
+				private int remainingTimes = 0;
+
+				@Override
+				public boolean hasNext() {
+					return backingIterator.hasNext() || remainingTimes > 0;
+				}
+
+				@Override
+				public RowData next() {
+					if (remainingTimes > 0) {
+						remainingTimes--;
+					} else {
+						Map.Entry<RowData, Integer> entry = backingIterator.next();
+						record = entry.getKey();
+						remainingTimes = entry.getValue() - 1;
+						if (remainingTimes > 0) {
+							checkNotNull(record);
+						}
+					}
+					return record;
+				}
+
+				@Nonnull
+				@Override
+				public Iterator<RowData> iterator() {
+					try {
+						reset();
+					} catch (Exception e) {
+						throw new RuntimeException(e);
+					}
+					return this;
+				}
+
+				/** Reset the iterator so that it can be visited from the start every time. */
+				private void reset() throws Exception {
+					if (backingRecords == null) {
+						backingRecords = Lists.newArrayList(recordState.entries().iterator());
+					}
+					backingIterator = backingRecords.iterator();
+					this.remainingTimes = 0;
+				}
+			};
+		}
+
+		@Override
+		public void setCurrentNamespace(W window) {
+			recordState.setCurrentNamespace(window);
+		}
+
+		@Override
+		public void clear() {
+			recordState.clear();
+		}
+
+		@Override
+		public void mergeNamespaces(W target, Iterable<W> sources) throws Exception {
+			for (W window : sources) {
+				recordState.setCurrentNamespace(window);
+				Iterable<Map.Entry<RowData, Integer>> entries = recordState.entries();
+				recordState.setCurrentNamespace(target);
+				for (Map.Entry<RowData, Integer> entry : entries) {
+					final RowData r = entry.getKey();
+					if (recordState.contains(r)) {
+						Integer newCnt = recordState.get(r) + entry.getValue();
+						recordState.put(r, newCnt);
+					} else {
+						recordState.put(r, entry.getValue());
+					}
+				}
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/state/WindowedStateView.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/join/state/WindowedStateView.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.runtime.operators.window.Window;
+
+/**
+ * A {@link WindowedStateView} is a view to the state with window namespaces.
+ * It provides some namespace management APIs. The state is used to store input records which are
+ * partitioned by the belonging window (or pane if there is overlapping between windows).
+ *
+ * <p>Before operating on the records, a right window namespace must be set up first
+ * using {@code setCurrentNamespace}.
+ */
+public interface WindowedStateView<W extends Window> {
+	/**
+	 * Set up the {@code window} as current namespace.
+	 */
+	void setCurrentNamespace(W window);
+
+	/**
+	 * Clear the state of current window records.
+	 */
+	void clear();
+
+	/**
+	 * Merges the namespaces of the underlying state.
+	 *
+	 * @param target Target window to merge into
+	 * @param sources The merged windows
+	 */
+	void mergeNamespaces(W target, Iterable<W> sources) throws Exception;
+
+	/** Container which takes the variables to create the keyed state. **/
+	interface Context {
+
+		/**
+		 * Retrieves a {@link State} object that can be used to interact with
+		 * fault-tolerant state that is scoped to the key of the current
+		 * trigger invocation.
+		 *
+		 * @param windowSerializer The window serializer
+		 * @param stateDescriptor  The StateDescriptor that contains the name and type of the
+		 *                         state that is being accessed
+		 * @param <S>              The type of the state
+		 * @return The partitioned state object.
+		 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for
+		 * the function (function is not part of a KeyedStream)
+		 */
+		<S extends State, W extends Window> S getOrCreateKeyedState(
+				TypeSerializer<W> windowSerializer,
+				StateDescriptor<S, ?> stateDescriptor) throws Exception;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowTestUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowTestUtils.java
@@ -18,8 +18,17 @@
 
 package org.apache.flink.table.runtime.operators.window;
 
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.generated.JoinCondition;
+import org.apache.flink.table.runtime.operators.join.Int2HashJoinOperatorTest;
+import org.apache.flink.table.runtime.operators.window.assigners.SessionWindowAssigner;
+
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Utilities that are useful for working with Window tests.
@@ -30,4 +39,68 @@ public interface WindowTestUtils {
 		return Matchers.equalTo(new TimeWindow(start, end));
 	}
 
+	static GeneratedJoinCondition alwaysTrueCondition() {
+		return new GeneratedJoinCondition("", "", new Object[0]) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public JoinCondition newInstance(ClassLoader classLoader) {
+				return new Int2HashJoinOperatorTest.TrueCondition();
+			}
+		};
+	}
+
+	/** A special session window assigner that assigns "point windows"
+	 * (windows that have the same timestamp for start and end)
+	 * when the given {@code targetRowIdx} field has the expected value {@code expectVal}.
+	 *
+	 * <p>The {@code expectVal} should be an integer.
+	 */
+	class PointSessionWindowAssigner extends SessionWindowAssigner {
+		private static final long serialVersionUID = 1L;
+
+		private final long sessionTimeout;
+		private final int targetRowIdx;
+		private final int expectVal;
+
+		public static PointSessionWindowAssigner of(long sessionTimeout, int targetRowIdx, int expectVal) {
+			return new PointSessionWindowAssigner(sessionTimeout, targetRowIdx, expectVal);
+		}
+
+		private PointSessionWindowAssigner(long sessionTimeout, int targetRowIdx, int expectVal) {
+			this(sessionTimeout, true, targetRowIdx, expectVal);
+		}
+
+		private PointSessionWindowAssigner(
+				long sessionTimeout,
+				boolean isEventTime,
+				int targetRowIdx,
+				int expectVal) {
+			super(sessionTimeout, isEventTime);
+			this.sessionTimeout = sessionTimeout;
+			this.targetRowIdx = targetRowIdx;
+			this.expectVal = expectVal;
+		}
+
+		@Override
+		public Collection<TimeWindow> assignWindows(RowData element, long timestamp) {
+			int second = element.getInt(targetRowIdx);
+			if (second == expectVal) {
+				return Collections.singletonList(new TimeWindow(timestamp, timestamp));
+			}
+			return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionTimeout));
+		}
+
+		@Override
+		public SessionWindowAssigner withEventTime() {
+			return new PointSessionWindowAssigner(
+					sessionTimeout, true, targetRowIdx, expectVal);
+		}
+
+		@Override
+		public SessionWindowAssigner withProcessingTime() {
+			return new PointSessionWindowAssigner(
+					sessionTimeout, false, targetRowIdx, expectVal);
+		}
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorContractTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorContractTest.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.WindowTestUtils;
+import org.apache.flink.table.runtime.operators.window.assigners.MergingWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * These tests verify that {@link WindowJoinOperator} correctly interacts with the other windowing
+ * components: {@link WindowAssigner}, {@link Trigger} and
+ * {@link org.apache.flink.table.runtime.operators.window.join.state.WindowJoinRecordStateView}.
+ *
+ * <p>These tests document the implicit contract that exists between the windowing components.
+ */
+public class WindowJoinOperatorContractTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testAssignerIsInvokedOncePerElement() throws Exception {
+		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(any(), anyLong()))
+				.thenReturn(Collections.singletonList(new TimeWindow(0, 0)));
+
+		testHarness.processElement1(insertRecord(1, "String", 0L));
+
+		verify(mockAssigner, times(1))
+				.assignWindows(eq(row(1, "String", 0L)), eq(0L));
+
+		testHarness.processElement1(insertRecord(1, "String", 0L));
+
+		verify(mockAssigner, times(2))
+				.assignWindows(eq(row(1, "String", 0L)), eq(0L));
+
+		testHarness.processElement2(insertRecord(1, "String", 0L));
+
+		verify(mockAssigner, times(3))
+				.assignWindows(eq(row(1, "String", 0L)), eq(0L));
+
+		testHarness.processElement2(insertRecord(1, "String", 0L));
+
+		verify(mockAssigner, times(4))
+				.assignWindows(eq(row(1, "String", 0L)), eq(0L));
+	}
+
+	@Test
+	public void testAssignerWithMultipleWindowsForJoin() throws Exception {
+		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(any(), anyLong()))
+				.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
+
+		shouldFireOnElement(mockTrigger);
+
+		testHarness.processElement1(insertRecord(1, "String", 0L));
+
+		assertThat(
+				outputToString(testHarness.getOutput()),
+				is("+I{row1=+I{row1=+I(1,String,0),"
+						+ " row2=+I(null,null,null)},"
+						+ " row2=+I(1970-01-01T00:00:00.002,1970-01-01T00:00:00.004)}\n"
+						+ "+I{row1=+I{row1=+I(1,String,0),"
+						+ " row2=+I(null,null,null)},"
+						+ " row2=+I(1970-01-01T00:00,1970-01-01T00:00:00.002)}"));
+
+		testHarness.processElement2(insertRecord(1, "String", 1L));
+
+		assertThat(
+				outputToString(testHarness.getOutput()),
+				is("+I{row1=+I{row1=+I(1,String,0),"
+						+ " row2=+I(null,null,null)},"
+						+ " row2=+I(1970-01-01T00:00:00.002,1970-01-01T00:00:00.004)}\n"
+						+ "+I{row1=+I{row1=+I(1,String,0),"
+						+ " row2=+I(null,null,null)},"
+						+ " row2=+I(1970-01-01T00:00,1970-01-01T00:00:00.002)}\n"
+						+ "+I{row1=+I{row1=+I(1,String,0),"
+						+ " row2=+I(1,String,1)},"
+						+ " row2=+I(1970-01-01T00:00:00.002,1970-01-01T00:00:00.004)}\n"
+						+ "+I{row1=+I{row1=+I(1,String,0),"
+						+ " row2=+I(1,String,1)},"
+						+ " row2=+I(1970-01-01T00:00,1970-01-01T00:00:00.002)}"));
+	}
+
+	@Test
+	public void testOnElementCalledPerWindow() throws Exception {
+
+		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(any(), anyLong()))
+				.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
+
+		testHarness.processElement1(insertRecord(42, "String", 1L));
+
+		verify(mockTrigger).onElement(eq(row(42, "String", 1L)), eq(1L), eq(new TimeWindow(2, 4)));
+		verify(mockTrigger).onElement(eq(row(42, "String", 1L)), eq(1L), eq(new TimeWindow(0, 2)));
+		verify(mockTrigger, times(2)).onElement(any(), anyLong(), any());
+
+		testHarness.processElement2(insertRecord(43, "String", 1L));
+
+		verify(mockTrigger).onElement(eq(row(43, "String", 1L)), eq(1L), eq(new TimeWindow(2, 4)));
+		verify(mockTrigger).onElement(eq(row(43, "String", 1L)), eq(1L), eq(new TimeWindow(0, 2)));
+		verify(mockTrigger, times(4)).onElement(any(), anyLong(), any());
+	}
+
+	@Test
+	public void testMergeWindowsIsCalled() throws Exception {
+		MergingWindowAssigner<TimeWindow> mockAssigner = mockMergingAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(any(), anyLong()))
+				.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
+
+		assertEquals(0, testHarness.getOutput().size());
+
+		testHarness.processElement1(insertRecord(42, "String", 0L));
+
+		verify(mockAssigner).mergeWindows(eq(new TimeWindow(2, 4)), any(), anyMergeCallback());
+		verify(mockAssigner).mergeWindows(eq(new TimeWindow(0, 2)), any(), anyMergeCallback());
+		verify(mockAssigner, times(2)).mergeWindows(any(), any(), anyMergeCallback());
+
+		testHarness.processElement2(insertRecord(43, "String", 0L));
+		verify(mockAssigner, times(2)).mergeWindows(eq(new TimeWindow(2, 4)), any(), anyMergeCallback());
+		verify(mockAssigner, times(2)).mergeWindows(eq(new TimeWindow(0, 2)), any(), anyMergeCallback());
+		verify(mockAssigner, times(4)).mergeWindows(any(), any(), anyMergeCallback());
+	}
+
+	// -------------------------------------------------------------------------
+	//  Utilities
+	// -------------------------------------------------------------------------
+
+	@SuppressWarnings("unchecked")
+	private String outputToString(Collection<Object> output) {
+		return output.stream()
+				.map(o -> ((StreamRecord<RowData>) o).getValue().toString())
+				.collect(Collectors.joining("\n"));
+	}
+
+	private <K, W extends Window> KeyedTwoInputStreamOperatorTestHarness
+			<RowData, RowData, RowData, RowData> createWindowOperator(
+			WindowAssigner<W> assigner,
+			Trigger<W> trigger,
+			long allowedLateness) throws Exception {
+
+		LogicalType[] leftTypes = new LogicalType[]{new IntType(), new VarCharType(VarCharType.MAX_LENGTH), new BigIntType()};
+		LogicalType[] rightTypes = new LogicalType[]{new IntType(), new VarCharType(VarCharType.MAX_LENGTH), new BigIntType()};
+		BinaryRowDataKeySelector keySelector = new BinaryRowDataKeySelector(new int[]{0}, leftTypes);
+		TypeInformation<RowData> keyType = keySelector.getProducedType();
+		JoinInputSideSpec leftJoinInputSideSpec = JoinInputSideSpec.withUniqueKeyContainedByJoinKey(
+				InternalTypeInfo.ofFields(new IntType()),
+				keySelector);
+		JoinInputSideSpec rightJoinInputSideSpec = JoinInputSideSpec.withUniqueKey(
+				InternalTypeInfo.ofFields(new IntType()),
+				keySelector);
+
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.assigner(assigner)
+				.trigger(trigger)
+				.allowedLateness(Duration.ofMillis(allowedLateness))
+				.inputType(
+						InternalTypeInfo.ofFields(leftTypes),
+						InternalTypeInfo.ofFields(rightTypes))
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.joinInputSpec(
+						leftJoinInputSideSpec,
+						rightJoinInputSideSpec)
+				.joinType(FlinkJoinType.LEFT)
+				.eventTime(2, 2)
+				.filterNullKeys(false).build();
+		return new KeyedTwoInputStreamOperatorTestHarness<>(
+				operator, keySelector, keySelector, keyType);
+	}
+
+	private <W extends Window> Trigger<W> mockTrigger() throws Exception {
+		@SuppressWarnings("unchecked")
+		Trigger<W> mockTrigger = mock(Trigger.class);
+
+		when(mockTrigger.onElement(any(), anyLong(), any())).thenReturn(false);
+		when(mockTrigger.onEventTime(anyLong(), any())).thenReturn(false);
+		when(mockTrigger.onProcessingTime(anyLong(), any())).thenReturn(false);
+
+		return mockTrigger;
+	}
+
+	private static WindowAssigner<TimeWindow> mockTimeWindowAssigner() {
+		@SuppressWarnings("unchecked")
+		WindowAssigner<TimeWindow> mockAssigner = mock(WindowAssigner.class);
+
+		when(mockAssigner.getWindowSerializer(any())).thenReturn(new TimeWindow.Serializer());
+		when(mockAssigner.isEventTime()).thenReturn(true);
+
+		return mockAssigner;
+	}
+
+	private static MergingWindowAssigner<TimeWindow> mockMergingAssigner() {
+		@SuppressWarnings("unchecked")
+		MergingWindowAssigner<TimeWindow> mockAssigner = mock(MergingWindowAssigner.class);
+
+		when(mockAssigner.getWindowSerializer(any())).thenReturn(new TimeWindow.Serializer());
+		when(mockAssigner.isEventTime()).thenReturn(true);
+
+		return mockAssigner;
+	}
+
+	private static MergingWindowAssigner.MergeCallback<TimeWindow> anyMergeCallback() {
+		return any();
+	}
+
+	private static void shouldFireOnElement(Trigger<TimeWindow> mockTrigger) throws Exception {
+		when(mockTrigger.onElement(any(), anyLong(), any())).thenReturn(true);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/join/WindowJoinOperatorTest.java
@@ -1,0 +1,1512 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.join;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.table.runtime.operators.window.WindowTestUtils;
+import org.apache.flink.table.runtime.operators.window.assigners.TumblingWindowAssigner;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
+import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.RowKind;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.flink.table.data.StringData.fromString;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link WindowJoinOperator} tests.
+ *
+ * <p>Add test cases for different window: tumbling, sliding, session
+ * and join type: INNER, LEFT, RIGHT, FULL OUTER.
+ *
+ * <p>Both join inputs use the first field as the equal join key. The join output type should be
+ * left_type + right_type + window_attributes(window_start, window_end).
+ */
+public class WindowJoinOperatorTest<K, W extends Window> {
+
+	// To simplify test, join left and right have the same type.
+	private final InternalTypeInfo<RowData> inputType = InternalTypeInfo.ofFields(
+			new IntType(),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new BigIntType());
+
+	// Key selector for both inputs.
+	private final BinaryRowDataKeySelector keySelector = new BinaryRowDataKeySelector(new int[] { 0 }, inputType.toRowFieldTypes());
+	private final TypeInformation<RowData> keyType = keySelector.getProducedType();
+
+	private final JoinInputSideSpec inputSideSpec1 = JoinInputSideSpec.withUniqueKeyContainedByJoinKey(
+			InternalTypeInfo.ofFields(new IntType()),
+			keySelector);
+	private final JoinInputSideSpec inputSideSpec2 = JoinInputSideSpec.withUniqueKey(
+			InternalTypeInfo.ofFields(new VarCharType(VarCharType.MAX_LENGTH)),
+			new BinaryRowDataKeySelector(new int[] { 1 }, inputType.toRowFieldTypes()));
+
+	private final InternalTypeInfo<RowData> outputType = InternalTypeInfo.ofFields(
+			new IntType(),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new BigIntType(),
+			new IntType(),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new BigIntType(),
+			new TimestampType(3),
+			new TimestampType(3));
+
+	private final RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(
+			outputType.toRowFieldTypes(),
+			new GenericRowRecordSortComparator(0, new IntType()));
+
+	@Test
+	public void testEventTimeSlidingWindows() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.sliding(Duration.ofSeconds(3), Duration.ofSeconds(1))
+				.eventTime(2, 2)
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		testHarness.open();
+
+		// process elements
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		// add elements out-of-order
+		testHarness.processElement1(insertRecord(1, "key1", 3999L));
+		testHarness.processElement1(insertRecord(1, "key1", 3000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 3999L));
+		testHarness.processElement2(insertRecord(1, "key2", 3000L));
+
+		testHarness.processElement1(insertRecord(1, "key1", 20L));
+		testHarness.processElement1(insertRecord(1, "key1", 0L));
+		testHarness.processElement1(insertRecord(1, "key1", 999L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 20L));
+		testHarness.processElement2(insertRecord(1, "key2", 0L));
+		testHarness.processElement2(insertRecord(1, "key2", 999L));
+
+		testHarness.processElement1(insertRecord(2, "key1", 1998L));
+		testHarness.processElement1(insertRecord(3, "key1", 1999L));
+		testHarness.processElement1(insertRecord(4, "key1", 1000L));
+
+		testHarness.processElement2(insertRecord(2, "key2", 1998L));
+		testHarness.processElement2(insertRecord(3, "key2", 1999L));
+		testHarness.processElement2(insertRecord(4, "key2", 1000L));
+
+		testHarness.processWatermark1(new Watermark(999));
+		testHarness.processWatermark2(new Watermark(999));
+		expectedOutput.add(insertRecord(1, "key1", 999L, 1, "key2", 999L,
+				TimestampData.fromEpochMillis(-2000), TimestampData.fromEpochMillis(1000)));
+		expectedOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(1999));
+		testHarness.processWatermark2(new Watermark(1999));
+		expectedOutput.add(insertRecord(1, "key1", 999L, 1, "key2", 999L,
+				TimestampData.fromEpochMillis(-1000), TimestampData.fromEpochMillis(2000)));
+		expectedOutput.add(insertRecord(2, "key1", 1998L, 2, "key2", 1998L,
+				TimestampData.fromEpochMillis(-1000), TimestampData.fromEpochMillis(2000)));
+		expectedOutput.add(insertRecord(3, "key1", 1999L, 3, "key2", 1999L,
+				TimestampData.fromEpochMillis(-1000), TimestampData.fromEpochMillis(2000)));
+		expectedOutput.add(insertRecord(4, "key1", 1000L, 4, "key2", 1000L,
+				TimestampData.fromEpochMillis(-1000), TimestampData.fromEpochMillis(2000)));
+		expectedOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(2999));
+		testHarness.processWatermark2(new Watermark(2999));
+		expectedOutput.add(insertRecord(1, "key1", 999L, 1, "key2", 999L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(2, "key1", 1998L, 2, "key2", 1998L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(3, "key1", 1999L, 3, "key2", 1999L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(4, "key1", 1000L, 4, "key2", 1000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(new Watermark(2999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processWatermark1(new Watermark(3999));
+		testHarness.processWatermark2(new Watermark(3999));
+		expectedOutput.add(insertRecord(1, "key1", 3000L, 1, "key2", 3000L,
+				TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(4000)));
+		expectedOutput.add(insertRecord(2, "key1", 1998L, 2, "key2", 1998L,
+				TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(4000)));
+		expectedOutput.add(insertRecord(3, "key1", 1999L, 3, "key2", 1999L,
+				TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(4000)));
+		expectedOutput.add(insertRecord(4, "key1", 1000L, 4, "key2", 1000L,
+				TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(4000)));
+		expectedOutput.add(new Watermark(3999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(4999));
+		testHarness.processWatermark2(new Watermark(4999));
+		expectedOutput.add(insertRecord(1, "key1", 3000L, 1, "key2", 3000L,
+				TimestampData.fromEpochMillis(2000), TimestampData.fromEpochMillis(5000)));
+		expectedOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(5999));
+		testHarness.processWatermark2(new Watermark(5999));
+		expectedOutput.add(insertRecord(1, "key1", 3000L, 1, "key2", 3000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark1(new Watermark(6999));
+		testHarness.processWatermark2(new Watermark(7999));
+		expectedOutput.add(new Watermark(6999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testProcessingTimeSlidingWindows() throws Throwable {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.sliding(Duration.ofSeconds(3), Duration.ofSeconds(1))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// timestamp is ignored in processing time
+		testHarness.setProcessingTime(3);
+		testHarness.processElement1(insertRecord(1, "key1", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(1, "key2", Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(1000);
+
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(-2000), TimestampData.fromEpochMillis(1000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(2, "key1", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(2, "key2", Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(2000);
+
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(-1000), TimestampData.fromEpochMillis(2000)));
+		expectedOutput.add(insertRecord(2, "key1", Long.MAX_VALUE, 2, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(-1000), TimestampData.fromEpochMillis(2000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(3, "key1", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(3, "key2", Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(3000);
+
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(2, "key1", Long.MAX_VALUE, 2, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(3, "key1", Long.MAX_VALUE, 3, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(4, "key1", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(4, "key2", Long.MAX_VALUE));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutput.add(insertRecord(2, "key1", Long.MAX_VALUE, 2, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(4000)));
+		expectedOutput.add(insertRecord(3, "key1", Long.MAX_VALUE, 3, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(4000)));
+		expectedOutput.add(insertRecord(4, "key1", Long.MAX_VALUE, 4, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(4000)));
+		expectedOutput.add(insertRecord(3, "key1", Long.MAX_VALUE, 3, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(2000), TimestampData.fromEpochMillis(5000)));
+		expectedOutput.add(insertRecord(4, "key1", Long.MAX_VALUE, 4, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(2000), TimestampData.fromEpochMillis(5000)));
+		expectedOutput.add(insertRecord(4, "key1", Long.MAX_VALUE, 4, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testEventTimeTumblingWindows() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.tumble(Duration.ofSeconds(3))
+				.eventTime(2, 2)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement1(insertRecord(1, "key1", 3999L));
+		testHarness.processElement1(insertRecord(1, "key1", 3000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 3999L));
+		testHarness.processElement2(insertRecord(1, "key2", 3000L));
+
+		testHarness.processElement1(insertRecord(2, "key1", 20L));
+		testHarness.processElement1(insertRecord(3, "key1", 0L));
+		testHarness.processElement1(insertRecord(4, "key1", 999L));
+
+		testHarness.processElement2(insertRecord(2, "key2", 20L));
+		testHarness.processElement2(insertRecord(3, "key2", 0L));
+		testHarness.processElement2(insertRecord(4, "key2", 999L));
+
+		testHarness.processElement1(insertRecord(5, "key1", 1998L));
+		testHarness.processElement1(insertRecord(6, "key1", 1999L));
+		testHarness.processElement1(insertRecord(7, "key1", 1000L));
+
+		testHarness.processElement2(insertRecord(5, "key2", 1998L));
+		testHarness.processElement2(insertRecord(6, "key2", 1999L));
+		testHarness.processElement2(insertRecord(7, "key2", 1000L));
+
+		testHarness.processWatermark1(new Watermark(999));
+		testHarness.processWatermark2(new Watermark(999));
+		expectedOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(1999));
+		testHarness.processWatermark2(new Watermark(1999));
+		expectedOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processWatermark1(new Watermark(2999));
+		testHarness.processWatermark2(new Watermark(2999));
+		expectedOutput.add(insertRecord(2, "key1", 20L, 2, "key2", 20L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(3, "key1", 0L, 3, "key2", 0L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(4, "key1", 999L, 4, "key2", 999L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(5, "key1", 1998L, 5, "key2", 1998L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(6, "key1", 1999L, 6, "key2", 1999L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(7, "key1", 1000L, 7, "key2", 1000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(new Watermark(2999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(3999));
+		testHarness.processWatermark2(new Watermark(3999));
+		expectedOutput.add(new Watermark(3999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(4999));
+		testHarness.processWatermark2(new Watermark(4999));
+		expectedOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(5999));
+		testHarness.processWatermark2(new Watermark(5999));
+		expectedOutput.add(insertRecord(1, "key1", 3000L, 1, "key2", 3000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark1(new Watermark(6999));
+		testHarness.processWatermark2(new Watermark(7999));
+		expectedOutput.add(new Watermark(6999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testProcessingTimeTumblingWindows() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.tumble(Duration.ofSeconds(3))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+
+		// timestamp is ignored in processing time
+		testHarness.processElement1(insertRecord(1, "key1", Long.MAX_VALUE));
+		testHarness.processElement1(insertRecord(2, "key1", 7000L));
+		testHarness.processElement1(insertRecord(3, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(2, "key2", 7000L));
+		testHarness.processElement2(insertRecord(3, "key2", 7000L));
+
+		testHarness.processElement1(insertRecord(4, "key1", 7000L));
+		testHarness.processElement1(insertRecord(5, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(4, "key2", 7000L));
+		testHarness.processElement2(insertRecord(5, "key2", 7000L));
+
+		testHarness.setProcessingTime(5000);
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(2, "key1", 7000L, 2, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(3, "key1", 7000L, 3, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(4, "key1", 7000L, 4, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(5, "key1", 7000L, 5, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(6, "key1", 7000L));
+		testHarness.processElement1(insertRecord(7, "key1", 7000L));
+		testHarness.processElement1(insertRecord(8, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(6, "key2", 7000L));
+		testHarness.processElement2(insertRecord(7, "key2", 7000L));
+		testHarness.processElement2(insertRecord(8, "key2", 7000L));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutput.add(insertRecord(6, "key1", 7000L, 6, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(7, "key1", 7000L, 7, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(8, "key1", 7000L, 8, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+
+		assertThat(operator.getWatermarkLatency().getValue(), is(0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testEventTimeSessionWindows() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				// Join input has no unique key, so there is no override.
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.session(Duration.ofSeconds(3))
+				.eventTime(2, 2)
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement1(insertRecord(1, "key1", 0L));
+		testHarness.processElement1(insertRecord(1, "key1", 1000L));
+		testHarness.processElement1(insertRecord(1, "key1", 2500L));
+
+		testHarness.processElement1(insertRecord(2, "key1", 10L));
+		testHarness.processElement1(insertRecord(2, "key1", 1000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 0L));
+		testHarness.processElement2(insertRecord(1, "key2", 1000L));
+		testHarness.processElement2(insertRecord(1, "key2", 2500L));
+
+		testHarness.processElement2(insertRecord(2, "key2", 10L));
+		testHarness.processElement2(insertRecord(2, "key2", 1000L));
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshotV2 = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshotV2);
+		testHarness.open();
+
+		assertThat(operator.getWatermarkLatency().getValue(), is(0L));
+
+		testHarness.processElement1(insertRecord(2, "key1", 2500L));
+		testHarness.processElement1(insertRecord(3, "key1", 5501L));
+		testHarness.processElement1(insertRecord(3, "key1", 6000L));
+		testHarness.processElement1(insertRecord(3, "key1", 6000L));
+		testHarness.processElement1(insertRecord(3, "key1", 6050L));
+
+		testHarness.processElement2(insertRecord(2, "key2", 2500L));
+		testHarness.processElement2(insertRecord(3, "key2", 5501L));
+		testHarness.processElement2(insertRecord(3, "key2", 6000L));
+		testHarness.processElement2(insertRecord(3, "key2", 6000L));
+		testHarness.processElement2(insertRecord(3, "key2", 6050L));
+
+		testHarness.processWatermark1(new Watermark(12000));
+		testHarness.processWatermark2(new Watermark(12000));
+
+		expectedOutput.add(insertRecord(1, "key1", 2500L, 1, "key2", 2500L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(5500)));
+		expectedOutput.add(insertRecord(2, "key1", 2500L, 2, "key2", 2500L,
+				TimestampData.fromEpochMillis(10), TimestampData.fromEpochMillis(5500)));
+		expectedOutput.add(insertRecord(3, "key1", 6050L, 3, "key2", 6050L,
+				TimestampData.fromEpochMillis(5501), TimestampData.fromEpochMillis(9050)));
+
+		expectedOutput.add(new Watermark(12000));
+
+		// add a late data
+		testHarness.processElement1(insertRecord(4, "key1", 4000L));
+		testHarness.processElement1(insertRecord(5, "key1", 15000L));
+		testHarness.processElement1(insertRecord(5, "key1", 15000L));
+
+		testHarness.processElement2(insertRecord(4, "key2", 4000L));
+		testHarness.processElement2(insertRecord(5, "key2", 15000L));
+		testHarness.processElement2(insertRecord(5, "key2", 15000L));
+
+		testHarness.processWatermark1(new Watermark(17999));
+		testHarness.processWatermark2(new Watermark(17999));
+
+		expectedOutput.add(insertRecord(5, "key1", 15000L, 5, "key2", 15000L,
+				TimestampData.fromEpochMillis(15000L), TimestampData.fromEpochMillis(18000L)));
+		expectedOutput.add(new Watermark(17999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(18000);
+		assertThat(operator.getWatermarkLatency().getValue(), is(1L));
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testProcessingTimeSessionWindows() throws Throwable {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.session(Duration.ofSeconds(3))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(
+			outputType.toRowFieldTypes(),
+			new GenericRowRecordSortComparator(0, new IntType()));
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// timestamp is ignored in processing time
+		testHarness.setProcessingTime(3);
+		testHarness.processElement1(insertRecord(1, "key1", 1L));
+		testHarness.processElement2(insertRecord(1, "key2", 1L));
+
+		testHarness.setProcessingTime(1000);
+		testHarness.processElement1(insertRecord(1, "key1", 1002L));
+		testHarness.processElement2(insertRecord(1, "key2", 1002L));
+
+		testHarness.setProcessingTime(5000);
+
+		expectedOutput.add(insertRecord(1, "key1", 1002L, 1, "key2", 1002L,
+				TimestampData.fromEpochMillis(3L), TimestampData.fromEpochMillis(4000L)));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(1, "key1", 5000L));
+		testHarness.processElement1(insertRecord(1, "key1", 5000L));
+		testHarness.processElement2(insertRecord(1, "key2", 5000L));
+		testHarness.processElement2(insertRecord(1, "key2", 5000L));
+
+		testHarness.setProcessingTime(10000);
+
+		expectedOutput.add(insertRecord(1, "key1", 5000L, 1, "key2", 5000L,
+				TimestampData.fromEpochMillis(5000L), TimestampData.fromEpochMillis(8000L)));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	/**
+	 * This tests a custom Session window assigner that assigns some elements to "point windows",
+	 * windows that have the same timestamp for start and end.
+	 *
+	 * <p>In this test, elements that have 33 as the record key will be put into a point
+	 * window.
+	 */
+	@Test
+	public void testPointSessions() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.assigner(WindowTestUtils.PointSessionWindowAssigner.of(3000, 0, 33))
+				.eventTime(2, 2)
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement1(insertRecord(1, "key1", 0L));
+		testHarness.processElement1(insertRecord(33, "key1", 1000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 0L));
+		testHarness.processElement2(insertRecord(33, "key2", 1000L));
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processElement1(insertRecord(1, "key1", 10L));
+		testHarness.processElement1(insertRecord(2, "key1", 1000L));
+		testHarness.processElement1(insertRecord(33, "key1", 2500L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 10L));
+		testHarness.processElement2(insertRecord(2, "key2", 1000L));
+		testHarness.processElement2(insertRecord(33, "key2", 2500L));
+
+		testHarness.processWatermark1(new Watermark(12000));
+		testHarness.processWatermark2(new Watermark(12000));
+
+		expectedOutput.add(insertRecord(1, "key1", 10L, 1, "key2", 10L,
+				TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(3010L)));
+		expectedOutput.add(insertRecord(2, "key1", 1000L, 2, "key2", 1000L,
+				TimestampData.fromEpochMillis(1000L), TimestampData.fromEpochMillis(4000L)));
+		expectedOutput.add(insertRecord(33, "key1", 1000L, 33, "key2", 1000L,
+				TimestampData.fromEpochMillis(1000L), TimestampData.fromEpochMillis(1000L)));
+		expectedOutput.add(insertRecord(33, "key1", 2500L, 33, "key2", 2500L,
+				TimestampData.fromEpochMillis(2500L), TimestampData.fromEpochMillis(2500L)));
+		expectedOutput.add(new Watermark(12000));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testLateness() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.tumble(Duration.ofSeconds(2))
+				.eventTime(2, 2)
+				.allowedLateness(Duration.ofMillis(500))
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement1(insertRecord(1, "key1", 500L));
+		testHarness.processElement2(insertRecord(1, "key2", 500L));
+
+		testHarness.processWatermark1(new Watermark(1500));
+		testHarness.processWatermark2(new Watermark(1500));
+
+		expectedOutput.add(new Watermark(1500));
+
+		testHarness.processElement1(insertRecord(1, "key1", 1300L));
+		testHarness.processElement2(insertRecord(1, "key2", 1300L));
+		testHarness.processWatermark1(new Watermark(2300));
+		testHarness.processWatermark2(new Watermark(2300));
+
+		expectedOutput.add(insertRecord(1, "key1", 1300L, 1, "key2", 1300L,
+				TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(2000L)));
+		expectedOutput.add(new Watermark(2300));
+
+		// this will not be dropped because window.maxTimestamp() + allowedLateness > currentWatermark
+		testHarness.processElement1(insertRecord(1, "key1", 1997L));
+		testHarness.processElement2(insertRecord(1, "key2", 1997L));
+		testHarness.processWatermark1(new Watermark(6000));
+		testHarness.processWatermark2(new Watermark(6000));
+
+		// element1 and element2 would trigger the join 2 times.
+		expectedOutput.add(insertRecord(1, "key1", 1997L, 1, "key2", 1300L,
+				TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(2000L)));
+		expectedOutput.add(insertRecord(1, "key1", 1997L, 1, "key2", 1997L,
+				TimestampData.fromEpochMillis(0L), TimestampData.fromEpochMillis(2000L)));
+		expectedOutput.add(new Watermark(6000));
+
+		// this will be dropped because window.maxTimestamp() + allowedLateness < currentWatermark
+		testHarness.processElement1(insertRecord(1, "key1", 1998L));
+		testHarness.processElement2(insertRecord(1, "key2", 1998L));
+		testHarness.processWatermark1(new Watermark(7000));
+		testHarness.processWatermark2(new Watermark(7000));
+
+		expectedOutput.add(new Watermark(7000));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		assertThat(operator.getNumLateRecordsDropped().getCount(), is(2L));
+
+		testHarness.close();
+	}
+
+	/**
+	 * 	See {@code WindowJoinOperator.cleanupTime} for how the cleaning time is wrapped-around.
+	 */
+	@Test
+	public void testCleanupTimeOverflow() throws Exception {
+		long windowSize = 1000;
+		long lateness = 2000;
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.tumble(Duration.ofMillis(windowSize))
+				.eventTime(2, 2)
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.allowedLateness(Duration.ofMillis(lateness))
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
+				createTestHarness(operator);
+
+		testHarness.open();
+
+		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+
+		WindowAssigner<TimeWindow> windowAssigner = TumblingWindowAssigner.of(Duration.ofMillis(windowSize));
+		long timestamp = Long.MAX_VALUE - 1750;
+		Collection<TimeWindow> windows = windowAssigner.assignWindows(GenericRowData.of(1, fromString("key2")), timestamp);
+		TimeWindow window = windows.iterator().next();
+
+		// window interval [Long.MAX_VALUE - 1807, Long.MAX_VALUE - 0807)
+		// the garbage collection timer would wrap-around
+		assertTrue(window.maxTimestamp() + lateness < window.maxTimestamp());
+		// and it would prematurely fire with watermark (Long.MAX_VALUE - 1500)
+		assertTrue(window.maxTimestamp() + lateness < Long.MAX_VALUE - 1500);
+
+		testHarness.processElement1(insertRecord(1, "key1", timestamp));
+		testHarness.processElement2(insertRecord(1, "key2", timestamp));
+
+		// if we don't correctly prevent wrap-around in the garbage collection
+		// timers, this watermark will clean our window state for the just-added
+		// element/window
+		testHarness.processWatermark1(new Watermark(Long.MAX_VALUE - 1500));
+		testHarness.processWatermark2(new Watermark(Long.MAX_VALUE - 1500));
+
+		// this watermark is before the end timestamp of our only window
+		assertTrue(Long.MAX_VALUE - 1500 < window.maxTimestamp());
+		assertTrue(window.maxTimestamp() < Long.MAX_VALUE);
+
+		// push in a watermark that will trigger computation of our window
+		testHarness.processWatermark1(new Watermark(window.maxTimestamp()));
+		testHarness.processWatermark2(new Watermark(window.maxTimestamp()));
+
+		expected.add(new Watermark(Long.MAX_VALUE - 1500));
+		expected.add(insertRecord(1, "key1", timestamp, 1, "key2", timestamp,
+				TimestampData.fromEpochMillis(window.getStart()), TimestampData.fromEpochMillis(window.getEnd())));
+		expected.add(new Watermark(window.maxTimestamp()));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	@Test
+	public void testCleanupTimerWithEmptyInputStateForTumblingWindows() throws Exception {
+		final int windowSize = 2;
+		final long lateness = 1;
+
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.tumble(Duration.ofSeconds(windowSize))
+				.eventTime(2, 2)
+				.allowedLateness(Duration.ofMillis(lateness))
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		testHarness.open();
+
+		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+
+		// normal element
+		testHarness.processElement1(insertRecord(1, "key1", 1000L));
+		testHarness.processElement2(insertRecord(1, "key2", 1000L));
+		testHarness.processWatermark1(new Watermark(1599));
+		testHarness.processWatermark2(new Watermark(1599));
+		testHarness.processWatermark1(new Watermark(1999));
+		testHarness.processWatermark2(new Watermark(1999));
+		testHarness.processWatermark1(new Watermark(2000));
+		testHarness.processWatermark2(new Watermark(2000));
+		testHarness.processWatermark1(new Watermark(5000));
+		testHarness.processWatermark2(new Watermark(5000));
+
+		expected.add(new Watermark(1599));
+		expected.add(insertRecord(1, "key1", 1000L, 1, "key2", 1000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(2000)));
+		expected.add(new Watermark(1999)); // here it fires and purges
+		expected.add(new Watermark(2000)); // here is the cleanup timer
+		expected.add(new Watermark(5000));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	// -------------------------------------------------------------------------
+	//  Test other join types: LEFT, RIGHT, FULL OUTER
+	//  using the processing time tumbling window. Different type of windows
+	//  only differ on how the window are assigned and triggered, here
+	//  we want to test the join behavior within one triggered window.
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testLeftJoinProcessingTimeTumbling() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.LEFT)
+				.tumble(Duration.ofSeconds(3))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+
+		// timestamp is ignored in processing time
+		testHarness.processElement1(insertRecord(1, "key1", Long.MAX_VALUE));
+		testHarness.processElement1(insertRecord(2, "key1", 7000L));
+		testHarness.processElement1(insertRecord(3, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(2, "key2", 7000L));
+
+		testHarness.processElement1(insertRecord(4, "key1", 7000L));
+		testHarness.processElement1(insertRecord(5, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(4, "key2", 7000L));
+
+		testHarness.setProcessingTime(5000);
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(2, "key1", 7000L, 2, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(3, "key1", 7000L, null, null, null,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(4, "key1", 7000L, 4, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(5, "key1", 7000L, null, null, null,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(6, "key1", 7000L));
+		testHarness.processElement1(insertRecord(7, "key1", 7000L));
+		testHarness.processElement1(insertRecord(8, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(6, "key2", 7000L));
+		testHarness.processElement2(insertRecord(8, "key2", 7000L));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutput.add(insertRecord(6, "key1", 7000L, 6, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(7, "key1", 7000L, null, null, null,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(8, "key1", 7000L, 8, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+
+		assertThat(operator.getWatermarkLatency().getValue(), is(0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testRightJoinProcessingTimeTumbling() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.RIGHT)
+				.tumble(Duration.ofSeconds(3))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(
+				outputType.toRowFieldTypes(),
+				new GenericRowRecordSortComparator(3, new IntType()));
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+
+		// timestamp is ignored in processing time
+		testHarness.processElement1(insertRecord(1, "key1", Long.MAX_VALUE));
+		testHarness.processElement1(insertRecord(2, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(2, "key2", 7000L));
+		testHarness.processElement2(insertRecord(3, "key2", 7000L));
+
+		testHarness.processElement1(insertRecord(4, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(4, "key2", 7000L));
+		testHarness.processElement2(insertRecord(5, "key2", 7000L));
+
+		testHarness.setProcessingTime(5000);
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(2, "key1", 7000L, 2, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(null, null, null, 3, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(4, "key1", 7000L, 4, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(null, null, null, 5, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(6, "key1", 7000L));
+		testHarness.processElement1(insertRecord(8, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(6, "key2", 7000L));
+		testHarness.processElement2(insertRecord(7, "key2", 7000L));
+		testHarness.processElement2(insertRecord(8, "key2", 7000L));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutput.add(insertRecord(6, "key1", 7000L, 6, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(null, null, null, 7, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(8, "key1", 7000L, 8, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+
+		assertThat(operator.getWatermarkLatency().getValue(), is(0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	@SuppressWarnings({"unchecked"})
+	public void testFullOuterJoinProcessingTimeTumbling() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.FULL)
+				.tumble(Duration.ofSeconds(3))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		final Comparator<GenericRowData> comparator = (row1, row2) -> {
+			RowKind kind1 = row1.getRowKind();
+			RowKind kind2 = row2.getRowKind();
+			if (kind1 != kind2) {
+				return kind1.toByteValue() - kind2.toByteValue();
+			} else {
+				Object key1 = row1.isNullAt(0)
+						? RowData.get(row1, 3, new IntType())
+						: RowData.get(row1, 0, new IntType());
+				Object key2 = row2.isNullAt(0)
+						? RowData.get(row2, 3, new IntType())
+						: RowData.get(row2, 0, new IntType());
+				if (key1 instanceof Comparable && key2 instanceof Comparable) {
+					return ((Comparable) key1).compareTo(key2);
+				} else {
+					throw new UnsupportedOperationException();
+				}
+			}
+		};
+
+		RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(
+				outputType.toRowFieldTypes(),
+				comparator);
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+
+		// timestamp is ignored in processing time
+		testHarness.processElement1(insertRecord(1, "key1", Long.MAX_VALUE));
+		testHarness.processElement1(insertRecord(2, "key1", 7000L));
+		testHarness.processElement1(insertRecord(3, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(2, "key2", 7000L));
+
+		testHarness.processElement1(insertRecord(4, "key1", 7000L));
+		testHarness.processElement1(insertRecord(5, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(4, "key2", 7000L));
+
+		testHarness.setProcessingTime(5000);
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(2, "key1", 7000L, 2, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(3, "key1", 7000L, null, null, null,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(4, "key1", 7000L, 4, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(5, "key1", 7000L, null, null, null,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(6, "key1", 7000L));
+		testHarness.processElement1(insertRecord(8, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(6, "key2", 7000L));
+		testHarness.processElement2(insertRecord(7, "key2", 7000L));
+		testHarness.processElement2(insertRecord(8, "key2", 7000L));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutput.add(insertRecord(6, "key1", 7000L, 6, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(null, null, null, 7, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(8, "key1", 7000L, 8, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+
+		assertThat(operator.getWatermarkLatency().getValue(), is(0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	/**
+	 * Test processing time tumbling window without any unique keys for both inputs.
+	 * Without unique keys, same value join key records of one input side can appear
+	 * multiple times.
+	 */
+	@Test
+	public void testProcessingTimeTumblingWithoutUniqueKeys() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(JoinInputSideSpec.withoutUniqueKey(), JoinInputSideSpec.withoutUniqueKey())
+				.joinType(FlinkJoinType.INNER)
+				.tumble(Duration.ofSeconds(3))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+
+		// timestamp is ignored in processing time
+		testHarness.processElement1(insertRecord(1, "key1", Long.MAX_VALUE));
+		testHarness.processElement1(insertRecord(1, "key1", 7000L));
+		testHarness.processElement1(insertRecord(3, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(2, "key2", 7000L));
+
+		testHarness.setProcessingTime(5000);
+		expectedOutput.add(insertRecord(1, "key1", 7000L, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		expectedOutput.add(insertRecord(1, "key1", Long.MAX_VALUE, 1, "key2", Long.MAX_VALUE,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(6, "key1", 7000L));
+		testHarness.processElement1(insertRecord(7, "key1", 7000L));
+		testHarness.processElement1(insertRecord(7, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(6, "key2", 7000L));
+		testHarness.processElement2(insertRecord(7, "key2", 7000L));
+		testHarness.processElement2(insertRecord(8, "key2", 7000L));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutput.add(insertRecord(6, "key1", 7000L, 6, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(7, "key1", 7000L, 7, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(7, "key1", 7000L, 7, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+
+		assertThat(operator.getWatermarkLatency().getValue(), is(0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	/**
+	 * Test processing time tumbling window with UPDATE and DELETE messages in the inputs.
+	 * The UPDATE_BEFORE message expect to be ignored, the DELETE message expect to retract the
+	 * message within the window.
+	 */
+	@Test
+	public void testProcessingTimeTumblingWithUpdatingMessages() throws Exception {
+		WindowJoinOperator<K, W> operator = WindowJoinOperator
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(JoinInputSideSpec.withoutUniqueKey(), JoinInputSideSpec.withoutUniqueKey())
+				.joinType(FlinkJoinType.INNER)
+				.tumble(Duration.ofSeconds(3))
+				.processingTime()
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+
+		// timestamp is ignored in processing time
+		testHarness.processElement1(insertRecord(1, "key1", Long.MAX_VALUE));
+		// update_before message should be ignored
+		testHarness.processElement1(updateBeforeRecord(1, "key1", 7000L));
+		// delete message retract the first message (by the same record)
+		testHarness.processElement1(deleteRecord(1, "key1", Long.MAX_VALUE));
+		testHarness.processElement1(insertRecord(2, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", Long.MAX_VALUE));
+		testHarness.processElement2(insertRecord(2, "key2", 7000L));
+
+		testHarness.setProcessingTime(5000);
+		expectedOutput.add(insertRecord(2, "key1", 7000L, 2, "key2", 7000L,
+				TimestampData.fromEpochMillis(0), TimestampData.fromEpochMillis(3000)));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processElement1(insertRecord(6, "key1", 7000L));
+		testHarness.processElement1(insertRecord(7, "key1", 7000L));
+		testHarness.processElement1(insertRecord(7, "key1", 7000L));
+
+		testHarness.processElement2(insertRecord(6, "key2", 7000L));
+		// update_after message behaviors same with insert message
+		testHarness.processElement2(updateAfterRecord(7, "key2", 7000L));
+		testHarness.processElement2(insertRecord(8, "key2", 7000L));
+
+		testHarness.setProcessingTime(7000);
+
+		expectedOutput.add(insertRecord(6, "key1", 7000L, 6, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(7, "key1", 7000L, 7, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+		expectedOutput.add(insertRecord(7, "key1", 7000L, 7, "key2", 7000L,
+				TimestampData.fromEpochMillis(3000), TimestampData.fromEpochMillis(6000)));
+
+		assertThat(operator.getWatermarkLatency().getValue(), is(0L));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testEventTimeWithInputWindowAttributes() throws Exception {
+		final InternalTypeInfo<RowData> inputType = InternalTypeInfo.ofFields(
+				new IntType(),
+				new VarCharType(VarCharType.MAX_LENGTH),
+				new BigIntType(),
+				new BigIntType());
+
+		// Key selector for both inputs.
+		final BinaryRowDataKeySelector keySelector =
+				new BinaryRowDataKeySelector(new int[] { 0 }, inputType.toRowFieldTypes());
+
+		final JoinInputSideSpec inputSideSpec1 = JoinInputSideSpec.withUniqueKeyContainedByJoinKey(
+				InternalTypeInfo.ofFields(new IntType()),
+				keySelector);
+		final JoinInputSideSpec inputSideSpec2 = JoinInputSideSpec.withUniqueKey(
+				InternalTypeInfo.ofFields(new VarCharType(VarCharType.MAX_LENGTH)),
+				new BinaryRowDataKeySelector(new int[] { 1 }, inputType.toRowFieldTypes()));
+
+		final InternalTypeInfo<RowData> outputType = InternalTypeInfo.ofFields(
+				new IntType(),
+				new VarCharType(VarCharType.MAX_LENGTH),
+				new BigIntType(),
+				new BigIntType(),
+				new IntType(),
+				new VarCharType(VarCharType.MAX_LENGTH),
+				new BigIntType(),
+				new BigIntType());
+
+		final RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(
+				outputType.toRowFieldTypes(),
+				new GenericRowRecordSortComparator(0, new IntType()));
+
+		WindowJoinOperatorBase<K, W> operator = WindowJoinOperatorSimple
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.windowAttributeRefs(new int[] {2, 3}, new int[] {2, 3})
+				.eventTime()
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		testHarness.open();
+
+		// process elements
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		// add elements out-of-order
+		testHarness.processElement1(insertRecord(1, "key1", -1000L, 2000L));
+		testHarness.processElement1(insertRecord(1, "key1", -1000L, 2000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", -1000L, 2000L));
+		testHarness.processElement2(insertRecord(1, "key2", -1000L, 2000L));
+
+		testHarness.processElement1(insertRecord(1, "key1", 1000L, 4000L));
+		testHarness.processElement1(insertRecord(1, "key1", 1000L, 4000L));
+		testHarness.processElement1(insertRecord(1, "key1", 1000L, 4000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 1000L, 4000L));
+		testHarness.processElement2(insertRecord(1, "key2", 1000L, 4000L));
+		testHarness.processElement2(insertRecord(1, "key2", 1000L, 4000L));
+
+		testHarness.processElement1(insertRecord(2, "key1", 3000L, 6000L));
+		testHarness.processElement1(insertRecord(3, "key1", 3000L, 6000L));
+		testHarness.processElement1(insertRecord(4, "key1", 3000L, 6000L));
+
+		testHarness.processElement2(insertRecord(2, "key2", 3000L, 6000L));
+		testHarness.processElement2(insertRecord(3, "key2", 3000L, 6000L));
+		testHarness.processElement2(insertRecord(4, "key2", 3000L, 6000L));
+
+		testHarness.processWatermark1(new Watermark(999));
+		testHarness.processWatermark2(new Watermark(999));
+		expectedOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(1999));
+		testHarness.processWatermark2(new Watermark(1999));
+		expectedOutput.add(insertRecord(1, "key1", -1000L, 2000L, 1, "key2", -1000L, 2000L));
+		expectedOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(3999));
+		testHarness.processWatermark2(new Watermark(3999));
+		expectedOutput.add(insertRecord(1, "key1", 1000L, 4000L, 1, "key2", 1000L, 4000L));
+		expectedOutput.add(new Watermark(3999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processWatermark1(new Watermark(4999));
+		testHarness.processWatermark2(new Watermark(4999));
+		expectedOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.processWatermark1(new Watermark(5999));
+		testHarness.processWatermark2(new Watermark(5999));
+		expectedOutput.add(insertRecord(2, "key1", 3000L, 6000L, 2, "key2", 3000L, 6000L));
+		expectedOutput.add(insertRecord(3, "key1", 3000L, 6000L, 3, "key2", 3000L, 6000L));
+		expectedOutput.add(insertRecord(4, "key1", 3000L, 6000L, 4, "key2", 3000L, 6000L));
+		expectedOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark1(new Watermark(6999));
+		testHarness.processWatermark2(new Watermark(7999));
+		expectedOutput.add(new Watermark(6999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testProcessingTimeWithInputWindowAttributes() throws Throwable {
+		final InternalTypeInfo<RowData> inputType = InternalTypeInfo.ofFields(
+				new IntType(),
+				new VarCharType(VarCharType.MAX_LENGTH),
+				new BigIntType(),
+				new BigIntType());
+
+		// Key selector for both inputs.
+		final BinaryRowDataKeySelector keySelector =
+				new BinaryRowDataKeySelector(new int[] { 0 }, inputType.toRowFieldTypes());
+
+		final JoinInputSideSpec inputSideSpec1 = JoinInputSideSpec.withUniqueKeyContainedByJoinKey(
+				InternalTypeInfo.ofFields(new IntType()),
+				keySelector);
+		final JoinInputSideSpec inputSideSpec2 = JoinInputSideSpec.withUniqueKey(
+				InternalTypeInfo.ofFields(new VarCharType(VarCharType.MAX_LENGTH)),
+				new BinaryRowDataKeySelector(new int[] { 1 }, inputType.toRowFieldTypes()));
+
+		final InternalTypeInfo<RowData> outputType = InternalTypeInfo.ofFields(
+				new IntType(),
+				new VarCharType(VarCharType.MAX_LENGTH),
+				new BigIntType(),
+				new BigIntType(),
+				new IntType(),
+				new VarCharType(VarCharType.MAX_LENGTH),
+				new BigIntType(),
+				new BigIntType());
+
+		final RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(
+				outputType.toRowFieldTypes(),
+				new GenericRowRecordSortComparator(0, new IntType()));
+
+		WindowJoinOperatorBase<K, W> operator = WindowJoinOperatorSimple
+				.builder()
+				.inputType(inputType, inputType)
+				.joinInputSpec(inputSideSpec1, inputSideSpec2)
+				.joinType(FlinkJoinType.INNER)
+				.joinCondition(WindowTestUtils.alwaysTrueCondition())
+				.filterNullKeys(true)
+				.windowAttributeRefs(new int[] {2, 3}, new int[] {2, 3})
+				.processingTime()
+				.build();
+
+		TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness = createTestHarness(operator);
+
+		testHarness.open();
+
+		// process elements
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		// add elements out-of-order
+		testHarness.processElement1(insertRecord(1, "key1", -1000L, 2000L));
+		testHarness.processElement1(insertRecord(1, "key1", -1000L, 2000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", -1000L, 2000L));
+		testHarness.processElement2(insertRecord(1, "key2", -1000L, 2000L));
+
+		testHarness.processElement1(insertRecord(1, "key1", 1000L, 4000L));
+		testHarness.processElement1(insertRecord(1, "key1", 1000L, 4000L));
+		testHarness.processElement1(insertRecord(1, "key1", 1000L, 4000L));
+
+		testHarness.processElement2(insertRecord(1, "key2", 1000L, 4000L));
+		testHarness.processElement2(insertRecord(1, "key2", 1000L, 4000L));
+		testHarness.processElement2(insertRecord(1, "key2", 1000L, 4000L));
+
+		testHarness.processElement1(insertRecord(2, "key1", 3000L, 6000L));
+		testHarness.processElement1(insertRecord(3, "key1", 3000L, 6000L));
+		testHarness.processElement1(insertRecord(4, "key1", 3000L, 6000L));
+
+		testHarness.processElement2(insertRecord(2, "key2", 3000L, 6000L));
+		testHarness.processElement2(insertRecord(3, "key2", 3000L, 6000L));
+		testHarness.processElement2(insertRecord(4, "key2", 3000L, 6000L));
+
+		testHarness.processWatermark1(new Watermark(999));
+		testHarness.processWatermark2(new Watermark(999));
+		expectedOutput.add(new Watermark(999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(2000L);
+
+		testHarness.processWatermark1(new Watermark(1999));
+		testHarness.processWatermark2(new Watermark(1999));
+		expectedOutput.add(insertRecord(1, "key1", -1000L, 2000L, 1, "key2", -1000L, 2000L));
+		expectedOutput.add(new Watermark(1999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(4000L);
+
+		testHarness.processWatermark1(new Watermark(3999));
+		testHarness.processWatermark2(new Watermark(3999));
+		expectedOutput.add(insertRecord(1, "key1", 1000L, 4000L, 1, "key2", 1000L, 4000L));
+		expectedOutput.add(new Watermark(3999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutput.clear();
+
+		testHarness = createTestHarness(operator);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.setProcessingTime(5000L);
+
+		testHarness.processWatermark1(new Watermark(4999));
+		testHarness.processWatermark2(new Watermark(4999));
+		expectedOutput.add(new Watermark(4999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.setProcessingTime(6000L);
+
+		testHarness.processWatermark1(new Watermark(5999));
+		testHarness.processWatermark2(new Watermark(5999));
+		expectedOutput.add(insertRecord(2, "key1", 3000L, 6000L, 2, "key2", 3000L, 6000L));
+		expectedOutput.add(insertRecord(3, "key1", 3000L, 6000L, 3, "key2", 3000L, 6000L));
+		expectedOutput.add(insertRecord(4, "key1", 3000L, 6000L, 4, "key2", 3000L, 6000L));
+		expectedOutput.add(new Watermark(5999));
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		// those don't have any effect...
+		testHarness.processWatermark1(new Watermark(6999));
+		testHarness.processWatermark2(new Watermark(7999));
+		expectedOutput.add(new Watermark(6999));
+
+		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
+
+		testHarness.close();
+	}
+
+	// -------------------------------------------------------------------------
+	//  Utilities
+	// -------------------------------------------------------------------------
+
+	private TwoInputStreamOperatorTestHarness<RowData, RowData, RowData> createTestHarness(
+			WindowJoinOperatorBase<K, W> operator)
+			throws Exception {
+		return new KeyedTwoInputStreamOperatorTestHarness<>(operator,
+				keySelector, keySelector, keyType);
+	}
+
+}


### PR DESCRIPTION

## What is the purpose of the change

This patch introduces `WindowJoinOperator` and `WindowJoinOperatorSimple`,

The `WindowJoinOperator` accepts two streams and windows each stream, when
watermark passes and triggers each window, it joins the dataset of the
two stream windows and emit the results. Note that the operator itself
generates the window attributes.

The `WindowJoinOperatorSimple` is a simpler version of `WindowJoinOperator`,
it assumes that all the inputs has window attributes(e.g. window_start
and window_end), so there is no need for windowing again.


## Brief change log

  - Add two operators, `WindowJoinOperator` and `WindowJoinOperatorSimple`
  - Refactor the table window process functions so that to reuse
  - Add test cases

## Verifying this change

Added UTs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
