### PR TITLE
[Hotfix][CheckStyle][Min] Fix DummyInputFormat class lacks Javadoc

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/DummyNoOpOperator.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/DummyNoOpOperator.java
@@ -40,6 +40,10 @@ public class DummyNoOpOperator<IN> extends NoOpOperator<IN> {
 		setInput(input);
 	}
 
+	/**
+	 * Provides a {@link FileInputFormat} for {@link DummyNoOpOperator}.
+	 * All the data it reads is NULL.
+	 */
 	public static class DummyInputFormat<IN> extends FileInputFormat<IN> {
 
 		@Override


### PR DESCRIPTION

## What is the purpose of the change

 Fix DummyInputFormat class lacks Javadoc

## Brief change log

Add Javadoc to DummyInputFormat class

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no / don't know)
  - The runtime per-record code paths (performance sensitive): (no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no / don't know)
  - The S3 file system connector: (no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
