### PR TITLE
[Hotfix][Connector-hive] Fix the banned dependency of "_2.10" for sca…

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
@@ -59,6 +59,10 @@ under the License.
 					<groupId>org.pentaho</groupId>
 					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>kafka_2.10</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
## What is the purpose of the change

Fix the banned dependencies failed for 'flink-sql-connector-hive-2.3.6'.

The error message,
` Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.apache.kafka:kafka_2.10:jar:0.10.2.0
Use 'mvn dependency:tree' to locate the source of the banned dependencies.`

For root pom has a rule as follow,

`<bannedDependencies>`
    `<excludes combine.children="append">`
      `<exclude>*:*_2.12</exclude>`
     ` <exclude>*:*_2.10</exclude>`
   `</excludes>`
`</bannedDependencies>`

Which forces scala_2.11 version, but this module contains kafka_2.10.

## Brief change log
Exclude dependency,
`<exclusion>`
	`<groupId>org.apache.kafka</groupId>`
	`<artifactId>kafka_2.10</artifactId>`
  `</exclusion>`
`

## Verifying this change

After excluding, build correctl