### PR TITLE
[FLINK-16595][YARN]support more HDFS nameServices in yarn mode when security enabled. Is…

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>yarn.access.hadoopFileSystems</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>If you have extra Hadoop filesystems and enabled security, list all of those URLs. (e.g. hdfs://nn1.com:8032;hdfs://nn2.com:8032;webhdfs://nn3.com:50070)</td>
+            <td>If you have extra Hadoop filesystems and enabled security, list all of those URLs.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -15,10 +15,10 @@
             <td>If configured, Flink will add this key to the resource profile of container request to Yarn. The value will be set to the value of external-resource.&lt;resource_name&gt;.amount.</td>
         </tr>
         <tr>
-            <td><h5>yarn.access.hadoopFileSystems</h5></td>
+            <td><h5>yarn.security.kerberos.additionalFileSystems</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>If you have extra Hadoop filesystems and enabled security, list all of those URLs.</td>
+            <td>A comma-separated list of additional Kerberos-secured Hadoop filesystems Flink is going to access. For example, yarn.security.kerberos.additionalFileSystems=hdfs://namenode2:9002,hdfs://namenode3:9003. The client submitting to YARN needs to have access to these file systems to retrieve the security tokens.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -15,6 +15,12 @@
             <td>If configured, Flink will add this key to the resource profile of container request to Yarn. The value will be set to the value of external-resource.&lt;resource_name&gt;.amount.</td>
         </tr>
         <tr>
+            <td><h5>yarn.access.hadoopFileSystems</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>If you have extra Hadoop filesystems and enabled security, list all of those URLs. (e.g. hdfs://nn1.com:8032;hdfs://nn2.com:8032;webhdfs://nn3.com:50070)</td>
+        </tr>
+        <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -61,7 +61,7 @@ import org.apache.flink.yarn.entrypoint.YarnApplicationClusterEntryPoint;
 import org.apache.flink.yarn.entrypoint.YarnJobClusterEntrypoint;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
 
-import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections.ListUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -61,6 +61,7 @@ import org.apache.flink.yarn.entrypoint.YarnApplicationClusterEntryPoint;
 import org.apache.flink.yarn.entrypoint.YarnJobClusterEntrypoint;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
 
+import org.apache.commons.collections4.ListUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -970,7 +971,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		if (UserGroupInformation.isSecurityEnabled()) {
 			// set HDFS delegation tokens when security is enabled
 			LOG.info("Adding delegation token to the AM container.");
-			Utils.setTokensFor(amContainer, fileUploader.getRemotePaths(), yarnConfiguration);
+			List<Path> yarnAccessList = ConfigUtils.decodeListFromConfig(configuration, YarnConfigOptions.YARN_ACCESS, Path::new);
+			Utils.setTokensFor(amContainer,
+				ListUtils.union(yarnAccessList, fileUploader.getRemotePaths()), yarnConfiguration
+			);
 		}
 
 		amContainer.setLocalResources(fileUploader.getRegisteredLocalResources());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -299,7 +299,7 @@ public class YarnConfigOptions {
 			.stringType()
 			.asList()
 			.noDefaultValue()
-			.withDescription("If you have extra Hadoop filesystems and enabled security, list all of those URLs.");
+			.withDescription("A comma-separated list of additional Kerberos-secured Hadoop filesystems Flink is going to access. For example, yarn.security.kerberos.additionalFileSystems=hdfs://namenode2:9002,hdfs://namenode3:9003. The client submitting to YARN needs to have access to these file systems to retrieve the security tokens.");
 
 	/** Defines the configuration key of that external resource in Yarn. This is used as a suffix in an actual config. */
 	public static final String EXTERNAL_RESOURCE_YARN_CONFIG_KEY_SUFFIX = "yarn.config-key";

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -295,7 +295,7 @@ public class YarnConfigOptions {
 				"hdfs://$namenode_address/path/of/flink/lib");
 
 	public static final ConfigOption<List<String>> YARN_ACCESS =
-		key("yarn.access.hadoopFileSystems")
+		key("yarn.security.kerberos.additionalFileSystems")
 			.stringType()
 			.asList()
 			.noDefaultValue()

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -298,7 +298,7 @@ public class YarnConfigOptions {
 		key("yarn.access.hadoopFileSystems")
 			.stringType()
 			.asList()
-			.noDefaultValue()
+			.defaultValue()
 			.withDescription("If you have extra Hadoop filesystems and enabled security, list all of those URLs.");
 
 	/** Defines the configuration key of that external resource in Yarn. This is used as a suffix in an actual config. */

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -298,7 +298,7 @@ public class YarnConfigOptions {
 		key("yarn.access.hadoopFileSystems")
 			.stringType()
 			.asList()
-			.defaultValue()
+			.noDefaultValue()
 			.withDescription("If you have extra Hadoop filesystems and enabled security, list all of those URLs.");
 
 	/** Defines the configuration key of that external resource in Yarn. This is used as a suffix in an actual config. */

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -294,6 +294,13 @@ public class YarnConfigOptions {
 				"they doesn't need to be downloaded every time for each application. An example could be " +
 				"hdfs://$namenode_address/path/of/flink/lib");
 
+	public static final ConfigOption<List<String>> YARN_ACCESS =
+		key("yarn.access.hadoopFileSystems")
+			.stringType()
+			.asList()
+			.noDefaultValue()
+			.withDescription("If you have extra Hadoop filesystems and enabled security, list all of those URLs.");
+
 	/** Defines the configuration key of that external resource in Yarn. This is used as a suffix in an actual config. */
 	public static final String EXTERNAL_RESOURCE_YARN_CONFIG_KEY_SUFFIX = "yarn.config-key";
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  https://issues.apache.org/jira/browse/FLINK-16595


  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request support more HDFS nameServices in yarn mode when security enabled.
For example,if we enable security config, and  there are two hdfs nameServices hdfs://nn1.com:8032  and hdfs://nn2.com:8032 ,we should add config like that:

yarn.access.hadoopFileSystems=hdfs://nn1.com:8032;hdfs://nn2.com:8032

## Brief change log



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? ( docs )
