### PR TITLE
[FLINK-19655][flink-table-runtime-blink]  add super.open() and write unit test for temporal process join

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalProcessTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalProcessTimeJoinOperator.java
@@ -63,6 +63,7 @@ public class LegacyTemporalProcessTimeJoinOperator
 
 	@Override
 	public void open() throws Exception {
+		super.open();
 		this.joinCondition = generatedJoinCondition.newInstance(getRuntimeContext().getUserCodeClassLoader());
 		FunctionUtils.setFunctionRuntimeContext(joinCondition, getRuntimeContext());
 		FunctionUtils.openFunction(joinCondition, new Configuration());

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalRowTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalRowTimeJoinOperator.java
@@ -137,6 +137,7 @@ public class LegacyTemporalRowTimeJoinOperator
 
 	@Override
 	public void open() throws Exception {
+		super.open();
 		joinCondition = generatedJoinCondition.newInstance(getRuntimeContext().getUserCodeClassLoader());
 		joinCondition.setRuntimeContext(getRuntimeContext());
 		joinCondition.open(new Configuration());

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalProcessTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalProcessTimeJoinOperatorTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.temporal;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+
+/**
+ * Test for {@link LegacyTemporalProcessTimeJoinOperator}.
+ */
+public class LegacyTemporalProcessTimeJoinOperatorTest extends LegacyTemporalTimeJoinOperatorTestBase {
+	private int keyIdx = 0;
+
+	private InternalTypeInfo<RowData> rowType = InternalTypeInfo.ofFields(
+			new BigIntType(),
+			new VarCharType(VarCharType.MAX_LENGTH));
+	private TypeInformation<RowData> keyType = InternalTypeInfo.ofFields();
+	private BinaryRowDataKeySelector keySelector = new BinaryRowDataKeySelector(
+			new int[]{keyIdx},
+			rowType.toRowFieldTypes());
+	private InternalTypeInfo<RowData> outputRowType = InternalTypeInfo.ofFields(
+			new BigIntType(),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new BigIntType(),
+			new VarCharType(VarCharType.MAX_LENGTH));
+	private RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(outputRowType.toRowFieldTypes());
+
+	/** test proctime temporal join when non state clear. **/
+	@Test
+	public void testProcTimeTemporalJoin() throws Exception {
+		LegacyTemporalProcessTimeJoinOperator joinOperator = new LegacyTemporalProcessTimeJoinOperator(
+				rowType,
+				joinCondition,
+				0,
+				0);
+		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
+				joinOperator);
+		testHarness.open();
+		testHarness.setProcessingTime(1);
+		testHarness.processElement1(insertRecord(1L, "1a1"));
+
+		testHarness.setProcessingTime(2);
+		testHarness.processElement2(insertRecord(2L, "2a2"));
+
+		testHarness.setProcessingTime(3);
+		testHarness.processElement1(insertRecord(2L, "2a3"));
+
+		testHarness.setProcessingTime(4);
+		testHarness.processElement2(insertRecord(1L, "1a4"));
+
+		testHarness.setProcessingTime(5);
+		testHarness.processElement1(insertRecord(1L, "1a5"));
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(insertRecord(2L, "2a3", 2L, "2a2"));
+		expectedOutput.add(insertRecord(1L, "1a5", 1L, "1a4"));
+		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	/** test proctime temporal join when set state clear. **/
+	@Test
+	public void testStateCleanUp() throws Exception {
+		final int minRetentionTime = 10;
+		final int maxRententionTime = minRetentionTime * 3 / 2;
+		LegacyTemporalProcessTimeJoinOperator joinOperator = new LegacyTemporalProcessTimeJoinOperator(
+				rowType,
+				joinCondition,
+				minRetentionTime,
+				maxRententionTime);
+		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
+				joinOperator);
+		testHarness.open();
+		testHarness.setProcessingTime(1);
+		testHarness.processElement1(insertRecord(1L, "1a1"));
+
+		testHarness.setProcessingTime(2);
+		testHarness.processElement2(insertRecord(2L, "2a2"));
+
+		testHarness.setProcessingTime(3);
+		testHarness.processElement1(insertRecord(2L, "2a3"));
+
+		testHarness.setProcessingTime(3 + maxRententionTime);
+		testHarness.processElement1(insertRecord(2L, "1a5"));
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(insertRecord(2L, "2a3", 2L, "2a2"));
+
+		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	private KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> createTestHarness(
+			LegacyTemporalProcessTimeJoinOperator temporalJoinOperator)
+			throws Exception {
+
+		return new KeyedTwoInputStreamOperatorTestHarness<>(
+				temporalJoinOperator,
+				keySelector,
+				keySelector,
+				keyType);
+	}
+}
+

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalProcessTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalProcessTimeJoinOperatorTest.java
@@ -35,35 +35,37 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
- * Test for {@link LegacyTemporalProcessTimeJoinOperator}.
+ * Harness tests for {@link LegacyTemporalProcessTimeJoinOperator}.
  */
 public class LegacyTemporalProcessTimeJoinOperatorTest extends LegacyTemporalTimeJoinOperatorTestBase {
-	private int keyIdx = 0;
 
+	private int keyIdx = 0;
 	private InternalTypeInfo<RowData> rowType = InternalTypeInfo.ofFields(
-			new BigIntType(),
-			new VarCharType(VarCharType.MAX_LENGTH));
+		new BigIntType(),
+		new VarCharType(VarCharType.MAX_LENGTH));
 	private TypeInformation<RowData> keyType = InternalTypeInfo.ofFields();
 	private BinaryRowDataKeySelector keySelector = new BinaryRowDataKeySelector(
-			new int[]{keyIdx},
-			rowType.toRowFieldTypes());
+		new int[]{keyIdx},
+		rowType.toRowFieldTypes());
 	private InternalTypeInfo<RowData> outputRowType = InternalTypeInfo.ofFields(
-			new BigIntType(),
-			new VarCharType(VarCharType.MAX_LENGTH),
-			new BigIntType(),
-			new VarCharType(VarCharType.MAX_LENGTH));
+		new BigIntType(),
+		new VarCharType(VarCharType.MAX_LENGTH),
+		new BigIntType(),
+		new VarCharType(VarCharType.MAX_LENGTH));
 	private RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(outputRowType.toRowFieldTypes());
 
