### PR TITLE
[FLINK-19632] Introduce a new ResultPartitionType for Approximate Local Recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumerWithPartialRecordLength;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A pipelined in-memory only subpartition, which allows to reconnecting after failure.
+ * Only one view is allowed at a time to read teh subpartition.
+ */
+public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PipelinedApproximateSubpartition.class);
+
+	@GuardedBy("buffers")
+	private boolean isPartialBufferCleanupRequired = false;
+
+	PipelinedApproximateSubpartition(int index, ResultPartition parent) {
+		super(index, parent);
+	}
+
+	/**
+	 * To simply the view releasing threading model, {@link PipelinedApproximateSubpartition#releaseView()} is called
+	 * only before creating a new view.
+	 *
+	 * <p>There is still one corner case when a downstream task fails continuously in a short period of time
+	 * then multiple netty worker threads can createReadView at the same time.
+	 * TODO: This problem will be solved in FLINK-19774
+	 */
+	@Override
+	public PipelinedSubpartitionView createReadView(BufferAvailabilityListener availabilityListener) {
+		synchronized (buffers) {
+			checkState(!isReleased);
+
+			releaseView();
+
+			LOG.debug("{}: Creating read view for subpartition {} of partition {}.",
+				parent.getOwningTaskName(), getSubPartitionIndex(), parent.getPartitionId());
+
+			readView = new PipelinedApproximateSubpartitionView(this, availabilityListener);
+		}
+
+		return readView;
+	}
+
+	@Override
+	Buffer buildSliceBuffer(BufferConsumerWithPartialRecordLength buffer) {
+		if (isPartialBufferCleanupRequired) {
+			isPartialBufferCleanupRequired = !buffer.cleanupPartialRecord();
+		}
+
+		return buffer.build();
+	}
+
+	private void releaseView() {
+		assert Thread.holdsLock(buffers);
+		if (readView != null) {
+			// upon reconnecting, two netty threads may require the same view to release
+			LOG.debug("Releasing view of subpartition {} of {}.", getSubPartitionIndex(), parent.getPartitionId());
+
+			readView.releaseAllResources();
+			readView = null;
+
+			isPartialBufferCleanupRequired = true;
+			isBlockedByCheckpoint = false;
+			sequenceNumber = 0;
+		}
+	}
+
+	/** for testing only. */
+	@VisibleForTesting
+	boolean isPartialBufferCleanupRequired() {
+		return isPartialBufferCleanupRequired;
+	}
+
+	/** for testing only. */
+	@VisibleForTesting
+	void setIsPartialBufferCleanupRequired() {
+		isPartialBufferCleanupRequired = true;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionView.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+/**
+ * View over a pipelined in-memory only subpartition allowing reconnecting.
+ */
+public class PipelinedApproximateSubpartitionView extends PipelinedSubpartitionView {
+
+	PipelinedApproximateSubpartitionView(PipelinedApproximateSubpartition parent, BufferAvailabilityListener listener) {
+		super(parent, listener);
+	}
+
+	/**
+	 * Pipelined ResultPartition relies on its subpartition view's release to decide whether the partition
+	 * is ready to release. In contrast, Approximate Pipelined ResultPartition is put into the JobMaster's
+	 * Partition Tracker and relies on the tracker to release partitions after the job is finished.
+	 * Hence in the approximate pipelined case, no resource related to view is needed to be released.
+	 */
+	@Override
+	public void releaseAllResources() {
+		isReleased.compareAndSet(false, true);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
@@ -158,7 +158,8 @@ public class PipelinedResultPartition extends BufferWritingResultPartition
 	// ------------------------------------------------------------------------
 
 	private static ResultPartitionType checkResultPartitionType(ResultPartitionType type) {
-		checkArgument(type == ResultPartitionType.PIPELINED || type == ResultPartitionType.PIPELINED_BOUNDED);
+		checkArgument(type == ResultPartitionType.PIPELINED || type == ResultPartitionType.PIPELINED_BOUNDED ||
+			type == ResultPartitionType.PIPELINED_APPROXIMATE);
 		return type;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -69,14 +70,14 @@ public class PipelinedSubpartition extends ResultSubpartition
 	// ------------------------------------------------------------------------
 
 	/** All buffers of this subpartition. Access to the buffers is synchronized on this object. */
-	private final PrioritizedDeque<BufferConsumerWithPartialRecordLength> buffers = new PrioritizedDeque<>();
+	final PrioritizedDeque<BufferConsumerWithPartialRecordLength> buffers = new PrioritizedDeque<>();
 
 	/** The number of non-event buffers currently in this subpartition. */
 	@GuardedBy("buffers")
 	private int buffersInBacklog;
 
 	/** The read view to consume this subpartition. */
-	private PipelinedSubpartitionView readView;
+	PipelinedSubpartitionView readView;
 
 	/** Flag indicating whether the subpartition has been finished. */
 	private boolean isFinished;
@@ -85,7 +86,7 @@ public class PipelinedSubpartition extends ResultSubpartition
 	private boolean flushRequested;
 
 	/** Flag indicating whether the subpartition has been released. */
-	private volatile boolean isReleased;
+	volatile boolean isReleased;
 
 	/** The total number of buffers (both data and event buffers). */
 	private long totalNumberOfBuffers;
@@ -98,9 +99,9 @@ public class PipelinedSubpartition extends ResultSubpartition
 
 	/** Whether this subpartition is blocked by exactly once checkpoint and is waiting for resumption. */
 	@GuardedBy("buffers")
-	private boolean isBlockedByCheckpoint = false;
+	boolean isBlockedByCheckpoint = false;
 
-	private int sequenceNumber = 0;
+	int sequenceNumber = 0;
 
 	// ------------------------------------------------------------------------
 
@@ -259,9 +260,10 @@ public class PipelinedSubpartition extends ResultSubpartition
 			}
 
 			while (!buffers.isEmpty()) {
-				BufferConsumer bufferConsumer = buffers.peek().getBufferConsumer();
+				BufferConsumerWithPartialRecordLength bufferConsumerWithPartialRecordLength = buffers.peek();
+				BufferConsumer bufferConsumer = bufferConsumerWithPartialRecordLength.getBufferConsumer();
 
-				buffer = bufferConsumer.build();
+				buffer = buildSliceBuffer(bufferConsumerWithPartialRecordLength);
 
 				checkState(bufferConsumer.isFinished() || buffers.size() == 1,
 					"When there are multiple buffers, an unfinished bufferConsumer can not be at the head of the buffers queue.");
@@ -272,7 +274,7 @@ public class PipelinedSubpartition extends ResultSubpartition
 				}
 
 				if (bufferConsumer.isFinished()) {
-					buffers.poll().getBufferConsumer().close();
+					requireNonNull(buffers.poll()).getBufferConsumer().close();
 					decreaseBuffersInBacklogUnsafe(bufferConsumer.isBuffer());
 				}
 
@@ -386,8 +388,14 @@ public class PipelinedSubpartition extends ResultSubpartition
 		}
 
 		return String.format(
-			"PipelinedSubpartition#%d [number of buffers: %d (%d bytes), number of buffers in backlog: %d, finished? %s, read view? %s]",
-			getSubPartitionIndex(), numBuffers, numBytes, getBuffersInBacklog(), finished, hasReadView);
+			"%s#%d [number of buffers: %d (%d bytes), number of buffers in backlog: %d, finished? %s, read view? %s]",
+			this.getClass().getSimpleName(),
+			getSubPartitionIndex(),
+			numBuffers,
+			numBytes,
+			getBuffersInBacklog(),
+			finished,
+			hasReadView);
 	}
 
 	@Override
