### PR TITLE
[FLINK-19723][Connector/JDBC] Solve the problem of repeated data submission in the failure retry

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
@@ -181,9 +181,9 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 				try {
 					if (!connection.isValid(CONNECTION_CHECK_TIMEOUT_SECONDS)) {
 						connection = connectionProvider.reestablishConnection();
-						jdbcStatementExecutor.closeStatements();
-						jdbcStatementExecutor.prepareStatements(connection);
 					}
+					jdbcStatementExecutor.closeStatements();
+					jdbcStatementExecutor.prepareStatements(connection);
 				} catch (Exception excpetion) {
 					LOG.error("JDBC connection is not valid, and reestablish connection failed.", excpetion);
 					throw new IOException("Reestablish JDBC connection failed", excpetion);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

for example,  if statement.executeBatch() failur for some reason, but the "statement" was not closed in the retry, there is a risk of data duplication:
```
for (int i = 1; i <= executionOptions.getMaxRetries(); i++) {
	try {
		attemptFlush();
		batchCount = 0;
		break;
	} catch (SQLException e) {
		LOG.error("JDBC executeBatch error, retry times = {}", i, e);
		if (i >= executionOptions.getMaxRetries()) {
			throw new IOException(e);
		}
		try {
			if (!connection.isValid(CONNECTION_CHECK_TIMEOUT_SECONDS)) {
				connection = connectionProvider.reestablishConnection();
                                jdbcStatementExecutor.closeStatements();
			        jdbcStatementExecutor.prepareStatements(connection);
			}
		} catch (Exception excpetion) {
			LOG.error("JDBC connection is not valid, and reestablish connection failed.", excpetion);
			throw new IOException("Reestablish JDBC connection failed", excpetion);
		}
		try {
			Thread.sleep(1000 * i);
		} catch (InterruptedException ex) {
			Thread.currentThread().interrupt();
			throw new IOException("unable to flush; interrupted while doing another attempt", e);
		}
	}
}
```
Should be always re-prepareStatement to solve the risk of data duplication
```
...
try {
	if (!connection.isValid(CONNECTION_CHECK_TIMEOUT_SECONDS)) {
		connection = connectionProvider.reestablishConnection();
	}
         jdbcStatementExecutor.closeStatements();
	jdbcStatementExecutor.prepareStatements(connection);
} catch (Exception excpetion) {
			LOG.error("JDBC connection is not valid, and reestablish connection failed.", excpetion);
			throw new IOException("Reestablish JDBC connection failed", excpetion);
}
```

## Brief change log

  - *When the retry occurs in flush method, we should be always re-prepareStatement*


## Verifying this change

This change is already covered by existing tests, such as *JdbcTableOutputFormatTest#testJdbcOutputFormat*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
