### PR TITLE
[FLINK-19669][coordination] PipelinedRegionSchedulingStrategy#init ResultPartitionType blocking check use isBlocking method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.scheduler.DeploymentOption;
@@ -70,7 +69,7 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 	private void init() {
 		for (SchedulingPipelinedRegion region : schedulingTopology.getAllPipelinedRegions()) {
 			for (SchedulingResultPartition partition : region.getConsumedResults()) {
-				checkState(partition.getResultType() == ResultPartitionType.BLOCKING);
+				checkState(partition.getResultType().isBlocking());
 
 				partitionConsumerRegions.computeIfAbsent(partition.getId(), pid -> new HashSet<>()).add(region);
 				correlatedResultPartitions.computeIfAbsent(partition.getResultId(), rid -> new HashSet<>()).add(partition);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategyTest.java
@@ -129,6 +129,25 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
 		assertLatestScheduledVerticesAreEqualTo(expectedScheduledVertices);
 	}
 
+	@Test
+	public void testSchedulingTopologyWithPersistentBlockingEdges() {
+		final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+		final List<TestingSchedulingExecutionVertex> v1 = topology.addExecutionVertices().withParallelism(1).finish();
+		final List<TestingSchedulingExecutionVertex> v2 = topology.addExecutionVertices().withParallelism(1).finish();
+
+		topology.connectPointwise(v1, v2)
+			.withResultPartitionState(ResultPartitionState.CREATED)
+			.withResultPartitionType(ResultPartitionType.BLOCKING_PERSISTENT)
+			.finish();
+
+		startScheduling(topology);
+
+		final List<List<TestingSchedulingExecutionVertex>> expectedScheduledVertices = new ArrayList<>();
+		expectedScheduledVertices.add(Arrays.asList(v1.get(0)));
+		assertLatestScheduledVerticesAreEqualTo(expectedScheduledVertices);
+	}
+
 	private PipelinedRegionSchedulingStrategy startScheduling(TestingSchedulingTopology testingSchedulingTopology) {
 		final PipelinedRegionSchedulingStrategy schedulingStrategy = new PipelinedRegionSchedulingStrategy(
 			testingSchedulerOperation,


### PR DESCRIPTION
PipelinedRegionSchedulingStrategy#init ResultPartitionType blocking check should use isBlocking method instead of checking of the enum type.
