### PR TITLE
[FLINK-19640] Enable sorting inputs for batch

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
@@ -55,4 +56,25 @@ public class ExecutionOptions {
 						"throughput")
 				)
 				.build());
+
+	@Documentation.ExcludeFromDocumentation("This is an expert option, that we do not want to expose in" +
+		" the documentation")
+	public static final ConfigOption<Boolean> SORT_INPUTS =
+		ConfigOptions.key("execution.sorted-inputs.enabled")
+			.booleanType()
+			.defaultValue(true)
+			.withDescription(
+				"A flag to enable or disable sorting inputs of keyed operators. " +
+					"NOTE: It takes effect only in the BATCH runtime mode.");
+
+	@Documentation.ExcludeFromDocumentation("This is an expert option, that we do not want to expose in" +
+		" the documentation")
+	public static final ConfigOption<Boolean> USE_BATCH_STATE_BACKEND =
+		ConfigOptions.key("execution.batch-state-backend.enabled")
+			.booleanType()
+			.defaultValue(true)
+			.withDescription(
+				"A flag to enable or disable batch runtime specific state backend and timer service for keyed" +
+					" operators. NOTE: It takes effect only in the BATCH runtime mode and requires sorted inputs" +
+					SORT_INPUTS.key() + " to be enabled.");
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -792,6 +792,12 @@ public class StreamExecutionEnvironment {
 			});
 		config.configure(configuration, classLoader);
 		checkpointCfg.configure(configuration);
