### PR TITLE
[FLINK-19625][table-planner] Introduce multi-input exec node

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -24,6 +24,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, WatermarkAssigner, WindowAggregate}
 import org.apache.flink.table.planner.plan.nodes.common.CommonLookupJoin
 import org.apache.flink.table.planner.plan.nodes.logical._
+import org.apache.flink.table.planner.plan.nodes.physical.MultipleInputRel
 import org.apache.flink.table.planner.plan.nodes.physical.batch._
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase
@@ -556,6 +557,12 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
   }
 
   def getUniqueKeys(
+      multipleInput: MultipleInputRel,
+      mq: RelMetadataQuery,
+      ignoreNulls: Boolean): JSet[ImmutableBitSet] =
+    mq.getUniqueKeys(multipleInput.outputRel, ignoreNulls)
+
+  def getUniqueKeys(
       subset: RelSubset,
       mq: RelMetadataQuery,
       ignoreNulls: Boolean): JSet[ImmutableBitSet] = {
@@ -588,16 +595,6 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
       rel: RelNode,
       mq: RelMetadataQuery,
       ignoreNulls: Boolean): JSet[ImmutableBitSet] = null
-
-  private def toImmutableSet(array: Array[Int]): JSet[ImmutableBitSet] = {
-    if (array.nonEmpty) {
-      val keys = new JArrayList[Integer]()
-      array.foreach(keys.add(_))
-      ImmutableSet.of(ImmutableBitSet.of(keys))
-    } else {
-      null
-    }
-  }
 
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/MultipleInputRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/MultipleInputRel.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical
+
+import org.apache.flink.table.planner.plan.utils.RelTreeWriterImpl
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{AbstractRelNode, RelNode, RelWriter}
+import org.apache.calcite.sql.SqlExplainLevel
+
+import java.io.{PrintWriter, StringWriter}
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+ * Base physical RelNode for multiple input rel which contains a sub-graph.
+ * The root node of the sub-graph is [[outputRel]], and the leaf nodes of the sub-graph are
+ * the output nodes of the [[inputRels]], which means the multiple input rel does not
+ * contain [[inputRels]].
+ *
+ * TODO this is a temporary solution, this class should be removed once we split the
+ *   implementation of physical rel and exec node.
+ */
+class MultipleInputRel(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRels: Array[RelNode],
+    val outputRel: RelNode,
+    readOrders: Array[Int])
+  extends AbstractRelNode(cluster, traitSet)
+  with FlinkPhysicalRel {
+
+  override def getInputs: util.List[RelNode] = inputRels.toList
+
+  override def deriveRowType(): RelDataType = outputRel.getRowType
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    inputRels.zipWithIndex.map {
+      case (rel, index) =>
+        pw.input("input" + index, rel)
+    }
+    val hasDiffReadOrder = readOrders.slice(1, readOrders.length).exists(readOrders.head != _)
+    pw.itemIf("readOrder", readOrders.mkString(","), hasDiffReadOrder)
+    pw.item("output", outputRel)
+    pw.item("members", "\\n" + getExplainTermsOfMembers.replace("\n", "\\n"))
+  }
+
+  private def getExplainTermsOfMembers: String = {
+    val sw = new StringWriter
+    val planWriter = new RelTreeWriterImpl(
+      new PrintWriter(sw),
+      SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+      borders = inputRels)
+    outputRel.explain(planWriter)
+    sw.toString
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInputNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInputNode.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.batch
+
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.delegation.BatchPlanner
+import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.physical.MultipleInputRel
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+ * Batch physical node for [[MultipleInputRel]].
+ *
+ * @param inputRels the input rels of multiple input rel,
+ *                  which are not a part of the multiple input rel.
+ * @param outputRel the root rel of the sub-graph of the multiple input rel.
+ * @param readOrders the read order corresponding each input. The values is lower,
+ *                   the read priority is higher. Note that, if a input has multiple output,
+ *                   their read order should be same. so each read order corresponds to an input.
+ */
+class BatchExecMultipleInputNode(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRels: Array[RelNode],
+    outputRel: RelNode,
+    readOrders: Array[Int])
+  extends MultipleInputRel(cluster, traitSet, inputRels, outputRel, readOrders)
+  with BatchExecNode[RowData]
+  with BatchPhysicalRel {
+
+  override def getDamBehavior: DamBehavior = {
+    throw new UnsupportedOperationException()
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  }
+
+  override def replaceInputNode(
+      ordinalInParent: Int,
+      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+    throw new UnsupportedOperationException()
+  }
+
+  override protected def translateToPlanInternal(
+      planner: BatchPlanner): Transformation[RowData] = ???
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMultipleInputNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMultipleInputNode.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
+import org.apache.flink.table.planner.plan.nodes.physical.MultipleInputRel
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+ * Stream physical node for [[MultipleInputRel]].
+ *
+ * @param inputRels the input rels of multiple input rel,
+ *                  which are not a part of the multiple input rel.
+ * @param outputRel the root rel of the sub-graph of the multiple input rel.
+ */
+class StreamExecMultipleInputNode(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRels: Array[RelNode],
+    outputRel: RelNode)
+  extends MultipleInputRel(cluster, traitSet, inputRels, outputRel, inputRels.map(_ => 0))
+  with StreamExecNode[RowData]
+  with StreamPhysicalRel {
+
+  override def requireWatermark: Boolean = {
+    throw new UnsupportedOperationException()
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  }
+
+  override def replaceInputNode(
+      ordinalInParent: Int,
+      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    throw new UnsupportedOperationException()
+  }
+
+  override protected def translateToPlanInternal(
+      planner: StreamPlanner): Transformation[RowData] = ???
+
+}
+

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
@@ -38,7 +38,8 @@ class RelTreeWriterImpl(
     withIdPrefix: Boolean = false,
     withChangelogTraits: Boolean = false,
     withRowType: Boolean = false,
-    withTreeStyle: Boolean = true)
+    withTreeStyle: Boolean = true,
+    borders: Array[RelNode] = Array())
   extends RelWriterImpl(pw, explainLevel, withIdPrefix) {
 
   var lastChildren: Seq[Boolean] = Nil
@@ -66,6 +67,12 @@ class RelTreeWriterImpl(
 
     if (withIdPrefix) {
       s.append(rel.getId).append(":")
+    }
+
+    val borderIndex = borders.indexOf(rel)
+    val reachBorder = borderIndex >= 0
+    if (reachBorder) {
+      s.append("[#").append(borderIndex + 1).append("] ")
     }
 
     rel.getRelTypeName match {
@@ -110,6 +117,10 @@ class RelTreeWriterImpl(
         .append(mq.getCumulativeCost(rel))
     }
     pw.println(s)
+    if (reachBorder) {
+      return
+    }
+
     if (inputs.length > 1) inputs.toSeq.init.foreach { rel =>
       if (withTreeStyle) {
         depth = depth + 1

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainMultipleInput.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainMultipleInput.out
@@ -1,0 +1,7 @@
+MultipleInputNode(readOrder=[0,1], members=[\nHashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, EXPR$1, d, EXPR$10], build=[right])\n:- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1])\n:  +- Exchange(distribution=[hash[a]])\n:     +- [#1] LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0])\n+- HashAggregate(isMerge=[true], groupBy=[d], select=[d, Final_SUM(sum$0) AS EXPR$1])\n   +- Exchange(distribution=[hash[d]])\n      +- [#2] LocalHashAggregate(groupBy=[d], select=[d, Partial_SUM(e) AS sum$0])\n])
+:- LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0])
+:  +- Calc(select=[a, b])
+:     +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
++- LocalHashAggregate(groupBy=[d], select=[d, Partial_SUM(e) AS sum$0])
+   +- Calc(select=[d, e])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f])

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -269,6 +269,12 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetUniqueKeysOnMultipleInput(): Unit = {
+    assertEquals(uniqueKeys(Array(0), Array(2), Array(0, 2)),
+      mq.getUniqueKeys(batchMultipleInput).toSet)
+  }
+
+  @Test
   def testGetUniqueKeysOnDefault(): Unit = {
     assertNull(mq.getUniqueKeys(testRel))
   }


### PR DESCRIPTION


## What is the purpose of the change

*This pr aims to introduce multi-input exec node for blink planner. Currently, all the exec nodes are extends from both FlinkPhysicalRel and ExecNode, because the ExecNode#translateToPlan method will access some info of FlinkPhysicalRel, For minimal changes, we also let multi-input exec node  extend them as a temporary solution*


## Brief change log

  - *Introduce BatchExecMultipleInputNode and StreamExecMultipleInputNode, and implement the necessary methods*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended ExplainTest to verify the explain result of multiple input plan*
  - *Extended FlinkRelMdUniqueKeysTest to verify the result of `getUniqueKeys` on multiple input rel *
  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
