### PR TITLE
[FLINK-19677][runtime] Make JobManager lazily resolve hostname of TaskManager and provide an option to turn off reverse resolution entirely

### DIFF
--- a/docs/_includes/generated/all_jobmanager_section.html
+++ b/docs/_includes/generated/all_jobmanager_section.html
@@ -27,6 +27,12 @@
             <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>jobmanager.retrieve-taskmanager-hostname</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether JobManager would retrieve canonical host name of TaskManager during registration. If the option is set to "false", TaskManager registration with JobManager could be faster, since no reverse DNS lookup is performed. However, local input split assignment (such as for HDFS files) may be impacted.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.rpc.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -87,6 +87,12 @@
             <td>Total Process Memory size for the JobManager. This includes all the memory that a JobManager JVM process consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. In containerized setups, this should be set to the container memory. See also 'jobmanager.memory.flink.size' for Total Flink Memory size configuration.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.retrieve-taskmanager-hostname</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether JobManager would retrieve canonical host name of TaskManager during registration. If the option is set to "false", TaskManager registration with JobManager could be faster, since no reverse DNS lookup is performed. However, local input split assignment (such as for HDFS files) may be impacted.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.rpc.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -309,6 +309,19 @@ public class JobManagerOptions {
 			.withDescription("The max number of completed jobs that can be kept in the job store.");
 
 	/**
+	 * Flag indicating whether JobManager would retrieve canonical host name of TaskManager during registration.
+	 */
+	@Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
+	public static final ConfigOption<Boolean> RETRIEVE_TASK_MANAGER_HOSTNAME =
+		key("jobmanager.retrieve-taskmanager-hostname")
+			.defaultValue(true)
+			.withDescription("Flag indicating whether JobManager would retrieve canonical "
+							+ "host name of TaskManager during registration. "
+							+ "If the option is set to \"false\", TaskManager registration with "
+							+ "JobManager could be faster, since no reverse DNS lookup is performed. "
+							+ "However, local input split assignment (such as for HDFS files) may be impacted.");
+
+	/**
 	 * The timeout in milliseconds for requesting a slot from Slot Pool.
 	 */
 	@Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobWriter;
@@ -87,6 +88,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorToJobManagerHeartbeatPa
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation.ResolutionMode;
 import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -162,6 +164,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	private final SchedulerNGFactory schedulerNGFactory;
 
 	private final long initializationTimestamp;
+
+	private final boolean retrieveTaskManagerHostName;
 
 	// --------- BackPressure --------
 
@@ -275,6 +279,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		this.heartbeatServices = checkNotNull(heartbeatServices);
 		this.jobMetricGroupFactory = checkNotNull(jobMetricGroupFactory);
 		this.initializationTimestamp = initializationTimestamp;
+		this.retrieveTaskManagerHostName = jobMasterConfiguration.getConfiguration()
+				.getBoolean(JobManagerOptions.RETRIEVE_TASK_MANAGER_HOSTNAME);
 
 		final String jobName = jobGraph.getName();
 		final JobID jid = jobGraph.getJobID();
@@ -606,7 +612,15 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		final TaskManagerLocation taskManagerLocation;
 		try {
-			taskManagerLocation = TaskManagerLocation.fromUnresolvedLocation(unresolvedTaskManagerLocation);
+			if (retrieveTaskManagerHostName) {
+				taskManagerLocation = TaskManagerLocation.fromUnresolvedLocation(
+						unresolvedTaskManagerLocation,
+						ResolutionMode.RETRIEVE_HOST_NAME);
+			} else {
+				taskManagerLocation = TaskManagerLocation.fromUnresolvedLocation(
+						unresolvedTaskManagerLocation,
+						ResolutionMode.USE_IP_ONLY);
+			}
 		} catch (Throwable throwable) {
 			final String errMsg = String.format(
 				"Could not accept TaskManager registration. TaskManager address %s cannot be resolved. %s",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
@@ -52,22 +52,22 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	 * the YARN container ID, Mesos container ID, or any other unique identifier. */
 	private final ResourceID resourceID;
 
-	/** The network address that the TaskManager binds its sockets to */
+	/** The network address that the TaskManager binds its sockets to. */
 	private final InetAddress inetAddress;
 
-	/** The supplier for fully qualified host name and pure hostname */
+	/** The supplier for fully qualified host name and pure hostname. */
 	private final HostNameSupplier hostNameSupplier;
 
-	/** The port that the TaskManager receive data transport connection requests at */
+	/** The port that the TaskManager receive data transport connection requests at. */
 	private final int dataPort;
 
-	/** The toString representation, eagerly constructed and cached to avoid repeated string building */  
+	/** The toString representation, eagerly constructed and cached to avoid repeated string building. */
 	private String stringRepresentation;
 
 	/**
 	 * Constructs a new instance connection info object. The constructor will attempt to retrieve the instance's
 	 * host name and domain name through the operating system's lookup mechanisms.
-	 * 
+	 *
 	 * @param inetAddress
 	 *        the network address the instance's task manager binds its sockets to
 	 * @param dataPort
@@ -104,8 +104,9 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 		this(resourceID, inetAddress, dataPort,	new DefaultHostNameSupplier(inetAddress));
 	}
 
-	public static TaskManagerLocation fromUnresolvedLocation(final UnresolvedTaskManagerLocation unresolvedLocation,
-	                                                         final ResolutionMode resolutionMode)
+	public static TaskManagerLocation fromUnresolvedLocation(
+			final UnresolvedTaskManagerLocation unresolvedLocation,
+			final ResolutionMode resolutionMode)
 		throws UnknownHostException {
 
 		InetAddress inetAddress = InetAddress.getByName(unresolvedLocation.getExternalAddress());
@@ -141,7 +142,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	 *     <li>If the TaskManager is started in standalone mode, or via a MiniCluster, this is a random ID.</li>
 	 *     <li>Other deployment modes can set the resource ID in other ways.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @return The ID of the resource in which the TaskManager is started
 	 */
 	public ResourceID getResourceID() {
@@ -150,7 +151,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	/**
 	 * Returns the port instance's task manager expects to receive transfer envelopes on.
-	 * 
+	 *
 	 * @return the port instance's task manager expects to receive transfer envelopes on
 	 */
 	public int dataPort() {
@@ -159,7 +160,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	/**
 	 * Returns the network address the instance's task manager binds its sockets to.
-	 * 
+	 *
 	 * @return the network address the instance's task manager binds its sockets to
 	 */
 	public InetAddress address() {
@@ -177,7 +178,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	/**
 	 * Returns the fully-qualified domain name of the TaskManager provided by {@link #hostNameSupplier}.
-	 * 
+	 *
 	 * @return The fully-qualified domain name of the TaskManager.
 	 */
 	public String getFQDNHostname() {
@@ -268,7 +269,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	@Override
 	public int hashCode() {
-		return resourceID.hashCode() + 
+		return resourceID.hashCode() +
 				17 * inetAddress.hashCode() +
 				129 * dataPort;
 	}
@@ -317,6 +318,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	public interface HostNameSupplier extends Serializable {
 		String getHostName();
+
 		String getFqdnHostName();
 	}
 
@@ -404,7 +406,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	}
 
 	/**
-	 * The DNS resolution mode for TaskManager's IP address
+	 * The DNS resolution mode for TaskManager's IP address.
 	 */
 	public enum ResolutionMode {
 		RETRIEVE_HOST_NAME,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerLocationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -197,5 +198,21 @@ public class TaskManagerLocationTest {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	@Test
+	public void testNotRetrieveHostName() {
+		InetAddress address = mock(InetAddress.class);
+		when(address.getCanonicalHostName()).thenReturn("worker10");
+		when(address.getHostName()).thenReturn("worker10");
+		when(address.getHostAddress()).thenReturn("127.0.0.1");
+
+		TaskManagerLocation info = new TaskManagerLocation(ResourceID.generate(), address, 19871,
+				new TaskManagerLocation.IpOnlyHostNameSupplier(address));
+
+		assertNotEquals("worker10", info.getHostname());
+		assertNotEquals("worker10", info.getFQDNHostname());
+		assertEquals("127.0.0.1", info.getHostname());
+		assertEquals("127.0.0.1", info.getFQDNHostname());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request moved retrieval of TaskManager's host name and FQDN host name in _TaskManagerLocation_ from the contructor to the corresponding Getter methods (a.k.a. lazy initialization), which greatly reduces the possibility of blocking the Akka dispatcher during TaskManager registration with JobManager.

Also, a new configuration parameter called `jobmanager.retrieve-taskmanager-hostname` is introduced to turn off aforementioned reverse DNS lookup steps during registration, which is especially useful in Kubernetes environment where a pod's IP might not be reversely resolved without being exposed with a Service.

## Brief change log

  - *Lazy initialization of hostname-related fields in TaskManagerLocation class*
  - *Allow for canonical hostname lookups being skipped during TaskManager registration with JobManager*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests for the parameter that turns off reverse hostname lookups during JobMaster registration*
  - *Manually verified the change by running a per-job Kubernetes cluser with 1 JobManager and 50 TaskManagers (one slot for each TaskManager), when lazy initialization is implemented and reverse DNS lookup is disabled via the new configuration parameter, the init time for the cluster (from job submission to complete RUNNING status) reduced from ~10 minutes to less than 1 minute.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies: no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes, JobManager (JobMaster)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
