### PR TITLE
[FLINK-19636][coordination] Add DeclarativeSlotPool 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+
+/**
+ * Slot pool interface which uses Flink's declarative resource management
+ * protocol to acquire resources.
+ *
+ * <p>In order to acquire new resources, users need to increase the required
+ * resources. Once they no longer need the resources, users need to decrease
+ * the required resources so that superfluous resources can be returned.
+ */
+public interface DeclarativeSlotPool {
+
+	/**
+	 * Increases the resource requirements by increment.
+	 *
+	 * @param increment increment by which to increase the resource requirements
+	 */
+	void increaseResourceRequirementsBy(ResourceCounter increment);
+
+	/**
+	 * Decreases the resource requirements by decrement.
+	 *
+	 * @param decrement decrement by which to decrease the resource requirements
+	 */
+	void decreaseResourceRequirementsBy(ResourceCounter decrement);
+
+	/**
+	 * Returns the current resource requirements.
+	 *
+	 * @return current resource requirements
+	 */
+	Collection<ResourceRequirement> getResourceRequirements();
+
+	/**
+	 * Offers slots to this slot pool. The slot pool is free to accept as many slots as it
+	 * needs.
+	 *
+	 * @param offers offers containing the list of slots offered to this slot pool
+	 * @param taskManagerLocation taskManagerLocation is the location of the offering TaskExecutor
+	 * @param taskManagerGateway taskManagerGateway is the gateway to talk to the offering TaskExecutor
+	 * @param currentTime currentTime is the time the slots are being offered
+	 * @return collection of accepted slots; the other slot offers are implicitly rejected
+	 */
+	Collection<SlotOffer> offerSlots(Collection<? extends SlotOffer> offers, TaskManagerLocation taskManagerLocation, TaskManagerGateway taskManagerGateway, long currentTime);
+
+	/**
+	 * Returns the slot information for all free slots (slots which can be allocated from the slot pool).
+	 *
+	 * @return collection of free slot information
+	 */
+	Collection<SlotInfoWithUtilization> getFreeSlotsInformation();
+
+	/**
+	 * Returns the slot information for all slots (free and allocated slots).
+	 *
+	 * @return collection of slot information
+	 */
+	Collection<? extends SlotInfo> getAllSlotsInformation();
+
+	/**
+	 * Reserves the free slot identified by the given allocationId and maps it to
+	 * the given requiredSlotProfile.
+	 *
+	 * @param allocationId allocationId identifies the free slot to allocate
+	 * @param requiredSlotProfile requiredSlotProfile specifying the resource requirement
+	 * @return a PhysicalSlot representing the allocated slot
+	 * @throws IllegalStateException if no free slot with the given allocationId exists or if
+	 *                               the specified slot cannot fulfill the requiredSlotProfile
+	 */
+	PhysicalSlot reserveFreeSlot(AllocationID allocationId, ResourceProfile requiredSlotProfile);
+
+	/**
+	 * Frees the reserved slot identified by the given allocationId. If no slot
+	 * with allocationId exists, then the call is ignored.
+	 *
+	 * <p>Whether the freed slot is returned to the owning TaskExecutor is implementation
+	 * dependent.
+	 *
+	 * @param allocationId allocationId identifying the slot to release
+	 * @param cause cause for releasing the slot; can be {@code null}
+	 * @param currentTime currentTime when the slot was released
+	 * @return resource information about freed slot
+	 */
+	ResourceCounter freeReservedSlot(AllocationID allocationId, @Nullable Throwable cause, long currentTime);
+
+	/**
+	 * Releases all slots belonging to the owning TaskExecutor if it has been registered.
+	 *
+	 * @param owner owner identifying the owning TaskExecutor
+	 * @param cause cause for failing the slots
+	 * @return resource information about released slots
+	 */
+	ResourceCounter releaseSlots(ResourceID owner, Exception cause);
+
+	/**
+	 * Releases the slot specified by allocationId if one exists.
+	 *
+	 * @param allocationId allocationId identifying the slot to fail
+	 * @param cause cause for failing the slot
+	 * @return resource information about released slot
+	 */
+	ResourceCounter releaseSlot(AllocationID allocationId, Exception cause);
+
+	/**
+	 * Returns whether the slot pool has a slot registered which is owned by the given
+	 * TaskExecutor.
+	 *
+	 * @param owner owner identifying the TaskExecutor for which to check whether the slot pool has some slots registered
+	 * @return true if the given TaskExecutor has a slot registered at the slot pool
+	 */
+	boolean containsSlots(ResourceID owner);
+
+	/**
+	 * Releases slots which have exceeded the idle slot timeout and are no longer
+	 * needed to fulfill the resource requirements.
+	 *
+	 * @param currentTimeMillis current time
+	 */
+	void releaseIdleSlots(long currentTimeMillis);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.slots.DefaultRequirementMatcher;
+import org.apache.flink.runtime.slots.RequirementMatcher;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * Default {@link DeclarativeSlotPool} implementation.
+ *
+ * <p>The implementation collects the current resource requirements and declares them
+ * at the ResourceManager. Whenever new slots are offered, the slot pool compares the
+ * offered slots to the set of available and required resources and only accepts those
+ * slots which are required.
+ *
+ * <p>Slots which are released won't be returned directly to their owners. Instead,
+ * the slot pool implementation will only return them after the idleSlotTimeout has
+ * been exceeded by a free slot.
+ *
+ * <p>The slot pool will call {@link #notifyNewSlots} whenever newly offered slots are
+ * accepted or if an allocated slot should become free after it is being
+ * {@link #freeReservedSlot freed}.
+ */
+public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultDeclarativeSlotPool.class);
+
+	private final Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements;
+
+	private final Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots;
+
+	private final Time idleSlotTimeout;
+	private final Time rpcTimeout;
+
+	private final AllocatedSlotPool slotPool;
+
+	private final Map<AllocationID, ResourceProfile> slotToRequirementProfileMappings;
+
+	private ResourceCounter totalResourceRequirements;
+
+	private ResourceCounter fulfilledResourceRequirements;
+
+	private final RequirementMatcher requirementMatcher = new DefaultRequirementMatcher();
+
+	public DefaultDeclarativeSlotPool(
+		AllocatedSlotPool slotPool,
+		Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
+		Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
+		Time idleSlotTimeout,
+		Time rpcTimeout) {
+
+		this.slotPool = slotPool;
+		this.notifyNewResourceRequirements = notifyNewResourceRequirements;
+		this.notifyNewSlots = notifyNewSlots;
+		this.idleSlotTimeout = idleSlotTimeout;
+		this.rpcTimeout = rpcTimeout;
+		this.totalResourceRequirements = ResourceCounter.empty();
+		this.fulfilledResourceRequirements = ResourceCounter.empty();
+		this.slotToRequirementProfileMappings = new HashMap<>();
+	}
+
+	@Override
+	public void increaseResourceRequirementsBy(ResourceCounter increment) {
+		totalResourceRequirements = totalResourceRequirements.add(increment);
+
+		declareResourceRequirements();
+	}
+
+	@Override
+	public void decreaseResourceRequirementsBy(ResourceCounter decrement) {
+		totalResourceRequirements = totalResourceRequirements.subtract(decrement);
+
+		declareResourceRequirements();
+	}
+
+	private void declareResourceRequirements() {
+		notifyNewResourceRequirements.accept(getResourceRequirements());
+	}
+
+	@Override
+	public Collection<ResourceRequirement> getResourceRequirements() {
+		final Collection<ResourceRequirement> currentResourceRequirements = new ArrayList<>();
+
+		for (Map.Entry<ResourceProfile, Integer> resourceRequirement : totalResourceRequirements.getResourcesWithCount()) {
+			currentResourceRequirements.add(ResourceRequirement.create(resourceRequirement.getKey(), resourceRequirement.getValue()));
+		}
+
+		return currentResourceRequirements;
+	}
+
+	@Override
+	public Collection<SlotOffer> offerSlots(
+		Collection<? extends SlotOffer> offers,
+		TaskManagerLocation taskManagerLocation,
+		TaskManagerGateway taskManagerGateway,
+		long currentTime) {
+
+		LOG.debug("Received {} slot offers from TaskExecutor {}.", offers.size(), taskManagerLocation);
+		final Collection<SlotOffer> acceptedSlotOffers = new ArrayList<>();
+		final Collection<AllocatedSlot> acceptedSlots = new ArrayList<>();
+
+		for (SlotOffer offer : offers) {
+			if (slotPool.containsSlot(offer.getAllocationId())) {
+				// we have already accepted this offer
+				acceptedSlotOffers.add(offer);
+			} else {
+				Optional<AllocatedSlot> acceptedSlot = matchOfferWithOutstandingRequirements(offer, taskManagerLocation, taskManagerGateway);
+				if (acceptedSlot.isPresent()) {
+					acceptedSlotOffers.add(offer);
+					acceptedSlots.add(acceptedSlot.get());
+				}
+			}
+		}
+
+		slotPool.addSlots(acceptedSlots, currentTime);
+
+		if (!acceptedSlots.isEmpty()) {
+			notifyNewSlots.accept(acceptedSlots);
+		}
+
+		return acceptedSlotOffers;
+	}
+
+	private Optional<AllocatedSlot> matchOfferWithOutstandingRequirements(
+			SlotOffer slotOffer,
+			TaskManagerLocation taskManagerLocation,
+			TaskManagerGateway taskManagerGateway) {
+
+		final Optional<ResourceProfile> match = requirementMatcher.match(
+				slotOffer.getResourceProfile(),
+				totalResourceRequirements.getResourcesWithCount(),
+				fulfilledResourceRequirements::getResourceCount);
+
+		if (match.isPresent()) {
+			final ResourceProfile matchedRequirement = match.get();
+			LOG.debug("Matched slot offer {} to requirement {}.", slotOffer.getAllocationId(), matchedRequirement);
+
+			increaseAvailableResources(ResourceCounter.withResource(matchedRequirement, 1));
+
+			final AllocatedSlot allocatedSlot = createAllocatedSlot(
+					slotOffer,
+					taskManagerLocation,
+					taskManagerGateway);
+
+			// store the ResourceProfile against which the given slot has matched for future book-keeping
+			slotToRequirementProfileMappings.put(allocatedSlot.getAllocationId(), matchedRequirement);
+
+			return Optional.of(allocatedSlot);
+		}
+		return Optional.empty();
+	}
+
+	@VisibleForTesting
+	ResourceCounter calculateUnfulfilledResources() {
+		return totalResourceRequirements.subtract(fulfilledResourceRequirements);
+	}
+
+	private AllocatedSlot createAllocatedSlot(
+		SlotOffer slotOffer,
+		TaskManagerLocation taskManagerLocation,
+		TaskManagerGateway taskManagerGateway) {
+		return new AllocatedSlot(
+			slotOffer.getAllocationId(),
+			taskManagerLocation,
+			slotOffer.getSlotIndex(),
+			slotOffer.getResourceProfile(),
+			taskManagerGateway);
+	}
+
+	private void increaseAvailableResources(ResourceCounter acceptedResources) {
+		fulfilledResourceRequirements = fulfilledResourceRequirements.add(acceptedResources);
+	}
+
+	@Nonnull
+	private ResourceProfile getMatchingResourceProfile(AllocationID allocationId) {
+		return Preconditions.checkNotNull(slotToRequirementProfileMappings.get(allocationId), "No matching resource profile found for %s", allocationId);
+	}
+
+	@Override
+	public PhysicalSlot reserveFreeSlot(AllocationID allocationId, ResourceProfile requiredSlotProfile) {
+		final AllocatedSlot allocatedSlot = slotPool.reserveFreeSlot(allocationId);
+
+		Preconditions.checkState(
+				allocatedSlot.getResourceProfile().isMatching(requiredSlotProfile),
+				"Slot {} cannot fulfill the given requirement. SlotProfile={} Requirement={}", allocationId, allocatedSlot.getResourceProfile(), requiredSlotProfile);
+
+		ResourceProfile previouslyMatchedResourceProfile = Preconditions.checkNotNull(slotToRequirementProfileMappings.get(allocationId));
+
+		if (!previouslyMatchedResourceProfile.equals(requiredSlotProfile)) {
+			// slots can be reserved for a requirement that is not in line with the mapping we computed when the slot was
+			// offered, so we have to update the mapping adjust the requirements accordingly to ensure we still request enough slots to
+			// be able to fulfill the total requirements
+			LOG.debug(
+					"Adjusting requirements because a slot was reserved for a different requirement than initially assumed. Slot={} assumedRequirement={} actualRequirement={}",
+					allocationId, previouslyMatchedResourceProfile, requiredSlotProfile);
+			updateSlotToRequirementProfileMapping(allocationId, requiredSlotProfile);
+			adjustRequirements(previouslyMatchedResourceProfile, requiredSlotProfile);
+		}
+
+		return allocatedSlot;
+	}
+
+	@Override
+	public ResourceCounter freeReservedSlot(AllocationID allocationId, @Nullable Throwable cause, long currentTime) {
+		LOG.debug("Free reserved slot {}.", allocationId);
+
+		final Optional<AllocatedSlot> freedSlot = slotPool.freeReservedSlot(allocationId, currentTime);
+
+		Optional<ResourceCounter> previouslyFulfilledRequirement = freedSlot.map(Collections::singleton).map(this::getFulfilledRequirements);
+
+		freedSlot.ifPresent(allocatedSlot -> {
+			releasePayload(Collections.singleton(allocatedSlot), cause);
+			tryToFulfillResourceRequirement(allocatedSlot);
+			notifyNewSlots.accept(Collections.singletonList(allocatedSlot));
+		});
+
+		return previouslyFulfilledRequirement.orElseGet(ResourceCounter::empty);
+	}
+
+	private void tryToFulfillResourceRequirement(AllocatedSlot allocatedSlot) {
+		matchOfferWithOutstandingRequirements(allocatedSlotToSlotOffer(allocatedSlot), allocatedSlot.getTaskManagerLocation(), allocatedSlot.getTaskManagerGateway());
+	}
+
+	private void updateSlotToRequirementProfileMapping(AllocationID allocationId, ResourceProfile matchedResourceProfile) {
+		final ResourceProfile oldResourceProfile = Preconditions.checkNotNull(slotToRequirementProfileMappings.put(allocationId, matchedResourceProfile), "Expected slot profile matching to be non-empty.");
+
+		fulfilledResourceRequirements = fulfilledResourceRequirements.add(matchedResourceProfile, 1);
+		fulfilledResourceRequirements = fulfilledResourceRequirements.subtract(oldResourceProfile, 1);
+	}
+
+	private void adjustRequirements(ResourceProfile oldResourceProfile, ResourceProfile newResourceProfile) {
+		// slots can be reserved for a requirement that is not in line with the mapping we computed when the slot was
+		// offered, so we have to adjust the requirements accordingly to ensure we still request enough slots to
+		// be able to fulfill the total requirements
+		decreaseResourceRequirementsBy(ResourceCounter.withResource(newResourceProfile, 1));
+		increaseResourceRequirementsBy(ResourceCounter.withResource(oldResourceProfile, 1));
+	}
+
+	@Nonnull
+	private SlotOffer allocatedSlotToSlotOffer(AllocatedSlot allocatedSlot) {
+		return new SlotOffer(allocatedSlot.getAllocationId(), allocatedSlot.getPhysicalSlotNumber(), allocatedSlot.getResourceProfile());
+	}
+
+	@Override
+	public ResourceCounter releaseSlots(ResourceID owner, Exception cause) {
+		final Collection<AllocatedSlot> removedSlots = slotPool.removeSlots(owner);
+
+		ResourceCounter previouslyFulfilledRequirements = getFulfilledRequirements(removedSlots);
+
+		releasePayload(removedSlots, cause);
+		releaseSlots(removedSlots, cause);
+
+		return previouslyFulfilledRequirements;
+	}
+
+	@Override
+	public ResourceCounter releaseSlot(AllocationID allocationId, Exception cause) {
+		final Optional<AllocatedSlot> removedSlot = slotPool.removeSlot(allocationId);
+
+		Optional<ResourceCounter> previouslyFulfilledRequirement = removedSlot.map(Collections::singleton).map(this::getFulfilledRequirements);
+
+		removedSlot.ifPresent(allocatedSlot -> {
+			releasePayload(Collections.singleton(allocatedSlot), cause);
+			releaseSlots(Collections.singleton(allocatedSlot), cause);
+		});
+
+		return previouslyFulfilledRequirement.orElseGet(ResourceCounter::empty);
+	}
+
+	private void releasePayload(Iterable<? extends AllocatedSlot> allocatedSlots, Throwable cause) {
+		for (AllocatedSlot allocatedSlot : allocatedSlots) {
+			allocatedSlot.releasePayload(cause);
+		}
+	}
+
+	@Override
+	public void releaseIdleSlots(long currentTimeMillis) {
+		final Collection<AllocatedSlotPool.FreeSlotInfo> freeSlotsInformation = slotPool.getFreeSlotsInformation();
+
+		ResourceCounter excessResources = fulfilledResourceRequirements.subtract(totalResourceRequirements);
+
+		final Iterator<AllocatedSlotPool.FreeSlotInfo> freeSlotIterator = freeSlotsInformation.iterator();
+
+		final Collection<AllocatedSlot> slotsToReturnToOwner = new ArrayList<>();
+
+		while (!excessResources.isEmpty() && freeSlotIterator.hasNext()) {
+			final AllocatedSlotPool.FreeSlotInfo idleSlot = freeSlotIterator.next();
+
+			if (currentTimeMillis >= idleSlot.getFreeSince() + idleSlotTimeout.toMilliseconds()) {
+				final ResourceProfile matchingProfile = getMatchingResourceProfile(idleSlot.getAllocationId());
+
+				if (excessResources.containsResource(matchingProfile)) {
+					excessResources = excessResources.subtract(matchingProfile, 1);
+					final Optional<AllocatedSlot> removedSlot = slotPool.removeSlot(idleSlot.getAllocationId());
+
+					final AllocatedSlot allocatedSlot = removedSlot.orElseThrow(() -> new IllegalStateException(String.format("Could not find slot for allocation id %s.", idleSlot.getAllocationId())));
+					slotsToReturnToOwner.add(allocatedSlot);
+				}
+			}
+		}
+
+		releaseSlots(slotsToReturnToOwner, new FlinkException("Returning idle slots to their owners."));
+	}
+
+	private void releaseSlots(Iterable<AllocatedSlot> slotsToReturnToOwner, Throwable cause) {
+		for (AllocatedSlot slotToReturn : slotsToReturnToOwner) {
+			Preconditions.checkState(!slotToReturn.isUsed(), "Free slot must not be used.");
+
+			if (LOG.isDebugEnabled()) {
+				LOG.info("Releasing slot [{}].", slotToReturn.getAllocationId(), cause);
+			} else {
+				LOG.info("Releasing slot [{}].", slotToReturn.getAllocationId());
+			}
+
+			final ResourceProfile matchingResourceProfile = getMatchingResourceProfile(slotToReturn.getAllocationId());
+			fulfilledResourceRequirements = fulfilledResourceRequirements.subtract(matchingResourceProfile, 1);
+			slotToRequirementProfileMappings.remove(slotToReturn.getAllocationId());
+
+			final CompletableFuture<Acknowledge> freeSlotFuture = slotToReturn.getTaskManagerGateway().freeSlot(
+				slotToReturn.getAllocationId(),
+				cause,
+				rpcTimeout);
+
+			freeSlotFuture.whenComplete((Acknowledge ignored, Throwable throwable) -> {
+				if (throwable != null) {
+					// The slot status will be synced to task manager in next heartbeat.
+					LOG.debug("Releasing slot [{}] of registered TaskExecutor {} failed. Discarding slot.",
+						slotToReturn.getAllocationId(), slotToReturn.getTaskManagerId(), throwable);
+				}
+			});
+		}
+	}
+
+	@Override
+	public Collection<SlotInfoWithUtilization> getFreeSlotsInformation() {
+		return slotPool.getFreeSlotsInformation().stream()
+			.map(AllocatedSlotPool.FreeSlotInfo::asSlotInfo)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public Collection<? extends SlotInfo> getAllSlotsInformation() {
+		return slotPool.getAllSlotsInformation();
+	}
+
+	@Override
+	public boolean containsSlots(ResourceID owner) {
+		return slotPool.containsSlots(owner);
+	}
+
+	private ResourceCounter getFulfilledRequirements(Iterable<? extends AllocatedSlot> allocatedSlots) {
+		ResourceCounter resourceDecrement = ResourceCounter.empty();
+
+		for (AllocatedSlot allocatedSlot : allocatedSlots) {
+			final ResourceProfile matchingResourceProfile = getMatchingResourceProfile(allocatedSlot.getAllocationId());
+			resourceDecrement = resourceDecrement.add(matchingResourceProfile, 1);
+		}
+
+		return resourceDecrement;
+	}
+
+	@VisibleForTesting
+	ResourceCounter getFulfilledResourceRequirements() {
+		return fulfilledResourceRequirements;
+	}
+
+	private static final class SlotOfferMatching {
+		private final SlotOffer slotOffer;
+
+		@Nullable
+		private final ResourceProfile matching;
+
+		private SlotOfferMatching(SlotOffer slotOffer, @Nullable ResourceProfile matching) {
+			this.slotOffer = slotOffer;
+			this.matching = matching;
+		}
+
+		private SlotOffer getSlotOffer() {
+			return slotOffer;
+		}
+
+		private Optional<ResourceProfile> getMatching() {
+			return Optional.ofNullable(matching);
+		}
+
+		private static SlotOfferMatching createMatching(SlotOffer slotOffer, ResourceProfile matching) {
+			return new SlotOfferMatching(slotOffer, matching);
+		}
+
+		private static SlotOfferMatching createMismatch(SlotOffer slotOffer) {
+			return new SlotOfferMatching(slotOffer, null);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounter.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Counter for {@link ResourceProfile ResourceProfiles}. This class is immutable.
+ *
+ * <p>ResourceCounter contains a set of {@link ResourceProfile ResourceProfiles} and their
+ * associated counts. The counts are always positive (> 0).
+ */
+final class ResourceCounter {
+
+	private final Map<ResourceProfile, Integer> resources;
+
+	private ResourceCounter(Map<ResourceProfile, Integer> resources) {
+		this.resources = Collections.unmodifiableMap(resources);
+	}
+
+	/**
+	 * Number of resources with the given {@link ResourceProfile}.
+	 *
+	 * @param resourceProfile resourceProfile for which to look up the count
+	 * @return number of resources with the given resourceProfile or {@code 0}
+	 * if the resource profile does not exist
+	 */
+	public int getResourceCount(ResourceProfile resourceProfile) {
+		return resources.getOrDefault(resourceProfile, 0);
+	}
+
+	/**
+	 * Adds increment to this resource counter value and returns the resulting value.
+	 *
+	 * @param increment increment to add to this resource counter value
+	 * @return new ResourceCounter containing the result of the addition
+	 */
+	public ResourceCounter add(ResourceCounter increment) {
+		return internalAdd(increment.getResourcesWithCount());
+	}
+
+	/**
+	 * Adds the given increment to this resource counter value and returns the resulting value.
+	 *
+	 * @param increment increment ot add to this resource counter value
+	 * @return new ResourceCounter containing the result of the addition
+	 */
+	public ResourceCounter add(Map<ResourceProfile, Integer> increment) {
+		return internalAdd(increment.entrySet());
+	}
+
+	/**
+	 * Adds increment to the count of resourceProfile and returns the new value.
+	 *
+	 * @param resourceProfile resourceProfile to which to add increment
+	 * @param increment increment is the number by which to increase the resourceProfile
+	 * @return new ResourceCounter containing the result of the addition
+	 */
+	public ResourceCounter add(ResourceProfile resourceProfile, int increment) {
+		final Map<ResourceProfile, Integer> newValues = new HashMap<>(resources);
+		final int newValue = resources.getOrDefault(resourceProfile, 0) + increment;
+
+		updateNewValue(newValues, resourceProfile, newValue);
+
+		return new ResourceCounter(newValues);
+	}
+
+	private ResourceCounter internalAdd(Iterable<? extends Map.Entry<ResourceProfile, Integer>> entries) {
+		final Map<ResourceProfile, Integer> newValues = new HashMap<>(resources);
+
+		for (Map.Entry<ResourceProfile, Integer> resourceIncrement : entries) {
+			final ResourceProfile resourceProfile = resourceIncrement.getKey();
+
+			final int newValue = resources.getOrDefault(resourceProfile, 0) + resourceIncrement.getValue();
+
+			updateNewValue(newValues, resourceProfile, newValue);
+		}
+
+		return new ResourceCounter(newValues);
+	}
+
+	private void updateNewValue(Map<ResourceProfile, Integer> newResources, ResourceProfile resourceProfile, int newValue) {
+		if (newValue > 0) {
+			newResources.put(resourceProfile, newValue);
+		} else {
+			newResources.remove(resourceProfile);
+		}
+	}
+
+	/**
+	 * Subtracts decrement from this resource counter value and returns the new value.
+	 *
+	 * @param decrement decrement to subtract from this resource counter
+	 * @return new ResourceCounter containing the new value
+	 */
+	public ResourceCounter subtract(ResourceCounter decrement) {
+		return internalSubtract(decrement.getResourcesWithCount());
+	}
+
+	/**
+	 * Subtracts decrement from this resource counter value and returns the new value.
+	 *
+	 * @param decrement decrement to subtract from this resource counter
+	 * @return new ResourceCounter containing the new value
+	 */
+	public ResourceCounter subtract(Map<ResourceProfile, Integer> decrement) {
+		return internalSubtract(decrement.entrySet());
+	}
+
+	/**
+	 * Subtracts decrement from the count of the given resourceProfile and returns the new value.
+	 *
+	 * @param resourceProfile resourceProfile from which to subtract decrement
+	 * @param decrement decrement is the number by which to decrease resourceProfile
+	 * @return new ResourceCounter containing the new value
+	 */
+	public ResourceCounter subtract(ResourceProfile resourceProfile, int decrement) {
+		final Map<ResourceProfile, Integer> newValues = new HashMap<>(resources);
+		final int newValue = resources.getOrDefault(resourceProfile, 0) - decrement;
+
+		updateNewValue(newValues, resourceProfile, newValue);
+
+		return new ResourceCounter(newValues);
+	}
+
+	private ResourceCounter internalSubtract(Iterable<? extends Map.Entry<ResourceProfile, Integer>> entries) {
+		final Map<ResourceProfile, Integer> newValues = new HashMap<>(resources);
+
+		for (Map.Entry<ResourceProfile, Integer> resourceDecrement : entries) {
+			final ResourceProfile resourceProfile = resourceDecrement.getKey();
+			final int newValue = resources.getOrDefault(resourceProfile, 0) - resourceDecrement.getValue();
+
+			updateNewValue(newValues, resourceProfile, newValue);
+		}
+
+		return new ResourceCounter(newValues);
+	}
+
+	/**
+	 * Gets the stored resources and their counts. The counts are guaranteed to be positive (> 0).
+	 *
+	 * @return collection of {@link ResourceProfile} and count pairs
+	 */
+	public Collection<Map.Entry<ResourceProfile, Integer>> getResourcesWithCount() {
+		return resources.entrySet();
+	}
+
+	/**
+	 * Checks whether resourceProfile is contained in this counter.
+	 *
+	 * @param resourceProfile resourceProfile to check whether it is contained
+	 * @return {@code true} if the counter has a positive count for the given resourceProfile;
+	 * otherwise {@code false}
+	 */
+	public boolean containsResource(ResourceProfile resourceProfile) {
+		return resources.containsKey(resourceProfile);
+	}
+
+	/**
+	 * Gets all stored {@link ResourceProfile ResourceProfiles}.
+	 *
+	 * @return collection of stored {@link ResourceProfile ResourceProfiles}
+	 */
+	public Set<ResourceProfile> getResources() {
+		return resources.keySet();
+	}
+
+	/**
+	 * Checks whether the resource counter is empty.
+	 *
+	 * @return {@code true} if the counter does not contain any counts;
+	 * otherwise {@code false}
+	 */
+	public boolean isEmpty() {
+		return resources.isEmpty();
+	}
+
+	/**
+	 * Creates an empty resource counter.
+	 *
+	 * @return empty resource counter
+	 */
+	public static ResourceCounter empty() {
+		return new ResourceCounter(Collections.emptyMap());
+	}
+
+	/**
+	 * Creates a resource counter with the specified set of resources.
+	 *
+	 * @param resources resources with which to initialize the resource counter
+	 * @return ResourceCounter which contains the specified set of resources
+	 */
+	public static ResourceCounter withResources(Map<ResourceProfile, Integer> resources) {
+		return new ResourceCounter(new HashMap<>(resources));
+	}
+
+	/**
+	 * Creates a resource counter with the given resourceProfile and its count.
+	 *
+	 * @param resourceProfile resourceProfile for the given count
+	 * @param count count of the given resourceProfile
+	 * @return ResourceCounter which contains the specified resourceProfile and its count
+	 */
+	public static ResourceCounter withResource(ResourceProfile resourceProfile, int count) {
+		return new ResourceCounter(Collections.singletonMap(resourceProfile, count));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ResourceCounter that = (ResourceCounter) o;
+		return Objects.equals(resources, that.resources);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(resources);
+	}
+
+	@Override
+	public String toString() {
+		return "ResourceCounter{" +
+			"resources=" + resources +
+			'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/slots/DefaultRequirementMatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/slots/DefaultRequirementMatcher.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.slots;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Default implementation of {@link RequirementMatcher}. This matcher finds the first requirement that a) is not unfulfilled and B) matches the resource profile.
+ */
+public class DefaultRequirementMatcher implements RequirementMatcher {
+	@Override
+	public Optional<ResourceProfile> match(ResourceProfile resourceProfile, Collection<Map.Entry<ResourceProfile, Integer>> totalRequirements, Function<ResourceProfile, Integer> numAssignedResourcesLookup) {
+		for (Map.Entry<ResourceProfile, Integer> requirementCandidate : totalRequirements) {
+			ResourceProfile requirementProfile = requirementCandidate.getKey();
+
+			// beware the order when matching resources to requirements, because ResourceProfile.UNKNOWN (which only
+			// occurs as a requirement) does not match any resource!
+			if (resourceProfile.isMatching(requirementProfile) && requirementCandidate.getValue() > numAssignedResourcesLookup.apply(requirementProfile)) {
+				return Optional.of(requirementProfile);
+			}
+		}
+		return Optional.empty();
+
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/slots/RequirementMatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/slots/RequirementMatcher.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.slots;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * A matcher for resource profiles to requirements.
+ */
+public interface RequirementMatcher {
+
+	/**
+	 * Attempts to match the given resource profile with one of the given requirements.
+	 *
+	 * @param resourceProfile resource profile to match
+	 * @param totalRequirements the total requirements
+	 * @param numAssignedResourcesLookup a lookup for how many resources have already been assigned to a requirement
+	 * @return matching requirement profile, if one exists
+	 */
+	Optional<ResourceProfile> match(ResourceProfile resourceProfile, Collection<Map.Entry<ResourceProfile, Integer>> totalRequirements, Function<ResourceProfile, Integer> numAssignedResourcesLookup);
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * Builder for {@link DefaultDeclarativeSlotPool}.
+ */
+final class DefaultDeclarativeSlotPoolBuilder {
+
+	private AllocatedSlotPool allocatedSlotPool = new DefaultAllocatedSlotPool();
+	private Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements = ignored -> {};
+	private Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots = ignored -> {};
+	private Time idleSlotTimeout = Time.seconds(20);
+	private Time rpcTimeout = Time.seconds(20);
+
+	public DefaultDeclarativeSlotPoolBuilder setAllocatedSlotPool(AllocatedSlotPool allocatedSlotPool) {
+		this.allocatedSlotPool = allocatedSlotPool;
+		return this;
+	}
+
+	public DefaultDeclarativeSlotPoolBuilder setNotifyNewResourceRequirements(Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements) {
+		this.notifyNewResourceRequirements = notifyNewResourceRequirements;
+		return this;
+	}
+
+	public DefaultDeclarativeSlotPoolBuilder setNotifyNewSlots(Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots) {
+		this.notifyNewSlots = notifyNewSlots;
+		return this;
+	}
+
+	public DefaultDeclarativeSlotPoolBuilder setIdleSlotTimeout(Time idleSlotTimeout) {
+		this.idleSlotTimeout = idleSlotTimeout;
+		return this;
+	}
+
+	public DefaultDeclarativeSlotPool build() {
+		return new DefaultDeclarativeSlotPool(
+				allocatedSlotPool,
+				notifyNewResourceRequirements,
+				notifyNewSlots,
+				idleSlotTimeout,
+				rpcTimeout);
+	}
+
+	public static DefaultDeclarativeSlotPoolBuilder builder() {
+		return new DefaultDeclarativeSlotPoolBuilder();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
@@ -1,0 +1,550 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link DefaultDeclarativeSlotPool}.
+ */
+public class DefaultDeclarativeSlotPoolTest extends TestLogger {
+
+	private static final ResourceProfile RESOURCE_PROFILE_1 = ResourceProfile.newBuilder().setCpuCores(1.7).build();
+	private static final ResourceProfile RESOURCE_PROFILE_2 = ResourceProfile.newBuilder().setManagedMemoryMB(100).build();
+
+	@Test
+	public void testIncreasingResourceRequirementsWillSendResourceRequirementNotification() throws InterruptedException {
+		final NewResourceRequirementsService requirementsListener = new NewResourceRequirementsService();
+		final DeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(requirementsListener);
+
+		final ResourceCounter increment1 = ResourceCounter.withResource(RESOURCE_PROFILE_1, 1);
+		final ResourceCounter increment2 = createResourceRequirements();
+		slotPool.increaseResourceRequirementsBy(increment1);
+		slotPool.increaseResourceRequirementsBy(increment2);
+
+		assertThat(requirementsListener.takeResourceRequirements(), is(toResourceRequirements(increment1)));
+
+		final ResourceCounter totalResources = increment1.add(increment2);
+		assertThat(requirementsListener.takeResourceRequirements(), is(toResourceRequirements(totalResources)));
+		assertThat(requirementsListener.hasNextResourceRequirements(), is(false));
+	}
+
+	@Test
+	public void testDecreasingResourceRequirementsWillSendResourceRequirementNotification() throws InterruptedException {
+		final NewResourceRequirementsService requirementsListener = new NewResourceRequirementsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(requirementsListener);
+
+		final ResourceCounter increment = ResourceCounter.withResource(RESOURCE_PROFILE_1, 3);
+		slotPool.increaseResourceRequirementsBy(increment);
+
+		requirementsListener.takeResourceRequirements();
+
+		final ResourceCounter decrement = ResourceCounter.withResource(RESOURCE_PROFILE_1, 2);
+		slotPool.decreaseResourceRequirementsBy(decrement);
+
+		final ResourceCounter totalResources = increment.subtract(decrement);
+		assertThat(requirementsListener.takeResourceRequirements(), is(toResourceRequirements(totalResources)));
+		assertThat(requirementsListener.hasNextResourceRequirements(), is(false));
+	}
+
+	@Test
+	public void testGetResourceRequirements() {
+		final DefaultDeclarativeSlotPool slotPool = DefaultDeclarativeSlotPoolBuilder.builder().build();
+
+		assertThat(slotPool.getResourceRequirements(), is(toResourceRequirements(ResourceCounter.empty())));
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+
+		slotPool.increaseResourceRequirementsBy(resourceRequirements);
+
+		assertThat(slotPool.getResourceRequirements(), is(toResourceRequirements(resourceRequirements)));
+	}
+
+	@Test
+	public void testOfferSlots() throws InterruptedException {
+		final NewSlotsService notifyNewSlots = new NewSlotsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(notifyNewSlots);
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+
+		slotPool.increaseResourceRequirementsBy(resourceRequirements);
+
+		Collection<SlotOffer> slotOffers = createSlotOffersForResourceRequirements(resourceRequirements);
+
+		final Collection<SlotOffer> acceptedSlots = offerSlots(slotPool, slotOffers);
+
+		assertThat(acceptedSlots, containsInAnyOrder(slotOffers.toArray()));
+
+		final Collection<PhysicalSlot> newSlots = drainNewSlotService(notifyNewSlots);
+
+		assertThat(newSlots, containsInAnyOrder(slotOffers.stream().map(DefaultDeclarativeSlotPoolTest::matchesSlotOffer).collect(Collectors.toList())));
+		assertThat(slotPool.getAllSlotsInformation(), containsInAnyOrder(newSlots.stream().map(DefaultAllocatedSlotPoolTest::matchesPhysicalSlot).collect(Collectors.toList())));
+	}
+
+	@Test
+	public void testDuplicateSlotOfferings() throws InterruptedException {
+		final NewSlotsService notifyNewSlots = new NewSlotsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(notifyNewSlots);
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+
+		slotPool.increaseResourceRequirementsBy(resourceRequirements);
+
+		final Collection<SlotOffer> slotOffers = createSlotOffersForResourceRequirements(resourceRequirements);
+
+		offerSlots(slotPool, slotOffers);
+
+		drainNewSlotService(notifyNewSlots);
+
+		final Collection<SlotOffer> acceptedSlots = offerSlots(slotPool, slotOffers);
+
+		assertThat(acceptedSlots, containsInAnyOrder(slotOffers.toArray()));
+		// duplicate slots should not trigger notify new slots
+		assertFalse(notifyNewSlots.hasNextNewSlots());
+	}
+
+	@Test
+	public void testOfferingTooManySlots() {
+		final NewSlotsService notifyNewSlots = new NewSlotsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(notifyNewSlots);
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+
+		slotPool.increaseResourceRequirementsBy(resourceRequirements);
+
+		final ResourceCounter increasedRequirements = resourceRequirements.add(RESOURCE_PROFILE_1, 2);
+
+		final Collection<SlotOffer> slotOffers = createSlotOffersForResourceRequirements(increasedRequirements);
+
+		final Collection<SlotOffer> acceptedSlots = offerSlots(slotPool, slotOffers);
+
+		final Map<ResourceProfile, Long> resourceProfileCount = acceptedSlots.stream().map(SlotOffer::getResourceProfile).collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+		for (Map.Entry<ResourceProfile, Integer> resourceCount : resourceRequirements.getResourcesWithCount()) {
+			assertThat(resourceProfileCount.getOrDefault(resourceCount.getKey(), 0L), is((long) resourceCount.getValue()));
+		}
+	}
+
+	@Test
+	public void testReleaseSlotsRemovesSlots() throws InterruptedException {
+		final NewResourceRequirementsService notifyNewResourceRequirements = new NewResourceRequirementsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(notifyNewResourceRequirements);
+
+		final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		increaseRequirementsAndOfferSlotsToSlotPool(slotPool, createResourceRequirements(), taskManagerLocation);
+
+		notifyNewResourceRequirements.takeResourceRequirements();
+
+		slotPool.releaseSlots(taskManagerLocation.getResourceID(), new FlinkException("Test failure"));
+		assertThat(slotPool.getAllSlotsInformation(), is(empty()));
+	}
+
+	@Test
+	public void testReleaseSlotsReturnsSlot() {
+		final DefaultDeclarativeSlotPool slotPool = DefaultDeclarativeSlotPoolBuilder.builder().build();
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+
+		final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final FreeSlotConsumer freeSlotConsumer = new FreeSlotConsumer();
+		final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setFreeSlotFunction(freeSlotConsumer)
+			.createTestingTaskExecutorGateway();
+
+		final Collection<SlotOffer> slotOffers = increaseRequirementsAndOfferSlotsToSlotPool(
+			slotPool,
+			resourceRequirements,
+			taskManagerLocation,
+			testingTaskExecutorGateway);
+
+		slotPool.releaseSlots(taskManagerLocation.getResourceID(), new FlinkException("Test failure"));
+
+		final Collection<AllocationID> freedSlots = freeSlotConsumer.drainFreedSlots();
+
+		assertThat(freedSlots, containsInAnyOrder(slotOffers.stream().map(SlotOffer::getAllocationId).toArray()));
+	}
+
+	@Test
+	public void testReleaseSlotDecreasesFulfilledResourceRequirements() throws InterruptedException {
+		final NewSlotsService notifyNewSlots = new NewSlotsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(notifyNewSlots);
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+		increaseRequirementsAndOfferSlotsToSlotPool(slotPool, resourceRequirements, null);
+
+		final Collection<? extends PhysicalSlot> physicalSlots = notifyNewSlots.takeNewSlots();
+
+		final PhysicalSlot physicalSlot = physicalSlots.iterator().next();
+
+		slotPool.releaseSlot(physicalSlot.getAllocationId(), new FlinkException("Test failure"));
+
+		final ResourceCounter finalResourceRequirements = resourceRequirements.subtract(physicalSlot.getResourceProfile(), 1);
+		assertThat(slotPool.getFulfilledResourceRequirements(), is(finalResourceRequirements));
+	}
+
+	@Test
+	public void testReleaseSlotReturnsSlot() throws InterruptedException {
+		final NewSlotsService notifyNewSlots = new NewSlotsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(notifyNewSlots);
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+		final FreeSlotConsumer freeSlotConsumer = new FreeSlotConsumer();
+		final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setFreeSlotFunction(freeSlotConsumer)
+			.createTestingTaskExecutorGateway();
+
+		increaseRequirementsAndOfferSlotsToSlotPool(
+			slotPool,
+			resourceRequirements,
+			new LocalTaskManagerLocation(),
+			testingTaskExecutorGateway);
+
+		final Collection<? extends PhysicalSlot> physicalSlots = notifyNewSlots.takeNewSlots();
+
+		final PhysicalSlot physicalSlot = physicalSlots.iterator().next();
+
+		slotPool.releaseSlot(physicalSlot.getAllocationId(), new FlinkException("Test failure"));
+
+		final AllocationID freedSlot = Iterables.getOnlyElement(freeSlotConsumer.drainFreedSlots());
+
+		assertThat(freedSlot, is(physicalSlot.getAllocationId()));
+	}
+
+	@Test
+	public void testReturnIdleSlotsAfterTimeout() {
+		final Time idleSlotTimeout = Time.seconds(10);
+		final long offerTime = 0;
+		final DefaultDeclarativeSlotPool slotPool = DefaultDeclarativeSlotPoolBuilder.builder()
+			.setIdleSlotTimeout(idleSlotTimeout)
+			.build();
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+		final FreeSlotConsumer freeSlotConsumer = new FreeSlotConsumer();
+		final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setFreeSlotFunction(freeSlotConsumer)
+			.createTestingTaskExecutorGateway();
+
+		final Collection<SlotOffer> acceptedSlots = increaseRequirementsAndOfferSlotsToSlotPool(
+			slotPool,
+			resourceRequirements,
+			new LocalTaskManagerLocation(),
+			testingTaskExecutorGateway);
+
+		// decrease the resource requirements so that slots are no longer needed
+		slotPool.decreaseResourceRequirementsBy(resourceRequirements);
+
+		slotPool.releaseIdleSlots(offerTime + idleSlotTimeout.toMilliseconds());
+
+		final Collection<AllocationID> freedSlots = freeSlotConsumer.drainFreedSlots();
+
+		assertThat(acceptedSlots, is(not(empty())));
+		assertThat(freedSlots, containsInAnyOrder(acceptedSlots.stream().map(SlotOffer::getAllocationId).toArray()));
+		assertNoAvailableAndRequiredResources(slotPool);
+	}
+
+	private void assertNoAvailableAndRequiredResources(DefaultDeclarativeSlotPool slotPool) {
+		assertTrue(slotPool.getFulfilledResourceRequirements().isEmpty());
+		assertTrue(slotPool.getResourceRequirements().isEmpty());
+		assertThat(slotPool.getAllSlotsInformation(), is(empty()));
+	}
+
+	@Test
+	public void testOnlyReturnExcessIdleSlots() {
+		final Time idleSlotTimeout = Time.seconds(10);
+		final long offerTime = 0;
+		final DefaultDeclarativeSlotPool slotPool = DefaultDeclarativeSlotPoolBuilder.builder()
+			.setIdleSlotTimeout(idleSlotTimeout)
+			.build();
+
+		final ResourceCounter resourceRequirements = createResourceRequirements();
+		final Collection<SlotOffer> slotOffers = createSlotOffersForResourceRequirements(resourceRequirements);
+
+		slotPool.increaseResourceRequirementsBy(resourceRequirements);
+		final Collection<SlotOffer> acceptedSlots = offerSlots(slotPool, slotOffers);
+
+		final ResourceCounter requiredResources = ResourceCounter.withResource(RESOURCE_PROFILE_1, 1);
+		final ResourceCounter excessRequirements = resourceRequirements.subtract(requiredResources);
+		slotPool.decreaseResourceRequirementsBy(excessRequirements);
+
+		slotPool.releaseIdleSlots(offerTime + idleSlotTimeout.toMilliseconds());
+
+		assertThat(acceptedSlots, is(not(empty())));
+		assertThat(slotPool.getFulfilledResourceRequirements(), is(requiredResources));
+	}
+
+	@Test
+	public void testFreedSlotWillBeUsedToFulfillOutstandingResourceRequirements() throws InterruptedException {
+		final NewSlotsService notifyNewSlots = new NewSlotsService();
+		final DefaultDeclarativeSlotPool slotPool = createDefaultDeclarativeSlotPool(notifyNewSlots);
+
+		final ResourceCounter initialRequirements = ResourceCounter.withResource(RESOURCE_PROFILE_1, 1);
+
+		increaseRequirementsAndOfferSlotsToSlotPool(slotPool, initialRequirements, null);
+
+		final Collection<PhysicalSlot> newSlots = drainNewSlotService(notifyNewSlots);
+		final PhysicalSlot newSlot = Iterables.getOnlyElement(newSlots);
+
+		slotPool.reserveFreeSlot(newSlot.getAllocationId(), RESOURCE_PROFILE_1);
+		slotPool.freeReservedSlot(newSlot.getAllocationId(), null, 0);
+
+		final Collection<PhysicalSlot> recycledSlots = drainNewSlotService(notifyNewSlots);
+
+		assertThat(Iterables.getOnlyElement(recycledSlots), sameInstance(newSlot));
+
+		final Collection<SlotOffer> newSlotOffers = createSlotOffersForResourceRequirements(initialRequirements);
+
+		// the pending requirement should be fulfilled by the freed slot --> rejecting new slot offers
+		final Collection<SlotOffer> acceptedSlots = slotPool.offerSlots(newSlotOffers, new LocalTaskManagerLocation(), createTaskManagerGateway(null), 0);
+
+		assertThat(acceptedSlots, is(empty()));
+		assertTrue(slotPool.calculateUnfulfilledResources().isEmpty());
+	}
+
+	@Test
+	public void testReserveFreeSlotForResourceUpdatesAvailableResourcesAndRequirements() {
+		final DefaultDeclarativeSlotPool slotPool = new DefaultDeclarativeSlotPoolBuilder().build();
+
+		final ResourceProfile largeResourceProfile = ResourceProfile.newBuilder().setManagedMemoryMB(1024).build();
+		final ResourceProfile smallResourceProfile = ResourceProfile.newBuilder().setManagedMemoryMB(512).build();
+
+		slotPool.increaseResourceRequirementsBy(ResourceCounter.withResource(largeResourceProfile, 1));
+		offerSlots(slotPool, createSlotOffersForResourceRequirements(ResourceCounter.withResource(largeResourceProfile, 1)));
+		slotPool.increaseResourceRequirementsBy(ResourceCounter.withResource(smallResourceProfile, 1));
+
+		final SlotInfoWithUtilization largeSlot = slotPool.getFreeSlotsInformation().stream().filter(slot -> slot.getResourceProfile().equals(largeResourceProfile)).findFirst().get();
+
+		slotPool.reserveFreeSlot(largeSlot.getAllocationId(), smallResourceProfile);
+
+		ResourceCounter availableResources = slotPool.getFulfilledResourceRequirements();
+		assertThat(availableResources.getResourceCount(smallResourceProfile), is(1));
+		assertThat(availableResources.getResourceCount(largeResourceProfile), is(0));
+
+		Collection<ResourceRequirement> currentResourceRequirements = slotPool.getResourceRequirements();
+		// since we used one of the large slots for fulfilling another profile, we now need another large slot for fulfill the original requirement
+		// conversely we no longer need the small slot, because we are now using another slot for it
+		assertThat(currentResourceRequirements, hasItems(ResourceRequirement.create(largeResourceProfile, 2)));
+	}
+
+	@Nonnull
+	private static ResourceCounter createResourceRequirements() {
+		final Map<ResourceProfile, Integer> requirements = new HashMap<>();
+		requirements.put(RESOURCE_PROFILE_1, 2);
+		requirements.put(RESOURCE_PROFILE_2, 1);
+
+		return ResourceCounter.withResources(requirements);
+	}
+
+	@Nonnull
+	private static Collection<SlotOffer> createSlotOffersForResourceRequirements(ResourceCounter resourceRequirements) {
+		Collection<SlotOffer> slotOffers = new ArrayList<>();
+		int slotIndex = 0;
+
+		for (Map.Entry<ResourceProfile, Integer> resourceWithCount : resourceRequirements.getResourcesWithCount()) {
+			for (int i = 0; i < resourceWithCount.getValue(); i++) {
+				ResourceProfile slotProfile = resourceWithCount.getKey();
+				slotOffers.add(new SlotOffer(new AllocationID(), slotIndex++, slotProfile == ResourceProfile.UNKNOWN ? ResourceProfile.ANY : slotProfile));
+			}
+		}
+		return slotOffers;
+	}
+
+	@Nonnull
+	private static Collection<ResourceRequirement> toResourceRequirements(ResourceCounter resourceCounter) {
+		return resourceCounter.getResourcesWithCount().stream()
+			.map(resourceCount -> ResourceRequirement.create(resourceCount.getKey(), resourceCount.getValue()))
+			.collect(Collectors.toList());
+	}
+
+	@Nonnull
+	private static DefaultDeclarativeSlotPool createDefaultDeclarativeSlotPool(NewResourceRequirementsService requirementsListener) {
+		return DefaultDeclarativeSlotPoolBuilder.builder()
+			.setNotifyNewResourceRequirements(requirementsListener)
+			.build();
+	}
+
+	@Nonnull
+	private static DefaultDeclarativeSlotPool createDefaultDeclarativeSlotPool(NewSlotsService newSlotsListener) {
+		return DefaultDeclarativeSlotPoolBuilder.builder()
+			.setNotifyNewSlots(newSlotsListener)
+			.build();
+	}
+
+	@Nonnull
+	private static Collection<SlotOffer> offerSlots(DeclarativeSlotPool slotPool, Collection<SlotOffer> slotOffers) {
+		return slotPool.offerSlots(slotOffers, new LocalTaskManagerLocation(), createTaskManagerGateway(null), 0);
+	}
+
+	@Nonnull
+	private static Collection<SlotOffer> increaseRequirementsAndOfferSlotsToSlotPool(DefaultDeclarativeSlotPool slotPool, ResourceCounter resourceRequirements, @Nullable LocalTaskManagerLocation taskManagerLocation) {
+		return increaseRequirementsAndOfferSlotsToSlotPool(slotPool, resourceRequirements, taskManagerLocation, null);
+	}
+
+	@Nonnull
+	private static Collection<SlotOffer> increaseRequirementsAndOfferSlotsToSlotPool(DefaultDeclarativeSlotPool slotPool, ResourceCounter resourceRequirements, @Nullable LocalTaskManagerLocation taskManagerLocation, @Nullable TaskExecutorGateway taskExecutorGateway) {
+		final Collection<SlotOffer> slotOffers = createSlotOffersForResourceRequirements(resourceRequirements);
+
+		slotPool.increaseResourceRequirementsBy(resourceRequirements);
+
+		return slotPool.offerSlots(slotOffers, taskManagerLocation == null ? new LocalTaskManagerLocation() : taskManagerLocation, createTaskManagerGateway(taskExecutorGateway), 0);
+	}
+
+	@Nonnull
+	private static Collection<PhysicalSlot> drainNewSlotService(NewSlotsService notifyNewSlots) throws InterruptedException {
+		final Collection<PhysicalSlot> newSlots = new ArrayList<>();
+
+		while (notifyNewSlots.hasNextNewSlots()) {
+			newSlots.addAll(notifyNewSlots.takeNewSlots());
+		}
+		return newSlots;
+	}
+
+	private static TypeSafeMatcher<PhysicalSlot> matchesSlotOffer(SlotOffer slotOffer) {
+		return new PhysicalSlotSlotOfferMatcher(slotOffer);
+	}
+
+	private static TaskManagerGateway createTaskManagerGateway(@Nullable TaskExecutorGateway taskExecutorGateway) {
+		return new RpcTaskManagerGateway(
+			taskExecutorGateway == null ? new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway() : taskExecutorGateway,
+			JobMasterId.generate());
+	}
+
+	private static final class NewResourceRequirementsService implements Consumer<Collection<ResourceRequirement>> {
+
+		private final BlockingQueue<Collection<ResourceRequirement>> resourceRequirementsQueue = new ArrayBlockingQueue<>(2);
+
+		@Override
+		public void accept(Collection<ResourceRequirement> resourceRequirements) {
+			resourceRequirementsQueue.offer(resourceRequirements);
+		}
+
+		private Collection<ResourceRequirement> takeResourceRequirements() throws InterruptedException {
+			return resourceRequirementsQueue.take();
+		}
+
+		public boolean hasNextResourceRequirements() {
+			return !resourceRequirementsQueue.isEmpty();
+		}
+	}
+
+	private static final class NewSlotsService implements Consumer<Collection<? extends PhysicalSlot>> {
+
+		private final BlockingQueue<Collection<? extends PhysicalSlot>> physicalSlotsQueue = new ArrayBlockingQueue<>(2);
+
+		@Override
+		public void accept(Collection<? extends PhysicalSlot> physicalSlots) {
+			physicalSlotsQueue.offer(physicalSlots);
+		}
+
+		private Collection<? extends PhysicalSlot> takeNewSlots() throws InterruptedException {
+			return physicalSlotsQueue.take();
+		}
+
+		private boolean hasNextNewSlots() {
+			return !physicalSlotsQueue.isEmpty();
+		}
+	}
+
+	private static class PhysicalSlotSlotOfferMatcher extends TypeSafeMatcher<PhysicalSlot> {
+		private final SlotOffer slotOffer;
+
+		public PhysicalSlotSlotOfferMatcher(SlotOffer slotOffer) {
+			this.slotOffer = slotOffer;
+		}
+
+		@Override
+		protected boolean matchesSafely(PhysicalSlot item) {
+			return item.getAllocationId().equals(slotOffer.getAllocationId()) &&
+				item.getResourceProfile().equals(slotOffer.getResourceProfile()) &&
+				item.getPhysicalSlotNumber() == slotOffer.getSlotIndex();
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("SlotOffer: ");
+			description.appendValueList("{", ",", "}",
+				slotOffer.getAllocationId(),
+				slotOffer.getResourceProfile(),
+				slotOffer.getSlotIndex());
+		}
+	}
+
+	private static class FreeSlotConsumer implements BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> {
+
+		final BlockingQueue<AllocationID> freedSlots = new ArrayBlockingQueue<>(10);
+
+		@Override
+		public CompletableFuture<Acknowledge> apply(AllocationID allocationID, Throwable throwable) {
+			freedSlots.offer(allocationID);
+			return CompletableFuture.completedFuture(Acknowledge.get());
+		}
+
+		private Collection<AllocationID> drainFreedSlots() {
+			final Collection<AllocationID> result = new ArrayList<>();
+
+			freedSlots.drainTo(result);
+
+			return result;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounterTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link ResourceCounter}.
+ */
+public class ResourceCounterTest extends TestLogger {
+
+	private ResourceProfile resourceProfile1 = ResourceProfile.newBuilder().setManagedMemoryMB(42).build();
+	private ResourceProfile resourceProfile2 = ResourceProfile.newBuilder().setCpuCores(1.7).build();
+
+	@Test
+	public void testIsEmpty() {
+		final ResourceCounter empty = ResourceCounter.empty();
+
+		assertTrue(empty.isEmpty());
+	}
+
+	@Test
+	public void testIsNonEmpty() {
+		final ResourceCounter resourceCounter = ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1);
+
+		assertFalse(resourceCounter.isEmpty());
+		assertTrue(resourceCounter.containsResource(ResourceProfile.UNKNOWN));
+	}
+
+	@Test
+	public void testGetResourceCount() {
+		final Map<ResourceProfile, Integer> resources = createResources();
+
+		final ResourceCounter resourceCounter = ResourceCounter.withResources(resources);
+
+		for (Map.Entry<ResourceProfile, Integer> resource : resources.entrySet()) {
+			assertThat(resourceCounter.getResourceCount(resource.getKey()), is(resource.getValue()));
+		}
+	}
+
+	@Test
+	public void testGetResourceCountReturnsZeroForUnknownResourceProfile() {
+		final ResourceCounter resourceCounter = ResourceCounter.withResources(createResources());
+
+		assertThat(resourceCounter.getResourceCount(ResourceProfile.newBuilder().build()), is(0));
+	}
+
+	@Test
+	public void testGetResources() {
+		final Map<ResourceProfile, Integer> resources = createResources();
+		final ResourceCounter resourceCounter = ResourceCounter.withResources(resources);
+
+		assertThat(resourceCounter.getResources(), Matchers.containsInAnyOrder(resources.keySet().toArray()));
+	}
+
+	@Test
+	public void testGetResourceWithCount() {
+		final Map<ResourceProfile, Integer> resources = createResources();
+		final ResourceCounter resourceCounter = ResourceCounter.withResources(resources);
+
+		assertThat(resourceCounter.getResourcesWithCount(), Matchers.containsInAnyOrder(resources.entrySet().toArray()));
+	}
+
+	@Test
+	public void testAddSameResourceProfile() {
+		final int value1 = 1;
+		final int value2 = 42;
+
+		final ResourceCounter resourceCounter1 = ResourceCounter.withResource(ResourceProfile.UNKNOWN, value1);
+		final ResourceCounter resourceCounter2 = ResourceCounter.withResource(ResourceProfile.UNKNOWN, value2);
+
+		final ResourceCounter result = resourceCounter1.add(resourceCounter2);
+
+		assertThat(resourceCounter1.getResourcesWithCount(), Matchers.containsInAnyOrder(Collections.singletonMap(ResourceProfile.UNKNOWN, value1).entrySet().toArray()));
+		assertThat(resourceCounter2.getResourcesWithCount(), Matchers.containsInAnyOrder(Collections.singletonMap(ResourceProfile.UNKNOWN, value2).entrySet().toArray()));
+
+		assertThat(result.getResourcesWithCount(), Matchers.containsInAnyOrder(Collections.singletonMap(ResourceProfile.UNKNOWN, value1 + value2).entrySet().toArray()));
+	}
+
+	@Test
+	public void testAddDifferentResourceProfile() {
+		final ResourceCounter resourceCounter1 = ResourceCounter.withResource(resourceProfile1, 1);
+		final ResourceCounter resourceCounter2 = ResourceCounter.withResource(resourceProfile2, 1);
+
+		final ResourceCounter result = resourceCounter1.add(resourceCounter2);
+
+		final Collection<Map.Entry<ResourceProfile, Integer>> expectedResult = new ArrayList<>(resourceCounter1.getResourcesWithCount());
+		expectedResult.addAll(resourceCounter2.getResourcesWithCount());
+
+		assertThat(result.getResourcesWithCount(), Matchers.containsInAnyOrder(expectedResult.toArray()));
+	}
+
+	@Test
+	public void testCountEqualToZeroRemovesResource() {
+		final ResourceCounter resourceCounter = ResourceCounter.withResource(resourceProfile1, 2);
+
+		final ResourceCounter result = resourceCounter.subtract(resourceProfile1, 2);
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void testCountBelowZeroRemovesResources() {
+		final ResourceCounter resourceCounter = ResourceCounter.withResource(resourceProfile1, 1);
+
+		final ResourceCounter result = resourceCounter.subtract(resourceProfile1, 2);
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void testSubtractSameResourceProfile() {
+		final int value1 = 5;
+		final int value2 = 3;
+
+		final ResourceCounter resourceCounter1 = ResourceCounter.withResource(ResourceProfile.UNKNOWN, value1);
+		final ResourceCounter resourceCounter2 = ResourceCounter.withResource(ResourceProfile.UNKNOWN, value2);
+
+		final ResourceCounter result = resourceCounter1.subtract(resourceCounter2);
+
+		assertThat(resourceCounter1.getResourcesWithCount(), Matchers.containsInAnyOrder(Collections.singletonMap(ResourceProfile.UNKNOWN, value1).entrySet().toArray()));
+		assertThat(resourceCounter2.getResourcesWithCount(), Matchers.containsInAnyOrder(Collections.singletonMap(ResourceProfile.UNKNOWN, value2).entrySet().toArray()));
+
+		assertThat(result.getResourcesWithCount(), Matchers.containsInAnyOrder(Collections.singletonMap(ResourceProfile.UNKNOWN, value1 - value2).entrySet().toArray()));
+	}
+
+	@Test
+	public void testSubtractDifferentResourceProfile() {
+		final ResourceCounter resourceCounter1 = ResourceCounter.withResource(resourceProfile1, 1);
+		final ResourceCounter resourceCounter2 = ResourceCounter.withResource(resourceProfile2, 1);
+
+		final ResourceCounter result = resourceCounter1.subtract(resourceCounter2);
+
+		assertThat(result.getResourcesWithCount(), Matchers.containsInAnyOrder(resourceCounter1.getResourcesWithCount().toArray()));
+	}
+
+	private Map<ResourceProfile, Integer> createResources() {
+		return ImmutableMap.of(
+			resourceProfile1, 2,
+			resourceProfile2, 3);
+	}
+}


### PR DESCRIPTION
Adds the DeclarativeSlotPool, a slot pool supporting declarative resource management.

This pool will for the time being not be used directly, as this will require proper integration into the scheduler. Instead, a wrapper will be added in FLINK-19314 that bridges the existing SlotRequest-based protocol to the declarative one.

### DeclarativeSlotPool

This pool no longer accepts slot requests but only in-/decrements to the requirements, which it accumulators, with the resulting total requirements being announced to the ResourceManager through a listener interface.

Slots that are offered by TaskExecutors are matched against these requirements; any slot not matching any requirement will be rejected.

The Scheduler then can make use of these slots by iterating over the free slots returned by the pool and reserving them.

The slot will remain reserved until it is either
a) freed by the Scheduler, in which case it will remain in the pool for future use
b) explicitly released, usually due to a failed allocated or TaskExecutor shutting down.

Freed slots remain in the pool so long as they correspond to a requirement; a slot that has been free for the idleTimeout and is required will be released. This action is periodically triggered from the outside.


As mentioned above, when slots are offered to the SlotPool they are matched against the declared requirements to figure out whether we actually need the slot.
However, this mapping between slots and the fulfilled requirement is mostly theoretical; the scheduler is free to use a slot to fulfill another requirement, e.g., because the locality of the slot makes it a desirable choice, despite potentially wasting resources.
To prevent deadlocks where the scheduler reserves slots in such a way that the requirements could no longer be fulfilled, the SlotPool automatically adjusts the requirements.
As an example, assume we have 2 types of resource profiles (small/large), where the large one can also be used for the small profile.
The job requires 1 of each, the slot pool is offered one of each, and it does a perfect match between the offered slots and requirements:
```
Requirements:
large: 1
small: 1

Mapping:
largeSlot <-> largeRequirement
smallSlot <-> smallRequirement
```

The scheduler may now decide to use the large slot to fulfill the small requirement. Without any further action, the job would not able to run since it is missing a large slot.
We prevent this by adjusting the requirements such that we need 1 more large slot (since we used up the other one) and one less small slot (since we fulfilled this requirement with the large one). The currently allocated small slot is hence no longer needed, and could be released:

```
Requirements:
large: 2
small: 0

Mapping:
largeSlot <-> smallRequirement
```

Once the second large slot is allocated and offered to the pool it will be matched against the outstanding large requirement, and the slot can start running.

### ResourceCounter

The ResourceCounter is an immutable version of the existing `org.apache.flink.runtime.slots.ResourceCounter`, it being immutable due to being exposed at various points in the API.

### AutoRequirementDecrementingSlotPoolWrapper

The current resource allocation protocol will be bridged to the declarative one by mapping SlotRequests to requirement increases, and slot freeing/releases to requirement reductions.
The increments will be done explicitly in the wrapper that we'll introduce in FLINK-19314, whereas the reductions will be handled in the `AutoRequirementDecrementingSlotPoolWrapper`.

