### PR TITLE
[FLINK-19689][yarn][test] Fix TaskExecutorProcessSpecContainerResourcePriorityAdapterTest for Hadoop 2.10+.

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/ResourceInformationReflectorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/ResourceInformationReflectorTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -93,7 +94,7 @@ public class ResourceInformationReflectorTest extends TestLogger {
 
 		// make sure that Resource has at least two associated resources (cpu and memory)
 		final Map<String, Long> resourcesResult = ResourceInformationReflector.INSTANCE.getAllResourceInfos(resource);
-		assertThat(resourcesResult.size(), is(2));
+		assertThat(resourcesResult.size(), greaterThanOrEqualTo(2));
 	}
 
 	@Test

--- a/flink-yarn/src/test/resources/resource-types.xml
+++ b/flink-yarn/src/test/resources/resource-types.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+    <property>
+        <name>yarn.resource-types</name>
+        <value>testing-external-resource</value>
+    </property>
+</configuration>


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the test failure of `TaskExecutorProcessSpecContainerResourcePriorityAdapterTest` when running with Hadoop 2.10+.

## Verifying this change

Verified `mvn clean test` for the `flink-yarn` module with Hadoop 2.4.1, 2.10.0, 3.1.3 and 3.3.0.
