### PR TITLE
[FLINK-19695][table-runtime-blink] Fix ClassCastException when writing table with rowtime attribute

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -209,6 +209,11 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		.stringType()
 		.defaultValue("DEFAULT"); // class path which implements DynamicTableSource
 
+	private static final ConfigOption<String> TABLE_SINK_CLASS = ConfigOptions
+		.key("table-sink-class")
+		.stringType()
+		.defaultValue("DEFAULT"); // class path which implements DynamicTableSink
+
 	private static final ConfigOption<String> LOOKUP_FUNCTION_CLASS  = ConfigOptions
 		.key("lookup-function-class")
 		.stringType()
@@ -315,15 +320,28 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 	public DynamicTableSink createDynamicTableSink(Context context) {
 		FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 		helper.validate();
+		String sinkClass = helper.getOptions().get(TABLE_SINK_CLASS);
+
 		boolean isInsertOnly = helper.getOptions().get(SINK_INSERT_ONLY);
 		String runtimeSink = helper.getOptions().get(RUNTIME_SINK);
 		int expectedNum = helper.getOptions().get(SINK_EXPECTED_MESSAGES_NUM);
 		TableSchema schema = context.getCatalogTable().getSchema();
-		return new TestValuesTableSink(
-			schema,
-			context.getObjectIdentifier().getObjectName(),
-			isInsertOnly,
-			runtimeSink, expectedNum);
+		if (sinkClass.equals("DEFAULT")) {
+			return new TestValuesTableSink(
+				schema,
+				context.getObjectIdentifier().getObjectName(),
+				isInsertOnly,
+				runtimeSink, expectedNum);
+		} else {
+			try {
+				return InstantiationUtil.instantiate(
+					sinkClass,
+					DynamicTableSink.class,
+					Thread.currentThread().getContextClassLoader());
+			} catch (FlinkException e) {
+				throw new TableException("Can't instantiate class " + sinkClass, e);
+			}
+		}
 	}
 
 	@Override
@@ -342,6 +360,7 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 			LOOKUP_FUNCTION_CLASS,
 			ASYNC_ENABLED,
 			TABLE_SOURCE_CLASS,
+			TABLE_SINK_CLASS,
 			SINK_INSERT_ONLY,
 			RUNTIME_SINK,
 			SINK_EXPECTED_MESSAGES_NUM,
@@ -845,6 +864,44 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		@Override
 		public String asSummaryString() {
 			return "TestValues";
+		}
+	}
+
+	public static class TestSinkContextTableSink implements DynamicTableSink {
+
+		public static final List<Long> ROWTIMES = new ArrayList<>();
+
+		@Override
+		public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+			return ChangelogMode.insertOnly();
+		}
+
+		@Override
+		public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+			// clear ROWTIMES first
+			synchronized (ROWTIMES) {
+				ROWTIMES.clear();
+			}
+			SinkFunction<RowData> sinkFunction = new SinkFunction<RowData>() {
+				private static final long serialVersionUID = -4871941979714977824L;
+				@Override
+				public void invoke(RowData value, Context context) throws Exception {
+					synchronized (ROWTIMES) {
+						ROWTIMES.add(context.timestamp());
+					}
+				}
+			};
+			return SinkFunctionProvider.of(sinkFunction);
+		}
+
+		@Override
+		public DynamicTableSink copy() {
+			return new TestSinkContextTableSink();
+		}
+
+		@Override
+		public String asSummaryString() {
+			return "TestSinkContextTableSink";
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -867,6 +867,9 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		}
 	}
 
+	/**
+	 * A TableSink used for testing the implementation of {@link SinkFunction.Context}.
+	 */
 	public static class TestSinkContextTableSink implements DynamicTableSink {
 
 		public static final List<Long> ROWTIMES = new ArrayList<>();

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -32,7 +32,7 @@ import org.junit.Test
 import java.lang.{Long => JLong}
 import java.math.{BigDecimal => JBigDecimal}
 import java.sql.Timestamp
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, OffsetDateTime, ZoneId, ZoneOffset}
 import java.util.TimeZone
 
 import scala.collection.JavaConversions._
@@ -672,7 +672,7 @@ class TableSinkITCase extends StreamingTestBase {
 
     tEnv.executeSql("INSERT INTO sink SELECT * FROM src").await()
 
-    val expected = List(1, 2, 3, 4, 7, 8, 16)
+    val expected = List(1000, 2000, 3000, 4000, 7000, 8000, 16000)
     assertEquals(expected.sorted, TestSinkContextTableSink.ROWTIMES.sorted)
 
     val sinkDDL2 =
@@ -695,20 +695,20 @@ class TableSinkITCase extends StreamingTestBase {
       """
         |INSERT INTO sink2
         |SELECT
-        |  TUMBLE_ROWTIME(ts, INTERVAL '0.005' SECOND),
+        |  TUMBLE_ROWTIME(ts, INTERVAL '5' SECOND),
         |  SUM(b)
         |FROM src
-        |GROUP BY TUMBLE(ts, INTERVAL '0.005' SECOND)
+        |GROUP BY TUMBLE(ts, INTERVAL '5' SECOND)
         |""".stripMargin
     ).await()
 
-    val expected2 = List(4, 9, 19)
+    val expected2 = List(4999, 9999, 19999)
     assertEquals(expected2.sorted, TestSinkContextTableSink.ROWTIMES.sorted)
   }
 
   // ------------------------------------------------------------------------------------------
 
-  private def localDateTime(ts: Long): LocalDateTime = {
-    new Timestamp(ts - TimeZone.getDefault.getOffset(ts)).toLocalDateTime
+  private def localDateTime(epochSecond: Long): LocalDateTime = {
+    LocalDateTime.ofEpochSecond(epochSecond, 0, ZoneOffset.UTC)
   }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
@@ -141,7 +141,7 @@ public class SinkOperator extends AbstractUdfStreamOperator<Object, SinkFunction
 
 		@Override
 		public Long timestamp() {
-			if (rowtimeFieldIndex > 0) {
+			if (rowtimeFieldIndex >= 0) {
 				TimestampData timestamp = element.getValue().getTimestamp(rowtimeFieldIndex, 3);
 				if (timestamp != null) {
 					return timestamp.getMillisecond();

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.ExecutionConfigOptions.NotNullEnforcer;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
 
 /**
  * A {@link StreamOperator} for executing {@link SinkFunction SinkFunctions}. This operator
@@ -141,7 +142,12 @@ public class SinkOperator extends AbstractUdfStreamOperator<Object, SinkFunction
 		@Override
 		public Long timestamp() {
 			if (rowtimeFieldIndex > 0) {
-				return element.getValue().getLong(rowtimeFieldIndex);
+				TimestampData timestamp = element.getValue().getTimestamp(rowtimeFieldIndex, 3);
+				if (timestamp != null) {
+					return timestamp.getMillisecond();
+				} else {
+					return null;
+				}
 			}
 			return null;
 		}


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When writing Table with rowtime column of type TIMESTAMP(3) to Kafka fails with ClassCastException. This is because `SinkOperator$SimpleContext#timestamp` only deal with long type timestamps. This is a legacy code, because we have changed timestamp from long type to `TimestampData` since 1.11. 


## Brief change log

- Fix `SinkOperator$SimpleContext#timestamp` to get `TimestampData` first. 


## Verifying this change

- Added an end-to-end test for `SinkContext#timestamp` .

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)