### PR TITLE
[FLINK-19699][e2e] Upload coredumps and jvm crash debugging information as well for e2e tests

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -40,6 +40,11 @@ if [ ! -z "$TF_BUILD" ] ; then
 	export ARTIFACTS_DIR="${END_TO_END_DIR}/artifacts"
 	mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
 
+	function run_on_exit {
+		collect_coredumps $(pwd) $ARTIFACTS_DIR
+		compress_logs
+	}
+
 	# compress and register logs for publication on exit
 	function compress_logs {
 		echo "COMPRESSING build artifacts."
@@ -48,7 +53,7 @@ if [ ! -z "$TF_BUILD" ] ; then
 		tar -zcvf compressed-archive-dir/${COMPRESSED_ARCHIVE} -C $ARTIFACTS_DIR .
 		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$(pwd)/compressed-archive-dir"
 	}
-	on_exit compress_logs
+	on_exit run_on_exit
 fi
 
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -73,7 +73,7 @@ public class ZooKeeperTestUtils {
 		config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperQuorum);
 
 		int connTimeout = 5000;
-		if (System.getenv().containsKey("CI") || System.getenv().containsKey("TF_BUILD")) {
+		if (runsOnCIInfrastructure()) {
 			// The regular timeout is to aggressive for Travis and connections are often lost.
 			LOG.info("Detected CI environment: Configuring connection and session timeout of 30 seconds");
 			connTimeout = 30000;
@@ -92,4 +92,10 @@ public class ZooKeeperTestUtils {
 		return config;
 	}
 
+	/**
+	 * @return true, if a CI environment is detected.
+	 */
+	public static boolean runsOnCIInfrastructure() {
+		return System.getenv().containsKey("CI") || System.getenv().containsKey("TF_BUILD");
+	}
 }


### PR DESCRIPTION

## What is the purpose of the change

I was unable to figure out the cause of JVM crashes of the `PrometheusReporterEndToEndITCase`. This PR is adding support for uploading crash files in e2e tests as well.


## Verifying this change


This has been tested: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8499&view=artifacts&type=publishedArtifacts


