### PR TITLE
[FLINK-19689] Fix TaskExecutorProcessSpecContainerResourcePriorityAdapterTest.

### DIFF
--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -224,6 +224,11 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
+						<configuration>
+							<excludes>
+								<exclude>resource-types.xml</exclude>
+							</excludes>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/ResourceInformationReflectorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/ResourceInformationReflectorTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -93,7 +94,7 @@ public class ResourceInformationReflectorTest extends TestLogger {
 
 		// make sure that Resource has at least two associated resources (cpu and memory)
 		final Map<String, Long> resourcesResult = ResourceInformationReflector.INSTANCE.getAllResourceInfos(resource);
-		assertThat(resourcesResult.size(), is(2));
+		assertThat(resourcesResult.size(), greaterThanOrEqualTo(2));
 	}
 
 	@Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TaskExecutorProcessSpecContainerResourcePriorityAdapterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TaskExecutorProcessSpecContainerResourcePriorityAdapterTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -36,6 +35,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -122,9 +122,8 @@ public class TaskExecutorProcessSpecContainerResourcePriorityAdapterTest extends
 	}
 
 	@Test
-	@Ignore("Test disabled until we fix FLINK-19689.")
 	public void testExternalResource() {
-		assumeTrue(HadoopUtils.isMinHadoopVersion(2, 10));
+		assumeTrue(isExternalResourceSupported());
 
 		final long amount = 1;
 		final TaskExecutorProcessSpecContainerResourcePriorityAdapter adapter =
@@ -137,25 +136,22 @@ public class TaskExecutorProcessSpecContainerResourcePriorityAdapterTest extends
 	}
 
 	@Test(expected = IllegalStateException.class)
-	@Ignore("Test disabled until we fix FLINK-19689.")
 	public void testExternalResourceFailExceedMax() {
-		assumeTrue(HadoopUtils.isMinHadoopVersion(2, 10));
+		assumeTrue(isExternalResourceSupported());
 
 		getAdapterWithExternalResources(SUPPORTED_EXTERNAL_RESOURCE_NAME, SUPPORTED_EXTERNAL_RESOURCE_MAX + 1);
 	}
 
 	@Test(expected = IllegalStateException.class)
-	@Ignore("Test disabled until we fix FLINK-19689.")
 	public void testExternalResourceFailResourceTypeNotSupported() {
-		assumeTrue(HadoopUtils.isMinHadoopVersion(2, 10));
+		assumeTrue(isExternalResourceSupported());
 
 		getAdapterWithExternalResources("testing-unsupported-resource", 1);
 	}
 
 	@Test(expected = IllegalStateException.class)
-	@Ignore("Test disabled until we fix FLINK-19689.")
 	public void testExternalResourceFailHadoopVersionNotSupported() {
-		assumeTrue(!HadoopUtils.isMinHadoopVersion(2, 10));
+		assumeFalse(isExternalResourceSupported());
 
 		getAdapterWithExternalResources(SUPPORTED_EXTERNAL_RESOURCE_NAME, 100);
 	}
@@ -181,5 +177,10 @@ public class TaskExecutorProcessSpecContainerResourcePriorityAdapterTest extends
 
 	private static Priority getPriority(TaskExecutorProcessSpecContainerResourcePriorityAdapter adapter, TaskExecutorProcessSpec spec) {
 		return adapter.getPriorityAndResource(spec).get().getPriority();
+	}
+
+	private static boolean isExternalResourceSupported() {
+		return HadoopUtils.isMinHadoopVersion(2, 10) &&
+			ClassLoader.getSystemResource("resource-types.xml") != null;
 	}
 }

--- a/flink-yarn/src/test/resources/resource-types.xml
+++ b/flink-yarn/src/test/resources/resource-types.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+	<property>
+		<name>yarn.resource-types</name>
+		<value>testing-external-resource</value>
+	</property>
+</configuration>

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -68,6 +68,28 @@ stages:
           run_end_to_end: false
           container: flink-build-container
           jdk: jdk8
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_hadoop241
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          environment: PROFILE="-Dhadoop.version=2.4.1 -Pskip-hive-tests"
+          run_end_to_end: true
+          container: flink-build-container
+          jdk: jdk8
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_hadoop313
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          environment: PROFILE="-Dinclude_hadoop_aws -Dhadoop.version=3.1.3 -Phadoop3-tests"
+          run_end_to_end: true
+          container: flink-build-container
+          jdk: jdk8
   # Special stage for nightly builds:
   - stage: cron_build
     displayName: "Cron build"


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes and re-activate failure tests in `TaskExecutorProcessSpecContainerResourcePriorityAdapterTest`.

## Brief change log

- Add `resource-types.xml` to `src/test/resources`. This fix the failure tests.
- Exclude `resource-types.xml` when building the test jar, because IT cases in `flink-yarn-test` (which depends on this test jar) does not work with this `resource-types.xml`.
- Ignore the related tests if `resource-types.xml` is not loaded, in case the tests are executed directly for the test jar.
