### PR TITLE
[FLINK-19673] Translate "Standalone Cluster" page into Chinese

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,6 +45,7 @@ website_url: "https://flink.apache.org"
 jira_url: "https://issues.apache.org/jira/browse/FLINK"
 github_url: "https://github.com/apache/flink"
 download_url: "https://flink.apache.org/downloads.html"
+zh_download_url: "https://flink.apache.org/zh/downloads.html"
 
 # please use a protocol relative URL here
 baseurl: //ci.apache.org/projects/flink/flink-docs-master

--- a/docs/ops/deployment/cluster_setup.md
+++ b/docs/ops/deployment/cluster_setup.md
@@ -80,7 +80,7 @@ configuration files (which need to be accessible at the same path on all machine
 
 <div class="row">
   <div class="col-md-6 text-center">
-    <img src="{{ site.baseurl }}/page/img/quickstart_cluster.png" style="width: 60%">
+    <img src="{% link /page/img/quickstart_cluster.png %}" style="width: 60%">
   </div>
 <div class="col-md-6">
   <div class="row">
@@ -102,12 +102,12 @@ configuration files (which need to be accessible at the same path on all machine
 
 The Flink directory must be available on every worker under the same path. You can use a shared NFS directory, or copy the entire Flink directory to every worker node.
 
-Please see the [configuration page](../config.html) for details and additional configuration options.
+Please see the [configuration page]({% link ops/config.md %}) for details and additional configuration options.
 
 In particular,
 
  * the amount of available memory per JobManager (`jobmanager.memory.process.size`),
- * the amount of available memory per TaskManager (`taskmanager.memory.process.size` and check [memory setup guide](../memory/mem_tuning.html#configure-memory-for-standalone-deployment)),
+ * the amount of available memory per TaskManager (`taskmanager.memory.process.size` and check [memory setup guide]({% link ops/memory/mem_tuning.zh.md %}#configure-memory-for-standalone-deployment)),
  * the number of available CPUs per machine (`taskmanager.numberOfTaskSlots`),
  * the total number of CPUs in the cluster (`parallelism.default`) and
  * the temporary directories (`io.tmp.dirs`)

--- a/docs/ops/deployment/cluster_setup.md
+++ b/docs/ops/deployment/cluster_setup.md
@@ -80,7 +80,7 @@ configuration files (which need to be accessible at the same path on all machine
 
 <div class="row">
   <div class="col-md-6 text-center">
-    <img src="{% link /page/img/quickstart_cluster.png %}" style="width: 60%">
+    <img src="{{ site.baseurl }}/page/img/quickstart_cluster.png" style="width: 60%">
   </div>
 <div class="col-md-6">
   <div class="row">
@@ -102,12 +102,12 @@ configuration files (which need to be accessible at the same path on all machine
 
 The Flink directory must be available on every worker under the same path. You can use a shared NFS directory, or copy the entire Flink directory to every worker node.
 
-Please see the [configuration page]({% link ops/config.md %}) for details and additional configuration options.
+Please see the [configuration page](../config.html) for details and additional configuration options.
 
 In particular,
 
  * the amount of available memory per JobManager (`jobmanager.memory.process.size`),
- * the amount of available memory per TaskManager (`taskmanager.memory.process.size` and check [memory setup guide]({% link ops/memory/mem_tuning.zh.md %}#configure-memory-for-standalone-deployment)),
+ * the amount of available memory per TaskManager (`taskmanager.memory.process.size` and check [memory setup guide](../memory/mem_tuning.html#configure-memory-for-standalone-deployment)),
  * the number of available CPUs per machine (`taskmanager.numberOfTaskSlots`),
  * the total number of CPUs in the cluster (`parallelism.default`) and
  * the temporary directories (`io.tmp.dirs`)

--- a/docs/ops/deployment/cluster_setup.zh.md
+++ b/docs/ops/deployment/cluster_setup.zh.md
@@ -60,7 +60,7 @@ Flink 需要 master 和所有 worker 节点设置 `JAVA_HOME` 环境变量，并
 
 ## Flink 设置
 
-前往 [下载页面]({{ site.zh_download_url }}) 获取可运行的软件包。请确保选择的 Flink 软件包**与你的 Hadoop 版本匹配**。如果你不准备使用 Hadoop，可以选择任意版本。
+前往 [下载页面]({{ site.zh_download_url }}) 获取可运行的软件包。
 
 在下载完最新的发布版本后，复制压缩文件到 master 节点并解压：
 

--- a/docs/ops/deployment/cluster_setup.zh.md
+++ b/docs/ops/deployment/cluster_setup.zh.md
@@ -125,7 +125,7 @@ Flink 目录必须放在所有 worker 节点的相同目录下。你可以使用
 
 ### 启动 Flink
 
-下面的脚本在本地节点启动了一个 JobManager 并通过 SSH 连接到 *workers* 文件中所有的 worker 节点，在每个节点上启动 TaskManager。现在你的 Flink 系统已经启动并运行着。在本地节点上运行的 JobManager 会在配置的 RPC 端口上接收作业。
+下面的脚本在本地节点启动了一个 JobManager 并通过 SSH 连接到 *workers* 文件中所有的 worker 节点，在每个节点上启动 TaskManager。现在你的 Flink 系统已经启动并运行着。可以通过配置的 RPC 端口向本地节点上的 JobManager 提交作业。
 
 假定你在 master 节点并且在 Flink 目录下：
 

--- a/docs/ops/deployment/cluster_setup.zh.md
+++ b/docs/ops/deployment/cluster_setup.zh.md
@@ -22,65 +22,70 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This page provides instructions on how to run Flink in a *fully distributed fashion* on a *static* (but possibly heterogeneous) cluster.
+本页面提供了关于如何在*静态*（但可能异构）集群上以*完全分布式方式*运行 Flink 的说明。
 
 * This will be replaced by the TOC
 {:toc}
 
-## Requirements
+<a name="requirements"></a>
 
-### Software Requirements
+## 需求
 
-Flink runs on all *UNIX-like environments*, e.g. **Linux**, **Mac OS X**, and **Cygwin** (for Windows) and expects the cluster to consist of **one master node** and **one or more worker nodes**. Before you start to setup the system, make sure you have the following software installed **on each node**:
+<a name="software-requirements"></a>
 
-- **Java 1.8.x** or higher,
-- **ssh** (sshd must be running to use the Flink scripts that manage
-  remote components)
+### 软件需求
 
-If your cluster does not fulfill these software requirements you will need to install/upgrade it.
+Flink 运行在所有*类 UNIX 环境*下，例如 **Linux**，**Mac OS X** 和 **Cygwin** （Windows），并且认为集群由**一个 master 节点**以及**一个或多个 worker 节点**构成。在配置系统之前，请确保**在每个节点上**安装有以下软件：
 
-Having __passwordless SSH__ and
-__the same directory structure__ on all your cluster nodes will allow you to use our scripts to control
-everything.
+- **Java 1.8.x** 或更高版本，
+- **ssh** （必须运行 sshd 以使用 Flink 脚本管理远程组件）
 
-{% top %}
+如果集群不满足软件要求，那么你需要安装/更新这些软件。
 
-### `JAVA_HOME` Configuration
-
-Flink requires the `JAVA_HOME` environment variable to be set on the master and all worker nodes and point to the directory of your Java installation.
-
-You can set this variable in `conf/flink-conf.yaml` via the `env.java.home` key.
+使集群中所有节点使用**免密码 SSH** 以及拥有**相同的目录结构**可以让你使用脚本来控制一切。
 
 {% top %}
 
-## Flink Setup
+<a name="java_home-configuration"></a>
 
-Go to the [downloads page]({{ site.download_url }}) and get the ready-to-run package.
+### `JAVA_HOME` 配置
 
-After downloading the latest release, copy the archive to your master node and extract it:
+Flink 需要 master 和所有 worker 节点设置 `JAVA_HOME` 环境变量，并指向你的 Java 安装目录。
+
+你可以在 `conf/flink-conf.yaml` 文件中通过 `env.java.home` 键来设置此变量。
+
+{% top %}
+
+<a name="flink-setup"></a>
+
+## Flink 设置
+
+前往 [下载页面]({{ site.download_url }}) 获取可运行的软件包。请确保选择的 Flink 软件包**与你的 Hadoop 版本匹配**。如果你不准备使用 Hadoop，可以选择任意版本。
+
+在下载完最新的发布版本后，复制压缩文件到 master 节点并解压：
 
 {% highlight bash %}
 tar xzf flink-*.tgz
 cd flink-*
 {% endhighlight %}
 
-### Configuring Flink
+<a name="configuring-flink"></a>
 
-After having extracted the system files, you need to configure Flink for the cluster by editing *conf/flink-conf.yaml*.
+### 配置 Flink
 
-Set the `jobmanager.rpc.address` key to point to your master node. You should also define the maximum amount of main memory Flink is allowed to allocate on each node by setting the `jobmanager.memory.process.size` and `taskmanager.memory.process.size` keys.
+在解压完系统文件后，你需要编辑 *conf/flink-conf.yaml* 文件来为集群配置 Flink。
 
-These values are given in MB. If some worker nodes have more main memory which you want to allocate to the Flink system you can overwrite the default value by setting setting `taskmanager.memory.process.size` or `taskmanager.memory.flink.size` in *conf/flink-conf.yaml* on those specific nodes.
+设置 `jobmanager.rpc.address` 键指向 master 节点。你也应该通过设置 `jobmanager.memory.process.size` 和 `taskmanager.memory.process.size` 键来定义 Flink 允许在每个节点上分配的最大内存值。
 
-Finally, you must provide a list of all nodes in your cluster that shall be used as worker nodes, i.e., nodes running a TaskManager. Edit the file *conf/workers* and enter the IP/host name of each worker node.
+这些值是以单位为 MB 所给出的。如果一些 worker 节点上有你想分配到 Flink 系统的多余内存，你可以在这些特定节点的 *conf/flink-conf.yaml* 文件中重写 `taskmanager.memory.process.size` 或 `taskmanager.memory.flink.size` 的默认值。
 
-The following example illustrates the setup with three nodes (with IP addresses from _10.0.0.1_
-to _10.0.0.3_ and hostnames _master_, _worker1_, _worker2_) and shows the contents of the
-configuration files (which need to be accessible at the same path on all machines):
+最后，你必须提供集群上会被用作为 worker 节点的所有节点列表，也就是运行 TaskManager 的节点。编辑文件 *conf/workers* 并输入每个 worker 节点的 IP 或主机名。
+
+以下例子展示了三个节点（IP 地址从 _10.0.0.1_ 到 _10.0.0.3_，主机名为 _master_、_worker1_、 _woker2_）的设置，以及配置文件（在所有机器上都需要在相同路径访问）的内容：
 
 <div class="row">
   <div class="col-md-6 text-center">
-    <img src="{{ site.baseurl }}/page/img/quickstart_cluster.png" style="width: 60%">
+    <img src="{% link /page/img/quickstart_cluster.png %}" style="width: 60%">
   </div>
 <div class="col-md-6">
   <div class="row">
@@ -100,52 +105,60 @@ configuration files (which need to be accessible at the same path on all machine
 </div>
 </div>
 
-The Flink directory must be available on every worker under the same path. You can use a shared NFS directory, or copy the entire Flink directory to every worker node.
+Flink 目录必须放在所有 worker 的相同目录下。你可以使用共享的 NFS 目录，或将 Flink 目录复制到每个 worker 节点上。
 
-Please see the [configuration page](../config.html) for details and additional configuration options.
+请参考 [配置参数页面]({% link ops/config.zh.md %}) 获取更多细节以及额外的配置项。
 
-In particular,
+特别地，
 
- * the amount of available memory per JobManager (`jobmanager.memory.process.size`),
- * the amount of available memory per TaskManager (`taskmanager.memory.process.size` and check [memory setup guide](../memory/mem_tuning.html#configure-memory-for-standalone-deployment)),
- * the number of available CPUs per machine (`taskmanager.numberOfTaskSlots`),
- * the total number of CPUs in the cluster (`parallelism.default`) and
- * the temporary directories (`io.tmp.dirs`)
+* 每个 JobManager 的可用内存值（`jobmanager.memory.process.size`），
+* 每个 TaskManager 的可用内存值 （`taskmanager.memory.process.size`，并检查 [内存调优指南]({% link ops/memory/mem_tuning.zh.md %}#configure-memory-for-standalone-deployment)），
+* 每台机器的可用 CPU 数（`taskmanager.numberOfTaskSlots`），
+* 集群中所有 CPU 数（`parallelism.default`）和
+* 临时目录（`io.tmp.dirs`）
 
-are very important configuration values.
+的值都是非常重要的配置项。
 
 {% top %}
 
-### Starting Flink
+<a name="starting-flink"></a>
 
-The following script starts a JobManager on the local node and connects via SSH to all worker nodes listed in the *workers* file to start the TaskManager on each node. Now your Flink system is up and running. The JobManager running on the local node will now accept jobs at the configured RPC port.
+### 启动 Flink
 
-Assuming that you are on the master node and inside the Flink directory:
+下面的脚本在本地节点启动了一个 JobManager 并通过 SSH 连接到 *workers* 文件中所有的 worker 节点，在每个节点上启动 TaskManager。现在你的 Flink 系统已经启动并运行着。在本地节点上运行的 JobManager 会在配置的 RPC 端口上接收作业。
+
+假定你在 master 节点并且在 Flink 目录下：
 
 {% highlight bash %}
 bin/start-cluster.sh
 {% endhighlight %}
 
-To stop Flink, there is also a `stop-cluster.sh` script.
+为了关闭 Flink，这里同样有一个 `stop-cluster.sh` 脚本。
 
 {% top %}
 
-### Adding JobManager/TaskManager Instances to a Cluster
+<a name="adding-jobmanagertaskmanager-instances-to-a-cluster"></a>
 
-You can add both JobManager and TaskManager instances to your running cluster with the `bin/jobmanager.sh` and `bin/taskmanager.sh` scripts.
+### 为集群添加 JobManager/TaskManager 实例
 
-#### Adding a JobManager
+你可以使用 `bin/jobmanager.sh` 和 `bin/taskmanager.sh` 脚本为正在运行的集群添加 JobManager 和 TaskManager 实例。
+
+<a name="adding-a-jobmanager"></a>
+
+#### 添加 JobManager
 
 {% highlight bash %}
 bin/jobmanager.sh ((start|start-foreground) [host] [webui-port])|stop|stop-all
 {% endhighlight %}
 
-#### Adding a TaskManager
+<a name="adding-a-taskmanager"></a>
+
+#### 添加 TaskManager
 
 {% highlight bash %}
 bin/taskmanager.sh start|start-foreground|stop|stop-all
 {% endhighlight %}
 
-Make sure to call these scripts on the hosts on which you want to start/stop the respective instance.
+确保在你想启动/关闭相应实例的主机上执行这些脚本。
 
 {% top %}

--- a/docs/ops/deployment/cluster_setup.zh.md
+++ b/docs/ops/deployment/cluster_setup.zh.md
@@ -60,7 +60,7 @@ Flink 需要 master 和所有 worker 节点设置 `JAVA_HOME` 环境变量，并
 
 ## Flink 设置
 
-前往 [下载页面]({{ site.download_url }}) 获取可运行的软件包。请确保选择的 Flink 软件包**与你的 Hadoop 版本匹配**。如果你不准备使用 Hadoop，可以选择任意版本。
+前往 [下载页面]({{ site.zh_download_url }}) 获取可运行的软件包。请确保选择的 Flink 软件包**与你的 Hadoop 版本匹配**。如果你不准备使用 Hadoop，可以选择任意版本。
 
 在下载完最新的发布版本后，复制压缩文件到 master 节点并解压：
 
@@ -73,11 +73,11 @@ cd flink-*
 
 ### 配置 Flink
 
-在解压完系统文件后，你需要编辑 *conf/flink-conf.yaml* 文件来为集群配置 Flink。
+在解压完文件后，你需要编辑 *conf/flink-conf.yaml* 文件来为集群配置 Flink。
 
 设置 `jobmanager.rpc.address` 键指向 master 节点。你也应该通过设置 `jobmanager.memory.process.size` 和 `taskmanager.memory.process.size` 键来定义 Flink 允许在每个节点上分配的最大内存值。
 
-这些值是以单位为 MB 所给出的。如果一些 worker 节点上有你想分配到 Flink 系统的多余内存，你可以在这些特定节点的 *conf/flink-conf.yaml* 文件中重写 `taskmanager.memory.process.size` 或 `taskmanager.memory.flink.size` 的默认值。
+这些值是以 MB 为单位所给出的。如果一些 worker 节点上有你想分配到 Flink 系统的多余内存，你可以在这些特定节点的 *conf/flink-conf.yaml* 文件中重写 `taskmanager.memory.process.size` 或 `taskmanager.memory.flink.size` 的默认值。
 
 最后，你必须提供集群上会被用作为 worker 节点的所有节点列表，也就是运行 TaskManager 的节点。编辑文件 *conf/workers* 并输入每个 worker 节点的 IP 或主机名。
 
@@ -105,7 +105,7 @@ cd flink-*
 </div>
 </div>
 
-Flink 目录必须放在所有 worker 的相同目录下。你可以使用共享的 NFS 目录，或将 Flink 目录复制到每个 worker 节点上。
+Flink 目录必须放在所有 worker 节点的相同目录下。你可以使用共享的 NFS 目录，或将 Flink 目录复制到每个 worker 节点上。
 
 请参考 [配置参数页面]({% link ops/config.zh.md %}) 获取更多细节以及额外的配置项。
 

--- a/docs/ops/deployment/cluster_setup.zh.md
+++ b/docs/ops/deployment/cluster_setup.zh.md
@@ -35,10 +35,10 @@ under the License.
 
 ### 软件需求
 
-Flink 运行在所有*类 UNIX 环境*下，例如 **Linux**，**Mac OS X** 和 **Cygwin** （Windows），并且认为集群由**一个 master 节点**以及**一个或多个 worker 节点**构成。在配置系统之前，请确保**在每个节点上**安装有以下软件：
+Flink 运行在所有*类 UNIX 环境*下，例如 **Linux**，**Mac OS X** 和 **Cygwin** （Windows），集群由**一个 master 节点**以及**一个或多个 worker 节点**构成。在配置系统之前，请确保**在每个节点上**安装有以下软件：
 
 - **Java 1.8.x** 或更高版本，
-- **ssh** （必须运行 sshd 以使用 Flink 脚本管理远程组件）
+- **ssh** （必须运行 sshd 以执行用于管理 Flink 各组件的脚本）
 
 如果集群不满足软件要求，那么你需要安装/更新这些软件。
 
@@ -52,7 +52,7 @@ Flink 运行在所有*类 UNIX 环境*下，例如 **Linux**，**Mac OS X** 和 
 
 Flink 需要 master 和所有 worker 节点设置 `JAVA_HOME` 环境变量，并指向你的 Java 安装目录。
 
-你可以在 `conf/flink-conf.yaml` 文件中通过 `env.java.home` 键来设置此变量。
+你可以在 `conf/flink-conf.yaml` 文件中通过 `env.java.home` 配置项来设置此变量。
 
 {% top %}
 
@@ -75,9 +75,9 @@ cd flink-*
 
 在解压完文件后，你需要编辑 *conf/flink-conf.yaml* 文件来为集群配置 Flink。
 
-设置 `jobmanager.rpc.address` 键指向 master 节点。你也应该通过设置 `jobmanager.memory.process.size` 和 `taskmanager.memory.process.size` 键来定义 Flink 允许在每个节点上分配的最大内存值。
+设置 `jobmanager.rpc.address` 配置项指向 master 节点。你也应该通过设置 `jobmanager.memory.process.size` 和 `taskmanager.memory.process.size` 配置项来定义 Flink 允许在每个节点上分配的最大内存值。
 
-这些值是以 MB 为单位所给出的。如果一些 worker 节点上有你想分配到 Flink 系统的多余内存，你可以在这些特定节点的 *conf/flink-conf.yaml* 文件中重写 `taskmanager.memory.process.size` 或 `taskmanager.memory.flink.size` 的默认值。
+这些值的单位是 MB。如果一些 worker 节点上有你想分配到 Flink 系统的多余内存，你可以在这些特定节点的 *conf/flink-conf.yaml* 文件中重写 `taskmanager.memory.process.size` 或 `taskmanager.memory.flink.size` 的默认值。
 
 最后，你必须提供集群上会被用作为 worker 节点的所有节点列表，也就是运行 TaskManager 的节点。编辑文件 *conf/workers* 并输入每个 worker 节点的 IP 或主机名。
 


### PR DESCRIPTION

## What is the purpose of the change

Translate "Standalone Cluster" of "Clusters & Depolyment" page into Chinese.

## Brief change log

- Translate `flink/docs/ops/deployment/cluster_setup.zh.md`
- Use `{% link %}` tag in `flink/docs/ops/deployment/cluster_setup.md`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