-	/** test proctime temporal join when non state clear. **/
+	/**
+	 * Test proctime temporal join.
+	 */
 	@Test
 	public void testProcTimeTemporalJoin() throws Exception {
 		LegacyTemporalProcessTimeJoinOperator joinOperator = new LegacyTemporalProcessTimeJoinOperator(
-				rowType,
-				joinCondition,
-				0,
-				0);
+			rowType,
+			joinCondition,
+			0,
+			0);
 		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
-				joinOperator);
+			joinOperator);
 		testHarness.open();
 		testHarness.setProcessingTime(1);
 		testHarness.processElement1(insertRecord(1L, "1a1"));
@@ -87,18 +89,20 @@ public class LegacyTemporalProcessTimeJoinOperatorTest extends LegacyTemporalTim
 		testHarness.close();
 	}
 
-	/** test proctime temporal join when set state clear. **/
+	/**
+	 * Test proctime temporal join when set idle state retention.
+	 */
 	@Test
-	public void testStateCleanUp() throws Exception {
+	public void testProcTimeTemporalJoinWithStateRetention() throws Exception {
 		final int minRetentionTime = 10;
-		final int maxRententionTime = minRetentionTime * 3 / 2;
+		final int maxRetentionTime = minRetentionTime * 3 / 2;
 		LegacyTemporalProcessTimeJoinOperator joinOperator = new LegacyTemporalProcessTimeJoinOperator(
-				rowType,
-				joinCondition,
-				minRetentionTime,
-				maxRententionTime);
+			rowType,
+			joinCondition,
+			minRetentionTime,
+			maxRetentionTime);
 		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
-				joinOperator);
+			joinOperator);
 		testHarness.open();
 		testHarness.setProcessingTime(1);
 		testHarness.processElement1(insertRecord(1L, "1a1"));
