### PR TITLE
[FLINK-19720][table-api] Introduce new Providers and parallelism API

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
@@ -24,16 +24,16 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.data.RowData;
 
 /**
- * Provider to consume a {@link DataStream} as a runtime implementation for
- * {@link DynamicTableSink}.
+ * Provider that consumes a Java {@link DataStream} as a runtime implementation for {@link DynamicTableSink}.
  *
- * <p>NOTE: This is only for advanced connector developers.
+ * <p>Note: This provider is only meant for advanced connector developers. Usually, a sink should consist
+ * of a single entity expressed via {@link OutputFormatProvider} or {@link SinkFunctionProvider}.
  */
 @PublicEvolving
 public interface DataStreamSinkProvider extends DynamicTableSink.SinkRuntimeProvider {
 
 	/**
-	 * Consume the DataStream and return the sink transformation {@link DataStreamSink}.
+	 * Consumes the given Java {@link DataStream} and returns the sink transformation {@link DataStreamSink}.
 	 */
-	DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream);
+	DataStreamSink<RowData> consumeDataStream(DataStream<RowData> dataStream);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider to consume a {@link DataStream} as a runtime implementation for {@link DynamicTableSink}.
+ *
+ * <p>NOTE: This is only for advanced connector developers.
+ */
+@PublicEvolving
+public interface DataStreamSinkProvider extends DynamicTableSink.SinkRuntimeProvider {
+
+  /**
+   * Consume the DataStream and return the sink transformation {@link DataStreamSink}.
+   */
+  DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream);
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
@@ -24,15 +24,16 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.data.RowData;
 
 /**
- * Provider to consume a {@link DataStream} as a runtime implementation for {@link DynamicTableSink}.
+ * Provider to consume a {@link DataStream} as a runtime implementation for
+ * {@link DynamicTableSink}.
  *
  * <p>NOTE: This is only for advanced connector developers.
  */
 @PublicEvolving
 public interface DataStreamSinkProvider extends DynamicTableSink.SinkRuntimeProvider {
 
-  /**
-   * Consume the DataStream and return the sink transformation {@link DataStreamSink}.
-   */
-  DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream);
+	/**
+	 * Consume the DataStream and return the sink transformation {@link DataStreamSink}.
+	 */
+	DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
@@ -35,5 +35,5 @@ public interface DataStreamSinkProvider extends DynamicTableSink.SinkRuntimeProv
 	/**
 	 * Consumes the given Java {@link DataStream} and returns the sink transformation {@link DataStreamSink}.
 	 */
