### PR TITLE
[FLINK-19658][e2e] Fix failing Local recovery and sticky scheduling test

### DIFF
--- a/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/src/main/java/org/apache/flink/streaming/tests/StickyAllocationAndLocalRecoveryTestJob.java
+++ b/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/src/main/java/org/apache/flink/streaming/tests/StickyAllocationAndLocalRecoveryTestJob.java
@@ -314,6 +314,8 @@ public class StickyAllocationAndLocalRecoveryTestJob {
 
 			StreamingRuntimeContext runtimeContext = (StreamingRuntimeContext) getRuntimeContext();
 			String allocationID = runtimeContext.getAllocationIDAsString();
+			// Pattern of the name: "Flat Map -> Sink: Unnamed (4/4)#0". Remove "#0" part:
+			String taskNameWithSubtasks = runtimeContext.getTaskNameWithSubtasks().split("#")[0];
 
 			final int thisJvmPid = getJvmPid();
 			final Set<Integer> killedJvmPids = new HashSet<>();
@@ -321,7 +323,6 @@ public class StickyAllocationAndLocalRecoveryTestJob {
 			// here we check if the sticky scheduling worked as expected
 			if (functionInitializationContext.isRestored()) {
 				Iterable<MapperSchedulingAndFailureInfo> iterable = schedulingAndFailureState.get();
-				String taskNameWithSubtasks = runtimeContext.getTaskNameWithSubtasks();
 
 				MapperSchedulingAndFailureInfo infoForThisTask = null;
 				List<MapperSchedulingAndFailureInfo> completeInfo = new ArrayList<>();
@@ -347,7 +348,7 @@ public class StickyAllocationAndLocalRecoveryTestJob {
 						"Sticky allocation test failed: Subtask %s in attempt %d was rescheduled from allocation %s " +
 							"on JVM with PID %d to unexpected allocation %s on JVM with PID %d.\n" +
 							"Complete information from before the crash: %s.",
-						runtimeContext.getTaskNameWithSubtasks(),
+						taskNameWithSubtasks,
 						runtimeContext.getAttemptNumber(),
 						infoForThisTask.allocationId,
 						infoForThisTask.jvmPid,
@@ -365,7 +366,7 @@ public class StickyAllocationAndLocalRecoveryTestJob {
 				failingTask,
 				failingTask && killTaskOnFailure,
 				thisJvmPid,
-				runtimeContext.getTaskNameWithSubtasks(),
+				taskNameWithSubtasks,
 				allocationID);
 
 			schedulingAndFailureState.clear();

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -227,12 +227,12 @@ fi
 # Sticky Scheduling
 ################################################################################
 
-#run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false false" "skip_check_exceptions"
-#run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false true" "skip_check_exceptions"
-#run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false false" "skip_check_exceptions"
-#run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true false" "skip_check_exceptions"
-#run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false true" "skip_check_exceptions"
-#run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true true" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false false" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false true" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false false" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true false" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false true" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true true" "skip_check_exceptions"
 
 printf "\n[PASS] All bash e2e-tests passed\n"
 

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -110,6 +110,6 @@ function run_local_recovery_test {
 
 ## MAIN
 trap cleanup_after_test_and_exit_fail EXIT
-run_local_recovery_test "$@"
+run_test_with_timeout 600 run_local_recovery_test "$@"
 trap - EXIT
 exit 0


### PR DESCRIPTION
## What is the purpose of the change

FLINK-16620 introduced a new naming scheme for tasks, whilst this e2e test was relying on the taskname to be constant across different attempts.


## Brief change log

- Remove attempt number from task name
- change the test to fail after a timeout (with logs)

## Verifying this change

Covered by CI


