### PR TITLE
[FLINK-19712][Coordination] Do not restart CREATED executions in RestartPipelinedRegionFailoverStrategy

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategyTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph.failover.flip1;
 
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -64,12 +65,12 @@ public class RestartPipelinedRegionFailoverStrategyTest extends TestLogger {
 	public void testRegionFailoverForRegionInternalErrors() {
 		final TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
-		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v5 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v6 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v5 = topology.newExecutionVertex(ExecutionState.SCHEDULED);
+		TestingSchedulingExecutionVertex v6 = topology.newExecutionVertex(ExecutionState.RUNNING);
 
 		topology.connect(v1, v4, ResultPartitionType.BLOCKING);
 		topology.connect(v1, v5, ResultPartitionType.BLOCKING);
@@ -142,12 +143,12 @@ public class RestartPipelinedRegionFailoverStrategyTest extends TestLogger {
 	public void testRegionFailoverForDataConsumptionErrors() throws Exception {
 		TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
-		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v5 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v6 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex(ExecutionState.RUNNING);
+		TestingSchedulingExecutionVertex v5 = topology.newExecutionVertex(ExecutionState.RUNNING);
+		TestingSchedulingExecutionVertex v6 = topology.newExecutionVertex(ExecutionState.RUNNING);
 
 		topology.connect(v1, v4, ResultPartitionType.BLOCKING);
 		topology.connect(v1, v5, ResultPartitionType.BLOCKING);
@@ -241,9 +242,9 @@ public class RestartPipelinedRegionFailoverStrategyTest extends TestLogger {
 	public void testRegionFailoverForVariousResultPartitionAvailabilityCombinations() throws Exception {
 		TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
-		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex(ExecutionState.RUNNING);
 
 		topology.connect(v1, v3, ResultPartitionType.BLOCKING);
 		topology.connect(v2, v3, ResultPartitionType.BLOCKING);
@@ -354,12 +355,12 @@ public class RestartPipelinedRegionFailoverStrategyTest extends TestLogger {
 	public void testRegionFailoverForMultipleVerticesRegions() throws Exception {
 		TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
-		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v5 = topology.newExecutionVertex();
-		TestingSchedulingExecutionVertex v6 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex(ExecutionState.FINISHED);
+		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex(ExecutionState.RUNNING);
+		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex(ExecutionState.RUNNING);
+		TestingSchedulingExecutionVertex v5 = topology.newExecutionVertex(ExecutionState.FAILED);
+		TestingSchedulingExecutionVertex v6 = topology.newExecutionVertex(ExecutionState.CANCELED);
 
 		topology.connect(v1, v2, ResultPartitionType.PIPELINED);
 		topology.connect(v2, v3, ResultPartitionType.BLOCKING);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/PipelinedRegionExecutionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/PipelinedRegionExecutionViewTest.java
@@ -40,9 +40,9 @@ public class PipelinedRegionExecutionViewTest extends TestLogger {
 	private static final ExecutionVertexID TEST_EXECUTION_VERTEX_ID = new ExecutionVertexID(new JobVertexID(), 0);
 
 	private static final TestingSchedulingPipelinedRegion TEST_PIPELINED_REGION = new TestingSchedulingPipelinedRegion(Collections.singleton(
-		new TestingSchedulingExecutionVertex(
-			TEST_EXECUTION_VERTEX_ID.getJobVertexId(),
-			TEST_EXECUTION_VERTEX_ID.getSubtaskIndex())));
+		TestingSchedulingExecutionVertex.withExecutionVertexID(
+				TEST_EXECUTION_VERTEX_ID.getJobVertexId(),
+				TEST_EXECUTION_VERTEX_ID.getSubtaskIndex())));
 
 	@Test
 	public void regionIsUnfinishedIfNotAllVerticesAreFinished() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategyTest.java
@@ -62,11 +62,11 @@ public class EagerSchedulingStrategyTest extends TestLogger {
 	public void testStartScheduling() {
 		final JobVertexID jobVertexID = new JobVertexID();
 		final List<TestingSchedulingExecutionVertex> executionVertices = Arrays.asList(
-			new TestingSchedulingExecutionVertex(jobVertexID, 4),
-			new TestingSchedulingExecutionVertex(jobVertexID, 0),
-			new TestingSchedulingExecutionVertex(jobVertexID, 2),
-			new TestingSchedulingExecutionVertex(jobVertexID, 1),
-			new TestingSchedulingExecutionVertex(jobVertexID, 3));
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 4),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 0),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 2),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 1),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 3));
 		testingSchedulingTopology.addSchedulingExecutionVertices(executionVertices);
 
 		schedulingStrategy.startScheduling();
@@ -89,11 +89,11 @@ public class EagerSchedulingStrategyTest extends TestLogger {
 	public void testRestartTasks() {
 		final JobVertexID jobVertexID = new JobVertexID();
 		final List<TestingSchedulingExecutionVertex> executionVertices = Arrays.asList(
-			new TestingSchedulingExecutionVertex(jobVertexID, 4),
-			new TestingSchedulingExecutionVertex(jobVertexID, 0),
-			new TestingSchedulingExecutionVertex(jobVertexID, 2),
-			new TestingSchedulingExecutionVertex(jobVertexID, 1),
-			new TestingSchedulingExecutionVertex(jobVertexID, 3));
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 4),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 0),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 2),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 1),
+			TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexID, 3));
 		testingSchedulingTopology.addSchedulingExecutionVertices(executionVertices);
 
 		final List<ExecutionVertexID> verticesToRestart1 = Arrays.asList(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintCheckerTest.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
-import org.apache.flink.api.common.InputDependencyConstraint;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -31,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
-import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
 import static org.junit.Assert.assertFalse;
@@ -44,7 +41,7 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 
 	@Test
 	public void testCheckInputVertex() {
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex().finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex.newBuilder().build();
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(Collections.emptyList());
 
 		assertTrue(inputChecker.check(vertex));
@@ -56,9 +53,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 			.withPartitionType(PIPELINED)
 			.withPartitionState(ResultPartitionState.CREATED)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
-			.withConsumedPartitions(partitions)
-			.finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex
+				.newBuilder()
+				.withConsumedPartitions(partitions)
+				.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -71,9 +69,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 			.withPartitionType(PIPELINED)
 			.withPartitionState(ResultPartitionState.CONSUMABLE)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
-			.withConsumedPartitions(partitions)
-			.finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex
+				.newBuilder()
+				.withConsumedPartitions(partitions)
+				.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -85,9 +84,9 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withPartitionCntPerDataSet(2)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex.newBuilder()
 			.withConsumedPartitions(partitions)
-			.finish();
+			.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -103,9 +102,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withPartitionCntPerDataSet(2)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
-			.withConsumedPartitions(partitions)
-			.finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex
+				.newBuilder()
+				.withConsumedPartitions(partitions)
+				.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -119,9 +119,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withPartitionCntPerDataSet(2)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
-			.withConsumedPartitions(partitions)
-			.finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex
+				.newBuilder()
+				.withConsumedPartitions(partitions)
+				.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -141,9 +142,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withDataSetCnt(2)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
-			.withConsumedPartitions(partitions)
-			.finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex
+				.newBuilder()
+				.withConsumedPartitions(partitions)
+				.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -157,10 +159,10 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withDataSetCnt(2)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex.newBuilder()
 			.withInputDependencyConstraint(ALL)
 			.withConsumedPartitions(partitions)
-			.finish();
+			.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -176,10 +178,11 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		final List<TestingSchedulingResultPartition> partitions = addResultPartition()
 			.withDataSetCnt(2)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
-			.withInputDependencyConstraint(ALL)
-			.withConsumedPartitions(partitions)
-			.finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex
+				.newBuilder()
+				.withInputDependencyConstraint(ALL)
+				.withConsumedPartitions(partitions)
+				.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -193,10 +196,11 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 			.withDataSetCnt(2)
 			.withPartitionCntPerDataSet(2)
 			.finish();
-		final TestingSchedulingExecutionVertex vertex = addSchedulingExecutionVertex()
-			.withInputDependencyConstraint(ALL)
-			.withConsumedPartitions(partitions)
-			.finish();
+		final TestingSchedulingExecutionVertex vertex = TestingSchedulingExecutionVertex
+				.newBuilder()
+				.withInputDependencyConstraint(ALL)
+				.withConsumedPartitions(partitions)
+				.build();
 
 		final InputDependencyConstraintChecker inputChecker = createInputDependencyConstraintChecker(partitions);
 
@@ -205,30 +209,6 @@ public class InputDependencyConstraintCheckerTest extends TestLogger {
 		}
 
 		assertFalse(inputChecker.check(vertex));
-	}
-
-	private static TestingSchedulingExecutionVertexBuilder addSchedulingExecutionVertex() {
-		return new TestingSchedulingExecutionVertexBuilder();
-	}
-
-	private static class TestingSchedulingExecutionVertexBuilder {
-		private static final JobVertexID jobVertexId = new JobVertexID();
-		private InputDependencyConstraint inputDependencyConstraint = ANY;
-		private List<TestingSchedulingResultPartition> partitions = Collections.emptyList();
-
-		TestingSchedulingExecutionVertexBuilder withInputDependencyConstraint(InputDependencyConstraint constraint) {
-			this.inputDependencyConstraint = constraint;
-			return this;
-		}
-
-		TestingSchedulingExecutionVertexBuilder withConsumedPartitions(List<TestingSchedulingResultPartition> partitions) {
-			this.partitions = partitions;
-			return this;
-		}
-
-		TestingSchedulingExecutionVertex finish() {
-			return new TestingSchedulingExecutionVertex(jobVertexId, 0, inputDependencyConstraint, partitions);
-		}
 	}
 
 	private static TestingSchedulingResultPartitionBuilder addResultPartition() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -24,7 +24,9 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
+import static org.apache.flink.api.common.InputDependencyConstraint.ANY;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -38,28 +40,22 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	private final Collection<TestingSchedulingResultPartition> producedPartitions;
 
-	private InputDependencyConstraint inputDependencyConstraint;
+	private final InputDependencyConstraint inputDependencyConstraint;
 
-	public TestingSchedulingExecutionVertex(JobVertexID jobVertexId, int subtaskIndex) {
-		this(jobVertexId, subtaskIndex, InputDependencyConstraint.ANY);
-	}
-
-	public TestingSchedulingExecutionVertex(JobVertexID jobVertexId, int subtaskIndex,
-		InputDependencyConstraint constraint) {
-
-		this(jobVertexId, subtaskIndex, constraint, new ArrayList<>());
-	}
+	private final ExecutionState executionState;
 
 	public TestingSchedulingExecutionVertex(
-		JobVertexID jobVertexId,
-		int subtaskIndex,
-		InputDependencyConstraint constraint,
-		Collection<TestingSchedulingResultPartition> consumedPartitions) {
+			JobVertexID jobVertexId,
+			int subtaskIndex,
+			InputDependencyConstraint constraint,
+			Collection<TestingSchedulingResultPartition> consumedPartitions,
+			ExecutionState executionState) {
 
 		this.executionVertexId = new ExecutionVertexID(jobVertexId, subtaskIndex);
 		this.inputDependencyConstraint = constraint;
 		this.consumedPartitions = checkNotNull(consumedPartitions);
 		this.producedPartitions = new ArrayList<>();
+		this.executionState = executionState;
 	}
 
 	@Override
@@ -69,7 +65,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	@Override
 	public ExecutionState getState() {
-		return ExecutionState.CREATED;
+		return executionState;
 	}
 
 	@Override
@@ -93,5 +89,56 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	void addProducedPartition(TestingSchedulingResultPartition partition) {
 		producedPartitions.add(partition);
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public static TestingSchedulingExecutionVertex withExecutionVertexID(
+			JobVertexID jobVertexId,
+			int subtaskIndex) {
+		return newBuilder().withExecutionVertexID(jobVertexId, subtaskIndex).build();
+	}
+
+	/**
+	 * Builder for {@link TestingSchedulingExecutionVertex}.
+	 */
+	public static class Builder {
+		private JobVertexID jobVertexId = new JobVertexID();
+		private int subtaskIndex = 0;
+		private InputDependencyConstraint inputDependencyConstraint = ANY;
+		private List<TestingSchedulingResultPartition> partitions = new ArrayList<>();
+		private ExecutionState executionState = ExecutionState.CREATED;
+
+		Builder withExecutionVertexID(JobVertexID jobVertexId, int subtaskIndex) {
+			this.jobVertexId = jobVertexId;
+			this.subtaskIndex = subtaskIndex;
+			return this;
+		}
+
+		Builder withInputDependencyConstraint(InputDependencyConstraint constraint) {
+			this.inputDependencyConstraint = constraint;
+			return this;
+		}
+
+		public Builder withConsumedPartitions(List<TestingSchedulingResultPartition> partitions) {
+			this.partitions = partitions;
+			return this;
+		}
+
+		public Builder withExecutionState(ExecutionState executionState) {
+			this.executionState = executionState;
+			return this;
+		}
+
+		public TestingSchedulingExecutionVertex build() {
+			return new TestingSchedulingExecutionVertex(
+					jobVertexId,
+					subtaskIndex,
+					inputDependencyConstraint,
+					partitions,
+					executionState);
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.api.common.InputDependencyConstraint;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.flip1.PipelinedRegionComputeUtil;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -156,7 +157,8 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 	}
 
 	public TestingSchedulingExecutionVertex newExecutionVertex(final JobVertexID jobVertexId, final int subtaskIndex) {
-		final TestingSchedulingExecutionVertex newVertex = new TestingSchedulingExecutionVertex(jobVertexId, subtaskIndex);
+		final TestingSchedulingExecutionVertex newVertex =
+				TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexId, subtaskIndex);
 		addSchedulingExecutionVertex(newVertex);
 		return newVertex;
 	}
@@ -350,12 +352,21 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 		public List<TestingSchedulingExecutionVertex> finish() {
 			final List<TestingSchedulingExecutionVertex> vertices = new ArrayList<>();
 			for (int subtaskIndex = 0; subtaskIndex < parallelism; subtaskIndex++) {
-				vertices.add(new TestingSchedulingExecutionVertex(jobVertexId, subtaskIndex, inputDependencyConstraint));
+				vertices.add(createTestingSchedulingExecutionVertex(subtaskIndex));
 			}
 
 			TestingSchedulingTopology.this.addSchedulingExecutionVertices(vertices);
 
 			return vertices;
+		}
+
+		private TestingSchedulingExecutionVertex createTestingSchedulingExecutionVertex(
+				final int subtaskIndex) {
+			return TestingSchedulingExecutionVertex
+					.newBuilder()
+					.withExecutionVertexID(jobVertexId, subtaskIndex)
+					.withInputDependencyConstraint(inputDependencyConstraint)
+					.build();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -156,6 +156,13 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 		return newExecutionVertex(new JobVertexID(), 0);
 	}
 
+	public TestingSchedulingExecutionVertex newExecutionVertex(ExecutionState executionState) {
+		final TestingSchedulingExecutionVertex newVertex =
+				TestingSchedulingExecutionVertex.newBuilder().withExecutionState(executionState).build();
+		addSchedulingExecutionVertex(newVertex);
+		return newVertex;
+	}
+
 	public TestingSchedulingExecutionVertex newExecutionVertex(final JobVertexID jobVertexId, final int subtaskIndex) {
 		final TestingSchedulingExecutionVertex newVertex =
 				TestingSchedulingExecutionVertex.withExecutionVertexID(jobVertexId, subtaskIndex);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -154,13 +154,10 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 		.map(i ->
 			// exception failure:
 				1 + // this mapper
-				i + // previous mappers
 			// TM failure:
 				(MAP_NUMBER - i - 1) + // subsequent mappers after PartitionNotFoundException
 				1 + // this mapper
-				1 + // this mapper after PartitionNotFoundException
-				i + // previous mappers
-				i) // previous mappers after PartitionNotFoundException
+				1) // this mapper after PartitionNotFoundException
 		.toArray();
 
 	private static final String TASK_NAME_PREFIX = "Test partition mapper ";


### PR DESCRIPTION
## What is the purpose of the change

When a task fails and it is `RestartPipelinedRegionFailoverStrategy`, all tasks in the region of the failed task and in the downstream regions will be canceled for later re-scheduling. However, these tasks can be still in `CREATED` state so that there is no need to cancel these tasks.

The PR skips canceling these tasks which can speed up the failover and reduce a lot of unnecessary CANCELING logs.ELING logs.

## Brief change log

  - refactor builder for `TestingSchedulingExecutionVertex`
  - add state to executions in `RestartPipelinedRegionFailoverStrategyTest`
  - refactor/deduplicate verification logic in `RestartPipelinedRegionFailoverStrategyTest`
  - add test that executions in `CREATED` state do not get restarted
  - fix expected restarts in `BatchFineGrainedRecoveryITCase` because subsequent mappers do not get restarted anymore if their parent mapper fails

## Verifying this change

unit tests