### PR TITLE
[FLINK-19616][tests][parquet] avoid re-generate the protobuf files due to time inconsistency

### DIFF
--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -244,7 +244,8 @@ under the License.
 					 directory, then it download the directory and run the corresponding tests. However, the protoc
 					 executable under the target directory would lost the execution permission bit after downloading.
 					 To solve this issue we would skip generating the target files if they already exist after
-					 downloading. -->
+					 downloading. Meanwhile, since the time might be not consistent between the pre-compile and
+					 the actual execution, we need to adjust the timestamp manually, see unpack_build_artifact.sh-->
 					<checkStaleness>true</checkStaleness>
 					<protoTestSourceRoot>${project.basedir}/src/test/resources/protobuf</protoTestSourceRoot>
 					<!-- Generates classes into a separate directory since the generator always removes existing files. -->

--- a/tools/azure-pipelines/unpack_build_artifact.sh
+++ b/tools/azure-pipelines/unpack_build_artifact.sh
@@ -27,6 +27,11 @@ echo "Merging cache"
 cp -RT "$FLINK_ARTIFACT_DIR" "."
 
 echo "Adjusting timestamps"
+# adjust timestamps of proto file to avoid re-generation
+find . -type f -name '*.proto' | xargs touch
+# wait a bit for better odds of different timestamps
+sleep 5
+
 # adjust timestamps to prevent recompilation
 find . -type f -name '*.java' | xargs touch
 find . -type f -name '*.scala' | xargs touch


### PR DESCRIPTION
## What is the purpose of the change

Currently Flink on Azure test first pre-compile the project, and then download the pre-compile projects to run each part of tests separately. For protobuf related tests, it would download protoc executable automatically. However, the protoc executable would lost execution permission after downloading, so previously https://github.com/apache/flink/pull/11326 we enable `checkstableness` for this maven plugin. Since we would always touch all the java files after downloading, the re-generation should be avoided. 

However, since the modification time of the downloaded file might be large than the current timestamp, the mechanism might fail. To fix this issue, we should also need to touch the proto files explicitly to make it 'younger' than the generated java files. 


## Brief change log

  - 548abe1c2b61698e8f8faf397b65864b5e367ed0 touches the proto files before the java files. 


## Verifying this change

This change is a trivial bugfix without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
