### PR TITLE
[FLINK-19618][Docs] Fix broken links in docs

### DIFF
--- a/docs/dev/python/user-guide/table/python_table_api_connectors.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.md
@@ -32,7 +32,7 @@ This page describes how to use connectors in PyFlink and highlights the details 
 
 ## Download connector and format jars
 
-Since Flink is a Java/Scala-based project, for both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/dev/python/user-guide/table/dependency_management.html).
+Since Flink is a Java/Scala-based project, for both connectors and formats, implementations are available as jars that need to be specified as job [dependencies]({{ site.baseurl }}/dev/python/table-api-users-guide/dependency_management.html).
 
 {% highlight python %}
 

--- a/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
+++ b/docs/dev/python/user-guide/table/python_table_api_connectors.zh.md
@@ -32,7 +32,7 @@ under the License.
 
 ## 下载连接器（connector）和格式（format）jar 包
 
-由于 Flink 是一个基于 Java/Scala 的项目，连接器（connector）和格式（format）的实现是作为 jar 包存在的，要在 PyFlink 作业中使用，首先需要将其指定为作业的 [依赖]({{ site.baseurl }}/zh/dev/python/user-guide/table/dependency_management.html)。
+由于 Flink 是一个基于 Java/Scala 的项目，连接器（connector）和格式（format）的实现是作为 jar 包存在的，要在 PyFlink 作业中使用，首先需要将其指定为作业的 [依赖]({{ site.baseurl }}/zh/dev/python/table-api-users-guide/dependency_management.html)。
 
 {% highlight python %}
 


### PR DESCRIPTION

## What is the purpose of the change

Fix broken links in docs


## Brief change log

Change dependency link in dev/python/user-guide/table/python_table_api_connectors.md


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no / don't know)
  - The runtime per-record code paths (performance sensitive): (no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no / don't know)
  - The S3 file system connector: (no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
