### PR TITLE
[FLINK-19557] Trigger LeaderRetrievalListener notification upon ZooKeeper reconnection in ZooKeeperLeaderRetrievalService

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.leaderretrieval;
 
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
@@ -174,6 +175,7 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 					notifyIfNewLeaderAddress(leaderAddress, leaderSessionID);
 				} catch (Exception e) {
 					leaderListener.handleError(new Exception("Could not handle node changed event.", e));
+					ExceptionUtils.checkInterrupted(e);
 				}
 			} else {
 				LOG.debug("Ignoring node change notification since the service has already been stopped.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -138,7 +138,11 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 	}
 
 	@Override
-	public void nodeChanged() throws Exception {
+	public void nodeChanged() {
+		retrieveLeaderInformationFromZooKeeper();
+	}
+
+	private void retrieveLeaderInformationFromZooKeeper() {
 		synchronized (lock) {
 			if (running) {
 				try {
@@ -170,7 +174,6 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 					notifyIfNewLeaderAddress(leaderAddress, leaderSessionID);
 				} catch (Exception e) {
 					leaderListener.handleError(new Exception("Could not handle node changed event.", e));
-					throw e;
 				}
 			} else {
 				LOG.debug("Ignoring node change notification since the service has already been stopped.");
@@ -192,6 +195,7 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 				break;
 			case RECONNECTED:
 				LOG.info("Connection to ZooKeeper was reconnected. Leader retrieval can be restarted.");
+				onReconnectedConnectionState();
 				break;
 			case LOST:
 				LOG.warn("Connection to ZooKeeper lost. Can no longer retrieve the leader from " +
@@ -201,6 +205,11 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 				}
 				break;
 		}
+	}
+
+	private void onReconnectedConnectionState() {
+		// check whether we find some new leader information in ZooKeeper
+		retrieveLeaderInformationFromZooKeeper();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -69,7 +69,7 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
 	@After
 	public void after() throws Exception {
-		stopTestServer();
+		closeTestServer();
 
 		if (zooKeeperClient != null) {
 			zooKeeperClient.close();
@@ -88,7 +88,7 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 		CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
 		assertThat("No results are expected, yet, since no leader was elected.", firstAddress, is(nullValue()));
 
-		stopTestServer();
+		closeTestServer();
 
 		CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
 		assertThat("No result is expected since there was no leader elected before stopping the server, yet.", secondAddress, is(nullValue()));
@@ -110,16 +110,16 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 		CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
 		assertThat("The first result is expected to be the initially set leader address.", firstAddress.get(), is(leaderAddress));
 
-		stopTestServer();
+		closeTestServer();
 
 		CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
 		assertThat("The next result must not be missing.", secondAddress, is(notNullValue()));
 		assertThat("The next result is expected to be null.", secondAddress.get(), is(nullValue()));
 	}
 
-	private void stopTestServer() throws IOException {
+	private void closeTestServer() throws IOException {
 		if (testingServer != null) {
-			testingServer.stop();
+			testingServer.close();
 			testingServer = null;
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

We have to trigger the LeaderRetrievalListener notification upon reconnecting to ZooKeeper
because the NodeCache might not trigger the nodeChanged call if the server state is the
same as the state cached in the NodeCache. Therefore, we would miss to tell the listener
that the old leader (before the connection loss) is still the valid leader.

## Verifying this change

- Added `ZooKeeperLeaderElectionConnectionHandlingTest.testSameLeaderAfterReconnectTriggersListenerNotification` and `ZooKeeperLeaderElectionConnectionHandlingTest.testNewLeaderAfterReconnectTriggersListenerNotification`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no**)**
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