@@ -508,6 +516,10 @@ public class PipelinedSubpartition extends ResultSubpartition
 	@Override
 	public BufferBuilder requestBufferBuilderBlocking() throws InterruptedException {
 		return parent.getBufferPool().requestBufferBuilderBlocking();
+	}
+
+	Buffer buildSliceBuffer(BufferConsumerWithPartialRecordLength buffer) {
+		return buffer.build();
 	}
 
 	/** for testing only. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -37,7 +37,7 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
 	private final BufferAvailabilityListener availabilityListener;
 
 	/** Flag indicating whether this view has been released. */
-	private final AtomicBoolean isReleased;
+	final AtomicBoolean isReleased;
 
 	public PipelinedSubpartitionView(PipelinedSubpartition parent, BufferAvailabilityListener listener) {
 		this.parent = checkNotNull(parent);
@@ -97,8 +97,9 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
 
 	@Override
 	public String toString() {
-		return String.format("PipelinedSubpartitionView(index: %d) of ResultPartition %s",
-				parent.getSubPartitionIndex(),
-				parent.parent.getPartitionId());
+		return String.format("%s(index: %d) of ResultPartition %s",
+			this.getClass().getSimpleName(),
+			parent.getSubPartitionIndex(),
+			parent.parent.getPartitionId());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
@@ -305,5 +306,10 @@ public abstract class ResultPartition implements ResultPartitionWriter {
 
 	protected void checkInProduceState() throws IllegalStateException {
 		checkState(!isFinished, "Partition already finished.");
+	}
+
+	@VisibleForTesting
+	public ResultPartitionManager getPartitionManager() {
+		return partitionManager;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -71,7 +71,17 @@ public enum ResultPartitionType {
 	 * <p>For batch jobs, it will be best to keep this unlimited ({@link #PIPELINED}) since there are
 	 * no checkpoint barriers.
 	 */
-	PIPELINED_BOUNDED(true, true, true, false);
+	PIPELINED_BOUNDED(true, true, true, false),
+
+	/**
+	 * Pipelined partitions with a bounded (local) buffer pool to support downstream task to
+	 * continue consuming data after reconnection in Approximate Local-Recovery.
+	 *
+	 * <p>Pipelined results can be consumed only once by a single consumer at one time.
+	 * {@link #PIPELINED_APPROXIMATE} is different from {@link #PIPELINED_BOUNDED} in that
+	 * {@link #PIPELINED_APPROXIMATE} is not decomposed automatically after consumption.
+	 */
+	PIPELINED_APPROXIMATE(true, true, true, true);
 
 	/** Can the partition be consumed while being produced? */
 	private final boolean isPipelined;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.disk.NoOpFileChannelManager;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderAndConsumerTest.assertContent;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderAndConsumerTest.toByteBuffer;
+import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link PipelinedApproximateSubpartition}.
+ */
+public class PipelinedApproximateSubpartitionTest extends PipelinedSubpartitionTest {
+	private static final int BUFFER_SIZE = 4 * Integer.BYTES;
+
+	@Override
+	PipelinedSubpartition createSubpartition() throws Exception {
+		return createPipelinedApproximateSubpartition();
+	}
+
+	@Test
+	@Override
+	public void testIllegalReadViewRequest() {
+		// This is one of the main differences between PipelinedApproximateSubpartition and PipelinedSubpartition
+		// PipelinedApproximateSubpartition allows to recreate a view (release the old view first)
+	}
+
+	@Test
+	public void testRecreateReadView() throws Exception {
+		final PipelinedApproximateSubpartition subpartition = createPipelinedApproximateSubpartition();
+
+		// first request
+		assertNotNull(subpartition.createReadView(() -> {}));
+		assertFalse(subpartition.isPartialBufferCleanupRequired());
+
+		// reconnecting request
+		assertNotNull(subpartition.createReadView(() -> {}));
+		assertTrue(subpartition.isPartialBufferCleanupRequired());
+	}
+
+	@Test
+	public void testSkipPartialDataEndsInBufferWithNoMoreData() throws Exception {
+		final BufferWritingResultPartition writer = createResultPartition();
+		final PipelinedApproximateSubpartition subpartition = getPipelinedApproximateSubpartition(writer);
+
+		writer.emitRecord(toByteBuffer(0, 1, 2, 3, 42), 0);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 0, 1, 2, 3);
+
+		subpartition.setIsPartialBufferCleanupRequired();
+		assertNull(subpartition.pollBuffer());
+
+		writer.emitRecord(toByteBuffer(8, 9), 0);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 8, 9);
+	}
+
+	@Test
+	public void testSkipPartialDataEndsInBufferWithMoreData() throws Exception {
+		final BufferWritingResultPartition writer = createResultPartition();
+		final PipelinedApproximateSubpartition subpartition = getPipelinedApproximateSubpartition(writer);
+
+		writer.emitRecord(toByteBuffer(0, 1, 2, 3, 42), 0);
+		writer.emitRecord(toByteBuffer(8, 9), 0);
+
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 0, 1, 2, 3);
+
+		subpartition.setIsPartialBufferCleanupRequired();
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 8, 9);
+	}
+
+	@Test
+	public void testSkipPartialDataStartWithFullRecord() throws Exception {
+		final BufferWritingResultPartition writer = createResultPartition();
+		final PipelinedApproximateSubpartition subpartition = getPipelinedApproximateSubpartition(writer);
+
+		writer.emitRecord(toByteBuffer(0, 1, 2, 3, 42), 0);
+		writer.emitRecord(toByteBuffer(8, 9), 0);
+
+		subpartition.setIsPartialBufferCleanupRequired();
+
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 0, 1, 2, 3);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 42, 8, 9);
+	}
+
+	@Test
+	public void testSkipPartialDataStartWithinBuffer() throws Exception {
+		final BufferWritingResultPartition writer = createResultPartition();
+		final PipelinedApproximateSubpartition subpartition = getPipelinedApproximateSubpartition(writer);
+
+		writer.emitRecord(toByteBuffer(0, 1, 2, 3, 42), 0);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 0, 1, 2, 3);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 42);
+
+		writer.emitRecord(toByteBuffer(8, 9), 0);
+		writer.emitRecord(toByteBuffer(10, 11), 0);
+
+		subpartition.setIsPartialBufferCleanupRequired();
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 8, 9, 10);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 11);
+	}
+
+	@Test
+	public void testSkipPartialDataLongRecordOccupyEntireBuffer() throws Exception {
+		final BufferWritingResultPartition writer = createResultPartition();
+		final PipelinedApproximateSubpartition subpartition = getPipelinedApproximateSubpartition(writer);
+
+		writer.emitRecord(toByteBuffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 42), 0);
+
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 0, 1, 2, 3);
+
+		subpartition.setIsPartialBufferCleanupRequired();
+		assertNull(subpartition.pollBuffer());
+	}
+
+	@Test
+	public void testSkipPartialDataLongRecordOccupyEntireBufferWithMoreData() throws Exception {
+		final BufferWritingResultPartition writer = createResultPartition();
+		final PipelinedApproximateSubpartition subpartition = getPipelinedApproximateSubpartition(writer);
+
+		writer.emitRecord(toByteBuffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 42), 0);
+		writer.emitRecord(toByteBuffer(100, 101, 102), 0);
+
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 0, 1, 2, 3);
+
+		subpartition.setIsPartialBufferCleanupRequired();
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 100, 101);
+
+		// release again
+		subpartition.setIsPartialBufferCleanupRequired();
+		// 102 is cleaned up
+		assertNull(subpartition.pollBuffer());
+
+		writer.emitRecord(toByteBuffer(200, 201, 202, 203), 0);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 200, 201, 202);
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 203);
+	}
+
+	@Test
+	public void testSkipPartialDataLongRecordEndWithBuffer() throws Exception {
+		final BufferWritingResultPartition writer = createResultPartition();
+		final PipelinedApproximateSubpartition subpartition = getPipelinedApproximateSubpartition(writer);
+
+		writer.emitRecord(toByteBuffer(0, 1, 2, 3, 4, 5, 6, 42), 0);
+		writer.emitRecord(toByteBuffer(100, 101, 102), 0);
+
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 0, 1, 2, 3);
+
+		subpartition.setIsPartialBufferCleanupRequired();
+		assertContent(requireNonNull(subpartition.pollBuffer()).buffer(), null, 100, 101, 102);
+	}
+
+	private static PipelinedApproximateSubpartition createPipelinedApproximateSubpartition() throws IOException {
+		final BufferWritingResultPartition parent = createResultPartition();
+		return (PipelinedApproximateSubpartition) parent.subpartitions[0];
+	}
+
+	private static PipelinedApproximateSubpartition getPipelinedApproximateSubpartition(
+			BufferWritingResultPartition resultPartition) {
+		return (PipelinedApproximateSubpartition) resultPartition.subpartitions[0];
+	}
+
+	private static BufferWritingResultPartition createResultPartition() throws IOException {
+		NettyShuffleEnvironment network = new NettyShuffleEnvironmentBuilder()
+			.setNumNetworkBuffers(10)
+			.setBufferSize(BUFFER_SIZE)
+			.build();
+		ResultPartition resultPartition =
+			createPartition(network, NoOpFileChannelManager.INSTANCE, ResultPartitionType.PIPELINED_APPROXIMATE, 2);
+		resultPartition.setup();
+		return (BufferWritingResultPartition) resultPartition;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionWithReadViewTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Additional tests for {@link PipelinedApproximateSubpartitionView} which require an availability listener and a
+ * read view.
+ *
+ * @see PipelinedSubpartitionTest
+ */
+public class PipelinedApproximateSubpartitionWithReadViewTest extends PipelinedSubpartitionWithReadViewTest {
+
+	@Before
+	@Override
+	public void before() throws IOException {
+		setup(ResultPartitionType.PIPELINED_APPROXIMATE);
+		subpartition = new PipelinedApproximateSubpartition(0, resultPartition);
+		availablityListener = new AwaitableBufferAvailablityListener();
+		readView = subpartition.createReadView(availablityListener);
+	}
+
+	@Test
+	@Override
+	public void testRelease() {
+		readView.releaseAllResources();
+		assertTrue(
+			resultPartition.getPartitionManager().getUnreleasedPartitions().contains(resultPartition.getPartitionId()));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -69,7 +69,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 	}
 
 	@Override
-	PipelinedSubpartition createSubpartition() {
+	PipelinedSubpartition createSubpartition() throws Exception {
 		return createPipelinedSubpartition();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -71,9 +71,10 @@ import static org.junit.Assert.assertNull;
 @RunWith(Parameterized.class)
 public class PipelinedSubpartitionWithReadViewTest {
 
-	private PipelinedSubpartition subpartition;
-	private AwaitableBufferAvailablityListener availablityListener;
-	private PipelinedSubpartitionView readView;
+	ResultPartition resultPartition;
+	PipelinedSubpartition subpartition;
+	AwaitableBufferAvailablityListener availablityListener;
+	PipelinedSubpartitionView readView;
 
 	@Parameterized.Parameter
 	public boolean compressionEnabled;
@@ -84,13 +85,9 @@ public class PipelinedSubpartitionWithReadViewTest {
 	}
 
 	@Before
-	public void setup() throws IOException {
-		final ResultPartition parent = PartitionTestUtils.createPartition(
-			ResultPartitionType.PIPELINED,
-			NoOpFileChannelManager.INSTANCE,
-			compressionEnabled,
-			BUFFER_SIZE);
-		subpartition = new PipelinedSubpartition(0, parent);
+	public void before() throws IOException {
+		setup(ResultPartitionType.PIPELINED);
+		subpartition = new PipelinedSubpartition(0, resultPartition);
 		availablityListener = new AwaitableBufferAvailablityListener();
 		readView = subpartition.createReadView(availablityListener);
 	}
@@ -106,6 +103,13 @@ public class PipelinedSubpartitionWithReadViewTest {
 		subpartition.add(createBufferBuilder().createBufferConsumer());
 		subpartition.add(createBufferBuilder().createBufferConsumer());
 		assertNull(readView.getNextBuffer());
+	}
+
+	@Test
+	public void testRelease() {
+		readView.releaseAllResources();
+		assertFalse(
+			resultPartition.getPartitionManager().getUnreleasedPartitions().contains(resultPartition.getPartitionId()));
 	}
 
 	@Test
@@ -575,5 +579,14 @@ public class PipelinedSubpartitionWithReadViewTest {
 
 	static void assertNoNextBuffer(ResultSubpartitionView readView) throws IOException, InterruptedException {
 		assertNull(readView.getNextBuffer());
+	}
+
+	void setup(ResultPartitionType resultPartitionType) throws IOException {
+		resultPartition = PartitionTestUtils.createPartition(
+			resultPartitionType,
+			NoOpFileChannelManager.INSTANCE,
+			compressionEnabled,
+			BUFFER_SIZE);
+		resultPartition.setup();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Introduce a new ResultPartitionType.PIPELINED_APPROXIMATE for Approximate Local Recovery

## Brief change log

The first two commits belong to another ticket [FLINK-19547], which has already been reviewed.
Please only review the third commit: [FLINK-19632] Introduce a new ResultPartitionType for Approximate Local Recovery #13648

1. a new ResultPartitionType (ResultPartitionType.PIPELINED_APPROXIMATE) and
2. PipelinedApproximateSubpartition and PipelinedApproximateSubpartitionView extending PipelinedSubpartition and PipelinedSubpartitionView respectively.

PipelinedApproximateSubpartition and PipelinedSubpartition are different mainly in three places
- how to release resources when downstream task disconnects to it
- how to create a view
- how to build a buffer when the subpartition is marked as "partial"

## Verifying this change

unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)

