### PR TITLE
[FLINK-19586] Add stream committer operators for new Sink API

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperator.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * Abstract base class for operators that work with a {@link Committer} or a
+ * {@link org.apache.flink.api.connector.sink.GlobalCommitter} in the streaming execution mode.
+ *
+ * <p>Sub-classes are responsible for implementing {@link #recoveredCommittables(List)},
+ * {@link #prepareCommit(List)} and {@link #commit(List)}.
+ *
+ * @param <InputT> The input type of the {@link Committer}.
+ * @param <CommT> The committable type of the {@link Committer}.
+ */
+abstract class AbstractStreamingCommitterOperator<InputT, CommT> extends AbstractStreamOperator<CommT>
+		implements OneInputStreamOperator<InputT, CommT> {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The operator's state descriptor. */
+	private static final ListStateDescriptor<byte[]> STREAMING_COMMITTER_RAW_STATES_DESC =
+			new ListStateDescriptor<>(
+					"streaming_committer_raw_states",
+					BytePrimitiveArraySerializer.INSTANCE);
+
+	/** Group the committable by the checkpoint id. */
+	private final NavigableMap<Long, List<CommT>> committablesPerCheckpoint;
+
+	/** The committable's serializer. */
+	private final StreamingCommitterStateSerializer<CommT> streamingCommitterStateSerializer;
+
+	/** The operator's state. */
+	private ListState<StreamingCommitterState<CommT>> streamingCommitterState;
+
+	/** Inputs collected between every pre-commit. */
+	private List<InputT> currentInputs;
+
+	/**
+	 * Notifies a list of committables that might need to be committed again after recovering from a failover.
+	 *
+	 * @param committables A list of committables
+	 */
+	abstract void recoveredCommittables(List<CommT> committables);
+
+	/**
+	 * Prepares a commit.
+	 *
+	 * @param input A list of input elements received since last pre-commit
+	 *
+	 * @return A list of committables that could be committed in the following checkpoint complete.
+	 */
+	abstract List<CommT> prepareCommit(List<InputT> input);
+
+	/**
+	 * Commits a list of committables.
+	 *
+	 * @param committables A list of committables that is ready for committing.
+	 *
+	 * @return A list of committables needed to re-commit.
+	 */
+	abstract List<CommT> commit(List<CommT> committables) throws Exception;
+
+	AbstractStreamingCommitterOperator(SimpleVersionedSerializer<CommT> committableSerializer) {
+		this.streamingCommitterStateSerializer = new StreamingCommitterStateSerializer<>(
+				committableSerializer);
+		this.committablesPerCheckpoint = new TreeMap<>();
+		this.currentInputs = new ArrayList<>();
+	}
+
+	@Override
+	public void initializeState(StateInitializationContext context) throws Exception {
+		super.initializeState(context);
+		streamingCommitterState = new SimpleVersionedListState<>(
+				context.getOperatorStateStore().getListState(STREAMING_COMMITTER_RAW_STATES_DESC),
+				streamingCommitterStateSerializer);
+		final List<CommT> restored = new ArrayList<>();
+		streamingCommitterState.get().forEach(s -> restored.addAll(s.getCommittables()));
+		recoveredCommittables(restored);
+	}
+
+	@Override
+	public void processElement(StreamRecord<InputT> element) throws Exception {
+		currentInputs.add(element.getValue());
+	}
+
+	@Override
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		super.snapshotState(context);
+		committablesPerCheckpoint.put(context.getCheckpointId(), prepareCommit(currentInputs));
+		currentInputs = new ArrayList<>();
+
+		streamingCommitterState.update(
+				Collections.singletonList(new StreamingCommitterState<>(committablesPerCheckpoint)));
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		super.notifyCheckpointComplete(checkpointId);
+		commitUpTo(checkpointId);
+	}
+
+	private void commitUpTo(long checkpointId) throws Exception {
+		final Iterator<Map.Entry<Long, List<CommT>>>
+				it = committablesPerCheckpoint.headMap(checkpointId, true).entrySet().iterator();
+
+		final List<CommT> readyCommittables = new ArrayList<>();
+
+		while (it.hasNext()) {
+			final Map.Entry<Long, List<CommT>> entry = it.next();
+			final List<CommT> committables = entry.getValue();
+
+			readyCommittables.addAll(committables);
+			it.remove();
+		}
+
+		LOG.info("Committing the state for checkpoint {}", checkpointId);
+		final List<CommT> neededToRetryCommittables = commit(readyCommittables);
+		if (!neededToRetryCommittables.isEmpty()) {
+			throw new UnsupportedOperationException("Currently does not support the re-commit!");
+		}
+
+		// TODO fix :: send only if needed what does this mean???
+		// send the committable to the down stream node. todo this is also for the global COMMITTER????
+		for (CommT committable : readyCommittables) {
+			output.collect(new StreamRecord<>(committable));
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperatorFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+/**
+ * Base {@link OneInputStreamOperatorFactory} for subclasses of {@link AbstractStreamingCommitterOperator}.
+ *
+ * @param <InputT> The input type of the {@link Committer}.
+ * @param <CommT> The committable type of the {@link Committer}.
+ */
+abstract class AbstractStreamingCommitterOperatorFactory<InputT, CommT> extends AbstractStreamOperatorFactory<CommT>
+		implements OneInputStreamOperatorFactory<InputT, CommT> {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T extends StreamOperator<CommT>> T createStreamOperator(StreamOperatorParameters<CommT> parameters) {
+		final AbstractStreamingCommitterOperator<InputT, CommT> streamingCommitterOperator = createStreamingCommitterOperator();
+		streamingCommitterOperator.setup(
+				parameters.getContainingTask(),
+				parameters.getStreamConfig(),
+				parameters.getOutput());
+		return (T) streamingCommitterOperator;
+	}
+
+	abstract AbstractStreamingCommitterOperator<InputT, CommT> createStreamingCommitterOperator();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperator.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Runtime {@link org.apache.flink.streaming.api.operators.StreamOperator} for executing
+ * {@link GlobalCommitter} in the streaming execution mode.
+ *
+ * @param <CommT> The committable type of the {@link GlobalCommitter}.
+ * @param <GlobalCommT> The global committable type of the {@link GlobalCommitter}.
+ */
+@Internal
+public final class GlobalStreamingCommitterOperator<CommT, GlobalCommT> extends AbstractStreamingCommitterOperator<CommT, GlobalCommT>
+		implements BoundedOneInput {
+
+	/** Aggregate committables to global committables and commit the global committables to the external system. */
+	private final GlobalCommitter<CommT, GlobalCommT> globalCommitter;
+
+	/** The global committables that might need to be committed again after recovering from a failover. */
+	private final List<GlobalCommT> recoveredGlobalCommittables;
+
+	private boolean endOfInput;
+
+	GlobalStreamingCommitterOperator(
+			GlobalCommitter<CommT, GlobalCommT> globalCommitter,
+			SimpleVersionedSerializer<GlobalCommT> committableSerializer) {
+		super(committableSerializer);
+		this.globalCommitter = checkNotNull(globalCommitter);
+
+		this.recoveredGlobalCommittables = new ArrayList<>();
+		this.endOfInput = false;
+	}
+
+	@Override
+	void recoveredCommittables(List<GlobalCommT> committables) {
+		final List<GlobalCommT> recovered = globalCommitter.
+				filterRecoveredCommittables(checkNotNull(committables));
+		recoveredGlobalCommittables.addAll(recovered);
+	}
+
+	@Override
+	List<GlobalCommT> prepareCommit(List<CommT> input) {
+		checkNotNull(input);
+		final List<GlobalCommT> result =
+				new ArrayList<>(recoveredGlobalCommittables);
+		recoveredGlobalCommittables.clear();
+
+		if (!input.isEmpty()) {
+			result.add(globalCommitter.combine(input));
+		}
+		return result;
+	}
+
+	@Override
+	List<GlobalCommT> commit(List<GlobalCommT> committables) throws Exception {
+		return globalCommitter.commit(checkNotNull(committables));
+	}
+
+	@Override
+	public void endInput() {
+		endOfInput = true;
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		globalCommitter.close();
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		super.notifyCheckpointComplete(checkpointId);
+		if (endOfInput) {
+			globalCommitter.endOfInput();
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link GlobalStreamingCommitterOperator}.
+ *
+ * @param <CommT> The committable type of the {@link GlobalCommitter}.
+ * @param <GlobalCommT> The global committable type of the {@link GlobalCommitter}.
+ */
+public class GlobalStreamingCommitterOperatorFactory<CommT, GlobalCommT> extends AbstractStreamingCommitterOperatorFactory<CommT, GlobalCommT> {
+
+	private final Sink<?, CommT, ?, GlobalCommT> sink;
+
+	public GlobalStreamingCommitterOperatorFactory(Sink<?, CommT, ?, GlobalCommT> sink) {
+		this.sink = checkNotNull(sink);
+	}
+
+	@Override
+	AbstractStreamingCommitterOperator<CommT, GlobalCommT> createStreamingCommitterOperator() {
+		return new GlobalStreamingCommitterOperator<>(
+				sink.createGlobalCommitter()
+						.orElseThrow(() -> new IllegalStateException(
+								"Could not create global committer from the sink")),
+				sink.getGlobalCommittableSerializer()
+						.orElseThrow(() -> new IllegalStateException(
+								"Could not create global committable serializer from the sink")));
+	}
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return GlobalStreamingCommitterOperator.class;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Runtime {@link org.apache.flink.streaming.api.operators.StreamOperator} for executing
+ * {@link Committer} in the streaming execution mode.
+ *
+ * @param <CommT> The committable type of the {@link Committer}.
+ */
+final class StreamingCommitterOperator<CommT> extends AbstractStreamingCommitterOperator<CommT, CommT> {
+
+	/** The committables that might need to be committed again after recovering from a failover. */
+	private final List<CommT> recoveredCommittables;
+
+	/** Responsible for committing the committable to the external system. **/
+	private final Committer<CommT> committer;
+
+	StreamingCommitterOperator(
+			Committer<CommT> committer,
+			SimpleVersionedSerializer<CommT> committableSerializer) {
+		super(committableSerializer);
+		this.committer = checkNotNull(committer);
+		this.recoveredCommittables = new ArrayList<>();
+	}
+
+	@Override
+	void recoveredCommittables(List<CommT> committables) {
+		recoveredCommittables.addAll(checkNotNull(committables));
+	}
+
+	@Override
+	List<CommT> prepareCommit(List<CommT> input) {
+		checkNotNull(input);
+		final List<CommT> result = new ArrayList<>(recoveredCommittables);
+		recoveredCommittables.clear();
+		result.addAll(input);
+		return result;
+	}
+
+	@Override
+	List<CommT> commit(List<CommT> committables) throws Exception {
+		return committer.commit(checkNotNull(committables));
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		committer.close();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link StreamingCommitterOperator}.
+ *
+ * @param <CommT> The committable type of the {@link Committer}.
+ */
+@Internal
+public class StreamingCommitterOperatorFactory<CommT> extends AbstractStreamingCommitterOperatorFactory<CommT, CommT> {
+
+	private final Sink<?, CommT, ?, ?> sink;
+
+	public StreamingCommitterOperatorFactory(Sink<?, CommT, ?, ?> sink) {
+		this.sink = checkNotNull(sink);
+	}
+
+	@Override
+	AbstractStreamingCommitterOperator<CommT, CommT> createStreamingCommitterOperator() {
+		return new StreamingCommitterOperator<>(
+				sink.createCommitter()
+						.orElseThrow(() -> new IllegalStateException(
+								"Could not create committer from the sink")),
+				sink.getCommittableSerializer()
+						.orElseThrow(() -> new IllegalStateException(
+								"Could not get committable serializer from the sink")));
+	}
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return StreamingCommitterOperator.class;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterState.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The state fo the {@link AbstractStreamingCommitterOperator}.
+ *
+ * @param <CommT> The committable type of the {@link Committer}.
+ */
+final class StreamingCommitterState<CommT> {
+
+	private final List<CommT> committables;
+
+	StreamingCommitterState(List<CommT> committables) {
+		this.committables = checkNotNull(committables);
+	}
+
+	StreamingCommitterState(NavigableMap<Long, List<CommT>> committablesPerCheckpoint) {
+		committables = new ArrayList<>();
+		for (Map.Entry<Long, List<CommT>> item : committablesPerCheckpoint.entrySet()) {
+			committables.addAll(item.getValue());
+		}
+	}
+
+	public List<CommT> getCommittables() {
+		return committables;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		StreamingCommitterState<?> that = (StreamingCommitterState<?>) o;
+		return committables.equals(that.committables);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(committables);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterStateSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterStateSerializer.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The serializer for the {@link StreamingCommitterState}.
+ */
+
+final class StreamingCommitterStateSerializer<CommT> implements SimpleVersionedSerializer<StreamingCommitterState<CommT>> {
+
+	private static final int MAGIC_NUMBER = 0xb91f252c;
+
+	private final SimpleVersionedSerializer<CommT> committableSerializer;
+
+	StreamingCommitterStateSerializer(SimpleVersionedSerializer<CommT> committableSerializer) {
+		this.committableSerializer = checkNotNull(committableSerializer);
+	}
+
+	@Override
+	public int getVersion() {
+		return 1;
+	}
+
+	@Override
+	public byte[] serialize(StreamingCommitterState<CommT> state) throws IOException {
+		DataOutputSerializer out = new DataOutputSerializer(256);
+		out.writeInt(MAGIC_NUMBER);
+		serializeV1(state, out);
+		return out.getCopyOfBuffer();
+	}
+
+	@Override
+	public StreamingCommitterState<CommT> deserialize(
+			int version,
+			byte[] serialized) throws IOException {
+		final DataInputDeserializer in = new DataInputDeserializer(serialized);
+		if (version == 1) {
+			validateMagicNumber(in);
+			return deserializeV1(in);
+		}
+		throw new IOException("Unrecognized version or corrupt state: " + version);
+	}
+
+	private StreamingCommitterState<CommT> deserializeV1(DataInputView in) throws IOException {
+		final List<CommT> r = new ArrayList<>();
+		final int committableSerializerVersion = in.readInt();
+		final int numOfCommittable = in.readInt();
+
+		for (int i = 0; i < numOfCommittable; i++) {
+			final byte[] bytes = new byte[in.readInt()];
+			in.readFully(bytes);
+			final CommT committable = committableSerializer.deserialize(
+					committableSerializerVersion,
+					bytes);
+			r.add(committable);
+		}
+
+		return new StreamingCommitterState<>(r);
+	}
+
+	private void serializeV1(
+			StreamingCommitterState<CommT> state,
+			DataOutputView dataOutputView) throws IOException {
+
+		dataOutputView.writeInt(committableSerializer.getVersion());
+		dataOutputView.writeInt(state.getCommittables().size());
+
+		for (CommT committable : state.getCommittables()) {
+			final byte[] serialized = committableSerializer.serialize(committable);
+			dataOutputView.writeInt(serialized.length);
+			dataOutputView.write(serialized);
+		}
+	}
+
+	private static void validateMagicNumber(DataInputView in) throws IOException {
+		final int magicNumber = in.readInt();
+		if (magicNumber != MAGIC_NUMBER) {
+			throw new IOException(String.format(
+					"Corrupt data: Unexpected magic number %08X",
+					magicNumber));
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.util.TestHarnessUtil.buildSubtaskState;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link GlobalStreamingCommitterOperator}.
+ */
+public class GlobalStreamingCommitterOperatorTest extends TestLogger {
+
+	@Test(expected = IllegalStateException.class)
+	public void throwExceptionWithoutSerializer() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(new TestSink.TestGlobalCommitter(""), null);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void throwExceptionWithoutCommitter() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(null, SimpleVersionedStringSerializer.INSTANCE);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void doNotSupportRetry() throws Exception {
+		final List<String> input = Arrays.asList("lazy", "leaf");
+
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(new TestSink.AlwaysRetryGlobalCommitter());
+
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.processElements(input
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(1L, 1L);
+		testHarness.notifyOfCompletedCheckpoint(1L);
+
+		testHarness.close();
+	}
+
+	@Test
+	public void closeCommitter() throws Exception {
+		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				globalCommitter);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.close();
+		assertThat(globalCommitter.isClosed(), is(true));
+	}
+
+	@Test
+	public void restoredFromMergedState() throws Exception {
+
+		final List<String> input1 = Arrays.asList("host", "drop");
+		final OperatorSubtaskState operatorSubtaskState1 = buildSubtaskState(
+				createTestHarness(),
+				input1);
+
+		final List<String> input2 = Arrays.asList("future", "evil", "how");
+		final OperatorSubtaskState operatorSubtaskState2 = buildSubtaskState(
+				createTestHarness(),
+				input2);
+
+		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				globalCommitter);
+
+		final OperatorSubtaskState mergedOperatorSubtaskState =
+				OneInputStreamOperatorTestHarness.repackageState(
+						operatorSubtaskState1,
+						operatorSubtaskState2);
+
+		testHarness.initializeState(
+				OneInputStreamOperatorTestHarness.repartitionOperatorState(
+						mergedOperatorSubtaskState, 2, 2, 1, 0));
+		testHarness.open();
+
+		final List<String> expectedOutput = new ArrayList<>();
+		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input1));
+		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input2));
+
+		testHarness.snapshot(1L, 1L);
+		testHarness.notifyOfCompletedCheckpoint(1L);
+		testHarness.close();
+
+		// TODO:: maybe there is no output at all
+		assertThat(
+				testHarness.getOutput(),
+				containsInAnyOrder(expectedOutput.stream().map(StreamRecord::new).toArray()));
+
+		assertThat(
+				globalCommitter.getCommittedData(),
+				containsInAnyOrder(expectedOutput.toArray()));
+	}
+
+	@Test
+	public void commitMultipleStagesTogether() throws Exception {
+
+		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+
+		final List<String> input1 = Arrays.asList("cautious", "nature");
+		final List<String> input2 = Arrays.asList("count", "over");
+		final List<String> input3 = Arrays.asList("lawyer", "grammar");
+
+		final List<String> expectedOutput = new ArrayList<>();
+
+		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input1));
+		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input2));
+		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input3));
+
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				globalCommitter);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+
+		testHarness.processElements(input1
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(1L, 1L);
+		testHarness.processElements(input2
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(2L, 2L);
+		testHarness.processElements(input3
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(3L, 3L);
+
+		testHarness.notifyOfCompletedCheckpoint(3L);
+
+		testHarness.close();
+
+		assertThat(
+				testHarness.getOutput().toArray(),
+				equalTo(expectedOutput.stream().map(StreamRecord::new).toArray()));
+
+		assertThat(
+				globalCommitter.getCommittedData().toArray(),
+				equalTo(expectedOutput.toArray()));
+	}
+
+	@Test
+	public void filterRecoveredCommittables() throws Exception {
+		final List<String> input = Arrays.asList("silent", "elder", "patience");
+		final String successCommittedCommittable = TestSink.TestGlobalCommitter.COMBINER.apply(input);
+
+		final OperatorSubtaskState operatorSubtaskState = buildSubtaskState(
+				createTestHarness(),
+				input);
+		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter(
+				successCommittedCommittable);
+
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				globalCommitter);
+
+		// all data from previous checkpoint are expected to be committed,
+		// so we expect no data to be re-committed.
+		testHarness.initializeState(operatorSubtaskState);
+		testHarness.open();
+		testHarness.snapshot(1L, 1L);
+		testHarness.notifyOfCompletedCheckpoint(1L);
+		assertTrue(globalCommitter.getCommittedData().isEmpty());
+		testHarness.close();
+	}
+
+	@Test
+	public void endOfInput() throws Exception {
+		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				globalCommitter);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.snapshot(1L, 1L);
+		testHarness.endInput();
+		testHarness.notifyOfCompletedCheckpoint(1L);
+		testHarness.close();
+		assertThat(
+				globalCommitter.getCommittedData(),
+				contains("end of input"));
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness() throws Exception {
+		return createTestHarness(
+				new TestSink.TestGlobalCommitter(""),
+				SimpleVersionedStringSerializer.INSTANCE);
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
+			GlobalCommitter<String, String> globalCommitter) throws Exception {
+		return createTestHarness(globalCommitter, SimpleVersionedStringSerializer.INSTANCE);
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
+			GlobalCommitter<String, String> globalCommitter,
+			SimpleVersionedStringSerializer serializer) throws Exception {
+		return new OneInputStreamOperatorTestHarness<>(
+				new GlobalStreamingCommitterOperatorFactory<>(
+						TestSink.create(
+								() -> TestSink.DEFAULT_WRITER,
+								() -> Optional.empty(),
+								() -> Optional.empty(),
+								() -> globalCommitter == null ? Optional.empty() :
+										Optional.of(globalCommitter),
+								() -> serializer == null ? Optional.empty() :
+										Optional.of(SimpleVersionedStringSerializer.INSTANCE))),
+				StringSerializer.INSTANCE);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.util.TestHarnessUtil.buildSubtaskState;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+
+/**
+ * Test the {@link StreamingCommitterOperator}.
+ *
+ * <p>This has no tests of its own because {@link StreamingCommitterOperator} has no functionality
+ * beyond what {@link AbstractStreamingCommitterOperator} provides.
+ */
+public class StreamingCommitterOperatorTest extends TestLogger {
+
+	@Test(expected = IllegalStateException.class)
+	public void throwExceptionWithoutSerializer() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(new TestSink.TestCommitter(), null);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void throwExceptionWithoutCommitter() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(null, SimpleVersionedStringSerializer.INSTANCE);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void doNotSupportRetry() throws Exception {
+		final List<String> input = Arrays.asList("lazy", "leaf");
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(new TestSink.AlwaysRetryCommitter());
+
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.processElements(input
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(1L, 1L);
+		testHarness.notifyOfCompletedCheckpoint(1L);
+
+		testHarness.close();
+	}
+
+	@Test
+	public void closeCommitter() throws Exception {
+		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				committer);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.close();
+		assertThat(committer.isClosed(), is(true));
+	}
+
+	@Test
+	public void restoredFromMergedState() throws Exception {
+
+		final List<String> input1 = Arrays.asList("today", "whom");
+		final OperatorSubtaskState operatorSubtaskState1 = buildSubtaskState(
+				createTestHarness(),
+				input1);
+
+		final List<String> input2 = Arrays.asList("future", "evil", "how");
+		final OperatorSubtaskState operatorSubtaskState2 = buildSubtaskState(
+				createTestHarness(),
+				input2);
+
+		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				committer);
+
+		final OperatorSubtaskState mergedOperatorSubtaskState =
+				OneInputStreamOperatorTestHarness.repackageState(
+						operatorSubtaskState1,
+						operatorSubtaskState2);
+
+		testHarness.initializeState(
+				OneInputStreamOperatorTestHarness.repartitionOperatorState(
+						mergedOperatorSubtaskState, 2, 2, 1, 0));
+		testHarness.open();
+
+		final List<String> expectedOutput = new ArrayList<>();
+		expectedOutput.addAll(input1);
+		expectedOutput.addAll(input2);
+
+		testHarness.snapshot(1L, 1L);
+		testHarness.notifyOfCompletedCheckpoint(1);
+
+		testHarness.close();
+
+		assertThat(
+				testHarness.getOutput(),
+				containsInAnyOrder(expectedOutput.stream().map(StreamRecord::new).toArray()));
+
+		assertThat(
+				committer.getCommittedData(),
+				containsInAnyOrder(expectedOutput.toArray()));
+	}
+
+	@Test
+	public void commitMultipleStagesTogether() throws Exception {
+
+		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+
+		final List<String> input1 = Arrays.asList("cautious", "nature");
+		final List<String> input2 = Arrays.asList("count", "over");
+		final List<String> input3 = Arrays.asList("lawyer", "grammar");
+
+		final List<String> expectedOutput = new ArrayList<>();
+
+		expectedOutput.addAll(input1);
+		expectedOutput.addAll(input2);
+		expectedOutput.addAll(input3);
+
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				committer);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+
+		testHarness.processElements(input1
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(1L, 1L);
+		testHarness.processElements(input2
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(2L, 2L);
+		testHarness.processElements(input3
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+		testHarness.snapshot(3L, 3L);
+
+		testHarness.notifyOfCompletedCheckpoint(1);
+		testHarness.notifyOfCompletedCheckpoint(3);
+
+		testHarness.close();
+
+		assertThat(
+				testHarness.getOutput().toArray(),
+				equalTo(expectedOutput.stream().map(StreamRecord::new).toArray()));
+
+		assertThat(
+				committer.getCommittedData().toArray(),
+				equalTo(expectedOutput.toArray()));
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness() throws Exception {
+		return createTestHarness(new TestSink.TestCommitter(), SimpleVersionedStringSerializer.INSTANCE);
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(Committer<String> committer) throws Exception {
+		return createTestHarness(committer, SimpleVersionedStringSerializer.INSTANCE);
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
+			Committer<String> committer,
+			SimpleVersionedStringSerializer serializer) throws Exception {
+		return new OneInputStreamOperatorTestHarness<>(
+				new StreamingCommitterOperatorFactory<>(
+						TestSink.create(
+								() -> TestSink.DEFAULT_WRITER,
+								() -> committer == null ? Optional.empty() : Optional.of(committer),
+								() -> serializer == null ? Optional.empty() : Optional.of(serializer),
+								// Can not use method reference because compiler cant not speculate the type
+								() -> Optional.empty(),
+								() -> Optional.empty())),
+				StringSerializer.INSTANCE);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterStateSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterStateSerializerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test {@link StreamingCommitterStateSerializer}.
+ */
+public class StreamingCommitterStateSerializerTest {
+
+	@Test
+	public void serializeNonEmptyState() throws IOException {
+		final StreamingCommitterState<String> expectedStreamingCommitterState =
+				new StreamingCommitterState<>(Arrays.asList("city", "great", "temper", "valley"));
+		final StreamingCommitterStateSerializer<String> streamingCommitterStateSerializer =
+				new StreamingCommitterStateSerializer<>(SimpleVersionedStringSerializer.INSTANCE);
+
+		final byte[] serialize = streamingCommitterStateSerializer.serialize(
+				expectedStreamingCommitterState);
+		final StreamingCommitterState<String> streamingCommitterState =
+				streamingCommitterStateSerializer.deserialize(
+						streamingCommitterStateSerializer.getVersion(),
+						serialize);
+
+		assertThat(
+				streamingCommitterState.getCommittables(),
+				equalTo(
+						expectedStreamingCommitterState.getCommittables()));
+	}
+
+	@Test
+	public void serializeEmptyState() throws IOException {
+		final StreamingCommitterState<String> expectedStreamingCommitterState =
+				new StreamingCommitterState<>(Collections.emptyList());
+		final StreamingCommitterStateSerializer<String> streamingCommitterStateSerializer =
+				new StreamingCommitterStateSerializer<>(SimpleVersionedStringSerializer.INSTANCE);
+
+		final byte[] serialize = streamingCommitterStateSerializer.serialize(
+				expectedStreamingCommitterState);
+		final StreamingCommitterState<String> streamingCommitterState =
+				streamingCommitterStateSerializer.deserialize(
+						streamingCommitterStateSerializer.getVersion(),
+						serialize);
+
+		assertThat(
+				streamingCommitterState.getCommittables(),
+				equalTo(
+						expectedStreamingCommitterState.getCommittables()));
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterStateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterStateTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test {@link StreamingCommitterState}.
+ */
+public class StreamingCommitterStateTest {
+
+	@Test
+	public void constructFromMap() {
+		final NavigableMap<Long, List<Integer>> r = new TreeMap<>();
+		final List<Integer> expectedList = Arrays.asList(0, 1, 2, 3, 10, 11, 12, 13, 30, 31, 32, 33);
+
+		r.put(1L, Arrays.asList(10, 11, 12, 13));
+		r.put(0L, Arrays.asList(0, 1, 2, 3));
+		r.put(3L, Arrays.asList(30, 31, 32, 33));
+
+		final StreamingCommitterState<Integer> streamingCommitterState = new StreamingCommitterState<>(
+				r);
+
+		assertThat(
+				streamingCommitterState.getCommittables(),
+				equalTo(
+						expectedList));
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link Sink} for testing that uses {@link Supplier Suppliers} to create various components
+ * under test.
+ */
+class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
+		implements Sink<InputT, CommT, WriterStateT, GlobalCommT> {
+
+	static final DefaultWriter<String> DEFAULT_WRITER = new DefaultWriter<>();
+
+	private final Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier;
+	private final Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier;
+
+	private final Supplier<Optional<Committer<CommT>>> committerSupplier;
+	private final Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier;
+
+	private final Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier;
+	private final Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier;
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Supplier<Writer<InputT, CommT, WriterStateT>> writer) {
+		// We cannot replace this by a method reference because the Java compiler will not be
+		// able to typecheck it.
+		//noinspection Convert2MethodRef
+		return new TestSink<>((state) -> writer.get(), () -> Optional.empty());
+	}
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+		return new TestSink<>((state) -> writer.get(), writerStateSerializerSupplier);
+	}
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+		return new TestSink<>(writer, writerStateSerializerSupplier);
+	}
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<Committer<CommT>>> committerSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
+			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommittableSerializer) {
+		return new TestSink<>(
+				(s) -> writer.get(),
+				() -> Optional.empty(),
+				committerSupplier,
+				committableSerializerSupplier,
+				globalCommitterSupplier,
+				globalCommittableSerializer);
+	}
+
+	private TestSink(
+			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier,
+			Supplier<Optional<Committer<CommT>>> committerSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
+			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier) {
+		this.writerSupplier = writerSupplier;
+		this.writerStateSerializerSupplier = writerStateSerializerSupplier;
+		this.committerSupplier = committerSupplier;
+		this.committableSerializerSupplier = committableSerializerSupplier;
+		this.globalCommitterSupplier = globalCommitterSupplier;
+		this.globalCommitterSerializerSupplier = globalCommitterSerializerSupplier;
+	}
+
+	private TestSink(
+			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+		this(
+				writer,
+				writerStateSerializerSupplier,
+				Optional::empty,
+				Optional::empty,
+				Optional::empty,
+				Optional::empty);
+	}
+
+	@Override
+	public Writer<InputT, CommT, WriterStateT> createWriter(
+			InitContext context,
+			List<WriterStateT> states) {
+		return writerSupplier.apply(states);
+	}
+
+	@Override
+	public Optional<Committer<CommT>> createCommitter() {
+		return committerSupplier.get();
+	}
+
+	@Override
+	public Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
+		return globalCommitterSupplier.get();
+	}
+
+	@Override
+	public Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
+		return committableSerializerSupplier.get();
+	}
+
+	@Override
+	public Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
+		return globalCommitterSerializerSupplier.get();
+	}
+
+	@Override
+	public Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
+		return writerStateSerializerSupplier.get();
+	}
+
+	/**
+	 * This is default writer used for testing {@link Committer} and {@link GlobalCommitter}'s operator.
+	 */
+	static class DefaultWriter<CommT> implements Writer<CommT, CommT, CommT> {
+
+		@Override
+		public void write(CommT element, Context context) {
+			//do nothing
+		}
+
+		@Override
+		public List<CommT> prepareCommit(boolean flush) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<CommT> snapshotState() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void close() throws Exception {
+
+		}
+	}
+
+	/**
+	 * Base class for testing {@link Committer} and {@link GlobalCommitter}.
+	 */
+	abstract static class AbstractTestCommitter<CommT> implements Committer<CommT> {
+
+		protected List<CommT> committedData;
+
+		private boolean isClosed;
+
+		public AbstractTestCommitter() {
+			this.committedData = new ArrayList<>();
+			this.isClosed = false;
+		}
+
+		public List<CommT> getCommittedData() {
+			return committedData;
+		}
+
+		@Override
+		public void close() throws Exception {
+			isClosed = true;
+		}
+
+		public boolean isClosed() {
+			return isClosed;
+		}
+	}
+
+	/**
+	 * The class used for normal committer test.
+	 */
+	static class TestCommitter extends AbstractTestCommitter<String> {
+
+		@Override
+		public List<String> commit(List<String> committables) {
+			if (committedData != null) {
+				committedData.addAll(committables);
+			}
+			return Collections.emptyList();
+		}
+	}
+
+	/**
+	 * This committer always re-commits the committables data it received.
+	 */
+	static class AlwaysRetryCommitter extends AbstractTestCommitter<String> {
+
+		@Override
+		public List<String> commit(List<String> committables) {
+			return committables;
+		}
+	}
+
+	/**
+	 * The class used for normal global committer test.
+	 */
+	static class TestGlobalCommitter extends TestCommitter implements GlobalCommitter<String, String> {
+
+		static final Function<List<String>, String> COMBINER = (x) -> String.join("+", x);
+
+		private final String committedSuccessData;
+
+		TestGlobalCommitter(String committedSuccessData) {
+			this.committedSuccessData = committedSuccessData;
+		}
+
+		@Override
+		public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
+			if (committedSuccessData == null) {
+				return globalCommittables;
+			}
+			return globalCommittables
+					.stream()
+					.filter(s -> !s.equals(committedSuccessData))
+					.collect(Collectors.toList());
+		}
+
+		@Override
+		public String combine(List<String> committables) {
+			return COMBINER.apply(committables);
+		}
+
+		@Override
+		public void endOfInput() {
+			this.committedData.add("end of input");
+		}
+	}
+
+	/**
+	 * This global committer always re-commits the committables data it received.
+	 */
+	static class AlwaysRetryGlobalCommitter extends AbstractTestCommitter<String> implements GlobalCommitter<String, String> {
+
+		@Override
+		public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public String combine(List<String> committables) {
+			return String.join("|", committables);
+		}
+
+		@Override
+		public void endOfInput() {
+
+		}
+
+		@Override
+		public List<String> commit(List<String> committables) {
+			return committables;
+		}
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This patch introduces two stream committer operator:
1. `StreamingCommitterOperator` is the runtime operator for the `Committer` in the new sink api
2. `StreamingGlobalCommitterOperator` is the runtime operator for the `GlobalCommitter` in the new sink api

The `AbstractStreamingCommitterOperator` is base class of the two operators

## Brief change log

1. Introduce the `AbstractStreamingCommitterOperator` as the base class of the committer operator
1. Introduce the `StreamingCommitterOperator` for the local committer
1. Introduce the `StreamingGlobalCommitterOperator` for the global committer
1. Introduce the `StreamingCommitterState` and `StreamingCommitterStateSerializer`
1. Makes'TestSink' as all test sinks's factory.


## Verifying this change

1. `StreamingCommitterTestBase` test the `open/process/presnapshot/snapshot/close/restore` of the two operator
2. `GlobalStreamingCommitterOperatorTest` test `filterRecoveredCommittables/endOfInput` of the `GlobalStreamingCommiterOperator`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
