### PR TITLE
[FLINK-19494][DataStream API] Adjust StreamExecutionEnvironment.generateSequence() to new API Sources

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -48,7 +48,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile', 'addSource',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
-                'clearJobListeners', 'getJobListeners', "fromSource"}
+                'clearJobListeners', 'getJobListeners', "fromSource", "fromSequence"}
 
 
 if __name__ == '__main__':

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -862,7 +862,6 @@ public class StreamExecutionEnvironment {
 	 *    The number to stop at (inclusive)
 	 * @return A data stream, containing parallel sequences covering the range [from, to] (both boundaries are inclusive)
 	 */
-	@Experimental
 	public DataStreamSource<Long> fromSequence(long from, long to) {
 		if (from > to) {
 			throw new IllegalArgumentException("Start of sequence must not be greater than the end");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -833,7 +833,10 @@ public class StreamExecutionEnvironment {
 	 * @param to
 	 * 		The number to stop at (inclusive)
 	 * @return A data stream, containing all number in the [from, to] interval
+	 * @deprecated Use {@link #fromSequence(long, long)} instead to create a new data stream
+	 * that contains {@link org.apache.flink.api.connector.source.lib.NumberSequenceSource}.
 	 */
+	@Deprecated
 	public DataStreamSource<Long> generateSequence(long from, long to) {
 		if (from > to) {
 			throw new IllegalArgumentException("Start of sequence must not be greater than the end");
@@ -842,21 +845,22 @@ public class StreamExecutionEnvironment {
 	}
 
 	/**
-	 * Creates a new data stream that contains a sequence of numbers (longs). This is a parallel {@link Source},
-	 * if you manually set the parallelism to {@code 1}
-	 * (using {@link org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator#setParallelism(int)})
-	 * the produced sequence of elements is in order.
+	 * Creates a new data stream that contains {@link org.apache.flink.api.connector.source.lib.NumberSequenceSource}
+	 * which produces a sequence of numbers (longs) and is useful for testing and for cases that just need a stream of N events
+	 * of any kind.
 	 *
-	 * <p>The result will always be a bounded data stream (that produces parallel sequences covering the range).
+	 * <p>The generated source splits the sequence into as many parallel sub-sequences as there are parallel source readers.
+	 * Each sub-sequence will be produced in order. If the parallelism is limited to one, the source will produce one sequence in order.
 	 *
-	 * <p>This method splits the sequence into as multiple parallel sub-sequences, which sub-sequence will be
-	 * produced in order. With the parallelism limited to one, this produced one sequence is in order.
+	 * <p>This source of the new data stream is always bounded. For very long sequences (for example over the entire domain
+	 * of long integer values), user considers executing the application in a streaming manner because of the end bound that is
+	 * pretty far away.
 	 *
 	 * @param from
 	 *    The number to start at (inclusive)
 	 * @param to
 	 *    The number to stop at (inclusive)
-	 * @return A data stream, containing all number in the [from, to] interval
+	 * @return A data stream, containing parallel sequences covering the range [from, to] (both boundaries are inclusive)
 	 */
 	@Experimental
 	public DataStreamSource<Long> fromSequence(long from, long to) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -833,7 +833,7 @@ public class StreamExecutionEnvironment {
 	 * @param to
 	 * 		The number to stop at (inclusive)
 	 * @return A data stream, containing all number in the [from, to] interval
-	 * @deprecated Use {@link #fromSequence(long, long)} instead to create a new data stream
+	 * @deprecated Use {@link #fromSequence(String, long, long)} instead to create a new data stream
 	 * that contains {@link org.apache.flink.api.connector.source.lib.NumberSequenceSource}.
 	 */
 	@Deprecated
@@ -856,17 +856,19 @@ public class StreamExecutionEnvironment {
 	 * of long integer values), user considers executing the application in a streaming manner because of the end bound that is
 	 * pretty far away.
 	 *
+	 * @param sourceName
+	 * 	Name of the data source
 	 * @param from
 	 *    The number to start at (inclusive)
 	 * @param to
 	 *    The number to stop at (inclusive)
 	 * @return A data stream, containing parallel sequences covering the range [from, to] (both boundaries are inclusive)
 	 */
-	public DataStreamSource<Long> fromSequence(long from, long to) {
+	public DataStreamSource<Long> fromSequence(String sourceName, long from, long to) {
 		if (from > to) {
 			throw new IllegalArgumentException("Start of sequence must not be greater than the end");
 		}
-		return fromSource(new NumberSequenceSource(from, to), WatermarkStrategy.noWatermarks(), "Sequence Source");
+		return fromSource(new NumberSequenceSource(from, to), WatermarkStrategy.noWatermarks(), sourceName);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -36,6 +36,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.Utils;
@@ -838,6 +839,31 @@ public class StreamExecutionEnvironment {
 			throw new IllegalArgumentException("Start of sequence must not be greater than the end");
 		}
 		return addSource(new StatefulSequenceSource(from, to), "Sequence Source");
+	}
+
+	/**
+	 * Creates a new data stream that contains a sequence of numbers (longs). This is a parallel {@link Source},
+	 * if you manually set the parallelism to {@code 1}
+	 * (using {@link org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator#setParallelism(int)})
+	 * the produced sequence of elements is in order.
+	 *
+	 * <p>The result will always be a bounded data stream (that produces parallel sequences covering the range).
+	 *
+	 * <p>This method splits the sequence into as multiple parallel sub-sequences, which sub-sequence will be
+	 * produced in order. With the parallelism limited to one, this produced one sequence is in order.
+	 *
+	 * @param from
+	 *    The number to start at (inclusive)
+	 * @param to
+	 *    The number to stop at (inclusive)
+	 * @return A data stream, containing all number in the [from, to] interval
+	 */
+	@Experimental
+	public DataStreamSource<Long> fromSequence(long from, long to) {
+		if (from > to) {
+			throw new IllegalArgumentException("Start of sequence must not be greater than the end");
+		}
+		return fromSource(new NumberSequenceSource(from, to), WatermarkStrategy.noWatermarks(), "Sequence Source");
 	}
 
 	/**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -455,7 +455,6 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Creates a new DataStream that contains a sequence of numbers (long).
    * This source is a parallel [[Source]].
    */
-  @Experimental
   def fromSequence(from: Long, to: Long): DataStream[Long] = {
     new DataStream[java.lang.Long](javaEnv.fromSequence(from, to))
       .asInstanceOf[DataStream[Long]]

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -442,7 +442,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Creates a new DataStream that contains a sequence of numbers. This source is a parallel source.
    * If you manually set the parallelism to `1` the emitted elements are in order.
    *
-   * @deprecated Use [[fromSequence(long, long)]] instead to create a new data stream
+   * @deprecated Use [[fromSequence(String, long, long)]] instead to create a new data stream
    *             that contains [[NumberSequenceSource]].
    */
   @deprecated
@@ -455,8 +455,8 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Creates a new DataStream that contains a sequence of numbers (long).
    * This source is a parallel [[Source]].
    */
-  def fromSequence(from: Long, to: Long): DataStream[Long] = {
-    new DataStream[java.lang.Long](javaEnv.fromSequence(from, to))
+  def fromSequence(sourceName: String, from: Long, to: Long): DataStream[Long] = {
+    new DataStream[java.lang.Long](javaEnv.fromSequence(sourceName, from, to))
       .asInstanceOf[DataStream[Long]]
   }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFor
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.{Source, SourceSplit}
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
@@ -440,7 +441,11 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   /**
    * Creates a new DataStream that contains a sequence of numbers. This source is a parallel source.
    * If you manually set the parallelism to `1` the emitted elements are in order.
+   *
+   * @deprecated Use [[fromSequence(long, long)]] instead to create a new data stream
+   *             that contains [[NumberSequenceSource]].
    */
+  @deprecated
   def generateSequence(from: Long, to: Long): DataStream[Long] = {
     new DataStream[java.lang.Long](javaEnv.generateSequence(from, to))
       .asInstanceOf[DataStream[Long]]

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -447,6 +447,16 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   }
 
   /**
+   * Creates a new DataStream that contains a sequence of numbers (long).
+   * This source is a parallel [[Source]].
+   */
+  @Experimental
+  def fromSequence(from: Long, to: Long): DataStream[Long] = {
+    new DataStream[java.lang.Long](javaEnv.fromSequence(from, to))
+      .asInstanceOf[DataStream[Long]]
+  }
+
+  /**
    * Creates a DataStream that contains the given elements. The elements must all be of the
    * same type.
    *

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironmentTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironmentTest.scala
@@ -59,31 +59,12 @@ class StreamExecutionEnvironmentTest {
    */
   @Test
   def testFromSequence(): Unit = {
+    val typeInfo = implicitly[TypeInformation[Long]]
     val env = StreamExecutionEnvironment.getExecutionEnvironment
 
-    val from = 284
-    val to = 618
-    env.fromSequence(from, to).addSink(new RichSinkFunction[Long]() {
-      val sequence = new util.ArrayList[Long]()
+    val stream = env.fromSequence(1, 100)
 
-      override def invoke(in: Long): Unit = {
-        sequence.add(in)
-      }
-
-      override def close(): Unit = {
-        if (sequence.size() != to - from + 1) {
-          fail(s"Expected: A sequence [$from, $to], but found: sequence " +
-            s"(size ${sequence.size()}) : $sequence")
-        }
-        for (next <- sequence) {
-          if (next < from || next > to) {
-            fail(s"Expected: A sequence [$from, $to], but found: sequence " +
-              s"(size ${sequence.size()}) : $sequence")
-          }
-        }
-      }
-    }).setParallelism(1)
-    env.execute("from sequence test")
+    assertEquals(typeInfo, stream.dataType)
   }
 
   // --------------------------------------------------------------------------

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironmentTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironmentTest.scala
@@ -62,7 +62,7 @@ class StreamExecutionEnvironmentTest {
     val typeInfo = implicitly[TypeInformation[Long]]
     val env = StreamExecutionEnvironment.getExecutionEnvironment
 
-    val stream = env.fromSequence(1, 100)
+    val stream = env.fromSequence("Sequence Source", 1, 100)
 
     assertEquals(typeInfo, stream.dataType)
   }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironmentTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironmentTest.scala
@@ -23,8 +23,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.Boundedness
 import org.apache.flink.api.connector.source.mocks.MockSource
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
-import org.junit.Assert.assertEquals
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
+import org.junit.Assert.{assertEquals, fail}
 import org.junit.Test
+
+import java.util
+
+import scala.collection.JavaConversions._
 
 /**
  * Tests for the [[StreamExecutionEnvironment]].
@@ -46,6 +51,39 @@ class StreamExecutionEnvironmentTest {
       "test source")
 
     assertEquals(typeInfo, stream.dataType)
+  }
+
+  /**
+   * Verifies that calls to fromSequence() instantiate a new DataStream
+   * that contains a sequence of numbers.
+   */
+  @Test
+  def testFromSequence(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+    val from = 284
+    val to = 618
+    env.fromSequence(from, to).addSink(new RichSinkFunction[Long]() {
+      val sequence = new util.ArrayList[Long]()
+
+      override def invoke(in: Long): Unit = {
+        sequence.add(in)
+      }
+
+      override def close(): Unit = {
+        if (sequence.size() != to - from + 1) {
+          fail(s"Expected: A sequence [$from, $to], but found: sequence " +
+            s"(size ${sequence.size()}) : $sequence")
+        }
+        for (next <- sequence) {
+          if (next < from || next > to) {
+            fail(s"Expected: A sequence [$from, $to], but found: sequence " +
+              s"(size ${sequence.size()}) : $sequence")
+          }
+        }
+      }
+    }).setParallelism(1)
+    env.execute("from sequence test")
   }
 
   // --------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SourceNAryInputChainingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SourceNAryInputChainingITCase.java
@@ -155,11 +155,11 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
+		final DataStream<Long> source1 = env.fromSequence("source-1", 1L, 10L);
 
-		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
+		final DataStream<Long> source2 = env.fromSequence("source-2", 11L, 20L);
 
-		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
+		final DataStream<Long> source3 = env.fromSequence("source-3", 21L, 30L);
 
 		return nAryInputStreamOperation(source1, source2, source3);
 	}
@@ -181,11 +181,11 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
+		final DataStream<Long> source1 = env.fromSequence("source-1", 1L, 10L);
 
-		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
+		final DataStream<Long> source2 = env.fromSequence("source-2", 11L, 20L);
 
-		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
+		final DataStream<Long> source3 = env.fromSequence("source-3", 21L, 30L);
 
 		final DataStream<Long> stream1 = source1.map(v -> v);
 		final DataStream<Long> stream3 = source3.map(v -> v);
@@ -212,13 +212,13 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
+		final DataStream<Long> source1 = env.fromSequence("source-1", 1L, 10L);
 
-		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
+		final DataStream<Long> source2 = env.fromSequence("source-2", 11L, 20L);
 
-		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
+		final DataStream<Long> source3 = env.fromSequence("source-3", 21L, 30L);
 
-		final DataStream<Long> source4 = env.fromSequence(31L, 40L).name("source-4");
+		final DataStream<Long> source4 = env.fromSequence("source-4", 31L, 40L);
 
 		return nAryInputStreamOperation(
 			source1.map((v) -> v),
@@ -249,17 +249,17 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
+		final DataStream<Long> source1 = env.fromSequence("source-1", 1L, 10L);
 
-		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
+		final DataStream<Long> source2 = env.fromSequence("source-2", 11L, 20L);
 
-		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
+		final DataStream<Long> source3 = env.fromSequence("source-3", 21L, 30L);
 
-		final DataStream<Long> source4 = env.fromSequence(31L, 40L).name("source-4");
+		final DataStream<Long> source4 = env.fromSequence("source-4", 31L, 40L);
 
-		final DataStream<Long> source5 = env.fromSequence(41L, 50L).name("source-5");
+		final DataStream<Long> source5 = env.fromSequence("source-5", 41L, 50L);
 
-		final DataStream<Long> source6 = env.fromSequence(51L, 60L).name("source-6");
+		final DataStream<Long> source6 = env.fromSequence("source-6", 51L, 60L);
 
 		return nAryInputStreamOperation(
 			source1.map((v) -> v),

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SourceNAryInputChainingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SourceNAryInputChainingITCase.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.test.streaming.runtime;
 
-import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -157,20 +155,11 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSource(
-				new NumberSequenceSource(1L, 10L),
-				WatermarkStrategy.noWatermarks(),
-				"source-1");
+		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
 
-		final DataStream<Long> source2 = env.fromSource(
-				new NumberSequenceSource(11L, 20L),
-				WatermarkStrategy.noWatermarks(),
-				"source-2");
+		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
 
-		final DataStream<Long> source3 = env.fromSource(
-				new NumberSequenceSource(21L, 30L),
-				WatermarkStrategy.noWatermarks(),
-				"source-3");
+		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
 
 		return nAryInputStreamOperation(source1, source2, source3);
 	}
@@ -192,20 +181,11 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSource(
-			new NumberSequenceSource(1L, 10L),
-			WatermarkStrategy.noWatermarks(),
-			"source-1");
+		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
 
-		final DataStream<Long> source2 = env.fromSource(
-			new NumberSequenceSource(11L, 20L),
-			WatermarkStrategy.noWatermarks(),
-			"source-2");
+		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
 
-		final DataStream<Long> source3 = env.fromSource(
-			new NumberSequenceSource(21L, 30L),
-			WatermarkStrategy.noWatermarks(),
-			"source-3");
+		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
 
 		final DataStream<Long> stream1 = source1.map(v -> v);
 		final DataStream<Long> stream3 = source3.map(v -> v);
@@ -232,25 +212,13 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSource(
-			new NumberSequenceSource(1L, 10L),
-			WatermarkStrategy.noWatermarks(),
-			"source-1");
+		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
 
-		final DataStream<Long> source2 = env.fromSource(
-			new NumberSequenceSource(11L, 20L),
-			WatermarkStrategy.noWatermarks(),
-			"source-2");
+		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
 
-		final DataStream<Long> source3 = env.fromSource(
-			new NumberSequenceSource(21L, 30L),
-			WatermarkStrategy.noWatermarks(),
-			"source-3");
+		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
 
-		final DataStream<Long> source4 = env.fromSource(
-			new NumberSequenceSource(31L, 40L),
-			WatermarkStrategy.noWatermarks(),
-			"source-4");
+		final DataStream<Long> source4 = env.fromSequence(31L, 40L).name("source-4");
 
 		return nAryInputStreamOperation(
 			source1.map((v) -> v),
@@ -281,35 +249,17 @@ public class SourceNAryInputChainingITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.getConfig().enableObjectReuse();
 
-		final DataStream<Long> source1 = env.fromSource(
-			new NumberSequenceSource(1L, 10L),
-			WatermarkStrategy.noWatermarks(),
-			"source-1");
+		final DataStream<Long> source1 = env.fromSequence(1L, 10L).name("source-1");
 
-		final DataStream<Long> source2 = env.fromSource(
-			new NumberSequenceSource(11L, 20L),
-			WatermarkStrategy.noWatermarks(),
-			"source-2");
+		final DataStream<Long> source2 = env.fromSequence(11L, 20L).name("source-2");
 
-		final DataStream<Long> source3 = env.fromSource(
-			new NumberSequenceSource(21L, 30L),
-			WatermarkStrategy.noWatermarks(),
-			"source-3");
+		final DataStream<Long> source3 = env.fromSequence(21L, 30L).name("source-3");
 
-		final DataStream<Long> source4 = env.fromSource(
-			new NumberSequenceSource(31L, 40L),
-			WatermarkStrategy.noWatermarks(),
-			"source-4");
+		final DataStream<Long> source4 = env.fromSequence(31L, 40L).name("source-4");
 
-		final DataStream<Long> source5 = env.fromSource(
-			new NumberSequenceSource(41L, 50L),
-			WatermarkStrategy.noWatermarks(),
-			"source-5");
+		final DataStream<Long> source5 = env.fromSequence(41L, 50L).name("source-5");
 
-		final DataStream<Long> source6 = env.fromSource(
-			new NumberSequenceSource(51L, 60L),
-			WatermarkStrategy.noWatermarks(),
-			"source-6");
+		final DataStream<Long> source6 = env.fromSequence(51L, 60L).name("source-6");
 
 		return nAryInputStreamOperation(
 			source1.map((v) -> v),


### PR DESCRIPTION
## What is the purpose of the change

*Currently the utility method `StreamExecutionEnvironment.generateSequence()` instantiates the `StatefulSequenceSource`. `StreamExecutionEnvironment` should add a new `fromSequence()` method that uses the `NumberSequenceSource` against the new `Source` interface based on FLIP-27.*

## Brief change log

  - *`StreamExecutionEnvironment` adds `fromSequence()` method to creates a new data stream that contains a sequence of numbers.*

## Verifying this change

  - *`StreamExecutionEnvironmentTest` add `testFromSequence()` test method to verify whether `fromSequence()` instantiates a new DataStream that contains a sequence of numbers.*
  - *Modify `SourceNAryInputChainingITCase` to use `fromSequence()` method instead of `fromSource(NumberSequenceSource)` to verify whether `fromSource(NumberSequenceSource)` could be replaced with `fromSequence()`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)