### PR TITLE
[FLINK-19769][streaming] Reuse StreamRecord in SourceOutputWithWatermarks#collect and BatchTimestampsAndWatermarks.TimestampsOnlyOutput#collect

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/BatchTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/BatchTimestampsAndWatermarks.java
@@ -77,6 +77,7 @@ public class BatchTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<
 
 		private final PushingAsyncDataInput.DataOutput<T> output;
 		private final TimestampAssigner<T> timestampAssigner;
+		private final StreamRecord<T> reusingRecord;
 
 		private TimestampsOnlyOutput(
 				PushingAsyncDataInput.DataOutput<T> output,
@@ -84,6 +85,7 @@ public class BatchTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<
 
 			this.output = output;
 			this.timestampAssigner = timestampAssigner;
+			this.reusingRecord = new StreamRecord<>(null);
 		}
 
 		@Override
@@ -94,7 +96,7 @@ public class BatchTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<
 		@Override
 		public void collect(T record, long timestamp) {
 			try {
-				output.emitRecord(new StreamRecord<>(record, timestampAssigner.extractTimestamp(record, timestamp)));
+				output.emitRecord(reusingRecord.replace(record, timestampAssigner.extractTimestamp(record, timestamp)));
 			} catch (ExceptionInChainedOperatorException e) {
 				throw e;
 			} catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

`SourceOutputWithWatermarks#collect` always creates a new `StreamRecord` object which can be reused quite easily. We should reuse the `StreamRecord` for optimization.

## Brief change log

 - Reuse StreamRecord in `SourceOutputWithWatermarks#collect`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
