### PR TITLE
[task][hotfix] Remove PipelinedSubpartition.addBufferConsumer method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultSubpartition.java
@@ -33,5 +33,5 @@ public interface CheckpointedResultSubpartition {
 
 	BufferBuilder requestBufferBuilderBlocking() throws IOException, RuntimeException, InterruptedException;
 
-	void addBufferConsumer(BufferConsumer bufferConsumer);
+	boolean add(BufferConsumer bufferConsumer);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -508,9 +508,4 @@ public class PipelinedSubpartition extends ResultSubpartition
 	public BufferBuilder requestBufferBuilderBlocking() throws InterruptedException {
 		return parent.getBufferPool().requestBufferBuilderBlocking();
 	}
-
-	@Override
-	public void addBufferConsumer(BufferConsumer bufferConsumer) {
-		add(bufferConsumer);
-	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Remove duplicated `PipelinedSubpartition.addBufferConsumer` method and use `PipelinedSubpartition.add()` instead.*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
