### PR TITLE
[FLINK-19357][FLINK-19357][fs-connector] Introduce createBucketWriter to BucketsBuilder & Introduce FileLifeCycleListener to Buckets

### DIFF
--- a/flink-formats/flink-hadoop-bulk/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/HadoopPathBasedBulkFormatBuilder.java
+++ b/flink-formats/flink-hadoop-bulk/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/HadoopPathBasedBulkFormatBuilder.java
@@ -118,15 +118,20 @@ public class HadoopPathBasedBulkFormatBuilder<IN, BucketID, T extends HadoopPath
 	}
 
 	@Override
+	public BucketWriter<IN, BucketID> createBucketWriter() {
+		return new HadoopPathBasedPartFileWriter.HadoopPathBasedBucketWriter<>(
+				serializableConfiguration.getConfiguration(),
+				writerFactory,
+				fileCommitterFactory);
+	}
+
+	@Override
 	public Buckets<IN, BucketID> createBuckets(int subtaskIndex) throws IOException {
 		return new Buckets<>(
 			basePath,
 			bucketAssigner,
 			bucketFactory,
-			new HadoopPathBasedPartFileWriter.HadoopPathBasedBucketWriter<>(
-				serializableConfiguration.getConfiguration(),
-				writerFactory,
-				fileCommitterFactory),
+			createBucketWriter(),
 			rollingPolicy,
 			subtaskIndex,
 			outputFileConfig);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -66,6 +66,9 @@ public class Bucket<IN, BucketID> {
 
 	private final OutputFileConfig outputFileConfig;
 
+	@Nullable
+	private final FileLifeCycleListener<BucketID> fileListener;
+
 	private long partCounter;
 
 	@Nullable
@@ -83,6 +86,7 @@ public class Bucket<IN, BucketID> {
 			final long initialPartCounter,
 			final BucketWriter<IN, BucketID> bucketWriter,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) {
 		this.subtaskIndex = subtaskIndex;
 		this.bucketId = checkNotNull(bucketId);
@@ -90,6 +94,7 @@ public class Bucket<IN, BucketID> {
 		this.partCounter = initialPartCounter;
 		this.bucketWriter = checkNotNull(bucketWriter);
 		this.rollingPolicy = checkNotNull(rollingPolicy);
+		this.fileListener = fileListener;
 
 		this.pendingFileRecoverablesForCurrentCheckpoint = new ArrayList<>();
 		this.pendingFileRecoverablesPerCheckpoint = new TreeMap<>();
@@ -107,6 +112,7 @@ public class Bucket<IN, BucketID> {
 			final BucketWriter<IN, BucketID> partFileFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
 			final BucketState<BucketID> bucketState,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) throws IOException {
 
 		this(
@@ -116,6 +122,7 @@ public class Bucket<IN, BucketID> {
 				initialPartCounter,
 				partFileFactory,
 				rollingPolicy,
+				fileListener,
 				outputFileConfig);
 
 		restoreInProgressFile(bucketState);
@@ -206,6 +213,10 @@ public class Bucket<IN, BucketID> {
 		closePartFile();
 
 		final Path partFilePath = assembleNewPartPath();
+
+		if (fileListener != null) {
+			fileListener.onPartFileOpened(bucketId, partFilePath);
+		}
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Subtask {} opening new part file \"{}\" for bucket id={}.",
@@ -345,6 +356,9 @@ public class Bucket<IN, BucketID> {
 	 * @param bucketPath the path to where the part files for the bucket will be written to.
 	 * @param initialPartCounter the initial counter for the part files of the bucket.
 	 * @param bucketWriter the {@link BucketWriter} used to write part files in the bucket.
+	 * @param rollingPolicy the policy based on which a bucket rolls its currently open part file
+	 *                      and opens a new one.
+	 * @param fileListener the listener about the status of file.
 	 * @param <IN> the type of input elements to the sink.
 	 * @param <BucketID> the type of the identifier of the bucket, as returned by the {@link BucketAssigner}
 	 * @param outputFileConfig the part file configuration.
@@ -357,8 +371,17 @@ public class Bucket<IN, BucketID> {
 			final long initialPartCounter,
 			final BucketWriter<IN, BucketID> bucketWriter,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) {
-		return new Bucket<>(subtaskIndex, bucketId, bucketPath, initialPartCounter, bucketWriter, rollingPolicy, outputFileConfig);
+		return new Bucket<>(
+				subtaskIndex,
+				bucketId,
+				bucketPath,
+				initialPartCounter,
+				bucketWriter,
+				rollingPolicy,
+				fileListener,
+				outputFileConfig);
 	}
 
 	/**
@@ -366,7 +389,10 @@ public class Bucket<IN, BucketID> {
 	 * @param subtaskIndex the index of the subtask creating the bucket.
 	 * @param initialPartCounter the initial counter for the part files of the bucket.
 	 * @param bucketWriter the {@link BucketWriter} used to write part files in the bucket.
+	 * @param rollingPolicy the policy based on which a bucket rolls its currently open part file
+	 *                      and opens a new one.
 	 * @param bucketState the initial state of the restored bucket.
+	 * @param fileListener the listener about the status of file.
 	 * @param <IN> the type of input elements to the sink.
 	 * @param <BucketID> the type of the identifier of the bucket, as returned by the {@link BucketAssigner}
 	 * @param outputFileConfig the part file configuration.
@@ -378,7 +404,15 @@ public class Bucket<IN, BucketID> {
 			final BucketWriter<IN, BucketID> bucketWriter,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
 			final BucketState<BucketID> bucketState,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) throws IOException {
-		return new Bucket<>(subtaskIndex, initialPartCounter, bucketWriter, rollingPolicy, bucketState, outputFileConfig);
+		return new Bucket<>(
+				subtaskIndex,
+				initialPartCounter,
+				bucketWriter,
+				rollingPolicy,
+				bucketState,
+				fileListener,
+				outputFileConfig);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.Path;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -37,6 +39,7 @@ interface BucketFactory<IN, BucketID> extends Serializable {
 			final long initialPartCounter,
 			final BucketWriter<IN, BucketID> bucketWriter,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) throws IOException;
 
 	Bucket<IN, BucketID> restoreBucket(
@@ -45,5 +48,6 @@ interface BucketFactory<IN, BucketID> extends Serializable {
 			final BucketWriter<IN, BucketID> bucketWriter,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
 			final BucketState<BucketID> bucketState,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) throws IOException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -78,6 +78,9 @@ public class Buckets<IN, BucketID> {
 	@Nullable
 	private BucketLifeCycleListener<IN, BucketID> bucketLifeCycleListener;
 
+	@Nullable
+	private FileLifeCycleListener<BucketID> fileLifeCycleListener;
+
 	// --------------------------- State Related Fields -----------------------------
 
 	private final BucketStateSerializer<BucketID> bucketStateSerializer;
@@ -121,6 +124,10 @@ public class Buckets<IN, BucketID> {
 
 	public void setBucketLifeCycleListener(BucketLifeCycleListener<IN, BucketID> bucketLifeCycleListener) {
 		this.bucketLifeCycleListener = Preconditions.checkNotNull(bucketLifeCycleListener);
+	}
+
+	public void setFileLifeCycleListener(FileLifeCycleListener<BucketID> fileLifeCycleListener) {
+		this.fileLifeCycleListener = Preconditions.checkNotNull(fileLifeCycleListener);
 	}
 
 	/**
@@ -179,6 +186,7 @@ public class Buckets<IN, BucketID> {
 						bucketWriter,
 						rollingPolicy,
 						recoveredState,
+						fileLifeCycleListener,
 						outputFileConfig
 				);
 
@@ -300,6 +308,7 @@ public class Buckets<IN, BucketID> {
 					maxPartCounter,
 					bucketWriter,
 					rollingPolicy,
+					fileLifeCycleListener,
 					outputFileConfig);
 			activeBuckets.put(bucketId, bucket);
 			notifyBucketCreate(bucket);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.Path;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -39,6 +41,7 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 			final long initialPartCounter,
 			final BucketWriter<IN, BucketID> bucketWriter,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) {
 
 		return Bucket.getNew(
@@ -48,6 +51,7 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 				initialPartCounter,
 				bucketWriter,
 				rollingPolicy,
+				fileListener,
 				outputFileConfig);
 	}
 
@@ -58,6 +62,7 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 			final BucketWriter<IN, BucketID> bucketWriter,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
 			final BucketState<BucketID> bucketState,
+			@Nullable final FileLifeCycleListener<BucketID> fileListener,
 			final OutputFileConfig outputFileConfig) throws IOException {
 
 		return Bucket.restore(
@@ -66,6 +71,7 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 				bucketWriter,
 				rollingPolicy,
 				bucketState,
+				fileListener,
 				outputFileConfig);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/FileLifeCycleListener.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/FileLifeCycleListener.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.Path;
+
+/**
+ * Listener about the status of file.
+ */
+@Internal
+public interface FileLifeCycleListener<BucketID> {
+
+	/**
+	 * Notifies a new file has been opened.
+	 *
+	 * <p>Note that this does not mean that the file has been created in the file system. It is
+	 * only created logically and the actual file will be generated after it is committed.
+	 *
+	 * @param bucketID The bucketID of newly opened file.
+	 * @param newPath The path of newly opened file.
+	 */
+	void onPartFileOpened(BucketID bucketID, Path newPath);
+
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -165,6 +165,9 @@ public class StreamingFileSink<IN>
 		}
 
 		@Internal
+		public abstract BucketWriter<IN, BucketID> createBucketWriter() throws IOException;
+
+		@Internal
 		public abstract Buckets<IN, BucketID> createBuckets(final int subtaskIndex) throws IOException;
 	}
 
@@ -253,12 +256,18 @@ public class StreamingFileSink<IN>
 
 		@Internal
 		@Override
+		public BucketWriter<IN, BucketID> createBucketWriter() throws IOException {
+			return new RowWiseBucketWriter<>(FileSystem.get(basePath.toUri()).createRecoverableWriter(), encoder);
+		}
+
+		@Internal
+		@Override
 		public Buckets<IN, BucketID> createBuckets(int subtaskIndex) throws IOException {
 			return new Buckets<>(
 					basePath,
 					bucketAssigner,
 					bucketFactory,
-					new RowWiseBucketWriter<>(FileSystem.get(basePath.toUri()).createRecoverableWriter(), encoder),
+					createBucketWriter(),
 					rollingPolicy,
 					subtaskIndex,
 					outputFileConfig);
@@ -364,12 +373,18 @@ public class StreamingFileSink<IN>
 
 		@Internal
 		@Override
+		public BucketWriter<IN, BucketID> createBucketWriter() throws IOException {
+			return new BulkBucketWriter<>(FileSystem.get(basePath.toUri()).createRecoverableWriter(), writerFactory);
+		}
+
+		@Internal
+		@Override
 		public Buckets<IN, BucketID> createBuckets(int subtaskIndex) throws IOException {
 			return new Buckets<>(
 					basePath,
 					bucketAssigner,
 					bucketFactory,
-					new BulkBucketWriter<>(FileSystem.get(basePath.toUri()).createRecoverableWriter(), writerFactory),
+					createBucketWriter(),
 					rollingPolicy,
 					subtaskIndex,
 					outputFileConfig);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
@@ -318,6 +318,7 @@ public class BucketStateSerializerTest {
 			0,
 			createBucketWriter(),
 			DefaultRollingPolicy.builder().withMaxPartSize(10).build(),
+			null,
 			OutputFileConfig.builder().build());
 	}
 
@@ -328,6 +329,7 @@ public class BucketStateSerializerTest {
 			createBucketWriter(),
 			DefaultRollingPolicy.builder().withMaxPartSize(10).build(),
 			bucketState,
+			null,
 			OutputFileConfig.builder().build());
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
@@ -366,6 +366,7 @@ public class BucketTest {
 				initialPartCounter,
 				new RowWiseBucketWriter<>(writer, ENCODER),
 				rollingPolicy,
+				null,
 				outputFileConfig);
 	}
 
@@ -382,6 +383,7 @@ public class BucketTest {
 				new RowWiseBucketWriter<>(writer, ENCODER),
 				rollingPolicy,
 				bucketState,
+				null,
 				outputFileConfig);
 	}
 
@@ -413,6 +415,7 @@ public class BucketTest {
 			new RowWiseBucketWriter<>(writer, ENCODER),
 			rollingPolicy,
 			stateWithOnlyInProgressFile,
+			null,
 			OutputFileConfig.builder().build());
 	}
 
@@ -432,7 +435,9 @@ public class BucketTest {
 			1L,
 			new RowWiseBucketWriter<>(writer, ENCODER),
 			rollingPolicy,
-			initStateWithOnlyInProgressFile, OutputFileConfig.builder().build());
+			initStateWithOnlyInProgressFile,
+			null,
+			OutputFileConfig.builder().build());
 	}
 
 	private Map<Long, List<InProgressFileWriter.PendingFileRecoverable>> createPendingPartsPerCheckpoint(int noOfCheckpoints) {


### PR DESCRIPTION

## What is the purpose of the change & Brief change log

- Introduce createBucketWriter to BucketsBuilder: Compaction operator depends on BucketWriter to write compacted file.
- Introduce FileLifeCycleListener to Buckets: Compaction operator depends on this to compact files in downstream operator

## Verifying this change

`BucketsTest.testFileLifeCycleListener`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
