### PR TITLE
[FLINK-19726][table] Implement new providers for blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestFileSourceFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestFileSourceFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.FileSource;
+import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test file source {@link DynamicTableSourceFactory}.
+ */
+public class TestFileSourceFactory implements DynamicTableSourceFactory {
+
+	@Override
+	public DynamicTableSource createDynamicTableSource(Context context) {
+		return new TestFileTableSource(new Path(context.getCatalogTable().getOptions().get("path")));
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return "filesource";
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		return new HashSet<>();
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		return new HashSet<>();
+	}
+
+	private static class TestFileTableSource implements ScanTableSource {
+
+		private final Path path;
+
+		private TestFileTableSource(Path path) {
+			this.path = path;
+		}
+
+		@Override
+		public ChangelogMode getChangelogMode() {
+			return ChangelogMode.insertOnly();
+		}
+
+		@Override
+		public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+			return SourceProvider.of(FileSource.forRecordStreamFormat(new FileFormat(), path).build());
+		}
+
+		@Override
+		public DynamicTableSource copy() {
+			return new TestFileTableSource(path);
+		}
+
+		@Override
+		public String asSummaryString() {
+			return "test-file-source";
+		}
+	}
+
+	private static class FileFormat extends SimpleStreamFormat<RowData> {
+
+		@Override
+		public Reader<RowData> createReader(Configuration config, FSDataInputStream stream) {
+			BufferedReader reader = new BufferedReader(
+					new InputStreamReader(stream, StandardCharsets.UTF_8));
+			return new Reader<RowData>() {
+				@Override
+				public RowData read() throws IOException {
+					String line = reader.readLine();
+					if (line == null) {
+						return null;
+					}
+					return GenericRowData.of(StringData.fromString(line));
+				}
+
+				@Override
+				public void close() throws IOException {
+					reader.close();
+				}
+			};
+		}
+
+		@Override
+		public TypeInformation<RowData> getProducedType() {
+			return InternalTypeInfo.ofFields(DataTypes.STRING().getLogicalType());
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -14,4 +14,5 @@
 # limitations under the License.
 
 org.apache.flink.table.planner.factories.TestValuesTableFactory
+org.apache.flink.table.planner.factories.TestFileSourceFactory
 org.apache.flink.table.planner.utils.TestCsvFileSystemFormatFactory

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
@@ -147,6 +147,15 @@ class TableSinkITCase extends BatchTestBase {
 
   @Test
   def testNotNullEnforcer(): Unit = {
+    innerTestNotNullEnforcer("SinkFunction")
+  }
+
+  @Test
+  def testDataStreamNotNullEnforcer(): Unit = {
+    innerTestNotNullEnforcer("DataStream")
+  }
+
+  def innerTestNotNullEnforcer(provider: String): Unit = {
     val dataId = TestValuesTableFactory.registerData(nullData4)
     tEnv.executeSql(
       s"""
@@ -168,7 +177,8 @@ class TableSinkITCase extends BatchTestBase {
          |  num INT NOT NULL
          |) WITH (
          |  'connector' = 'values',
-         |  'sink-insert-only' = 'true'
+         |  'sink-insert-only' = 'true',
+         |  'runtime-sink' = '$provider'
          |)
          |""".stripMargin)
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkNotNullEnforcer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkNotNullEnforcer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sink;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.config.ExecutionConfigOptions.NotNullEnforcer;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Checks writing null values into NOT NULL columns.
+ */
+public class SinkNotNullEnforcer implements FilterFunction<RowData> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final NotNullEnforcer notNullEnforcer;
+	private final int[] notNullFieldIndices;
+	private final boolean notNullCheck;
+	private final String[] allFieldNames;
+
+	public SinkNotNullEnforcer(
+			NotNullEnforcer notNullEnforcer, int[] notNullFieldIndices, String[] allFieldNames) {
+		this.notNullFieldIndices = notNullFieldIndices;
+		this.notNullEnforcer = notNullEnforcer;
+		this.notNullCheck = notNullFieldIndices.length > 0;
+		this.allFieldNames = allFieldNames;
+	}
+
+	@Override
+	public boolean filter(RowData row) {
+		if (!notNullCheck) {
+			return true;
+		}
+
+		for (int index : notNullFieldIndices) {
+			if (row.isNullAt(index)) {
+				if (notNullEnforcer == NotNullEnforcer.ERROR) {
+					String optionKey = ExecutionConfigOptions.TABLE_EXEC_SINK_NOT_NULL_ENFORCER.key();
+					throw new TableException(
+							String.format("Column '%s' is NOT NULL, however, a null value is being written into it. " +
+									"You can set job configuration '" + optionKey + "'='drop' " +
+									"to suppress this exception and drop such records silently.", allFieldNames[index]));
+				} else {
+					// simply drop the record
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
@@ -28,9 +28,6 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
-import org.apache.flink.table.api.config.ExecutionConfigOptions.NotNullEnforcer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 
@@ -44,10 +41,7 @@ public class SinkOperator extends AbstractUdfStreamOperator<Object, SinkFunction
 	private static final long serialVersionUID = 1L;
 
 	private final int rowtimeFieldIndex;
-	private final int[] notNullFieldIndices;
-	private final String[] allFieldNames;
-	private final NotNullEnforcer notNullEnforcer;
-	private final boolean notNullCheck;
+	private final SinkNotNullEnforcer enforcer;
 
 	private transient SimpleContext sinkContext;
 
@@ -57,15 +51,10 @@ public class SinkOperator extends AbstractUdfStreamOperator<Object, SinkFunction
 	public SinkOperator(
 			SinkFunction<RowData> sinkFunction,
 			int rowtimeFieldIndex,
-			NotNullEnforcer notNullEnforcer,
-			int[] notNullFieldIndices,
-			String[] allFieldNames) {
+			SinkNotNullEnforcer enforcer) {
 		super(sinkFunction);
 		this.rowtimeFieldIndex = rowtimeFieldIndex;
-		this.notNullFieldIndices = notNullFieldIndices;
-		this.notNullEnforcer = notNullEnforcer;
-		this.notNullCheck = notNullFieldIndices.length > 0;
-		this.allFieldNames = allFieldNames;
+		this.enforcer = enforcer;
 		chainingStrategy = ChainingStrategy.ALWAYS;
 	}
 
@@ -79,30 +68,9 @@ public class SinkOperator extends AbstractUdfStreamOperator<Object, SinkFunction
 	public void processElement(StreamRecord<RowData> element) throws Exception {
 		sinkContext.element = element;
 		RowData row = element.getValue();
-		if (notNullCheck) {
-			if (failOrFilterNullValues(row)) {
-				return;
-			}
+		if (enforcer.filter(row)) {
+			userFunction.invoke(row, sinkContext);
 		}
-		userFunction.invoke(row, sinkContext);
-	}
-
-	private boolean failOrFilterNullValues(RowData row) {
-		for (int index : notNullFieldIndices) {
-			if (row.isNullAt(index)) {
-				if (notNullEnforcer == NotNullEnforcer.ERROR) {
-					String optionKey = ExecutionConfigOptions.TABLE_EXEC_SINK_NOT_NULL_ENFORCER.key();
-					throw new TableException(
-						String.format("Column '%s' is NOT NULL, however, a null value is being written into it. " +
-							"You can set job configuration '" + optionKey + "'='drop' " +
-							"to suppress this exception and drop such records silently.", allFieldNames[index]));
-				} else {
-					// simply drop the record
-					return true;
-				}
-			}
-		}
-		return false;
 	}
 
 	@Override


### PR DESCRIPTION

## What is the purpose of the change

Implement SourceProvider DataStreamScanProvider DataStreamSinkProvider in Blink planner.

## Brief change log

- `CommonPhysicalTableSourceScan`
- `CommonPhysicalSink`
- Add tests

## Verifying this change

- `TableSinkITCase`
- `TableSourceITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
