### PR TITLE
[FLINK-19732] Disable checkpointing in BATCH mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -520,4 +520,25 @@ public class CheckpointConfig implements java.io.Serializable {
 		configuration.getOptional(ExecutionCheckpointingOptions.ENABLE_UNALIGNED)
 			.ifPresent(this::enableUnalignedCheckpoints);
 	}
+
+	/**
+	 * Creates a deep copy of the provided {@link CheckpointConfig}.
+	 * @param checkpointConfig the config to copy.
+	 * @return the newly created copy.
+	 */
+	public static CheckpointConfig copyOf(final CheckpointConfig checkpointConfig) {
+		checkNotNull(checkpointConfig);
+
+		final CheckpointConfig config = new CheckpointConfig();
+		config.checkpointInterval = checkpointConfig.checkpointInterval;
+		config.checkpointingMode = checkpointConfig.checkpointingMode;
+		config.checkpointTimeout = checkpointConfig.checkpointTimeout;
+		config.maxConcurrentCheckpoints = checkpointConfig.maxConcurrentCheckpoints;
+		config.minPauseBetweenCheckpoints = checkpointConfig.minPauseBetweenCheckpoints;
+		config.preferCheckpointForRecovery = checkpointConfig.preferCheckpointForRecovery;
+		config.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
+		config.unalignedCheckpointsEnabled = checkpointConfig.isUnalignedCheckpointsEnabled();
+		config.externalizedCheckpointCleanup = checkpointConfig.externalizedCheckpointCleanup;
+		return config;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -104,6 +104,13 @@ public class CheckpointConfig implements java.io.Serializable {
 	// ------------------------------------------------------------------------
 
 	/**
+	 * Disables checkpointing.
+	 */
+	public void disableCheckpointing() {
+		this.checkpointInterval = -1;
+	}
+
+	/**
 	 * Checks whether checkpointing is enabled.
 	 *
 	 * @return True if checkpointing is enables, false otherwise.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -101,6 +101,30 @@ public class CheckpointConfig implements java.io.Serializable {
 	 * */
 	private int tolerableCheckpointFailureNumber = UNDEFINED_TOLERABLE_CHECKPOINT_NUMBER;
 
+	/**
+	 * Creates a deep copy of the provided {@link CheckpointConfig}.
+	 * @param checkpointConfig the config to copy.
+	 */
+	public CheckpointConfig(final CheckpointConfig checkpointConfig) {
+		checkNotNull(checkpointConfig);
+
+		this.checkpointInterval = checkpointConfig.checkpointInterval;
+		this.checkpointingMode = checkpointConfig.checkpointingMode;
+		this.checkpointTimeout = checkpointConfig.checkpointTimeout;
+		this.maxConcurrentCheckpoints = checkpointConfig.maxConcurrentCheckpoints;
+		this.minPauseBetweenCheckpoints = checkpointConfig.minPauseBetweenCheckpoints;
+		this.preferCheckpointForRecovery = checkpointConfig.preferCheckpointForRecovery;
+		this.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
+		this.unalignedCheckpointsEnabled = checkpointConfig.isUnalignedCheckpointsEnabled();
+		this.externalizedCheckpointCleanup = checkpointConfig.externalizedCheckpointCleanup;
+		this.forceCheckpointing = checkpointConfig.forceCheckpointing;
+		this.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
+	}
+
+	public CheckpointConfig() {
+
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -519,26 +543,5 @@ public class CheckpointConfig implements java.io.Serializable {
 			.ifPresent(this::enableExternalizedCheckpoints);
 		configuration.getOptional(ExecutionCheckpointingOptions.ENABLE_UNALIGNED)
 			.ifPresent(this::enableUnalignedCheckpoints);
-	}
-
-	/**
-	 * Creates a deep copy of the provided {@link CheckpointConfig}.
-	 * @param checkpointConfig the config to copy.
-	 * @return the newly created copy.
-	 */
-	public static CheckpointConfig copyOf(final CheckpointConfig checkpointConfig) {
-		checkNotNull(checkpointConfig);
-
-		final CheckpointConfig config = new CheckpointConfig();
-		config.checkpointInterval = checkpointConfig.checkpointInterval;
-		config.checkpointingMode = checkpointConfig.checkpointingMode;
-		config.checkpointTimeout = checkpointConfig.checkpointTimeout;
-		config.maxConcurrentCheckpoints = checkpointConfig.maxConcurrentCheckpoints;
-		config.minPauseBetweenCheckpoints = checkpointConfig.minPauseBetweenCheckpoints;
-		config.preferCheckpointForRecovery = checkpointConfig.preferCheckpointForRecovery;
-		config.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
-		config.unalignedCheckpointsEnabled = checkpointConfig.isUnalignedCheckpointsEnabled();
-		config.externalizedCheckpointCleanup = checkpointConfig.externalizedCheckpointCleanup;
-		return config;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -266,6 +266,12 @@ public class StreamGraphGenerator {
 		graph.setJobName(jobName);
 
 		if (shouldExecuteInBatchMode) {
+
+			if (checkpointConfig.isCheckpointingEnabled()) {
+				LOG.info("Disabled Checkpointing. Checkpointing is not supported when executing jobs in BATCH mode.");
+				checkpointConfig.disableCheckpointing();
+			}
+
 			graph.setAllVerticesInSameSlotSharingGroupByDefault(false);
 			graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED);
 			graph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -194,7 +194,7 @@ public class StreamGraphGenerator {
 			ReadableConfig configuration) {
 		this.transformations = checkNotNull(transformations);
 		this.executionConfig = checkNotNull(executionConfig);
-		this.checkpointConfig = CheckpointConfig.copyOf(checkpointConfig);
+		this.checkpointConfig = new CheckpointConfig(checkpointConfig);
 		this.configuration = checkNotNull(configuration);
 	}
 
@@ -268,7 +268,7 @@ public class StreamGraphGenerator {
 		if (shouldExecuteInBatchMode) {
 
 			if (checkpointConfig.isCheckpointingEnabled()) {
-				LOG.info("Disabled Checkpointing. Checkpointing is not supported when executing jobs in BATCH mode.");
+				LOG.info("Disabled Checkpointing. Checkpointing is not supported and not needed when executing jobs in BATCH mode.");
 				checkpointConfig.disableCheckpointing();
 			}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -194,7 +194,7 @@ public class StreamGraphGenerator {
 			ReadableConfig configuration) {
 		this.transformations = checkNotNull(transformations);
 		this.executionConfig = checkNotNull(executionConfig);
-		this.checkpointConfig = checkNotNull(checkpointConfig);
+		this.checkpointConfig = CheckpointConfig.copyOf(checkpointConfig);
 		this.configuration = checkNotNull(configuration);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

When a pipeline is executed in BATCH mode, its tasks are scheduled in independent regions and not all tasks are present throughout the execution. This implies that checkpoints cannot go through and checkpointing should be disabled.

Given that we want the user code to be able to be executed in BATCH and STREAMING without modifications, with this PR we are simply disabling checkpointing and logging the fact when executing in BATCH mode, but we do not throw an exception.

## Brief change log

Changes are mainly in the `StreamGraphGenerator`.

## Verifying this change

Tests can be found in the `StreamGraphGeneratorExecutionModeDetectionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