@@ -109,7 +113,7 @@ public class LegacyTemporalProcessTimeJoinOperatorTest extends LegacyTemporalTim
 		testHarness.setProcessingTime(3);
 		testHarness.processElement1(insertRecord(2L, "2a3"));
 
-		testHarness.setProcessingTime(3 + maxRententionTime);
+		testHarness.setProcessingTime(3 + maxRetentionTime);
 		testHarness.processElement1(insertRecord(2L, "1a5"));
 
 		List<Object> expectedOutput = new ArrayList<>();
@@ -120,14 +124,12 @@ public class LegacyTemporalProcessTimeJoinOperatorTest extends LegacyTemporalTim
 	}
 
 	private KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> createTestHarness(
-			LegacyTemporalProcessTimeJoinOperator temporalJoinOperator)
-			throws Exception {
+		LegacyTemporalProcessTimeJoinOperator temporalJoinOperator) throws Exception {
 
 		return new KeyedTwoInputStreamOperatorTestHarness<>(
-				temporalJoinOperator,
-				keySelector,
-				keySelector,
-				keyType);
+			temporalJoinOperator,
+			keySelector,
+			keySelector,
+			keyType);
 	}
 }
-

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalRowTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalRowTimeJoinOperatorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.temporal;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+
+/**
+ * Test for {@link LegacyTemporalRowTimeJoinOperator}.
+ */
+public class LegacyTemporalRowTimeJoinOperatorTest extends LegacyTemporalTimeJoinOperatorTestBase {
+	private InternalTypeInfo<RowData> rowType = InternalTypeInfo.ofFields(
+			new BigIntType(),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new VarCharType(VarCharType.MAX_LENGTH));
+
+	private InternalTypeInfo<RowData> outputRowType = InternalTypeInfo.ofFields(
+			new BigIntType(),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new BigIntType(),
+			new VarCharType(VarCharType.MAX_LENGTH),
+			new VarCharType(VarCharType.MAX_LENGTH));
+	private RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(outputRowType.toRowFieldTypes());
+	private int keyIdx = 1;
+	private BinaryRowDataKeySelector keySelector = new BinaryRowDataKeySelector(
+			new int[]{keyIdx},
+			rowType.toRowFieldTypes());
+	private TypeInformation<RowData> keyType = InternalTypeInfo.ofFields();
+
+	/** test rowtime temporal join when non state clear. **/
+	@Test
+	public void testRowTimeTemporalJoin() throws Exception {
+		LegacyTemporalRowTimeJoinOperator joinOperator = new LegacyTemporalRowTimeJoinOperator(
+				rowType,
+				rowType,
+				joinCondition,
+				0,
+				0,
+				0,
+				0);
+		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
+				joinOperator);
+
+		testHarness.open();
+
+		testHarness.processWatermark1(new Watermark(1));
+		testHarness.processWatermark2(new Watermark(1));
+
+		testHarness.processElement1(insertRecord(1L, "k1", "1a1"));
+		testHarness.processElement2(insertRecord(2L, "k1", "1a2"));
+
+		testHarness.processWatermark1(new Watermark(2));
+		testHarness.processWatermark2(new Watermark(2));
+
+		testHarness.processElement1(insertRecord(1L, "k1", "2a1"));
+		testHarness.processElement1(insertRecord(3L, "k1", "2a3"));
+		testHarness.processElement2(insertRecord(4L, "k2", "2a4"));
+
+		testHarness.processWatermark1(new Watermark(5));
+		testHarness.processWatermark2(new Watermark(5));
+
+		testHarness.processElement1(insertRecord(6L, "k2", "5a6"));
+		testHarness.processElement2(insertRecord(8L, "k2", "5a8"));
+		testHarness.processElement1(insertRecord(11L, "k2", "5a11"));
+		testHarness.processElement1(insertRecord(7L, "k2", "5a7"));
+
+		testHarness.processWatermark1(new Watermark(13));
+		testHarness.processWatermark2(new Watermark(13));
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(new Watermark(1));
+		expectedOutput.add(new Watermark(2));
+		expectedOutput.add(insertRecord(3L, "k1", "2a3", 2L, "k1", "1a2"));
+		expectedOutput.add(new Watermark(5));
+		expectedOutput.add(insertRecord(6L, "k2", "5a6", 4L, "k2", "2a4"));
+		expectedOutput.add(insertRecord(11L, "k2", "5a11", 8L, "k2", "5a8"));
+		expectedOutput.add(insertRecord(7L, "k2", "5a7", 4L, "k2", "2a4"));
+		expectedOutput.add(new Watermark(13));
+
+		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	/** test rowtime temporal join when set state clear. **/
+	@Test
+	public void testStateCleanUp() throws Exception {
+		final int minRetentionTime = 4;
+		final int maxRententionTime = minRetentionTime * 3 / 2;
+		LegacyTemporalRowTimeJoinOperator joinOperator = new LegacyTemporalRowTimeJoinOperator(
+				rowType,
+				rowType,
+				joinCondition,
+				0,
+				0,
+				minRetentionTime,
+				maxRententionTime);
+		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
+				joinOperator);
+		testHarness.open();
+
+		testHarness.setProcessingTime(3);
+		testHarness.processElement2(insertRecord(3L, "k1", "0a3"));
+		testHarness.setProcessingTime(6);
+		testHarness.processElement1(insertRecord(6L, "k1", "0a6"));
+
+		testHarness.processWatermark1(new Watermark(7));
+		testHarness.processWatermark2(new Watermark(7));
+
+		testHarness.setProcessingTime(9);
+		testHarness.processElement1(insertRecord(9L, "k1", "7a9"));
+
+		testHarness.processWatermark1(new Watermark(13));
+		testHarness.processWatermark2(new Watermark(13));
+
+		testHarness.setProcessingTime(9 + maxRententionTime);
+		testHarness.processElement1(insertRecord(15L, "k1", "13a15"));
+
+		testHarness.processWatermark1(new Watermark(16));
+		testHarness.processWatermark2(new Watermark(16));
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(insertRecord(6L, "k1", "0a6", 3L, "k1", "0a3"));
+		expectedOutput.add(new Watermark(7));
+		expectedOutput.add(insertRecord(9L, "k1", "7a9", 3L, "k1", "0a3"));
+		expectedOutput.add(new Watermark(13));
+		expectedOutput.add(new Watermark(16));
+
+		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	private KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> createTestHarness(
+			LegacyTemporalRowTimeJoinOperator temporalJoinOperator)
+			throws Exception {
+
+		return new KeyedTwoInputStreamOperatorTestHarness<>(
+				temporalJoinOperator,
+				keySelector,
+				keySelector,
+				keyType);
+	}
+}
+

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalRowTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalRowTimeJoinOperatorTest.java
@@ -36,41 +36,43 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
- * Test for {@link LegacyTemporalRowTimeJoinOperator}.
+ * Harness tests for {@link LegacyTemporalRowTimeJoinOperator}.
  */
 public class LegacyTemporalRowTimeJoinOperatorTest extends LegacyTemporalTimeJoinOperatorTestBase {
 	private InternalTypeInfo<RowData> rowType = InternalTypeInfo.ofFields(
-			new BigIntType(),
-			new VarCharType(VarCharType.MAX_LENGTH),
-			new VarCharType(VarCharType.MAX_LENGTH));
+		new BigIntType(),
+		new VarCharType(VarCharType.MAX_LENGTH),
+		new VarCharType(VarCharType.MAX_LENGTH));
 
 	private InternalTypeInfo<RowData> outputRowType = InternalTypeInfo.ofFields(
-			new BigIntType(),
-			new VarCharType(VarCharType.MAX_LENGTH),
-			new VarCharType(VarCharType.MAX_LENGTH),
-			new BigIntType(),
-			new VarCharType(VarCharType.MAX_LENGTH),
-			new VarCharType(VarCharType.MAX_LENGTH));
+		new BigIntType(),
+		new VarCharType(VarCharType.MAX_LENGTH),
+		new VarCharType(VarCharType.MAX_LENGTH),
+		new BigIntType(),
+		new VarCharType(VarCharType.MAX_LENGTH),
+		new VarCharType(VarCharType.MAX_LENGTH));
 	private RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(outputRowType.toRowFieldTypes());
 	private int keyIdx = 1;
 	private BinaryRowDataKeySelector keySelector = new BinaryRowDataKeySelector(
-			new int[]{keyIdx},
-			rowType.toRowFieldTypes());
+		new int[]{keyIdx},
+		rowType.toRowFieldTypes());
 	private TypeInformation<RowData> keyType = InternalTypeInfo.ofFields();
 
