### PR TITLE
[FLINK-19326][cep] Allow explicitly configuring time behaviour on CEP PatternStream

### DIFF
--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
@@ -450,6 +450,16 @@ class PatternStream[T](jPatternStream: JPatternStream[T]) {
    jPatternStream.sideOutputLateData(lateDataOutputTag)
    this
  }
+
+  def inProcessingTime(): PatternStream[T] = {
+    jPatternStream.inProcessingTime()
+    this
+  }
+
+  def inEventTime(): PatternStream[T] = {
+    jPatternStream.inEventTime()
+    this
+  }
 }
 
 object PatternStream {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/PatternStream.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/PatternStream.java
@@ -68,6 +68,14 @@ public class PatternStream<T> {
 		return new PatternStream<>(builder.withLateDataOutputTag(lateDataOutputTag));
 	}
 
+	public PatternStream<T> inProcessingTime() {
+		return new PatternStream<>(builder.inProcessingTime());
+	}
+
+	public PatternStream<T> inEventTime() {
+		return new PatternStream<>(builder.inEventTime());
+	}
+
 	/**
 	 * Applies a process function to the detected pattern sequence. For each pattern sequence the
 	 * provided {@link PatternProcessFunction} is called. In order to process timed out partial matches as well one can

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/PatternStreamBuilder.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/PatternStreamBuilder.java
@@ -60,29 +60,18 @@ final class PatternStreamBuilder<IN> {
 	private final OutputTag<IN> lateDataOutputTag;
 
 	/**
+	 * The time behaviour to specify processing time or event time.
+	 * Default time behaviour is {@link TimeBehaviour#EventTime}.
+	 */
+	private final TimeBehaviour timeBehaviour;
+
+	/**
 	 * The time behaviour enum defines how the system determines time for time-dependent order and
 	 * operations that depend on time.
 	 */
 	enum TimeBehaviour {
 		ProcessingTime,
 		EventTime
-	}
-
-	/**
-	 * The time behaviour to specify processing time or event time.
-	 * Default time behaviour is {@link TimeBehaviour#EventTime}.
-	 */
-	private TimeBehaviour timeBehaviour = TimeBehaviour.EventTime;
-
-	private PatternStreamBuilder(
-			final DataStream<IN> inputStream,
-			final Pattern<IN, ?> pattern,
-			@Nullable final EventComparator<IN> comparator,
-			@Nullable final OutputTag<IN> lateDataOutputTag) {
-		this.inputStream = checkNotNull(inputStream);
-		this.pattern = checkNotNull(pattern);
-		this.comparator = comparator;
-		this.lateDataOutputTag = lateDataOutputTag;
 	}
 
 	private PatternStreamBuilder(
@@ -113,11 +102,11 @@ final class PatternStreamBuilder<IN> {
 	}
 
 	PatternStreamBuilder<IN> withComparator(final EventComparator<IN> comparator) {
-		return new PatternStreamBuilder<>(inputStream, pattern, checkNotNull(comparator), lateDataOutputTag);
+		return new PatternStreamBuilder<>(inputStream, pattern, timeBehaviour, checkNotNull(comparator), lateDataOutputTag);
 	}
 
 	PatternStreamBuilder<IN> withLateDataOutputTag(final OutputTag<IN> lateDataOutputTag) {
-		return new PatternStreamBuilder<>(inputStream, pattern, comparator, checkNotNull(lateDataOutputTag));
+		return new PatternStreamBuilder<>(inputStream, pattern, timeBehaviour, comparator, checkNotNull(lateDataOutputTag));
 	}
 
 	PatternStreamBuilder<IN> inProcessingTime() {
@@ -183,6 +172,6 @@ final class PatternStreamBuilder<IN> {
 	// ---------------------------------------- factory-like methods ---------------------------------------- //
 
 	static <IN> PatternStreamBuilder<IN> forStreamAndPattern(final DataStream<IN> inputStream, final Pattern<IN, ?> pattern) {
-		return new PatternStreamBuilder<>(inputStream, pattern, null, null);
+		return new PatternStreamBuilder<>(inputStream, pattern, TimeBehaviour.EventTime, null, null);
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/time/TimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/time/TimeContext.java
@@ -32,7 +32,7 @@ public interface TimeContext {
 	/**
 	 * Timestamp of the element currently being processed.
 	 *
-	 * <p>In case of {@link org.apache.flink.streaming.api.TimeCharacteristic#ProcessingTime} this means the
+	 * <p>In case of {@link org.apache.flink.cep.time.TimeBehaviour#ProcessingTime} this means the
 	 * time when the event entered the cep operator.
 	 */
 	long timestamp();

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -30,7 +30,6 @@ import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.RichIterativeCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
@@ -67,7 +66,6 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testSimplePatternCEP() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStream<Event> input = env.fromElements(
 			new Event(1, "barfoo", 1.0),
@@ -105,7 +103,7 @@ public class CEPITCase extends AbstractTestBase {
 			}
 		});
 
-		DataStream<String> result = CEP.pattern(input, pattern).flatSelect((p, o) -> {
+		DataStream<String> result = CEP.pattern(input, pattern).inProcessingTime().flatSelect((p, o) -> {
 			StringBuilder builder = new StringBuilder();
 
 			builder.append(p.get("start").get(0).getId()).append(",")
@@ -125,7 +123,6 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testSimpleKeyedPatternCEP() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 		env.setParallelism(2);
 
 		DataStream<Event> input = env.fromElements(
@@ -176,7 +173,7 @@ public class CEPITCase extends AbstractTestBase {
 				}
 			});
 
-		DataStream<String> result = CEP.pattern(input, pattern).select(p -> {
+		DataStream<String> result = CEP.pattern(input, pattern).inProcessingTime().select(p -> {
 			StringBuilder builder = new StringBuilder();
 
 			builder.append(p.get("start").get(0).getId()).append(",")
@@ -365,7 +362,6 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testSimplePatternWithSingleState() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStream<Tuple2<Integer, Integer>> input = env.fromElements(
 			new Tuple2<>(0, 1),
@@ -380,7 +376,7 @@ public class CEPITCase extends AbstractTestBase {
 					}
 				});
 
-		PatternStream<Tuple2<Integer, Integer>> pStream = CEP.pattern(input, pattern);
+		PatternStream<Tuple2<Integer, Integer>> pStream = CEP.pattern(input, pattern).inProcessingTime();
 
 		DataStream<Tuple2<Integer, Integer>> result = pStream.select(new PatternSelectFunction<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>>() {
 			@Override
@@ -399,14 +395,13 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testProcessingTimeWithWindow() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 		env.setParallelism(1);
 
 		DataStream<Integer> input = env.fromElements(1, 2);
 
 		Pattern<Integer, ?> pattern = Pattern.<Integer>begin("start").followedByAny("end").within(Time.days(1));
 
-		DataStream<Integer> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Integer, Integer>() {
+		DataStream<Integer> result = CEP.pattern(input, pattern).inProcessingTime().select(new PatternSelectFunction<Integer, Integer>() {
 			@Override
 			public Integer select(Map<String, List<Integer>> pattern) throws Exception {
 				return pattern.get("start").get(0) + pattern.get("end").get(0);
@@ -517,7 +512,6 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testSimpleOrFilterPatternCEP() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStream<Event> input = env.fromElements(
 			new Event(1, "start", 1.0),
@@ -556,7 +550,7 @@ public class CEPITCase extends AbstractTestBase {
 				}
 			});
 
-		DataStream<String> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Event, String>() {
+		DataStream<String> result = CEP.pattern(input, pattern).inProcessingTime().select(new PatternSelectFunction<Event, String>() {
 
 			@Override
 			public String select(Map<String, List<Event>> pattern) {
@@ -691,7 +685,6 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testSimpleAfterMatchSkip() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStream<Tuple2<Integer, String>> input = env.fromElements(
 			new Tuple2<>(1, "a"),
@@ -708,7 +701,7 @@ public class CEPITCase extends AbstractTestBase {
 					}
 				}).times(2);
 
-		PatternStream<Tuple2<Integer, String>> pStream = CEP.pattern(input, pattern);
+		PatternStream<Tuple2<Integer, String>> pStream = CEP.pattern(input, pattern).inProcessingTime();
 
 		DataStream<Tuple2<Integer, String>> result = pStream.select(new PatternSelectFunction<Tuple2<Integer, String>, Tuple2<Integer, String>>() {
 			@Override
@@ -731,7 +724,6 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testRichPatternFlatSelectFunction() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStream<Event> input = env.fromElements(
 			new Event(1, "barfoo", 1.0),
@@ -768,7 +760,7 @@ public class CEPITCase extends AbstractTestBase {
 		});
 
 		DataStream<String> result =
-			CEP.pattern(input, pattern).flatSelect(new RichPatternFlatSelectFunction<Event, String>() {
+			CEP.pattern(input, pattern).inProcessingTime().flatSelect(new RichPatternFlatSelectFunction<Event, String>() {
 
 				@Override
 				public void open(Configuration config) {
@@ -807,7 +799,6 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testRichPatternSelectFunction() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 		env.setParallelism(2);
 
 		DataStream<Event> input = env.fromElements(
@@ -856,7 +847,7 @@ public class CEPITCase extends AbstractTestBase {
 				}
 			});
 
-		DataStream<String> result = CEP.pattern(input, pattern).select(new RichPatternSelectFunction<Event, String>() {
+		DataStream<String> result = CEP.pattern(input, pattern).inProcessingTime().select(new RichPatternSelectFunction<Event, String>() {
 			@Override
 			public void open(Configuration config) {
 				try {
@@ -896,11 +887,10 @@ public class CEPITCase extends AbstractTestBase {
 	@Test
 	public void testFlatSelectSerializationWithAnonymousClass() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
 		DataStreamSource<Integer> elements = env.fromElements(1, 2, 3);
 		OutputTag<Integer> outputTag = new OutputTag<Integer>("AAA") {};
-		CEP.pattern(elements, Pattern.begin("A")).flatSelect(
+		CEP.pattern(elements, Pattern.begin("A")).inProcessingTime().flatSelect(
 			outputTag,
 			new PatternFlatTimeoutFunction<Integer, Integer>() {
 				@Override

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.api.stream.table.validation
 
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableSourceValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableSourceValidationTest.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.api.validation
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
 import org.apache.flink.table.api.internal.TableEnvironmentInternal

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/MatchHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/MatchHarnessTest.scala
@@ -29,8 +29,6 @@ import org.junit.Test
 import java.time.{Instant, ZoneId}
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import org.apache.flink.streaming.api.TimeCharacteristic
-
 import scala.collection.mutable
 
 class MatchHarnessTest extends HarnessTestBase {
@@ -40,7 +38,6 @@ class MatchHarnessTest extends HarnessTestBase {
   @Test
   def testAccessingProctime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
 
     val tEnv = StreamTableEnvironment.create(
       env, EnvironmentSettings.newInstance().useOldPlanner().build())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/SortProcessFunctionHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/SortProcessFunctionHarnessTest.scala
@@ -27,7 +27,6 @@ import org.apache.flink.api.common.typeutils.{TypeComparator, TypeSerializer}
 import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.java.typeutils.runtime.RowComparator
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
@@ -183,7 +182,6 @@ class SortProcessFunctionHarnessTest {
 
    testHarness.open()
 
-   testHarness.setTimeCharacteristic(TimeCharacteristic.EventTime)
    testHarness.processWatermark(3)
 
       // timestamp is ignored in processing time

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/TimeAttributesITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/TimeAttributesITCase.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.stream
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/InsertIntoITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/InsertIntoITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.stream.sql
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.stream.sql
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
@@ -42,7 +41,6 @@ import scala.collection.mutable
 class MatchRecognizeITCase extends StreamingWithStateTestBase {
 
   val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
-  env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
   env.setParallelism(1)
   val settings: EnvironmentSettings = EnvironmentSettings.newInstance().useOldPlanner().build
   val tEnv: StreamTableEnvironment = StreamTableEnvironment.create(env, settings)
@@ -140,7 +138,6 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   @Test
   def testCodeSplitsAreProperlyGenerated(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
     env.setParallelism(1)
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
     val tEnv = StreamTableEnvironment.create(env, settings)
@@ -195,7 +192,6 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   @Test
   def testEventsAreProperlyOrdered(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(1)
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build
     val tEnv = StreamTableEnvironment.create(env, settings)
@@ -254,7 +250,6 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   @Test
   def testMatchRecognizeAppliedToWindowedGrouping(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(1)
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build
     val tEnv = StreamTableEnvironment.create(env, settings)
@@ -316,7 +311,6 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   @Test
   def testWindowedGroupingAppliedToMatchRecognize(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(1)
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build
     val tEnv = StreamTableEnvironment.create(env, settings)
@@ -520,7 +514,6 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   @Test
   def testAggregates(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
     env.setParallelism(1)
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
     val tEnv = StreamTableEnvironment.create(env, settings)
@@ -583,7 +576,6 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   @Test
   def testAggregatesWithNullInputs(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
     env.setParallelism(1)
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
     val tEnv = StreamTableEnvironment.create(env, settings)
@@ -675,7 +667,6 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   @Test
   def testUserDefinedFunctions(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
     env.setParallelism(1)
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
     val tEnv = StreamTableEnvironment.create(env, settings)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/OverWindowITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.stream.sql
 
 import org.apache.flink.api.java.tuple.{Tuple1, Tuple2}
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SortITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.stream.sql
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api._

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.stream.sql
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowTableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowTableAggregateITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.sink.SinkFunction

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.stream.table
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JExecEnv}
 import org.apache.flink.streaming.api.functions.ProcessFunction


### PR DESCRIPTION
## What is the purpose of the change

*With the deprecation of `StreamExecutionEnvironment.setStreamTimeCharacteristic()`, we need a way of explicitly configuring the time behaviour of CEP operations. Currently, all CEP operations use the characteristic to configure themselves. `PatternStream` could add `inProcessingTIme` and `inEventTime` that specify time behaviour to processing time or event time.*

## Brief change log

  - *`PatternStream` adds `inProcessingTIme` and `inEventTime` method instead of `setStreamTimeCharacteristic()` that specify time behaviour to processing time or event time.*

## Verifying this change

  - *Modify `CEPITCase` test cases which use `StreamExecutionEnvironment.setStreamTimeCharacteristic()` through `CEP.pattern(input, pattern, isProcessingTime`) to verify the `inProcessingTIme` of `PatternStream` whether could be instead of `setStreamTimeCharacteristic()`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)