### PR TITLE
[FLINK-19483][python][e2] Remove conda install zip

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -90,8 +90,6 @@ pip install dist/*
 
 cd dev
 
-conda install -y -q zip=3.0
-
 rm -rf .conda/pkgs
 
 zip -q -r "${TEST_DATA_DIR}/venv.zip" .conda


### PR DESCRIPTION
##  What is the purpose of the change

*This pull request will remove conda install zip since the machine of Azure has preinstalled zip, which can avoid conda installation zip failures caused by unknown permissions*


## Brief change log

  - *Remove conda install zip in test_pyflink.sh*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
