### PR TITLE
[FLINK-19675][python] Fix PythonCalcExpandProjectRule to handle cases when the calc node contains WHERE clause, composite fields access and Python UDF at the same time

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
@@ -231,7 +231,9 @@ object PythonCalcExpandProjectRule extends PythonCalcSplitRuleBase(
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
-    (None, None, program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+    (Option(program.getCondition).map(program.expandLocalRef),
+      None,
+      program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
   }
 
   private def containsFieldAccessInputs(node: RexNode): Boolean = {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -387,24 +387,6 @@ FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testReorderPythonCalc">
-    <Resource name="sql">
-      <![CDATA[SELECT a, pyFunc1(a, c), b FROM MyTable]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a=[$0], EXPR$1=[pyFunc1($0, $2)], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
-+- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
-   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testPythonFunctionMixedWithJavaFunctionInWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b), c + 1 FROM MyTable WHERE pyFunc2(a, c) > 0]]>
@@ -423,6 +405,43 @@ FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
    +- FlinkLogicalCalc(select=[c, a, b], where=[>(f0, 0)])
       +- FlinkLogicalCalc(select=[a, b, c, pyFunc2(a, c) AS f0])
          +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReorderPythonCalc">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pyFunc1(a, c), b FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pyFunc1($0, $2)], b=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
++- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPythonFunctionWithCompositeInputsAndWhereClause">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pyFunc1(b, d._1) FROM MyTable WHERE a + 1 > 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pyFunc1($1, $3._1)])
++- LogicalFilter(condition=[>(+($0, 1), 0)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, pyFunc1(b, f0) AS EXPR$1])
++- FlinkLogicalCalc(select=[a, b, d._1 AS f0], where=[>(+(a, 1), 0)])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -187,6 +187,12 @@ class PythonCalcSplitRuleTest extends TableTestBase {
   }
 
   @Test
+  def testPythonFunctionWithCompositeInputsAndWhereClause(): Unit = {
+    val sqlQuery = "SELECT a, pyFunc1(b, d._1) FROM MyTable WHERE a + 1 > 0"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
   def testChainingPythonFunctionWithCompositeInputs(): Unit = {
     val sqlQuery = "SELECT a, pyFunc1(b, pyFunc1(c, d._1)) FROM MyTable"
     util.verifyPlan(sqlQuery)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PythonCalcSplitRule.scala
@@ -231,7 +231,9 @@ object PythonCalcExpandProjectRule extends PythonCalcSplitRuleBase(
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
-    (None, None, program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+    (Option(program.getCondition).map(program.expandLocalRef),
+      None,
+      program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
   }
 
   private def containsFieldAccessInputs(node: RexNode): Boolean = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
@@ -584,6 +584,30 @@ class PythonCalcSplitRuleTest extends TableTestBase {
   }
 
   @Test
+  def testPythonFunctionWithCompositeInputsAndWhereClause(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c)
+    util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
+
+    val resultTable = table.select('a, 'b, 'c.flatten())
+      .select($"a", call("pyFunc1", $"b", $"c$$_1"))
+      .where($"a".plus(lit(1)).isGreater(lit(0)))
+
+    val expected = unaryNode(
+      "DataStreamPythonCalc",
+      unaryNode(
+        "DataStreamCalc",
+        streamTableNode(table),
+        term("select", "a", "b", "c._1 AS f0"),
+        term("where", ">(+(a, 1), 0)")
+      ),
+      term("select", "a", "pyFunc1(b, f0) AS _c1")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
   def testPandasFunctionWithCompositeInputs(): Unit = {
     val util = streamTestUtil()
     val table = util.addTable[(Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c)


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fix PythonCalcExpandProjectRule to handle cases when the calc node contains WHERE clause, composite fields access and Python UDF at the same time*

## Brief change log

  - *Fix rule PythonCalcExpandProjectRule*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests testPythonFunctionMixedWithJavaFunctionInWhereClause*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
