### PR TITLE
[FLINK-19572][FLINK-19573] Port Two and MultiInputTransformation to Translator framework

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.AbstractMultipleInputTransformation;
+import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TransformationTranslator} for the {@link MultipleInputTransformation} and the
+ * {@link KeyedMultipleInputTransformation}.
+ *
+ * @param <OUT> The type of the elements that result from this {@code MultipleInputTransformation}
+ */
+@Internal
+public class MultiInputTransformationTranslator<OUT>
+		extends SimpleTransformationTranslator<OUT, AbstractMultipleInputTransformation<OUT>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final AbstractMultipleInputTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final AbstractMultipleInputTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final AbstractMultipleInputTransformation<OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final List<Transformation<?>> inputTransformations = transformation.getInputs();
+		checkArgument(!inputTransformations.isEmpty(),
+				"Empty inputs for MultipleInputTransformation. Did you forget to add inputs?");
+		MultipleInputSelectionHandler.checkSupportedInputCount(inputTransformations.size());
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		streamGraph.addMultipleInputOperator(
+				transformationId,
+				slotSharingGroup,
+				transformation.getCoLocationGroupKey(),
+				transformation.getOperatorFactory(),
+				transformation.getInputTypes(),
+				transformation.getOutputType(),
+				transformation.getName());
+
+		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+				? transformation.getParallelism()
+				: executionConfig.getParallelism();
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+
+		if (transformation instanceof KeyedMultipleInputTransformation) {
+			KeyedMultipleInputTransformation<OUT> keyedTransform = (KeyedMultipleInputTransformation<OUT>) transformation;
+			TypeSerializer<?> keySerializer = keyedTransform.getStateKeyType().createSerializer(executionConfig);
+			streamGraph.setMultipleInputStateKey(transformationId, keyedTransform.getStateKeySelectors(), keySerializer);
+		}
+
+		for (int i = 0; i < inputTransformations.size(); i++) {
+			final Transformation<?> inputTransformation = inputTransformations.get(i);
+			final Collection<Integer> inputIds = context.getStreamNodeIds(inputTransformation);
+			for (Integer inputId: inputIds) {
+				streamGraph.addEdge(inputId, transformationId, i + 1);
+			}
+		}
+
+		return Collections.singleton(transformationId);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TransformationTranslator} for the {@link TwoInputTransformation}.
+ *
+ * @param <IN1> The type of the elements in the first input {@code Transformation}
+ * @param <IN2> The type of the elements in the second input {@code Transformation}
+ * @param <OUT> The type of the elements that result from this {@link TwoInputTransformation}
+ */
+@Internal
+public class TwoInputTransformationTranslator<IN1, IN2, OUT>
+		extends SimpleTransformationTranslator<OUT, TwoInputTransformation<IN1, IN2, OUT>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final TwoInputTransformation<IN1, IN2, OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final TwoInputTransformation<IN1, IN2, OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final TwoInputTransformation<IN1, IN2, OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		streamGraph.addCoOperator(
+				transformationId,
+				slotSharingGroup,
+				transformation.getCoLocationGroupKey(),
+				transformation.getOperatorFactory(),
+				transformation.getInputType1(),
+				transformation.getInputType2(),
+				transformation.getOutputType(),
+				transformation.getName());
+
+		if (transformation.getStateKeySelector1() != null || transformation.getStateKeySelector2() != null) {
+			final TypeSerializer<?> keySerializer = transformation.getStateKeyType().createSerializer(executionConfig);
+			streamGraph.setTwoInputStateKey(
+					transformationId,
+					transformation.getStateKeySelector1(),
+					transformation.getStateKeySelector2(),
+					keySerializer);
+		}
+
+		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+				? transformation.getParallelism()
+				: executionConfig.getParallelism();
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+
+		for (Integer inputId: context.getStreamNodeIds(transformation.getInput1())) {
+			streamGraph.addEdge(inputId, transformationId, 1);
+		}
+
+		for (Integer inputId: context.getStreamNodeIds(transformation.getInput2())) {
+			streamGraph.addEdge(inputId, transformationId, 2);
+		}
+
+		return Collections.singleton(transformationId);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `StreamGraphGenerator` is responsible for:
1. traversing the graph of `Transformations`
2. translating them to their runtime implementations

With the addition of the `TransformationTranslator` framework in [FLINK-19485](https://issues.apache.org/jira/browse/FLINK-19485), we can now pull the translation logic out of the `StreamGraphGenerator` and put it into dedicated translators, one for each type of transformation.

This PR does so for the `TwoInputTransformation` and the `MultiInputTransformation`.

## Brief change log

The changes are in the `StreamGraphGenerator` and the two new `TransformationTranslator` `s.

## Verifying this change

This change is mainly a code refactoring so it is expected to be covered by existing unit and e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
