### PR TITLE
[FLINK-19716][Kinesis][EFO] Unable to use Assume Role with EFO 

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -38,6 +38,8 @@ under the License.
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
+		<httpclient.version>4.5.9</httpclient.version>
+		<httpcore.version>4.4.11</httpcore.version>
 	</properties>
 
 	<packaging>jar</packaging>
@@ -180,6 +182,17 @@ under the License.
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>sts</artifactId>
 			<version>${aws.sdkv2.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${httpclient.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>${httpcore.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/services/org.apache.flink.kinesis.shaded.software.amazon.awssdk.http.SdkHttpService
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/services/org.apache.flink.kinesis.shaded.software.amazon.awssdk.http.SdkHttpService
@@ -1,0 +1,20 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+org.apache.flink.kinesis.shaded.software.amazon.awssdk.http.apache.ApacheSdkHttpService


### PR DESCRIPTION
## What is the purpose of the change

Consuming from Kinesis using EFO fails with Assume Role credential provider. The following error is encountered:
- `Caused by: org.apache.flink.kinesis.shaded.software.amazon.awssdk.core.exception.SdkClientException: Unable to load an HTTP implementation from any provider in the chain. You must declare a dependency on an appropriate HTTP implementation or pass in an SdkHttpClient explicitly to the client builder.`

## Brief change log

* Add a service manifest such that the shaded HTTP client is used
* Update the shaded HTTP client/core version used by Kinesis connector due to incompatibilities with existing versions

## Verifying this change

- This change was verified manually since:
  - The unit tests do not/should not contact AWS
  - This is a configuration/dependency upgrade only change 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented (not a feature)
