### PR TITLE
[FLINK-19721] [flink-runtime] Support exponential backoff retries in RpcGatewayRetriever

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.Preconditions;
+
+import java.time.Duration;
+
+/**
+ * An implementation of {@link RetryStrategy} that retries that has an exponential backoff with
+ * a cap.
+ */
+public class ExponentialBackoffRetryStrategy implements RetryStrategy {
+	private final int remainingRetries;
+	private final Duration currentRetryDelay;
+	private final Duration maxRetryDelay;
+
+	/**
+	 * @param remainingRetries number of times to retry
+	 * @param currentRetryDelay the current delay between retries
+	 * @param maxRetryDelay the max delay between retries
+	 */
+	public ExponentialBackoffRetryStrategy(int remainingRetries, Duration currentRetryDelay, Duration maxRetryDelay) {
+		Preconditions.checkArgument(remainingRetries >= 0, "The number of retries must be greater or equal to 0.");
+		this.remainingRetries = remainingRetries;
+		Preconditions.checkArgument(currentRetryDelay.toMillis() >= 0, "The currentRetryDelay must be positive");
+		this.currentRetryDelay = currentRetryDelay;
+		Preconditions.checkArgument(maxRetryDelay.toMillis() >= 0, "The maxRetryDelay must be positive");
+		this.maxRetryDelay = maxRetryDelay;
+	}
+
+	@Override
+	public int getNumRemainingRetries() {
+		return remainingRetries;
+	}
+
+	@Override
+	public Duration getRetryDelay() {
+		return currentRetryDelay;
+	}
+
+	@Override
+	public RetryStrategy getNextRetryStrategy() {
+		int nextRemainingRetries = remainingRetries - 1;
+		Preconditions.checkState(nextRemainingRetries >= 0, "The number of remaining retries must not be negative");
+		long nextRetryDelayMillis = Math.min(2 * currentRetryDelay.toMillis(), maxRetryDelay.toMillis());
+		return new ExponentialBackoffRetryStrategy(nextRemainingRetries, Duration.ofMillis(nextRetryDelayMillis), maxRetryDelay);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FixedRetryStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FixedRetryStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.Preconditions;
+
+import java.time.Duration;
+
+/**
+ * An implementation of {@link RetryStrategy} that retries at a fixed delay.
+ */
+public class FixedRetryStrategy implements RetryStrategy {
+	private final int remainingRetries;
+	private final Duration retryDelay;
+
+	/**
+	 * @param remainingRetries number of times to retry
+	 * @param retryDelay delay between retries
+	 */
+	public FixedRetryStrategy(int remainingRetries, Duration retryDelay) {
+		Preconditions.checkArgument(remainingRetries >= 0, "The number of retries must be greater or equal to 0.");
+		this.remainingRetries = remainingRetries;
+		Preconditions.checkArgument(retryDelay.toMillis() >= 0, "The retryDelay must be positive");
+		this.retryDelay = retryDelay;
+	}
+
+	@Override
+	public int getNumRemainingRetries() {
+		return remainingRetries;
+	}
+
+	@Override
+	public Duration getRetryDelay() {
+		return retryDelay;
+	}
+
+	@Override
+	public RetryStrategy getNextRetryStrategy() {
+		int nextRemainingRetries = remainingRetries - 1;
+		Preconditions.checkState(nextRemainingRetries >= 0, "The number of remaining retries must not be negative");
+		return new FixedRetryStrategy(nextRemainingRetries, retryDelay);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/RetryStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/RetryStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import java.time.Duration;
+
+/**
+ * Interface that encapsulates retry logic.  An instances should be immutable.
+ */
+public interface RetryStrategy {
+	/**
+	 * @return the number of remaining retries
+	 */
+	int getNumRemainingRetries();
+
+	/**
+	 * @return the current delay if we need to retry
+	 */
+	Duration getRetryDelay();
+
+	/**
+	 * @return the next retry strategy to current delay if we need to retry
+	 */
+	RetryStrategy getNextRetryStrategy();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.runtime.entrypoint.component;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ExponentialBackoffRetryStrategy;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.ArchivedExecutionGraphStore;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
@@ -66,6 +66,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -125,15 +126,13 @@ public class DefaultDispatcherResourceManagerComponentFactory implements Dispatc
 				rpcService,
 				DispatcherGateway.class,
 				DispatcherId::fromUuid,
-				10,
-				Time.milliseconds(50L));
+				new ExponentialBackoffRetryStrategy(12, Duration.ofMillis(10), Duration.ofMillis(50)));
 
 			final LeaderGatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever = new RpcGatewayRetriever<>(
 				rpcService,
 				ResourceManagerGateway.class,
 				ResourceManagerId::fromUuid,
-				10,
-				Time.milliseconds(50L));
+				new ExponentialBackoffRetryStrategy(12, Duration.ofMillis(10), Duration.ofMillis(50)));
 
 			final ScheduledExecutorService executor = WebMonitorEndpoint.createExecutorService(
 				configuration.getInteger(RestOptions.SERVER_NUM_THREADS),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ExponentialBackoffRetryStrategy;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
@@ -96,6 +97,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -339,14 +341,12 @@ public class MiniCluster implements AutoCloseableAsync {
 					commonRpcService,
 					DispatcherGateway.class,
 					DispatcherId::fromUuid,
-					20,
-					Time.milliseconds(20L));
+					new ExponentialBackoffRetryStrategy(21, Duration.ofMillis(5L), Duration.ofMillis(20L)));
 				resourceManagerGatewayRetriever = new RpcGatewayRetriever<>(
 					commonRpcService,
 					ResourceManagerGateway.class,
 					ResourceManagerId::fromUuid,
-					20,
-					Time.milliseconds(20L));
+					new ExponentialBackoffRetryStrategy(21, Duration.ofMillis(5L), Duration.ofMillis(20L)));
 				webMonitorLeaderRetriever = new LeaderRetriever();
 
 				resourceManagerLeaderRetriever.start(resourceManagerGatewayRetriever);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetriever.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.retriever.impl;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.concurrent.FixedRetryStrategy;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.RetryStrategy;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
@@ -29,7 +27,6 @@ import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
-import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -46,15 +43,6 @@ public class RpcGatewayRetriever<F extends Serializable, T extends FencedRpcGate
 	private final Class<T> gatewayType;
 	private final Function<UUID, F> fencingTokenMapper;
 	private final RetryStrategy retryStrategy;
-
-	public RpcGatewayRetriever(
-			RpcService rpcService,
-			Class<T> gatewayType,
-			Function<UUID, F> fencingTokenMapper,
-			int retries,
-			Time retryDelay) {
-		this(rpcService, gatewayType, fencingTokenMapper, new FixedRetryStrategy(retries, Duration.ofMillis(retryDelay.toMilliseconds())));
-	}
 
 	public RpcGatewayRetriever(
 			RpcService rpcService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategyTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ExponentialBackoffRetryStrategy}.
+ */
+public class ExponentialBackoffRetryStrategyTest extends TestLogger {
+
+	@Test
+	public void testGettersNotCapped() throws Exception {
+		RetryStrategy retryStrategy = new ExponentialBackoffRetryStrategy(10, Duration.ofMillis(5L), Duration.ofMillis(20L));
+		assertEquals(10, retryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(5L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(9, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(10L), nextRetryStrategy.getRetryDelay());
+	}
+
+	@Test
+	public void testGettersHitCapped() throws Exception {
+		RetryStrategy retryStrategy = new ExponentialBackoffRetryStrategy(5, Duration.ofMillis(15L), Duration.ofMillis(20L));
+		assertEquals(5, retryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(15L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(4, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(20L), nextRetryStrategy.getRetryDelay());
+	}
+
+	@Test
+	public void testGettersAtCap() throws Exception {
+		RetryStrategy retryStrategy = new ExponentialBackoffRetryStrategy(5, Duration.ofMillis(20L), Duration.ofMillis(20L));
+		assertEquals(5, retryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(20L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(4, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(20L), nextRetryStrategy.getRetryDelay());
+	}
+
+	/**
+	 * Tests that getting a next RetryStrategy below zero remaining retries fails.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void testRetryFailure() throws Throwable {
+		new ExponentialBackoffRetryStrategy(0, Duration.ofMillis(20L), Duration.ofMillis(20L)).getNextRetryStrategy();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FixedRetryStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FixedRetryStrategyTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FixedRetryStrategy}.
+ */
+public class FixedRetryStrategyTest extends TestLogger {
+
+	@Test
+	public void testGetters() throws Exception {
+		RetryStrategy retryStrategy = new FixedRetryStrategy(10, Duration.ofMillis(5L));
+		assertEquals(10, retryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(5L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(9, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Duration.ofMillis(5L), nextRetryStrategy.getRetryDelay());
+	}
+
+	/**
+	 * Tests that getting a next RetryStrategy below zero remaining retries fails.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void testRetryFailure() throws Throwable {
+		new FixedRetryStrategy(0, Duration.ofMillis(5L)).getNextRetryStrategy();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -95,7 +96,7 @@ public class FutureUtilsTest extends TestLogger {
 	 * Tests that a retry future is failed after all retries have been consumed.
 	 */
 	@Test(expected = FutureUtils.RetryException.class)
-	public void testRetryFailure() throws Throwable {
+	public void testRetryFailureFixedRetries() throws Throwable {
 		final int retries = 3;
 
 		CompletableFuture<?> retryFuture = FutureUtils.retry(
@@ -163,7 +164,7 @@ public class FutureUtilsTest extends TestLogger {
 	 * Tests that retry with delay fails after having exceeded all retries.
 	 */
 	@Test(expected = FutureUtils.RetryException.class)
-	public void testRetryWithDelayFailure() throws Throwable {
+	public void testRetryWithDelayFixedArgsFailure() throws Throwable {
 		CompletableFuture<?> retryFuture = FutureUtils.retryWithDelay(
 			() -> FutureUtils.completedExceptionally(new FlinkException("Test exception")),
 			3,
@@ -178,10 +179,27 @@ public class FutureUtilsTest extends TestLogger {
 	}
 
 	/**
+	 * Tests that retry with delay fails after having exceeded all retries.
+	 */
+	@Test(expected = FutureUtils.RetryException.class)
+	public void testRetryWithDelayRetryStrategyFailure() throws Throwable {
+		CompletableFuture<?> retryFuture = FutureUtils.retryWithDelay(
+				() -> FutureUtils.completedExceptionally(new FlinkException("Test exception")),
+				new FixedRetryStrategy(3, Duration.ofMillis(1L)),
+				TestingUtils.defaultScheduledExecutor());
+
+		try {
+			retryFuture.get(TestingUtils.TIMEOUT().toMilliseconds(), TimeUnit.MILLISECONDS);
+		} catch (ExecutionException ee) {
+			throw ExceptionUtils.stripExecutionException(ee);
+		}
+	}
+
+	/**
 	 * Tests that the delay is respected between subsequent retries of a retry future with retry delay.
 	 */
 	@Test
-	public void testRetryWithDelay() throws Exception {
+	public void testRetryWithDelayFixedArgs() throws Exception {
 		final int retries = 4;
 		final Time delay = Time.milliseconds(5L);
 		final AtomicInteger countDown = new AtomicInteger(retries);
@@ -205,7 +223,37 @@ public class FutureUtilsTest extends TestLogger {
 		long completionTime = System.currentTimeMillis() - start;
 
 		assertTrue(result);
-		assertTrue("The completion time should be at least rertries times delay between retries.", completionTime >= retries * delay.toMilliseconds());
+		assertTrue("The completion time should be at least retries times delay between retries.", completionTime >= retries * delay.toMilliseconds());
+	}
+
+	/**
+	 * Tests that the delay is respected between subsequent retries of a retry future with retry delay.
+	 */
+	@Test
+	public void testRetryWithDelayRetryStrategy() throws Exception {
+		final int retries = 4;
+		final Time delay = Time.milliseconds(5L);
+		final AtomicInteger countDown = new AtomicInteger(retries);
+
+		long start = System.currentTimeMillis();
+
+		CompletableFuture<Boolean> retryFuture = FutureUtils.retryWithDelay(
+				() -> {
+					if (countDown.getAndDecrement() == 0) {
+						return CompletableFuture.completedFuture(true);
+					} else {
+						return FutureUtils.completedExceptionally(new FlinkException("Test exception."));
+					}
+				},
+				new ExponentialBackoffRetryStrategy(retries, Duration.ofMillis(2L), Duration.ofMillis(5L)),
+				TestingUtils.defaultScheduledExecutor());
+
+		Boolean result = retryFuture.get();
+
+		long completionTime = System.currentTimeMillis() - start;
+
+		assertTrue(result);
+		assertTrue("The completion time should be at least retries times delay between retries.", completionTime >= (2 + 4 + 5 + 5));
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.retriever.impl;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FixedRetryStrategy;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
@@ -33,6 +34,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -73,7 +75,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 		final String expectedValue2 = "barfoo";
 		final UUID leaderSessionId = UUID.randomUUID();
 
-		RpcGatewayRetriever<UUID, DummyGateway> gatewayRetriever = new RpcGatewayRetriever<>(rpcService, DummyGateway.class, Function.identity(), 0, Time.milliseconds(0L));
+		RpcGatewayRetriever<UUID, DummyGateway> gatewayRetriever = new RpcGatewayRetriever<>(rpcService, DummyGateway.class, Function.identity(), new FixedRetryStrategy(0, Duration.ZERO));
 		SettableLeaderRetrievalService settableLeaderRetrievalService = new SettableLeaderRetrievalService();
 		DummyRpcEndpoint dummyRpcEndpoint = new DummyRpcEndpoint(rpcService, "dummyRpcEndpoint1", expectedValue);
 		DummyRpcEndpoint dummyRpcEndpoint2 = new DummyRpcEndpoint(rpcService, "dummyRpcEndpoint2", expectedValue2);


### PR DESCRIPTION
## What is the purpose of the change

This is to speed up tests that spend unnecessary time sleeping.

## Brief change log

- Add a RetryStrategy interface that encapsulates retry configuration details.
- Support it in FuturesUtil.
- Plumb interface to Minicluster utils.

## Verifying this change

This change added tests and can be verified as follows:
- Added unit tests

I could not get the test suite to fully pass locally.  I sent an email to the user group about it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
