### PR TITLE
[FLINK-19657][yarn][tests] Whitelist common error in logs

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -143,7 +143,9 @@ public abstract class YarnTestBase extends TestLogger {
 
 		Pattern.compile("org\\.apache\\.flink.util\\.FlinkException: Stopping JobMaster"),
 		Pattern.compile("org\\.apache\\.flink.util\\.FlinkException: JobManager is shutting down\\."),
-		Pattern.compile("lost the leadership.")
+		Pattern.compile("lost the leadership."),
+
+		Pattern.compile("akka.remote.transport.netty.NettyTransport.*Remote connection to \\[[^]]+\\] failed with java.io.IOException: Broken pipe")
 	};
 
 	// Temp directory which is deleted after the unit test.

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBaseTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBaseTest.java
@@ -32,6 +32,7 @@ public class YarnTestBaseTest {
 	public void ensureWhitelistEntryMatches() {
 		ensureWhitelistEntryMatch("465 java.lang.InterruptedException: sleep interrupted");
 		ensureWhitelistEntryMatch("2020-09-19 22:06:19,458 WARN  akka.remote.ReliableDeliverySupervisor                       [] - Association with remote system [akka.tcp://flink@e466f3e261f3:42352] has failed, address is now gated for [50] ms. Reason: [Association failed with [akka.tcp://flink@e466f3e261f3:42352]] Caused by: [java.net.ConnectException: Connection refused: e466f3e261f3/192.168.224.2:42352]");
+		ensureWhitelistEntryMatch("2020-10-15 10:31:09,661 WARN  akka.remote.transport.netty.NettyTransport                   [] - Remote connection to [61b81e62b514/192.168.128.2:39365] failed with java.io.IOException: Broken pipe");
 	}
 
 	private void ensureWhitelistEntryMatch(String probe) {


### PR DESCRIPTION


## What is the purpose of the change

Whitelist a common error message, which can occur if the JobManager is shutting down faster than the TaskManager on YARN. See FLINK-19657 for a detailed analysis.



