### PR TITLE
[FLINK-19733][python] Make fast_operation and slow_operation produce functions consistent

### DIFF
--- a/flink-python/pyflink/fn_execution/tests/test_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_coders.py
@@ -146,12 +146,12 @@ class CodersTest(PyFlinkTestCase):
         field_coder = BigIntCoder()
         field_count = 10
         coder = FlattenRowCoder([field_coder for _ in range(field_count)]).get_impl()
-        v = [[None if i % 2 == 0 else i for i in range(field_count)]]
+        v = [None if i % 2 == 0 else i for i in range(field_count)]
         generator_result = coder.decode(coder.encode(v))
         result = []
         for item in generator_result:
             result.append(item)
-        self.assertEqual(v, result)
+        self.assertEqual([v], result)
 
     def test_row_coder(self):
         from pyflink.common import Row, RowKind

--- a/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
@@ -53,8 +53,9 @@ class CodersTest(PyFlinkTestCase):
         for item in generator_result:
             result.append(item)
         try:
-            self.assertEqual(result, data)
+            self.assertEqual(result, [data])
         except AssertionError:
+            data = [data]
             self.assertEqual(len(result), len(data))
             self.assertEqual(len(result[0]), len(data[0]))
             for i in range(len(data[0])):
@@ -73,82 +74,82 @@ class CodersTest(PyFlinkTestCase):
         data = [1, 100, -100, -1000]
         python_field_coders = [coder_impl.BigIntCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.BigIntCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_tinyint_coder(self):
         data = [1, 10, 127, -128]
         python_field_coders = [coder_impl.TinyIntCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.TinyIntCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_boolean_coder(self):
         data = [True, False]
         python_field_coders = [coder_impl.BooleanCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.BooleanCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_smallint_coder(self):
         data = [32767, -32768, 0]
         python_field_coders = [coder_impl.SmallIntCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.SmallIntCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_int_coder(self):
         data = [-2147483648, 2147483647]
         python_field_coders = [coder_impl.IntCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.IntCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_float_coder(self):
         data = [1.02, 1.32]
         python_field_coders = [coder_impl.FloatCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.FloatCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_double_coder(self):
         data = [-12.02, 1.98932]
         python_field_coders = [coder_impl.DoubleCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.DoubleCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_binary_coder(self):
         data = [b'pyflink', b'x\x00\x00\x00']
         python_field_coders = [coder_impl.BinaryCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.BinaryCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_char_coder(self):
         data = ['flink', '🐿']
         python_field_coders = [coder_impl.CharCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.CharCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_date_coder(self):
         import datetime
         data = [datetime.date(2019, 9, 10)]
         python_field_coders = [coder_impl.DateCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.DateCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_time_coder(self):
         import datetime
         data = [datetime.time(hour=11, minute=11, second=11, microsecond=123000)]
         python_field_coders = [coder_impl.TimeCoderImpl() for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.TimeCoderImpl() for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_decimal_coder(self):
         import decimal
         data = [decimal.Decimal('0.00001'), decimal.Decimal('1.23E-8')]
         python_field_coders = [coder_impl.DecimalCoderImpl(38, 18) for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.DecimalCoderImpl(38, 18) for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
         decimal.getcontext().prec = 2
         data = [decimal.Decimal('1.001')]
         python_field_coders = [coder_impl.DecimalCoderImpl(4, 3) for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.DecimalCoderImpl(4, 3) for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
         self.assertEqual(decimal.getcontext().prec, 2)
 
     def test_cython_timestamp_coder(self):
@@ -157,12 +158,12 @@ class CodersTest(PyFlinkTestCase):
         data = [datetime.datetime(2019, 9, 10, 18, 30, 20, 123000)]
         python_field_coders = [coder_impl.TimestampCoderImpl(3) for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.TimestampCoderImpl(3) for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
         data = [datetime.datetime(2019, 9, 10, 18, 30, 20, 123456)]
         python_field_coders = [coder_impl.TimestampCoderImpl(6) for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.TimestampCoderImpl(6) for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_local_zoned_timestamp_coder(self):
         import datetime
@@ -173,14 +174,14 @@ class CodersTest(PyFlinkTestCase):
                                for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.LocalZonedTimestampCoderImpl(3, timezone)
                                for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
         data = [timezone.localize(datetime.datetime(2019, 9, 10, 18, 30, 20, 123456))]
         python_field_coders = [coder_impl.LocalZonedTimestampCoderImpl(6, timezone)
                                for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.LocalZonedTimestampCoderImpl(6, timezone)
                                for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_array_coder(self):
         data = [[1, 2, 3, None]]
@@ -188,7 +189,7 @@ class CodersTest(PyFlinkTestCase):
                                for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.BasicArrayCoderImpl(
             coder_impl_fast.BigIntCoderImpl()) for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_primitive_array_coder(self):
         data = [[1, 2, 3, 4]]
@@ -196,7 +197,7 @@ class CodersTest(PyFlinkTestCase):
                                for _ in range(len(data))]
         cython_field_coders = [coder_impl_fast.PrimitiveArrayCoderImpl(
             coder_impl_fast.BigIntCoderImpl()) for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_map_coder(self):
         data = [{'flink': 1, 'pyflink': 2, 'coder': None}]
@@ -206,7 +207,7 @@ class CodersTest(PyFlinkTestCase):
         cython_field_coders = [coder_impl_fast.MapCoderImpl(coder_impl_fast.CharCoderImpl(),
                                                             coder_impl_fast.BigIntCoderImpl())
                                for _ in range(len(data))]
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
     def test_cython_row_coder(self):
         from pyflink.common import Row, RowKind
@@ -218,13 +219,13 @@ class CodersTest(PyFlinkTestCase):
         cython_field_coders = [coder_impl_fast.RowCoderImpl([coder_impl_fast.BigIntCoderImpl()
                                                              for _ in range(field_count)])]
         row.set_row_kind(RowKind.INSERT)
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
         row.set_row_kind(RowKind.UPDATE_BEFORE)
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
         row.set_row_kind(RowKind.UPDATE_AFTER)
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
         row.set_row_kind(RowKind.DELETE)
-        self.check_cython_coder(python_field_coders, cython_field_coders, [data])
+        self.check_cython_coder(python_field_coders, cython_field_coders, data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will make fast_operation and slow_operation produce functions consistent*


## Brief change log

  - *make the generated functions of slow operation consistent with fast operations*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
