### PR TITLE
[FLINK-19458] Fix ZK-related CI instabilities

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -24,12 +24,17 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * ZooKeeper test utilities.
  */
 public class ZooKeeperTestUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperTestUtils.class);
 
 	/**
 	 * Creates a configuration to operate in {@link HighAvailabilityMode#ZOOKEEPER}.
@@ -68,8 +73,9 @@ public class ZooKeeperTestUtils {
 		config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperQuorum);
 
 		int connTimeout = 5000;
-		if (System.getenv().containsKey("CI")) {
+		if (System.getenv().containsKey("CI") || System.getenv().containsKey("TF_BUILD")) {
 			// The regular timeout is to aggressive for Travis and connections are often lost.
+			LOG.info("Detected CI environment: Configuring connection and session timeout of 30 seconds");
 			connTimeout = 30000;
 		}
 


### PR DESCRIPTION

## What is the purpose of the change

We used to have an increased session and connection timeout configured for TravisCI.
On Azure, the environment variable we used for checking if we are in an CI environment doesn't exist anymore.
This change enables the increased timeout on Azure as well.

