### PR TITLE
[FLINK-19649][sql-parser] Fix unparse method of sql create table. Keep syntax the same for tables without columns

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
@@ -265,24 +265,26 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 			writer.keyword("IF NOT EXISTS");
 		}
 		tableName.unparse(writer, leftPrec, rightPrec);
-		SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.create("sds"), "(", ")");
-		for (SqlNode column : columnList) {
-			printIndent(writer);
-			column.unparse(writer, leftPrec, rightPrec);
-		}
-		if (tableConstraints.size() > 0) {
-			for (SqlTableConstraint constraint : tableConstraints) {
+		if (columnList.size() > 0) {
+			SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.create("sds"), "(", ")");
+			for (SqlNode column : columnList) {
 				printIndent(writer);
-				constraint.unparse(writer, leftPrec, rightPrec);
+				column.unparse(writer, leftPrec, rightPrec);
 			}
-		}
-		if (watermark != null) {
-			printIndent(writer);
-			watermark.unparse(writer, leftPrec, rightPrec);
-		}
+			if (tableConstraints.size() > 0) {
+				for (SqlTableConstraint constraint : tableConstraints) {
+					printIndent(writer);
+					constraint.unparse(writer, leftPrec, rightPrec);
+				}
+			}
+			if (watermark != null) {
+				printIndent(writer);
+				watermark.unparse(writer, leftPrec, rightPrec);
+			}
 
-		writer.newlineAndIndent();
-		writer.endList(frame);
+			writer.newlineAndIndent();
+			writer.endList(frame);
+		}
 
 		if (comment != null) {
 			writer.newlineAndIndent();

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -784,6 +784,19 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testCreateTableWithNoColumns() {
+		final String sql = "create table source_table with (\n" +
+				"  'x' = 'y',\n" +
+				"  'abc' = 'def'\n" +
+				")";
+		final String expected = "CREATE TABLE `SOURCE_TABLE` WITH (\n" +
+				"  'x' = 'y',\n" +
+				"  'abc' = 'def'\n" +
+				")";
+		sql(sql).ok(expected);
+	}
+
+	@Test
 	public void testDropTable() {
 		final String sql = "DROP table catalog1.db1.tbl1";
 		final String expected = "DROP TABLE `CATALOG1`.`DB1`.`TBL1`";


### PR DESCRIPTION
## What is the purpose of the change

In Flink's module flink-sql-parser, the sqlCreateTable.class unparse method the create table statement does not match the new rules of the print connector.

The print connector supports this:

`CREATE TABLE table_print WITH ('connector' = 'print') LIKE table (EXCLUDING ALL)`

When a print table is created without any columns, the parentheses must be omitted.

However, the unparse generated statements in SqlCreateTable contain parentheses. This will affect the SqlCreateTable.toString() ,SqlCreateTable.toSqlString() methods.

`
CREATE TABLE table_print() WITH ('connector' = 'print') LIKE table (EXCLUDING ALL)  `

Might need to add the following to the unparse method for columnList.size > 0.

## Brief change log

- Add the following to the unparse method for columnList.size > 0.
- Add unit tests to unparse methods to create tables without columns.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / **no**)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
- The serializers: (yes / **no** / don't know)
- The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
- The S3 file system connector: (yes / **no** / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)