### PR TITLE
[FLINK-19619][e2e] Pin CloudSDK version to have access to pubsub emulator in test

### DIFF
--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudEmulatorManager.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/GCloudEmulatorManager.java
@@ -57,7 +57,8 @@ public class GCloudEmulatorManager {
 	private static String dockerIpAddress = "127.0.0.1";
 
 	public static final String INTERNAL_PUBSUB_PORT = "22222";
-	public static final String DOCKER_IMAGE_NAME = "google/cloud-sdk:latest";
+	// TODO: use :latest again once https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/225 is resolved.
+	public static final String DOCKER_IMAGE_NAME = "google/cloud-sdk:313.0.0";
 
 	private static String pubsubPort;
 
@@ -120,6 +121,7 @@ public class GCloudEmulatorManager {
 			.cmd("sh", "-c", "mkdir -p /opt/data/pubsub ; gcloud beta emulators pubsub start --data-dir=/opt/data/pubsub --host-port=0.0.0.0:" + INTERNAL_PUBSUB_PORT)
 			.build();
 
+		LOG.debug("Launching container with configuration {}", containerConfig);
 		final ContainerCreation creation = docker.createContainer(containerConfig, CONTAINER_NAME_JUNIT);
 		id = creation.id();
 

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -142,8 +142,7 @@ if [[ ${PROFILE} != *"jdk11"* ]]; then
 		run_test "Run Mesos multiple submission test" "$END_TO_END_DIR/test-scripts/test_mesos_multiple_submissions.sh"
 
 		# `google/cloud-sdk` docker image doesn't support aarch64 currently.
-		# Disabled until https://issues.apache.org/jira/browse/FLINK-19619 is fixed.
-		#run_test "Test PubSub connector with Docker based Google PubSub Emulator" "$END_TO_END_DIR/test-scripts/test_streaming_gcp_pubsub.sh"
+		run_test "Test PubSub connector with Docker based Google PubSub Emulator" "$END_TO_END_DIR/test-scripts/test_streaming_gcp_pubsub.sh"
 	fi
 fi
 


### PR DESCRIPTION

## What is the purpose of the change

The :latest version of google/cloud-sdk:latest has the pubsub emulator disabled.

Google plans to add it again at a later point. See https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/225 for details.


## Verifying this change

The e2e test was permanently failing. This PRs CI run will tell us if the fix is valid.

## Does this pull request potentially affect one of the following parts:

test infra change only
