### PR TITLE
[FLINK-13553] Ignore KvStateServerHandlerTest because it is unstable

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
@@ -65,6 +65,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFra
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -79,6 +80,9 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for {@link KvStateServerHandler}.
  */
+@Ignore("KvStateServerHandlerTest is unstable. See FLINK-13553 for more information. Since the community "
+		+ "does not have time to work on QS, we decided to temporarily ignore this test case in order"
+		+ "to maintain build stability.")
 public class KvStateServerHandlerTest extends TestLogger {
 
 	private static KvStateServerImpl testServer;

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -69,11 +69,6 @@ logger.zkclient.appenderRef.out.ref = ConsoleAppender
 logger.consumer.name = org.apache.flink.streaming.connectors.kafka.internals.SimpleConsumerThread
 logger.consumer.level = OFF
 
-# Enable TRACE logging to debug FLINK-13553
-logger.queryablestate.name = org.apache.flink.queryablestate
-logger.queryablestate.level = TRACE
-logger.queryablestate.appenderRef.out.ref = ConsoleAppender
-
 # Enable TRACE logging for the sources to debug FLINK-19448
 logger.sources.name = org.apache.flink.connector.base.source.reader
 logger.sources.level = TRACE


### PR DESCRIPTION
This PR temporarily disables `KvStateServerHandlerTest` because it is unstable. As soon as the community decides to actively support queryable state again, we should fix this test and enable it again.