-	/** test rowtime temporal join when non state clear. **/
+	/**
+	 * Test rowtime temporal join.
+	 */
 	@Test
 	public void testRowTimeTemporalJoin() throws Exception {
 		LegacyTemporalRowTimeJoinOperator joinOperator = new LegacyTemporalRowTimeJoinOperator(
-				rowType,
-				rowType,
-				joinCondition,
-				0,
-				0,
-				0,
-				0);
+			rowType,
+			rowType,
+			joinCondition,
+			0,
+			0,
+			0,
+			0);
 		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
-				joinOperator);
+			joinOperator);
 
 		testHarness.open();
 
@@ -112,21 +114,23 @@ public class LegacyTemporalRowTimeJoinOperatorTest extends LegacyTemporalTimeJoi
 		testHarness.close();
 	}
 
-	/** test rowtime temporal join when set state clear. **/
+	/**
+	 * Test rowtime temporal join when set idle state retention.
+	 */
 	@Test
-	public void testStateCleanUp() throws Exception {
+	public void testRowTimeTemporalJoinWithStateRetention() throws Exception {
 		final int minRetentionTime = 4;
-		final int maxRententionTime = minRetentionTime * 3 / 2;
+		final int maxRetentionTime = minRetentionTime * 3 / 2;
 		LegacyTemporalRowTimeJoinOperator joinOperator = new LegacyTemporalRowTimeJoinOperator(
-				rowType,
-				rowType,
-				joinCondition,
-				0,
-				0,
-				minRetentionTime,
-				maxRententionTime);
+			rowType,
+			rowType,
+			joinCondition,
+			0,
+			0,
+			minRetentionTime,
+			maxRetentionTime);
 		KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness = createTestHarness(
-				joinOperator);
+			joinOperator);
 		testHarness.open();
 
 		testHarness.setProcessingTime(3);
