### PR TITLE
[FLINK-18811] Pick another tmpDir if an IOException occurs when creating spill file

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapper.java
@@ -291,8 +291,9 @@ final class SpanningWrapper {
 
 		// try to find a unique file name for the spilling channel
 		int maxAttempts = 10;
+		int initialDirIndex = rnd.nextInt(tempDirs.length);
 		for (int attempt = 0; attempt < maxAttempts; attempt++) {
-			int dirIndex = rnd.nextInt(tempDirs.length);
+			int dirIndex = (initialDirIndex + attempt) % tempDirs.length;
 			String directory = tempDirs[dirIndex];
 			File file = new File(directory, randomString(rnd) + ".inputchannel");
 			try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapper.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.runtime.io.network.api.serialization;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.core.fs.RefCountedFile;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataInputView;
@@ -31,6 +30,8 @@ import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.StringUtils;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -301,11 +302,11 @@ final class SpanningWrapper {
 				}
 			} catch (IOException e) {
 				// if there is no tempDir left to try
-				if(tempDirs.length <= 1) {
+				if (tempDirs.length <= 1) {
 					throw e;
 				}
 				LOG.warn("Caught an IOException when creating spill file: " + directory + ". Attempt " + attempt, e);
-				tempDirs = (String[]) ArrayUtils.remove(tempDirs,dirIndex);
+				tempDirs = (String[]) ArrayUtils.remove(tempDirs, dirIndex);
 			}
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapperTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapperTest.java
@@ -25,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -52,7 +53,10 @@ public class SpanningWrapperTest {
 		byte[] record1 = recordBytes(recordLen);
 		byte[] record2 = recordBytes(recordLen * 2);
 
-		SpanningWrapper spanningWrapper = new SpanningWrapper(new String[]{folder.newFolder().getAbsolutePath()}, spillingThreshold, recordLen);
+		File canNotEecutableFile = folder.newFolder();
+		canNotEecutableFile.setExecutable(false);
+		// Always pick 'canNotEecutableFile' first as the Spilling Channel TmpDir. Thus trigger an IOException.
+		SpanningWrapper spanningWrapper = new SpanningWrapper(new String[]{folder.newFolder().getAbsolutePath(),canNotEecutableFile.getAbsolutePath() + File.separator + "pathdonotexit"}, spillingThreshold, recordLen);
 		spanningWrapper.transferFrom(wrapNonSpanning(record1, firstChunk), recordLen);
 		spanningWrapper.addNextChunkFromMemorySegment(wrap(record1), firstChunk, recordLen - firstChunk + LENGTH_BYTES);
 		spanningWrapper.addNextChunkFromMemorySegment(wrap(record2), 0, record2.length);
@@ -62,6 +66,8 @@ public class SpanningWrapperTest {
 		spanningWrapper.getInputView().readFully(new byte[recordLen], 0, recordLen); // read out from file
 		spanningWrapper.transferLeftOverTo(new NonSpanningWrapper()); // clear any leftover
 		spanningWrapper.transferFrom(wrapNonSpanning(recordBytes(recordLen), recordLen), recordLen); // overwrite with new data
+
+		canNotEecutableFile.setExecutable(true);
 
 		assertArrayEquals(concat(record1, record2), toByteArray(unconsumedSegment));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapperTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningWrapperTest.java
@@ -56,7 +56,7 @@ public class SpanningWrapperTest {
 		File canNotEecutableFile = folder.newFolder();
 		canNotEecutableFile.setExecutable(false);
 		// Always pick 'canNotEecutableFile' first as the Spilling Channel TmpDir. Thus trigger an IOException.
-		SpanningWrapper spanningWrapper = new SpanningWrapper(new String[]{folder.newFolder().getAbsolutePath(),canNotEecutableFile.getAbsolutePath() + File.separator + "pathdonotexit"}, spillingThreshold, recordLen);
+		SpanningWrapper spanningWrapper = new SpanningWrapper(new String[]{folder.newFolder().getAbsolutePath(), canNotEecutableFile.getAbsolutePath() + File.separator + "pathdonotexit"}, spillingThreshold, recordLen);
 		spanningWrapper.transferFrom(wrapNonSpanning(record1, firstChunk), recordLen);
 		spanningWrapper.addNextChunkFromMemorySegment(wrap(record1), firstChunk, recordLen - firstChunk + LENGTH_BYTES);
 		spanningWrapper.addNextChunkFromMemorySegment(wrap(record2), 0, record2.length);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Pick another disk(tmpDir) for Spilling Channel, rather than throw an IOException, which causes flink job restart over and over again.


## Brief change log


## Verifying this change

This change is already covered by existing tests, such as *SpanningWrapperTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
