### PR TITLE
[FlINK-19688][network] Don't cache InterruptedExceptions in PartitionRequestClientFactory

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NeverCompletingChannelFuture.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NeverCompletingChannelFuture.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
+import org.apache.flink.shaded.netty4.io.netty.util.concurrent.Future;
+import org.apache.flink.shaded.netty4.io.netty.util.concurrent.GenericFutureListener;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@SuppressWarnings({"InfiniteLoopStatement", "BusyWait"})
+class NeverCompletingChannelFuture implements ChannelFuture {
+
+	@Override
+	public Channel channel() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isSuccess() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isCancellable() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Throwable cause() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture addListener(GenericFutureListener<? extends Future<? super Void>> genericFutureListener) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture addListeners(GenericFutureListener<? extends Future<? super Void>>... genericFutureListeners) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture removeListener(GenericFutureListener<? extends Future<? super Void>> genericFutureListener) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture removeListeners(GenericFutureListener<? extends Future<? super Void>>... genericFutureListeners) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture sync() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture syncUninterruptibly() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture await() throws InterruptedException {
+		while (true) {
+			Thread.sleep(50);
+		}
+	}
+
+	@Override
+	public ChannelFuture awaitUninterruptibly() {
+		while (true) {
+			try {
+				Thread.sleep(50);
+			} catch (InterruptedException e) {
+				// ignore
+			}
+		}
+	}
+
+	@Override
+	public boolean await(long l, TimeUnit timeUnit) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean await(long l) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean awaitUninterruptibly(long l, TimeUnit timeUnit) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean awaitUninterruptibly(long l) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Void getNow() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean cancel(boolean b) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isCancelled() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isDone() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Void get() throws InterruptedException, ExecutionException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isVoid() {
+		throw new UnsupportedOperationException();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This is a fix for the following case(s):
1. clientA requests a connection
2. clientB  requests the same connection and waits on the same future
3. clientA is interrupted; `PartitionRequestClientFactory` caches the `InterruptedException`
4. clientB as well as all subsequent clients get cached `InterruptedException`

## Verifying this change

Added `PartitionRequestClientFactoryTest.testInterruptsNotCached`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
