### PR TITLE
[FLINK-18836][python] Support Python UDTF return types which are not generator

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -144,7 +144,9 @@ class TableFunctionRowCoderImpl(StreamCoderImpl):
     def encode_to_stream(self, iter_value, out_stream, nested):
         for value in iter_value:
             if value:
-                if self._field_count == 1:
+                if isinstance(value, tuple):
+                    value = [value]
+                elif self._field_count == 1:
                     value = self._create_tuple_result(value)
                 self._flatten_row_coder.encode_to_stream(value, out_stream, nested)
             out_stream.write_var_int64(1)

--- a/flink-python/pyflink/fn_execution/fast_coder_impl.pyx
+++ b/flink-python/pyflink/fn_execution/fast_coder_impl.pyx
@@ -50,13 +50,17 @@ cdef class TableFunctionRowCoderImpl(FlattenRowCoderImpl):
 
     cpdef encode_to_stream(self, input_stream_and_function_wrapper, OutputStream out_stream,
                            bint nested):
+        cdef bint is_tuple = False
         self._prepare_encode(input_stream_and_function_wrapper, out_stream)
         while self._input_buffer_size > self._input_pos:
             self._decode_next_row()
             result = self.func(self.row)
             if result:
+                if isinstance(result, tuple):
+                    result = [result]
+                    is_tuple = True
                 for value in result:
-                    if self._output_field_count == 1:
+                    if self._output_field_count == 1 and not is_tuple:
                         value = (value,)
                     self._encode_one_row(value)
                     self._maybe_flush(out_stream)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Support Python UDTF return types which are not generator*


## Brief change log

  - *Add the support of UDTF return type is Row*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add the it test in test_udtf.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
