### PR TITLE
[FLINK-19583] Expose the execution.runtime-mode to users

### DIFF
--- a/docs/_includes/generated/execution_configuration.html
+++ b/docs/_includes/generated/execution_configuration.html
@@ -20,5 +20,11 @@
             <td>Boolean</td>
             <td>Tells if we should use compression for the state snapshot data or not</td>
         </tr>
+        <tr>
+            <td><h5>execution.runtime-mode</h5></td>
+            <td style="word-wrap: break-word;">STREAMING</td>
+            <td><p>Enum</p>Possible values: [STREAMING, BATCH, AUTOMATIC]</td>
+            <td>Runtime execution mode of DataStream programs. Among other things, this controls task scheduling, network shuffle behavior, and time semantics.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/api/common/RuntimeExecutionMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/RuntimeExecutionMode.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api;
+package org.apache.flink.api.common;
 
 import org.apache.flink.annotation.Internal;
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -20,6 +20,7 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
@@ -30,6 +31,13 @@ import java.time.Duration;
  */
 @PublicEvolving
 public class ExecutionOptions {
+
+	public static final ConfigOption<RuntimeExecutionMode> RUNTIME_MODE =
+			ConfigOptions.key("execution.runtime-mode")
+					.enumType(RuntimeExecutionMode.class)
+					.defaultValue(RuntimeExecutionMode.STREAMING)
+					.withDescription("Runtime execution mode of DataStream programs. Among other things, " +
+							"this controls task scheduling, network shuffle behavior, and time semantics.");
 
 	/**
 	 * Should be moved to {@code ExecutionCheckpointingOptions} along with

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.streaming.api.graph;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
-import org.apache.flink.streaming.api.RuntimeExecutionMode;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.MultipleConnectedStreams;


### PR DESCRIPTION
## What is the purpose of the change

As part of [FLIP-134](https://cwiki.apache.org/confluence/display/FLINK/FLIP-134%3A+Batch+execution+for+the+DataStream+API), this PR exposes the `execution.runtime-mode` to the users. This options allows users to specify, among other things, the task scheduling, network shuffle behaviour, and the time semantics.

In addition now we throw an `IllegalArgumentException` when we detect that the user has requested `BATCH` execution with an unbounded source.

## Brief change log

The changes are in the `StreamExecutionEnvironment` and the `StreamGraphGenerator`.

## Verifying this change

 *Added tests in the `StreamGraphGeneratorExecutionModeDetectionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