@@ -143,7 +147,7 @@ public class LegacyTemporalRowTimeJoinOperatorTest extends LegacyTemporalTimeJoi
 		testHarness.processWatermark1(new Watermark(13));
 		testHarness.processWatermark2(new Watermark(13));
 
-		testHarness.setProcessingTime(9 + maxRententionTime);
+		testHarness.setProcessingTime(9 + maxRetentionTime);
 		testHarness.processElement1(insertRecord(15L, "k1", "13a15"));
 
 		testHarness.processWatermark1(new Watermark(16));
@@ -160,14 +164,12 @@ public class LegacyTemporalRowTimeJoinOperatorTest extends LegacyTemporalTimeJoi
 	}
 
 	private KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> createTestHarness(
-			LegacyTemporalRowTimeJoinOperator temporalJoinOperator)
-			throws Exception {
+		LegacyTemporalRowTimeJoinOperator temporalJoinOperator) throws Exception {
 
 		return new KeyedTwoInputStreamOperatorTestHarness<>(
-				temporalJoinOperator,
-				keySelector,
-				keySelector,
-				keyType);
+			temporalJoinOperator,
+			keySelector,
+			keySelector,
+			keyType);
 	}
 }
-

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalTimeJoinOperatorTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalTimeJoinOperatorTestBase.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.temporal;
+
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+
+/**
+ * Base Test for all subclass of {@link BaseTwoInputStreamOperatorWithStateRetention}.
+ */
+public class LegacyTemporalTimeJoinOperatorTestBase {
+	String funcCode =
+			"public class TimeTemporalJoinCondition extends org.apache.flink.api.common.functions.AbstractRichFunction implements org.apache.flink.table.runtime.generated.JoinCondition {\n"
+					+ "\n"
+					+ "    public TimeTemporalJoinCondition(Object[] reference) {\n"
+					+ "    }\n"
+					+ "\n"
+					+ "    @Override\n"
+					+ "    public boolean apply(org.apache.flink.table.data.RowData in1, org.apache.flink.table.data.RowData in2) {\n"
+					+ "        return true;\n"
+					+ "    }\n"
+					+ "}\n";
+	GeneratedJoinCondition joinCondition = new GeneratedJoinCondition(
+			"TimeTemporalJoinCondition",
+			funcCode,
+			new Object[0]);
+}
+

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalTimeJoinOperatorTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/LegacyTemporalTimeJoinOperatorTestBase.java
@@ -21,23 +21,23 @@ package org.apache.flink.table.runtime.operators.join.temporal;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 
 /**
- * Base Test for all subclass of {@link BaseTwoInputStreamOperatorWithStateRetention}.
+ * Base test class for LegacyTemporalJoinOperator.
  */
 public class LegacyTemporalTimeJoinOperatorTestBase {
-	String funcCode =
-			"public class TimeTemporalJoinCondition extends org.apache.flink.api.common.functions.AbstractRichFunction implements org.apache.flink.table.runtime.generated.JoinCondition {\n"
-					+ "\n"
-					+ "    public TimeTemporalJoinCondition(Object[] reference) {\n"
-					+ "    }\n"
-					+ "\n"
-					+ "    @Override\n"
-					+ "    public boolean apply(org.apache.flink.table.data.RowData in1, org.apache.flink.table.data.RowData in2) {\n"
-					+ "        return true;\n"
-					+ "    }\n"
-					+ "}\n";
-	GeneratedJoinCondition joinCondition = new GeneratedJoinCondition(
-			"TimeTemporalJoinCondition",
-			funcCode,
-			new Object[0]);
+	protected String funcCode =
+		"public class TimeTemporalJoinCondition extends org.apache.flink.api.common.functions.AbstractRichFunction " +
+			"implements org.apache.flink.table.runtime.generated.JoinCondition {\n"
+			+ "\n"
+			+ "    public TimeTemporalJoinCondition(Object[] reference) {\n"
+			+ "    }\n"
+			+ "\n"
+			+ "    @Override\n"
+			+ "    public boolean apply(org.apache.flink.table.data.RowData in1, org.apache.flink.table.data.RowData in2) {\n"
+			+ "        return true;\n"
+			+ "    }\n"
+			+ "}\n";
+	protected GeneratedJoinCondition joinCondition = new GeneratedJoinCondition(
+		"TimeTemporalJoinCondition",
+		funcCode,
+		new Object[0]);
 }
-


### PR DESCRIPTION


<!--
Fixes #

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The ultimate goal of this PR is to fix a bug where NPE is thrown when using blink planner and TemporalTableFunction after setting IdleStateRetentionTime .TemporalProcessTimeJoinOperator should initialize timer service for processing time.
See #FLINK-19655


## Brief change log
  - Add super.open() in LegacyTemporalProcessTimeJoinOperator#open() to solve NPE
  - Write two unit test for LegacyTemporalProcessTimeJoinOperator to verify the code worked fine


## Verifying this change

This change added tests and can be verified as follows:
  - Added test that validates that:
    - 1.test proctime temporal join when non state clear. 
    - 2.test proctime temporal join when set state clear.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:   no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  not documented
