### PR TITLE
[FLINK-19571] Port existing Transformations to the new TransformationTranslator framework

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -54,6 +54,7 @@ import org.apache.flink.streaming.runtime.translators.LegacySinkTransformationTr
 import org.apache.flink.streaming.runtime.translators.LegacySourceTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.MultiInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.OneInputTransformationTranslator;
+import org.apache.flink.streaming.runtime.translators.PartitionTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.SourceTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.TwoInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.UnionTransformationTranslator;
@@ -154,6 +155,7 @@ public class StreamGraphGenerator {
 		tmp.put(LegacySinkTransformation.class, new LegacySinkTransformationTranslator<>());
 		tmp.put(LegacySourceTransformation.class, new LegacySourceTransformationTranslator<>());
 		tmp.put(UnionTransformation.class, new UnionTransformationTranslator<>());
+		tmp.put(PartitionTransformation.class, new PartitionTransformationTranslator<>());
 		translatorMap = Collections.unmodifiableMap(tmp);
 	}
 
@@ -374,8 +376,6 @@ public class StreamGraphGenerator {
 			transformedIds = transformFeedback((FeedbackTransformation<?>) transform);
 		} else if (transform instanceof CoFeedbackTransformation<?>) {
 			transformedIds = transformCoFeedback((CoFeedbackTransformation<?>) transform);
-		} else if (transform instanceof PartitionTransformation<?>) {
-			transformedIds = transformPartition((PartitionTransformation<?>) transform);
 		} else if (transform instanceof SideOutputTransformation<?>) {
 			transformedIds = transformSideOutput((SideOutputTransformation<?>) transform);
 		} else {
@@ -414,30 +414,6 @@ public class StreamGraphGenerator {
 			transform.getManagedMemorySlotScopeUseCases());
 
 		return transformedIds;
-	}
-
-	/**
-	 * Transforms a {@code PartitionTransformation}.
-	 *
-	 * <p>For this we create a virtual node in the {@code StreamGraph} that holds the partition
-	 * property. @see StreamGraphGenerator
-	 */
-	private <T> Collection<Integer> transformPartition(PartitionTransformation<T> partition) {
-		List<Transformation<?>> inputs = partition.getInputs();
-		checkState(inputs.size() == 1);
-		Transformation<?> input = inputs.get(0);
-
-		List<Integer> resultIds = new ArrayList<>();
-
-		Collection<Integer> transformedIds = transform(input);
-		for (Integer transformedId: transformedIds) {
-			int virtualId = Transformation.getNewNodeId();
-			streamGraph.addVirtualPartitionNode(
-					transformedId, virtualId, partition.getPartitioner(), partition.getShuffleMode());
-			resultIds.add(virtualId);
-		}
-
-		return resultIds;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -55,6 +55,7 @@ import org.apache.flink.streaming.runtime.translators.LegacySourceTransformation
 import org.apache.flink.streaming.runtime.translators.MultiInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.OneInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.PartitionTransformationTranslator;
+import org.apache.flink.streaming.runtime.translators.SideOutputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.SourceTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.TwoInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.UnionTransformationTranslator;
@@ -156,6 +157,7 @@ public class StreamGraphGenerator {
 		tmp.put(LegacySourceTransformation.class, new LegacySourceTransformationTranslator<>());
 		tmp.put(UnionTransformation.class, new UnionTransformationTranslator<>());
 		tmp.put(PartitionTransformation.class, new PartitionTransformationTranslator<>());
+		tmp.put(SideOutputTransformation.class, new SideOutputTransformationTranslator<>());
 		translatorMap = Collections.unmodifiableMap(tmp);
 	}
 
@@ -376,8 +378,6 @@ public class StreamGraphGenerator {
 			transformedIds = transformFeedback((FeedbackTransformation<?>) transform);
 		} else if (transform instanceof CoFeedbackTransformation<?>) {
 			transformedIds = transformCoFeedback((CoFeedbackTransformation<?>) transform);
-		} else if (transform instanceof SideOutputTransformation<?>) {
-			transformedIds = transformSideOutput((SideOutputTransformation<?>) transform);
 		} else {
 			throw new IllegalStateException("Unknown transformation: " + transform);
 		}
@@ -414,36 +414,6 @@ public class StreamGraphGenerator {
 			transform.getManagedMemorySlotScopeUseCases());
 
 		return transformedIds;
-	}
-
-	/**
-	 * Transforms a {@code SideOutputTransformation}.
-	 *
-	 * <p>For this we create a virtual node in the {@code StreamGraph} that holds the side-output
-	 * {@link org.apache.flink.util.OutputTag}.
-	 *
-	 * @see org.apache.flink.streaming.api.graph.StreamGraphGenerator
-	 */
-	private <T> Collection<Integer> transformSideOutput(SideOutputTransformation<T> sideOutput) {
-		List<Transformation<?>> inputs = sideOutput.getInputs();
-		checkState(inputs.size() == 1);
-		Transformation<?> input = inputs.get(0);
-
-		Collection<Integer> resultIds = transform(input);
-
-		// the recursive transform might have already transformed this
-		if (alreadyTransformed.containsKey(sideOutput)) {
-			return alreadyTransformed.get(sideOutput);
-		}
-
-		List<Integer> virtualResultIds = new ArrayList<>();
-
-		for (int inputId : resultIds) {
-			int virtualId = Transformation.getNewNodeId();
-			streamGraph.addVirtualSideOutputNode(inputId, virtualId, sideOutput.getOutputTag());
-			virtualResultIds.add(virtualId);
-		}
-		return virtualResultIds;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TransformationTranslator} for the {@link LegacySinkTransformation}.
+ *
+ * @param <IN> The type of the elements that are coming in the {@link LegacySinkTransformation}.
+ */
+@Internal
+public class LegacySinkTransformationTranslator<IN>
+		extends SimpleTransformationTranslator<Object, LegacySinkTransformation<IN>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final LegacySinkTransformation<IN> transformation,
+			final Context context) {
+		final Collection<Integer> ids = translateInternal(transformation, context);
+		boolean isKeyed = transformation.getStateKeySelector() != null;
+		if (isKeyed) {
+			BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+		}
+		return ids;
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final LegacySinkTransformation<IN> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final LegacySinkTransformation<IN> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		final List<Transformation<?>> parentTransformations = transformation.getInputs();
+		checkState(
+				parentTransformations.size() == 1,
+				"Expected exactly one input transformation but found " + parentTransformations.size());
+		final Transformation<?> input = parentTransformations.get(0);
+
+		streamGraph.addSink(
+				transformationId,
+				slotSharingGroup,
+				transformation.getCoLocationGroupKey(),
+				transformation.getOperatorFactory(),
+				input.getOutputType(),
+				null,
+				"Sink: " + transformation.getName());
+
+		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+				? transformation.getParallelism()
+				: executionConfig.getParallelism();
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+
+		for (Integer inputId: context.getStreamNodeIds(input)) {
+			streamGraph.addEdge(inputId, transformationId, 0);
+		}
+
+		if (transformation.getStateKeySelector() != null) {
+			TypeSerializer<?> keySerializer = transformation.getStateKeyType().createSerializer(executionConfig);
+			streamGraph.setOneInputStateKey(transformationId, transformation.getStateKeySelector(), keySerializer);
+		}
+
+		return Collections.emptyList();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySourceTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySourceTransformationTranslator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.operators.InputFormatOperatorFactory;
+import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TransformationTranslator} for the {@link LegacySourceTransformation}.
+ *
+ * @param <OUT> The type of the elements that the {@link LegacySourceTransformation} we
+ *             are translating is producing.
+ */
+@Internal
+public class LegacySourceTransformationTranslator<OUT>
+		extends SimpleTransformationTranslator<OUT, LegacySourceTransformation<OUT>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final LegacySourceTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final LegacySourceTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final LegacySourceTransformation<OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		streamGraph.addLegacySource(
+				transformationId,
+				slotSharingGroup,
+				transformation.getCoLocationGroupKey(),
+				transformation.getOperatorFactory(),
+				null,
+				transformation.getOutputType(),
+				"Source: " + transformation.getName());
+
+		if (transformation.getOperatorFactory() instanceof InputFormatOperatorFactory) {
+			streamGraph.setInputFormat(
+					transformationId,
+					((InputFormatOperatorFactory<OUT>) transformation.getOperatorFactory())
+							.getInputFormat());
+		}
+
+		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+				? transformation.getParallelism()
+				: executionConfig.getParallelism();
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+
+		return Collections.singleton(transformationId);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/PartitionTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/PartitionTransformationTranslator.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TransformationTranslator} for the {@link PartitionTransformation}.
+ *
+ * @param <OUT> The type of the elements that result from the {@code PartitionTransformation} being translated.
+ */
+@Internal
+public class PartitionTransformationTranslator<OUT>
+		extends SimpleTransformationTranslator<OUT, PartitionTransformation<OUT>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final PartitionTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final PartitionTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final PartitionTransformation<OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+
+		final List<Transformation<?>> parentTransformations = transformation.getInputs();
+		checkState(
+				parentTransformations.size() == 1,
+				"Expected exactly one input transformation but found " + parentTransformations.size());
+		final Transformation<?> input = parentTransformations.get(0);
+
+		List<Integer> resultIds = new ArrayList<>();
+
+		for (Integer inputId: context.getStreamNodeIds(input)) {
+			final int virtualId = Transformation.getNewNodeId();
+			streamGraph.addVirtualPartitionNode(
+					inputId,
+					virtualId,
+					transformation.getPartitioner(),
+					transformation.getShuffleMode());
+			resultIds.add(virtualId);
+		}
+		return resultIds;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SideOutputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SideOutputTransformationTranslator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TransformationTranslator} for the {@link SideOutputTransformation}.
+ *
+ * @param <OUT> The type of the elements that result from the {@code SideOutputTransformation} being translated.
+ */
+@Internal
+public class SideOutputTransformationTranslator<OUT>
+		extends SimpleTransformationTranslator<OUT, SideOutputTransformation<OUT>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final SideOutputTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final SideOutputTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final SideOutputTransformation<OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final List<Transformation<?>> parentTransformations = transformation.getInputs();
+		checkState(
+				parentTransformations.size() == 1,
+				"Expected exactly one input transformation but found " + parentTransformations.size());
+
+		final List<Integer> virtualResultIds = new ArrayList<>();
+		final Transformation<?> parentTransformation = parentTransformations.get(0);
+		for (int inputId : context.getStreamNodeIds(parentTransformation)) {
+			final int virtualId = Transformation.getNewNodeId();
+			streamGraph.addVirtualSideOutputNode(inputId, virtualId, transformation.getOutputTag());
+			virtualResultIds.add(virtualId);
+		}
+		return virtualResultIds;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SourceTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SourceTransformationTranslator.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TransformationTranslator} for the {@link SourceTransformation}.
+ *
+ * @param <OUT> The type of the elements that this source produces.
+ */
+@Internal
+public class SourceTransformationTranslator<OUT>
+		extends SimpleTransformationTranslator<OUT, SourceTransformation<OUT>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final SourceTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final SourceTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final SourceTransformation<OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		streamGraph.addSource(
+				transformationId,
+				slotSharingGroup,
+				transformation.getCoLocationGroupKey(),
+				transformation.getOperatorFactory(),
+				null,
+				transformation.getOutputType(),
+				"Source: " + transformation.getName());
+
+		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+				? transformation.getParallelism()
+				: executionConfig.getParallelism();
+
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+		return Collections.singleton(transformationId);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/UnionTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/UnionTransformationTranslator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.UnionTransformation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TransformationTranslator} for the {@link UnionTransformation}.
+ *
+ * @param <OUT> The type of the elements that result from the {@link UnionTransformation} being translated.
+ */
+@Internal
+public class UnionTransformationTranslator<OUT>
+		extends SimpleTransformationTranslator<OUT, UnionTransformation<OUT>> {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final UnionTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final UnionTransformation<OUT> transformation,
+			final Context context) {
+		return translateInternal(transformation, context);
+	}
+
+	private Collection<Integer> translateInternal(
+			final UnionTransformation<OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final List<Integer> resultIds = new ArrayList<>();
+		for (Transformation<?> input: transformation.getInputs()) {
+			resultIds.addAll(context.getStreamNodeIds(input));
+		}
+		return resultIds;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `StreamGraphGenerator` is responsible for:
1. traversing the graph of `Transformations`
2. translating them to their runtime implementations

With the addition of the `TransformationTranslator` framework in [FLINK-19485](https://issues.apache.org/jira/browse/FLINK-19485), we can now pull the translation logic out of the `StreamGraphGenerator` and put it into dedicated translators, one for each type of transformation.

This PR does so for the:

* SideOutputTransformation
* PartitionTransformation 
* UnionTransformation 
* LegacySourceTransformation 
* LegacySinkTransformation 
* SourceTransformation

## Brief change log

The changes are in the `StreamGraphGenerator` and the individual `TransformationTranslator` 's.

## Verifying this change

This change is a (big) code cleanup and does not introduce any new features, so it is expected to be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
