### PR TITLE
[FLINK-19617] Added new metric for monitoring the JVM's Metaspace memory pool usage.

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -847,6 +847,8 @@ Thus, in order to infer the metric identifier:
 </table>
 
 ### Memory
+The memory-related metrics require Oracle's memory management (also included in OpenJDK's Hotspot implementation) to be in place. 
+Some metrics might not be exposed when using other JVM implementations (e.g. IBM's J9).
 <table class="table table-bordered">                               
   <thead>                                                          
     <tr>                                                           
@@ -859,8 +861,8 @@ Thus, in order to infer the metric identifier:
   </thead>                                                         
   <tbody>                                                          
     <tr>                                                           
-      <th rowspan="12"><strong>Job-/TaskManager</strong></th>
-      <td rowspan="12">Status.JVM.Memory</td>
+      <th rowspan="15"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="15">Status.JVM.Memory</td>
       <td>Heap.Used</td>
       <td>The amount of heap memory currently used (in bytes).</td>
       <td>Gauge</td>
@@ -888,6 +890,21 @@ Thus, in order to infer the metric identifier:
     <tr>
       <td>NonHeap.Max</td>
       <td>The maximum amount of non-heap memory that can be used for memory management (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Metaspace.Used</td>
+      <td>The amount of memory currently used in the Metaspace memory pool (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Metaspace.Committed</td>
+      <td>The amount of memory guaranteed to be available to the JVM in the Metaspace memory pool (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Metaspace.Max</td>
+      <td>The maximum amount of memory that can be used in the Metaspace memory pool (in bytes).</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -846,6 +846,8 @@ Thus, in order to infer the metric identifier:
 </table>
 
 ### Memory
+The memory-related metrics require Oracle's memory management (also included in OpenJDK's Hotspot implementation) to be in place. 
+Some metrics might not be exposed when using other JVM implementations (e.g. IBM's J9).
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -858,8 +860,8 @@ Thus, in order to infer the metric identifier:
   </thead>
   <tbody>
     <tr>
-      <th rowspan="12"><strong>Job-/TaskManager</strong></th>
-      <td rowspan="12">Status.JVM.Memory</td>
+      <th rowspan="15"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="15">Status.JVM.Memory</td>
       <td>Heap.Used</td>
       <td>The amount of heap memory currently used (in bytes).</td>
       <td>Gauge</td>
@@ -887,6 +889,21 @@ Thus, in order to infer the metric identifier:
     <tr>
       <td>NonHeap.Max</td>
       <td>The maximum amount of non-heap memory that can be used for memory management (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Metaspace.Used</td>
+      <td>The amount of memory currently used in the Metaspace memory pool (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Metaspace.Committed</td>
+      <td>The amount of memory guaranteed to be available to the JVM in the Metaspace memory pool (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>Metaspace.Max</td>
+      <td>The maximum amount of memory that can be used in the Metaspace memory pool (in bytes).</td>
       <td>Gauge</td>
     </tr>
     <tr>


### PR DESCRIPTION
## What is the purpose of the change
A new metric for monitoring the Metaspace usage needs to be introduced to finish [FLIP-102](https://cwiki.apache.org/confluence/display/FLINK/FLIP-102%3A+Add+More+Metrics+to+TaskManager).

## Brief change log
* Added new metric analogous to `Heap` and `NonHeap` metric.
* Extended documentation accordingly.
* Added note to the memory metrics documentation after we ran into problems with IBM's J9 OpenJDK implementation.
* Included missing testcase for nonheap metric to check whether the metric's value is not static.

## Verifying this change

* Added new tests to `MetricUtils` to cover the new metric

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
