### PR TITLE
[FLINK-19237] Fix rejected slot offer bug in JobMaster 

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerConcurrencyCheckInactiveITCase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerConcurrencyCheckInactiveITCase.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.api.java.typeutils.runtime.kryo;
 
+import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * A test that validates that the concurrency checks in the Kryo Serializer
@@ -33,7 +36,7 @@ import static org.junit.Assert.assertTrue;
  * <p><b>Important:</b> If you see this test fail and the initial settings are still
  * correct, check the assumptions above (on fresh JVM fork).
  */
-public class KryoSerializerConcurrencyCheckInactiveITCase {
+public class KryoSerializerConcurrencyCheckInactiveITCase extends TestLogger {
 
 	// this sets the debug initialization back to its default, even if
 	// by default tests modify it (implicitly via assertion loading)
@@ -47,6 +50,9 @@ public class KryoSerializerConcurrencyCheckInactiveITCase {
 	 */
 	@Test
 	public void testWithNoConcurrencyCheck() throws Exception {
+		// this test will fail on DEBUG log level: If we run the test with DEBUG log level
+		// the KryoSerializer.CONCURRENT_ACCESS_CHECK will be enabled, causing a failure here.
+		assumeFalse(log.isDebugEnabled());
 		boolean assertionError;
 		try {
 			new KryoSerializerConcurrencyTest().testConcurrentUseOfSerializer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -378,17 +378,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	public CompletableFuture<Void> onStop() {
 		log.info("Stopping the JobMaster for job {}({}).", jobGraph.getName(), jobGraph.getJobID());
 
-		// disconnect from all registered TaskExecutors
-		final Set<ResourceID> taskManagerResourceIds = new HashSet<>(registeredTaskManagers.keySet());
-		final FlinkException cause = new FlinkException("Stopping JobMaster for job " + jobGraph.getName() +
-			'(' + jobGraph.getJobID() + ").");
-
-		for (ResourceID taskManagerResourceId : taskManagerResourceIds) {
-			disconnectTaskManager(taskManagerResourceId, cause);
-		}
-
 		// make sure there is a graceful exit
-		suspendExecution(new FlinkException("JobManager is shutting down."));
+		suspendExecution(new FlinkException("Stopping JobMaster for job " + jobGraph.getName() +
+			'(' + jobGraph.getJobID() + ")."));
 
 		// shut down will internally release all registered slots
 		slotPool.close();
@@ -855,6 +847,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		suspendAndClearSchedulerFields(cause);
+
+		// disconnect from all registered TaskExecutors
+		final Set<ResourceID> taskManagerResourceIds = new HashSet<>(registeredTaskManagers.keySet());
+
+		for (ResourceID taskManagerResourceId : taskManagerResourceIds) {
+			disconnectTaskManager(taskManagerResourceId, cause);
+		}
 
 		// the slot pool stops receiving messages and clears its pooled slots
 		slotPool.suspend();


### PR DESCRIPTION
## What is the purpose of the change

Fix rejected slot offer bug in JobMaster. The bug surfaced as a test instability in `LeaderChangeClusterComponentsTest.testReelectionOfJobMaster`.


## Brief change log

- Move disconnect of TaskManagers to the Dispatcher.suspend() method.
- Add a test


## Verifying this change

Covered by a dedicated test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / *no*)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / *no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (*yes* / no / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

