### PR TITLE
[FLINK-19694][table] Support Upsert ChangelogMode for ScanTableSource

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -20,17 +20,21 @@ package org.apache.flink.table.planner.plan.rules.logical;
 
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
 import org.apache.flink.table.planner.plan.utils.RexNodeRewriter;
+import org.apache.flink.table.planner.plan.utils.ScanUtil;
 import org.apache.flink.table.planner.sources.DynamicSourceUtils;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.RowKind;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -40,6 +44,7 @@ import org.apache.calcite.rel.rules.ProjectRemoveRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -87,7 +92,22 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
 		final List<String> fieldNames = scan.getRowType().getFieldNames();
 		final int fieldCount = fieldNames.size();
 
-		final int[] usedFields = RexNodeExtractor.extractRefInputFields(project.getProjects());
+		final int[] refFields = RexNodeExtractor.extractRefInputFields(project.getProjects());
+		final int[] usedFields;
+
+		TableSourceTable oldTableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
+		if (isUpsertSource(oldTableSourceTable)) {
+			// primary key fields are needed for upsert source
+			List<String> keyFields = oldTableSourceTable.catalogTable().getSchema()
+				.getPrimaryKey().get().getColumns();
+			// we should get source fields from scan node instead of CatalogTable,
+			// because projection may have been pushed down
+			List<String> sourceFields = scan.getRowType().getFieldNames();
+			int[] primaryKey = ScanUtil.getPrimaryKeyIndices(sourceFields, keyFields);
+			usedFields = mergeFields(refFields, primaryKey);
+		} else {
+			usedFields = refFields;
+		}
 		// if no fields can be projected, we keep the original plan.
 		if (usedFields.length == fieldCount) {
 			return;
@@ -96,8 +116,6 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
 		final List<String> projectedFieldNames = IntStream.of(usedFields)
 			.mapToObj(fieldNames::get)
 			.collect(Collectors.toList());
-
-		TableSourceTable oldTableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
 
 		final TableSchema oldSchema = oldTableSourceTable.catalogTable().getSchema();
 		final DynamicTableSource oldSource = oldTableSourceTable.tableSource();
@@ -202,5 +220,31 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
 
 			((SupportsReadingMetadata) newSource).applyReadableMetadata(usedMetadataKeys, newProducedDataType);
 		}
