### PR TITLE
[FLINK-19641][hive] Optimize parallelism calculating of HiveTableSource by checking file number

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connectors.hive.read.HiveTableInputFormat;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * A utility class to calculate parallelism for Hive connector considering various factors.
+ */
+public class HiveParallelismInference {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HiveParallelismInference.class);
+
+	private final ObjectPath tablePath;
+	private final ReadableConfig flinkConf;
+
+	private long limit;
+	private HiveTableInputFormat inputFormat;
+
+	public HiveParallelismInference(ObjectPath tablePath, ReadableConfig flinkConf) {
+		this.tablePath = tablePath;
+		this.flinkConf = flinkConf;
+
+		this.limit = -1L;
+		this.inputFormat = null;
+	}
+
+	public HiveParallelismInference limit(long limit) {
+		this.limit = limit;
+		return this;
+	}
+
+	public HiveParallelismInference inputFormat(HiveTableInputFormat inputFormat) {
+		this.inputFormat = inputFormat;
+		return this;
+	}
+
+	public int infer() {
+		int parallelism;
+		if (flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM)) {
+			parallelism = inferFromInputSplit();
+		} else {
+			parallelism = flinkConf.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM);
+		}
+
+		// apply limit
+		if (limit > 0) {
+			parallelism = Math.min(parallelism, (int) limit / 1000);
+		}
+
+		// make sure that parallelism is at least 1
+		return Math.max(1, parallelism);
+	}
+
+	private int inferFromInputSplit() {
+		Preconditions.checkNotNull(
+			inputFormat,
+			"Input format must be provided when " +
+				HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM.key() + " is set");
+
+		int max = flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX);
+		Preconditions.checkArgument(
+			max >= 1,
+			HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX.key() + " cannot be less than 1");
+
+		try {
+			// `createInputSplits` is costly,
+			// so we try to avoid calling it by first checking the number of files
+			// which is the lower bound of the number of splits
+			int lowerBound = logRunningTime("getNumFiles", inputFormat::getNumFiles);
+			if (lowerBound >= max) {
+				return max;
+			}
+
+			int splitNum = logRunningTime("createInputSplits", () -> inputFormat.createInputSplits(0).length);
+			return Math.min(splitNum, max);
+		} catch (IOException e) {
+			throw new FlinkHiveException(e);
+		}
+	}
+
+	private int logRunningTime(String operationName, ThrowingIntSupplier supplier) throws IOException {
+		long startTimeMillis = System.currentTimeMillis();
+		int result = supplier.getAsInt();
+		LOG.info(
+			"Hive source({}}) {} use time: {} ms, result: {}",
+			tablePath,
+			operationName,
+			System.currentTimeMillis() - startTimeMillis,
+			result);
+		return result;
+	}
+
+	private interface ThrowingIntSupplier {
+		int getAsInt() throws IOException;
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -62,7 +62,6 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TimeUtils;
-import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -75,7 +74,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -202,8 +200,7 @@ public class HiveTableSource implements
 
 		int parallelism = new HiveParallelismInference(tablePath, flinkConf)
 				.infer(inputFormat::getNumFiles, () -> inputFormat.createInputSplits(0).length)
-				.limit(limit)
-				.parallelism();
+				.limit(limit);
 
 		source.setParallelism(parallelism);
 		return source.name(explainSource());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -50,6 +50,7 @@ import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.FileUtils;
 
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.annotations.HiveSQL;
@@ -66,6 +67,9 @@ import org.junit.runner.RunWith;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -398,6 +402,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 		TableEnvironment tEnv = createTableEnv();
 		tEnv.executeSql("CREATE TABLE source_db.test_parallelism " +
 				"(`year` STRING, `value` INT) partitioned by (pt int)");
+
 		HiveTestUtils.createTextTableInserter(hiveShell, dbName, tblName)
 				.addRow(new Object[]{"2014", 3})
 				.addRow(new Object[]{"2014", 4})
@@ -406,13 +411,41 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 				.addRow(new Object[]{"2015", 2})
 				.addRow(new Object[]{"2015", 5})
 				.commit("pt=1");
+
 		Table table = tEnv.sqlQuery("select * from hive.source_db.test_parallelism");
+		testParallelismSettingTranslateAndAssert(2, table, tEnv);
+	}
+
+	@Test
+	public void testParallelismSettingWithFileNum() throws IOException {
+		// create test files
+		File dir = Files.createTempDirectory("testParallelismSettingWithFileNum").toFile();
+		dir.deleteOnExit();
+		for (int i = 0; i < 3; i++) {
+			File csv = new File(dir, "data" + i + ".csv");
+			csv.createNewFile();
+			FileUtils.writeFileUtf8(csv, "1|100\n2|200\n");
+		}
+
+		TableEnvironment tEnv = createTableEnv();
+		tEnv.executeSql("CREATE EXTERNAL TABLE source_db.test_parallelism_setting_with_file_num " +
+			"(a INT, b INT) ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' LOCATION '" + dir.toString() + "'");
+
+		Table table = tEnv.sqlQuery("select * from hive.source_db.test_parallelism_setting_with_file_num");
+		testParallelismSettingTranslateAndAssert(3, table, tEnv);
+
+		tEnv.getConfig().getConfiguration().setInteger(
+			HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX, 2);
+		testParallelismSettingTranslateAndAssert(2, table, tEnv);
+	}
+
+	private void testParallelismSettingTranslateAndAssert(int expected, Table table, TableEnvironment tEnv) {
 		PlannerBase planner = (PlannerBase) ((TableEnvironmentImpl) tEnv).getPlanner();
 		RelNode relNode = planner.optimize(TableTestUtil.toRelNode(table));
 		ExecNode execNode = planner.translateToExecNodePlan(toScala(Collections.singletonList(relNode))).get(0);
 		@SuppressWarnings("unchecked")
 		Transformation transformation = execNode.translateToPlan(planner);
-		Assert.assertEquals(2, transformation.getParallelism());
+		Assert.assertEquals(expected, transformation.getParallelism());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

The current implementation of `HiveTableSource#createBatchSource` for calculating parallelism directly uses `inputFormat.createInputSplits(0).length` as the number of splits. However `createInputSplits` may be costly as it will read some data from all source files, especially when the table is not partitioned and the number of files are large.

Many Hive tables maintain the number of files in that table, and it's obvious that the number of splits is at least the number of files. So we can try to fetch the number of files (almost without cost) first and if the number of files already exceeds maximum parallelism we can directly use the maximum parallelism without calling `createInputSplits`.

This is a significant optimization on the current Flink TPCDS benchmark, which will create some table with 15000 files without partitioning. This optimization will improve the performance of the whole benchmark by 300s and more.

## Brief change log

 - Optimize parallelism calculating of `HiveTableSource` by checking file number

## Verifying this change

This change added tests and can be verified as follows: Run newly added test case in `HiveTableSourceITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
