### PR TITLE
[FLINK-19654][python][e2e] Change Dependency of scipy Module to pytest

### DIFF
--- a/flink-end-to-end-tests/flink-python-test/python/add_one.py
+++ b/flink-end-to-end-tests/flink-python-test/python/add_one.py
@@ -21,5 +21,5 @@ from pyflink.table.udf import udf
 
 @udf(input_types=[DataTypes.BIGINT()], result_type=DataTypes.BIGINT())
 def add_one(i):
-    from scipy.special import jv
-    return i + int(jv([0], [0])[0])
+    import pytest
+    return i + 1

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -108,7 +108,7 @@ echo "Test PyFlink Table job:"
 FLINK_PYTHON_TEST_DIR=`cd "${CURRENT_DIR}/../flink-python-test" && pwd -P`
 REQUIREMENTS_PATH="${TEST_DATA_DIR}/requirements.txt"
 
-echo "scipy==1.4.1" > "${REQUIREMENTS_PATH}"
+echo "pytest==4.4.1" > "${REQUIREMENTS_PATH}"
 
 echo "Test submitting python job with 'pipeline.jars':\n"
 PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will change dependency of scipy module to pytest because scipy package is too big to download*


## Brief change log

  - *Change dependency of scipy module to pytest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