+	}
+
+	/**
+	 * Returns true if the table is a upsert source when it is works in scan mode.
+	 */
+	private static boolean isUpsertSource(TableSourceTable table) {
+		TableSchema schema = table.catalogTable().getSchema();
+		if (!schema.getPrimaryKey().isPresent()) {
+			return false;
+		}
+		DynamicTableSource tableSource = table.tableSource();
+		if (tableSource instanceof ScanTableSource) {
+			ChangelogMode mode = ((ScanTableSource) tableSource).getChangelogMode();
+			return mode.contains(RowKind.UPDATE_AFTER) && !mode.contains(RowKind.UPDATE_BEFORE);
+		}
+		return false;
+	}
+
+	private static int[] mergeFields(int[] fields1, int[] fields2) {
+		List<Integer> results = Arrays.stream(fields1).boxed().collect(Collectors.toList());
+		Arrays.stream(fields2).forEach(idx -> {
+			if (!results.contains(idx)) {
+				results.add(idx);
+			}
+		});
+		return results.stream().mapToInt(Integer::intValue).toArray();
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
@@ -305,6 +305,14 @@ class FlinkRelMdColumnUniqueness private extends MetadataHandler[BuiltInMetadata
   }
 
   def areColumnsUnique(
+      rel: StreamExecChangelogNormalize,
+      mq: RelMetadataQuery,
+      columns: ImmutableBitSet,
+      ignoreNulls: Boolean): JBoolean = {
+    columns != null && ImmutableBitSet.of(rel.uniqueKeys: _*).equals(columns)
+  }
+
+  def areColumnsUnique(
       rel: Aggregate,
       mq: RelMetadataQuery,
       columns: ImmutableBitSet,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
@@ -164,8 +164,7 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
     }
 
     // if partitionBy a update field or partitionBy a field whose mono is null, just return null
-    if (rel.partitionKey.exists(e =>
-      inputMonotonicity == null || inputMonotonicity.fieldMonotonicities(e) != CONSTANT)) {
+    if (rel.partitionKey.exists(e => inputMonotonicity.fieldMonotonicities(e) != CONSTANT)) {
       return null
     }
 
@@ -209,12 +208,21 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
       rel: StreamExecDeduplicate,
       mq: RelMetadataQuery): RelModifiedMonotonicity = {
     if (allAppend(mq, rel.getInput)) {
-      val mono = new RelModifiedMonotonicity(Array.fill(rel.getRowType.getFieldCount)(MONOTONIC))
+      val mono = new RelModifiedMonotonicity(
+        Array.fill(rel.getRowType.getFieldCount)(NOT_MONOTONIC))
       rel.getUniqueKeys.foreach(e => mono.fieldMonotonicities(e) = CONSTANT)
       mono
     } else {
       null
     }
+  }
+
+  def getRelModifiedMonotonicity(
+      rel: StreamExecChangelogNormalize,
+      mq: RelMetadataQuery): RelModifiedMonotonicity = {
+    val mono = new RelModifiedMonotonicity(Array.fill(rel.getRowType.getFieldCount)(NOT_MONOTONIC))
+    rel.uniqueKeys.foreach(e => mono.fieldMonotonicities(e) = CONSTANT)
+    mono
   }
 
   def getRelModifiedMonotonicity(
@@ -336,8 +344,8 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
     val inputMonotonicity = fmq.getRelModifiedMonotonicity(input)
 
     // if group by an update field or group by a field mono is null, just return null
-    if (grouping.exists(e =>
-      inputMonotonicity == null || inputMonotonicity.fieldMonotonicities(e) != CONSTANT)) {
+    if (inputMonotonicity == null ||
+        grouping.exists(e => inputMonotonicity.fieldMonotonicities(e) != CONSTANT)) {
       return null
     }
 
@@ -357,8 +365,8 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
     val inputMonotonicity = fmq.getRelModifiedMonotonicity(input)
 
     // if group by a update field or group by a field mono is null, just return null
-    if (grouping.exists(e =>
-      inputMonotonicity == null || inputMonotonicity.fieldMonotonicities(e) != CONSTANT)) {
+    if (inputMonotonicity == null ||
+        grouping.exists(e => inputMonotonicity.fieldMonotonicities(e) != CONSTANT)) {
       return null
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -315,6 +315,13 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
   }
 
   def getUniqueKeys(
+      rel: StreamExecChangelogNormalize,
+      mq: RelMetadataQuery,
+      ignoreNulls: Boolean): JSet[ImmutableBitSet] = {
+    ImmutableSet.of(ImmutableBitSet.of(rel.uniqueKeys.map(Integer.valueOf).toList))
+  }
+
+  def getUniqueKeys(
       rel: Aggregate,
       mq: RelMetadataQuery,
       ignoreNulls: Boolean): JSet[ImmutableBitSet] = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecChangelogNormalize.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecChangelogNormalize.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator
+import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
+import org.apache.flink.table.planner.plan.utils.{AggregateUtil, ChangelogPlanUtils, KeySelectorUtil}
+import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator
+import org.apache.flink.table.runtime.operators.deduplicate.{DeduplicateKeepLastRowFunction, MiniBatchDeduplicateKeepLastRowFunction}
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+ * Stream physical RelNode which normalizes a changelog stream which maybe an upsert stream or
+ * a changelog stream containing duplicate events. This node normalize such stream into a regular
+ * changelog stream that contains INSERT/UPDATE_BEFORE/UPDATE_AFTER/DELETE records without
+ * duplication.
+ */
+class StreamExecChangelogNormalize(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    val uniqueKeys: Array[Int])
+  extends SingleRel(cluster, traitSet, input)
+  with StreamPhysicalRel
+  with StreamExecNode[RowData] {
+
+  override def requireWatermark: Boolean = false
+
+  override def deriveRowType(): RelDataType = getInput.getRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecChangelogNormalize(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      uniqueKeys)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val fieldNames = getRowType.getFieldNames
+    super.explainTerms(pw)
+      .item("key", uniqueKeys.map(fieldNames.get).mkString(", "))
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
+    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  }
+
+  override def replaceInputNode(
+    ordinalInParent: Int,
+    newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
+  }
+
+  override protected def translateToPlanInternal(
+      planner: StreamPlanner): Transformation[RowData] = {
+
+    val inputTransform = getInputNodes.get(0).translateToPlan(planner)
+      .asInstanceOf[Transformation[RowData]]
+
+    val rowTypeInfo = inputTransform.getOutputType.asInstanceOf[InternalTypeInfo[RowData]]
+    val generateUpdateBefore = ChangelogPlanUtils.generateUpdateBefore(this)
+    val tableConfig = planner.getTableConfig
+    val isMiniBatchEnabled = tableConfig.getConfiguration.getBoolean(
+      ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)
+    val operator = if (isMiniBatchEnabled) {
+      val exeConfig = planner.getExecEnv.getConfig
+      val rowSerializer = rowTypeInfo.createSerializer(exeConfig)
+      val processFunction = new MiniBatchDeduplicateKeepLastRowFunction(
+        rowTypeInfo,
+        generateUpdateBefore,
+        true,   // generateInsert
+        false,  // inputInsertOnly
+        rowSerializer,
+        // disable state ttl, the changelog normalize should keep all state to have data integrity
+        // we can enable state ttl if this is really needed in some cases
+        -1)
+      val trigger = AggregateUtil.createMiniBatchTrigger(tableConfig)
+      new KeyedMapBundleOperator(
+        processFunction,
+        trigger)
+    } else {
+      val processFunction = new DeduplicateKeepLastRowFunction(
+        -1,     // disable state ttl
+        rowTypeInfo,
+        generateUpdateBefore,
+        true,   // generateInsert
+        false)  // inputInsertOnly
+      new KeyedProcessOperator[RowData, RowData, RowData](processFunction)
+    }
+
+    val ret = new OneInputTransformation(
+      inputTransform,
+      getRelDetailedDescription,
+      operator,
+      rowTypeInfo,
+      inputTransform.getParallelism)
+
+    if (inputsContainSingleton()) {
+      ret.setParallelism(1)
+      ret.setMaxParallelism(1)
+    }
+
+    val selector = KeySelectorUtil.getRowDataSelector(uniqueKeys, rowTypeInfo)
+    ret.setStateKeySelector(selector)
+    ret.setStateKeyType(selector.getProducedType)
+    ret
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDeduplicate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDeduplicate.scala
@@ -117,6 +117,7 @@ class StreamExecDeduplicate(
           rowTypeInfo,
           generateUpdateBefore,
           generateInsert,
+          true,
           rowSerializer,
           minRetentionTime)
       } else {
@@ -134,7 +135,8 @@ class StreamExecDeduplicate(
           minRetentionTime,
           rowTypeInfo,
           generateUpdateBefore,
-          generateInsert)
+          generateInsert,
+          true)
       } else {
         new DeduplicateKeepFirstRowFunction(minRetentionTime)
       }
@@ -163,12 +165,14 @@ object StreamExecDeduplicate {
 
   @Experimental
   val TABLE_EXEC_INSERT_AND_UPDATE_AFTER_SENSITIVE: ConfigOption[JBoolean] =
-  key("table.exec.insert-and-updateafter-sensitive")
-    .defaultValue(JBoolean.valueOf(true))
-    .withDescription("Set whether the job (especially the sinks) is sensitive to " +
-      "INSERT messages and UPDATE_AFTER messages. " +
-      "If false, Flink may send UPDATE_AFTER instead of INSERT for the first row " +
-      "at some times (e.g. deduplication for last row). " +
-      "If true, Flink will guarantee to send INSERT for the first row. " +
-      "Default is true.")
+    key("table.exec.insert-and-updateafter-sensitive")
+      .booleanType()
+      .defaultValue(JBoolean.valueOf(true))
+      .withDescription("Set whether the job (especially the sinks) is sensitive to " +
+        "INSERT messages and UPDATE_AFTER messages. " +
+        "If false, Flink may send UPDATE_AFTER instead of INSERT for the first row " +
+        "at some times (e.g. deduplication for last row). " +
+        "If true, Flink will guarantee to send INSERT for the first row, " +
+        "but there will be additional overhead." +
+        "Default is true.")
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecTableSourceScanRule.scala
@@ -18,19 +18,25 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.connector.source.ScanTableSource
+import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecTableSourceScan
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamExecChangelogNormalize, StreamExecTableSourceScan}
 import org.apache.flink.table.planner.plan.schema.TableSourceTable
-
-import org.apache.calcite.plan.{RelOptRuleCall, RelTraitSet}
+import org.apache.flink.types.RowKind
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.core.TableScan
+import org.apache.flink.table.planner.plan.utils.ScanUtil
 
 /**
   * Rule that converts [[FlinkLogicalTableSourceScan]] to [[StreamExecTableSourceScan]].
+ *
+ * <p>Depends whether this is a scan source, this rule will also generate
+ * [[StreamExecChangelogNormalize]] to materialize the upsert stream.
   */
 class StreamExecTableSourceScanRule
   extends ConverterRule(
@@ -56,12 +62,40 @@ class StreamExecTableSourceScanRule
   def convert(rel: RelNode): RelNode = {
     val scan = rel.asInstanceOf[FlinkLogicalTableSourceScan]
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-
-    new StreamExecTableSourceScan(
+    val newScan = new StreamExecTableSourceScan(
       rel.getCluster,
       traitSet,
-      scan.getTable.asInstanceOf[TableSourceTable]
-    )
+      scan.getTable.asInstanceOf[TableSourceTable])
+
+    val table = scan.getTable.asInstanceOf[TableSourceTable]
+    val tableSource = table.tableSource.asInstanceOf[ScanTableSource]
+    val changelogMode = tableSource.getChangelogMode
+    if (changelogMode.contains(RowKind.UPDATE_AFTER) &&
+        !changelogMode.contains(RowKind.UPDATE_BEFORE)) {
+      // generate changelog normalize node for upsert source
+      val primaryKey = table.catalogTable.getSchema.getPrimaryKey
+      if (!primaryKey.isPresent) {
+        throw new TableException(s"Table '${table.tableIdentifier.asSummaryString()}' produces" +
+          " a changelog stream contains UPDATE_AFTER but no UPDATE_BEFORE," +
+          " this requires to define primary key on the table.")
+      }
+      val keyFields = primaryKey.get().getColumns
+      val inputFieldNames = newScan.getRowType.getFieldNames
+      val primaryKeyIndices = ScanUtil.getPrimaryKeyIndices(inputFieldNames, keyFields)
+      val requiredDistribution = FlinkRelDistribution.hash(primaryKeyIndices, requireStrict = true)
+      val requiredTraitSet = rel.getCluster.getPlanner.emptyTraitSet()
+        .replace(requiredDistribution)
+        .replace(FlinkConventions.STREAM_PHYSICAL)
+      val newInput: RelNode = RelOptRule.convert(newScan, requiredTraitSet)
+
+      new StreamExecChangelogNormalize(
+        scan.getCluster,
+        traitSet,
+        newInput,
+        primaryKeyIndices)
+    } else {
+      newScan
+    }
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.api.dag.Transformation
-import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.data.{RowData, GenericRowData}
+import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.table.data.{GenericRowData, RowData}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{DEFAULT_INPUT1_TERM, GENERIC_ROW}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.generateCollect
@@ -33,10 +33,11 @@ import org.apache.flink.table.sources.TableSource
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
-
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
 import org.apache.calcite.rex.RexNode
+
+import java.util
 
 import scala.collection.JavaConversions._
 
@@ -134,5 +135,25 @@ object ScanUtil {
     val tableQualifiedName = qualifiedName.mkString(".")
     val fieldNames = rowType.getFieldNames.mkString(", ")
     s"SourceConversion(table=[$tableQualifiedName], fields=[$fieldNames])"
+  }
+
+  /**
+   * Returns the field indices of primary key in given fields.
+   */
+  def getPrimaryKeyIndices(
+      fieldNames: util.List[String],
+      keyFields: util.List[String]): Array[Int] = {
+    // we must use the output field names of scan node instead of the original schema
+    // to calculate the primary key indices, because the scan node maybe projection pushed down
+    keyFields.map { k =>
+      val index = fieldNames.indexOf(k)
+      if (index < 0) {
+        // primary key shouldn't be pruned, otherwise it's a bug
+        throw new TableException(
+          s"Can't find primary key field $k in the input fields $fieldNames. " +
+            s"This is a bug, please file an issue.")
+      }
+      index
+    }.toArray
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -37,6 +37,49 @@ GroupAggregate(select=[COUNT_RETRACT(*) AS EXPR$0], changelogMode=[I,UA,D])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAggregateOnUpsertSource">
+    <Resource name="sql">
+      <![CDATA[SELECT b, COUNT(*), MAX(ts), MIN(ts) FROM src GROUP BY b]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[MAX($1)], EXPR$3=[MIN($1)])
++- LogicalProject(b=[$2], ts=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(*) AS EXPR$1, MAX_RETRACT(ts) AS EXPR$2, MIN_RETRACT(ts) AS EXPR$3], changelogMode=[I,UA,D])
++- Exchange(distribution=[hash[b]], changelogMode=[I,UB,UA,D])
+   +- Calc(select=[b, ts], changelogMode=[I,UB,UA,D])
+      +- ChangelogNormalize(key=[a], changelogMode=[I,UB,UA,D])
+         +- Exchange(distribution=[hash[a]], changelogMode=[UA,D])
+            +- TableSourceScan(table=[[default_catalog, default_database, src, project=[b, ts, a]]], fields=[b, ts, a], changelogMode=[UA,D])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateOnUpsertSourcePrimaryKey">
+    <Resource name="sql">
+      <![CDATA[SELECT a, COUNT(*), MAX(ts), MIN(ts) FROM src GROUP BY a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[MAX($1)], EXPR$3=[MIN($1)])
++- LogicalProject(a=[$1], ts=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+GroupAggregate(groupBy=[a], select=[a, COUNT_RETRACT(*) AS EXPR$1, MAX_RETRACT(ts) AS EXPR$2, MIN_RETRACT(ts) AS EXPR$3], changelogMode=[I,UA,D])
++- Exchange(distribution=[hash[a]], changelogMode=[I,UB,UA,D])
+   +- ChangelogNormalize(key=[a], changelogMode=[I,UB,UA,D])
+      +- Exchange(distribution=[hash[a]], changelogMode=[UA,D])
+         +- TableSourceScan(table=[[default_catalog, default_database, src, project=[a, ts]]], fields=[a, ts], changelogMode=[UA,D])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDataStreamScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM DataStreamTable]]>
@@ -90,6 +133,39 @@ Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTemporalJoinOnUpsertSource">
+    <Resource name="sql">
+      <![CDATA[
+SELECT o.currency, o.amount, r.rate, o.amount * r.rate
+FROM orders AS o LEFT JOIN rates_history FOR SYSTEM_TIME AS OF o.proctime AS r
+ON o.currency = r.currency
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(currency=[$1], amount=[$0], rate=[$4], EXPR$3=[*($0, $4)])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1, 2}])
+   :- LogicalProject(amount=[$0], currency=[$1], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, orders]])
+   +- LogicalFilter(condition=[=($cor0.currency, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, rates_history]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[currency, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[I])
++- TemporalJoin(joinType=[LeftOuterJoin], where=[AND(=(currency, currency0), __TEMPORAL_JOIN_CONDITION(proctime, __TEMPORAL_JOIN_LEFT_KEY(currency), __TEMPORAL_JOIN_RIGHT_KEY(currency0)))], select=[amount, currency, proctime, currency0, rate], changelogMode=[I])
+   :- Exchange(distribution=[hash[currency]], changelogMode=[I])
+   :  +- Calc(select=[amount, currency, PROCTIME() AS proctime], changelogMode=[I])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, orders]], fields=[amount, currency], changelogMode=[I])
+   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UB,UA,D])
+      +- ChangelogNormalize(key=[currency], changelogMode=[I,UB,UA,D])
+         +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
+            +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate], changelogMode=[UA,D])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDDLWithComputedColumnReferRowtime">
     <Resource name="sql">
       <![CDATA[SELECT * FROM src WHERE a > 1]]>
