### PR TITLE
[FLINK-19696] Add runtime batch committer operators for the new sink API

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Runtime {@link org.apache.flink.streaming.api.operators.StreamOperator} for executing
+ * {@link Committer} in the batch execution mode.
+ *
+ * @param <CommT> The committable type of the {@link Committer}.
+ */
+final class BatchCommitterOperator<CommT> extends AbstractStreamOperator<CommT>
+		implements OneInputStreamOperator<CommT, CommT>, BoundedOneInput {
+
+	/** Responsible for committing the committable to the external system. */
+	private final Committer<CommT> committer;
+
+	/** Record all the committables until the end of the input. */
+	private final List<CommT> allCommittables;
+
+	public BatchCommitterOperator(Committer<CommT> committer) {
+		this.committer = checkNotNull(committer);
+		allCommittables = Lists.newArrayList();
+	}
+
+	@Override
+	public void processElement(StreamRecord<CommT> element) {
+		allCommittables.add(element.getValue());
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		if (!allCommittables.isEmpty()) {
+			final List<CommT> neededRetryCommittables = committer.commit(allCommittables);
+			if (!neededRetryCommittables.isEmpty()) {
+				throw new UnsupportedOperationException("Currently does not support the re-commit!");
+			}
+			for (CommT committable : allCommittables) {
+				output.collect(new StreamRecord<>(committable));
+			}
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		committer.close();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for
+ * {@link BatchCommitterOperator}.
+ *
+ * @param <CommT> The committable type of the {@link Committer}.
+ */
+public final class BatchCommitterOperatorFactory<CommT> extends AbstractStreamOperatorFactory<CommT>
+		implements OneInputStreamOperatorFactory<CommT, CommT> {
+
+	private final Sink<?, CommT, ?, ?> sink;
+
+	public BatchCommitterOperatorFactory(Sink<?, CommT, ?, ?> sink) {
+		this.sink = checkNotNull(sink);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends StreamOperator<CommT>> T createStreamOperator(
+			StreamOperatorParameters<CommT> parameters) {
+		final BatchCommitterOperator<CommT> committerOperator =
+				new BatchCommitterOperator<>(
+						sink.createCommitter().orElseThrow(
+								() -> new IllegalStateException(
+										"Could not create committer from the sink")));
+		committerOperator.setup(
+				parameters.getContainingTask(),
+				parameters.getStreamConfig(),
+				parameters.getOutput());
+		return (T) committerOperator;
+	}
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return BatchCommitterOperator.class;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Runtime {@link org.apache.flink.streaming.api.operators.StreamOperator} for executing
+ * {@link GlobalCommitter} in the batch execution mode.
+ *
+ * @param <CommT> The committable type of the {@link GlobalCommitter}
+ * @param <GlobalCommT> The committable type of the {@link GlobalCommitter}
+ */
+final class BatchGlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator<GlobalCommT>
+		implements OneInputStreamOperator<CommT, GlobalCommT>, BoundedOneInput {
+
+	/** Aggregate committables to global committables and commit the global committables to the external system. */
+	private final GlobalCommitter<CommT, GlobalCommT> globalCommitter;
+
+	/** Record all the committables until the end of the input. */
+	private final List<CommT> allCommittables;
+
+	BatchGlobalCommitterOperator(GlobalCommitter<CommT, GlobalCommT> globalCommitter) {
+		this.globalCommitter = checkNotNull(globalCommitter);
+		allCommittables = new ArrayList<>();
+	}
+
+	@Override
+	public void processElement(StreamRecord<CommT> element) {
+		allCommittables.add(element.getValue());
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		if (!allCommittables.isEmpty()) {
+			final GlobalCommT globalCommittable = globalCommitter.combine(allCommittables);
+			final List<GlobalCommT> neededRetryCommittables = globalCommitter.commit(Collections.singletonList(
+					globalCommittable));
+			if (!neededRetryCommittables.isEmpty()) {
+				throw new UnsupportedOperationException("Currently does not support the re-commit!");
+			}
+		}
+		globalCommitter.endOfInput();
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		globalCommitter.close();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for
+ * {@link BatchGlobalCommitterOperator}.
+ *
+ * @param <CommT> The committable type of the {@link GlobalCommitter}
+ * @param <GlobalCommT> The committable type of the {@link GlobalCommitter}
+ */
+public final class BatchGlobalCommitterOperatorFactory<CommT, GlobalCommT> extends AbstractStreamOperatorFactory<GlobalCommT>
+		implements OneInputStreamOperatorFactory<CommT, GlobalCommT> {
+
+	private final Sink<?, CommT, ?, GlobalCommT> sink;
+
+	public BatchGlobalCommitterOperatorFactory(Sink<?, CommT, ?, GlobalCommT> sink) {
+		this.sink = checkNotNull(sink);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends StreamOperator<GlobalCommT>> T createStreamOperator(StreamOperatorParameters<GlobalCommT> parameters) {
+		final BatchGlobalCommitterOperator<CommT, GlobalCommT> batchGlobalCommitterOperator =
+				new BatchGlobalCommitterOperator<>(
+						sink.createGlobalCommitter().orElseThrow(
+								() -> new IllegalStateException(
+										"Could not create global committer from the sink")));
+
+		batchGlobalCommitterOperator.setup(
+				parameters.getContainingTask(),
+				parameters.getStreamConfig(),
+				parameters.getOutput());
+		return (T) batchGlobalCommitterOperator;
+	}
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		return BatchGlobalCommitterOperator.class;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.runtime.operators.sink.TestSink.DEFAULT_WRITER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for {@link BatchCommitterOperator}.
+ */
+public class BatchCommitterOperatorTest extends TestLogger {
+
+	@Test(expected = IllegalStateException.class)
+	public void throwExceptionWithoutCommitter() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(null);
+		testHarness.initializeEmptyState();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void doNotSupportRetry() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(new TestSink.AlwaysRetryCommitter());
+
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.processElement(new StreamRecord<>("those"));
+		testHarness.endInput();
+		testHarness.close();
+	}
+
+	@Test
+	public void commit() throws Exception {
+
+		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				committer);
+
+		final List<String> expectedCommittedData = Arrays.asList("youth", "laugh", "nothing");
+
+		testHarness.initializeEmptyState();
+		testHarness.open();
+
+		testHarness.processElements(expectedCommittedData.stream().map(StreamRecord::new).collect(
+				Collectors.toList()));
+		testHarness.endInput();
+		testHarness.close();
+
+		assertThat(
+				committer.getCommittedData(),
+				containsInAnyOrder(expectedCommittedData.toArray()));
+
+		assertThat(testHarness.getOutput(), containsInAnyOrder(expectedCommittedData
+				.stream()
+				.map(StreamRecord::new)
+				.toArray()));
+	}
+
+	@Test
+	public void close() throws Exception {
+		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+				committer);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.close();
+
+		assertThat(committer.isClosed(), is(true));
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(Committer<String> committer) throws Exception {
+		return new OneInputStreamOperatorTestHarness<>(
+				new BatchCommitterOperatorFactory<>(
+						TestSink.create(
+								() -> DEFAULT_WRITER,
+								() -> committer == null ? Optional.empty() : Optional.of(committer),
+								() -> Optional.of(SimpleVersionedStringSerializer.INSTANCE),
+								() -> Optional.empty(),
+								() -> Optional.empty())),
+				StringSerializer.INSTANCE);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.runtime.operators.sink.TestSink.DEFAULT_WRITER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for {@link BatchGlobalCommitterOperator}.
+ */
+public class BatchGlobalCommitterOperatorTest extends TestLogger {
+
+	@Test(expected = IllegalStateException.class)
+	public void throwExceptionWithoutCommitter() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(null);
+
+		testHarness.initializeEmptyState();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void doNotSupportRetry() throws Exception {
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(new TestSink.AlwaysRetryGlobalCommitter());
+
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.processElement(new StreamRecord<>("hotel"));
+		testHarness.endInput();
+		testHarness.close();
+	}
+
+	@Test
+	public void endOfInput() throws Exception {
+		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(globalCommitter);
+		final List<String> inputs = Arrays.asList("compete", "swear", "shallow");
+
+		testHarness.initializeEmptyState();
+		testHarness.open();
+
+		testHarness.processElements(inputs
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
+
+		testHarness.endInput();
+
+		final List<String> expectedCommittedData = Arrays.asList(
+				globalCommitter.combine(inputs),
+				"end of input");
+
+		assertThat(
+				globalCommitter.getCommittedData(),
+				containsInAnyOrder(expectedCommittedData.toArray()));
+
+		testHarness.close();
+
+	}
+
+	@Test
+	public void close() throws Exception {
+		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+				createTestHarness(globalCommitter);
+		testHarness.initializeEmptyState();
+		testHarness.open();
+		testHarness.close();
+
+		assertThat(globalCommitter.isClosed(), is(true));
+	}
+
+	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
+			GlobalCommitter<String, String> globalCommitter) throws Exception {
+
+		return new OneInputStreamOperatorTestHarness<>(
+				new BatchGlobalCommitterOperatorFactory<>(TestSink.create(
+						() -> DEFAULT_WRITER,
+						() -> Optional.empty(),
+						() -> Optional.empty(),
+						() -> globalCommitter == null ? Optional.empty() : Optional.of(
+								globalCommitter),
+						() -> Optional.of(SimpleVersionedStringSerializer.INSTANCE))),
+				StringSerializer.INSTANCE);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link Sink} for testing that uses {@link Supplier Suppliers} to create various components
+ * under test.
+ */
+class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
+		implements Sink<InputT, CommT, WriterStateT, GlobalCommT> {
+
+	static final DefaultWriter<String> DEFAULT_WRITER = new DefaultWriter<>();
+
+	private final Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier;
+	private final Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier;
+
+	private final Supplier<Optional<Committer<CommT>>> committerSupplier;
+	private final Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier;
+
+	private final Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier;
+	private final Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier;
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Supplier<Writer<InputT, CommT, WriterStateT>> writer) {
+		// We cannot replace this by a method reference because the Java compiler will not be
+		// able to typecheck it.
+		//noinspection Convert2MethodRef
+		return new TestSink<>((state) -> writer.get(), () -> Optional.empty());
+	}
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+		return new TestSink<>((state) -> writer.get(), writerStateSerializerSupplier);
+	}
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+		return new TestSink<>(writer, writerStateSerializerSupplier);
+	}
+
+	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
+			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<Committer<CommT>>> committerSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
+			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommittableSerializer) {
+		return new TestSink<>(
+				(s) -> writer.get(),
+				() -> Optional.empty(),
+				committerSupplier,
+				committableSerializerSupplier,
+				globalCommitterSupplier,
+				globalCommittableSerializer);
+	}
+
+	private TestSink(
+			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier,
+			Supplier<Optional<Committer<CommT>>> committerSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
+			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
+			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier) {
+		this.writerSupplier = writerSupplier;
+		this.writerStateSerializerSupplier = writerStateSerializerSupplier;
+		this.committerSupplier = committerSupplier;
+		this.committableSerializerSupplier = committableSerializerSupplier;
+		this.globalCommitterSupplier = globalCommitterSupplier;
+		this.globalCommitterSerializerSupplier = globalCommitterSerializerSupplier;
+	}
+
+	private TestSink(
+			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
+			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
+		this(
+				writer,
+				writerStateSerializerSupplier,
+				Optional::empty,
+				Optional::empty,
+				Optional::empty,
+				Optional::empty);
+	}
+
+	@Override
+	public Writer<InputT, CommT, WriterStateT> createWriter(
+			InitContext context,
+			List<WriterStateT> states) {
+		return writerSupplier.apply(states);
+	}
+
+	@Override
+	public Optional<Committer<CommT>> createCommitter() {
+		return committerSupplier.get();
+	}
+
+	@Override
+	public Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
+		return globalCommitterSupplier.get();
+	}
+
+	@Override
+	public Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
+		return committableSerializerSupplier.get();
+	}
+
+	@Override
+	public Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
+		return globalCommitterSerializerSupplier.get();
+	}
+
+	@Override
+	public Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
+		return writerStateSerializerSupplier.get();
+	}
+
+	/**
+	 * This is default writer used for testing {@link Committer} and {@link GlobalCommitter}'s operator.
+	 */
+	static class DefaultWriter<CommT> implements Writer<CommT, CommT, CommT> {
+
+		@Override
+		public void write(CommT element, Context context) {
+			//do nothing
+		}
+
+		@Override
+		public List<CommT> prepareCommit(boolean flush) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<CommT> snapshotState() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void close() throws Exception {
+
+		}
+	}
+
+	/**
+	 * Base class for testing {@link Committer} and {@link GlobalCommitter}.
+	 */
+	abstract static class AbstractTestCommitter<CommT> implements Committer<CommT> {
+
+		protected List<CommT> committedData;
+
+		private boolean isClosed;
+
+		public AbstractTestCommitter() {
+			this.committedData = new ArrayList<>();
+			this.isClosed = false;
+		}
+
+		public List<CommT> getCommittedData() {
+			return committedData;
+		}
+
+		@Override
+		public void close() throws Exception {
+			isClosed = true;
+		}
+
+		public boolean isClosed() {
+			return isClosed;
+		}
+	}
+
+	/**
+	 * The class used for normal committer test.
+	 */
+	static class TestCommitter extends AbstractTestCommitter<String> {
+
+		@Override
+		public List<String> commit(List<String> committables) {
+			if (committedData != null) {
+				committedData.addAll(committables);
+			}
+			return Collections.emptyList();
+		}
+	}
+
+	/**
+	 * This committer always re-commits the committables data it received.
+	 */
+	static class AlwaysRetryCommitter extends AbstractTestCommitter<String> {
+
+		@Override
+		public List<String> commit(List<String> committables) {
+			return committables;
+		}
+	}
+
+	/**
+	 * The class used for normal global committer test.
+	 */
+	static class TestGlobalCommitter extends TestCommitter implements GlobalCommitter<String, String> {
+
+		static final Function<List<String>, String> COMBINER = (x) -> String.join("+", x);
+
+		private final String committedSuccessData;
+
+		TestGlobalCommitter(String committedSuccessData) {
+			this.committedSuccessData = committedSuccessData;
+		}
+
+		@Override
+		public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
+			if (committedSuccessData == null) {
+				return globalCommittables;
+			}
+			return globalCommittables
+					.stream()
+					.filter(s -> !s.equals(committedSuccessData))
+					.collect(Collectors.toList());
+		}
+
+		@Override
+		public String combine(List<String> committables) {
+			return COMBINER.apply(committables);
+		}
+
+		@Override
+		public void endOfInput() {
+			this.committedData.add("end of input");
+		}
+	}
+
+	/**
+	 * This global committer always re-commits the committables data it received.
+	 */
+	static class AlwaysRetryGlobalCommitter extends AbstractTestCommitter<String> implements GlobalCommitter<String, String> {
+
+		@Override
+		public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public String combine(List<String> committables) {
+			return String.join("|", committables);
+		}
+
+		@Override
+		public void endOfInput() {
+
+		}
+
+		@Override
+		public List<String> commit(List<String> committables) {
+			return committables;
+		}
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This patch introduce two operators:
1. `BatchCommitterOperator` is the runtime operator for executing the sink’s `Committer` in the batch execution mode.
2. `BatchGlobalCommitterOperator` is the runtime operator for executing the sink’s `GlobalCommitter` in the batch execution mode


## Brief change log

1. Introduce the `BatchCommitterOperator`
2. Introduce the `BatchGlobalCommitterOperator`

## Verifying this change
1. `BatchCommitterOperatorTest` tests the `open/close/process` of the `BatchCommitterOperator`.
2. `BatchGlobalCommitterOperatorTest` tests the `open/close/process/endInput` of the `GlobalBatchCommitterOperator`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