+		configuration.getOptional(ExecutionOptions.SORT_INPUTS).ifPresent(
+			sortInputs -> this.getConfiguration().set(ExecutionOptions.SORT_INPUTS, sortInputs)
+		);
+		configuration.getOptional(ExecutionOptions.USE_BATCH_STATE_BACKEND).ifPresent(
+			sortInputs -> this.getConfiguration().set(ExecutionOptions.USE_BATCH_STATE_BACKEND, sortInputs)
+		);
 	}
 
 	private void registerCustomListeners(final ClassLoader classLoader, final List<String> listeners) {
@@ -1915,7 +1921,7 @@ public class StreamExecutionEnvironment {
 		if (transformations.size() <= 0) {
 			throw new IllegalStateException("No operators defined in streaming topology. Cannot execute.");
 		}
-		return new StreamGraphGenerator(transformations, config, checkpointCfg)
+		return new StreamGraphGenerator(transformations, config, checkpointCfg, getConfiguration())
 			.setStateBackend(defaultStateBackend)
 			.setChaining(isChainingEnabled)
 			.setUserArtifacts(cacheFile)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -336,12 +336,11 @@ public class StreamNode {
 		this.userHash = userHash;
 	}
 
-	@VisibleForTesting
 	public void setSortedInputs(boolean sortedInputs) {
 		this.sortedInputs = sortedInputs;
 	}
 
-	boolean getSortedInputs() {
+	public boolean getSortedInputs() {
 		return sortedInputs;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/TransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/TransformationTranslator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.ReadableConfig;
 
 import java.util.Collection;
 
@@ -88,5 +89,10 @@ public interface TransformationTranslator<OUT, T extends Transformation<OUT>> {
 		 * Returns the default buffer timeout to be used.
 		 */
 		long getDefaultBufferTimeout();
+
+		/**
+		 * Retrieves additional configuration for the graph generation process.
+		 */
+		ReadableConfig getGraphGeneratorConfig();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
+import java.io.Serializable;
+
 /**
  * An entity keeping all the time-related services.
  *
@@ -68,7 +70,7 @@ public interface InternalTimeServiceManager<K> {
 	 * Allows substituting the manager that will be used at the runtime.
 	 */
 	@FunctionalInterface
-	interface Provider {
+	interface Provider extends Serializable {
 		<K> InternalTimeServiceManager<K> create(
 			CheckpointableKeyedStateBackend<K> keyedStatedBackend,
 			ClassLoader userClassloader,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A utility class for applying sorting inputs.
+ */
+class BatchExecutionUtils {
+	private static final Logger LOG = LoggerFactory.getLogger(BatchExecutionUtils.class);
+
+	static void applySortingInputs(
+			int transformationId,
+			TransformationTranslator.Context context) {
+		StreamNode node = context.getStreamGraph().getStreamNode(transformationId);
+		boolean sortInputs = context.getGraphGeneratorConfig().get(ExecutionOptions.SORT_INPUTS);
+		boolean isInputSelectable = isInputSelectable(node);
+
+		adjustChainingStrategy(node);
+
+		checkState(
+			!isInputSelectable || !sortInputs,
+			"Batch state backend and sorting inputs are not supported in graphs with an InputSelectable operator."
+		);
+
+		if (sortInputs) {
+			LOG.debug("Enabling sorting inputs for an operator {}.", node);
+			node.setSortedInputs(true);
+			Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights = new HashMap<>();
+			operatorScopeUseCaseWeights.put(ManagedMemoryUseCase.BATCH_OP, 1);
+			node.setManagedMemoryUseCaseWeights(
+				operatorScopeUseCaseWeights,
+				Collections.emptySet()
+			);
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static boolean isInputSelectable(StreamNode node) {
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		Class<? extends StreamOperator> operatorClass = node.getOperatorFactory()
+			.getStreamOperatorClass(classLoader);
+		return InputSelectable.class.isAssignableFrom(operatorClass);
+	}
+
+	private static void adjustChainingStrategy(StreamNode node) {
+		StreamOperatorFactory<?> operatorFactory = node.getOperatorFactory();
+		ChainingStrategy currentChainingStrategy = operatorFactory.getChainingStrategy();
+		switch (currentChainingStrategy) {
+			case ALWAYS:
+			case HEAD_WITH_SOURCES:
+				LOG.debug(
+					"Setting chaining strategy to HEAD for operator {}, because of the BATCH execution mode.",
+					node);
+				operatorFactory.setChainingStrategy(ChainingStrategy.HEAD);
+				break;
+			case NEVER:
+			case HEAD:
+				break;
+		}
+	}
+
+	private BatchExecutionUtils() {
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
@@ -51,7 +51,12 @@ public class MultiInputTransformationTranslator<OUT>
 	protected Collection<Integer> translateForBatchInternal(
 			final AbstractMultipleInputTransformation<OUT> transformation,
 			final Context context) {
-		return translateInternal(transformation, context);
+		Collection<Integer> ids = translateInternal(transformation, context);
+		boolean isKeyed = transformation instanceof KeyedMultipleInputTransformation;
+		if (isKeyed) {
+			BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+		}
+		return ids;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
@@ -47,7 +47,13 @@ public class OneInputTransformationTranslator<IN, OUT> extends SimpleTransformat
 	public Collection<Integer> translateForBatchInternal(
 			final OneInputTransformation<IN, OUT> transformation,
 			final Context context) {
-		return translateInternal(transformation, context);
+		Collection<Integer> ids = translateInternal(transformation, context);
+		boolean isKeyed = transformation.getStateKeySelector() != null;
+		if (isKeyed) {
+			BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+		}
+
+		return ids;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
@@ -46,7 +46,13 @@ public class TwoInputTransformationTranslator<IN1, IN2, OUT>
 	protected Collection<Integer> translateForBatchInternal(
 			final TwoInputTransformation<IN1, IN2, OUT> transformation,
 			final Context context) {
-		return translateInternal(transformation, context);
+		Collection<Integer> ids = translateInternal(transformation, context);
+		boolean isKeyed =
+			transformation.getStateKeySelector1() != null && transformation.getStateKeySelector2() != null;
+		if (isKeyed) {
+			BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+		}
+		return ids;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
@@ -1,0 +1,497 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.streaming.api.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.MultipleConnectedStreams;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionStateBackend;
+import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for generating correct properties for sorting inputs in {@link RuntimeExecutionMode#BATCH} runtime mode.
+ */
+public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void testOneInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		SingleOutputStreamOperator<Integer> process = env.fromElements(1, 2)
+			.keyBy(Integer::intValue)
+			.process(DUMMY_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig()
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		StreamGraph graph = graphGenerator.generate();
+		StreamNode processNode = graph.getStreamNode(process.getId());
+		assertThat(processNode.getSortedInputs(), equalTo(true));
+		assertThat(processNode.getOperatorFactory().getChainingStrategy(), equalTo(ChainingStrategy.HEAD));
+		assertThat(graph.getStateBackend(), instanceOf(BatchExecutionStateBackend.class));
+		// the provider is passed as a lambda therefore we cannot assert the class of the provider
+		assertThat(graph.getTimerServiceProvider(), notNullValue());
+	}
+
+	@Test
+	public void testDisablingStateBackendOneInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		SingleOutputStreamOperator<Integer> process = env.fromElements(1, 2)
+			.keyBy(Integer::intValue)
+			.process(DUMMY_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		Configuration configuration = new Configuration();
+		configuration.set(ExecutionOptions.USE_BATCH_STATE_BACKEND, false);
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig(),
+			configuration
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		StreamGraph graph = graphGenerator.generate();
+		StreamNode processNode = graph.getStreamNode(process.getId());
+		assertThat(processNode.getSortedInputs(), equalTo(true));
+		assertThat(processNode.getOperatorFactory().getChainingStrategy(), equalTo(ChainingStrategy.HEAD));
+		assertThat(graph.getStateBackend(), nullValue());
+		assertThat(graph.getTimerServiceProvider(), nullValue());
+	}
+
+	@Test
+	public void testDisablingSortingInputsOneInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		SingleOutputStreamOperator<Integer> process = env.fromElements(1, 2)
+			.keyBy(Integer::intValue)
+			.process(DUMMY_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		Configuration configuration = new Configuration();
+		configuration.set(ExecutionOptions.USE_BATCH_STATE_BACKEND, false);
+		configuration.set(ExecutionOptions.SORT_INPUTS, false);
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig(),
+			configuration
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		StreamGraph graph = graphGenerator.generate();
+		StreamNode processNode = graph.getStreamNode(process.getId());
+		assertThat(processNode.getSortedInputs(), equalTo(false));
+		assertThat(graph.getStateBackend(), nullValue());
+		assertThat(graph.getTimerServiceProvider(), nullValue());
+	}
+
+	@Test
+	public void testDisablingSortingInputsWithoutBatchStateBackendOneInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		SingleOutputStreamOperator<Integer> process = env.fromElements(1, 2)
+			.keyBy(Integer::intValue)
+			.process(DUMMY_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		Configuration configuration = new Configuration();
+		configuration.set(ExecutionOptions.SORT_INPUTS, false);
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig(),
+			configuration
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage("Batch state backend requires the sorted inputs to be enabled!");
+		graphGenerator.generate();
+	}
+
+	@Test
+	public void testTwoInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements2 = env.fromElements(1, 2);
+		SingleOutputStreamOperator<Integer> process = elements1.connect(elements2)
+			.keyBy(Integer::intValue, Integer::intValue)
+			.process(DUMMY_KEYED_CO_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig()
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		StreamGraph graph = graphGenerator.generate();
+		StreamNode processNode = graph.getStreamNode(process.getId());
+		assertThat(processNode.getSortedInputs(), equalTo(true));
+		assertThat(processNode.getOperatorFactory().getChainingStrategy(), equalTo(ChainingStrategy.HEAD));
+		assertThat(graph.getStateBackend(), instanceOf(BatchExecutionStateBackend.class));
+		// the provider is passed as a lambda therefore we cannot assert the class of the provider
+		assertThat(graph.getTimerServiceProvider(), notNullValue());
+	}
+
+	@Test
+	public void testDisablingStateBackendTwoInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements2 = env.fromElements(1, 2);
+		SingleOutputStreamOperator<Integer> process = elements1.connect(elements2)
+			.keyBy(Integer::intValue, Integer::intValue)
+			.process(DUMMY_KEYED_CO_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		Configuration configuration = new Configuration();
+		configuration.set(ExecutionOptions.USE_BATCH_STATE_BACKEND, false);
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig(),
+			configuration
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		StreamGraph graph = graphGenerator.generate();
+		StreamNode processNode = graph.getStreamNode(process.getId());
+		assertThat(processNode.getSortedInputs(), equalTo(true));
+		assertThat(processNode.getOperatorFactory().getChainingStrategy(), equalTo(ChainingStrategy.HEAD));
+		assertThat(graph.getStateBackend(), nullValue());
+		assertThat(graph.getTimerServiceProvider(), nullValue());
+	}
+
+	@Test
+	public void testDisablingSortingInputsTwoInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements2 = env.fromElements(1, 2);
+		SingleOutputStreamOperator<Integer> process = elements1.connect(elements2)
+			.keyBy(Integer::intValue, Integer::intValue)
+			.process(DUMMY_KEYED_CO_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		Configuration configuration = new Configuration();
+		configuration.set(ExecutionOptions.USE_BATCH_STATE_BACKEND, false);
+		configuration.set(ExecutionOptions.SORT_INPUTS, false);
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig(),
+			configuration
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		StreamGraph graph = graphGenerator.generate();
+		StreamNode processNode = graph.getStreamNode(process.getId());
+		assertThat(processNode.getSortedInputs(), equalTo(false));
+		assertThat(graph.getStateBackend(), nullValue());
+		assertThat(graph.getTimerServiceProvider(), nullValue());
+	}
+
+	@Test
+	public void testDisablingSortingInputsWithoutBatchStateBackendTwoInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements2 = env.fromElements(1, 2);
+		SingleOutputStreamOperator<Integer> process = elements1.connect(elements2)
+			.keyBy(Integer::intValue, Integer::intValue)
+			.process(DUMMY_KEYED_CO_PROCESS_FUNCTION);
+		DataStreamSink<Integer> sink = process.addSink(new DiscardingSink<>());
+
+		Configuration configuration = new Configuration();
+		configuration.set(ExecutionOptions.SORT_INPUTS, false);
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig(),
+			configuration
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage("Batch state backend requires the sorted inputs to be enabled!");
+		graphGenerator.generate();
+	}
+
+	@Test
+	public void testInputSelectableTwoInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements2 = env.fromElements(1, 2);
+		SingleOutputStreamOperator<Integer> process = elements1.connect(elements2)
+			.keyBy(Integer::intValue, Integer::intValue)
+			.process(DUMMY_KEYED_CO_PROCESS_FUNCTION);
+
+		SingleOutputStreamOperator<Integer> selectableOperator = process.connect(elements1)
+			.keyBy(Integer::intValue, Integer::intValue)
+			.transform(
+				"operator",
+				BasicTypeInfo.INT_TYPE_INFO,
+				new InputSelectableTwoInputOperator()
+			);
+
+		DataStreamSink<Integer> sink = selectableOperator.addSink(new DiscardingSink<>());
+
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig()
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(
+			"Batch state backend and sorting inputs are not supported in graphs with an InputSelectable operator.");
+		graphGenerator.generate();
+	}
+
+	@Test
+	public void testMultiInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements2 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements3 = env.fromElements(1, 2);
+
+		MultipleInputOperatorFactory selectableOperator = new MultipleInputOperatorFactory(3, false);
+		KeyedMultipleInputTransformation<Integer> multipleInputTransformation = new KeyedMultipleInputTransformation<>(
+			"operator",
+			selectableOperator,
+			BasicTypeInfo.INT_TYPE_INFO,
+			1,
+			BasicTypeInfo.INT_TYPE_INFO
+		);
+		multipleInputTransformation.addInput(elements1.getTransformation(), e -> e);
+		multipleInputTransformation.addInput(elements2.getTransformation(), e -> e);
+		multipleInputTransformation.addInput(elements3.getTransformation(), e -> e);
+
+		DataStreamSink<Integer> sink = new MultipleConnectedStreams(env)
+			.transform(multipleInputTransformation)
+			.addSink(new DiscardingSink<>());
+
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig()
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		StreamGraph graph = graphGenerator.generate();
+		StreamNode operatorNode = graph.getStreamNode(multipleInputTransformation.getId());
+		assertThat(operatorNode.getSortedInputs(), equalTo(true));
+		assertThat(operatorNode.getOperatorFactory().getChainingStrategy(), equalTo(ChainingStrategy.HEAD));
+		assertThat(graph.getStateBackend(), instanceOf(BatchExecutionStateBackend.class));
+		// the provider is passed as a lambda therefore we cannot assert the class of the provider
+		assertThat(graph.getTimerServiceProvider(), notNullValue());
+	}
+
+	@Test
+	public void testInputSelectableMultiInputTransformation() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStreamSource<Integer> elements1 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements2 = env.fromElements(1, 2);
+		DataStreamSource<Integer> elements3 = env.fromElements(1, 2);
+
+		MultipleInputOperatorFactory selectableOperator = new MultipleInputOperatorFactory(3, true);
+		KeyedMultipleInputTransformation<Integer> multipleInputTransformation = new KeyedMultipleInputTransformation<>(
+			"operator",
+			selectableOperator,
+			BasicTypeInfo.INT_TYPE_INFO,
+			1,
+			BasicTypeInfo.INT_TYPE_INFO
+		);
+		multipleInputTransformation.addInput(elements1.getTransformation(), e -> e);
+		multipleInputTransformation.addInput(elements2.getTransformation(), e -> e);
+		multipleInputTransformation.addInput(elements3.getTransformation(), e -> e);
+
+		DataStreamSink<Integer> sink = new MultipleConnectedStreams(env)
+			.transform(multipleInputTransformation)
+			.addSink(new DiscardingSink<>());
+
+		StreamGraphGenerator graphGenerator = new StreamGraphGenerator(
+			Collections.singletonList(sink.getTransformation()),
+			env.getConfig(),
+			env.getCheckpointConfig()
+		);
+		graphGenerator.setRuntimeExecutionMode(RuntimeExecutionMode.BATCH);
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(
+			"Batch state backend and sorting inputs are not supported in graphs with an InputSelectable operator.");
+		graphGenerator.generate();
+	}
+
+	private static final KeyedProcessFunction<Integer, Integer, Integer> DUMMY_PROCESS_FUNCTION =
+		new KeyedProcessFunction<Integer, Integer, Integer>() {
+			@Override
+			public void processElement(
+				Integer value,
+				Context ctx,
+				Collector<Integer> out) {
+
+			}
+		};
+	private static final KeyedCoProcessFunction<Integer, Integer, Integer, Integer> DUMMY_KEYED_CO_PROCESS_FUNCTION =
+		new KeyedCoProcessFunction<Integer, Integer, Integer, Integer>() {
+			@Override
+			public void processElement1(
+				Integer value,
+				Context ctx, Collector<Integer> out) {
+
+			}
+
+			@Override
+			public void processElement2(
+				Integer value,
+				Context ctx, Collector<Integer> out) {
+
+			}
+		};
+
+	private static final class InputSelectableTwoInputOperator
+			extends AbstractStreamOperator<Integer>
+			implements TwoInputStreamOperator<Integer, Integer, Integer>, InputSelectable {
+		@Override
+		public InputSelection nextSelection() {
+			return null;
+		}
+
+		@Override
+		public void processElement1(StreamRecord<Integer> element) {
+
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Integer> element) {
+
+		}
+	}
+
+	private static class MultipleInputOperator
+			extends AbstractStreamOperatorV2<Integer>
+			implements MultipleInputStreamOperator<Integer> {
+
+		public MultipleInputOperator(
+				StreamOperatorParameters<Integer> parameters,
+				int inputsCount) {
+			super(parameters, inputsCount);
+		}
+
+		@Override
+		@SuppressWarnings({"rawtypes"})
+		public List<Input> getInputs() {
+			return Collections.emptyList();
+		}
+	}
+
+	private static final class InputSelectableMultipleInputOperator
+			extends MultipleInputOperator
+			implements InputSelectable {
+		public InputSelectableMultipleInputOperator(
+				StreamOperatorParameters<Integer> parameters,
+				int inputsCount) {
+			super(parameters, inputsCount);
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return null;
+		}
+	}
+
+	private static final class MultipleInputOperatorFactory extends AbstractStreamOperatorFactory<Integer> {
+
+		private final int inputsCount;
+		private final boolean selectable;
+
+		private MultipleInputOperatorFactory(int inputsCount, boolean selectable) {
+			this.inputsCount = inputsCount;
+			this.selectable = selectable;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T extends StreamOperator<Integer>> T createStreamOperator(StreamOperatorParameters<Integer> parameters) {
+			if (selectable) {
+				return (T) new InputSelectableMultipleInputOperator(
+					parameters,
+					inputsCount
+				);
+			} else {
+				return (T) new MultipleInputOperator(
+					parameters,
+					inputsCount
+				);
+			}
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			if (selectable) {
+				return InputSelectableMultipleInputOperator.class;
+			} else {
+				return MultipleInputOperator.class;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds feature flags for enabling/disabling the sorting inputs and
special types of a state backend and a timer service for BATCH execution
runtime. Those options are enabled by default for BATCH runtime
execution mode.

## Verifying this change

Added tests in `StreamGraphGeneratorBatchExecutionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) -> will be documented along with the RuntimeExecutionMode