@@ -126,41 +202,6 @@ LogicalProject(a=[$0], other_metadata=[CAST($4):INTEGER], b=[$1], c=[$2], metada
       <![CDATA[
 Calc(select=[a, CAST(metadata_3) AS other_metadata, b, c, metadata_1])
 +- TableSourceScan(table=[[default_catalog, default_database, MetadataTable]], fields=[a, b, c, metadata_1, metadata_3])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testUnionChangelogSourceAndAggregation">
-    <Resource name="sql">
-      <![CDATA[
-SELECT b, ts, a
-FROM (
-  SELECT * FROM changelog_src
-  UNION ALL
-  SELECT MAX(ts) as t, a, MAX(b) as b FROM append_src GROUP BY a
-)
-]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(b=[$2], ts=[$0], a=[$1])
-+- LogicalUnion(all=[true])
-   :- LogicalProject(ts=[$0], a=[$1], b=[$2])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, changelog_src]])
-   +- LogicalProject(t=[$1], a=[$0], b=[$2])
-      +- LogicalAggregate(group=[{0}], t=[MAX($1)], b=[MAX($2)])
-         +- LogicalProject(a=[$1], ts=[$0], b=[$2])
-            +- LogicalTableScan(table=[[default_catalog, default_database, append_src]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Union(all=[true], union=[b, ts, a], changelogMode=[I,UB,UA,D])
-:- Calc(select=[b, ts, a], changelogMode=[I,UB,UA,D])
-:  +- TableSourceScan(table=[[default_catalog, default_database, changelog_src]], fields=[ts, a, b], changelogMode=[I,UB,UA,D])
-+- Calc(select=[b, t AS ts, a], changelogMode=[I,UB,UA])
-   +- GroupAggregate(groupBy=[a], select=[a, MAX(ts) AS t, MAX(b) AS b], changelogMode=[I,UB,UA])
-      +- Exchange(distribution=[hash[a]], changelogMode=[I])
-         +- TableSourceScan(table=[[default_catalog, default_database, append_src]], fields=[ts, a, b], changelogMode=[I])
 ]]>
     </Resource>
   </TestCase>
@@ -246,6 +287,55 @@ Calc(select=[currency, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinOnUpsertSource">
+    <Resource name="sql">
+      <![CDATA[
+SELECT o.currency, o.amount, r.rate, o.amount * r.rate
+FROM orders AS o JOIN rates_history AS r
+ON o.currency = r.currency
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(currency=[$1], amount=[$0], rate=[$3], EXPR$3=[*($0, $3)])
++- LogicalJoin(condition=[=($1, $2)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, orders]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, rates_history]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[currency, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[I,UA,D])
++- Join(joinType=[InnerJoin], where=[=(currency, currency0)], select=[amount, currency, currency0, rate], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], changelogMode=[I,UA,D])
+   :- Exchange(distribution=[hash[currency]], changelogMode=[I])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, orders]], fields=[amount, currency], changelogMode=[I])
+   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
+      +- ChangelogNormalize(key=[currency], changelogMode=[I,UA,D])
+         +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
+            +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate], changelogMode=[UA,D])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testKeywordsWithWatermarkComputedColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM t1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], time=[$2], mytime=[$3], current_time=[$4], json_row=[$5], timestamp=[$6])
++- LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[$6])
+   +- LogicalProject(a=[$0], b=[$1], time=[$2], mytime=[$2], current_time=[CURRENT_TIME], json_row=[$3], timestamp=[$3.timestamp])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+WatermarkAssigner(rowtime=[timestamp], watermark=[timestamp])
++- Calc(select=[a, b, time, time AS mytime, CURRENT_TIME() AS current_time, json_row, json_row.timestamp AS timestamp])
+   +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b, time, json_row])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testLegacyTableSourceScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable]]>
@@ -297,23 +387,118 @@ Calc(select=[b, a, ts], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testKeywordsWithWatermarkComputedColumn">
+  <TestCase name="testScanOnUpsertSource">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM t1]]>
+      <![CDATA[SELECT id1, a, b FROM src]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], time=[$2], mytime=[$3], current_time=[$4], json_row=[$5], timestamp=[$6])
-+- LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[$6])
-   +- LogicalProject(a=[$0], b=[$1], time=[$2], mytime=[$2], current_time=[CURRENT_TIME], json_row=[$3], timestamp=[$3.timestamp])
-      +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+LogicalProject(id1=[$1], a=[$2], b=[$4])
++- LogicalTableScan(table=[[default_catalog, default_database, src]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-WatermarkAssigner(rowtime=[timestamp], watermark=[timestamp])
-+- Calc(select=[a, b, time, time AS mytime, CURRENT_TIME() AS current_time, json_row, json_row.timestamp AS timestamp])
-   +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b, time, json_row])
+Calc(select=[id1, a, b], changelogMode=[I,UA,D])
++- ChangelogNormalize(key=[id2, id1], changelogMode=[I,UA,D])
+   +- Exchange(distribution=[hash[id2, id1]], changelogMode=[UA])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id1, a, b, id2]]], fields=[id1, a, b, id2], changelogMode=[UA])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionUpsertSourceAndAggregation">
+    <Resource name="sql">
+      <![CDATA[
+SELECT b, ts, a
+FROM (
+  SELECT * FROM upsert_src
+  UNION ALL
+  SELECT MAX(ts) as t, a, MAX(b) as b FROM append_src GROUP BY a
+)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$2], ts=[$0], a=[$1])
++- LogicalUnion(all=[true])
+   :- LogicalProject(ts=[$0], a=[$1], b=[$2])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, upsert_src]])
+   +- LogicalProject(t=[$1], a=[$0], b=[$2])
+      +- LogicalAggregate(group=[{0}], t=[MAX($1)], b=[MAX($2)])
+         +- LogicalProject(a=[$1], ts=[$0], b=[$2])
+            +- LogicalTableScan(table=[[default_catalog, default_database, append_src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[b, ts, a], changelogMode=[I,UA,D])
+:- Calc(select=[b, ts, CAST(a) AS a], changelogMode=[I,UA,D])
+:  +- ChangelogNormalize(key=[a], changelogMode=[I,UA,D])
+:     +- Exchange(distribution=[hash[a]], changelogMode=[UA,D])
+:        +- TableSourceScan(table=[[default_catalog, default_database, upsert_src]], fields=[ts, a, b], changelogMode=[UA,D])
++- Calc(select=[b, t AS ts, a], changelogMode=[I,UA])
+   +- GroupAggregate(groupBy=[a], select=[a, MAX(ts) AS t, MAX(b) AS b], changelogMode=[I,UA])
+      +- Exchange(distribution=[hash[a]], changelogMode=[I])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src]], fields=[ts, a, b], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionChangelogSourceAndAggregation">
+    <Resource name="sql">
+      <![CDATA[
+SELECT b, ts, a
+FROM (
+  SELECT * FROM changelog_src
+  UNION ALL
+  SELECT MAX(ts) as t, a, MAX(b) as b FROM append_src GROUP BY a
+)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(b=[$2], ts=[$0], a=[$1])
++- LogicalUnion(all=[true])
+   :- LogicalProject(ts=[$0], a=[$1], b=[$2])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, changelog_src]])
+   +- LogicalProject(t=[$1], a=[$0], b=[$2])
+      +- LogicalAggregate(group=[{0}], t=[MAX($1)], b=[MAX($2)])
+         +- LogicalProject(a=[$1], ts=[$0], b=[$2])
+            +- LogicalTableScan(table=[[default_catalog, default_database, append_src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[b, ts, a], changelogMode=[I,UB,UA,D])
+:- Calc(select=[b, ts, a], changelogMode=[I,UB,UA,D])
+:  +- TableSourceScan(table=[[default_catalog, default_database, changelog_src]], fields=[ts, a, b], changelogMode=[I,UB,UA,D])
++- Calc(select=[b, t AS ts, a], changelogMode=[I,UB,UA])
+   +- GroupAggregate(groupBy=[a], select=[a, MAX(ts) AS t, MAX(b) AS b], changelogMode=[I,UB,UA])
+      +- Exchange(distribution=[hash[a]], changelogMode=[I])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src]], fields=[ts, a, b], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpsertSourceWithComputedColumnAndWatermark">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c FROM src WHERE a > 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$1], b=[$2], c=[$3])
++- LogicalFilter(condition=[>($1, 1)])
+   +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($4, 1000:INTERVAL SECOND)])
+      +- LogicalProject(id=[$0], a=[$1], b=[+($1, 1)], c=[$2], ts=[TO_TIMESTAMP($2)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[>(a, 1)], changelogMode=[I,UB,UA,D])
++- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 1000:INTERVAL SECOND)], changelogMode=[I,UB,UA,D])
+   +- Calc(select=[id, a, +(a, 1) AS b, c, TO_TIMESTAMP(c) AS ts], changelogMode=[I,UB,UA,D])
+      +- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
+         +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
+            +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[id, a, c], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/SemiAntiJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/SemiAntiJoinTest.xml
@@ -307,7 +307,7 @@ Join(joinType=[LeftSemiJoin], where=[$f0], select=[a, b, c], leftInputSpec=[NoUn
 :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, l, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 +- Exchange(distribution=[single])
    +- Calc(select=[IS NOT NULL(m) AS $f0])
-      +- GroupAggregate(select=[MIN(i) AS m])
+      +- GroupAggregate(select=[MIN_RETRACT(i) AS m])
          +- Exchange(distribution=[single])
             +- Calc(select=[true AS i])
                +- Join(joinType=[LeftSemiJoin], where=[$f0], select=[d], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
@@ -131,6 +131,29 @@ class TableScanTest extends TableTestBase {
   }
 
   @Test
+  def testScanOnUpsertSource(): Unit = {
+    util.addTable(
+      """
+        |CREATE TABLE src (
+        |  id STRING,
+        |  a INT,
+        |  b DOUBLE,
+        |  PRIMARY KEY (id) NOT ENFORCED
+        |) WITH (
+        |  'connector' = 'values',
+        |  'bounded' = 'true',
+        |  'changelog-mode' = 'UA,D'
+        |)
+      """.stripMargin)
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage(
+      "Querying a table in batch mode is currently only possible for INSERT-only table sources. " +
+      "But the source for table 'default_catalog.default_database.src' produces other changelog " +
+      "messages than just INSERT.")
+    util.verifyPlan("SELECT * FROM src WHERE a > 1")
+  }
+
+  @Test
   def testDDLWithComputedColumn(): Unit = {
     util.verifyPlan("SELECT * FROM computed_column_t")
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -276,6 +276,15 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testAreColumnsUniqueCountOnStreamExecChangelogNormalize(): Unit = {
+    assertTrue(mq.areColumnsUnique(streamChangelogNormalize, ImmutableBitSet.of(0, 1)))
+    assertTrue(mq.areColumnsUnique(streamChangelogNormalize, ImmutableBitSet.of(1, 0)))
+    assertFalse(mq.areColumnsUnique(streamChangelogNormalize, ImmutableBitSet.of(1)))
+    assertFalse(mq.areColumnsUnique(streamChangelogNormalize, ImmutableBitSet.of(2)))
+    assertFalse(mq.areColumnsUnique(streamChangelogNormalize, ImmutableBitSet.of(1, 2)))
+  }
+
+  @Test
   def testAreColumnsUniqueOnAggregate(): Unit = {
     Array(logicalAgg, flinkLogicalAgg).foreach { agg =>
       assertTrue(mq.areColumnsUnique(agg, ImmutableBitSet.of(0)))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -691,6 +691,18 @@ class FlinkRelMdHandlerTestBase {
     (calcOfFirstRow, calcOfLastRow)
   }
 
+  protected lazy val streamChangelogNormalize = {
+    val key = Array(1, 0)
+    val hash1 = FlinkRelDistribution.hash(key, requireStrict = true)
+    val streamExchange = new StreamExecExchange(
+      cluster, studentStreamScan.getTraitSet.replace(hash1), studentStreamScan, hash1)
+    new StreamExecChangelogNormalize(
+      cluster,
+      streamPhysicalTraits,
+      streamExchange,
+      key)
+  }
+
   // equivalent SQL is
   // select a, b, c from (
   //  select a, b, c, rowtime
@@ -703,7 +715,7 @@ class FlinkRelMdHandlerTestBase {
       cluster,
       flinkLogicalTraits,
       temporalLogicalScan,
-      ImmutableBitSet.of(5),
+      ImmutableBitSet.of(1),
       RelCollations.of(4),
       RankType.ROW_NUMBER,
       new ConstantRankRange(1, 1),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
@@ -315,5 +315,30 @@ class FlinkRelMdModifiedMonotonicityTest extends FlinkRelMdHandlerTestBase {
     assertNull(mq.getRelModifiedMonotonicity(logicalAntiJoinOnUniqueKeys))
   }
 
+  @Test
+  def testGetRelMonotonicityOnDeduplicate(): Unit = {
+    assertEquals(
+      new RelModifiedMonotonicity(Array(NOT_MONOTONIC, CONSTANT, NOT_MONOTONIC)),
+      mq.getRelModifiedMonotonicity(streamDeduplicateFirstRow))
+
+    assertEquals(
+      new RelModifiedMonotonicity(Array(NOT_MONOTONIC, CONSTANT, CONSTANT)),
+      mq.getRelModifiedMonotonicity(streamDeduplicateLastRow))
+
+    assertEquals(
+      new RelModifiedMonotonicity(Array(
+        NOT_MONOTONIC, CONSTANT, NOT_MONOTONIC, NOT_MONOTONIC, NOT_MONOTONIC)),
+      mq.getRelModifiedMonotonicity(rowtimeDeduplicate))
+  }
+
+  @Test
+  def testGetRelMonotonicityOnChangelogNormalize(): Unit = {
+    assertEquals(
+      new RelModifiedMonotonicity(Array(
+        CONSTANT, CONSTANT, NOT_MONOTONIC, NOT_MONOTONIC,
+        NOT_MONOTONIC, NOT_MONOTONIC, NOT_MONOTONIC)),
+      mq.getRelModifiedMonotonicity(streamChangelogNormalize))
+  }
+
 }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -155,7 +155,12 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   def testGetUniqueKeysOnStreamExecDeduplicate(): Unit = {
     assertEquals(uniqueKeys(Array(1)), mq.getUniqueKeys(streamDeduplicateFirstRow).toSet)
     assertEquals(uniqueKeys(Array(1, 2)), mq.getUniqueKeys(streamDeduplicateLastRow).toSet)
-    assertEquals(uniqueKeys(Array(5)), mq.getUniqueKeys(rowtimeDeduplicate).toSet)
+    assertEquals(uniqueKeys(Array(1)), mq.getUniqueKeys(rowtimeDeduplicate).toSet)
+  }
+
+  @Test
+  def testGetUniqueKeysOnStreamExecChangelogNormalize(): Unit = {
+    assertEquals(uniqueKeys(Array(1, 0)), mq.getUniqueKeys(streamChangelogNormalize).toSet)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
@@ -20,46 +20,60 @@ package org.apache.flink.table.planner.runtime.stream.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
-import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestData, TestingRetractSink}
+import org.apache.flink.table.planner.runtime.utils.{StreamingWithMiniBatchTestBase, TestData, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.planner.runtime.stream.sql.ChangelogSourceITCase.SourceMode
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND}
+import org.apache.flink.table.planner.runtime.stream.sql.ChangelogSourceITCase.{CHANGELOG_SOURCE, NO_UPDATE_SOURCE, UPSERT_SOURCE}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.{MiniBatchOff, MiniBatchOn}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.MiniBatchMode
 import org.apache.flink.types.{Row, RowKind}
 import org.junit.Assert.assertEquals
 import org.junit.{Before, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+import java.util
+
 import scala.collection.JavaConversions._
 import scala.collection.Seq
 
+/**
+ * Integration tests for operations on changelog source, including upsert source.
+ */
 @RunWith(classOf[Parameterized])
-class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateTestBase(state) {
-
-  val dataId: String = TestValuesTableFactory.registerData(TestData.userChangelog)
+class ChangelogSourceITCase(
+    sourceMode: SourceMode,
+    miniBatch: MiniBatchMode,
+    state: StateBackendMode)
+  extends StreamingWithMiniBatchTestBase(miniBatch, state) {
 
   @Before
   override def before(): Unit = {
     super.before()
-    val ddl =
+    val orderDataId = TestValuesTableFactory.registerData(TestData.ordersData)
+    tEnv.executeSql(
       s"""
-         |CREATE TABLE user_logs (
-         |  user_id STRING,
-         |  user_name STRING,
-         |  email STRING,
-         |  balance DECIMAL(18,2),
-         |  balance2 AS balance * 2
+         |CREATE TABLE orders (
+         |  amount BIGINT,
+         |  currency STRING
          |) WITH (
          | 'connector' = 'values',
-         | 'data-id' = '$dataId',
-         | 'changelog-mode' = 'I,UA,UB,D'
+         | 'data-id' = '$orderDataId',
+         | 'changelog-mode' = 'I'
          |)
-         |""".stripMargin
-    tEnv.executeSql(ddl)
+         |""".stripMargin)
+    sourceMode match {
+      case CHANGELOG_SOURCE => registerChangelogSource()
+      case UPSERT_SOURCE => registerUpsertSource()
+      case NO_UPDATE_SOURCE => registerNoUpdateSource()
+    }
   }
 
   @Test
-  def testChangelogSourceAndToRetractStream(): Unit = {
-    val result = tEnv.sqlQuery("SELECT * FROM user_logs").toRetractStream[Row]
+  def testToRetractStream(): Unit = {
+    val result = tEnv.sqlQuery(s"SELECT * FROM ${sourceMode.usersTable}").toRetractStream[Row]
     val sink = new TestingRetractSink()
     result.addSink(sink).setParallelism(result.parallelism)
     env.execute()
@@ -72,7 +86,7 @@ class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateT
   }
 
   @Test
-  def testChangelogSourceAndUpsertSink(): Unit = {
+  def testToUpsertSink(): Unit = {
     val sinkDDL =
       s"""
          |CREATE TABLE user_sink (
@@ -89,7 +103,7 @@ class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateT
     val dml =
       s"""
          |INSERT INTO user_sink
-         |SELECT * FROM user_logs
+         |SELECT * FROM ${sourceMode.usersTable}
          |""".stripMargin
     tEnv.executeSql(sinkDDL)
     tEnv.executeSql(dml).await()
@@ -102,11 +116,11 @@ class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateT
   }
 
   @Test
-  def testAggregateOnChangelogSource(): Unit = {
+  def testAggregate(): Unit = {
     val query =
       s"""
          |SELECT count(*), sum(balance), max(email)
-         |FROM user_logs
+         |FROM ${sourceMode.usersTable}
          |""".stripMargin
 
     val result = tEnv.sqlQuery(query).toRetractStream[Row]
@@ -119,7 +133,7 @@ class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateT
   }
 
   @Test
-  def testAggregateOnChangelogSourceAndUpsertSink(): Unit = {
+  def testAggregateToUpsertSink(): Unit = {
     val sinkDDL =
       s"""
          |CREATE TABLE user_sink (
@@ -137,7 +151,7 @@ class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateT
       s"""
          |INSERT INTO user_sink
          |SELECT 'ALL', count(*), sum(balance), max(email)
-         |FROM user_logs
+         |FROM ${sourceMode.usersTable}
          |GROUP BY 'ALL'
          |""".stripMargin
     tEnv.executeSql(sinkDDL)
@@ -148,9 +162,193 @@ class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateT
   }
 
   @Test
-  def testAggregateOnInsertDeleteChangelogSource(): Unit = {
+  def testGroupByNonPrimaryKey(): Unit = {
+    val sinkDDL =
+      s"""
+         |CREATE TABLE user_sink (
+         |  balance DECIMAL(18,2),
+         |  cnt BIGINT,
+         |  max_email STRING,
+         |  PRIMARY KEY (balance) NOT ENFORCED
+         |) WITH (
+         | 'connector' = 'values',
+         | 'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin
+    val dml =
+      s"""
+         |INSERT INTO user_sink
+         |SELECT balance2, count(*), max(email)
+         |FROM ${sourceMode.usersTable}
+         |GROUP BY balance2
+         |""".stripMargin
+    tEnv.executeSql(sinkDDL)
+    tEnv.executeSql(dml).await()
+
+    val expected = Seq(
+      "16.20,1,tom123@gmail.com",
+      "19.98,1,bailey@qq.com",
+      "22.60,1,tina@gmail.com")
+    assertEquals(expected.sorted, TestValuesTableFactory.getResults("user_sink").sorted)
+  }
+
+  @Test
+  def testFilter(): Unit = {
+    val sinkDDL =
+      s"""
+         |CREATE TABLE user_sink (
+         |  user_id STRING PRIMARY KEY NOT ENFORCED,
+         |  user_name STRING,
+         |  email STRING,
+         |  balance DECIMAL(18,2),
+         |  balance2 DECIMAL(18,2)
+         |) WITH (
+         | 'connector' = 'values',
+         | 'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin
+
+    // the sink is an upsert sink, but the update_before must be sent,
+    // otherwise "user1=8.10" can't be removed
+    val dml =
+      s"""
+         |INSERT INTO user_sink
+         |SELECT * FROM ${sourceMode.usersTable} WHERE balance > 9
+         |""".stripMargin
+    tEnv.executeSql(sinkDDL)
+    tEnv.executeSql(dml).await()
+
+    val expected = Seq(
+      "user3,Bailey,bailey@qq.com,9.99,19.98",
+      "user4,Tina,tina@gmail.com,11.30,22.60")
+    assertEquals(expected.sorted, TestValuesTableFactory.getResults("user_sink").sorted)
+  }
+
+  @Test
+  def testRegularJoin(): Unit = {
+    val sql =
+      s"""
+        |SELECT o.currency, o.amount, r.rate, o.amount * r.rate
+        |FROM orders AS o JOIN ${sourceMode.ratesTable} AS r
+        |ON o.currency = r.currency
+        |""".stripMargin
+
+    val sink = new TestingRetractSink
+    val result = tEnv.sqlQuery(sql).toRetractStream[Row]
+    result.addSink(sink).setParallelism(result.parallelism)
+    env.execute()
+
+    val expected = Seq(
+      "Euro,2,119,238", "Euro,3,119,357",
+      "US Dollar,1,102,102", "US Dollar,5,102,510")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  // ------------------------------------------------------------------------------------------
+
+  private def registerChangelogSource(): Unit = {
+    val userDataId: String = TestValuesTableFactory.registerData(TestData.userChangelog)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE ${CHANGELOG_SOURCE.usersTable} (
+         |  user_id STRING,
+         |  user_name STRING,
+         |  email STRING,
+         |  balance DECIMAL(18,2),
+         |  balance2 AS balance * 2
+         |) WITH (
+         | 'connector' = 'values',
+         | 'data-id' = '$userDataId',
+         | 'changelog-mode' = 'I,UA,UB,D',
+         | 'disable-lookup' = 'true'
+         |)
+         |""".stripMargin)
+    val ratesDataId = TestValuesTableFactory.registerData(TestData.ratesHistoryData)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE ${CHANGELOG_SOURCE.ratesTable} (
+         |  currency STRING,
+         |  rate BIGINT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$ratesDataId',
+         |  'changelog-mode' = 'I,UB,UA,D',
+         |  'disable-lookup' = 'true'
+         |)
+      """.stripMargin)
+  }
+
+  private def registerUpsertSource(): Unit = {
+    val userDataId = TestValuesTableFactory.registerData(TestData.userUpsertlog)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE ${UPSERT_SOURCE.usersTable} (
+         |  user_id STRING,
+         |  user_name STRING,
+         |  email STRING,
+         |  balance DECIMAL(18,2),
+         |  balance2 AS balance * 2,
+         |  PRIMARY KEY (user_name, user_id) NOT ENFORCED
+         |) WITH (
+         | 'connector' = 'values',
+         | 'data-id' = '$userDataId',
+         | 'changelog-mode' = 'UA,D',
+         | 'disable-lookup' = 'true'
+         |)
+         |""".stripMargin)
+    val ratesDataId = TestValuesTableFactory.registerData(TestData.ratesUpsertData)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE ${UPSERT_SOURCE.ratesTable} (
+         |  currency STRING,
+         |  rate BIGINT,
+         |  PRIMARY KEY (currency) NOT ENFORCED
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$ratesDataId',
+         |  'changelog-mode' = 'UA,D',
+         |  'disable-lookup' = 'true'
+         |)
+      """.stripMargin)
+  }
+
+  private def registerNoUpdateSource(): Unit = {
     // only contains INSERT and DELETE
-    val userChangelog = TestData.userChangelog.map { row =>
+    val userChangelog = convertToNoUpdateData(TestData.userChangelog)
+    val userDataId = TestValuesTableFactory.registerData(userChangelog)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE ${NO_UPDATE_SOURCE.usersTable} (
+         |  user_id STRING,
+         |  user_name STRING,
+         |  email STRING,
+         |  balance DECIMAL(18,2),
+         |  balance2 AS balance * 2
+         |) WITH (
+         | 'connector' = 'values',
+         | 'data-id' = '$userDataId',
+         | 'changelog-mode' = 'I,D',
+         | 'disable-lookup' = 'true'
+         |)
+         |""".stripMargin)
+    val ratesChangelog = convertToNoUpdateData(TestData.ratesHistoryData)
+    val ratesDataId = TestValuesTableFactory.registerData(ratesChangelog)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE ${NO_UPDATE_SOURCE.ratesTable} (
+         |  currency STRING,
+         |  rate BIGINT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$ratesDataId',
+         |  'changelog-mode' = 'I,D',
+         |  'disable-lookup' = 'true'
+         |)
+      """.stripMargin)
+  }
+
+  private def convertToNoUpdateData(data: Seq[Row]): Seq[Row] = {
+    data.map { row =>
       row.getKind match {
         case RowKind.INSERT | RowKind.DELETE => row
         case RowKind.UPDATE_BEFORE =>
@@ -163,34 +361,31 @@ class ChangelogSourceITCase(state: StateBackendMode) extends StreamingWithStateT
           ret
       }
     }
-    val dataId = TestValuesTableFactory.registerData(userChangelog)
-    val ddl =
-      s"""
-         |CREATE TABLE user_logs2 (
-         |  user_id STRING,
-         |  user_name STRING,
-         |  email STRING,
-         |  balance DECIMAL(18,2)
-         |) WITH (
-         | 'connector' = 'values',
-         | 'data-id' = '$dataId',
-         | 'changelog-mode' = 'I,D'
-         |)
-         |""".stripMargin
-    tEnv.executeSql(ddl)
+  }
 
-    val query =
-      s"""
-         |SELECT count(*), sum(balance), max(email)
-         |FROM user_logs2
-         |""".stripMargin
+}
 
-    val result = tEnv.sqlQuery(query).toRetractStream[Row]
-    val sink = new TestingRetractSink()
-    result.addSink(sink).setParallelism(result.parallelism)
-    env.execute()
+object ChangelogSourceITCase {
 
-    val expected = Seq("3,29.39,tom123@gmail.com")
-    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  case class SourceMode(mode: String, usersTable: String, ratesTable: String) {
+    override def toString: String = mode.toString
+  }
+
+  val CHANGELOG_SOURCE: SourceMode = SourceMode("CHANGELOG", "users_changelog", "rates_changelog")
+  val UPSERT_SOURCE: SourceMode = SourceMode("UPSERT", "users_upsert", "rates_upsert")
+  val NO_UPDATE_SOURCE: SourceMode = SourceMode("NO_UPDATE", "users_no_update", "rates_no_update")
+
+  @Parameterized.Parameters(name = "Source={0}, StateBackend={1}")
+  def parameters(): util.Collection[Array[java.lang.Object]] = {
+    Seq[Array[AnyRef]](
+      Array(CHANGELOG_SOURCE, MiniBatchOff, HEAP_BACKEND),
+      Array(CHANGELOG_SOURCE, MiniBatchOff, ROCKSDB_BACKEND),
+      Array(UPSERT_SOURCE, MiniBatchOff, HEAP_BACKEND),
+      Array(UPSERT_SOURCE, MiniBatchOff, ROCKSDB_BACKEND),
+      // upsert source supports minibatch, we enable minibatch only for RocksDB to save time
+      Array(UPSERT_SOURCE, MiniBatchOn, ROCKSDB_BACKEND),
+      // we only test not_update for RocksDB to save time
+      Array(NO_UPDATE_SOURCE, MiniBatchOff, ROCKSDB_BACKEND)
+    )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
@@ -1140,48 +1140,4 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt")
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
-
-  @Test
-  def testJoinOnChangelogSource(): Unit = {
-    val orderDataId = TestValuesTableFactory.registerData(TestData.ordersData)
-    val ratesDataId = TestValuesTableFactory.registerData(TestData.ratesHistoryData)
-    tEnv.executeSql(
-      s"""
-         |CREATE TABLE orders (
-         |  amount BIGINT,
-         |  currency STRING
-         |) WITH (
-         | 'connector' = 'values',
-         | 'data-id' = '$orderDataId',
-         | 'changelog-mode' = 'I'
-         |)
-         |""".stripMargin)
-    tEnv.executeSql(
-      s"""
-        |CREATE TABLE rates_history (
-        |  currency STRING,
-        |  rate BIGINT
-        |) WITH (
-        |  'connector' = 'values',
-        |  'data-id' = '$ratesDataId',
-        |  'changelog-mode' = 'I,UB,UA'
-        |)
-      """.stripMargin)
-
-    val sql =
-      """
-        |SELECT o.currency, o.amount, r.rate, o.amount * r.rate
-        |FROM orders AS o JOIN rates_history AS r
-        |ON o.currency = r.currency
-        |""".stripMargin
-
-    val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
-    env.execute()
-
-    val expected = Seq(
-      "Euro,2,119,238", "Euro,3,119,357",
-      "US Dollar,1,102,102", "US Dollar,5,102,510")
-    assertEquals(expected.sorted, sink.getRetractResults.sorted)
-  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -490,6 +490,15 @@ object TestData {
     changelogRow("-U", "user3", "Bailey", "bailey@gmail.com", new JBigDecimal("9.99")),
     changelogRow("+U", "user3", "Bailey", "bailey@qq.com", new JBigDecimal("9.99")))
 
+  val userUpsertlog: Seq[Row] = Seq(
+    changelogRow("+U", "user1", "Tom", "tom@gmail.com", new JBigDecimal("10.02")),
+    changelogRow("+U", "user2", "Jack", "jack@hotmail.com", new JBigDecimal("71.2")),
+    changelogRow("+U", "user1", "Tom", "tom123@gmail.com", new JBigDecimal("8.1")),
+    changelogRow("+U", "user3", "Bailey", "bailey@gmail.com", new JBigDecimal("9.99")),
+    changelogRow("-D", "user2", "Jack", "jack@hotmail.com", new JBigDecimal("71.2")),
+    changelogRow("+U", "user4", "Tina", "tina@gmail.com", new JBigDecimal("11.3")),
+    changelogRow("+U", "user3", "Bailey", "bailey@qq.com", new JBigDecimal("9.99")))
+
   // [amount, currency]
   val ordersData: Seq[Row] = Seq(
     row(2L, "Euro"),
@@ -507,6 +516,15 @@ object TestData {
     changelogRow("-U", "Euro", JLong.valueOf(114L)),
     changelogRow("+U", "Euro", JLong.valueOf(116L)),
     changelogRow("-U", "Euro", JLong.valueOf(116L)),
+    changelogRow("+U", "Euro", JLong.valueOf(119L)),
+    changelogRow("-D", "Yen", JLong.valueOf(1L))
+  )
+
+  val ratesUpsertData: Seq[Row] = Seq(
+    changelogRow("+U", "US Dollar", JLong.valueOf(102L)),
+    changelogRow("+U", "Euro", JLong.valueOf(114L)),
+    changelogRow("+U", "Yen", JLong.valueOf(1L)),
+    changelogRow("+U", "Euro", JLong.valueOf(116L)),
     changelogRow("+U", "Euro", JLong.valueOf(119L)),
     changelogRow("-D", "Yen", JLong.valueOf(1L))
   )

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
@@ -38,7 +38,7 @@ class DeduplicateFunctionHelper {
 	 * @param state state of function, null if generateUpdateBefore is false
 	 * @param out underlying collector
 	 */
-	static void processLastRow(
+	static void processLastRowOnInsertOnly(
 			RowData currentRow,
 			boolean generateUpdateBefore,
 			boolean generateInsert,
@@ -68,6 +68,60 @@ class DeduplicateFunctionHelper {
 			// always send UPDATE_AFTER if INSERT is not needed
 			currentRow.setRowKind(RowKind.UPDATE_AFTER);
 			out.collect(currentRow);
+		}
+	}
+
+	/**
+	 * Processes element to deduplicate on keys, sends current element as last row, retracts previous element if
+	 * needed.
+	 *
+	 * <p>Note: we don't support stateless mode yet. Because this is not safe for Kafka tombstone
+	 * messages which doesn't contain full content. This can be a future improvement if the
+	 * downstream (e.g. sink) doesn't require full content for DELETE messages.
+	 *
+	 * @param currentRow latest row received by deduplicate function
+	 * @param generateUpdateBefore whether need to send UPDATE_BEFORE message for updates
+	 * @param state state of function
+	 * @param out underlying collector
+	 */
+	static void processLastRowOnChangelog(
+			RowData currentRow,
+			boolean generateUpdateBefore,
+			ValueState<RowData> state,
+			Collector<RowData> out) throws Exception {
+		RowData preRow = state.value();
+		RowKind currentKind = currentRow.getRowKind();
+		if (currentKind == RowKind.INSERT || currentKind == RowKind.UPDATE_AFTER) {
+			if (preRow == null) {
+				// the first row, send INSERT message
+				currentRow.setRowKind(RowKind.INSERT);
+				out.collect(currentRow);
+			} else {
+				if (generateUpdateBefore) {
+					preRow.setRowKind(RowKind.UPDATE_BEFORE);
+					out.collect(preRow);
+				}
+				currentRow.setRowKind(RowKind.UPDATE_AFTER);
+				out.collect(currentRow);
+			}
+			// normalize row kind
+			currentRow.setRowKind(RowKind.INSERT);
+			// save to state
+			state.update(currentRow);
+		} else {
+			// DELETE or UPDATER_BEFORE
+			if (preRow != null) {
+				// always set to DELETE because this row has been removed
+				// even the the input is UPDATE_BEFORE, there may no UPDATE_AFTER after it.
+				preRow.setRowKind(RowKind.DELETE);
+				// output the preRow instead of currentRow,
+				// because preRow always contains the full content.
+				// currentRow may only contain key parts (e.g. Kafka tombstone records).
+				out.collect(preRow);
+				// clear state as the row has been removed
+				state.clear();
+			}
+			// nothing to do if removing a non-existed row
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunctionTest.java
@@ -42,7 +42,8 @@ public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestB
 			minTime.toMilliseconds(),
 			inputRowType,
 			generateUpdateBefore,
-			generateInsert);
+			generateInsert,
+			true);
 	}
 
 	private OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunctionTest.java
@@ -52,6 +52,7 @@ public class MiniBatchDeduplicateKeepLastRowFunctionTest extends DeduplicateFunc
 			inputRowType,
 			generateUpdateBefore,
 			generateInsert,
+			true,
 			typeSerializer,
 			minRetentionTime);
 	}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support `[UPDATE_AFTER, DELETE]` ChangelogMode which indicates the source will emit only `UPDATE_AFTER` and `DELETE` messages during runtime (e.g. an upsert source). The planner will add the a materialization operator when the ChangelogMode of the source is `[UPDATE_AFTER, DELETE]`.

The materialization operator will materialize the upsert stream and generate changelog stream with full change messages. In the physical operator, we will use state to know whether the key is the first time to be seen. The operator will produce INSERT rows, or additionally generate UPDATE_BEFORE rows for the previous image, or produce DELETE rows with all columns filled with values.

## Brief change log

- **Support in planner:** Generate a `StreamExecUpsertMaterialize` when the scan is a upsert source.
- **Update metadata handlers:** Update ColumnUniqueness, ModifiedMonotonicity, UniqueKeys metadatas and fix some minor bugs in `FlinkRelMdModifiedMonotonicity`. 
- **Support in runtime:** Reuse the implementation of deduplicate function, add a new process path for changelog input stream.

## Verifying this change

- Added many tests for plan and runtime to cover different operations on upsert source.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
