### PR TITLE
[FLINK-17528][table] Remove RowData#get() and ArrayData#get() and use FieldGetter and ElementGetter instead

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcRowDataInputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcRowDataInputFormatTest.java
@@ -283,10 +283,11 @@ public class JdbcRowDataInputFormatTest extends JdbcDataTestBase {
 
 		RowData row = new GenericRowData(5);
 		inputFormat.open(split);
+		RowData.FieldGetter idFieldGetter = RowData.createFieldGetter(new IntType(), 0);
 		while (!inputFormat.reachedEnd()) {
 			row = inputFormat.nextRecord(row);
 
-			int id = ((int) RowData.get(row, 0, new IntType()));
+			int id = (int) idFieldGetter.getFieldOrNull(row);
 			int testDataIndex = id - 1001;
 
 			assertEquals(TEST_DATA[testDataIndex], row);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -265,6 +265,10 @@ public class RowDataToJsonConverters implements Serializable {
 			.map(this::createConverter)
 			.toArray(RowDataToJsonConverter[]::new);
 		final int fieldCount = type.getFieldCount();
+		final RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[fieldTypes.length];
+		for (int i = 0; i < fieldCount; i++) {
+			fieldGetters[i] = RowData.createFieldGetter(fieldTypes[i], i);
+		}
 
 		return (mapper, reuse, value) -> {
 			ObjectNode node;
@@ -277,7 +281,7 @@ public class RowDataToJsonConverters implements Serializable {
 			RowData row = (RowData) value;
 			for (int i = 0; i < fieldCount; i++) {
 				String fieldName = fieldNames[i];
-				Object field = RowData.get(row, i, fieldTypes[i]);
+				Object field = fieldGetters[i].getFieldOrNull(row);
 				node.set(fieldName, fieldConverters[i].convert(mapper, node.get(fieldName), field));
 			}
 			return node;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -203,6 +203,7 @@ public class RowDataToJsonConverters implements Serializable {
 	private RowDataToJsonConverter createArrayConverter(ArrayType type) {
 		final LogicalType elementType = type.getElementType();
 		final RowDataToJsonConverter elementConverter = createConverter(elementType);
+		final ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(elementType);
 		return (mapper, reuse, value) -> {
 			ArrayNode node;
 
@@ -217,7 +218,7 @@ public class RowDataToJsonConverters implements Serializable {
 			ArrayData array = (ArrayData) value;
 			int numElements = array.size();
 			for (int i = 0; i < numElements; i++) {
-				Object element = ArrayData.get(array, i, elementType);
+				Object element = elementGetter.getElementOrNull(array, i);
 				node.add(elementConverter.convert(mapper, null, element));
 			}
 
@@ -233,6 +234,7 @@ public class RowDataToJsonConverters implements Serializable {
 					"The type is: " + typeSummary);
 		}
 		final RowDataToJsonConverter valueConverter = createConverter(valueType);
+		final ArrayData.ElementGetter valueGetter = ArrayData.createElementGetter(valueType);
 		return (mapper, reuse, object) -> {
 			ObjectNode node;
 			// reuse could be a NullNode if last record is null.
@@ -248,7 +250,7 @@ public class RowDataToJsonConverters implements Serializable {
 			int numElements = map.size();
 			for (int i = 0; i < numElements; i++) {
 				String fieldName = keyArray.getString(i).toString(); // key must be string
-				Object value = ArrayData.get(valueArray, i, valueType);
+				Object value = valueGetter.getElementOrNull(valueArray, i);
 				node.set(fieldName, valueConverter.convert(mapper, node.get(fieldName), value));
 			}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializer.java
@@ -49,6 +49,8 @@ public class ArrayDataSerializer extends org.apache.flink.table.runtime.typeutil
 
 	private final TypeSerializer elementTypeSerializer;
 
+	private final ArrayData.ElementGetter elementGetter;
+
 	private final int elementSize;
 
 	public ArrayDataSerializer(LogicalType eleType, TypeSerializer elementTypeSerializer) {
@@ -56,6 +58,7 @@ public class ArrayDataSerializer extends org.apache.flink.table.runtime.typeutil
 		this.elementType = eleType;
 		this.elementTypeSerializer = elementTypeSerializer;
 		this.elementSize = BinaryArrayData.calculateFixLengthPartSize(this.elementType);
+		this.elementGetter = ArrayData.createElementGetter(elementType);
 	}
 
 	@Override
@@ -67,7 +70,7 @@ public class ArrayDataSerializer extends org.apache.flink.table.runtime.typeutil
 				target.writeBoolean(false);
 			} else {
 				target.writeBoolean(true);
-				Object element = ArrayData.get(array, i, elementType);
+				Object element = elementGetter.getElementOrNull(array, i);
 				elementTypeSerializer.serialize(element, target);
 			}
 		}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializer.java
@@ -56,6 +56,10 @@ public class MapDataSerializer extends org.apache.flink.table.runtime.typeutils.
 
 	private final TypeSerializer valueTypeSerializer;
 
+	private final ArrayData.ElementGetter keyGetter;
+
+	private final ArrayData.ElementGetter valueGetter;
+
 	private final int keySize;
 
 	private final int valueSize;
@@ -69,6 +73,8 @@ public class MapDataSerializer extends org.apache.flink.table.runtime.typeutils.
 		this.valueTypeSerializer = valueTypeSerializer;
 		this.keySize = BinaryArrayData.calculateFixLengthPartSize(this.keyType);
 		this.valueSize = BinaryArrayData.calculateFixLengthPartSize(this.valueType);
+		this.keyGetter = ArrayData.createElementGetter(keyType);
+		this.valueGetter = ArrayData.createElementGetter(valueType);
 	}
 
 	@Override
@@ -82,13 +88,13 @@ public class MapDataSerializer extends org.apache.flink.table.runtime.typeutils.
 			if (keyArray.isNullAt(i)) {
 				throw new IllegalArgumentException("The key of BinaryMapData must not be null.");
 			}
-			Object key = ArrayData.get(keyArray, i, keyType);
+			Object key = keyGetter.getElementOrNull(keyArray, i);
 			keyTypeSerializer.serialize(key, target);
 			if (valueArray.isNullAt(i)) {
 				target.writeBoolean(true);
 			} else {
 				target.writeBoolean(false);
-				Object value = ArrayData.get(valueArray, i, valueType);
+				Object value = valueGetter.getElementOrNull(valueArray, i);
 				valueTypeSerializer.serialize(value, target);
 			}
 		}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
@@ -20,12 +20,8 @@ package org.apache.flink.table.data;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DistinctType;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampType;
 
 import javax.annotation.Nullable;
 
@@ -164,71 +160,6 @@ public interface ArrayData {
 	// ------------------------------------------------------------------------------------------
 	// Access Utilities
 	// ------------------------------------------------------------------------------------------
-
-	/**
-	 * Returns the element object in the internal array data structure at the given position.
-	 *
-	 * @param array the internal array data
-	 * @param pos position of the element to return
-	 * @param elementType the element type of the array
-	 * @return the element object at the specified position in this array data
-	 * @deprecated Use {@link #createElementGetter(LogicalType)} for avoiding logical types during runtime.
-	 */
-	@Deprecated
-	static Object get(ArrayData array, int pos, LogicalType elementType) {
-		if (array.isNullAt(pos)) {
-			return null;
-		}
-		switch (elementType.getTypeRoot()) {
-			case BOOLEAN:
-				return array.getBoolean(pos);
-			case TINYINT:
-				return array.getByte(pos);
-			case SMALLINT:
-				return array.getShort(pos);
-			case INTEGER:
-			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
-			case INTERVAL_YEAR_MONTH:
-				return array.getInt(pos);
-			case BIGINT:
-			case INTERVAL_DAY_TIME:
-				return array.getLong(pos);
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				TimestampType timestampType = (TimestampType) elementType;
-				return array.getTimestamp(pos, timestampType.getPrecision());
-			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-				LocalZonedTimestampType lzTs = (LocalZonedTimestampType) elementType;
-				return array.getTimestamp(pos, lzTs.getPrecision());
-			case FLOAT:
-				return array.getFloat(pos);
-			case DOUBLE:
-				return array.getDouble(pos);
-			case CHAR:
-			case VARCHAR:
-				return array.getString(pos);
-			case DECIMAL:
-				DecimalType decimalType = (DecimalType) elementType;
-				return array.getDecimal(pos, decimalType.getPrecision(), decimalType.getScale());
-			case ARRAY:
-				return array.getArray(pos);
-			case MAP:
-			case MULTISET:
-				return array.getMap(pos);
-			case ROW:
-				return array.getRow(pos, ((RowType) elementType).getFieldCount());
-			case STRUCTURED_TYPE:
-				// not the most efficient code but ok for a deprecated method
-				return array.getRow(pos, getFieldCount(elementType));
-			case BINARY:
-			case VARBINARY:
-				return array.getBinary(pos);
-			case RAW:
-				return array.getRawValue(pos);
-			default:
-				throw new UnsupportedOperationException("Unsupported type: " + elementType);
-		}
-	}
 
 	/**
 	 * Creates an accessor for getting elements in an internal array data structure at the

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -20,13 +20,10 @@ package org.apache.flink.table.data;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DistinctType;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
-import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.types.RowKind;
 
 import javax.annotation.Nullable;
@@ -229,70 +226,6 @@ public interface RowData {
 	// ------------------------------------------------------------------------------------------
 	// Access Utilities
 	// ------------------------------------------------------------------------------------------
-
-	/**
-	 * Returns the field object in the internal row data structure at the given position.
-	 *
-	 * @param row the internal row data
-	 * @param pos position of the field to return
-	 * @param fieldType the field type
-	 * @return the field object at the specified position in this row data.
-	 * @deprecated Use {@link #createFieldGetter(LogicalType, int)} for avoiding logical types during runtime.
-	 */
-	static Object get(RowData row, int pos, LogicalType fieldType) {
-		if (row.isNullAt(pos)) {
-			return null;
-		}
-		switch (fieldType.getTypeRoot()) {
-			case BOOLEAN:
-				return row.getBoolean(pos);
-			case TINYINT:
-				return row.getByte(pos);
-			case SMALLINT:
-				return row.getShort(pos);
-			case INTEGER:
-			case DATE:
-			case TIME_WITHOUT_TIME_ZONE:
-			case INTERVAL_YEAR_MONTH:
-				return row.getInt(pos);
-			case BIGINT:
-			case INTERVAL_DAY_TIME:
-				return row.getLong(pos);
-			case TIMESTAMP_WITHOUT_TIME_ZONE:
-				TimestampType timestampType = (TimestampType) fieldType;
-				return row.getTimestamp(pos, timestampType.getPrecision());
-			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-				LocalZonedTimestampType lzTs = (LocalZonedTimestampType) fieldType;
-				return row.getTimestamp(pos, lzTs.getPrecision());
-			case FLOAT:
-				return row.getFloat(pos);
-			case DOUBLE:
-				return row.getDouble(pos);
-			case CHAR:
-			case VARCHAR:
-				return row.getString(pos);
-			case DECIMAL:
-				DecimalType decimalType = (DecimalType) fieldType;
-				return row.getDecimal(pos, decimalType.getPrecision(), decimalType.getScale());
-			case ARRAY:
-				return row.getArray(pos);
-			case MAP:
-			case MULTISET:
-				return row.getMap(pos);
-			case ROW:
-				return row.getRow(pos, ((RowType) fieldType).getFieldCount());
-			case STRUCTURED_TYPE:
-				// not the most efficient code but ok for a deprecated method
-				return row.getRow(pos, getFieldCount(fieldType));
-			case BINARY:
-			case VARBINARY:
-				return row.getBinary(pos);
-			case RAW:
-				return row.getRawValue(pos);
-			default:
-				throw new UnsupportedOperationException("Unsupported type: " + fieldType);
-		}
-	}
 
 	/**
 	 * Creates an accessor for getting elements in an internal row data structure at the

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
@@ -504,10 +504,11 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
 	@SuppressWarnings("unchecked")
 	public <T> T[] toObjectArray(LogicalType elementType) {
 		Class<T> elementClass = (Class<T>) LogicalTypeUtils.toInternalConversionClass(elementType);
+		ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(elementType);
 		T[] values = (T[]) Array.newInstance(elementClass, size);
 		for (int i = 0; i < size; i++) {
 			if (!isNullAt(i)) {
-				values[i] = (T) ArrayData.get(this, i, elementType);
+				values[i] = (T) elementGetter.getElementOrNull(this, i);
 			}
 		}
 		return values;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
@@ -490,11 +490,12 @@ public class SortCodeGeneratorTest {
 				boolean order = orders[i];
 				Object first = null;
 				Object second = null;
+				RowData.FieldGetter fieldGetter = RowData.createFieldGetter(keyTypes[i], keys[i]);
 				if (!o1.isNullAt(keys[i])) {
-					first = RowData.get(o1, keys[i], keyTypes[i]);
+					first = fieldGetter.getFieldOrNull(o1);
 				}
 				if (!o2.isNullAt(keys[i])) {
-					second = RowData.get(o2, keys[i], keyTypes[i]);
+					second = fieldGetter.getFieldOrNull(o2);
 				}
 
 				if (first != null || second != null) {
@@ -585,8 +586,9 @@ public class SortCodeGeneratorTest {
 				boolean isNull2 = result.get(i).isNullAt(keys[j]);
 				Assert.assertEquals(msg, isNull1, isNull2);
 				if (!isNull1 || !isNull2) {
-					Object o1 = RowData.get(data.get(i), keys[j], keyTypes[j]);
-					Object o2 = RowData.get(result.get(i), keys[j], keyTypes[j]);
+					RowData.FieldGetter fieldGetter = RowData.createFieldGetter(keyTypes[j], keys[j]);
+					Object o1 = fieldGetter.getFieldOrNull(data.get(i));
+					Object o2 = fieldGetter.getFieldOrNull(result.get(i));
 					if (keyTypes[j] instanceof VarBinaryType) {
 						Assert.assertArrayEquals(msg, (byte[]) o1, (byte[]) o2);
 					} else if (keyTypes[j] instanceof TypeInformationRawType) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
@@ -25,12 +25,13 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.runtime.tasks.{OneInputStreamTask, OneInputStreamTaskTestHarness}
 import org.apache.flink.table.data.{GenericRowData, RowData, StringData}
 import org.apache.flink.table.planner.codegen.agg.AggTestBase
-import org.apache.flink.table.planner.utils.RowDataTestUtil
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.flink.table.runtime.util.RowDataTestUtil
 import org.apache.flink.table.types.logical._
 import org.apache.flink.util.function.FunctionWithException
 import org.junit.Assert
+
 import java.util
 
 import scala.collection.JavaConverters._

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
@@ -35,16 +35,16 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 import org.apache.flink.table.planner.runtime.utils.BatchAbstractTestBase.DEFAULT_PARALLELISM
-import org.apache.flink.table.planner.utils.{RowDataTestUtil, TableTestUtil, TestingTableEnvironment}
+import org.apache.flink.table.planner.utils.{TableTestUtil, TestingTableEnvironment}
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.{BigIntType, LogicalType}
 import org.apache.flink.types.Row
 import org.apache.flink.util.CollectionUtil
-
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.runtime.CalciteContextException
 import org.apache.calcite.sql.SqlExplainLevel
 import org.apache.calcite.sql.parser.SqlParseException
+import org.apache.flink.table.runtime.util.RowDataTestUtil
 import org.junit.Assert._
 import org.junit.{After, Assert, Before}
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
@@ -32,9 +32,9 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.data.util.DataFormatConverters
 import org.apache.flink.table.data.{GenericRowData, RowData}
-import org.apache.flink.table.planner.utils.RowDataTestUtil
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.flink.table.runtime.util.RowDataTestUtil
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.types.Row

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/util/MapDataUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/util/MapDataUtil.java
@@ -39,9 +39,11 @@ public final class MapDataUtil {
 		ArrayData keyArray = map.keyArray();
 		ArrayData valueArray = map.valueArray();
 		Map<Object, Object> javaMap = new HashMap<>();
+		ArrayData.ElementGetter keyGetter = ArrayData.createElementGetter(keyType);
+		ArrayData.ElementGetter valueGetter = ArrayData.createElementGetter(valueType);
 		for (int i = 0; i < map.size(); i++) {
-			Object key = ArrayData.get(keyArray, i, keyType);
-			Object value = ArrayData.get(valueArray, i, valueType);
+			Object key = keyGetter.getElementOrNull(keyArray, i);
+			Object value = valueGetter.getElementOrNull(valueArray, i);
 			javaMap.put(key, value);
 		}
 		return javaMap;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/util/RowDataUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/util/RowDataUtil.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.table.data.util;
 
-import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.RowKind;
 
 /**
@@ -44,24 +42,5 @@ public final class RowDataUtil {
 	public static boolean isRetractMsg(RowData row) {
 		RowKind kind = row.getRowKind();
 		return kind == RowKind.UPDATE_BEFORE || kind == RowKind.DELETE;
-	}
-
-	public static GenericRowData toGenericRow(
-			RowData row,
-			LogicalType[] types) {
-		if (row instanceof GenericRowData) {
-			return (GenericRowData) row;
-		} else {
-			GenericRowData newRow = new GenericRowData(row.getArity());
-			newRow.setRowKind(row.getRowKind());
-			for (int i = 0; i < row.getArity(); i++) {
-				if (row.isNullAt(i)) {
-					newRow.setField(i, null);
-				} else {
-					newRow.setField(i, RowData.get(row, i, types[i]));
-				}
-			}
-			return newRow;
-		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/RowDataPartitionComputer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/RowDataPartitionComputer.java
@@ -42,9 +42,11 @@ public class RowDataPartitionComputer implements PartitionComputer<RowData> {
 	protected final String[] partitionColumns;
 	protected final int[] partitionIndexes;
 	protected final LogicalType[] partitionTypes;
+	protected final RowData.FieldGetter[] partitionFieldGetters;
 
 	private final int[] nonPartitionIndexes;
 	private final LogicalType[] nonPartitionTypes;
+	protected final RowData.FieldGetter[] nonPartitionFieldGetters;
 
 	private transient GenericRowData reuseRow;
 
@@ -67,6 +69,9 @@ public class RowDataPartitionComputer implements PartitionComputer<RowData> {
 		this.partitionTypes = Arrays.stream(partitionIndexes)
 				.mapToObj(columnTypeList::get)
 				.toArray(LogicalType[]::new);
+		this.partitionFieldGetters = IntStream.range(0, partitionTypes.length)
+			.mapToObj(i -> RowData.createFieldGetter(partitionTypes[i], partitionIndexes[i]))
+			.toArray(RowData.FieldGetter[]::new);
 
 		List<Integer> partitionIndexList = Arrays.stream(partitionIndexes).boxed().collect(Collectors.toList());
 		this.nonPartitionIndexes = IntStream.range(0, columnNames.length)
@@ -75,6 +80,9 @@ public class RowDataPartitionComputer implements PartitionComputer<RowData> {
 		this.nonPartitionTypes = Arrays.stream(nonPartitionIndexes)
 				.mapToObj(columnTypeList::get)
 				.toArray(LogicalType[]::new);
+		this.nonPartitionFieldGetters = IntStream.range(0, nonPartitionTypes.length)
+			.mapToObj(i -> RowData.createFieldGetter(nonPartitionTypes[i], nonPartitionIndexes[i]))
+			.toArray(RowData.FieldGetter[]::new);
 	}
 
 	@Override
@@ -82,7 +90,7 @@ public class RowDataPartitionComputer implements PartitionComputer<RowData> {
 		LinkedHashMap<String, String> partSpec = new LinkedHashMap<>();
 
 		for (int i = 0; i < partitionIndexes.length; i++) {
-			Object field = RowData.get(in, partitionIndexes[i], partitionTypes[i]);
+			Object field = partitionFieldGetters[i].getFieldOrNull(in);
 			String partitionValue = field != null ? field.toString() : null;
 			if (partitionValue == null || "".equals(partitionValue)) {
 				partitionValue = defaultPartValue;
@@ -103,8 +111,7 @@ public class RowDataPartitionComputer implements PartitionComputer<RowData> {
 		}
 
 		for (int i = 0; i < nonPartitionIndexes.length; i++) {
-			reuseRow.setField(i, RowData.get(
-					in, nonPartitionIndexes[i], nonPartitionTypes[i]));
+			reuseRow.setField(i, nonPartitionFieldGetters[i].getFieldOrNull(in));
 		}
 		return reuseRow;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
@@ -53,26 +53,31 @@ public class MapDataSerializer extends TypeSerializer<MapData> {
 	private final TypeSerializer keySerializer;
 	private final TypeSerializer valueSerializer;
 
+	private final ArrayData.ElementGetter keyGetter;
+	private final ArrayData.ElementGetter valueGetter;
+
 	private transient BinaryArrayData reuseKeyArray;
 	private transient BinaryArrayData reuseValueArray;
 	private transient BinaryArrayWriter reuseKeyWriter;
 	private transient BinaryArrayWriter reuseValueWriter;
 
 	public MapDataSerializer(LogicalType keyType, LogicalType valueType) {
-		this.keyType = keyType;
-		this.valueType = valueType;
-
-		this.keySerializer = InternalSerializers.create(keyType);
-		this.valueSerializer = InternalSerializers.create(valueType);
+		this(keyType, valueType, InternalSerializers.create(keyType), InternalSerializers.create(valueType));
 	}
 
 	private MapDataSerializer(
-		LogicalType keyType, LogicalType valueType, TypeSerializer keySerializer, TypeSerializer valueSerializer) {
+			LogicalType keyType,
+			LogicalType valueType,
+			TypeSerializer keySerializer,
+			TypeSerializer valueSerializer) {
 		this.keyType = keyType;
 		this.valueType = valueType;
 
 		this.keySerializer = keySerializer;
 		this.valueSerializer = valueSerializer;
+
+		this.keyGetter = ArrayData.createElementGetter(keyType);
+		this.valueGetter = ArrayData.createElementGetter(valueType);
 	}
 
 	@Override
@@ -148,8 +153,8 @@ public class MapDataSerializer extends TypeSerializer<MapData> {
 		ArrayData keyArray = from.keyArray();
 		ArrayData valueArray = from.valueArray();
 		for (int i = 0; i < from.size(); i++) {
-			Object key = ArrayData.get(keyArray, i, keyType);
-			Object value = ArrayData.get(valueArray, i, valueType);
+			Object key = keyGetter.getElementOrNull(keyArray, i);
+			Object value = valueGetter.getElementOrNull(valueArray, i);
 			if (key == null) {
 				reuseKeyWriter.setNullAt(i, keyType);
 			} else {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/util/DataFormatTestUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/util/DataFormatTestUtil.java
@@ -47,7 +47,8 @@ public class DataFormatTestUtil {
 			if (row.isNullAt(i)) {
 				build.append("null");
 			} else {
-				build.append(RowData.get(row, i, types[i]));
+				RowData.FieldGetter fieldGetter = RowData.createFieldGetter(types[i], i);
+				build.append(fieldGetter.getFieldOrNull(row));
 			}
 		}
 		build.append(')');

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.JoinedRowData;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.util.RowDataUtil;
 import org.apache.flink.table.runtime.dataview.StateDataViewStore;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
@@ -43,6 +42,7 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
 import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.runtime.util.RowDataTestUtil;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -1591,8 +1591,8 @@ public class WindowOperatorTest {
 
 		@Override
 		public boolean equals(RowData row1, RowData row2) {
-			GenericRowData left = RowDataUtil.toGenericRow(row1, fieldTypes);
-			GenericRowData right = RowDataUtil.toGenericRow(row2, fieldTypes);
+			GenericRowData left = RowDataTestUtil.toGenericRowDeeply(row1, fieldTypes);
+			GenericRowData right = RowDataTestUtil.toGenericRowDeeply(row2, fieldTypes);
 			return left.equals(right);
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BinaryRowDataKeySelector.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BinaryRowDataKeySelector.java
@@ -39,15 +39,18 @@ public class BinaryRowDataKeySelector implements RowDataKeySelector {
 	private final LogicalType[] inputFieldTypes;
 	private final LogicalType[] keyFieldTypes;
 	private final TypeSerializer[] keySers;
+	private final RowData.FieldGetter[] fieldGetters;
 
 	public BinaryRowDataKeySelector(int[] keyFields, LogicalType[] inputFieldTypes) {
 		this.keyFields = keyFields;
 		this.inputFieldTypes = inputFieldTypes;
 		this.keyFieldTypes = new LogicalType[keyFields.length];
 		this.keySers = new TypeSerializer[keyFields.length];
+		this.fieldGetters = new RowData.FieldGetter[keyFields.length];
 		for (int i = 0; i < keyFields.length; ++i) {
 			keyFieldTypes[i] = inputFieldTypes[keyFields[i]];
 			keySers[i] = InternalSerializers.create(keyFieldTypes[i]);
+			fieldGetters[i] = RowData.createFieldGetter(inputFieldTypes[keyFields[i]], keyFields[i]);
 		}
 	}
 
@@ -62,7 +65,7 @@ public class BinaryRowDataKeySelector implements RowDataKeySelector {
 				BinaryWriter.write(
 						writer,
 						i,
-						RowData.get(value, keyFields[i], inputFieldTypes[keyFields[i]]),
+						fieldGetters[i].getFieldOrNull(value),
 						inputFieldTypes[keyFields[i]],
 						keySers[i]);
 			}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/GenericRowRecordSortComparator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/GenericRowRecordSortComparator.java
@@ -34,12 +34,10 @@ public class GenericRowRecordSortComparator implements Comparator<GenericRowData
 
 	private static final long serialVersionUID = -4988371592272863772L;
 
-	private final int sortKeyIdx;
-	private final LogicalType sortKeyType;
+	private final RowData.FieldGetter sortKeyGetter;
 
 	public GenericRowRecordSortComparator(int sortKeyIdx, LogicalType sortKeyType) {
-		this.sortKeyIdx = sortKeyIdx;
-		this.sortKeyType = sortKeyType;
+		this.sortKeyGetter = RowData.createFieldGetter(sortKeyType, sortKeyIdx);
 	}
 
 	@Override
@@ -49,8 +47,8 @@ public class GenericRowRecordSortComparator implements Comparator<GenericRowData
 		if (kind1 != kind2) {
 			return kind1.toByteValue() - kind2.toByteValue();
 		} else {
-			Object key1 = RowData.get(row1, sortKeyIdx, sortKeyType);
-			Object key2 = RowData.get(row2, sortKeyIdx, sortKeyType);
+			Object key1 = sortKeyGetter.getFieldOrNull(row1);
+			Object key2 = sortKeyGetter.getFieldOrNull(row2);
 			if (key1 instanceof Comparable) {
 				return ((Comparable) key1).compareTo(key2);
 			} else {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/RowDataHarnessAssertor.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/RowDataHarnessAssertor.java
@@ -22,7 +22,6 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.util.RowDataUtil;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Preconditions;
 
@@ -106,7 +105,7 @@ public class RowDataHarnessAssertor {
 				if (row instanceof GenericRowData) {
 					expectedRecords.add((GenericRowData) row);
 				} else {
-					GenericRowData genericRow = RowDataUtil.toGenericRow(
+					GenericRowData genericRow = RowDataTestUtil.toGenericRowDeeply(
 						row,
 						types);
 					expectedRecords.add(genericRow);
@@ -118,7 +117,7 @@ public class RowDataHarnessAssertor {
 			if (act instanceof StreamRecord) {
 				RowData actualOutput = (RowData) ((StreamRecord) act).getValue();
 				// joined row can't equals to generic row, so cast joined row to generic row first
-				GenericRowData actualRow = RowDataUtil.toGenericRow(
+				GenericRowData actualRow = RowDataTestUtil.toGenericRowDeeply(
 						actualOutput,
 						types);
 				actualRecords.add(actualRow);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/RowDataTestUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/RowDataTestUtil.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.utils;
+package org.apache.flink.table.runtime.util;
 
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -89,7 +89,8 @@ public class RowDataTestUtil {
 					row.setField(i, null);
 				} else {
 					LogicalType type = types.get(i);
-					Object o = RowData.get(rowData, i, type);
+					RowData.FieldGetter fieldGetter = RowData.createFieldGetter(type, i);
+					Object o = fieldGetter.getFieldOrNull(rowData);
 					if (type instanceof RowType) {
 						o = toGenericRowDeeply((RowData) o, type.getChildren());
 					}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, we are using utility `RowData#get(RowData, int, LogicalType)` and `ArrayData#get(ArrayData, int, LogicalType)` to get the field/element objects. They have been deprecated since 1.11, we should replace them by `RowData#FieldGetter` and `ArrayData#ElementGetter`.

## Brief change log

- Use `RowData#FieldGetter` and `ArrayData#ElementGetter` to replace `RowData#get(..)` and `ArrayData#get(..)`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
