### PR TITLE
[FLINK-19707][table-runtime] Refactor table streaming file sink

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/AbstractStreamingWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/AbstractStreamingWriter.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.functions.sink.filesystem.Bucket;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketLifeCycleListener;
+import org.apache.flink.streaming.api.functions.sink.filesystem.Buckets;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSinkHelper;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * Operator for file system sink. It is a operator version of {@link StreamingFileSink}.
+ * It can send file and bucket information to downstream.
+ */
+public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOperator<OUT>
+		implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------------ configuration fields --------------------------
+
+	private final long bucketCheckInterval;
+
+	private final StreamingFileSink.BucketsBuilder<IN, String, ? extends
+			StreamingFileSink.BucketsBuilder<IN, String, ?>> bucketsBuilder;
+
+	// --------------------------- runtime fields -----------------------------
+
+	private transient Buckets<IN, String> buckets;
+
+	private transient StreamingFileSinkHelper<IN> helper;
+
+	private transient long currentWatermark;
+
+	public AbstractStreamingWriter(
+			long bucketCheckInterval,
+			StreamingFileSink.BucketsBuilder<IN, String, ? extends
+					StreamingFileSink.BucketsBuilder<IN, String, ?>> bucketsBuilder) {
+		this.bucketCheckInterval = bucketCheckInterval;
+		this.bucketsBuilder = bucketsBuilder;
+		setChainingStrategy(ChainingStrategy.ALWAYS);
+	}
+
+	/**
+	 * Notifies a partition become inactive. A partition becomes inactive after all
+	 * the records received so far have been committed.
+	 */
+	protected abstract void partitionInactive(String partition);
+
+	/**
+	 * Commit up to this checkpoint id.
+	 */
+	protected void commitUpToCheckpoint(long checkpointId) throws Exception {
+		helper.commitUpToCheckpoint(checkpointId);
+	}
+
+	@Override
+	public void initializeState(StateInitializationContext context) throws Exception {
+		super.initializeState(context);
+		buckets = bucketsBuilder.createBuckets(getRuntimeContext().getIndexOfThisSubtask());
+
+		// Set listener before the initialization of Buckets.
+		buckets.setBucketLifeCycleListener(new BucketLifeCycleListener<IN, String>() {
+
+			@Override
+			public void bucketCreated(Bucket<IN, String> bucket) {
+			}
+
+			@Override
+			public void bucketInactive(Bucket<IN, String> bucket) {
+				AbstractStreamingWriter.this.partitionInactive(bucket.getBucketId());
+			}
+		});
+
+		helper = new StreamingFileSinkHelper<>(
+				buckets,
+				context.isRestored(),
+				context.getOperatorStateStore(),
+				getRuntimeContext().getProcessingTimeService(),
+				bucketCheckInterval);
+
+		currentWatermark = Long.MIN_VALUE;
+	}
+
+	@Override
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		super.snapshotState(context);
+		helper.snapshotState(context.getCheckpointId());
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		super.processWatermark(mark);
+		currentWatermark = mark.getTimestamp();
+	}
+
+	@Override
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		helper.onElement(
+				element.getValue(),
+				getProcessingTimeService().getCurrentProcessingTime(),
+				element.hasTimestamp() ? element.getTimestamp() : null,
+				currentWatermark);
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		super.notifyCheckpointComplete(checkpointId);
+		commitUpToCheckpoint(checkpointId);
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		buckets.onProcessingTime(Long.MAX_VALUE);
+		helper.snapshotState(Long.MAX_VALUE);
+		output.emitWatermark(new Watermark(Long.MAX_VALUE));
+		commitUpToCheckpoint(Long.MAX_VALUE);
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		super.dispose();
+		if (helper != null) {
+			helper.close();
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionCommitInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionCommitInfo.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The message sent by upstream.
+ *
+ * <p>Need to ensure that the partitions are ready to commit. That is to say, the files in
+ * the partition have become readable rather than temporary.
+ */
+public class PartitionCommitInfo implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private long checkpointId;
+	private int taskId;
+	private int numberOfTasks;
+	private List<String> partitions;
+
+	public PartitionCommitInfo() {
+	}
+
+	public PartitionCommitInfo(
+			long checkpointId, int taskId, int numberOfTasks, List<String> partitions) {
+		this.checkpointId = checkpointId;
+		this.taskId = taskId;
+		this.numberOfTasks = numberOfTasks;
+		this.partitions = partitions;
+	}
+
+	public long getCheckpointId() {
+		return checkpointId;
+	}
+
+	public void setCheckpointId(long checkpointId) {
+		this.checkpointId = checkpointId;
+	}
+
+	public int getTaskId() {
+		return taskId;
+	}
+
+	public void setTaskId(int taskId) {
+		this.taskId = taskId;
+	}
+
+	public int getNumberOfTasks() {
+		return numberOfTasks;
+	}
+
+	public void setNumberOfTasks(int numberOfTasks) {
+		this.numberOfTasks = numberOfTasks;
+	}
+
+	public List<String> getPartitions() {
+		return partitions;
+	}
+
+	public void setPartitions(List<String> partitions) {
+		this.partitions = partitions;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
@@ -19,143 +19,48 @@
 package org.apache.flink.table.filesystem.stream;
 
 import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.runtime.state.StateSnapshotContext;
-import org.apache.flink.streaming.api.functions.sink.filesystem.Bucket;
-import org.apache.flink.streaming.api.functions.sink.filesystem.BucketLifeCycleListener;
-import org.apache.flink.streaming.api.functions.sink.filesystem.Buckets;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
-import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSinkHelper;
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.filesystem.stream.StreamingFileCommitter.CommitMessage;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Operator for file system sink. It is a operator version of {@link StreamingFileSink}.
- * It sends partition commit message to downstream for committing.
- *
- * <p>See {@link StreamingFileCommitter}.
+ * Writer for emitting {@link PartitionCommitInfo} to downstream.
  */
-public class StreamingFileWriter extends AbstractStreamOperator<CommitMessage>
-		implements OneInputStreamOperator<RowData, CommitMessage>, BoundedOneInput{
+public class StreamingFileWriter<IN> extends AbstractStreamingWriter<IN, PartitionCommitInfo> {
 
-	private static final long serialVersionUID = 1L;
-
-	// ------------------------ configuration fields --------------------------
-
-	private final long bucketCheckInterval;
-
-	private final StreamingFileSink.BucketsBuilder<RowData, String, ? extends
-			StreamingFileSink.BucketsBuilder<RowData, String, ?>> bucketsBuilder;
-
-	// --------------------------- runtime fields -----------------------------
-
-	private transient Buckets<RowData, String> buckets;
-
-	private transient StreamingFileSinkHelper<RowData> helper;
-
-	private transient long currentWatermark;
+	private static final long serialVersionUID = 2L;
 
 	private transient Set<String> inactivePartitions;
 
 	public StreamingFileWriter(
 			long bucketCheckInterval,
-			StreamingFileSink.BucketsBuilder<RowData, String, ? extends
-					StreamingFileSink.BucketsBuilder<RowData, String, ?>> bucketsBuilder) {
-		this.bucketCheckInterval = bucketCheckInterval;
-		this.bucketsBuilder = bucketsBuilder;
-		setChainingStrategy(ChainingStrategy.ALWAYS);
+			StreamingFileSink.BucketsBuilder<IN, String, ? extends
+					StreamingFileSink.BucketsBuilder<IN, String, ?>> bucketsBuilder) {
+		super(bucketCheckInterval, bucketsBuilder);
 	}
 
 	@Override
 	public void initializeState(StateInitializationContext context) throws Exception {
-		super.initializeState(context);
-		buckets = bucketsBuilder.createBuckets(getRuntimeContext().getIndexOfThisSubtask());
-
-		// Set listener before the initialization of Buckets.
 		inactivePartitions = new HashSet<>();
-		buckets.setBucketLifeCycleListener(new BucketLifeCycleListener<RowData, String>() {
-			@Override
-			public void bucketCreated(Bucket<RowData, String> bucket) {
-			}
-
-			@Override
-			public void bucketInactive(Bucket<RowData, String> bucket) {
-				inactivePartitions.add(bucket.getBucketId());
-			}
-		});
-
-		helper = new StreamingFileSinkHelper<>(
-				buckets,
-				context.isRestored(),
-				context.getOperatorStateStore(),
-				getRuntimeContext().getProcessingTimeService(),
-				bucketCheckInterval);
-		currentWatermark = Long.MIN_VALUE;
+		super.initializeState(context);
 	}
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
-		helper.snapshotState(context.getCheckpointId());
+	protected void partitionInactive(String partition) {
+		inactivePartitions.add(partition);
 	}
 
 	@Override
-	public void processWatermark(Watermark mark) throws Exception {
-		super.processWatermark(mark);
-		currentWatermark = mark.getTimestamp();
-	}
-
-	@Override
-	public void processElement(StreamRecord<RowData> element) throws Exception {
-		helper.onElement(
-				element.getValue(),
-				getProcessingTimeService().getCurrentProcessingTime(),
-				element.hasTimestamp() ? element.getTimestamp() : null,
-				currentWatermark);
-	}
-
-	/**
-	 * Commit up to this checkpoint id, also send inactive partitions to downstream for committing.
-	 */
-	@Override
-	public void notifyCheckpointComplete(long checkpointId) throws Exception {
-		super.notifyCheckpointComplete(checkpointId);
-		commitUpToCheckpoint(checkpointId);
-	}
-
-	private void commitUpToCheckpoint(long checkpointId) throws Exception {
-		helper.commitUpToCheckpoint(checkpointId);
-		CommitMessage message = new CommitMessage(
+	protected void commitUpToCheckpoint(long checkpointId) throws Exception {
+		super.commitUpToCheckpoint(checkpointId);
+		output.collect(new StreamRecord<>(new PartitionCommitInfo(
 				checkpointId,
 				getRuntimeContext().getIndexOfThisSubtask(),
 				getRuntimeContext().getNumberOfParallelSubtasks(),
-				new ArrayList<>(inactivePartitions));
-		output.collect(new StreamRecord<>(message));
+				new ArrayList<>(inactivePartitions))));
 		inactivePartitions.clear();
-	}
-
-	@Override
-	public void endInput() throws Exception {
-		buckets.onProcessingTime(Long.MAX_VALUE);
-		helper.snapshotState(Long.MAX_VALUE);
-		output.emitWatermark(new Watermark(Long.MAX_VALUE));
-		commitUpToCheckpoint(Long.MAX_VALUE);
-	}
-
-	@Override
-	public void dispose() throws Exception {
-		super.dispose();
-		if (helper != null) {
-			helper.close();
-		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
@@ -41,6 +41,10 @@ public class StreamingSink {
 	private StreamingSink() {
 	}
 
+	/**
+	 * Create a file writer by input stream. This is similar to {@link StreamingFileSink},
+	 * in addition, it can emit {@link PartitionCommitInfo} to down stream.
+	 */
 	public static <T> DataStream<PartitionCommitInfo> writer(
 			DataStream<T> inputStream,
 			long bucketCheckInterval,
@@ -55,6 +59,10 @@ public class StreamingSink {
 				fileWriter).setParallelism(inputStream.getParallelism());
 	}
 
+	/**
+	 * Create a sink from file writer. Decide whether to add the node to commit partitions
+	 * according to options.
+	 */
 	public static DataStreamSink<?> sink(
 			DataStream<PartitionCommitInfo> writer,
 			Path locationPath,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.filesystem.FileSystemFactory;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory;
+
+import java.util.List;
+
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
+
+/**
+ * Helper for creating streaming file sink.
+ */
+public class StreamingSink {
+	private StreamingSink() {
+	}
+
+	public static <T> DataStream<PartitionCommitInfo> writer(
+			DataStream<T> inputStream,
+			long bucketCheckInterval,
+			StreamingFileSink.BucketsBuilder<T, String, ? extends
+					StreamingFileSink.BucketsBuilder<T, String, ?>> bucketsBuilder) {
+		StreamingFileWriter<T> fileWriter = new StreamingFileWriter<>(
+				bucketCheckInterval,
+				bucketsBuilder);
+		return inputStream.transform(
+				StreamingFileWriter.class.getSimpleName(),
+				TypeInformation.of(PartitionCommitInfo.class),
+				fileWriter).setParallelism(inputStream.getParallelism());
+	}
+
+	public static DataStreamSink<?> sink(
+			DataStream<PartitionCommitInfo> writer,
+			Path locationPath,
+			ObjectIdentifier identifier,
+			List<String> partitionKeys,
+			TableMetaStoreFactory msFactory,
+			FileSystemFactory fsFactory,
+			Configuration options) {
+		DataStream<?> stream = writer;
+		if (partitionKeys.size() > 0 && options.contains(SINK_PARTITION_COMMIT_POLICY_KIND)) {
+			PartitionCommitter committer = new PartitionCommitter(
+					locationPath, identifier, partitionKeys, msFactory, fsFactory, options);
+			stream = writer
+					.transform(PartitionCommitter.class.getSimpleName(), Types.VOID, committer)
+					.setParallelism(1)
+					.setMaxParallelism(1);
+		}
+
+		return stream.addSink(new DiscardingSink<>()).name("end").setParallelism(1);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/TaskTracker.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/TaskTracker.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Track the upstream tasks to determine whether all the upstream data of a checkpoint
+ * has been received.
+ */
+public class TaskTracker {
+
+	private final int numberOfTasks;
+
+	/**
+	 * Checkpoint id to notified tasks.
+	 */
+	private final TreeMap<Long, Set<Integer>> notifiedTasks = new TreeMap<>();
+
+	public TaskTracker(int numberOfTasks) {
+		this.numberOfTasks = numberOfTasks;
+	}
+
+	/**
+	 * @return true, if this checkpoint id need be committed.
+	 */
+	public boolean add(long checkpointId, int task) {
+		Set<Integer> tasks = notifiedTasks.computeIfAbsent(checkpointId, (k) -> new HashSet<>());
+		tasks.add(task);
+		if (tasks.size() == numberOfTasks) {
+			notifiedTasks.headMap(checkpointId, true).clear();
+			return true;
+		}
+		return false;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/StreamingFileWriterTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/StreamingFileWriterTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.filesystem.stream.StreamingFileCommitter.CommitMessage;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,7 +65,7 @@ public class StreamingFileWriterTest {
 	@Test
 	public void testFailover() throws Exception {
 		OperatorSubtaskState state;
-		try (OneInputStreamOperatorTestHarness<RowData, CommitMessage> harness = create()) {
+		try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness = create()) {
 			harness.setup();
 			harness.initializeEmptyState();
 			harness.open();
@@ -82,7 +81,7 @@ public class StreamingFileWriterTest {
 		}
 
 		// first retry, no partition {1, 2} records
-		try (OneInputStreamOperatorTestHarness<RowData, CommitMessage> harness = create()) {
+		try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness = create()) {
 			harness.setup();
 			harness.initializeState(state);
 			harness.open();
@@ -95,7 +94,7 @@ public class StreamingFileWriterTest {
 		}
 
 		// second retry, partition {4} repeat
-		try (OneInputStreamOperatorTestHarness<RowData, CommitMessage> harness = create()) {
+		try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness = create()) {
 			harness.setup();
 			harness.initializeState(state);
 			harness.open();
@@ -108,7 +107,7 @@ public class StreamingFileWriterTest {
 		}
 
 		// third retry, multiple snapshots
-		try (OneInputStreamOperatorTestHarness<RowData, CommitMessage> harness = create()) {
+		try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness = create()) {
 			harness.setup();
 			harness.initializeState(state);
 			harness.open();
@@ -131,14 +130,14 @@ public class StreamingFileWriterTest {
 	}
 
 	private static List<String> collect(
-			OneInputStreamOperatorTestHarness<RowData, CommitMessage> harness) {
+			OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness) {
 		List<String> parts = new ArrayList<>();
-		harness.extractOutputValues().forEach(m -> parts.addAll(m.partitions));
+		harness.extractOutputValues().forEach(m -> parts.addAll(m.getPartitions()));
 		return parts;
 	}
 
-	private OneInputStreamOperatorTestHarness<RowData, CommitMessage> create() throws Exception {
-		StreamingFileWriter writer = new StreamingFileWriter(1000, StreamingFileSink.forRowFormat(
+	private OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> create() throws Exception {
+		StreamingFileWriter<RowData> writer = new StreamingFileWriter<>(1000, StreamingFileSink.forRowFormat(
 				path, (Encoder<RowData>) (element, stream) ->
 						stream.write((element.getString(0) + "\n").getBytes(StandardCharsets.UTF_8)))
 				.withBucketAssigner(new BucketAssigner<RowData, String>() {
@@ -153,7 +152,7 @@ public class StreamingFileWriterTest {
 					}
 				})
 				.withRollingPolicy(OnCheckpointRollingPolicy.build()));
-		OneInputStreamOperatorTestHarness<RowData, CommitMessage> harness = new OneInputStreamOperatorTestHarness<>(
+		OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness = new OneInputStreamOperatorTestHarness<>(
 				writer, 1, 1, 0);
 		harness.getStreamConfig().setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 		return harness;


### PR DESCRIPTION

## What is the purpose of the change

Refactor table streaming file sink classes for extensive compaction feature.

## Brief change log

- Extract `AbstractStreamingWriter`
- Rename Committer and Commit message.
- Make writer more generic
- Provides StreamingSink util class

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no