### PR TITLE
[FLINK-19680][checkpointing] Announce timeoutable CheckpointBarriers

### DIFF
--- a/docs/_includes/generated/execution_checkpointing_configuration.html
+++ b/docs/_includes/generated/execution_checkpointing_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>execution.checkpointing.alignment-timeout</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Only relevant if <span markdown="span">`execution.checkpointing.unaligned`</span> is enabled.<br /><br />If timeout is 0, checkpoints will always start unaligned.<br /><br />If timeout has a positive value, checkpoints will start aligned. If during checkpointing, checkpoint start delay exceeds this timeout, alignment will timeout and checkpoint barrier will start working as unaligned checkpoint.</td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.externalized-checkpoint-retention</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p>Possible values: [DELETE_ON_CANCELLATION, RETAIN_ON_CANCELLATION]</td>

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -52,7 +52,8 @@ public final class SnapshotUtils {
 			CheckpointType.SAVEPOINT,
 			AbstractFsCheckpointStorageAccess.encodePathAsReference(savepointPath),
 			isExactlyOnceMode,
-			isUnalignedCheckpoint);
+			isUnalignedCheckpoint,
+			CheckpointOptions.NO_ALIGNMENT_TIME_OUT);
 
 		operator.prepareSnapshotPreBarrier(CHECKPOINT_ID);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -163,6 +163,8 @@ public class CheckpointCoordinator {
 
 	private final boolean unalignedCheckpointsEnabled;
 
+	private final long alignmentTimeout;
+
 	/** Actor that receives status updates from the execution graph this coordinator works for. */
 	private JobStatusListener jobStatusListener;
 
@@ -296,6 +298,7 @@ public class CheckpointCoordinator {
 		this.clock = checkNotNull(clock);
 		this.isExactlyOnceMode = chkConfig.isExactlyOnce();
 		this.unalignedCheckpointsEnabled = chkConfig.isUnalignedCheckpointsEnabled();
+		this.alignmentTimeout = chkConfig.getAlignmentTimeout();
 
 		this.recentPendingCheckpoints = new ArrayDeque<>(NUM_GHOST_CHECKPOINT_IDS);
 		this.masterHooks = new HashMap<>();
@@ -773,11 +776,12 @@ public class CheckpointCoordinator {
 		Execution[] executions,
 		boolean advanceToEndOfTime) {
 
-		final CheckpointOptions checkpointOptions = new CheckpointOptions(
+		final CheckpointOptions checkpointOptions = CheckpointOptions.create(
 			props.getCheckpointType(),
 			checkpointStorageLocation.getLocationReference(),
 			isExactlyOnceMode,
-			props.getCheckpointType() == CheckpointType.CHECKPOINT && unalignedCheckpointsEnabled);
+			unalignedCheckpointsEnabled,
+			alignmentTimeout);
 
 		// send the messages to the tasks that trigger their checkpoint
 		for (Execution execution: executions) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EventAnnouncement.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EventAnnouncement.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.event.RuntimeEvent;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * {@link EventAnnouncement} is announcing presence or receiving of an {@link AbstractEvent}.
+ * That {@link #announcedEvent} is identified by it's sequence number.
+ */
+public class EventAnnouncement extends RuntimeEvent {
+
+	private final AbstractEvent announcedEvent;
+	private final int sequenceNumber;
+
+	public EventAnnouncement(AbstractEvent announcedEvent, int sequenceNumber) {
+		this.announcedEvent = announcedEvent;
+		this.sequenceNumber = sequenceNumber;
+	}
+
+	public AbstractEvent getAnnouncedEvent() {
+		return announcedEvent;
+	}
+
+	public int getSequenceNumber() {
+		return sequenceNumber;
+	}
+
+	// ------------------------------------------------------------------------
+	// Serialization
+	// ------------------------------------------------------------------------
+
+	//
+	//  These methods are inherited form the generic serialization of AbstractEvent
+	//  but would require the CheckpointBarrier to be mutable. Since all serialization
+	//  for events goes through the EventSerializer class, which has special serialization
+	//  for the CheckpointBarrier, we don't need these methods
+	//
+
+	@Override
+	public void write(DataOutputView out) throws IOException {
+		throw new UnsupportedOperationException("This method should never be called");
+	}
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		throw new UnsupportedOperationException("This method should never be called");
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(announcedEvent, sequenceNumber);
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other == this) {
+			return true;
+		}
+		else if (other == null || other.getClass() != EventAnnouncement.class) {
+			return false;
+		}
+		else {
+			EventAnnouncement that = (EventAnnouncement) other;
+			return Objects.equals(this.announcedEvent, that.announcedEvent) &&
+					this.sequenceNumber == that.sequenceNumber;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Announcement of [%s] at %d", announcedEvent, sequenceNumber);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -110,48 +110,6 @@ public class EventSerializer {
 		}
 	}
 
-	/**
-	 * Identifies whether the given buffer encodes the given event. Custom events are not supported.
-	 *
-	 * <p><strong>Pre-condition</strong>: This buffer must encode some event!</p>
-	 *
-	 * @param buffer the buffer to peak into
-	 * @param eventClass the expected class of the event type
-	 * @return whether the event class of the <tt>buffer</tt> matches the given <tt>eventClass</tt>
-	 */
-	private static boolean isEvent(ByteBuffer buffer, Class<?> eventClass) throws IOException {
-		if (buffer.remaining() < 4) {
-			throw new IOException("Incomplete event");
-		}
-
-		final int bufferPos = buffer.position();
-		final ByteOrder bufferOrder = buffer.order();
-		buffer.order(ByteOrder.BIG_ENDIAN);
-
-		try {
-			int type = buffer.getInt();
-
-			if (eventClass.equals(EndOfPartitionEvent.class)) {
-				return type == END_OF_PARTITION_EVENT;
-			} else if (eventClass.equals(CheckpointBarrier.class)) {
-				return type == CHECKPOINT_BARRIER_EVENT;
-			} else if (eventClass.equals(EndOfSuperstepEvent.class)) {
-				return type == END_OF_SUPERSTEP_EVENT;
-			} else if (eventClass.equals(EndOfChannelStateEvent.class)) {
-				return type == END_OF_CHANNEL_STATE_EVENT;
-			} else if (eventClass.equals(CancelCheckpointMarker.class)) {
-				return type == CANCEL_CHECKPOINT_MARKER_EVENT;
-			} else {
-				throw new UnsupportedOperationException("Unsupported eventClass = " + eventClass);
-			}
-		}
-		finally {
-			buffer.order(bufferOrder);
-			// restore the original position in the buffer (recall: we only peak into it!)
-			buffer.position(bufferPos);
-		}
-	}
-
 	public static AbstractEvent fromSerializedEvent(ByteBuffer buffer, ClassLoader classLoader) throws IOException {
 		if (buffer.remaining() < 4) {
 			throw new IOException("Incomplete event");
@@ -314,16 +272,5 @@ public class EventSerializer {
 
 	public static AbstractEvent fromBuffer(Buffer buffer, ClassLoader classLoader) throws IOException {
 		return fromSerializedEvent(buffer.getNioBufferReadable(), classLoader);
-	}
-
-	/**
-	 * Identifies whether the given buffer encodes the given event. Custom events are not supported.
-	 *
-	 * @param buffer the buffer to peak into
-	 * @param eventClass the expected class of the event type
-	 * @return whether the event class of the <tt>buffer</tt> matches the given <tt>eventClass</tt>
-	 */
-	public static boolean isEvent(Buffer buffer, Class<?> eventClass) throws IOException {
-		return !buffer.isBuffer() && isEvent(buffer.getNioBufferReadable(), eventClass);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -207,6 +207,7 @@ public class EventSerializer {
 		}
 		buf.put((byte) (checkpointOptions.isExactlyOnceMode() ? 1 : 0));
 		buf.put((byte) (checkpointOptions.isUnalignedCheckpoint() ? 1 : 0));
+		buf.putLong(checkpointOptions.getAlignmentTimeout());
 
 		buf.flip();
 		return buf;
@@ -240,11 +241,17 @@ public class EventSerializer {
 		}
 		final boolean isExactlyOnceMode = buffer.get() == 1;
 		final boolean isUnalignedCheckpoint = buffer.get() == 1;
+		final long alignmentTimeout = buffer.getLong();
 
 		return new CheckpointBarrier(
 			id,
 			timestamp,
-			new CheckpointOptions(checkpointType, locationRef, isExactlyOnceMode, isUnalignedCheckpoint));
+			new CheckpointOptions(
+				checkpointType,
+				locationRef,
+				isExactlyOnceMode,
+				isUnalignedCheckpoint,
+				alignmentTimeout));
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -245,19 +245,19 @@ public interface Buffer {
 	 */
 	enum DataType {
 		/**
-		 * Flag value indicating that there is no buffer.
+		 * {@link #NONE} indicates that there is no buffer.
 		 */
 		NONE(false, false, false, false),
 
 		/**
-		 * DATA_BUFFER indicates that this buffer represents a non-event data buffer.
+		 * {@link #DATA_BUFFER} indicates that this buffer represents a non-event data buffer.
 		 */
 		DATA_BUFFER(true, false, false, false),
 
 		/**
-		 * EVENT_BUFFER indicates that this buffer represents serialized data of an event.
+		 * {@link #EVENT_BUFFER} indicates that this buffer represents serialized data of an event.
 		 * Note that this type can be further divided into more fine-grained event types
-		 * like {@link #ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER} and etc.
+		 * like {@link #ALIGNED_CHECKPOINT_BARRIER} and etc.
 		 */
 		EVENT_BUFFER(false, true, false, false),
 
@@ -267,10 +267,10 @@ public interface Buffer {
 		PRIORITIZED_EVENT_BUFFER(false, true, false, true),
 
 		/**
-		 * ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER indicates that this buffer represents a
+		 * {@link #ALIGNED_CHECKPOINT_BARRIER} indicates that this buffer represents a
 		 * serialized checkpoint barrier of aligned exactly-once checkpoint mode.
 		 */
-		ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER(false, true, true, false);
+		ALIGNED_CHECKPOINT_BARRIER(false, true, true, false);
 
 		private final boolean isBuffer;
 		private final boolean isEvent;
@@ -305,7 +305,7 @@ public interface Buffer {
 				return PRIORITIZED_EVENT_BUFFER;
 			}
 			return event instanceof CheckpointBarrier && ((CheckpointBarrier) event).getCheckpointOptions().needsAlignment() ?
-					ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER :
+					ALIGNED_CHECKPOINT_BARRIER :
 					EVENT_BUFFER;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -21,12 +21,15 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EventAnnouncement;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
@@ -437,19 +440,18 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 
 				wasEmpty = receivedBuffers.isEmpty();
 
-				if (buffer.getDataType().hasPriority()) {
-					receivedBuffers.addPriorityElement(new SequenceBuffer(buffer, sequenceNumber));
-					if (channelStatePersister.checkForBarrier(buffer)) {
-						// checkpoint was not yet started by task thread,
-						// so remember the numbers of buffers to spill for the time when it will be started
-						numBuffersOvertaken = receivedBuffers.getNumUnprioritizedElements();
-					}
-					firstPriorityEvent = receivedBuffers.getNumPriorityElements() == 1;
-				} else {
-					receivedBuffers.add(new SequenceBuffer(buffer, sequenceNumber));
-					channelStatePersister.maybePersist(buffer);
+				SequenceBuffer sequenceBuffer = new SequenceBuffer(buffer, sequenceNumber);
+				DataType dataType = buffer.getDataType();
+				if (dataType.hasPriority()) {
+					firstPriorityEvent = addPriorityBuffer(sequenceBuffer);
 				}
-
+				else {
+					receivedBuffers.add(sequenceBuffer);
+					channelStatePersister.maybePersist(buffer);
+					if (dataType.requiresAnnouncement()) {
+						firstPriorityEvent = addPriorityBuffer(announce(sequenceBuffer));
+					}
+				}
 				++expectedSequenceNumber;
 			}
 			recycleBuffer = false;
@@ -469,6 +471,31 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 				buffer.recycleBuffer();
 			}
 		}
+	}
+
+	/**
+	 * @return {@code true} if this was first priority buffer added.
+	 */
+	private boolean addPriorityBuffer(SequenceBuffer sequenceBuffer) throws IOException {
+		receivedBuffers.addPriorityElement(sequenceBuffer);
+		if (channelStatePersister.checkForBarrier(sequenceBuffer.buffer)) {
+			// checkpoint was not yet started by task thread,
+			// so remember the numbers of buffers to spill for the time when it will be started
+			numBuffersOvertaken = receivedBuffers.getNumUnprioritizedElements();
+		}
+		return receivedBuffers.getNumPriorityElements() == 1;
+	}
+
+	private SequenceBuffer announce(SequenceBuffer sequenceBuffer) throws IOException {
+		checkState(!sequenceBuffer.buffer.isBuffer(), "Only a CheckpointBarrier can be announced but found %s", sequenceBuffer.buffer);
+		AbstractEvent event = EventSerializer.fromBuffer(
+				sequenceBuffer.buffer,
+				getClass().getClassLoader());
+		checkState(event instanceof CheckpointBarrier, "Only a CheckpointBarrier can be announced but found %s", sequenceBuffer.buffer);
+		CheckpointBarrier barrier = (CheckpointBarrier) event;
+		return new SequenceBuffer(
+				EventSerializer.toBuffer(new EventAnnouncement(barrier, sequenceBuffer.sequenceNumber), true),
+				sequenceBuffer.sequenceNumber);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -63,6 +63,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
 	private final boolean isUnalignedCheckpointsEnabled;
 
+	private final long alignmentTimeout;
+
 	/**
 	 * @deprecated use {@link #builder()}.
 	 */
@@ -87,7 +89,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 			isExactlyOnce,
 			isPreferCheckpointForRecovery,
 			tolerableCpFailureNumber,
-			isUnalignedCheckpoint);
+			isUnalignedCheckpoint,
+			0);
 	}
 
 	private CheckpointCoordinatorConfiguration(
@@ -99,7 +102,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 			boolean isExactlyOnce,
 			boolean isPreferCheckpointForRecovery,
 			int tolerableCpFailureNumber,
-			boolean isUnalignedCheckpointsEnabled) {
+			boolean isUnalignedCheckpointsEnabled,
+			long alignmentTimeout) {
 
 		// sanity checks
 		if (checkpointInterval < MINIMAL_CHECKPOINT_TIME || checkpointTimeout < MINIMAL_CHECKPOINT_TIME ||
@@ -119,6 +123,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 		this.isPreferCheckpointForRecovery = isPreferCheckpointForRecovery;
 		this.tolerableCheckpointFailureNumber = tolerableCpFailureNumber;
 		this.isUnalignedCheckpointsEnabled = isUnalignedCheckpointsEnabled;
+		this.alignmentTimeout = alignmentTimeout;
 	}
 
 	public long getCheckpointInterval() {
@@ -155,6 +160,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
 	public boolean isUnalignedCheckpointsEnabled() {
 		return isUnalignedCheckpointsEnabled;
+	}
+
+	public long getAlignmentTimeout() {
+		return alignmentTimeout;
 	}
 
 	@Override
@@ -223,6 +232,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 		private boolean isPreferCheckpointForRecovery = true;
 		private int tolerableCheckpointFailureNumber;
 		private boolean isUnalignedCheckpointsEnabled;
+		private long alignmentTimeout = 0;
 
 		public CheckpointCoordinatorConfiguration build() {
 			return new CheckpointCoordinatorConfiguration(
@@ -234,7 +244,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 				isExactlyOnce,
 				isPreferCheckpointForRecovery,
 				tolerableCheckpointFailureNumber,
-				isUnalignedCheckpointsEnabled
+				isUnalignedCheckpointsEnabled,
+				alignmentTimeout
 			);
 		}
 
@@ -280,6 +291,11 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
 		public CheckpointCoordinatorConfigurationBuilder setUnalignedCheckpointsEnabled(boolean unalignedCheckpointsEnabled) {
 			isUnalignedCheckpointsEnabled = unalignedCheckpointsEnabled;
+			return this;
+		}
+
+		public CheckpointCoordinatorConfigurationBuilder setAlignmentTimeout(long alignmentTimeout) {
+			this.alignmentTimeout = alignmentTimeout;
 			return this;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
@@ -66,18 +66,61 @@ public class CheckpointOptionsTest {
 	@Test
 	public void testSavepointNeedsAlignment() {
 		CheckpointStorageLocationReference location = CheckpointStorageLocationReference.getDefault();
-		assertTrue(new CheckpointOptions(SAVEPOINT, location, true, true).needsAlignment());
-		assertFalse(new CheckpointOptions(SAVEPOINT, location, false, true).needsAlignment());
-		assertTrue(new CheckpointOptions(SAVEPOINT, location, true, false).needsAlignment());
-		assertFalse(new CheckpointOptions(SAVEPOINT, location, false, false).needsAlignment());
+		assertTrue(new CheckpointOptions(SAVEPOINT, location, true, true, 0).needsAlignment());
+		assertFalse(new CheckpointOptions(SAVEPOINT, location, false, true, 0).needsAlignment());
+		assertTrue(new CheckpointOptions(SAVEPOINT, location, true, false, 0).needsAlignment());
+		assertFalse(new CheckpointOptions(SAVEPOINT, location, false, false, 0).needsAlignment());
 	}
 
 	@Test
 	public void testCheckpointNeedsAlignment() {
 		CheckpointStorageLocationReference location = CheckpointStorageLocationReference.getDefault();
-		assertFalse(new CheckpointOptions(CHECKPOINT, location, true, true).needsAlignment());
-		assertTrue(new CheckpointOptions(CHECKPOINT, location, true, false).needsAlignment());
-		assertFalse(new CheckpointOptions(CHECKPOINT, location, false, true).needsAlignment());
-		assertFalse(new CheckpointOptions(CHECKPOINT, location, false, false).needsAlignment());
+		assertFalse(new CheckpointOptions(CHECKPOINT, location, true, true, 0).needsAlignment());
+		assertTrue(new CheckpointOptions(CHECKPOINT, location, true, false, 0).needsAlignment());
+		assertFalse(new CheckpointOptions(CHECKPOINT, location, false, true, 0).needsAlignment());
+		assertFalse(new CheckpointOptions(CHECKPOINT, location, false, false, 0).needsAlignment());
+	}
+
+	@Test
+	public void testCheckpointIsTimeoutable() {
+		CheckpointStorageLocationReference location = CheckpointStorageLocationReference.getDefault();
+		assertTimeoutable(
+			CheckpointOptions.create(
+				CHECKPOINT,
+				location,
+				true,
+				true,
+				10),
+			false,
+			true,
+			10);
+		assertTimeoutable(
+			CheckpointOptions.create(
+				CHECKPOINT,
+				location,
+				true,
+				false,
+				10),
+			false,
+			false,
+			CheckpointOptions.NO_ALIGNMENT_TIME_OUT);
+		assertTimeoutable(
+			CheckpointOptions.create(
+				CHECKPOINT,
+				location,
+				true,
+				true,
+				0),
+			true,
+			false,
+			0);
+	}
+
+	private void assertTimeoutable(CheckpointOptions options, boolean isUnaligned, boolean isTimeoutable, long timeout) {
+		assertTrue(options.isExactlyOnceMode());
+		assertEquals(!isUnaligned, options.needsAlignment());
+		assertEquals(isUnaligned, options.isUnalignedCheckpoint());
+		assertEquals(isTimeoutable, options.isTimeoutable());
+		assertEquals(timeout, options.getAlignmentTimeout());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -19,14 +19,17 @@
 package org.apache.flink.runtime.io.network.api.serialization;
 
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
+import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.util.TestTaskEvent;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 
 import org.junit.Test;
 
@@ -48,7 +51,17 @@ public class EventSerializerTest {
 		EndOfSuperstepEvent.INSTANCE,
 		new CheckpointBarrier(1678L, 4623784L, CheckpointOptions.forCheckpointWithDefaultLocation()),
 		new TestTaskEvent(Math.random(), 12361231273L),
-		new CancelCheckpointMarker(287087987329842L)
+		new CancelCheckpointMarker(287087987329842L),
+		new EventAnnouncement(new CheckpointBarrier(
+			42L,
+			1337L,
+			CheckpointOptions.create(
+				CheckpointType.CHECKPOINT,
+				CheckpointStorageLocationReference.getDefault(),
+				true,
+				true,
+				10)),
+			44)
 	};
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -396,7 +396,7 @@ public class PartitionRequestQueueTest {
 	@Test
 	public void testEnqueueReaderByResumingConsumption() throws Exception {
 		PipelinedSubpartition subpartition = PipelinedSubpartitionTest.createPipelinedSubpartition();
-		Buffer.DataType dataType1 = Buffer.DataType.ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER;
+		Buffer.DataType dataType1 = Buffer.DataType.ALIGNED_CHECKPOINT_BARRIER;
 		Buffer.DataType dataType2 = Buffer.DataType.DATA_BUFFER;
 		subpartition.add(createEventBufferConsumer(4096, dataType1));
 		subpartition.add(createEventBufferConsumer(4096, dataType2));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -338,7 +338,8 @@ public class PipelinedSubpartitionWithReadViewTest {
 			CheckpointType.CHECKPOINT,
 			new CheckpointStorageLocationReference(new byte[]{0, 1, 2}),
 			true,
-			true);
+			true,
+			0);
 		channelStateWriter.start(0, options);
 		BufferConsumer barrierBuffer = EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options), true);
 		subpartition.add(barrierBuffer);
@@ -365,7 +366,8 @@ public class PipelinedSubpartitionWithReadViewTest {
 			CheckpointType.CHECKPOINT,
 			new CheckpointStorageLocationReference(new byte[]{0, 1, 2}),
 			true,
-			true);
+			true,
+			0);
 		BufferConsumer barrierBuffer = EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options), true);
 		subpartition.add(barrierBuffer);
 		assertEquals(1, availablityListener.getNumNotifications());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -477,7 +477,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 	// ------------------------------------------------------------------------
 
 	private void blockSubpartitionByCheckpoint(int numNotifications) throws IOException, InterruptedException {
-		subpartition.add(createEventBufferConsumer(BUFFER_SIZE, Buffer.DataType.ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER));
+		subpartition.add(createEventBufferConsumer(BUFFER_SIZE, Buffer.DataType.ALIGNED_CHECKPOINT_BARRIER));
 
 		assertEquals(numNotifications, availablityListener.getNumNotifications());
 		assertNextEvent(readView, BUFFER_SIZE, null, false, 0, false, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -475,7 +475,7 @@ public class LocalInputChannelTest {
 		inputGate.setChannelStateWriter(stateWriter);
 
 		final CheckpointStorageLocationReference location = CheckpointStorageLocationReference.getDefault();
-		CheckpointOptions options = new CheckpointOptions(CheckpointType.CHECKPOINT, location, true, true);
+		CheckpointOptions options = new CheckpointOptions(CheckpointType.CHECKPOINT, location, true, true, 0);
 		stateWriter.start(0, options);
 
 		final CheckpointBarrier barrier = new CheckpointBarrier(0, 123L, options);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -79,6 +79,8 @@ public class CheckpointConfig implements java.io.Serializable {
 	/** Flag to enable unaligned checkpoints. */
 	private boolean unalignedCheckpointsEnabled;
 
+	private long alignmentTimeout = ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT.defaultValue().toMillis();
+
 	/** Cleanup behaviour for persistent checkpoints. */
 	private ExternalizedCheckpointCleanup externalizedCheckpointCleanup;
 
@@ -116,6 +118,7 @@ public class CheckpointConfig implements java.io.Serializable {
 		this.preferCheckpointForRecovery = checkpointConfig.preferCheckpointForRecovery;
 		this.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
 		this.unalignedCheckpointsEnabled = checkpointConfig.isUnalignedCheckpointsEnabled();
+		this.alignmentTimeout = checkpointConfig.alignmentTimeout;
 		this.externalizedCheckpointCleanup = checkpointConfig.externalizedCheckpointCleanup;
 		this.forceCheckpointing = checkpointConfig.forceCheckpointing;
 		this.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
@@ -455,6 +458,29 @@ public class CheckpointConfig implements java.io.Serializable {
 	}
 
 	/**
+	 * Only relevant if {@link #unalignedCheckpointsEnabled} is enabled.
+	 *
+	 * <p>If {@link #alignmentTimeout} has value equal to <code>0</code>, checkpoints will always start unaligned.
+	 *
+	 * <p>If {@link #alignmentTimeout} has value greater then <code>0</code>, checkpoints will start aligned.
+	 * If during checkpointing, checkpoint start delay exceeds this {@link #alignmentTimeout}, alignment
+	 * will timeout and checkpoint will start working as unaligned checkpoint.
+	 */
+	@PublicEvolving
+	public void setAlignmentTimeout(long alignmentTimeout) {
+		this.alignmentTimeout = alignmentTimeout;
+	}
+
+	/**
+	 * @return value of alignment timeout, as configured via {@link #setAlignmentTimeout(long)} or
+	 * {@link ExecutionCheckpointingOptions#ALIGNMENT_TIMEOUT}.
+	 */
+	@PublicEvolving
+	public long getAlignmentTimeout() {
+		return alignmentTimeout;
+	}
+
+	/**
 	 * Returns the cleanup behaviour for externalized checkpoints.
 	 *
 	 * @return The cleanup behaviour for externalized checkpoints or
@@ -543,5 +569,7 @@ public class CheckpointConfig implements java.io.Serializable {
 			.ifPresent(this::enableExternalizedCheckpoints);
 		configuration.getOptional(ExecutionCheckpointingOptions.ENABLE_UNALIGNED)
 			.ifPresent(this::enableUnalignedCheckpoints);
+		configuration.getOptional(ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT)
+			.ifPresent(timeout -> setAlignmentTimeout(timeout.toMillis()));
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -143,4 +143,20 @@ public class ExecutionCheckpointingOptions {
 					TextElement.code(CheckpointingMode.EXACTLY_ONCE.toString()),
 					TextElement.code(MAX_CONCURRENT_CHECKPOINTS.key()))
 				.build());
+
+	public static final ConfigOption<Duration> ALIGNMENT_TIMEOUT =
+		ConfigOptions.key("execution.checkpointing.alignment-timeout")
+			.durationType()
+			.defaultValue(Duration.ofSeconds(30))
+			.withDescription(Description.builder()
+				.text("Only relevant if %s is enabled.", TextElement.code(ENABLE_UNALIGNED.key()))
+				.linebreak()
+				.linebreak()
+				.text("If timeout is 0, checkpoints will always start unaligned.")
+				.linebreak()
+				.linebreak()
+				.text("If timeout has a positive value, checkpoints will start aligned. " +
+					"If during checkpointing, checkpoint start delay exceeds this timeout, alignment " +
+					"will timeout and checkpoint barrier will start working as unaligned checkpoint.")
+				.build());
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -443,6 +443,16 @@ public class StreamConfig implements Serializable {
 		return getCheckpointMode() == CheckpointingMode.EXACTLY_ONCE;
 	}
 
+	public long getAlignmentTimeout() {
+		return config.getLong(
+				ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT.key(),
+				ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT.defaultValue().toMillis());
+	}
+
+	public void setAlignmentTimeout(long alignmentTimeout) {
+		config.setLong(ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT.key(), alignmentTimeout);
+	}
+
 	public void setOutEdgesInOrder(List<StreamEdge> outEdgeList) {
 		try {
 			InstantiationUtil.writeObjectToConfig(outEdgeList, this.config, EDGES_IN_ORDER);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -612,6 +612,7 @@ public class StreamingJobGraphGenerator {
 		config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
 		config.setCheckpointMode(getCheckpointingMode(checkpointCfg));
 		config.setUnalignedCheckpointsEnabled(checkpointCfg.isUnalignedCheckpointsEnabled());
+		config.setAlignmentTimeout(checkpointCfg.getAlignmentTimeout());
 
 		for (int i = 0; i < vertex.getStatePartitioners().length; i++) {
 			config.setStatePartitioner(i, vertex.getStatePartitioners()[i]);
@@ -1149,6 +1150,7 @@ public class StreamingJobGraphGenerator {
 				.setPreferCheckpointForRecovery(cfg.isPreferCheckpointForRecovery())
 				.setTolerableCheckpointFailureNumber(cfg.getTolerableCheckpointFailureNumber())
 				.setUnalignedCheckpointsEnabled(cfg.isUnalignedCheckpointsEnabled())
+				.setAlignmentTimeout(cfg.getAlignmentTimeout())
 				.build(),
 			serializedStateBackend,
 			serializedHooks);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
@@ -35,7 +35,6 @@ public class AlternatingController implements CheckpointBarrierBehaviourControll
 	private final AlignedController alignedController;
 	private final UnalignedController unalignedController;
 	private  CheckpointBarrierBehaviourController activeController;
-	private long lastSeenBarrierId;
 
 	public AlternatingController(
 			AlignedController alignedController,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
@@ -83,7 +83,7 @@ public class AlternatingController implements CheckpointBarrierBehaviourControll
 	}
 
 	private boolean isAligned(CheckpointBarrier barrier) {
-		return !barrier.isCheckpoint();
+		return barrier.getCheckpointOptions().needsAlignment();
 	}
 
 	private CheckpointBarrierBehaviourController chooseController(CheckpointBarrier barrier) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -74,6 +74,11 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 
 	public abstract void processBarrier(CheckpointBarrier receivedBarrier, InputChannelInfo channelInfo) throws IOException;
 
+	public abstract void processBarrierAnnouncement(
+			CheckpointBarrier announcedBarrier,
+			int sequenceNumber,
+			InputChannelInfo channelInfo) throws IOException;
+
 	public abstract void processCancellationBarrier(CancelCheckpointMarker cancelBarrier) throws IOException;
 
 	public abstract void processEndOfPartition() throws IOException;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
@@ -144,6 +144,14 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 	}
 
 	@Override
+	public void processBarrierAnnouncement(
+			CheckpointBarrier announcedBarrier,
+			int sequenceNumber,
+			InputChannelInfo channelInfo) throws IOException {
+		// Ignore
+	}
+
+	@Override
 	public void processCancellationBarrier(CancelCheckpointMarker cancelBarrier) throws IOException {
 		final long checkpointId = cancelBarrier.getCheckpointId();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/SingleCheckpointBarrierHandler.java
@@ -148,6 +148,14 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
 	}
 
 	@Override
+	public void processBarrierAnnouncement(
+			CheckpointBarrier announcedBarrier,
+			int sequenceNumber,
+			InputChannelInfo channelInfo) throws IOException {
+		// TODO: FLINK-19681
+	}
+
+	@Override
 	public void processCancellationBarrier(CancelCheckpointMarker cancelBarrier) throws IOException {
 		final long cancelledId = cancelBarrier.getCheckpointId();
 		if (currentCheckpointId > cancelledId || (currentCheckpointId == cancelledId && numBarriersReceived == 0)) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -91,7 +91,9 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 					// TODO -   source's trigger message, but do a handshake in this task between the trigger
 					// TODO -   message from the master, and the source's trigger notification
 					final CheckpointOptions checkpointOptions = CheckpointOptions.forCheckpointWithDefaultLocation(
-						configuration.isExactlyOnceCheckpointMode(), configuration.isUnalignedCheckpointsEnabled());
+						configuration.isExactlyOnceCheckpointMode(),
+						configuration.isUnalignedCheckpointsEnabled(),
+						configuration.getAlignmentTimeout());
 					final long timestamp = System.currentTimeMillis();
 
 					final CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
@@ -84,7 +84,7 @@ public class InputProcessorUtilTest {
 			for (IndexedInputGate inputGate : allInputGates) {
 				for (int channelId = 0; channelId < inputGate.getNumberOfInputChannels(); channelId++) {
 					barrierHandler.processBarrier(
-						new CheckpointBarrier(1, 42, CheckpointOptions.forCheckpointWithDefaultLocation(true, true)),
+						new CheckpointBarrier(1, 42, CheckpointOptions.forCheckpointWithDefaultLocation(true, true, 0)),
 						new InputChannelInfo(inputGate.getGateIndex(), channelId));
 				}
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -828,6 +828,7 @@ public class MultipleInputStreamTaskTest {
 		return new StreamTaskMailboxTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
 			.modifyExecutionConfig(config -> config.enableObjectReuse())
 			.modifyStreamConfig(config -> config.setUnalignedCheckpointsEnabled(unaligned))
+			.modifyStreamConfig(config -> config.setAlignmentTimeout(0))
 			.addInput(BasicTypeInfo.STRING_TYPE_INFO)
 			.addSourceInput(
 				new SourceOperatorFactory<>(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -104,7 +104,7 @@ public class SubtaskCheckpointCoordinatorTest {
 		MockWriter writer = new MockWriter();
 		SubtaskCheckpointCoordinator coordinator = coordinator(unalignedCheckpointEnabled, writer);
 		CheckpointStorageLocationReference locationReference = CheckpointStorageLocationReference.getDefault();
-		CheckpointOptions options = new CheckpointOptions(checkpointType, locationReference, true, unalignedCheckpointEnabled);
+		CheckpointOptions options = new CheckpointOptions(checkpointType, locationReference, true, unalignedCheckpointEnabled, 0);
 		coordinator.initCheckpoint(1L, options);
 		return writer.started;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -211,6 +211,7 @@ public class UnalignedCheckpointITCase extends TestLogger {
 
 		final LocalStreamEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(parallelism, conf);
 		env.enableCheckpointing(100);
+		env.getCheckpointConfig().setAlignmentTimeout(0);
 		env.setParallelism(parallelism);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(EXPECTED_FAILURES, Time.milliseconds(100)));
 		env.getCheckpointConfig().enableUnalignedCheckpoints(true);


### PR DESCRIPTION
This PR adds `CheckpointBarrierAnnouncement` messages 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