-	DataStreamSink<RowData> consumeDataStream(DataStream<RowData> dataStream);
+	DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
@@ -24,15 +24,16 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 
 /**
- * Provider to create a {@link DataStream} instance as a runtime implementation for {@link ScanTableSource}.
+ * Provider to create a {@link DataStream} instance as a runtime implementation for
+ * {@link ScanTableSource}.
  *
  * <p>NOTE: This is only for advanced connector developers.
  */
 @PublicEvolving
 public interface DataStreamScanProvider extends ScanTableSource.ScanRuntimeProvider {
 
-  /**
-   * Creates a scan {@link DataStream} from {@link StreamExecutionEnvironment}.
-   */
-  DataStream<RowData> createDataStream(StreamExecutionEnvironment execEnv);
+	/**
+	 * Creates a scan {@link DataStream} from {@link StreamExecutionEnvironment}.
+	 */
+	DataStream<RowData> createDataStream(StreamExecutionEnvironment execEnv);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
@@ -24,16 +24,17 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 
 /**
- * Provider to create a {@link DataStream} instance as a runtime implementation for
- * {@link ScanTableSource}.
+ * Provider that produces a Java {@link DataStream} as a runtime implementation for {@link ScanTableSource}.
  *
- * <p>NOTE: This is only for advanced connector developers.
+ * <p>Note: This provider is only meant for advanced connector developers. Usually, a source should consist
+ * of a single entity expressed via {@link InputFormatProvider}, {@link SourceFunctionProvider}, or
+ * {@link SourceProvider}.
  */
 @PublicEvolving
 public interface DataStreamScanProvider extends ScanTableSource.ScanRuntimeProvider {
 
 	/**
-	 * Creates a scan {@link DataStream} from {@link StreamExecutionEnvironment}.
+	 * Creates a scan Java {@link DataStream} from a {@link StreamExecutionEnvironment}.
 	 */
-	DataStream<RowData> createDataStream(StreamExecutionEnvironment execEnv);
+	DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider to create a {@link DataStream} instance as a runtime implementation for {@link ScanTableSource}.
+ *
+ * <p>NOTE: This is only for advanced connector developers.
+ */
+@PublicEvolving
+public interface DataStreamScanProvider extends ScanTableSource.ScanRuntimeProvider {
+
+  /**
+   * Creates a scan {@link DataStream} from {@link StreamExecutionEnvironment}.
+   */
+  DataStream<RowData> createDataStream(StreamExecutionEnvironment execEnv);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
@@ -19,24 +19,28 @@
 package org.apache.flink.table.connector;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.sink.OutputFormatProvider;
 
 import java.util.Optional;
 
 /**
- * Parallelism provider for connector providers.
+ * Parallelism provider for other connector providers. It allows to express a custom parallelism for
+ * the connector runtime implementation. Otherwise the parallelism is determined by the planner.
  *
- * <p>Note: currently, it only supports to work with {@code SinkFunctionProvider} and
- * {@code OutputFormatProvider}.
+ * <p>Note: Currently, this interface can only work with {@code org.apache.flink.table.connector.sink.SinkFunctionProvider}
+ * in {@code flink-table-api-java-bridge} module and {@link OutputFormatProvider}.
  */
 @PublicEvolving
 public interface ParallelismProvider {
 
 	/**
-	 * Gets the parallelism for this contract instance. The parallelism denotes how many parallel
-	 * instances of the user source/sink will be spawned during the execution.
+	 * Returns the parallelism for this instance.
 	 *
-	 * @return empty if the connector does not want to provide parallelism, then the planner will
-	 * decide the number of parallel instances by itself.
+	 * <p>The parallelism denotes how many parallel instances of a source or sink will be spawned
+	 * during the execution.
+	 *
+	 * @return empty if the connector does not provide a custom parallelism, then the planner will
+	 *         decide the number of parallel instances by itself.
 	 */
 	default Optional<Integer> getParallelism() {
 		return Optional.empty();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
@@ -24,20 +24,21 @@ import java.util.Optional;
 
 /**
  * Parallelism provider for connector providers.
- * 
- * <p>Note: currently, it only supports to work with {@code SinkFunctionProvider} and {@code OutputFormatProvider}.
+ *
+ * <p>Note: currently, it only supports to work with {@code SinkFunctionProvider} and
+ * {@code OutputFormatProvider}.
  */
 @PublicEvolving
 public interface ParallelismProvider {
 
-  /**
-   * Gets the parallelism for this contract instance. The parallelism denotes how many parallel
-   * instances of the user source/sink will be spawned during the execution.
-   *
-   * @return empty if the connector does not want to provide parallelism, then the planner will
-   * decide the number of parallel instances by itself.
-   */
-  default Optional<Integer> getParallelism() {
-     return Optional.empty();
-  }
+	/**
+	 * Gets the parallelism for this contract instance. The parallelism denotes how many parallel
+	 * instances of the user source/sink will be spawned during the execution.
+	 *
+	 * @return empty if the connector does not want to provide parallelism, then the planner will
+	 * decide the number of parallel instances by itself.
+	 */
+	default Optional<Integer> getParallelism() {
+		return Optional.empty();
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Optional;
+
+/**
+ * Parallelism provider for connector providers.
+ * Now only works on {@code SinkFunctionProvider} and {@code OutputFormatProvider}.
+ */
+@PublicEvolving
+public interface ParallelismProvider {
+
+  /**
+   * Gets the parallelism for this contract instance. The parallelism denotes how many parallel
+   * instances of the user source/sink will be spawned during the execution.
+   *
+   * @return empty if the connector does not want to provide parallelism, then the planner will
+   * decide the number of parallel instances by itself.
+   */
+  default Optional<Integer> getParallelism() {
+     return Optional.empty();
+  }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
@@ -24,7 +24,8 @@ import java.util.Optional;
 
 /**
  * Parallelism provider for connector providers.
- * Now only works on {@code SinkFunctionProvider} and {@code OutputFormatProvider}.
+ * 
+ * <p>Note: currently, it only supports to work with {@code SinkFunctionProvider} and {@code OutputFormatProvider}.
  */
 @PublicEvolving
 public interface ParallelismProvider {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.connector.RuntimeConverter;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
@@ -99,6 +100,8 @@ public interface DynamicTableSink {
 	 * with minimal dependencies to internal data structures.
 	 *
 	 * <p>See {@code org.apache.flink.table.connector.sink.SinkFunctionProvider} in {@code flink-table-api-java-bridge}.
+	 *
+	 * @see ParallelismProvider
 	 */
 	SinkRuntimeProvider getSinkRuntimeProvider(Context context);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/SourceProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/SourceProvider.java
@@ -24,30 +24,30 @@ import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.table.data.RowData;
 
 /**
-* Provider of a {@link Source} instance as a runtime implementation for {@link ScanTableSource}.
-*/
+ * Provider of a {@link Source} instance as a runtime implementation for {@link ScanTableSource}.
+ */
 @PublicEvolving
 public interface SourceProvider extends ScanTableSource.ScanRuntimeProvider {
 
-  /**
-   * Helper method for creating a static provider.
-   */
-  static SourceProvider of(Source<RowData, ?, ?> source) {
-     return new SourceProvider() {
-        @Override
-        public Source<RowData, ?, ?> createSource() {
-           return source;
-        }
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static SourceProvider of(Source<RowData, ?, ?> source) {
+		return new SourceProvider() {
+			@Override
+			public Source<RowData, ?, ?> createSource() {
+				return source;
+			}
 
-        @Override
-        public boolean isBounded() {
-           return Boundedness.BOUNDED.equals(source.getBoundedness());
-        }
-     };
-  }
+			@Override
+			public boolean isBounded() {
+				return Boundedness.BOUNDED.equals(source.getBoundedness());
+			}
+		};
+	}
 
-  /**
-   * Creates a {@link Source} instance.
-   */
-  Source<RowData, ?, ?> createSource();
+	/**
+	 * Creates a {@link Source} instance.
+	 */
+	Source<RowData, ?, ?> createSource();
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/SourceProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/SourceProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.table.data.RowData;
+
+/**
+* Provider of a {@link Source} instance as a runtime implementation for {@link ScanTableSource}.
+*/
+@PublicEvolving
+public interface SourceProvider extends ScanTableSource.ScanRuntimeProvider {
+
+  /**
+   * Helper method for creating a static provider.
+   */
+  static SourceProvider of(Source<RowData, ?, ?> source) {
+     return new SourceProvider() {
+        @Override
+        public Source<RowData, ?, ?> createSource() {
+           return source;
+        }
+
+        @Override
+        public boolean isBounded() {
+           return Boundedness.BOUNDED.equals(source.getBoundedness());
+        }
+     };
+  }
+
+  /**
+   * Creates a {@link Source} instance.
+   */
+  Source<RowData, ?, ?> createSource();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -77,7 +77,9 @@ public final class FactoryUtil {
 			.key("sink.parallelism")
 			.intType()
 			.noDefaultValue()
-			.withDescription("Defines the user specified parallelism for the sink.");
+			.withDescription("Defines a custom parallelism for the sink. "
+					+ "By default, if this option is not defined, the planner will derive the parallelism "
+					+ "for each statement individually by also considering the global configuration.");
 
 	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
 		.key("key.format")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -73,6 +73,12 @@ public final class FactoryUtil {
 			"Uniquely identifies the connector of a dynamic table that is used for accessing data in " +
 			"an external system. Its value is used during table source and table sink discovery.");
 
+	public static final ConfigOption<Integer> SINK_PARALLELISM = ConfigOptions
+			.key("sink.parallelism")
+			.intType()
+			.noDefaultValue()
+			.withDescription("Defines the user specified sink parallelism.");
+
 	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
 		.key("key.format")
 		.stringType()

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -77,7 +77,7 @@ public final class FactoryUtil {
 			.key("sink.parallelism")
 			.intType()
 			.noDefaultValue()
-			.withDescription("Defines the user specified sink parallelism.");
+			.withDescription("Defines the user specified parallelism for the sink.");
 
 	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
 		.key("key.format")


### PR DESCRIPTION

## What is the purpose of the change

Introduce new Providers and parallelism API

PR for All Public API.

## Brief change log

- Introduce SourceProvider
- Introduce DataStreamSourceProvider
- Introduce DataStreamSinkProvider
- Introduce ParallelismProvider
- Introduce SINK_PARALLELISM option

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes