### PR TITLE
[FLINK-19581][orc] Introduce Orc ColumnarRow File source bulk Format

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/AbstractOrcFileInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/AbstractOrcFileInputFormat.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.orc.shim.OrcShim;
+import org.apache.flink.orc.util.SerializableHadoopConfigWrapper;
+import org.apache.flink.orc.vector.OrcVectorizedBatchWrapper;
+
+import org.apache.orc.RecordReader;
+import org.apache.orc.TypeDescription;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The base for ORC readers for the {@link org.apache.flink.connector.file.src.FileSource}.
+ * Implements the reader initialization, vectorized reading, and pooling of column vector objects.
+ *
+ * <p>Subclasses implement the conversion to the specific result record(s) that they return by creating
+ * via extending {@link AbstractOrcFileInputFormat.OrcReaderBatch}.
+ *
+ * @param <T> The type of records produced by this reader format.
+ */
+public abstract class AbstractOrcFileInputFormat<T, BatchT, SplitT extends FileSourceSplit>
+		implements BulkFormat<T, SplitT> {
+
+	private static final long serialVersionUID = 1L;
+
+	protected final OrcShim<BatchT> shim;
+
+	protected final SerializableHadoopConfigWrapper hadoopConfigWrapper;
+
+	protected final TypeDescription schema;
+
+	protected final int[] selectedFields;
+
+	protected final List<OrcFilters.Predicate> conjunctPredicates;
+
+	protected final int batchSize;
+
+	/**
+	 * @param shim the shim for various Orc dependent versions. If you use the latest version,
+	 *             please use {@link OrcShim#defaultShim()} directly.
+	 * @param hadoopConfig the hadoop config for orc reader.
+	 * @param schema the full schema of orc format.
+	 * @param selectedFields the read selected field of orc format.
+	 * @param conjunctPredicates the filter predicates that can be evaluated.
+	 * @param batchSize the batch size of orc reader.
+	 */
+	protected AbstractOrcFileInputFormat(
+			final OrcShim<BatchT> shim,
+			final org.apache.hadoop.conf.Configuration hadoopConfig,
+			final TypeDescription schema,
+			final int[] selectedFields,
+			final List<OrcFilters.Predicate> conjunctPredicates,
+			final int batchSize) {
+
+		this.shim = shim;
+		this.hadoopConfigWrapper = new SerializableHadoopConfigWrapper(checkNotNull(hadoopConfig));
+		this.schema = checkNotNull(schema);
+		this.selectedFields = checkNotNull(selectedFields);
+		this.conjunctPredicates = checkNotNull(conjunctPredicates);
+		this.batchSize = batchSize;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public OrcVectorizedReader<T, BatchT> createReader(
+			final Configuration config,
+			final SplitT split) throws IOException {
+
+		final int numBatchesToCirculate = config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
+		final Pool<OrcReaderBatch<T, BatchT>> poolOfBatches = createPoolOfBatches(split, numBatchesToCirculate);
+
+		final RecordReader orcReader = shim.createRecordReader(
+				hadoopConfigWrapper.getHadoopConfig(),
+				schema,
+				selectedFields,
+				conjunctPredicates,
+				split.path(), split.offset(), split.length());
+
+		return new OrcVectorizedReader<>(shim, orcReader, poolOfBatches);
+	}
+
+	@Override
+	public OrcVectorizedReader<T, BatchT> restoreReader(
+			final Configuration config,
+			final SplitT split) throws IOException {
+		assert split.getReaderPosition().isPresent();
+		final OrcVectorizedReader<T, BatchT> reader = createReader(config, split);
+		reader.seek(split.getReaderPosition().get());
+		return reader;
+	}
+
+	@Override
+	public boolean isSplittable() {
+		return true;
+	}
+
+	/**
+	 * Creates the {@link OrcReaderBatch} structure, which is responsible for holding the data structures
+	 * that hold the batch data (column vectors, row arrays, ...) and the batch conversion from the
+	 * ORC representation to the result format.
+	 */
+	public abstract OrcReaderBatch<T, BatchT> createReaderBatch(
+			SplitT split,
+			OrcVectorizedBatchWrapper<BatchT> orcBatch,
+			Pool.Recycler<OrcReaderBatch<T, BatchT>> recycler,
+			int batchSize);
+
+	/**
+	 * Gets the type produced by this format.
+	 */
+	@Override
+	public abstract TypeInformation<T> getProducedType();
+
+	// ------------------------------------------------------------------------
+
+	private Pool<OrcReaderBatch<T, BatchT>> createPoolOfBatches(final SplitT split, final int numBatches) {
+		final Pool<OrcReaderBatch<T, BatchT>> pool = new Pool<>(numBatches);
+
+		for (int i = 0; i < numBatches; i++) {
+			final OrcVectorizedBatchWrapper<BatchT> orcBatch = shim.createBatchWrapper(schema, batchSize);
+			final OrcReaderBatch<T, BatchT> batch = createReaderBatch(split, orcBatch, pool.recycler(), batchSize);
+			pool.add(batch);
+		}
+
+		return pool;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The {@code OrcReaderBatch} class holds the data structures containing the batch data
+	 * (column vectors, row arrays, ...) and performs the batch conversion from the ORC
+	 * representation to the result format.
+	 *
+	 * <p>This base class only holds the ORC Column Vectors, subclasses hold additionally the result
+	 * structures and implement the conversion in
+	 * {@link OrcReaderBatch#convertAndGetIterator(OrcVectorizedBatchWrapper, long)}.
+	 */
+	protected abstract static class OrcReaderBatch<T, BatchT> {
+
+		private final OrcVectorizedBatchWrapper<BatchT> orcVectorizedRowBatch;
+		private final Pool.Recycler<OrcReaderBatch<T, BatchT>> recycler;
+
+		protected OrcReaderBatch(
+				final OrcVectorizedBatchWrapper<BatchT> orcVectorizedRowBatch,
+				final Pool.Recycler<OrcReaderBatch<T, BatchT>> recycler) {
+			this.orcVectorizedRowBatch = checkNotNull(orcVectorizedRowBatch);
+			this.recycler = checkNotNull(recycler);
+		}
+
+		/**
+		 * Puts this batch back into the pool. This should be called after all records from the
+		 * batch have been returned, typically in the {@link RecordIterator#releaseBatch()} method.
+		 */
+		public void recycle() {
+			recycler.recycle(this);
+		}
+
+		/**
+		 * Gets the ORC VectorizedRowBatch structure from this batch.
+		 */
+		public OrcVectorizedBatchWrapper<BatchT> orcVectorizedRowBatch() {
+			return orcVectorizedRowBatch;
+		}
+
+		/**
+		 * Converts the ORC VectorizedRowBatch into the result structure and returns an iterator
+		 * over the entries.
+		 *
+		 * <p>This method may, for example, return a single element iterator that returns the entire
+		 * batch as one, or (as another example) return an iterator over the rows projected from this
+		 * column batch.
+		 *
+		 * <p>The position information in the result needs to be constructed as follows: The
+		 * value of {@code startingOffset} is the offset value ({@link RecordAndPosition#getOffset()})
+		 * for all rows in the batch. Each row then increments the records-to-skip value
+		 * ({@link RecordAndPosition#getRecordSkipCount()}).
+		 */
+		public abstract RecordIterator<T> convertAndGetIterator(
+				final OrcVectorizedBatchWrapper<BatchT> orcVectorizedRowBatch,
+				final long startingOffset) throws IOException;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A vectorized ORC reader. This reader reads an ORC {@link BatchT} at a time and
+	 * converts it to one or more records to be returned. An ORC Row-wise reader would convert the
+	 * batch into a set of rows, while a reader for a vectorized query processor might return
+	 * the whole batch as one record.
+	 *
+	 * <p>The conversion of the {@code VectorizedRowBatch} happens in the specific {@link OrcReaderBatch}
+	 * implementation.
+	 *
+	 * <p>The reader tracks its current position using ORC's <i>row numbers</i>. Each record in a
+	 * batch is addressed by the starting row number of the batch, plus the number of records to
+	 * be skipped before.
+	 *
+	 * @param <T> The type of the records returned by the reader.
+	 */
+	protected static final class OrcVectorizedReader<T, BatchT> implements BulkFormat.Reader<T> {
+
+		private final OrcShim<BatchT> shim;
+		private final RecordReader orcReader;
+		private final Pool<OrcReaderBatch<T, BatchT>> pool;
+		private long recordsToSkip;
+
+		protected OrcVectorizedReader(
+				final OrcShim<BatchT> shim,
+				final RecordReader orcReader,
+				final Pool<OrcReaderBatch<T, BatchT>> pool) {
+
+			this.shim = checkNotNull(shim, "orc shim");
+			this.orcReader = checkNotNull(orcReader, "orcReader");
+			this.pool = checkNotNull(pool, "pool");
+		}
+
+		@Nullable
+		@Override
+		public RecordIterator<T> readBatch() throws IOException {
+			final OrcReaderBatch<T, BatchT> batch = getCachedEntry();
+			final OrcVectorizedBatchWrapper<BatchT> orcVectorBatch = batch.orcVectorizedRowBatch();
+
+			final long orcRowNumber = orcReader.getRowNumber();
+			if (!shim.nextBatch(orcReader, orcVectorBatch.getBatch())) {
+				batch.recycle();
+				return null;
+			}
+
+			final RecordIterator<T> records = batch.convertAndGetIterator(orcVectorBatch, orcRowNumber);
+			if (recordsToSkip > 0) {
+				// this may leave an exhausted iterator, which is a valid result for this method
+				// and is not interpreted as end-of-input or anything
+				skipRecord(records);
+			}
+			return records;
+		}
+
+		@Override
+		public void close() throws IOException {
+			orcReader.close();
+		}
+
+		/**
+		 * The argument of {@link RecordReader#seekToRow(long)} must come from
+		 * {@link RecordReader#getRowNumber()}. The internal implementation of
+		 * ORC is very confusing. It has special behavior when dealing with
+		 * Predicate.
+		 */
+		public void seek(CheckpointedPosition position) throws IOException {
+			orcReader.seekToRow(position.getOffset());
+			recordsToSkip = position.getRecordsAfterOffset();
+		}
+
+		private OrcReaderBatch<T, BatchT> getCachedEntry() throws IOException {
+			try {
+				return pool.pollEntry();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IOException("Interrupted");
+			}
+		}
+
+		private void skipRecord(RecordIterator<T> records) {
+			while (recordsToSkip > 0 && records.next() != null) {
+				recordsToSkip--;
+			}
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcColumnarRowFileInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcColumnarRowFileInputFormat.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.flink.orc.shim.OrcShim;
+import org.apache.flink.orc.vector.ColumnBatchFactory;
+import org.apache.flink.orc.vector.OrcVectorizedBatchWrapper;
+import org.apache.flink.table.data.ColumnarRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.data.vector.VectorizedColumnBatch;
+import org.apache.flink.table.filesystem.ColumnarRowIterator;
+import org.apache.flink.table.filesystem.PartitionFieldExtractor;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.TypeDescription;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.orc.OrcSplitReaderUtil.convertToOrcTypeWithPart;
+import static org.apache.flink.orc.OrcSplitReaderUtil.getNonPartNames;
+import static org.apache.flink.orc.OrcSplitReaderUtil.getSelectedOrcFields;
+import static org.apache.flink.orc.vector.AbstractOrcColumnVector.createFlinkVector;
+import static org.apache.flink.orc.vector.AbstractOrcColumnVector.createFlinkVectorFromConstant;
+
+/**
+ * An ORC reader that produces a stream of {@link ColumnarRowData} records.
+ *
+ * <p>This class can add extra fields through {@link ColumnBatchFactory}, for example,
+ * add partition fields, which can be extracted from path. Therefore, the {@link #getProducedType()}
+ * may be different and types of extra fields need to be added.
+ */
+public class OrcColumnarRowFileInputFormat<BatchT, SplitT extends FileSourceSplit> extends
+		AbstractOrcFileInputFormat<RowData, BatchT, SplitT> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final ColumnBatchFactory<BatchT, SplitT> batchFactory;
+	private final RowType projectedOutputType;
+
+	public OrcColumnarRowFileInputFormat(
+			final OrcShim<BatchT> shim,
+			final Configuration hadoopConfig,
+			final TypeDescription schema,
+			final int[] selectedFields,
+			final List<OrcFilters.Predicate> conjunctPredicates,
+			final int batchSize,
+			final ColumnBatchFactory<BatchT, SplitT> batchFactory,
+			final RowType projectedOutputType) {
+		super(shim, hadoopConfig, schema, selectedFields, conjunctPredicates, batchSize);
+		this.batchFactory = batchFactory;
+		this.projectedOutputType = projectedOutputType;
+	}
+
+	@Override
+	public OrcReaderBatch<RowData, BatchT> createReaderBatch(
+			final SplitT split,
+			final OrcVectorizedBatchWrapper<BatchT> orcBatch,
+			final Pool.Recycler<OrcReaderBatch<RowData, BatchT>> recycler,
+			final int batchSize) {
+
+		final VectorizedColumnBatch flinkColumnBatch = batchFactory.create(split, orcBatch.getBatch());
+		return new VectorizedColumnReaderBatch<>(orcBatch, flinkColumnBatch, recycler);
+	}
+
+	@Override
+	public TypeInformation<RowData> getProducedType() {
+		return InternalTypeInfo.of(projectedOutputType);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * One batch of ORC columnar vectors and Flink column vectors.
+	 */
+	private static final class VectorizedColumnReaderBatch<BatchT> extends OrcReaderBatch<RowData, BatchT> {
+
+		private final VectorizedColumnBatch flinkColumnBatch;
+		private final ColumnarRowIterator result;
+
+		VectorizedColumnReaderBatch(
+				final OrcVectorizedBatchWrapper<BatchT> orcBatch,
+				final VectorizedColumnBatch flinkColumnBatch,
+				final Pool.Recycler<OrcReaderBatch<RowData, BatchT>> recycler) {
+			super(orcBatch, recycler);
+			this.flinkColumnBatch = flinkColumnBatch;
+			this.result = new ColumnarRowIterator(new ColumnarRowData(flinkColumnBatch), this::recycle);
+		}
+
+		@Override
+		public RecordIterator<RowData> convertAndGetIterator(
+				final OrcVectorizedBatchWrapper<BatchT> orcBatch,
+				final long startingOffset) {
+			// no copying from the ORC column vectors to the Flink columns vectors necessary,
+			// because they point to the same data arrays internally design
+			int batchSize = orcBatch.size();
+			flinkColumnBatch.setNumRows(batchSize);
+			result.set(batchSize, startingOffset, 0);
+			return result;
+		}
+	}
+
+	/**
+	 * Create a partitioned {@link OrcColumnarRowFileInputFormat}, the partition columns can be
+	 * generated by split.
+	 */
+	public static <SplitT extends FileSourceSplit> OrcColumnarRowFileInputFormat<VectorizedRowBatch, SplitT> createPartitionedFormat(
+			OrcShim<VectorizedRowBatch> shim,
+			Configuration hadoopConfig,
+			RowType tableType,
+			List<String> partitionKeys,
+			PartitionFieldExtractor<SplitT> extractor,
+			int[] selectedFields,
+			List<OrcFilters.Predicate> conjunctPredicates,
+			int batchSize) {
+		String[] tableFieldNames = tableType.getFieldNames().toArray(new String[0]);
+		LogicalType[] tableFieldTypes = tableType.getChildren().toArray(new LogicalType[0]);
+		List<String> orcFieldNames = getNonPartNames(tableFieldNames, partitionKeys);
+		int[] orcSelectedFields = getSelectedOrcFields(tableFieldNames, selectedFields, orcFieldNames);
+
+		ColumnBatchFactory<VectorizedRowBatch, SplitT> batchGenerator = (SplitT split, VectorizedRowBatch rowBatch) -> {
+			// create and initialize the row batch
+			ColumnVector[] vectors = new ColumnVector[selectedFields.length];
+			for (int i = 0; i < vectors.length; i++) {
+				String name = tableFieldNames[selectedFields[i]];
+				LogicalType type = tableFieldTypes[selectedFields[i]];
+				vectors[i] = partitionKeys.contains(name) ?
+						createFlinkVectorFromConstant(
+								type, extractor.extract(split, name, type), batchSize) :
+						createFlinkVector(rowBatch.cols[orcFieldNames.indexOf(name)], type);
+			}
+			return new VectorizedColumnBatch(vectors);
+		};
+
+		return new OrcColumnarRowFileInputFormat<>(
+				shim,
+				hadoopConfig,
+				convertToOrcTypeWithPart(tableFieldNames, tableFieldTypes, partitionKeys),
+				orcSelectedFields,
+				conjunctPredicates,
+				batchSize,
+				batchGenerator,
+				new RowType(Arrays.stream(selectedFields).mapToObj(i ->
+						tableType.getFields().get(i)).collect(Collectors.toList())));
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileFormatFactory.java
@@ -56,7 +56,7 @@ import java.util.Set;
 /**
  * Orc format factory for file system.
  */
-public class OrcFileSystemFormatFactory implements BulkReaderFormatFactory, BulkWriterFormatFactory {
+public class OrcFileFormatFactory implements BulkReaderFormatFactory, BulkWriterFormatFactory {
 
 	public static final String IDENTIFIER = "orc";
 

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
@@ -52,7 +52,7 @@ import java.util.function.Function;
  */
 public class OrcFilters {
 
-	private static final Logger LOG = LoggerFactory.getLogger(OrcFileSystemFormatFactory.class);
+	private static final Logger LOG = LoggerFactory.getLogger(OrcFilters.class);
 
 	private static final ImmutableMap<FunctionDefinition, Function<CallExpression, Predicate>> FILTERS =
 			new ImmutableMap.Builder<FunctionDefinition, Function<CallExpression, Predicate>>()

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
@@ -107,6 +107,12 @@ public class OrcSplitReaderUtil {
 					.toArray();
 	}
 
+	public static List<String> getNonPartNames(String[] fullFieldNames, Collection<String> partitionKeys) {
+		return Arrays.stream(fullFieldNames)
+				.filter(n -> !partitionKeys.contains(n))
+				.collect(Collectors.toList());
+	}
+
 	public static List<String> getNonPartNames(String[] fullFieldNames,
 			Map<String, Object> partitionSpec) {
 		return Arrays.stream(fullFieldNames)
@@ -118,13 +124,23 @@ public class OrcSplitReaderUtil {
 			String[] fullFieldNames,
 			DataType[] fullFieldTypes,
 			Collection<String> partitionKeys) {
+		return convertToOrcTypeWithPart(
+				fullFieldNames,
+				Arrays.stream(fullFieldTypes).map(DataType::getLogicalType).toArray(LogicalType[]::new),
+				partitionKeys);
+	}
+
+	public static TypeDescription convertToOrcTypeWithPart(
+			String[] fullFieldNames,
+			LogicalType[] fullFieldTypes,
+			Collection<String> partitionKeys) {
 		List<String> fullNameList = Arrays.asList(fullFieldNames);
 		String[] orcNames = fullNameList.stream()
 				.filter(n -> !partitionKeys.contains(n))
 				.toArray(String[]::new);
 		LogicalType[] orcTypes = Arrays.stream(orcNames)
 				.mapToInt(fullNameList::indexOf)
-				.mapToObj(i -> fullFieldTypes[i].getLogicalType())
+				.mapToObj(i -> fullFieldTypes[i])
 				.toArray(LogicalType[]::new);
 		return logicalTypeToOrcType(RowType.of(
 				orcTypes,

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/SerializableHadoopConfigWrapper.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/SerializableHadoopConfigWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.util;
+
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility class to make a {@link Configuration Hadoop Configuration} serializable.
+ */
+public final class SerializableHadoopConfigWrapper implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private transient Configuration hadoopConfig;
+
+	public SerializableHadoopConfigWrapper(Configuration hadoopConfig) {
+		this.hadoopConfig = checkNotNull(hadoopConfig);
+	}
+
+	public Configuration getHadoopConfig() {
+		return hadoopConfig;
+	}
+
+	// ------------------------------------------------------------------------
+
+	private void writeObject(ObjectOutputStream out) throws IOException {
+		out.defaultWriteObject();
+
+		// we write the Hadoop config through a separate serializer to avoid cryptic exceptions when it
+		// corrupts the serialization stream
+		final DataOutputSerializer ser = new DataOutputSerializer(256);
+		hadoopConfig.write(ser);
+		out.writeInt(ser.length());
+		out.write(ser.getSharedBuffer(), 0, ser.length());
+	}
+
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+
+		final byte[] data = new byte[in.readInt()];
+		in.readFully(data);
+		final DataInputDeserializer deser = new DataInputDeserializer(data);
+		this.hadoopConfig = new Configuration();
+
+		try {
+			this.hadoopConfig.readFields(deser);
+		} catch (IOException e) {
+			throw new IOException(
+				"Could not deserialize Hadoop Configuration, the serialized and de-serialized don't match.", e);
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/ColumnBatchFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/ColumnBatchFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.vector;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.table.data.vector.VectorizedColumnBatch;
+
+import java.io.Serializable;
+
+/**
+ * Interface to create {@link VectorizedColumnBatch}.
+ */
+@FunctionalInterface
+public interface ColumnBatchFactory<BatchT, SplitT extends FileSourceSplit> extends Serializable {
+
+	VectorizedColumnBatch create(SplitT splitT, BatchT rowBatch);
+}

--- a/flink-formats/flink-orc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-formats/flink-orc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.orc.OrcFileSystemFormatFactory
+org.apache.flink.orc.OrcFileFormatFactory

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowFileInputFormatTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowFileInputFormatTest.java
@@ -1,0 +1,435 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.connector.file.src.util.Utils;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.orc.OrcFilters.Between;
+import org.apache.flink.orc.OrcFilters.Equals;
+import org.apache.flink.orc.OrcFilters.Or;
+import org.apache.flink.orc.OrcFilters.Predicate;
+import org.apache.flink.orc.shim.OrcShim;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalDataUtils;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.filesystem.PartitionFieldExtractor;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.IOUtils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import static org.apache.flink.table.utils.PartitionPathUtils.generatePartitionPath;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test for {@link OrcColumnarRowFileInputFormat}.
+ */
+public class OrcColumnarRowFileInputFormatTest {
+
+	/**
+	 * Small batch size for test more boundary conditions.
+	 */
+	protected static final int BATCH_SIZE = 9;
+
+	private static final RowType FLAT_FILE_TYPE = RowType.of(
+			new LogicalType[] {
+					DataTypes.INT().getLogicalType(),
+					DataTypes.STRING().getLogicalType(),
+					DataTypes.STRING().getLogicalType(),
+					DataTypes.STRING().getLogicalType(),
+					DataTypes.INT().getLogicalType(),
+					DataTypes.STRING().getLogicalType(),
+					DataTypes.INT().getLogicalType(),
+					DataTypes.INT().getLogicalType(),
+					DataTypes.INT().getLogicalType()},
+			new String[] {
+					"_col0",
+					"_col1",
+					"_col2",
+					"_col3",
+					"_col4",
+					"_col5",
+					"_col6",
+					"_col7",
+					"_col8"});
+
+	private static final RowType DECIMAL_FILE_TYPE = RowType.of(
+			new LogicalType[] {
+				new DecimalType(10, 5)},
+			new String[] {
+					"_col0"});
+
+	private final Path flatFile = copyFileFromResource("test-data-flat.orc");
+
+	private final Path decimalFile = copyFileFromResource("test-data-decimal.orc");
+
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+	@Test
+	public void testReadFileInSplits() throws IOException {
+		OrcColumnarRowFileInputFormat<?, FileSourceSplit> format = createFormat(FLAT_FILE_TYPE, new int[]{0, 1});
+
+		AtomicInteger cnt = new AtomicInteger(0);
+		AtomicLong totalF0 = new AtomicLong(0);
+
+		// read all splits
+		for (FileSourceSplit split : createSplits(flatFile, 4)) {
+			forEach(format, split, row -> {
+				Assert.assertFalse(row.isNullAt(0));
+				Assert.assertFalse(row.isNullAt(1));
+				totalF0.addAndGet(row.getInt(0));
+				Assert.assertNotNull(row.getString(1).toString());
+				cnt.incrementAndGet();
+			});
+		}
+
+		// check that all rows have been read
+		assertEquals(1920800, cnt.get());
+		assertEquals(1844737280400L, totalF0.get());
+	}
+
+	@Test
+	public void testReadFileWithSelectFields() throws IOException {
+		OrcColumnarRowFileInputFormat<?, FileSourceSplit> format = createFormat(FLAT_FILE_TYPE, new int[] {2, 0, 1});
+
+		AtomicInteger cnt = new AtomicInteger(0);
+		AtomicLong totalF0 = new AtomicLong(0);
+
+		// read all splits
+		for (FileSourceSplit split : createSplits(flatFile, 4)) {
+			forEach(format, split, row -> {
+				Assert.assertFalse(row.isNullAt(0));
+				Assert.assertFalse(row.isNullAt(1));
+				Assert.assertFalse(row.isNullAt(2));
+				Assert.assertNotNull(row.getString(0).toString());
+				totalF0.addAndGet(row.getInt(1));
+				Assert.assertNotNull(row.getString(2).toString());
+				cnt.incrementAndGet();
+			});
+		}
+
+		// check that all rows have been read
+		assertEquals(1920800, cnt.get());
+		assertEquals(1844737280400L, totalF0.get());
+	}
+
+	@Test
+	public void testReadDecimalTypeFile() throws IOException {
+		OrcColumnarRowFileInputFormat<?, FileSourceSplit> format = createFormat(DECIMAL_FILE_TYPE, new int[]{0});
+
+		AtomicInteger cnt = new AtomicInteger(0);
+		AtomicInteger nullCount = new AtomicInteger(0);
+
+		// read all splits
+		for (FileSourceSplit split : createSplits(decimalFile, 4)) {
+			forEach(format, split, row -> {
+
+				if (cnt.get() == 0) {
+					// validate first row
+					assertNotNull(row);
+					assertEquals(1, row.getArity());
+					assertEquals(
+							DecimalDataUtils.castFrom(-1000.5d, 10, 5),
+							row.getDecimal(0, 10, 5));
+				} else {
+					if (!row.isNullAt(0)) {
+						assertNotNull(row.getDecimal(0, 10, 5));
+					} else {
+						nullCount.incrementAndGet();
+					}
+				}
+				cnt.incrementAndGet();
+			});
+		}
+
+		assertEquals(6000, cnt.get());
+		assertEquals(2000, nullCount.get());
+	}
+
+	@Test
+	public void testReadFileWithPartitionFields() throws IOException {
+		LinkedHashMap<String, String> partSpec = new LinkedHashMap<>();
+		partSpec.put("f1", "1");
+		partSpec.put("f3", "3");
+		partSpec.put("f5", "f5");
+		partSpec.put("f8", BigDecimal.valueOf(5.333).toString());
+		partSpec.put("f13", "f13");
+
+		final Path flatFile = copyFileFromResource("test-data-flat.orc", partSpec);
+
+		RowType tableType = RowType.of(
+				/* 0 */ DataTypes.INT().getLogicalType(),
+				/* 1 */ DataTypes.INT().getLogicalType(), // part-1
+				/* 2 */ DataTypes.STRING().getLogicalType(),
+				/* 3 */ DataTypes.BIGINT().getLogicalType(), // part-2
+				/* 4 */ DataTypes.STRING().getLogicalType(),
+				/* 5 */ DataTypes.STRING().getLogicalType(), // part-3
+				/* 6 */ DataTypes.STRING().getLogicalType(),
+				/* 7 */ DataTypes.INT().getLogicalType(),
+				/* 8 */ DataTypes.DECIMAL(10, 5).getLogicalType(), // part-4
+				/* 9 */ DataTypes.STRING().getLogicalType(),
+				/* 11*/ DataTypes.INT().getLogicalType(),
+				/* 12*/ DataTypes.INT().getLogicalType(),
+				/* 13*/ DataTypes.STRING().getLogicalType(), // part-5
+				/* 14*/ DataTypes.INT().getLogicalType());
+
+		int[] projectedFields = {8, 1, 3, 0, 5, 2};
+
+		OrcColumnarRowFileInputFormat<?, FileSourceSplit> format = createPartitionFormat(
+				tableType, new ArrayList<>(partSpec.keySet()), projectedFields);
+
+		AtomicInteger cnt = new AtomicInteger(0);
+		AtomicLong totalF0 = new AtomicLong(0);
+
+		// read all splits
+		for (FileSourceSplit split : createSplits(flatFile, 4)) {
+			forEach(format, split, row -> {
+				// data values
+				Assert.assertFalse(row.isNullAt(3));
+				Assert.assertFalse(row.isNullAt(5));
+				totalF0.addAndGet(row.getInt(3));
+				Assert.assertNotNull(row.getString(5).toString());
+
+				// part values
+				Assert.assertFalse(row.isNullAt(0));
+				Assert.assertFalse(row.isNullAt(1));
+				Assert.assertFalse(row.isNullAt(2));
+				Assert.assertFalse(row.isNullAt(4));
+				Assert.assertEquals(DecimalDataUtils.castFrom(5.333, 10, 5), row.getDecimal(0, 10, 5));
+				Assert.assertEquals(1, row.getInt(1));
+				Assert.assertEquals(3, row.getLong(2));
+				Assert.assertEquals("f5", row.getString(4).toString());
+				cnt.incrementAndGet();
+			});
+		}
+
+		// check that all rows have been read
+		assertEquals(1920800, cnt.get());
+		assertEquals(1844737280400L, totalF0.get());
+	}
+
+	@Test
+	public void testReadFileAndRestore() throws IOException {
+		OrcColumnarRowFileInputFormat<?, FileSourceSplit> format = createFormat(FLAT_FILE_TYPE, new int[]{0, 1});
+
+		// pick a middle split
+		FileSourceSplit split = createSplits(flatFile, 3).get(1);
+
+		int expectedCnt = 660000;
+
+		innerTestRestore(format, split, expectedCnt / 2, expectedCnt, 656700330000L);
+	}
+
+	@Test
+	public void testReadFileAndRestoreWithFilter() throws IOException {
+		List<Predicate> filter = Collections.singletonList(new Or(
+					new Between("_col0", PredicateLeaf.Type.LONG, 0L, 975000L),
+					new Equals("_col0", PredicateLeaf.Type.LONG, 980001L),
+					new Between("_col0", PredicateLeaf.Type.LONG, 990000L, 1800000L)));
+		OrcColumnarRowFileInputFormat<?, FileSourceSplit> format = createFormat(
+				FLAT_FILE_TYPE, new int[]{0, 1}, filter);
+
+		// pick a middle split
+		FileSourceSplit split = createSplits(flatFile, 1).get(0);
+
+		int breakCnt = 975001;
+		int expectedCnt = 1795000;
+		long expectedTotalF0 = 1615113397500L;
+
+		innerTestRestore(format, split, breakCnt, expectedCnt, expectedTotalF0);
+	}
+
+	private void innerTestRestore(
+			OrcColumnarRowFileInputFormat<?, FileSourceSplit> format,
+			FileSourceSplit split,
+			int breakCnt,
+			int expectedCnt,
+			long expectedTotalF0) throws IOException {
+		AtomicInteger cnt = new AtomicInteger(0);
+		AtomicLong totalF0 = new AtomicLong(0);
+
+		Consumer<RowData> consumer = row -> {
+			Assert.assertFalse(row.isNullAt(0));
+			Assert.assertFalse(row.isNullAt(1));
+			totalF0.addAndGet(row.getInt(0));
+			assertNotNull(row.getString(1).toString());
+			cnt.incrementAndGet();
+		};
+
+		// ---------- restore reading ---------------
+
+		long offset = -1;
+		long recordSkipCount = -1;
+		try (BulkFormat.Reader<RowData> reader = createReader(format, split)) {
+			while (cnt.get() < breakCnt) {
+				BulkFormat.RecordIterator<RowData> batch = reader.readBatch();
+				Assert.assertNotNull(batch);
+
+				RecordAndPosition<RowData> record;
+				while ((record = batch.next()) != null && cnt.get() < breakCnt) {
+					consumer.accept(record.getRecord());
+					offset = record.getOffset();
+					recordSkipCount = record.getRecordSkipCount();
+				}
+				batch.releaseBatch();
+			}
+		}
+
+		Utils.forEachRemaining(restoreReader(format, split, offset, recordSkipCount), consumer);
+
+		// ---------- end restore reading ---------------
+		// the results should be the same as:
+		// forEach(format, split, consumer);
+
+		// check that all rows have been read
+		assertEquals(expectedCnt, cnt.get());
+		assertEquals(expectedTotalF0, totalF0.get());
+	}
+
+	protected OrcColumnarRowFileInputFormat<?, FileSourceSplit> createFormat(RowType formatType, int[] selectedFields) {
+		return createFormat(formatType, selectedFields, new ArrayList<>());
+	}
+
+	protected OrcColumnarRowFileInputFormat<?, FileSourceSplit> createFormat(
+			RowType formatType,
+			int[] selectedFields,
+			List<Predicate> conjunctPredicates) {
+		return OrcColumnarRowFileInputFormat.createPartitionedFormat(
+				OrcShim.defaultShim(),
+				new Configuration(),
+				formatType,
+				new ArrayList<>(),
+				PartitionFieldExtractor.forFileSystem(""),
+				selectedFields,
+				conjunctPredicates,
+				BATCH_SIZE);
+	}
+
+	protected OrcColumnarRowFileInputFormat<?, FileSourceSplit> createPartitionFormat(
+			RowType tableType,
+			List<String> partitionKeys,
+			int[] selectedFields) {
+		return OrcColumnarRowFileInputFormat.createPartitionedFormat(
+				OrcShim.defaultShim(),
+				new Configuration(),
+				tableType,
+				partitionKeys,
+				PartitionFieldExtractor.forFileSystem(""),
+				selectedFields,
+				new ArrayList<>(),
+				BATCH_SIZE);
+	}
+
+	private BulkFormat.Reader<RowData> createReader(
+			OrcColumnarRowFileInputFormat<?, FileSourceSplit> format,
+			FileSourceSplit split) throws IOException {
+		return format.createReader(new org.apache.flink.configuration.Configuration(), split);
+	}
+
+	private BulkFormat.Reader<RowData> restoreReader(
+			OrcColumnarRowFileInputFormat<?, FileSourceSplit> format,
+			FileSourceSplit split,
+			long offset,
+			long recordSkipCount) throws IOException {
+		FileSourceSplit restoreSplit = split.updateWithCheckpointedPosition(
+				new CheckpointedPosition(offset, recordSkipCount));
+		return format.restoreReader(new org.apache.flink.configuration.Configuration(), restoreSplit);
+	}
+
+	private void forEach(
+			OrcColumnarRowFileInputFormat<?, FileSourceSplit> format,
+			FileSourceSplit split,
+			Consumer<RowData> action) throws IOException {
+		Utils.forEachRemaining(createReader(format, split), action);
+	}
+
+	private Path copyFileFromResource(String fileName) {
+		try {
+			File file = TEMPORARY_FOLDER.newFile();
+			return copyFileFromResource(fileName, file);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Path copyFileFromResource(String fileName, LinkedHashMap<String, String> partSpec) {
+		try {
+			File folder = TEMPORARY_FOLDER.newFolder();
+			folder = new File(folder, generatePartitionPath(partSpec));
+			return copyFileFromResource(fileName, new File(folder, UUID.randomUUID().toString()));
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Path copyFileFromResource(String fileName, File file) {
+		try {
+			file.getParentFile().mkdirs();
+			file.delete();
+			file.createNewFile();
+			IOUtils.copyBytes(
+					getClass().getClassLoader().getResource(fileName).openStream(),
+					new FileOutputStream(file),
+					true);
+			return new Path(file.getPath());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static List<FileSourceSplit> createSplits(Path path, int minNumSplits) throws IOException {
+		List<FileSourceSplit> splits = new ArrayList<>(minNumSplits);
+		long len = path.getFileSystem().getFileStatus(path).getLen();
+		long preferSplitSize = len / minNumSplits + (len % minNumSplits == 0 ? 0 : 1);
+		int splitNum = 0;
+		long position = 0;
+		while (position < len) {
+			long splitLen = Math.min(preferSplitSize, len - position);
+			splits.add(new FileSourceSplit(String.valueOf(splitNum++), path, position, splitLen));
+			position += splitLen;
+		}
+		return splits;
+	}
+}

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 
 /**
- * Unit Tests for {@link OrcFileSystemFormatFactory}.
+ * Unit Tests for {@link OrcFileFormatFactory}.
  */
 public class OrcFileSystemFilterTest {
 

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 /**
- * ITCase for {@link OrcFileSystemFormatFactory}.
+ * ITCase for {@link OrcFileFormatFactory}.
  */
 @RunWith(Parameterized.class)
 public class OrcFileSystemITCase extends BatchFileSystemITCaseBase {

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFsStreamingSinkITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFsStreamingSinkITCase.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Checkpoint ITCase for {@link OrcFileSystemFormatFactory}.
+ * Checkpoint ITCase for {@link OrcFileFormatFactory}.
  */
 public class OrcFsStreamingSinkITCase extends FsStreamingSinkITCaseBase {
 

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -50,7 +50,7 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 /**
  * Parquet format factory for file system.
  */
-public class ParquetFileSystemFormatFactory implements BulkReaderFormatFactory, BulkWriterFormatFactory {
+public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWriterFormatFactory {
 
 	public static final String IDENTIFIER = "parquet";
 

--- a/flink-formats/flink-parquet/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-formats/flink-parquet/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.formats.parquet.ParquetFileSystemFormatFactory
+org.apache.flink.formats.parquet.ParquetFileFormatFactory

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileCompactionITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileCompactionITCase.java
@@ -21,7 +21,7 @@ package org.apache.flink.formats.parquet;
 import org.apache.flink.table.planner.runtime.stream.sql.FileCompactionITCaseBase;
 
 /**
- * Compaction it case for {@link ParquetFileSystemFormatFactory}.
+ * Compaction it case for {@link ParquetFileFormatFactory}.
  */
 public class ParquetFileCompactionITCase extends FileCompactionITCaseBase {
 

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
@@ -39,7 +39,7 @@ import static org.apache.parquet.format.converter.ParquetMetadataConverter.range
 import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
 
 /**
- * ITCase for {@link ParquetFileSystemFormatFactory}.
+ * ITCase for {@link ParquetFileFormatFactory}.
  */
 @RunWith(Parameterized.class)
 public class ParquetFileSystemITCase extends BatchFileSystemITCaseBase {

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFsStreamingSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFsStreamingSinkITCase.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Checkpoint ITCase for {@link ParquetFileSystemFormatFactory}.
+ * Checkpoint ITCase for {@link ParquetFileFormatFactory}.
  */
 public class ParquetFsStreamingSinkITCase extends FsStreamingSinkITCaseBase {
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/ColumnarRowIterator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/ColumnarRowIterator.java
@@ -48,12 +48,19 @@ public class ColumnarRowIterator extends RecyclableIterator<RowData> {
 
 	/**
 	 * @param num number rows in this batch.
-	 * @param rowsReturned The number of rows that have been returned before this batch.
+	 * @param recordSkipCount The number of rows that have been returned before this batch.
 	 */
-	public void set(final int num, final long rowsReturned) {
+	public void set(final int num, final long recordSkipCount) {
+		set(num, CheckpointedPosition.NO_OFFSET, recordSkipCount);
+	}
+
+	/**
+	 * Set number rows in this batch and updates the position.
+	 */
+	public void set(final int num, final long offset, final long recordSkipCount) {
 		this.num = num;
 		this.pos = 0;
-		this.recordAndPosition.set(null, CheckpointedPosition.NO_OFFSET, rowsReturned);
+		this.recordAndPosition.set(null, offset, recordSkipCount);
 	}
 
 	@Nullable


### PR DESCRIPTION

## What is the purpose of the change

Implement File source ORC Vectorized Reader

## Brief change log

The `AbstractOrcFileInputFormat` reference from https://github.com/apache/flink/pull/13401
   - The base for ORC readers, Implements the reader initialization, vectorized reading, and pooling of column vector objects.
      The format of `Row` and `GenericRow` can be implemented based on this class.
   - Use `OrcShim` to do orc related operations.
   - Use both `offset` and `recordsAfterOffset` in `CheckpointedPosition` for better fitting the concept of `RecordReader`. Avoid skipping some of the middle rows when using pushdown filter.

The `OrcColumnarRowFileInputFormat`:
   - This class can add extra fields through `ColumnBatchFactory`, for example, add partition fields.
   - Provides `ColumnarRow` as a view of column batch for high performance.

## Verifying this change

`OrcColumnarRowFileInputFormatTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
